### PR TITLE
Add visitor and printer utils to schema language

### DIFF
--- a/src/language/schema/__tests__/printer.js
+++ b/src/language/schema/__tests__/printer.js
@@ -1,0 +1,82 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseSchemaIntoAST } from '../parser';
+import { printSchema } from '../printer';
+
+describe('Printer', () => {
+
+  it('prints minimal ast', () => {
+    var ast = {
+      kind: 'ScalarDefinition',
+      name: { kind: 'Name', value: 'foo' }
+    };
+    expect(printSchema(ast)).to.equal('scalar foo');
+  });
+
+  it('produces helpful error messages', () => {
+    var badAst1 = { random: 'Data' };
+    expect(() => printSchema(badAst1)).to.throw(
+      'Invalid AST Node: {"random":"Data"}'
+    );
+  });
+
+  var kitchenSink = readFileSync(
+    join(__dirname, '/schema-kitchen-sink.graphql'),
+    { encoding: 'utf8' }
+  );
+
+  it('does not alter ast', () => {
+    var ast = parseSchemaIntoAST(kitchenSink);
+    var astCopy = JSON.parse(JSON.stringify(ast));
+    printSchema(ast);
+    expect(ast).to.deep.equal(astCopy);
+  });
+
+  it('prints kitchen sink', () => {
+
+    var ast = parseSchemaIntoAST(kitchenSink);
+
+    var printed = printSchema(ast);
+
+    expect(printed).to.equal(
+`type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+}
+
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+union Feed = Story | Article | Advert
+
+scalar CustomScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+input InputType {
+  key: String!
+}
+`);
+
+  });
+});

--- a/src/language/schema/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/schema/__tests__/schema-kitchen-sink.graphql
@@ -1,0 +1,33 @@
+# Copyright (c) 2015, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+}
+
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+union Feed = Story | Article | Advert
+
+scalar CustomScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+input InputType {
+  key: String!
+}

--- a/src/language/schema/index.js
+++ b/src/language/schema/index.js
@@ -11,8 +11,11 @@ import { GraphQLSchema } from '../../type';
 import { parseSchemaIntoAST } from './parser';
 import { materializeSchemaAST } from './materializer';
 
-// DSL --> AST
-export { parseSchemaIntoAST };
+import * as Kind from './kinds';
+export { Kind };
+export { parseSchemaIntoAST } from './parser';
+export { printSchema } from './printer';
+export { visit } from './visitor';
 
 // DSL --> Schema
 export async function createSchemaFromDSL(

--- a/src/language/schema/printer.js
+++ b/src/language/schema/printer.js
@@ -1,0 +1,64 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { visitSchema } from './visitor';
+import { printDocASTReducer, join, block, wrap } from '../printer';
+
+/**
+ * Converts a Schema AST into a string, using one set of reasonable
+ * formatting rules.
+ */
+export function printSchema(ast) {
+  return visitSchema(ast, { leave: printSchemaASTReducer });
+}
+
+export var printSchemaASTReducer = {
+  Name: printDocASTReducer.Name,
+
+  // Document
+
+  SchemaDocument: ({definitions}) =>
+    join(definitions, '\n\n') + '\n',
+
+  TypeDefinition: ({name, interfaces, fields}) =>
+    'type ' + name + ' ' +
+    wrap('implements ', join(interfaces, ', '), ' ') +
+    block(fields),
+
+  FieldDefinition: ({name, arguments: args, type}) =>
+    name + wrap('(', join(args, ', '), ')') + ': ' + type,
+
+  ArgumentDefinition: ({name, type, defaultValue}) =>
+    name + ': ' + type + wrap(' = ', defaultValue),
+
+  InterfaceDefinition: ({name, fields}) => `interface ${name} ${block(fields)}`,
+  UnionDefinition: ({name, types}) => `union ${name} = ${join(types, ' | ')}`,
+  ScalarDefinition: ({name}) => `scalar ${name}`,
+  EnumDefinition: ({name, values}) => `enum ${name} ${block(values)}`,
+  EnumValueDefinition: ({name}) => name,
+  InputObjectDefinition: ({name, fields}) => `input ${name} ${block(fields)}`,
+  InputFieldDefinition: ({name, type}) => `${name}: ${type}`,
+
+  // Value
+
+  IntValue: printDocASTReducer.IntValue,
+  FloatValue: printDocASTReducer.FloatValue,
+  StringValue: printDocASTReducer.StringValue,
+  BooleanValue: printDocASTReducer.BooleanValue,
+  EnumValue: printDocASTReducer.EnumValue,
+  ListValue: printDocASTReducer.ListValue,
+  ObjectValue: printDocASTReducer.ObjectValue,
+  ObjectField: printDocASTReducer.ObjectField,
+
+  // Type
+
+  NamedType: printDocASTReducer.NamedType,
+  ListType: printDocASTReducer.ListType,
+  NonNullType: printDocASTReducer.NonNullType,
+};

--- a/src/language/schema/visitor.js
+++ b/src/language/schema/visitor.js
@@ -1,0 +1,44 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { visit, QueryDocumentKeys } from '../visitor';
+
+
+export var SchemaKeys = {
+  Name: QueryDocumentKeys.Name,
+
+  SchemaDocument: ['definitions'],
+  TypeDefinition: ['name', 'interfaces', 'fields'],
+  FieldDefinition: ['name', 'arguments', 'type'],
+  ArgumentDefinition: ['name', 'type', 'defaultValue'],
+  InterfaceDefinition: ['name', 'fields'],
+  UnionDefinition: ['name', 'types'],
+  ScalarDefinition: ['name'],
+  EnumDefinition: ['name', 'values'],
+  EnumValueDefinition: ['name'],
+  InputObjectDefinition: ['name', 'fields'],
+  InputFieldDefinition: ['name', 'type'],
+
+  IntValue: QueryDocumentKeys.IntValue,
+  FloatValue: QueryDocumentKeys.FloatValue,
+  StringValue: QueryDocumentKeys.StringValue,
+  BooleanValue: QueryDocumentKeys.BooleanValue,
+  EnumValue: QueryDocumentKeys.EnumValue,
+  ListValue: QueryDocumentKeys.ListValue,
+  ObjectValue: QueryDocumentKeys.ObjectValue,
+  ObjectField: QueryDocumentKeys.ObjectField,
+
+  NamedType: QueryDocumentKeys.NamedType,
+  ListType: QueryDocumentKeys.ListType,
+  NonNullType: QueryDocumentKeys.NonNullType,
+};
+
+export function visitSchema(root, visitor, keys) {
+  return visit(root, visitor, keys || SchemaKeys);
+}


### PR DESCRIPTION
This adds a "visitor" and "printer" utilities for the schema language in the same form as those used for the document language.