### PR TITLE
Allow an episode to be passed to hero

### DIFF
--- a/src/__tests__/starWarsData.js
+++ b/src/__tests__/starWarsData.js
@@ -13,7 +13,11 @@
  * JSON objects in a more complex demo.
  */
 
-var luke = {
+/**
+ * We export luke directly because the schema returns him
+ * from a root field, and hence needs to reference him.
+ */
+export var luke = {
   id: '1000',
   name: 'Luke Skywalker',
   friends: ['1002', '1003', '2000', '2001'],

--- a/src/__tests__/starWarsIntrospectionTests.js
+++ b/src/__tests__/starWarsIntrospectionTests.js
@@ -34,6 +34,9 @@ describe('Star Wars Introspection Tests', () => {
               name: 'Query'
             },
             {
+              name: 'Episode'
+            },
+            {
               name: 'Character'
             },
             {
@@ -41,9 +44,6 @@ describe('Star Wars Introspection Tests', () => {
             },
             {
               name: 'String'
-            },
-            {
-              name: 'Episode'
             },
             {
               name: 'Droid'
@@ -327,7 +327,20 @@ describe('Star Wars Introspection Tests', () => {
             fields: [
               {
                 name: 'hero',
-                args: []
+                args: [
+                  {
+                    defaultValue: null,
+                    description: 'If omitted, returns the hero of the whole ' +
+                                 'saga. If provided, returns the hero of ' +
+                                 'that particular episode.',
+                    name: 'episode',
+                    type: {
+                      kind: 'ENUM',
+                      name: 'Episode',
+                      ofType: null
+                    }
+                  }
+                ]
               },
               {
                 name: 'human',

--- a/src/__tests__/starWarsQueryTests.js
+++ b/src/__tests__/starWarsQueryTests.js
@@ -344,5 +344,24 @@ describe('Star Wars Query Tests', () => {
       var result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
     });
+
+    it('Allows us to verify that Luke is a human', async () => {
+      var query = `
+        query CheckTypeOfLuke {
+          hero(episode: EMPIRE) {
+            __typename
+            name
+          }
+        }
+      `;
+      var expected = {
+        hero: {
+          __typename: 'Human',
+          name: 'Luke Skywalker'
+        },
+      };
+      var result = await graphql(StarWarsSchema, query);
+      expect(result).to.deep.equal({ data: expected });
+    });
   });
 });

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -17,7 +17,7 @@ import {
   GraphQLString,
 } from '../type';
 
-import { starWarsData, getFriends, artoo } from './starWarsData.js';
+import { starWarsData, getFriends, artoo, luke } from './starWarsData.js';
 
 /**
  * This is designed to be an end-to-end test, demonstrating
@@ -60,7 +60,7 @@ import { starWarsData, getFriends, artoo } from './starWarsData.js';
  * }
  *
  * type Query {
- *   hero: Character
+ *   hero(episode: Episode): Character
  *   human(id: String!): Human
  *   droid(id: String!): Droid
  * }
@@ -222,7 +222,7 @@ var droidType = new GraphQLObjectType({
  *
  * This implements the following type system shorthand:
  *   type Query {
- *     hero: Character
+ *     hero(episode: Episode): Character
  *     human(id: String!): Human
  *     droid(id: String!): Droid
  *   }
@@ -233,7 +233,21 @@ var queryType = new GraphQLObjectType({
   fields: () => ({
     hero: {
       type: characterInterface,
-      resolve: () => artoo,
+      args: {
+        episode: {
+          description: 'If omitted, returns the hero of the whole saga. If ' +
+                       'provided, returns the hero of that particular episode.',
+          type: episodeEnum
+        }
+      },
+      resolve: (root, {episode}) => {
+        if (episode === 5) {
+          // Luke is the hero of Episode V.
+          return luke;
+        }
+        // Artoo is the hero otherwise.
+        return artoo;
+      }
     },
     human: {
       type: humanType,


### PR DESCRIPTION
It was odd in our demo that `hero` returned a `Character`, but it always returned R2-D2, who is a `Droid`. Change it so this takes an optional `episode`, and returns Luke as the hero for Episode V, demonstrating more clearly why this field returns an Interface, and the value of querying for `__typename` to find the concrete type.