### PR TITLE
Set encoding when reading schema file

### DIFF
--- a/src/tools/print-schema/src/index.js
+++ b/src/tools/print-schema/src/index.js
@@ -37,7 +37,7 @@ export async function executeTool() {
       process.exit(0);
     }
 
-    var body = await fs.readFileAsync(argDict.file);
+    var body = await fs.readFileAsync(argDict.file, 'utf8');
     var result = await getIntrospectionResult(body, argDict.query);
     var out = await JSON.stringify(result, null, 2);
     console.log(out);


### PR DESCRIPTION
Update print-schema tool to set the file encoding when reading the schema definition.