### PR TITLE
Fix async resolve promises not being resolved properly in list types.

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -164,7 +164,11 @@ var humanType = new GraphQLObjectType({
       type: new GraphQLList(characterInterface),
       description: 'The friends of the human, or an empty list if they ' +
                    'have none.',
-      resolve: (human) => getFriends(human),
+      resolve: (human) => {
+        return new Promise((resolve) => {
+          resolve(getFriends(human));
+        });
+      }
     },
     appearsIn: {
       type: new GraphQLList(episodeEnum),

--- a/src/executor/executor.js
+++ b/src/executor/executor.js
@@ -596,12 +596,18 @@ function completeField(
       Array.isArray(result),
       'User Error: expected iterable, but did not find one.'
     );
-    return result.map(item => completeField(
+    var results = result.map(item => completeField(
       exeContext,
       itemType,
       fieldASTs,
       item
     ));
+
+    if (results.some(isThenable)) {
+      return Promise.all(results);
+    } else {
+      return results;
+    }
   }
 
   // If field type is Scalar or Enum, coerce to a valid value, returning null


### PR DESCRIPTION
Fixes: #17 

Made one of the fields in the tests return a promise to demonstrate the bug in #17, and added code as discussed in #17 to fix it.

`completeField` seemed to be the best place to put this logic, but let me know if it makes sense somewhere else and I can move it.