### PR TITLE
Schema Materializer

### DIFF
--- a/src/executor/values.js
+++ b/src/executor/values.js
@@ -214,7 +214,7 @@ function coerceValue(type: GraphQLInputType, value: any): any {
  * Given a type and a value AST node known to match this type, build a
  * runtime value.
  */
-function coerceValueAST(
+export function coerceValueAST(
   type: GraphQLInputType,
   valueAST: any,
   variables?: ?{ [key: string]: any }

--- a/src/language/schema/__tests__/materializer.js
+++ b/src/language/schema/__tests__/materializer.js
@@ -1,0 +1,277 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+*  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { parseSchema } from '../parser';
+import { materializeSchema } from '../materializer';
+import { printSchema } from '../../../type/printer';
+import { introspectionQuery } from '../../../type/introspectionQuery';
+import { graphql } from '../../../';
+
+// 80+ char lines are useful in describe/it, so ignore in this file.
+/*eslint-disable max-len */
+
+function printForTest(result) {
+  return '\n' + printSchema(result) + '\n';
+}
+
+async function getOutput(body, queryType) {
+  var doc = parseSchema(body);
+  var schema = materializeSchema(doc, queryType);
+  var result = await graphql(schema, introspectionQuery);
+  return await printForTest(result);
+}
+
+describe('Schema Materializer', () => {
+  it('Simple type', async () => {
+    var body = `
+type HelloScalars {
+  str: String
+  int: Int
+  bool: Boolean
+}
+`;
+    var output = await getOutput(body, 'HelloScalars');
+    expect(output).to.equal(body);
+  });
+
+  it('Type modifiers', async () => {
+    var body = `
+type HelloScalars {
+  nonNullStr: String!
+  listOfStrs: [String]
+  listOfNonNullStrs: [String!]
+  nonNullListOfStrs: [String]!
+  nonNullListOfNonNullStrs: [String!]!
+}
+`;
+    var output = await getOutput(body, 'HelloScalars');
+    expect(output).to.equal(body);
+  });
+
+
+  it('Recursive type', async () => {
+    var body = `
+type Recurse {
+  str: String
+  recurse: Recurse
+}
+`;
+    var output = await getOutput(body, 'Recurse');
+    expect(output).to.equal(body);
+  });
+
+  it('Two types circular', async () => {
+    var body = `
+type TypeOne {
+  str: String
+  typeTwo: TypeTwo
+}
+
+type TypeTwo {
+  str: String
+  typeOne: TypeOne
+}
+`;
+    var output = await getOutput(body, 'TypeOne');
+    expect(output).to.equal(body);
+  });
+
+  it('Single argument field', async () => {
+    var body = `
+type Hello {
+  str(int: Int): String
+}
+`;
+    var output = await getOutput(body, 'Hello');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple type with multiple arguments', async () => {
+    var body = `
+type Hello {
+  str(int: Int, bool: Boolean): String
+}
+`;
+    var output = await getOutput(body, 'Hello');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple type with interface', async () => {
+    var body = `
+type HelloInterface implements WorldInterface {
+  str: String
+}
+
+interface WorldInterface {
+  str: String
+}
+`;
+    var output = await getOutput(body, 'HelloInterface');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple output enum', async () => {
+    var body = `
+enum Hello {
+  WORLD
+}
+
+type OutputEnumRoot {
+  hello: Hello
+}
+`;
+    var output = await getOutput(body, 'OutputEnumRoot');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple input enum', async () => {
+    var body = `
+enum Hello {
+  WORLD
+}
+
+type InputEnumRoot {
+  str(hello: Hello): String
+}
+`;
+    var output = await getOutput(body, 'InputEnumRoot');
+    expect(output).to.equal(body);
+  });
+
+  it('Multiple value enum', async () => {
+    var body = `
+enum Hello {
+  WO
+  RLD
+}
+
+type OutputEnumRoot {
+  hello: Hello
+}
+`;
+    var output = await getOutput(body, 'OutputEnumRoot');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple Union', async () => {
+    var body = `
+union Hello = World
+
+type Root {
+  hello: Hello
+}
+
+type World {
+  str: String
+}
+`;
+    var output = await getOutput(body, 'Root');
+    expect(output).to.equal(body);
+  });
+
+  it('Multiple Union', async () => {
+    var body = `
+union Hello = WorldOne | WorldTwo
+
+type Root {
+  hello: Hello
+}
+
+type WorldOne {
+  str: String
+}
+
+type WorldTwo {
+  str: String
+}
+`;
+    var output = await getOutput(body, 'Root');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple Union', async () => {
+    var body = `
+scalar CustomScalar
+
+type Root {
+  customScalar: CustomScalar
+}
+`;
+
+    var output = await getOutput(body, 'Root');
+    expect(output).to.equal(body);
+  });
+
+  it('Input Object', async() => {
+    var body = `
+input Input {
+  int: Int
+}
+
+type Root {
+  field(in: Input): String
+}
+`;
+
+    var output = await getOutput(body, 'Root');
+    expect(output).to.equal(body);
+  });
+
+  it('Simple argument field with default', async () => {
+    var body = `
+type Hello {
+  str(int: Int = 2): String
+}
+`;
+    var output = await getOutput(body, 'Hello');
+    expect(output).to.equal(body);
+  });
+});
+
+describe('Schema Parser Failures', () => {
+  it('Unknown type referenced', () => {
+    var body = `
+type Hello {
+  bar: Bar
+}
+`;
+    var doc = parseSchema(body);
+    expect(() => materializeSchema(doc, 'Hello')).to.throw('Type Bar not found in document');
+  });
+
+  it('Unknown type in interface list', () => {
+    var body = `
+type Hello implements Bar { }
+`;
+    var doc = parseSchema(body);
+    expect(() => materializeSchema(doc, 'Hello')).to.throw('Type Bar not found in document');
+  });
+
+  it('Unknown type in union list', () => {
+    var body = `
+union TestUnion = Bar
+type Hello { testUnion: TestUnion }
+`;
+    var doc = parseSchema(body);
+    expect(() => materializeSchema(doc, 'Hello')).to.throw('Type Bar not found in document');
+  });
+
+
+  it('Unknown query type', () => {
+    var body = `
+type Hello {
+  str: String
+}
+`;
+    var doc = parseSchema(body);
+    expect(() => materializeSchema(doc, 'Wat')).to.throw('Type Wat not found in document');
+  });
+});

--- a/src/language/schema/ast.js
+++ b/src/language/schema/ast.js
@@ -30,6 +30,11 @@ export type SchemaDefinition =
   EnumDefinition |
   InputObjectDefinition
 
+export type CompositeDefinition =
+  TypeDefinition |
+  InterfaceDefinition |
+  UnionDefinition;
+
 export type TypeDefinition = {
   kind: 'TypeDefinition';
   loc?: ?Location;

--- a/src/language/schema/materializer.js
+++ b/src/language/schema/materializer.js
@@ -1,0 +1,279 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import {
+  TYPE_DEFINITION,
+  INTERFACE_DEFINITION,
+  ENUM_DEFINITION,
+  UNION_DEFINITION,
+  SCALAR_DEFINITION,
+  INPUT_OBJECT_DEFINITION,
+} from './kinds';
+
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLScalarType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLBoolean,
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+} from '../../type';
+
+import {
+  SchemaDocument,
+  EnumDefinition,
+  InterfaceDefinition,
+  UnionDefinition,
+  TypeDefinition,
+  CompositeDefinition,
+  ArgumentDefinition,
+  ScalarDefinition,
+  InputObjectDefinition,
+} from './ast';
+
+import {
+  coerceValueAST
+} from '../../executor/values';
+
+import {
+  LIST_TYPE,
+  NON_NULL_TYPE,
+} from '../kinds';
+
+function nullish(obj) {
+  return obj === null || obj === undefined;
+}
+
+/**
+ * Takes the array of N elements constructs an object.
+ * For each elemenet sets obj[keyFnArg(e}] = valueFnArg
+ * If they are not specified they default to the identity function
+ */
+function makeDict(array, keyFnArg, valueFnArg) {
+  var map = {};
+  var keyFn = nullish(keyFnArg) ? t => t : keyFnArg;
+  var valueFn = nullish(valueFnArg) ? t => t : valueFnArg;
+  array.forEach((item) => {
+    map[keyFn(item)] = valueFn(item);
+  });
+  return map;
+}
+
+function buildWrappedType(innerType, inputTypeAST) {
+  if (inputTypeAST.kind === LIST_TYPE) {
+    return new GraphQLList(buildWrappedType(innerType, inputTypeAST.type));
+  }
+  if (inputTypeAST.kind === NON_NULL_TYPE) {
+    return new GraphQLNonNull(buildWrappedType(innerType, inputTypeAST.type));
+  }
+  return innerType;
+}
+
+function getInnerTypeName(typeAST) {
+  if (typeAST.kind === LIST_TYPE || typeAST.kind === NON_NULL_TYPE) {
+    return getInnerTypeName(typeAST.type);
+  }
+  return typeAST.name.value;
+}
+
+/**
+ * This takes the ast of a schema document produced by parseSchema in
+ * src/language/schema/parser.js.
+ *
+ * Given that AST it constructs a GraphQLSchema. As constructed
+ * they are not particularly useful for non-introspection queries
+ * since they have no resolve methods.
+ */
+export function materializeSchema(
+  ast: SchemaDocument,
+  queryTypeName: string,
+  mutationTypeName: ?string): GraphQLSchema {
+
+  if (nullish(ast)) {
+    throw new Error('must pass in ast');
+  }
+  if (nullish(queryTypeName)) {
+    throw new Error('must pass in query type');
+  }
+
+  var astMap = makeDict(ast.definitions, d => d.name.value);
+
+  /**
+   * This generates a function that allows you to produce
+   * type definitions on demand. We produce the function
+   * in order to close over the memoization dictionaries
+   * that need to be retained over multiple functions calls.
+   **/
+  function getTypeDefProducer() {
+
+    var innerTypeMap = {
+      String: GraphQLString,
+      Int: GraphQLInt,
+      Boolean: GraphQLBoolean,
+      ID: GraphQLID,
+    };
+
+    return (typeAST) => {
+      var typeName = getInnerTypeName(typeAST);
+      if (!nullish(innerTypeMap[typeName])) {
+        return buildWrappedType(innerTypeMap[typeName], typeAST);
+      }
+
+      if (nullish(astMap[typeName])) {
+        throw new Error(`Type ${typeName} not found in document`);
+      }
+
+      var innerTypeDef = makeSchemaDef(astMap[typeName]);
+      if (nullish(innerTypeDef)) {
+        throw new Error('Nothing constructed for ' + typeName);
+      }
+      innerTypeMap[typeName] = innerTypeDef;
+      return buildWrappedType(innerTypeDef, typeAST);
+    };
+  }
+
+
+  var produceTypeDef = getTypeDefProducer(ast);
+
+  if (nullish(astMap[queryTypeName])) {
+    throw new Error(`Type ${queryTypeName} not found in document`);
+  }
+
+  var queryType = produceTypeDef(astMap[queryTypeName]);
+  var schema;
+  if (nullish(mutationTypeName)) {
+    schema = new GraphQLSchema({query: queryType});
+  } else {
+    schema = new GraphQLSchema({
+      query: queryTypeName,
+      mutation: produceTypeDef(astMap[mutationTypeName]),
+    });
+  }
+
+  // This actually constructs all the types by iterating over the schema
+  // This makes it so that errors actually get caught before this function
+  // exits.
+  schema.getTypeMap();
+  return schema;
+
+  function makeSchemaDef(def) {
+    if (nullish(def)) {
+      throw new Error('def must be defined');
+    }
+    switch (def.kind) {
+      case TYPE_DEFINITION:
+        return makeTypeDef(def);
+      case INTERFACE_DEFINITION:
+        return makeInterfaceDef(def);
+      case ENUM_DEFINITION:
+        return makeEnumDef(def);
+      case UNION_DEFINITION:
+        return makeUnionDef(def);
+      case SCALAR_DEFINITION:
+        return makeScalarDef(def);
+      case INPUT_OBJECT_DEFINITION:
+        return makeInputObjectDef(def);
+      default:
+        throw new Error(def.kind + ' not supported');
+    }
+  }
+
+  function makeTypeDef(def: TypeDefinition) {
+    var typeName = def.name.value;
+    var config = {
+      name: typeName,
+      fields: () => makeFieldDefMap(def),
+      interfaces: () => makeImplementedInterfaces(def),
+    };
+    return new GraphQLObjectType(config);
+  }
+
+  function makeFieldDefMap(def: CompositeDefinition) {
+    return makeDict(
+      def.fields,
+      field => field.name.value,
+      field => ({
+        type: produceTypeDef(field.type),
+        args: makeArgs(field.arguments),
+      })
+    );
+  }
+
+  function makeImplementedInterfaces(def: TypeDefinition) {
+    return def.interfaces.map(inter => produceTypeDef(inter));
+  }
+
+  function makeArgs(args: Array<ArgumentDefinition>) {
+    return makeDict(
+      args,
+      arg => arg.name.value,
+      arg => {
+        var type = produceTypeDef(arg.type);
+        return {
+          type: type,
+          defaultValue: coerceValueAST(type, arg.defaultValue),
+        };
+      }
+    );
+  }
+
+  function makeInterfaceDef(def: InterfaceDefinition) {
+    var typeName = def.name.value;
+    var config = {
+      name: typeName,
+      fields: () => makeFieldDefMap(def),
+    };
+    return new GraphQLInterfaceType(config);
+  }
+
+  function makeEnumDef(def: EnumDefinition) {
+    var enumType = new GraphQLEnumType({
+      name: def.name.value,
+      values: makeDict(def.values, v => v.name.value, () => ({})),
+    });
+
+    return enumType;
+  }
+
+  function makeUnionDef(def: UnionDefinition) {
+    return new GraphQLUnionType({
+      name: def.name.value,
+      types: def.types.map(t => produceTypeDef(t)),
+    });
+  }
+
+  function makeScalarDef(def: ScalarDefinition) {
+    return new GraphQLScalarType({
+      name: def.name.value,
+    });
+  }
+
+  function makeInputObjectDef(def: InputObjectDefinition) {
+    return new GraphQLInputObjectType({
+      name: def.name.value,
+      fields: () => makeInputFieldDefMap(def),
+    });
+  }
+
+  function makeInputFieldDefMap(def: InputObjectDefinition) {
+    return makeDict(
+      def.fields,
+      field => field.name.value,
+      field => ({type: produceTypeDef(field.type)})
+    );
+  }
+}
+

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -334,11 +334,13 @@ function addImplementationToInterfaces(impl) {
 
 type GraphQLObjectTypeConfig = {
   name: string;
-  interfaces?: Array<GraphQLInterfaceType>;
+  interfaces?: GraphQLInterfacesThunk | Array<GraphQLInterfaceType>;
   fields: GraphQLFieldConfigMapThunk | GraphQLFieldConfigMap;
   isTypeOf?: (value: any) => boolean;
   description?: string
 }
+
+type GraphQLInterfacesThunk = () => Array<GraphQLInterfaceType>;
 
 type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 


### PR DESCRIPTION
Adds the schema materializer. This components takes a schema definition
AST and produces a set of type definition objects corresponding to the
schema definitions. This allows a user to specify schema in a far
more literate fashion

The next tool that I'm going to write is one that takes the
schema definition DSL and outputs the result of the introspection
query against that schema. This will be really useful for tests, etc.