### PR TITLE
Leverage 'graphql/tools' for common utilities

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,3 @@ export {
 
 // Produce and format errors.
 export { GraphQLError, formatError } from './error';
-
-// Tools for printing a GraphQL type schema.
-export { printSchema } from './type/schemaPrinter';

--- a/src/language/schema/index.js
+++ b/src/language/schema/index.js
@@ -7,21 +7,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import { GraphQLSchema } from '../../type';
-import { parseSchemaIntoAST } from './parser';
-import { materializeSchemaAST } from './materializer';
-
 import * as Kind from './kinds';
 export { Kind };
 export { parseSchemaIntoAST } from './parser';
 export { printSchema } from './printer';
 export { visit } from './visitor';
-
-// DSL --> Schema
-export async function createSchemaFromDSL(
-  schemaDSL: string,
-  queryType: string
-) : GraphQLSchema {
-  var doc = parseSchemaIntoAST(schemaDSL);
-  return await materializeSchemaAST(doc, queryType);
-}

--- a/src/tools/__tests__/buildClientSchema.js
+++ b/src/tools/__tests__/buildClientSchema.js
@@ -10,7 +10,7 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { buildClientSchema } from '../buildClientSchema';
-import { introspectionQuery } from '../introspectionQuery';
+import { introspectionQuery } from '../../type/introspectionQuery';
 import {
   graphql,
   GraphQLSchema,

--- a/src/tools/__tests__/schemaPrinter.js
+++ b/src/tools/__tests__/schemaPrinter.js
@@ -24,7 +24,7 @@ import {
   GraphQLBoolean,
   GraphQLList,
   GraphQLNonNull,
-} from '../';
+} from '../../';
 
 // 80+ char lines are useful in describe/it, so ignore in this file.
 /*eslint-disable max-len */

--- a/src/tools/buildClientSchema.js
+++ b/src/tools/buildClientSchema.js
@@ -15,7 +15,7 @@ import valueFromAST from '../utils/valueFromAST';
 
 import { parseValue } from '../language/parser';
 
-import { GraphQLSchema } from './schema';
+import { GraphQLSchema } from '../type/schema';
 
 import {
   isInputType,
@@ -28,7 +28,7 @@ import {
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
-} from './definition';
+} from '../type/definition';
 
 import {
   GraphQLInt,
@@ -36,16 +36,16 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID
-} from './scalars';
+} from '../type/scalars';
 
-import { TypeKind } from './introspection';
+import { TypeKind } from '../type/introspection';
 
 import type {
   GraphQLType,
   GraphQLInputType,
   GraphQLOutputType,
   GraphQLNamedType,
-} from './definition';
+} from '../type/definition';
 
 import type {
   IntrospectionQuery,
@@ -59,7 +59,7 @@ import type {
   IntrospectionTypeRef,
   IntrospectionListTypeRef,
   IntrospectionNonNullTypeRef,
-} from './introspectionQuery';
+} from '../type/introspectionQuery';
 
 
 /**

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -1,0 +1,24 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// Build a GraphQLSchema from an introspection result.
+export {
+  buildClientSchema,
+} from './buildClientSchema';
+
+// Build a GraphQLSchema from a parsed GraphQL Schema language AST.
+export {
+  buildASTSchema,
+} from './buildASTSchema';
+
+// Print a GraphQLSchema to GraphQL Schema language
+export {
+  printSchema,
+  printIntrospectionSchema,
+} from './schemaPrinter';

--- a/src/tools/schemaPrinter.js
+++ b/src/tools/schemaPrinter.js
@@ -12,8 +12,8 @@ import invariant from '../utils/invariant';
 import isNullish from '../utils/isNullish';
 import astFromValue from '../utils/astFromValue';
 import { print } from '../language/printer';
-import type { GraphQLSchema } from './schema';
-import type { GraphQLNamedType } from './definition';
+import type { GraphQLSchema } from '../type/schema';
+import type { GraphQLNamedType } from '../type/definition';
 import {
   GraphQLScalarType,
   GraphQLObjectType,
@@ -21,7 +21,7 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-} from './definition';
+} from '../type/definition';
 
 
 export function printSchema(schema: GraphQLSchema): string {

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -29,9 +29,3 @@ export {
   GraphQLBoolean,
   GraphQLID
 } from './scalars';
-
-export {
-  printSchema,
-  printIntrospectionSchema,
-  printSchemaFromResult,
-} from './schemaPrinter';

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -85,7 +85,7 @@ type GraphQLSchemaConfig = {
   mutation?: ?GraphQLObjectType;
 }
 
-export function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
+function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   if (type instanceof GraphQLList || type instanceof GraphQLNonNull) {
     return typeMapReducer(map, type.ofType);
   }


### PR DESCRIPTION
These are all utilities that will be useful for building custom client tools.

This moves the client-side schema builders (from introspection and from DSL) along with the schema printer into the `graphql/tools` sub-module, and sets up an index export for these tools.

This also clarifies the `graphql/language/schema` sub-module's exports as only dealing with the language.

Finally, this makes some small improvements to leverage existing utility functions and remove async where it's not necessary.