### PR TITLE
Simplify coveralls script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,9 @@
     "testonly": "mocha $npm_package_options_mocha",
     "lint": "eslint src",
     "check": "flow check",
-    "cover": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha -- $npm_package_options_mocha",
     "build": "rm -rf lib/* && babel src --ignore __tests__ --out-dir lib",
     "watch": "babel scripts/watch.js | node",
-    "coveralls": "babel-node node_modules/.bin/isparta cover --report html node_modules/.bin/_mocha --report lcovonly -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "coveralls": "isparta cover --root src --report lcovonly node_modules/.bin/_mocha -- $npm_package_options_mocha && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
     "babel-runtime": "5.7.0"


### PR DESCRIPTION
Removes `npm run cover` in favor of the one `npm run coveralls` integration.

Also simplifies that script, removing the need for babel-node.

Finally, ensures the root is at "src" which removes the transient error parsing _mocha, speeds up the script, and does not count "scripts" as part of coverage score.