### PR TITLE
Fix paths and dependencies in print-schema tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,12 +53,14 @@
     "babel": "5.8.3",
     "babel-core": "5.8.3",
     "babel-eslint": "3.1.26",
+    "bluebird": "2.9.34",
     "chai": "3.0.0",
     "chai-subset": "1.0.1",
     "coveralls": "2.11.2",
     "eslint": "0.24.0",
     "flow-bin": "0.13.1",
     "isparta": "3.0.3",
+    "minimist": "1.1.2",
     "mocha": "2.2.5",
     "sane": "1.1.3"
   }

--- a/src/tools/print-schema/src/index.js
+++ b/src/tools/print-schema/src/index.js
@@ -8,7 +8,7 @@
  */
 
 import { getIntrospectionResult }
-  from '../../../../src/language/schema/printer';
+  from '../../../language/schema/printer';
 
 var Promise = require('bluebird');
 var parseArgs = require('minimist');


### PR DESCRIPTION
Fixes the relative path used in `print-schema` output and adds missing npm dependencies.