### PR TITLE
Test that exponents on integers like `1e6` do not parse

### DIFF
--- a/src/language/__tests__/parser.js
+++ b/src/language/__tests__/parser.js
@@ -104,6 +104,12 @@ fragment MissingOn Type
     ).to.throw('Syntax Error GraphQL (1:9) Expected Name, found }');
   });
 
+  it('does not accept exponents on integers', () => {
+    expect(
+      () => parse('{ f(arg:1e6) })')
+    ).to.throw('Syntax Error GraphQL (1:12) Expected :, found )');
+  });
+
   var kitchenSink = readFileSync(
     join(__dirname, '/kitchen-sink.graphql'),
     { encoding: 'utf8' }


### PR DESCRIPTION
I didn't see a test for this. It's legal JSON but intentionally illegal GraphQL.