### PR TITLE
build: use && instead of &

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "eslint src",
     "check": "flow check",
     "cover": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",
-    "build": "rm -rf lib/* & babel src --ignore __tests__ --optional runtime --out-dir lib",
+    "build": "rm -rf lib/* && babel src --ignore __tests__ --optional runtime --out-dir lib",
     "watch": "babel --optional runtime scripts/watch.js | node"
   },
   "dependencies": {


### PR DESCRIPTION
Using `&` looks like a typo. It causes `rm` to run in background, which introduces race condition