### PR TITLE
Add parser tests for accepting non-keywords

### DIFF
--- a/src/language/__tests__/parser.js
+++ b/src/language/__tests__/parser.js
@@ -119,6 +119,34 @@ fragment MissingOn Type
     expect(() => parse(kitchenSink)).to.not.throw();
   });
 
+  it('allows non-keywords anywhere a Name is allowed', () => {
+    const nonKeywords = [
+      'on',
+      'fragment',
+      'query',
+      'mutation',
+      'true',
+      'false'
+    ];
+    nonKeywords.forEach((keyword) => {
+      let fragmentName = keyword;
+      // You can't define or reference a fragment named `on`.
+      if (keyword === 'on') {
+        fragmentName = 'a';
+      }
+      expect(() => {
+        parse(`query ${keyword} {
+  ... ${fragmentName}
+  ... on ${keyword} { field }
+}
+fragment ${fragmentName} on Type {
+  ${keyword}(${keyword}: $${keyword}) @${keyword}(${keyword}: ${keyword})
+}`
+        );
+      }).to.not.throw();
+    });
+  });
+
   it('parse creates ast', () => {
 
     var source = new Source(`{


### PR DESCRIPTION
Resolves issue #58. There is one special case because fragments named `on` may be defined according to the current specification (`fragment on on SomeType { someField }`), but may not be referenced.

(If you try to reference your fragment named `on`, it's at best a syntax error, as in `{ ...on }`, which is the start of an inline fragment definition that doesn't have a type.)