### PR TITLE
Fixes issue #104 with buildASTSchema and Float fields

### DIFF
--- a/src/utilities/__tests__/buildASTSchema.js
+++ b/src/utilities/__tests__/buildASTSchema.js
@@ -32,6 +32,8 @@ describe('Schema Materializer', () => {
 type HelloScalars {
   str: String
   int: Int
+  float: Float
+  id: ID
   bool: Boolean
 }
 `;
@@ -85,6 +87,10 @@ type TypeTwo {
     var body = `
 type Hello {
   str(int: Int): String
+  floatToStr(float: Float): String
+  idToStr(id: ID): String
+  booleanToStr(bool: Boolean): String
+  strToStr(bool: String): String
 }
 `;
     var output = cycleOutput(body, 'Hello');

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -47,6 +47,7 @@ import {
   GraphQLInputObjectType,
   GraphQLString,
   GraphQLInt,
+  GraphQLFloat,
   GraphQLBoolean,
   GraphQLID,
   GraphQLList,
@@ -115,6 +116,7 @@ export function buildASTSchema(
     var innerTypeMap = {
       String: GraphQLString,
       Int: GraphQLInt,
+      Float: GraphQLFloat,
       Boolean: GraphQLBoolean,
       ID: GraphQLID,
     };


### PR DESCRIPTION
Fixes issue #104 and allows buildASTSchema to materialize a type with a Float field. Adds tests for Float and ID to 'Simple type' test and for Float, ID, Int and Boolean to 'Single argument field' test.