### PR TITLE
Babel async await

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,6 @@
 {
   "parser": "babel-eslint",
   "arrowFunctions": true,
-  "asyncFunctions": true,
-  "es7.asyncFunctions": true,
   "blockBindings": true,
   "classes": true,
   "defaultParams": true,
@@ -15,7 +13,6 @@
   "objectLiteralShorthandProperties": true,
   "spread": true,
   "templateStrings": true,
-  "experimental" : true,
   "env": {
     "node": true,
     "es6": true

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,8 @@
 {
   "parser": "babel-eslint",
   "arrowFunctions": true,
+  "asyncFunctions": true,
+  "es7.asyncFunctions": true,
   "blockBindings": true,
   "classes": true,
   "defaultParams": true,
@@ -13,6 +15,7 @@
   "objectLiteralShorthandProperties": true,
   "spread": true,
   "templateStrings": true,
+  "experimental" : true,
   "env": {
     "node": true,
     "es6": true

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "lint": "eslint src",
     "check": "flow check",
     "cover": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",
-    "build": "rm -rf lib/* && babel src --ignore __tests__ --optional runtime --out-dir lib",
-    "watch": "babel --optional runtime scripts/watch.js | node",
+    "build": "rm -rf lib/* && babel src --ignore __tests__ --optional runtime,es7.asyncFunctions --out-dir lib",
+    "watch": "babel --optional runtime,es7.asyncFunctions scripts/watch.js | node",
     "coveralls": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha --report lcovonly -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "options": {
     "mocha": "--require scripts/mocha-bootload src/**/__tests__/**/*.js"
   },
+  "babel": {
+    "optional": ["runtime", "es7.asyncFunctions"]
+  },
   "scripts": {
     "prepublish": "npm test && npm run build",
     "test": "npm run lint && npm run check && mocha $npm_package_options_mocha",
@@ -36,16 +39,16 @@
     "lint": "eslint src",
     "check": "flow check",
     "cover": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",
-    "build": "rm -rf lib/* && babel src --ignore __tests__ --optional runtime,es7.asyncFunctions --out-dir lib",
-    "watch": "babel --optional runtime,es7.asyncFunctions scripts/watch.js | node",
+    "build": "rm -rf lib/* && babel src --ignore __tests__ --out-dir lib",
+    "watch": "babel scripts/watch.js | node",
     "coveralls": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha --report lcovonly -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
-    "babel-runtime": "5.6.12"
+    "babel-runtime": "5.7.0"
   },
   "devDependencies": {
-    "babel": "5.6.14",
-    "babel-core": "5.6.20",
+    "babel": "5.6.23",
+    "babel-core": "5.7.2",
     "babel-eslint": "3.1.23",
     "chai": "3.0.0",
     "chai-as-promised": "5.1.0",

--- a/scripts/mocha-bootload.js
+++ b/scripts/mocha-bootload.js
@@ -8,7 +8,7 @@
  */
 
 require('babel/register')({
-  optional: ['runtime']
+  optional: ['runtime', 'es7.asyncFunctions']
 });
 
 var chai = require('chai');

--- a/src/__tests__/starWarsIntrospectionTests.js
+++ b/src/__tests__/starWarsIntrospectionTests.js
@@ -15,19 +15,9 @@ import { graphql } from '../graphql';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /*eslint-disable max-len */
 
-/**
- * Helper function to test a query and the expected response.
- */
-function testQuery(query, expected) {
-  return expect(
-    graphql(StarWarsSchema, query)
-  ).to.become({data: expected});
-}
-
-
 describe('Star Wars Introspection Tests', () => {
   describe('Basic Introspection', () => {
-    it('Allows querying the schema for types', () => {
+    it('Allows querying the schema for types', async () => {
       var query = `
         query IntrospectionTypeQuery {
           __schema {
@@ -85,10 +75,11 @@ describe('Star Wars Introspection Tests', () => {
           ]
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for query type', () => {
+    it('Allows querying the schema for query type', async () => {
       var query = `
         query IntrospectionQueryTypeQuery {
           __schema {
@@ -105,10 +96,11 @@ describe('Star Wars Introspection Tests', () => {
           },
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for a specific type', () => {
+    it('Allows querying the schema for a specific type', async () => {
       var query = `
         query IntrospectionDroidTypeQuery {
           __type(name: "Droid") {
@@ -121,10 +113,11 @@ describe('Star Wars Introspection Tests', () => {
           name: 'Droid'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for an object kind', () => {
+    it('Allows querying the schema for an object kind', async () => {
       var query = `
         query IntrospectionDroidKindQuery {
           __type(name: "Droid") {
@@ -139,10 +132,11 @@ describe('Star Wars Introspection Tests', () => {
           kind: 'OBJECT'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for an interface kind', () => {
+    it('Allows querying the schema for an interface kind', async () => {
       var query = `
         query IntrospectionCharacterKindQuery {
           __type(name: "Character") {
@@ -157,10 +151,11 @@ describe('Star Wars Introspection Tests', () => {
           kind: 'INTERFACE'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for object fields', () => {
+    it('Allows querying the schema for object fields', async () => {
       var query = `
         query IntrospectionDroidFieldsQuery {
           __type(name: "Droid") {
@@ -217,10 +212,12 @@ describe('Star Wars Introspection Tests', () => {
           ]
         }
       };
-      return testQuery(query, expected);
+
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for nested object fields', () => {
+    it('Allows querying the schema for nested object fields', async () => {
       var query = `
         query IntrospectionDroidNestedFieldsQuery {
           __type(name: "Droid") {
@@ -295,10 +292,11 @@ describe('Star Wars Introspection Tests', () => {
           ]
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for field args', () => {
+    it('Allows querying the schema for field args', async () => {
       var query = `
         query IntrospectionQueryTypeQuery {
           __schema {
@@ -372,10 +370,12 @@ describe('Star Wars Introspection Tests', () => {
         }
       };
 
-      return testQuery(query, expected);
+
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows querying the schema for documentation', () => {
+    it('Allows querying the schema for documentation', async () => {
       var query = `
         query IntrospectionDroidDescriptionQuery {
           __type(name: "Droid") {
@@ -390,7 +390,8 @@ describe('Star Wars Introspection Tests', () => {
           description: 'A mechanical creature in the Star Wars universe.'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 });

--- a/src/__tests__/starWarsQueryTests.js
+++ b/src/__tests__/starWarsQueryTests.js
@@ -15,27 +15,9 @@ import { graphql } from '../graphql';
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /*eslint-disable max-len */
 
-/**
- * Helper function to test a query and the expected response.
- */
-function testQuery(query, expected) {
-  return expect(
-    graphql(StarWarsSchema, query)
-  ).to.become({data: expected});
-}
-
-/**
- * Helper function to test a query with params and the expected response.
- */
-function testQueryWithParams(query, params, expected) {
-  return expect(
-    graphql(StarWarsSchema, query, null, params)
-  ).to.become({data: expected});
-}
-
 describe('Star Wars Query Tests', () => {
   describe('Basic Queries', () => {
-    it('Correctly identifies R2-D2 as the hero of the Star Wars Saga', () => {
+    it('Correctly identifies R2-D2 as the hero of the Star Wars Saga', async () => {
       var query = `
         query HeroNameQuery {
           hero {
@@ -48,10 +30,11 @@ describe('Star Wars Query Tests', () => {
           name: 'R2-D2'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows us to query for the ID and friends of R2-D2', () => {
+    it('Allows us to query for the ID and friends of R2-D2', async () => {
       var query = `
         query HeroNameAndFriendsQuery {
           hero {
@@ -80,12 +63,13 @@ describe('Star Wars Query Tests', () => {
           ]
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 
   describe('Nested Queries', () => {
-    it('Allows us to query for the friends of friends of R2-D2', () => {
+    it('Allows us to query for the friends of friends of R2-D2', async () => {
       var query = `
         query NestedQuery {
           hero {
@@ -158,12 +142,13 @@ describe('Star Wars Query Tests', () => {
           ]
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 
   describe('Using IDs and query parameters to refetch objects', () => {
-    it('Allows us to query for Luke Skywalker directly, using his ID', () => {
+    it('Allows us to query for Luke Skywalker directly, using his ID', async () => {
       var query = `
         query FetchLukeQuery {
           human(id: "1000") {
@@ -176,10 +161,11 @@ describe('Star Wars Query Tests', () => {
           name: 'Luke Skywalker'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows us to create a generic query, then use it to fetch Luke Skywalker using his ID', () => {
+    it('Allows us to create a generic query, then use it to fetch Luke Skywalker using his ID', async () => {
       var query = `
         query FetchSomeIDQuery($someId: String!) {
           human(id: $someId) {
@@ -195,10 +181,11 @@ describe('Star Wars Query Tests', () => {
           name: 'Luke Skywalker'
         }
       };
-      return testQueryWithParams(query, params, expected);
+      var result = await graphql(StarWarsSchema, query, null, params);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows us to create a generic query, then use it to fetch Han Solo using his ID', () => {
+    it('Allows us to create a generic query, then use it to fetch Han Solo using his ID', async () => {
       var query = `
         query FetchSomeIDQuery($someId: String!) {
           human(id: $someId) {
@@ -214,10 +201,11 @@ describe('Star Wars Query Tests', () => {
           name: 'Han Solo'
         }
       };
-      return testQueryWithParams(query, params, expected);
+      var result = await graphql(StarWarsSchema, query, null, params);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows us to create a generic query, then pass an invalid ID to get null back', () => {
+    it('Allows us to create a generic query, then pass an invalid ID to get null back', async () => {
       var query = `
         query humanQuery($id: String!) {
           human(id: $id) {
@@ -231,12 +219,13 @@ describe('Star Wars Query Tests', () => {
       var expected = {
         human: null
       };
-      return testQueryWithParams(query, params, expected);
+      var result = await graphql(StarWarsSchema, query, null, params);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 
   describe('Using aliases to change the key in the response', () => {
-    it('Allows us to query for Luke, changing his key with an alias', () => {
+    it('Allows us to query for Luke, changing his key with an alias', async () => {
       var query = `
         query FetchLukeAliased {
           luke: human(id: "1000") {
@@ -249,10 +238,11 @@ describe('Star Wars Query Tests', () => {
           name: 'Luke Skywalker'
         },
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows us to query for both Luke and Leia, using two root fields and an alias', () => {
+    it('Allows us to query for both Luke and Leia, using two root fields and an alias', async () => {
       var query = `
         query FetchLukeAndLeiaAliased {
           luke: human(id: "1000") {
@@ -271,12 +261,13 @@ describe('Star Wars Query Tests', () => {
           name: 'Leia Organa'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 
   describe('Uses fragments to express more complex queries', () => {
-    it('Allows us to query using duplicated content', () => {
+    it('Allows us to query using duplicated content', async() => {
       var query = `
         query DuplicateFields {
           luke: human(id: "1000") {
@@ -299,10 +290,11 @@ describe('Star Wars Query Tests', () => {
           homePlanet: 'Alderaan'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
 
-    it('Allows us to use a fragment to avoid duplicating content', () => {
+    it('Allows us to use a fragment to avoid duplicating content', async () => {
       var query = `
         query UseFragment {
           luke: human(id: "1000") {
@@ -328,12 +320,13 @@ describe('Star Wars Query Tests', () => {
           homePlanet: 'Alderaan'
         }
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 
   describe('Using __typename to find the type of an object', () => {
-    it('Allows us to verify that R2-D2 is a droid', () => {
+    it('Allows us to verify that R2-D2 is a droid', async () => {
       var query = `
         query CheckTypeOfR2 {
           hero {
@@ -348,7 +341,8 @@ describe('Star Wars Query Tests', () => {
           name: 'R2-D2'
         },
       };
-      return testQuery(query, expected);
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
     });
   });
 });


### PR DESCRIPTION
This PR adds the async/await babel polyfill and then changes src/__tests__ (the Star Wars tests) to use them. Using this transform makes life a lot easier.

1) The syntax is nicer
2) No need to use the promise-friendly chai from the chai-as-promised module. I dislike these directives because it makes it awkward to add console logging in a test in between the executed test code and then test of the result. I also think its often desirable to do multiple expects with more granular error messaging.
3) No more forgetting to return the promise and then have false-passes because the code just doesn't execute.
4) From brief testing the errors messages appear more reasonable. 

I think we should just get rid of chai-as-promised and switch to this.