### PR TITLE
Print the schema directly, rather than the introspection result.

### DIFF
--- a/src/language/schema/__tests__/materializer.js
+++ b/src/language/schema/__tests__/materializer.js
@@ -26,7 +26,7 @@ import { createSchemaFromDSL } from '../';
  */
 async function cycleOutput(body, queryType) {
   var schema = await createSchemaFromDSL(body, queryType);
-  return '\n' + await printSchema(schema) + '\n';
+  return '\n' + await printSchema(schema);
 }
 
 describe('Schema Materializer', () => {

--- a/src/type/__tests__/schemaPrinter.js
+++ b/src/type/__tests__/schemaPrinter.js
@@ -29,16 +29,16 @@ import {
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /*eslint-disable max-len */
 
-async function printForTest(schema) {
-  return '\n' + await printSchema(schema) + '\n';
+function printForTest(schema) {
+  return '\n' + printSchema(schema);
 }
 
-async function printSingleFieldSchema(fieldConfig) {
+function printSingleFieldSchema(fieldConfig) {
   var Root = new GraphQLObjectType({
     name: 'Root',
     fields: { singleField: fieldConfig },
   });
-  return await printForTest(new GraphQLSchema({query: Root}));
+  return printForTest(new GraphQLSchema({query: Root}));
 }
 
 function listOf(type) {
@@ -50,8 +50,8 @@ function nonNull(type) {
 }
 
 describe('Type System Printer', () => {
-  it('Prints String Field', async () => {
-    var output = await printSingleFieldSchema({type: GraphQLString});
+  it('Prints String Field', () => {
+    var output = printSingleFieldSchema({type: GraphQLString});
     expect(output).to.equal(`
 type Root {
   singleField: String
@@ -60,8 +60,8 @@ type Root {
     );
   });
 
-  it('Prints [String] Field', async () => {
-    var output = await printSingleFieldSchema({type: listOf(GraphQLString)});
+  it('Prints [String] Field', () => {
+    var output = printSingleFieldSchema({type: listOf(GraphQLString)});
     expect(output).to.equal(`
 type Root {
   singleField: [String]
@@ -70,8 +70,8 @@ type Root {
     );
   });
 
-  it('Prints String! Field', async () => {
-    var output = await printSingleFieldSchema({type: nonNull(GraphQLString)});
+  it('Prints String! Field', () => {
+    var output = printSingleFieldSchema({type: nonNull(GraphQLString)});
     expect(output).to.equal(`
 type Root {
   singleField: String!
@@ -80,8 +80,8 @@ type Root {
     );
   });
 
-  it('Prints [String]! Field', async () => {
-    var output = await printSingleFieldSchema({type: nonNull(listOf(GraphQLString))});
+  it('Prints [String]! Field', () => {
+    var output = printSingleFieldSchema({type: nonNull(listOf(GraphQLString))});
     expect(output).to.equal(`
 type Root {
   singleField: [String]!
@@ -90,8 +90,8 @@ type Root {
     );
   });
 
-  it('Prints [String!] Field', async () => {
-    var output = await printSingleFieldSchema({type: listOf(nonNull(GraphQLString))});
+  it('Prints [String!] Field', () => {
+    var output = printSingleFieldSchema({type: listOf(nonNull(GraphQLString))});
     expect(output).to.equal(`
 type Root {
   singleField: [String!]
@@ -100,8 +100,8 @@ type Root {
     );
   });
 
-  it('Prints [String!]! Field', async () => {
-    var output = await printSingleFieldSchema({type: nonNull(listOf(nonNull(GraphQLString)))});
+  it('Prints [String!]! Field', () => {
+    var output = printSingleFieldSchema({type: nonNull(listOf(nonNull(GraphQLString)))});
     expect(output).to.equal(`
 type Root {
   singleField: [String!]!
@@ -110,7 +110,7 @@ type Root {
     );
   });
 
-  it('Print Object Field', async() => {
+  it('Print Object Field', () => {
     var FooType = new GraphQLObjectType({
       name: 'Foo',
       fields: { str: { type: GraphQLString } }
@@ -122,7 +122,7 @@ type Root {
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 type Foo {
   str: String
@@ -135,8 +135,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Int Arg', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Int Arg', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: { argOne: { type: GraphQLInt } },
@@ -150,8 +150,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Int Arg With Default', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Int Arg With Default', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: { argOne: { type: GraphQLInt, defaultValue: 2 } },
@@ -165,8 +165,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Int! Arg', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Int! Arg', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: { argOne: { type: nonNull(GraphQLInt) } },
@@ -180,8 +180,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Multiple Args', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Multiple Args', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: {
@@ -198,8 +198,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Multiple Args, First is Default', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Multiple Args, First is Default', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: {
@@ -217,8 +217,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Multiple Args, Second is Default', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Multiple Args, Second is Default', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: {
@@ -236,8 +236,8 @@ type Root {
     );
   });
 
-  it('Prints String Field With Multiple Args, Last is Default', async () => {
-    var output = await printSingleFieldSchema(
+  it('Prints String Field With Multiple Args, Last is Default', () => {
+    var output = printSingleFieldSchema(
       {
         type: GraphQLString,
         args: {
@@ -255,7 +255,7 @@ type Root {
     );
   });
 
-  it('Print Interface', async() => {
+  it('Print Interface', () => {
     var FooType = new GraphQLInterfaceType({
       name: 'Foo',
       fields: { str: { type: GraphQLString } },
@@ -273,7 +273,7 @@ type Root {
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 type Bar implements Foo {
   str: String
@@ -290,7 +290,7 @@ type Root {
     );
   });
 
-  it('Print Multiple Interface', async() => {
+  it('Print Multiple Interface', () => {
     var FooType = new GraphQLInterfaceType({
       name: 'Foo',
       fields: { str: { type: GraphQLString } },
@@ -316,7 +316,7 @@ type Root {
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 interface Baaz {
   int: Int
@@ -338,7 +338,7 @@ type Root {
     );
   });
 
-  it('Print Unions', async() => {
+  it('Print Unions', () => {
     var FooType = new GraphQLObjectType({
       name: 'Foo',
       fields: {
@@ -372,7 +372,7 @@ type Root {
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 type Bar {
   str: String
@@ -394,7 +394,7 @@ union SingleUnion = Foo
     );
   });
 
-  it('Print Input Type', async() => {
+  it('Print Input Type', () => {
     var InputType = new GraphQLInputObjectType({
       name: 'InputType',
       fields: {
@@ -413,7 +413,7 @@ union SingleUnion = Foo
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 input InputType {
   int: Int
@@ -425,7 +425,7 @@ type Root {
 `);
   });
 
-  it('Custom Scalar', async () => {
+  it('Custom Scalar', () => {
     var OddType = new GraphQLScalarType({
       name: 'Odd',
       coerce(value) {
@@ -441,7 +441,7 @@ type Root {
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 scalar Odd
 
@@ -452,7 +452,7 @@ type Root {
      );
   });
 
-  it('Enum', async() => {
+  it('Enum', () => {
     var RGBType = new GraphQLEnumType({
       name: 'RGB',
       values: {
@@ -470,7 +470,7 @@ type Root {
     });
 
     var Schema = new GraphQLSchema({query: Root});
-    var output = await printForTest(Schema);
+    var output = printForTest(Schema);
     expect(output).to.equal(`
 enum RGB {
   RED
@@ -484,13 +484,13 @@ type Root {
 `);
   });
 
-  it('Print Introspection Schema', async() => {
+  it('Print Introspection Schema', () => {
     var Root = new GraphQLObjectType({
       name: 'Root',
       fields: {},
     });
     var Schema = new GraphQLSchema({query: Root});
-    var output = '\n' + await printIntrospectionSchema(Schema) + '\n';
+    var output = '\n' + printIntrospectionSchema(Schema);
     var introspectionSchema = `
 type __Directive {
   name: String!

--- a/src/utils/__tests__/astFromValue.js
+++ b/src/utils/__tests__/astFromValue.js
@@ -1,0 +1,187 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import astFromValue from '../astFromValue';
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList
+} from '../../type/definition';
+import { GraphQLFloat } from '../../type/scalars';
+
+
+describe('astFromValue', () => {
+
+  it('converts boolean values to ASTs', () => {
+    expect(astFromValue(true)).to.deep.equal(
+      { kind: 'BooleanValue', value: true }
+    );
+
+    expect(astFromValue(false)).to.deep.equal(
+      { kind: 'BooleanValue', value: false }
+    );
+  });
+
+  it('converts numeric values to ASTs', () => {
+    expect(astFromValue(123)).to.deep.equal(
+      { kind: 'IntValue', value: '123' }
+    );
+
+    expect(astFromValue(123.0)).to.deep.equal(
+      { kind: 'IntValue', value: '123' }
+    );
+
+    expect(astFromValue(123.5)).to.deep.equal(
+      { kind: 'FloatValue', value: '123.5' }
+    );
+
+    expect(astFromValue(1e4)).to.deep.equal(
+      { kind: 'IntValue', value: '10000' }
+    );
+
+    expect(astFromValue(1e40)).to.deep.equal(
+      { kind: 'FloatValue', value: '1e+40' }
+    );
+  });
+
+  it('converts numeric values to Float ASTs', () => {
+    expect(astFromValue(123, GraphQLFloat)).to.deep.equal(
+      { kind: 'FloatValue', value: '123.0' }
+    );
+
+    expect(astFromValue(123.0, GraphQLFloat)).to.deep.equal(
+      { kind: 'FloatValue', value: '123.0' }
+    );
+
+    expect(astFromValue(123.5, GraphQLFloat)).to.deep.equal(
+      { kind: 'FloatValue', value: '123.5' }
+    );
+
+    expect(astFromValue(1e4, GraphQLFloat)).to.deep.equal(
+      { kind: 'FloatValue', value: '10000.0' }
+    );
+
+    expect(astFromValue(1e40, GraphQLFloat)).to.deep.equal(
+      { kind: 'FloatValue', value: '1e+40' }
+    );
+  });
+
+  it('converts string values to ASTs', () => {
+    expect(astFromValue('hello')).to.deep.equal(
+      { kind: 'StringValue', value: 'hello' }
+    );
+
+    expect(astFromValue('VALUE')).to.deep.equal(
+      { kind: 'StringValue', value: 'VALUE' }
+    );
+
+    expect(astFromValue('VA\nLUE')).to.deep.equal(
+      { kind: 'StringValue', value: 'VA\\nLUE' }
+    );
+
+    expect(astFromValue('123')).to.deep.equal(
+      { kind: 'StringValue', value: '123' }
+    );
+  });
+
+  var myEnum = new GraphQLEnumType({
+    name: 'MyEnum',
+    values: {
+      HELLO: {},
+      GOODBYE: {},
+    }
+  });
+
+  it('converts string values to Enum ASTs if possible', () => {
+    expect(astFromValue('hello', myEnum)).to.deep.equal(
+      { kind: 'EnumValue', value: 'hello' }
+    );
+
+    expect(astFromValue('HELLO', myEnum)).to.deep.equal(
+      { kind: 'EnumValue', value: 'HELLO' }
+    );
+
+    expect(astFromValue('VALUE', myEnum)).to.deep.equal(
+      { kind: 'EnumValue', value: 'VALUE' }
+    );
+
+    expect(astFromValue('VA\nLUE', myEnum)).to.deep.equal(
+      { kind: 'StringValue', value: 'VA\\nLUE' }
+    );
+
+    expect(astFromValue('123', myEnum)).to.deep.equal(
+      { kind: 'StringValue', value: '123' }
+    );
+  });
+
+  it('converts array values to List ASTs', () => {
+    expect(astFromValue(['FOO', 'BAR'])).to.deep.equal(
+      { kind: 'ListValue',
+        values: [
+          { kind: 'StringValue', value: 'FOO' },
+          { kind: 'StringValue', value: 'BAR' } ] }
+    );
+
+    expect(
+      astFromValue(['FOO', 'BAR'],
+      new GraphQLList(myEnum))
+    ).to.deep.equal(
+      { kind: 'ListValue',
+        values: [
+         { kind: 'EnumValue', value: 'FOO' },
+         { kind: 'EnumValue', value: 'BAR' } ] }
+    );
+  });
+
+  it('converts list singletons', () => {
+    expect(astFromValue(
+      'FOO',
+      new GraphQLList(myEnum)
+    )).to.deep.equal(
+      { kind: 'EnumValue', value: 'FOO' }
+    );
+  });
+
+  it('converts input objects', () => {
+    expect(astFromValue({ foo: 3, bar: 'HELLO' })).to.deep.equal(
+      { kind: 'ObjectValue',
+        fields: [
+         { kind: 'ObjectField',
+           name: 'foo',
+           value: { kind: 'IntValue', value: '3' } },
+         { kind: 'ObjectField',
+           name: 'bar',
+           value: { kind: 'StringValue', value: 'HELLO' } } ] }
+    );
+
+    var inputObj = new GraphQLInputObjectType({
+      name: 'MyInputObj',
+      fields: {
+        foo: { type: GraphQLFloat },
+        bar: { type: myEnum }
+      }
+    });
+
+    expect(astFromValue(
+      { foo: 3, bar: 'HELLO' },
+      inputObj
+    )).to.deep.equal(
+      { kind: 'ObjectValue',
+        fields: [
+          { kind: 'ObjectField',
+            name: 'foo',
+            value: { kind: 'FloatValue', value: '3.0' } },
+          { kind: 'ObjectField',
+            name: 'bar',
+            value: { kind: 'EnumValue', value: 'HELLO' } } ] }
+    );
+  });
+});

--- a/src/utils/astFromValue.js
+++ b/src/utils/astFromValue.js
@@ -1,0 +1,132 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import invariant from '../utils/invariant';
+import isNullish from '../utils/isNullish';
+import type { Value } from '../language/ast';
+import {
+  INT,
+  FLOAT,
+  STRING,
+  BOOLEAN,
+  ENUM,
+  LIST,
+  OBJECT,
+  OBJECT_FIELD,
+} from '../language/kinds';
+import {
+  GraphQLType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+} from '../type/definition';
+import { GraphQLFloat } from '../type/scalars';
+
+
+/**
+ * Produces a GraphQL Value AST given a JavaScript value.
+ *
+ * Optionally, a GraphQL type may be provided, which will be used to
+ * disambiguate between value primitives.
+ *
+ * | JSON Value    | GraphQL Value        |
+ * | ------------- | -------------------- |
+ * | Object        | Input Object         |
+ * | Array         | List                 |
+ * | Boolean       | Boolean              |
+ * | String        | String / Enum Value  |
+ * | Number        | Int / Float          |
+ *
+ */
+export default function astFromValue(
+  value: any,
+  type?: ?GraphQLType
+): ?Value {
+  if (type instanceof GraphQLNonNull) {
+    // Note: we're not checking that the result is non-null.
+    // This function is not responsible for validating the input value.
+    return astFromValue(value, type.ofType);
+  }
+
+  if (isNullish(value)) {
+    return null;
+  }
+
+  // Convert JavaScript array to GraphQL list. If the GraphQLType is a list, but
+  // the value is not an array, convert the value using the list's item type.
+  if (Array.isArray(value)) {
+    var itemType = type instanceof GraphQLList ? type.ofType : null;
+    return {
+      kind: LIST,
+      values: value.map(item => astFromValue(item, itemType))
+    };
+  } else if (type instanceof GraphQLList) {
+    // Because GraphQL will accept single values as a "list of one" when
+    // expecting a list, if there's a non-array value and an expected list type,
+    // create an AST using the list's item type.
+    return astFromValue(value, (type: any).ofType);
+  }
+
+  if (typeof value === 'boolean') {
+    return { kind: BOOLEAN, value };
+  }
+
+  // JavaScript numbers can be Float or Int values. Use the GraphQLType to
+  // differentiate if available, otherwise prefer Int if the value is a
+  // valid Int.
+  if (typeof value === 'number') {
+    var stringNum = String(value);
+    var isIntValue = /^[0-9]+$/.test(stringNum);
+    if (isIntValue) {
+      if (type === GraphQLFloat) {
+        return { kind: FLOAT, value: stringNum + '.0' };
+      } else {
+        return { kind: INT, value: stringNum };
+      }
+    }
+    return { kind: FLOAT, value: stringNum };
+  }
+
+  // JavaScript strings can be Enum values or String values. Use the
+  // GraphQLType to differentiate if possible.
+  if (typeof value === 'string') {
+    if (type instanceof GraphQLEnumType &&
+        /^[_a-zA-Z][_a-zA-Z0-9]*$/.test(value)) {
+      return { kind: ENUM, value };
+    }
+    // Use JSON stringify, which uses the same string encoding as GraphQL,
+    // then remove the quotes.
+    return { kind: STRING, value: JSON.stringify(value).slice(1, -1) };
+  }
+
+  // last remaining possible typeof
+  invariant(typeof value === 'object');
+
+  // Populate the fields of the input object by creating ASTs from each value
+  // in the JavaScript object.
+  var fields = [];
+  Object.keys(value).forEach(fieldName => {
+    var fieldType;
+    if (type instanceof GraphQLInputObjectType) {
+      var fieldDef = type.getFields()[fieldName];
+      fieldType = fieldDef && fieldDef.type;
+    }
+    var fieldValue = astFromValue(value[fieldName], fieldType);
+    if (fieldValue) {
+      fields.push({
+        kind: OBJECT_FIELD,
+        name: fieldName,
+        value: fieldValue
+      });
+    }
+  });
+  return { kind: OBJECT, fields };
+}


### PR DESCRIPTION
This allows schemaPrinter to be a sync rather than async function.

Also introduces the (meaty) "astFromValue" utility which accepts arbitrary JS values and outputs GraphQL AST.