### PR TITLE
Minor follow-on re-org.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,4 +37,5 @@ export {
 // Produce and format errors.
 export { GraphQLError, formatError } from './error';
 
-export { printSchema } from './language/schema/printer';
+// Tools for printing a GraphQL type schema.
+export { printSchema } from './type/schemaPrinter';

--- a/src/language/schema/__tests__/materializer.js
+++ b/src/language/schema/__tests__/materializer.js
@@ -10,7 +10,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { parseSchemaIntoAST } from '../parser';
-import { printSchema } from '../';
+import { printSchema } from '../../../type/schemaPrinter';
 import { materializeSchemaAST } from '../materializer';
 import { createSchemaFromDSL } from '../';
 

--- a/src/language/schema/index.js
+++ b/src/language/schema/index.js
@@ -11,13 +11,8 @@ import { GraphQLSchema } from '../../type';
 import { parseSchemaIntoAST } from './parser';
 import { materializeSchemaAST } from './materializer';
 
-export {
-  // GraphQL Schema Instance --> DSL
-  printSchema,
-  printIntrospectionSchema,
-  // Introspection Result --> DSL
-  printSchemaFromResult,
-} from './printer';
+// DSL --> AST
+export { parseSchemaIntoAST };
 
 // DSL --> Schema
 export async function createSchemaFromDSL(

--- a/src/type/__tests__/schemaPrinter.js
+++ b/src/type/__tests__/schemaPrinter.js
@@ -9,7 +9,7 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { printSchema, printIntrospectionSchema } from '../printer';
+import { printSchema, printIntrospectionSchema } from '../schemaPrinter';
 
 import {
   GraphQLSchema,
@@ -24,7 +24,7 @@ import {
   GraphQLBoolean,
   GraphQLList,
   GraphQLNonNull,
-} from '../../../type';
+} from '../';
 
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /*eslint-disable max-len */

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -29,3 +29,9 @@ export {
   GraphQLBoolean,
   GraphQLID
 } from './scalars';
+
+export {
+  printSchema,
+  printIntrospectionSchema,
+  printSchemaFromResult,
+} from './schemaPrinter';

--- a/src/type/schemaPrinter.js
+++ b/src/type/schemaPrinter.js
@@ -8,8 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import { introspectionQuery } from './../../type/introspectionQuery';
-import { graphql } from '../../';
+import { introspectionQuery } from './introspectionQuery';
+import { graphql } from '../';
 
 import type {
   IntrospectionQueryResult,
@@ -19,11 +19,9 @@ import type {
   FieldResult,
   ArgResult,
   EnumValue,
-} from '../../type/introspectionQuery';
+} from './introspectionQuery';
 
-import type {
-  GraphQLSchema
-} from '../../type';
+import type { GraphQLSchema } from './schema';
 
 var TypeKind = {
   SCALAR: 'SCALAR',


### PR DESCRIPTION
I'm making some room here for a "printer" in language/schema/printer which mirrors the behavior of language/printer: it takes the AST in, and prints out the DSL.

The printer as written makes sense to live in type/schemaPrinter IMO, since it's within the family of tools that operate upon GraphQLSchema instances.