### PR TITLE
Add Schema Printer

### DIFF
--- a/src/type/__tests__/printer.js
+++ b/src/type/__tests__/printer.js
@@ -1,0 +1,571 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { printSchema, printIntrospectionSchema } from '../printer';
+import { introspectionQuery } from '../introspectionQuery';
+import { graphql } from '../../';
+
+import {
+  GraphQLSchema,
+  GraphQLInputObjectType,
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLBoolean,
+  GraphQLList,
+  GraphQLNonNull,
+} from '../';
+
+// 80+ char lines are useful in describe/it, so ignore in this file.
+/*eslint-disable max-len */
+
+function printForTest(result) {
+  return '\n' + printSchema(result) + '\n';
+}
+
+async function printSingleFieldSchema(fieldConfig) {
+  var Root = new GraphQLObjectType({
+    name: 'Root',
+    fields: { singleField: fieldConfig },
+  });
+  var Schema = new GraphQLSchema({query: Root});
+  var result = await graphql(Schema, introspectionQuery);
+  return printForTest(result);
+}
+
+function listOf(type) {
+  return new GraphQLList(type);
+}
+
+function nonNull(type) {
+  return new GraphQLNonNull(type);
+}
+
+describe('Type System Printer', () => {
+  it('Prints String Field', async () => {
+    var schema = await printSingleFieldSchema({type: GraphQLString});
+    expect(schema).to.equal(`
+type Root {
+  singleField: String
+}
+`
+    );
+  });
+
+  it('Prints [String] Field', async () => {
+    var schema = await printSingleFieldSchema({type: listOf(GraphQLString)});
+    expect(schema).to.equal(`
+type Root {
+  singleField: [String]
+}
+`
+    );
+  });
+
+  it('Prints String! Field', async () => {
+    var schema = await printSingleFieldSchema({type: nonNull(GraphQLString)});
+    expect(schema).to.equal(`
+type Root {
+  singleField: String!
+}
+`
+    );
+  });
+
+  it('Prints [String]! Field', async () => {
+    var schema = await printSingleFieldSchema({type: nonNull(listOf(GraphQLString))});
+    expect(schema).to.equal(`
+type Root {
+  singleField: [String]!
+}
+`
+    );
+  });
+
+  it('Prints [String!] Field', async () => {
+    var schema = await printSingleFieldSchema({type: listOf(nonNull(GraphQLString))});
+    expect(schema).to.equal(`
+type Root {
+  singleField: [String!]
+}
+`
+    );
+  });
+
+  it('Prints [String!]! Field', async () => {
+    var schema = await printSingleFieldSchema({type: nonNull(listOf(nonNull(GraphQLString)))});
+    expect(schema).to.equal(`
+type Root {
+  singleField: [String!]!
+}
+`
+    );
+  });
+
+  it('Print Object Field', async() => {
+    var FooType = new GraphQLObjectType({
+      name: 'Foo',
+      fields: { str: { type: GraphQLString } }
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: { foo: { type: FooType } },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+type Foo {
+  str: String
+}
+
+type Root {
+  foo: Foo
+}
+`
+    );
+  });
+
+  it('Prints String Field With Int Arg', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: { argOne: { type: GraphQLInt } },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int): String
+}
+`
+    );
+  });
+
+  it('Prints String Field With Int Arg With Default', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: { argOne: { type: GraphQLInt, defaultValue: 2 } },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int = 2): String
+}
+`
+    );
+  });
+
+  it('Prints String Field With Int! Arg', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: { argOne: { type: nonNull(GraphQLInt) } },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int!): String
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt },
+          argTwo: { type: GraphQLString },
+        },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int, argTwo: String): String
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args, First is Default', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt, defaultValue: 1 },
+          argTwo: { type: GraphQLString },
+          argThree: { type: GraphQLBoolean },
+        },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args, Second is Default', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt },
+          argTwo: { type: GraphQLString, defaultValue: 'foo' },
+          argThree: { type: GraphQLBoolean },
+        },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args, Last is Default', async () => {
+    var schema = await printSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt },
+          argTwo: { type: GraphQLString },
+          argThree: { type: GraphQLBoolean, defaultValue: false },
+        },
+      }
+    );
+    expect(schema).to.equal(`
+type Root {
+  singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
+}
+`
+    );
+  });
+
+  it('Print Interface', async() => {
+    var FooType = new GraphQLInterfaceType({
+      name: 'Foo',
+      fields: { str: { type: GraphQLString } },
+    });
+
+    var BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: { str: { type: GraphQLString } },
+      interfaces: [FooType],
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: { bar: { type: BarType } },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+type Bar implements Foo {
+  str: String
+}
+
+interface Foo {
+  str: String
+}
+
+type Root {
+  bar: Bar
+}
+`
+    );
+  });
+
+  it('Print Multiple Interface', async() => {
+    var FooType = new GraphQLInterfaceType({
+      name: 'Foo',
+      fields: { str: { type: GraphQLString } },
+    });
+
+    var BaazType = new GraphQLInterfaceType({
+      name: 'Baaz',
+      fields: { int: { type: GraphQLInt } },
+    });
+
+    var BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: {
+        str: { type: GraphQLString },
+        int: { type: GraphQLInt },
+      },
+      interfaces: [FooType, BaazType],
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: { bar: { type: BarType } },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+interface Baaz {
+  int: Int
+}
+
+type Bar implements Foo, Baaz {
+  str: String
+  int: Int
+}
+
+interface Foo {
+  str: String
+}
+
+type Root {
+  bar: Bar
+}
+`
+    );
+  });
+
+  it('Print Unions', async() => {
+    var FooType = new GraphQLObjectType({
+      name: 'Foo',
+      fields: {
+        bool: { type: GraphQLBoolean },
+      },
+    });
+
+    var BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: {
+        str: { type: GraphQLString },
+      },
+    });
+
+    var SingleUnion = new GraphQLUnionType({
+      name: 'SingleUnion',
+      types: [FooType],
+    });
+
+    var MultipleUnion = new GraphQLUnionType({
+      name: 'MultipleUnion',
+      types: [FooType, BarType],
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        single: { type: SingleUnion },
+        multiple: { type: MultipleUnion },
+      },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+type Bar {
+  str: String
+}
+
+type Foo {
+  bool: Boolean
+}
+
+union MultipleUnion = Foo | Bar
+
+type Root {
+  single: SingleUnion
+  multiple: MultipleUnion
+}
+
+union SingleUnion = Foo
+`
+    );
+  });
+
+  it('Print Input Type', async() => {
+    var InputType = new GraphQLInputObjectType({
+      name: 'InputType',
+      fields: {
+        int: { type: GraphQLInt },
+      },
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        str: {
+          type: GraphQLString,
+          args: { argOne: { type: InputType } },
+        },
+      },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+input InputType {
+  int: Int
+}
+
+type Root {
+  str(argOne: InputType): String
+}
+`);
+  });
+
+  it('Custom Scalar', async () => {
+    var OddType = new GraphQLScalarType({
+      name: 'Odd',
+      coerce(value) {
+        return value % 2 === 1 ? value : null;
+      }
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        odd: { type: OddType },
+      },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+scalar Odd
+
+type Root {
+  odd: Odd
+}
+`
+     );
+  });
+
+  it('Enum', async() => {
+    var RGBType = new GraphQLEnumType({
+      name: 'RGB',
+      values: {
+        RED: { value: 0 },
+        GREEN: { value: 1 },
+        BLUE: { value: 2 }
+      }
+    });
+
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        rgb: { type: RGBType },
+      },
+    });
+
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = printForTest(result);
+    expect(schema).to.equal(`
+enum RGB {
+  RED
+  GREEN
+  BLUE
+}
+
+type Root {
+  rgb: RGB
+}
+`);
+  });
+
+  it('Print Introspection Schema', async() => {
+    var Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {},
+    });
+    var Schema = new GraphQLSchema({query: Root});
+    var result = await graphql(Schema, introspectionQuery);
+    var schema = '\n' + printIntrospectionSchema(result) + '\n';
+    var introspectionSchema = `
+type __Directive {
+  name: String!
+  description: String
+  args: [__InputValue!]!
+  onOperation: Boolean
+  onFragment: Boolean
+  onField: Boolean
+}
+
+type __EnumValue {
+  name: String!
+  description: String
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type __Field {
+  name: String!
+  description: String
+  args: [__InputValue!]!
+  type: __Type!
+  isDeprecated: Boolean!
+  deprecationReason: String
+}
+
+type __InputValue {
+  name: String!
+  description: String
+  type: __Type!
+  defaultValue: String
+}
+
+type __Schema {
+  types: [__Type!]!
+  queryType: __Type!
+  mutationType: __Type
+  directives: [__Directive!]!
+}
+
+type __Type {
+  kind: __TypeKind!
+  name: String
+  description: String
+  fields(includeDeprecated: Boolean = false): [__Field!]
+  interfaces: [__Type!]
+  possibleTypes: [__Type!]
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+  inputFields: [__InputValue!]
+  ofType: __Type
+}
+
+enum __TypeKind {
+  SCALAR
+  OBJECT
+  INTERFACE
+  UNION
+  ENUM
+  INPUT_OBJECT
+  LIST
+  NON_NULL
+}
+`;
+    expect(schema).to.equal(introspectionSchema);
+  });
+});

--- a/src/type/printer.js
+++ b/src/type/printer.js
@@ -1,0 +1,155 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+var TypeKind = {
+  SCALAR: 'SCALAR',
+  OBJECT: 'OBJECT',
+  INTERFACE: 'INTERFACE',
+  UNION: 'UNION',
+  ENUM: 'ENUM',
+  INPUT_OBJECT: 'INPUT_OBJECT',
+  LIST: 'LIST',
+  NON_NULL: 'NON_NULL',
+};
+
+// e.g Int, Int!, [Int!]!
+function printTypeDecl(type) {
+  if (type.kind === TypeKind.LIST) {
+    return '[' + printTypeDecl(type.ofType) + ']';
+  } else if (type.kind === TypeKind.NON_NULL) {
+    return printTypeDecl(type.ofType) + '!';
+  } else {
+    return type.name;
+  }
+}
+
+function printField(field) {
+  return `${field.name}${printArgs(field)}: ${printTypeDecl(field.type)}`;
+}
+
+function printArg(arg) {
+  var argDecl = `${arg.name}: ${printTypeDecl(arg.type)}`;
+  if (arg.defaultValue !== null) {
+    argDecl += ` = ${arg.defaultValue}`;
+  }
+  return argDecl;
+}
+
+function printArgs(field) {
+  if (field.args.length === 0) {
+    return '';
+  }
+  return '(' + field.args.map(printArg).join(', ') + ')';
+}
+
+function printImplementedInterfaces(type) {
+  if (type.interfaces.length === 0) {
+    return '';
+  }
+  return ' implements ' + type.interfaces.map(i => i.name).join(', ');
+}
+
+function printObject(type) {
+  return `type ${type.name}${printImplementedInterfaces(type)} {` + '\n' +
+    printFields(type.fields) + '\n' +
+  '}';
+}
+
+function printInterface(type) {
+  return `interface ${type.name} {` + '\n' +
+    printFields(type.fields) + '\n' +
+  '}';
+}
+
+function printInputObject(type) {
+  return `input ${type.name} {` + '\n' +
+    printInputFields(type.inputFields) + '\n' +
+  '}';
+}
+
+function printFields(fields) {
+  return fields.map(f => '  ' + printField(f)).join('\n');
+}
+
+function printInputFields(fields) {
+  return fields.map(f => '  ' + printInputField(f)).join('\n');
+}
+
+function printInputField(field) {
+  return `${field.name}: ${printTypeDecl(field.type)}`;
+}
+
+
+function printUnion(type) {
+  var typeList = type.possibleTypes.map(t => t.name).join(' | ');
+  return `union ${type.name} = ${typeList}`;
+}
+
+function printScalar(type) {
+  return `scalar ${type.name}`;
+}
+
+function printEnumValues(values) {
+  return values.map(v => '  ' + v.name).join('\n');
+}
+
+function printEnum(type) {
+  return `enum ${type.name} {
+${printEnumValues(type.enumValues)}
+}`;
+}
+
+function printType(type) {
+  switch (type.kind) {
+    case TypeKind.OBJECT:
+      return printObject(type);
+    case TypeKind.UNION:
+      return printUnion(type);
+    case TypeKind.INTERFACE:
+      return printInterface(type);
+    case TypeKind.INPUT_OBJECT:
+      return printInputObject(type);
+    case TypeKind.SCALAR:
+      return printScalar(type);
+    case TypeKind.ENUM:
+      return printEnum(type);
+    default:
+      throw new Error('Invalid kind: ' + type.kind);
+  }
+}
+
+function isBuiltInScalar(type) {
+  return type.name === 'String' ||
+    type.name === 'Boolean' ||
+    type.name === 'Int' ||
+    type.name === 'Float' ||
+    type.name === 'ID';
+}
+
+function isIntrospectionType(type) {
+  return type.name.startsWith('__');
+}
+
+function isBuiltIn(type) {
+  return isIntrospectionType(type) || isBuiltInScalar(type);
+}
+
+export function printSchema(introspectionResult) {
+  var schema = introspectionResult.data.__schema;
+  var types = schema.types.filter(t => !isBuiltIn(t));
+  types = types.sort((t1, t2) => t1.name.localeCompare(t2.name));
+  return types.map(printType).join('\n\n');
+}
+
+export function printIntrospectionSchema(introspectionResult) {
+  var schema = introspectionResult.data.__schema;
+  var types = schema.types.filter(t => isIntrospectionType(t));
+  types = types.sort((t1, t2) => t1.name.localeCompare(t2.name));
+  return types.map(printType).join('\n\n');
+}


### PR DESCRIPTION
This adds a printer to translate the result of an introspection query
to the grammar that is currently used as shorthand in the specification.
This should be treated as the de facto specification until a formalized
grammar is produced.

The next step is to do the transformation in the other
direction.

A tool that should be built on top of this is one that executes
the introspection query against an arbitrary GraphQL HTTP endpoint
(specified per the upcoming graphql-http spec) and then performs
acceptable tests with that tool.

In the interim we hope that this will be useful for implementors
building and debugging their own type systems.