### PR TITLE
[RFC] standard printer uses no comma between fields

### DIFF
--- a/src/language/__tests__/printer.js
+++ b/src/language/__tests__/printer.js
@@ -49,12 +49,12 @@ describe('Printer', () => {
     expect(printed).to.equal(
   `query queryName($foo: ComplexType, $site: Site = MOBILE) {
   whoever123is: node(id: [123, 456]) {
-    id,
+    id
     ... on User @defer {
       field2 {
-        id,
+        id
         alias: field1(first: 10, after: $foo) @include(if: $foo) {
-          id,
+          id
           ...frag
         }
       }
@@ -75,7 +75,7 @@ fragment frag on Friend {
 }
 
 {
-  unnamed(truthy: true, falsey: false),
+  unnamed(truthy: true, falsey: false)
   query
 }
 `);

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -33,7 +33,9 @@ export function print(ast) {
       },
       VariableDefinition: node =>
         join([node.variable + ': ' + node.type, node.defaultValue], ' = '),
-      SelectionSet: node => blockList(node.selections, ',\n'),
+      SelectionSet: node =>
+        length(node.selections) === 0 ? null :
+        indent('{\n' + join(node.selections, '\n')) + '\n}',
       Field: node =>
         join([
           join([
@@ -92,11 +94,6 @@ export function print(ast) {
       NonNullType: node => node.type + '!',
     }
   });
-}
-
-function blockList(list, separator) {
-  return length(list) === 0 ? null :
-    indent('{\n' + join(list, separator)) + '\n}';
 }
 
 function indent(maybeString) {


### PR DESCRIPTION
A couple issues have opened up about inconsistency in rendering graphql queries in the spec and in the ref impl - especially with respect to whitespace and commas.

Here I'm proposing that it's easier to read queries where every field is always on it's own line (eg, no `image { width, height }` one-liners) and that lines are split only by line-terminators and not also commas.

If there's agreement around this proposal, the second step will be to apply the printer to all graphql examples in the spec.