### PR TITLE
Rename GraphQLFieldArgument to GraphQLArgument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ lib
 node_modules
 npm-debug.log
 coverage
+*.iml

--- a/src/executor/values.js
+++ b/src/executor/values.js
@@ -21,7 +21,7 @@ import {
   GraphQLList,
   GraphQLNonNull,
 } from '../type/definition';
-import type { GraphQLFieldArgument, GraphQLType } from '../type/definition';
+import type { GraphQLArgument, GraphQLType } from '../type/definition';
 import type { GraphQLSchema } from '../type/schema';
 import type {
   Argument,
@@ -55,7 +55,7 @@ export function getVariableValues(
  * definitions and list of argument AST nodes.
  */
 export function getArgumentValues(
-  argDefs: Array<GraphQLFieldArgument>,
+  argDefs: Array<GraphQLArgument>,
   argASTs: ?Array<Argument>,
   variables: { [key: string]: any }
 ): { [key: string]: any } {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -364,7 +364,7 @@ export type GraphQLFieldDefinition = {
   name: string;
   description: ?string;
   type: GraphQLOutputType;
-  args: Array<GraphQLFieldArgument>;
+  args: Array<GraphQLArgument>;
   resolve?: (
     source?: any,
     args?: ?{[argName: string]: any},
@@ -377,7 +377,7 @@ export type GraphQLFieldDefinition = {
   deprecationReason?: ?string;
 }
 
-export type GraphQLFieldArgument = {
+export type GraphQLArgument = {
   name: string;
   type: GraphQLInputType;
   defaultValue?: any;

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -9,7 +9,7 @@
  */
 
 import { GraphQLNonNull } from './definition';
-import type { GraphQLFieldArgument } from './definition';
+import type { GraphQLArgument } from './definition';
 import { GraphQLBoolean } from './scalars';
 
 
@@ -20,7 +20,7 @@ import { GraphQLBoolean } from './scalars';
 export class GraphQLDirective {
   name: string;
   description: ?string;
-  args: Array<GraphQLFieldArgument>;
+  args: Array<GraphQLArgument>;
   onOperation: boolean;
   onFragment: boolean;
   onField: boolean;
@@ -38,7 +38,7 @@ export class GraphQLDirective {
 type GraphQLDirectiveConfig = {
   name: string;
   description?: string;
-  args: Array<GraphQLFieldArgument>;
+  args: Array<GraphQLArgument>;
   onOperation: boolean;
   onFragment: boolean;
   onField: boolean;

--- a/src/utils/TypeInfo.js
+++ b/src/utils/TypeInfo.js
@@ -26,7 +26,7 @@ import type {
   GraphQLOutputType,
   GraphQLCompositeType,
   GraphQLFieldDefinition,
-  GraphQLFieldArgument
+  GraphQLArgument
 } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';
 import {
@@ -52,7 +52,7 @@ export default class TypeInfo {
   _inputTypeStack: Array<?GraphQLInputType>;
   _fieldDefStack: Array<?GraphQLFieldDefinition>;
   _directive: ?GraphQLDirective;
-  _argument: ?GraphQLFieldArgument;
+  _argument: ?GraphQLArgument;
 
   constructor(schema: GraphQLSchema) {
     this._schema = schema;
@@ -92,7 +92,7 @@ export default class TypeInfo {
     return this._directive;
   }
 
-  getArgument(): ?GraphQLFieldArgument {
+  getArgument(): ?GraphQLArgument {
     return this._argument;
   }
 

--- a/src/validator/index.js
+++ b/src/validator/index.js
@@ -23,7 +23,7 @@ import type {
   GraphQLOutputType,
   GraphQLCompositeType,
   GraphQLFieldDefinition,
-  GraphQLFieldArgument
+  GraphQLArgument
 } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';
 import TypeInfo from '../utils/TypeInfo';
@@ -263,7 +263,7 @@ export class ValidationContext {
     return this._typeInfo.getDirective();
   }
 
-  getArgument(): ?GraphQLFieldArgument {
+  getArgument(): ?GraphQLArgument {
     return this._typeInfo.getArgument();
   }
 }


### PR DESCRIPTION
This PR renames GraphQLFieldArgument to GraphQLArgument to make it more clear, that it's not only an argument type for Fields, but a more generic type (currently also used in directives)