### PR TITLE
Bugfix TypeInfo: Missing/Wrong cleanup in leave

### DIFF
--- a/src/utils/TypeInfo.js
+++ b/src/utils/TypeInfo.js
@@ -190,8 +190,11 @@ export default class TypeInfo {
         this._typeStack.pop();
         break;
       case Kind.VARIABLE_DEFINITION:
+        this._inputTypeStack.pop();
+        break;
       case Kind.ARGUMENT:
         this._argument = null;
+        this._inputTypeStack.pop();
         break;
       case Kind.ARRAY:
       case Kind.OBJECT_FIELD:


### PR DESCRIPTION
VariableDefinition needs to cleanup the inputTypeStack and not argument
Argument needs to cleanup inputTypeStack too