### PR TITLE
Directive name is not-null

### DIFF
--- a/src/type/__tests__/introspection.js
+++ b/src/type/__tests__/introspection.js
@@ -790,9 +790,14 @@ describe('Introspection', () => {
                   args: [],
                   type: {
                     __typename: '__Type',
-                    kind: 'SCALAR',
-                    name: 'String',
-                    ofType: null,
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      __typename: '__Type',
+                      kind: 'SCALAR',
+                      name: 'String',
+                      ofType: null
+                    }
                   },
                   isDeprecated: false,
                   deprecationReason: null

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -60,7 +60,7 @@ export var __Schema = new GraphQLObjectType({
 var __Directive = new GraphQLObjectType({
   name: '__Directive',
   fields: () => ({
-    name: { type: GraphQLString },
+    name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     args: {
       type:


### PR DESCRIPTION
According to the spec, directive name should be not-null in the introspection API:

http://facebook.github.io/graphql/#sec-Schema-Introspection