### PR TITLE
Change variable names to reduce confusion

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -206,7 +206,7 @@ var droidType = new GraphQLObjectType({
       type: new GraphQLList(characterInterface),
       description: 'The friends of the droid, or an empty list if they ' +
                    'have none.',
-      resolve: (human) => getFriends(human),
+      resolve: (droid) => getFriends(droid),
     },
     appearsIn: {
       type: new GraphQLList(episodeEnum),


### PR DESCRIPTION
The `resolve` function for `friends` on the `droid` type has `human` as a variable name. This is somewhat confusing, since it will be called on a droid.