### PR TITLE
Don't resolve when invalid

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -39,14 +39,15 @@ export function graphql(
     var validationResult = validateDocument(schema, ast);
     if (!validationResult.isValid) {
       resolve({ errors: validationResult.errors });
+    } else {
+      resolve(execute(
+        schema,
+        rootObject,
+        ast,
+        operationName,
+        variableValues
+      ));
     }
-    resolve(execute(
-      schema,
-      rootObject,
-      ast,
-      operationName,
-      variableValues
-    ));
   }).catch(error => {
     return { errors: [ formatError(error) ] };
   });


### PR DESCRIPTION
You are calling `execute` and double resolving even when document validation has failed.