### PR TITLE
Add missing `description` to field args

### DIFF
--- a/src/__tests__/starWarsIntrospectionTests.js
+++ b/src/__tests__/starWarsIntrospectionTests.js
@@ -298,6 +298,83 @@ describe('Star Wars Introspection Tests', () => {
       return testQuery(query, expected);
     });
 
+    it('Allows querying the schema for field args', () => {
+      var query = `
+        query IntrospectionQueryTypeQuery {
+          __schema {
+            queryType {
+              fields {
+                name
+                args {
+                  name
+                  description
+                  type {
+                    name
+                    kind
+                    ofType {
+                      name
+                      kind
+                    }
+                  }
+                  defaultValue
+                }
+              }
+            }
+          }
+        }
+      `;
+      var expected = {
+        __schema: {
+          queryType: {
+            fields: [
+              {
+                name: 'hero',
+                args: []
+              },
+              {
+                name: 'human',
+                args: [
+                  {
+                    name: 'id',
+                    description: 'id of the human',
+                    type: {
+                      kind: 'NON_NULL',
+                      name: null,
+                      ofType: {
+                        kind: 'SCALAR',
+                        name: 'String'
+                      }
+                    },
+                    defaultValue: null
+                  }
+                ]
+              },
+              {
+                name: 'droid',
+                args: [
+                  {
+                    name: 'id',
+                    description: 'id of the droid',
+                    type: {
+                      kind: 'NON_NULL',
+                      name: null,
+                      ofType: {
+                        kind: 'SCALAR',
+                        name: 'String'
+                      }
+                    },
+                    defaultValue: null
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      };
+
+      return testQuery(query, expected);
+    });
+
     it('Allows querying the schema for documentation', () => {
       var query = `
         query IntrospectionDroidDescriptionQuery {

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -243,12 +243,22 @@ var queryType = new GraphQLObjectType({
     },
     human: {
       type: humanType,
-      args: {id: { name: 'id', type: new GraphQLNonNull(GraphQLString)}},
+      args: {
+        id: {
+          description: 'id of the human',
+          type: new GraphQLNonNull(GraphQLString)
+        }
+      },
       resolve: (root, {id}) => starWarsData.Humans[id],
     },
     droid: {
       type: droidType,
-      args: {id: { name: 'id', type: new GraphQLNonNull(GraphQLString)}},
+      args: {
+        id: {
+          description: 'id of the droid',
+          type: new GraphQLNonNull(GraphQLString)
+        }
+      },
       resolve: (root, {id}) => starWarsData.Droids[id],
     },
   })

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -300,6 +300,7 @@ function defineFieldMap(
         );
         return {
           name: argName,
+          description: arg.description === undefined ? null : arg.description,
           type: arg.type,
           defaultValue: arg.defaultValue === undefined ? null : arg.defaultValue
         };


### PR DESCRIPTION
As the schema sais [__InputValue](http://facebook.github.io/graphql/#sec-Schema-Introspection) can have a `description`. When I tried to set a description inline (Not using an `INPUT_OBJECT `) it did not work. It seems the code in `definition.js` was missing the `description` in a map functions return object.

I've have fixed this an added a Star Wars spec to go with it.

Also a side note: `starWarsSchema.js` was setting [`name`](https://github.com/graphql/graphql-js/blob/master/src/__tests__/starWarsSchema.js#L246) values on the args but it serves no purpose because the name of the arg is set to the value of the key [here](https://github.com/graphql/graphql-js/blob/master/src/type/definition.js#L302). So I removed the two `name` declarations in the `#human` and `#droid` field args section in `starWarsSchema.js`.