### PR TITLE
Client Schema Builder

### DIFF
--- a/src/type/__tests__/buildClientSchema.js
+++ b/src/type/__tests__/buildClientSchema.js
@@ -1,0 +1,599 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { buildClientSchema } from '../buildClientSchema';
+import { introspectionQuery } from '../introspectionQuery';
+import {
+  graphql,
+  GraphQLSchema,
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLID,
+} from '../../';
+
+
+// Test property:
+// Given a server's schema, a client may query that server with introspection,
+// and use the result to produce a client-side representation of the schema
+// by using "buildClientSchema". If the client then runs the introspection
+// query against the client-side schema, it should get a result identical to
+// what was returned by the server.
+async function testSchema(serverSchema) {
+  var initialIntrospection = await graphql(serverSchema, introspectionQuery);
+  var clientSchema = buildClientSchema(initialIntrospection.data);
+  var secondIntrospection = await graphql(clientSchema, introspectionQuery);
+  expect(secondIntrospection).to.deep.equal(initialIntrospection);
+}
+
+describe('Type System: build schema from introspection', () => {
+
+  it('builds a simple schema', async () => {
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Simple',
+        description: 'This is a simple type',
+        fields: {
+          string: {
+            type: GraphQLString,
+            description: 'This is a string field'
+          }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a simple schema with a mutation type', async () => {
+    var queryType = new GraphQLObjectType({
+      name: 'QueryType',
+      description: 'This is a simple query type',
+      fields: {
+        string: {
+          type: GraphQLString,
+          description: 'This is a string field'
+        }
+      }
+    });
+
+    var mutationType = new GraphQLObjectType({
+      name: 'MutationType',
+      description: 'This is a simple mutation type',
+      fields: {
+        setString: {
+          type: GraphQLString,
+          description: 'Set the string field',
+          args: {
+            value: { type: GraphQLString }
+          }
+        }
+      }
+    });
+
+    var schema = new GraphQLSchema({
+      query: queryType,
+      mutation: mutationType
+    });
+
+    await testSchema(schema);
+  });
+
+  it('uses built-in scalars when possible', async () => {
+    var customScalar = new GraphQLScalarType({
+      name: 'CustomScalar'
+    });
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Scalars',
+        fields: {
+          int: { type: GraphQLInt },
+          float: { type: GraphQLFloat },
+          string: { type: GraphQLString },
+          boolean: { type: GraphQLBoolean },
+          id: { type: GraphQLID },
+          custom: { type: customScalar },
+        }
+      })
+    });
+
+    await testSchema(schema);
+
+    var introspection = await graphql(schema, introspectionQuery);
+    var clientSchema = buildClientSchema(introspection.data);
+
+    // Built-ins are used
+    expect(clientSchema.getType('Int')).to.equal(GraphQLInt);
+    expect(clientSchema.getType('Float')).to.equal(GraphQLFloat);
+    expect(clientSchema.getType('String')).to.equal(GraphQLString);
+    expect(clientSchema.getType('Boolean')).to.equal(GraphQLBoolean);
+    expect(clientSchema.getType('ID')).to.equal(GraphQLID);
+
+    // Custom are built
+    expect(clientSchema.getType('CustomScalar')).not.to.equal(customScalar);
+  });
+
+  it('builds a schema with a recursive type reference', async () => {
+    var recurType = new GraphQLObjectType({
+      name: 'Recur',
+      fields: () => ({
+        recur: { type: recurType }
+      })
+    });
+    var schema = new GraphQLSchema({
+      query: recurType
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with a circular type reference', async () => {
+    var dogType = new GraphQLObjectType({
+      name: 'Dog',
+      fields: () => ({
+        bestFriend: { type: humanType }
+      })
+    });
+    var humanType = new GraphQLObjectType({
+      name: 'Human',
+      fields: () => ({
+        bestFriend: { type: dogType }
+      })
+    });
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Circular',
+        fields: {
+          dog: { type: dogType },
+          human: { type: humanType }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with an interface', async () => {
+    var friendlyType = new GraphQLInterfaceType({
+      name: 'Friendly',
+      fields: () => ({
+        bestFriend: {
+          type: friendlyType,
+          description: 'The best friend of this friendly thing'
+        }
+      })
+    });
+    /* eslint-disable no-new */
+    new GraphQLObjectType({
+      name: 'Dog',
+      interfaces: [friendlyType],
+      fields: () => ({
+        bestFriend: { type: friendlyType }
+      })
+    });
+    new GraphQLObjectType({
+      name: 'Human',
+      interfaces: [friendlyType],
+      fields: () => ({
+        bestFriend: { type: friendlyType }
+      })
+    });
+    /* eslint-enable no-new */
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'WithInterface',
+        fields: {
+          friendly: { type: friendlyType }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with a union', async () => {
+    var dogType = new GraphQLObjectType({
+      name: 'Dog',
+      fields: () => ({
+        bestFriend: { type: friendlyType }
+      })
+    });
+    var humanType = new GraphQLObjectType({
+      name: 'Human',
+      fields: () => ({
+        bestFriend: { type: friendlyType }
+      })
+    });
+    var friendlyType = new GraphQLUnionType({
+      name: 'Friendly',
+      types: [dogType, humanType]
+    });
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'WithUnion',
+        fields: {
+          friendly: { type: friendlyType }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with complex field values', async () => {
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'ComplexFields',
+        fields: {
+          string: { type: GraphQLString },
+          listOfString: { type: new GraphQLList(GraphQLString) },
+          nonNullString: {
+            type: new GraphQLNonNull(GraphQLString)
+          },
+          nonNullListOfString: {
+            type: new GraphQLNonNull(new GraphQLList(GraphQLString))
+          },
+          nonNullListOfNonNullString: {
+            type: new GraphQLNonNull(
+              new GraphQLList(new GraphQLNonNull(GraphQLString))
+            )
+          },
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with field arguments', async () => {
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'ArgFields',
+        fields: {
+          one: {
+            description: 'A field with a single arg',
+            type: GraphQLString,
+            args: {
+              intArg: {
+                description: 'This is an int arg',
+                type: GraphQLInt
+              }
+            }
+          },
+          two: {
+            description: 'A field with a two args',
+            type: GraphQLString,
+            args: {
+              listArg: {
+                description: 'This is an list of int arg',
+                type: new GraphQLList(GraphQLInt)
+              },
+              requiredArg: {
+                description: 'This is a required arg',
+                type: new GraphQLNonNull(GraphQLBoolean)
+              }
+            }
+          }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with an enum', async () => {
+    var foodEnum = new GraphQLEnumType({
+      name: 'Food',
+      description: 'Varieties of food stuffs',
+      values: {
+        VEGETABLES: {
+          description: 'Foods that are vegetables.',
+          value: 1
+        },
+        FRUITS: {
+          description: 'Foods that are fruits.',
+          value: 2
+        },
+        OILS: {
+          description: 'Foods that are oils.',
+          value: 3
+        },
+        DAIRY: {
+          description: 'Foods that are dairy.',
+          value: 4
+        },
+        MEAT: {
+          description: 'Foods that are meat.',
+          value: 5
+        }
+      }
+    });
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'EnumFields',
+        fields: {
+          food: {
+            description: 'Repeats the arg you give it',
+            type: foodEnum,
+            args: {
+              kind: {
+                description: 'what kind of food?',
+                type: foodEnum
+              }
+            }
+          }
+        }
+      })
+    });
+
+    await testSchema(schema);
+
+    var introspection = await graphql(schema, introspectionQuery);
+    var clientSchema = buildClientSchema(introspection.data);
+    var clientFoodEnum = clientSchema.getType('Food');
+
+    // It's also an Enum type on the client.
+    expect(clientFoodEnum).to.be.an.instanceOf(GraphQLEnumType);
+
+    // Client types do not get server-only values, so `value` mirrors `name`,
+    // rather than using the integers defined in the "server" schema.
+    expect(clientFoodEnum.getValues()).to.deep.equal({
+      DAIRY: {
+        description: 'Foods that are dairy.',
+        name: 'DAIRY',
+        value: 'DAIRY',
+      },
+      FRUITS: {
+        description: 'Foods that are fruits.',
+        name: 'FRUITS',
+        value: 'FRUITS',
+      },
+      MEAT: {
+        description: 'Foods that are meat.',
+        name: 'MEAT',
+        value: 'MEAT',
+      },
+      OILS: {
+        description: 'Foods that are oils.',
+        name: 'OILS',
+        value: 'OILS',
+      },
+      VEGETABLES: {
+        description: 'Foods that are vegetables.',
+        name: 'VEGETABLES',
+        value: 'VEGETABLES',
+      },
+    });
+  });
+
+  it('builds a schema with an input object', async () => {
+    var addressType = new GraphQLInputObjectType({
+      name: 'Address',
+      description: 'An input address',
+      fields: {
+        street: {
+          description: 'What street is this address?',
+          type: new GraphQLNonNull(GraphQLString)
+        },
+        city: {
+          description: 'The city the address is within?',
+          type: new GraphQLNonNull(GraphQLString)
+        },
+        country: {
+          description: 'The country (blank will assume USA).',
+          type: GraphQLString,
+          defaultValue: 'USA'
+        }
+      }
+    });
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'HasInputObjectFields',
+        fields: {
+          geocode: {
+            description: 'Get a geocode from an address',
+            type: GraphQLString,
+            args: {
+              address: {
+                description: 'The address to lookup',
+                type: addressType
+              }
+            }
+          }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+
+  it('builds a schema with field arguments with default values', async () => {
+    var geoType = new GraphQLInputObjectType({
+      name: 'Geo',
+      fields: {
+        lat: { type: GraphQLFloat },
+        lon: { type: GraphQLFloat },
+      }
+    });
+
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'ArgFields',
+        fields: {
+          defaultInt: {
+            type: GraphQLString,
+            args: {
+              intArg: {
+                type: GraphQLInt,
+                defaultValue: 10
+              }
+            }
+          },
+          defaultList: {
+            type: GraphQLString,
+            args: {
+              listArg: {
+                type: new GraphQLList(GraphQLInt),
+                defaultValue: [1, 2, 3]
+              }
+            }
+          },
+          defaultObject: {
+            type: GraphQLString,
+            args: {
+              objArg: {
+                type: geoType,
+                defaultValue: {lat: 37.485, lon: -122.148}
+              }
+            }
+          }
+        }
+      })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('cannot use client schema for general execution', async () => {
+    var customScalar = new GraphQLScalarType({
+      name: 'CustomScalar'
+    });
+
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          foo: {
+            type: GraphQLString,
+            args: {
+              custom1: { type: customScalar },
+              custom2: { type: customScalar }
+            }
+          }
+        }
+      })
+    });
+
+    var introspection = await graphql(schema, introspectionQuery);
+    var clientSchema = buildClientSchema(introspection.data);
+
+    var result = await graphql(
+      clientSchema,
+      'query NoNo($v: CustomScalar) { foo(custom1: 123, custom2: $v) }',
+      { foo: 'bar' },
+      { v: 'baz' }
+    );
+    expect(result).to.deep.equal({
+      data: {
+        foo: null,
+      },
+      errors: [
+        { message: 'Client Schema cannot be used for execution.',
+          locations: [ { line: 1, column: 32 } ] }
+      ]
+    });
+  });
+
+  describe('throws when given incomplete introspection', () => {
+
+    it('throws when given empty types', () => {
+      var incompleteIntrospection = {
+        __schema: {
+          queryType: { name: 'QueryType' },
+          types: []
+        }
+      };
+
+      expect(
+        () => buildClientSchema(incompleteIntrospection)
+      ).to.throw(
+        'Invalid or incomplete schema, unknown type: QueryType. Ensure ' +
+        'that a full introspection query is used in order to build a ' +
+        'client schema.'
+      );
+    });
+
+    it('throws when missing kind', () => {
+      var incompleteIntrospection = {
+        __schema: {
+          queryType: { name: 'QueryType' },
+          types: [
+            { name: 'QueryType' }
+          ]
+        }
+      };
+
+      expect(
+        () => buildClientSchema(incompleteIntrospection)
+      ).to.throw(
+        'Invalid or incomplete schema, unknown kind: undefined. Ensure ' +
+        'that a full introspection query is used in order to build a ' +
+        'client schema.'
+      );
+    });
+
+  });
+
+  describe('KP: very deep decorators are not supported', () => {
+
+    it('fails on very deep lists', async () => {
+      var schema = new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: 'Query',
+          fields: {
+            foo: {
+              type: new GraphQLList(new GraphQLList(new GraphQLList(
+                new GraphQLList(GraphQLString)
+              )))
+            }
+          }
+        })
+      });
+
+      var introspection = await graphql(schema, introspectionQuery);
+      expect(
+        () => buildClientSchema(introspection.data)
+      ).to.throw('Decorated type deeper than introspection query.');
+    });
+
+    it('fails on a deep non-null', async () => {
+      var schema = new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: 'Query',
+          fields: {
+            foo: {
+              type: new GraphQLList(new GraphQLList(new GraphQLList(
+                new GraphQLNonNull(GraphQLString)
+              )))
+            }
+          }
+        })
+      });
+
+      var introspection = await graphql(schema, introspectionQuery);
+      expect(
+        () => buildClientSchema(introspection.data)
+      ).to.throw('Decorated type deeper than introspection query.');
+    });
+
+  });
+
+});

--- a/src/type/buildClientSchema.js
+++ b/src/type/buildClientSchema.js
@@ -1,0 +1,323 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import invariant from '../utils/invariant';
+import keyMap from '../utils/keyMap';
+import keyValMap from '../utils/keyValMap';
+
+import { GraphQLSchema } from './schema';
+
+import {
+  isInputType,
+  isOutputType,
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+} from './definition';
+
+import {
+  GraphQLInt,
+  GraphQLFloat,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLID
+} from './scalars';
+
+import { TypeKind } from './introspection';
+
+import type {
+  GraphQLType,
+  GraphQLInputType,
+  GraphQLOutputType,
+  GraphQLNamedType,
+} from './definition';
+
+import type {
+  IntrospectionQuery,
+  IntrospectionType,
+  IntrospectionScalarType,
+  IntrospectionObjectType,
+  IntrospectionInterfaceType,
+  IntrospectionUnionType,
+  IntrospectionEnumType,
+  IntrospectionInputObjectType,
+  IntrospectionTypeRef,
+  IntrospectionListTypeRef,
+  IntrospectionNonNullTypeRef,
+} from './introspectionQuery';
+
+
+/**
+ * Build a GraphQLSchema for use by client tools.
+ *
+ * Given the result of a client running the introspection query, creates and
+ * returns a GraphQLSchema instance which can be then used with all graphql-js
+ * tools, but cannot be used to execute a query, as introspection does not
+ * represent the "resolver" or "coerce" functions or any other server-internal
+ * mechanisms.
+ */
+export function buildClientSchema(
+  introspection: IntrospectionQuery
+): GraphQLSchema {
+
+  // Get the schema from the introspection result.
+  var schemaIntrospection = introspection.__schema;
+
+  // Converts the list of types into a keyMap based on the type names.
+  var typeIntrospectionMap = keyMap(
+    schemaIntrospection.types,
+    type => type.name
+  );
+
+  // A cache to use to store the actual GraphQLType definition objects by name.
+  // Initialize to the GraphQL built in scalars. All functions below are inline
+  // so that this type def cache is within the scope of the closure.
+  var typeDefCache = {
+    String: GraphQLString,
+    Int: GraphQLInt,
+    Float: GraphQLFloat,
+    Boolean: GraphQLBoolean,
+    ID: GraphQLID,
+  };
+
+  // Given a type reference in introspection, return the GraphQLType instance.
+  // preferring cached instances before building new instances.
+  function getType(typeRef: IntrospectionTypeRef): GraphQLType {
+    if (typeRef.kind === TypeKind.LIST) {
+      var itemRef = ((typeRef: any): IntrospectionListTypeRef).ofType;
+      if (!itemRef) {
+        throw new Error('Decorated type deeper than introspection query.');
+      }
+      return new GraphQLList(getType(itemRef));
+    } else if (typeRef.kind === TypeKind.NON_NULL) {
+      var nullableRef = ((typeRef: any): IntrospectionNonNullTypeRef).ofType;
+      if (!nullableRef) {
+        throw new Error('Decorated type deeper than introspection query.');
+      }
+      return new GraphQLNonNull(getType(nullableRef));
+    } else {
+      return getNamedType(typeRef.name);
+    }
+  }
+
+  function getNamedType(typeName: string): GraphQLNamedType {
+    if (typeDefCache[typeName]) {
+      return typeDefCache[typeName];
+    }
+    var typeIntrospection = typeIntrospectionMap[typeName];
+    if (!typeIntrospection) {
+      throw new Error(
+        `Invalid or incomplete schema, unknown type: ${typeName}. Ensure ` +
+        `that a full introspection query is used in order to build a ` +
+        `client schema.`
+      );
+    }
+    var typeDef = buildType(typeIntrospection);
+    typeDefCache[typeName] = typeDef;
+    return typeDef;
+  }
+
+  function getInputType(typeRef: IntrospectionTypeRef): GraphQLInputType {
+    var type = getType(typeRef);
+    invariant(
+      isInputType(type),
+      `Introspection must provide input type for arguments.`
+    );
+    return (type: any);
+  }
+
+  function getOutputType(typeRef: IntrospectionTypeRef): GraphQLOutputType {
+    var type = getType(typeRef);
+    invariant(
+      isOutputType(type),
+      `Introspection must provide output type for fields.`
+    );
+    return (type: any);
+  }
+
+  function getObjectType(typeRef: IntrospectionTypeRef): GraphQLObjectType {
+    var type = getType(typeRef);
+    invariant(
+      type instanceof GraphQLObjectType,
+      `Introspection must provide object type for possibleTypes.`
+    );
+    return (type: any);
+  }
+
+  function getInterfaceType(
+    typeRef: IntrospectionTypeRef
+  ): GraphQLInterfaceType {
+    var type = getType(typeRef);
+    invariant(
+      type instanceof GraphQLInterfaceType,
+      `Introspection must provide interface type for interfaces.`
+    );
+    return (type: any);
+  }
+
+
+  // Given a type's introspection result, construct the correct
+  // GraphQLType instance.
+  function buildType(type: IntrospectionType): GraphQLType {
+    switch (type.kind) {
+      case TypeKind.SCALAR:
+        return buildScalarDef(type);
+      case TypeKind.OBJECT:
+        return buildObjectDef(type);
+      case TypeKind.INTERFACE:
+        return buildInterfaceDef(type);
+      case TypeKind.UNION:
+        return buildUnionDef(type);
+      case TypeKind.ENUM:
+        return buildEnumDef(type);
+      case TypeKind.INPUT_OBJECT:
+        return buildInputObjectDef(type);
+      default:
+        throw new Error(
+          `Invalid or incomplete schema, unknown kind: ${type.kind}. Ensure ` +
+          `that a full introspection query is used in order to build a ` +
+          `client schema.`
+        );
+    }
+  }
+
+  function buildScalarDef(
+    scalarIntrospection: IntrospectionScalarType
+  ): GraphQLScalarType {
+    return new GraphQLScalarType({
+      name: scalarIntrospection.name,
+      description: scalarIntrospection.description,
+      // Note: validation calls the coerce functions to determine if a
+      // query value is correct. Returning null would cause use of custom
+      // scalars to always fail validation. Returning false causes them to
+      // always pass validation.
+      coerce: () => false,
+      coerceLiteral: () => false,
+    });
+  }
+
+  function buildObjectDef(
+    objectIntrospection: IntrospectionObjectType
+  ): GraphQLObjectType {
+    return new GraphQLObjectType({
+      name: objectIntrospection.name,
+      description: objectIntrospection.description,
+      interfaces: objectIntrospection.interfaces.map(getInterfaceType),
+      fields: () => buildFieldDefMap(objectIntrospection),
+    });
+  }
+
+  function buildInterfaceDef(
+    interfaceIntrospection: IntrospectionInterfaceType
+  ): GraphQLInterfaceType {
+    return new GraphQLInterfaceType({
+      name: interfaceIntrospection.name,
+      description: interfaceIntrospection.description,
+      fields: () => buildFieldDefMap(interfaceIntrospection),
+    });
+  }
+
+  function buildUnionDef(
+    unionIntrospection: IntrospectionUnionType
+  ): GraphQLUnionType {
+    return new GraphQLUnionType({
+      name: unionIntrospection.name,
+      description: unionIntrospection.description,
+      types: unionIntrospection.possibleTypes.map(getObjectType),
+    });
+  }
+
+  function buildEnumDef(
+    enumIntrospection: IntrospectionEnumType
+  ): GraphQLEnumType {
+    return new GraphQLEnumType({
+      name: enumIntrospection.name,
+      description: enumIntrospection.description,
+      values: keyValMap(
+        enumIntrospection.enumValues,
+        valueIntrospection => valueIntrospection.name,
+        valueIntrospection => ({
+          description: valueIntrospection.description,
+        })
+      )
+    });
+  }
+
+  function buildInputObjectDef(
+    inputObjectIntrospection: IntrospectionInputObjectType
+  ): GraphQLInputObjectType {
+    return new GraphQLInputObjectType({
+      name: inputObjectIntrospection.name,
+      description: inputObjectIntrospection.description,
+      fields: () => buildInputValueDefMap(inputObjectIntrospection.inputFields),
+    });
+  }
+
+  function buildFieldDefMap(typeIntrospection): any {
+    return keyValMap(
+      typeIntrospection.fields,
+      fieldIntrospection => fieldIntrospection.name,
+      fieldIntrospection => ({
+        description: fieldIntrospection.description,
+        type: getOutputType(fieldIntrospection.type),
+        args: buildInputValueDefMap(fieldIntrospection.args),
+        resolve: () => {
+          throw new Error('Client Schema cannot be used for execution.');
+        },
+      })
+    );
+  }
+
+  function buildInputValueDefMap(inputValueIntrospections) {
+    return keyValMap(
+      inputValueIntrospections,
+      inputValueIntrospection => inputValueIntrospection.name,
+      inputValueIntrospection => ({
+        description: inputValueIntrospection.description,
+        type: getInputType(inputValueIntrospection.type),
+        defaultValue: inputValueIntrospection.defaultValue &&
+          JSON.parse(inputValueIntrospection.defaultValue),
+      })
+    );
+  }
+
+  // TODO: deprecation
+  // TODO: directives
+
+  // Iterate through all types, getting the type definition for each, ensuring
+  // that any type not directly referenced by a field will get created.
+  schemaIntrospection.types.forEach(
+    typeIntrospection => getNamedType(typeIntrospection.name)
+  );
+
+  // Get the root Query and Mutation types.
+  var queryType = getType(schemaIntrospection.queryType);
+  var mutationType = schemaIntrospection.mutationType ?
+    getType(schemaIntrospection.mutationType) :
+    null;
+
+  // Then produce and return a Schema with these types.
+  var schema = new GraphQLSchema({
+    query: (queryType: any),
+    mutation: (mutationType: any)
+  });
+
+  // The schema is lazy by default, getting the type map will resolve any
+  // deferred functions, ensuring that any errors are presented before this
+  // function exits.
+  schema.getTypeMap();
+
+  return schema;
+}

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -202,7 +202,7 @@ export class GraphQLScalarType/*<T>*/ {
 
 type GraphQLScalarTypeConfig/*<T>*/ = {
   name: string;
-  description?: string;
+  description?: ?string;
   coerce: (value: any) => ?any/*T*/;
   coerceLiteral: (value: Value) => ?any/*T*/;
 }
@@ -337,7 +337,7 @@ type GraphQLObjectTypeConfig = {
   interfaces?: GraphQLInterfacesThunk | Array<GraphQLInterfaceType>;
   fields: GraphQLFieldConfigMapThunk | GraphQLFieldConfigMap;
   isTypeOf?: (value: any) => boolean;
-  description?: string
+  description?: ?string
 }
 
 type GraphQLInterfacesThunk = () => Array<GraphQLInterfaceType>;
@@ -357,7 +357,7 @@ type GraphQLFieldConfig = {
     schema?: GraphQLSchema
   ) => any;
   deprecationReason?: string;
-  description?: string;
+  description?: ?string;
 }
 
 type GraphQLFieldConfigArgumentMap = {
@@ -394,7 +394,7 @@ export type GraphQLArgument = {
   name: string;
   type: GraphQLInputType;
   defaultValue?: any;
-  description?: string;
+  description?: ?string;
 };
 
 type GraphQLFieldDefinitionMap = {
@@ -501,7 +501,7 @@ type GraphQLInterfaceTypeConfig = {
    * Object type.
    */
   resolveType?: (value: any) => ?GraphQLObjectType,
-  description?: string
+  description?: ?string
 };
 
 
@@ -593,7 +593,7 @@ type GraphQLUnionTypeConfig = {
    * Object type.
    */
   resolveType?: (value: any) => ?GraphQLObjectType;
-  description?: string;
+  description?: ?string;
 };
 
 
@@ -698,7 +698,7 @@ export class GraphQLEnumType/*<T>*/ {
 type GraphQLEnumTypeConfig/*<T>*/ = {
   name: string;
   values: GraphQLEnumValueConfigMap/*<T>*/;
-  description?: string;
+  description?: ?string;
 }
 
 type GraphQLEnumValueConfigMap/*<T>*/ = {
@@ -708,7 +708,7 @@ type GraphQLEnumValueConfigMap/*<T>*/ = {
 type GraphQLEnumValueConfig/*<T>*/ = {
   value?: any/*T*/;
   deprecationReason?: string;
-  description?: string;
+  description?: ?string;
 }
 
 type GraphQLEnumValueDefinitionMap/*<T>*/ = {
@@ -719,7 +719,7 @@ type GraphQLEnumValueDefinition/*<T>*/ = {
   name: string;
   value?: any/*T*/;
   deprecationReason?: string;
-  description?: string;
+  description?: ?string;
 }
 
 
@@ -780,7 +780,7 @@ export class GraphQLInputObjectType {
 type InputObjectConfig = {
   name: string;
   fields: InputObjectConfigFieldMapThunk | InputObjectConfigFieldMap;
-  description?: string;
+  description?: ?string;
 }
 
 type InputObjectConfigFieldMapThunk = () => InputObjectConfigFieldMap;
@@ -788,7 +788,7 @@ type InputObjectConfigFieldMapThunk = () => InputObjectConfigFieldMap;
 type InputObjectFieldConfig = {
   type: GraphQLInputType;
   defaultValue?: any;
-  description?: string;
+  description?: ?string;
 }
 
 type InputObjectConfigFieldMap = {
@@ -799,7 +799,7 @@ export type InputObjectField = {
   name: string;
   type: GraphQLInputType;
   defaultValue?: any;
-  description?: string;
+  description?: ?string;
 }
 
 type InputObjectFieldMap = {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -219,15 +219,15 @@ var __EnumValue = new GraphQLObjectType({
   }
 });
 
-var TypeKind = {
-  SCALAR: 0,
-  OBJECT: 1,
-  INTERFACE: 2,
-  UNION: 3,
-  ENUM: 4,
-  INPUT_OBJECT: 5,
-  LIST: 6,
-  NON_NULL: 7,
+export var TypeKind = {
+  SCALAR: 'SCALAR',
+  OBJECT: 'OBJECT',
+  INTERFACE: 'INTERFACE',
+  UNION: 'UNION',
+  ENUM: 'ENUM',
+  INPUT_OBJECT: 'INPUT_OBJECT',
+  LIST: 'LIST',
+  NON_NULL: 'NON_NULL',
 };
 
 var __TypeKind = new GraphQLEnumType({

--- a/src/utils/keyValMap.js
+++ b/src/utils/keyValMap.js
@@ -10,30 +10,28 @@
 
 /**
  * Creates a keyed JS object from an array, given a function to produce the keys
- * for each value in the array.
- *
- * This provides a convenient lookup for the array items if the key function
- * produces unique results.
+ * and a function to produce the values from each item in the array.
  *
  *     var phoneBook = [
  *       { name: 'Jon', num: '555-1234' },
  *       { name: 'Jenny', num: '857-6309' }
  *     ]
  *
- *     // { Jon: { name: 'Jon', num: '555-1234' },
- *     //   Jenny: { name: 'Jenny', num: '857-6309' } }
- *     var entriesByName = keyMap(
+ *     // { Jon: '555-1234', Jenny: '857-6309' }
+ *     var phonesByName = keyValMap(
  *       phoneBook,
- *       entry => entry.name
+ *       entry => entry.name,
+ *       entry => entry.num
  *     )
  *
- *     // { name: 'Jenny', num: '857-6309' }
- *     var jennyEntry = entriesByName['Jenny']
- *
  */
-export default function keyMap<T>(
+export default function keyValMap<T, V>(
   list: Array<T>,
-  keyFn: (item: T) => string
-): {[key: string]: T} {
-  return list.reduce((map, item) => ((map[keyFn(item)] = item), map), {});
+  keyFn: (item: T) => string,
+  valFn: (item: T) => V
+): {[key: string]: V} {
+  return list.reduce(
+    (map, item) => ((map[keyFn(item)] = valFn(item)), map),
+    {}
+  );
 }


### PR DESCRIPTION
Given a full introspection result, this builds a GraphQLSchema instance that can be used for everything except execution, allowing clients to use it throughout tools, establishing GraphQLSchema as the common in-mem representation of the type system for use across both server and client.

This differs from the DSL materializer in a few important ways:

1. Input. This accepts introspection result, which is trivial for a client to produce given any server. This avoids requiring client tools to leverage the whole GraphQL executor locally to derive this information, which lets it be a sync operation.
2. Scope. This preserves everything that introspection represents including descriptions (and in a follow-up, deprecations).