### PR TITLE
fix directive inspection according to spec

### DIFF
--- a/src/type/__tests__/introspection.js
+++ b/src/type/__tests__/introspection.js
@@ -651,9 +651,13 @@ describe('Introspection', () => {
                   name: 'onOperation',
                   args: [],
                   type: {
-                    kind: 'SCALAR',
-                    name: 'Boolean',
-                    ofType: null,
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Boolean',
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
                   deprecationReason: null
@@ -662,9 +666,13 @@ describe('Introspection', () => {
                   name: 'onFragment',
                   args: [],
                   type: {
-                    kind: 'SCALAR',
-                    name: 'Boolean',
-                    ofType: null,
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Boolean',
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
                   deprecationReason: null
@@ -673,9 +681,13 @@ describe('Introspection', () => {
                   name: 'onField',
                   args: [],
                   type: {
-                    kind: 'SCALAR',
-                    name: 'Boolean',
-                    ofType: null,
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Boolean',
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
                   deprecationReason: null

--- a/src/type/__tests__/printer.js
+++ b/src/type/__tests__/printer.js
@@ -508,9 +508,9 @@ type __Directive {
   name: String!
   description: String
   args: [__InputValue!]!
-  onOperation: Boolean
-  onFragment: Boolean
-  onField: Boolean
+  onOperation: Boolean!
+  onFragment: Boolean!
+  onField: Boolean!
 }
 
 type __EnumValue {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -67,9 +67,9 @@ var __Directive = new GraphQLObjectType({
         new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__InputValue))),
       resolve: directive => directive.args || []
     },
-    onOperation: { type: GraphQLBoolean },
-    onFragment: { type: GraphQLBoolean },
-    onField: { type: GraphQLBoolean },
+    onOperation: { type: new GraphQLNonNull(GraphQLBoolean) },
+    onFragment: { type: new GraphQLNonNull(GraphQLBoolean) },
+    onField: { type: new GraphQLNonNull(GraphQLBoolean) },
   }),
 });
 


### PR DESCRIPTION
The spec states that

```
type __Directive {
  # ...
  onOperation: Boolean!
  onFragment: Boolean!
  onField: Boolean!
}
```

but the implementation defines it as

```
type __Directive {
  # ...
  onOperation: Boolean
  onFragment: Boolean
  onField: Boolean
}
```
