### PR TITLE
Test recursion avoidance correctly

### DIFF
--- a/src/executor/__tests__/executor.js
+++ b/src/executor/__tests__/executor.js
@@ -473,7 +473,7 @@ describe('Execute: Handles basic execution tasks', () => {
         ...Frag
       }
 
-      fragment Frag on DataType {
+      fragment Frag on Type {
         a,
         ...Frag
       }


### PR DESCRIPTION
`DataType` is unknown type, so `...Frag` fragment spread was ignored and recursion was not tested correctly.

Additional question: is it intended to just ignore a fragment on the unknown type?