### PR TITLE
Ensure unreferenced types that implement reference interfaces are detected

### DIFF
--- a/src/utilities/__tests__/buildASTSchema.js
+++ b/src/utilities/__tests__/buildASTSchema.js
@@ -253,6 +253,40 @@ type Mutation {
     var output = cycleOutput(body, 'HelloScalars', 'Mutation');
     expect(output).to.equal(body);
   });
+
+  it('Unreferenced type implementing referenced interface', () => {
+    var body = `
+type Concrete implements Iface {
+  key: String
+}
+
+interface Iface {
+  key: String
+}
+
+type Query {
+  iface: Iface
+}
+`;
+    var output = cycleOutput(body, 'Query');
+    expect(output).to.equal(body);
+  });
+
+  it('Unreferenced type implementing referenced union', () => {
+    var body = `
+type Concrete {
+  key: String
+}
+
+type Query {
+  union: Union
+}
+
+union Union = Concrete
+`;
+    var output = cycleOutput(body, 'Query');
+    expect(output).to.equal(body);
+  });
 });
 
 describe('Schema Parser Failures', () => {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -136,6 +136,11 @@ export function buildASTSchema(
         throw new Error('Nothing constructed for ' + typeName);
       }
       innerTypeMap[typeName] = innerTypeDef;
+      if (astMap[typeName].kind === INTERFACE_DEFINITION) {
+        // Now that we've created and cached our interface, ensure
+        // we create all implementations to point to it.
+        makeInterfaceImplementations(astMap[typeName]);
+      }
       return buildWrappedType(innerTypeDef, typeAST);
     };
   }
@@ -209,6 +214,16 @@ export function buildASTSchema(
 
   function makeImplementedInterfaces(def: TypeDefinition) {
     return def.interfaces.map(inter => produceTypeDef(inter));
+  }
+
+  function makeInterfaceImplementations(inter: InterfaceDefinition) {
+    var interName = inter.name.value;
+    var types = ast.definitions.filter(def => def.kind === TYPE_DEFINITION);
+    var implementingTypes = types.filter(def => {
+      var names = def.interfaces.map(namedType => namedType.name.value);
+      return names.indexOf(interName) !== -1;
+    });
+    implementingTypes.forEach(produceTypeDef);
   }
 
   function makeInputValues(values: Array<InputValueDefinition>) {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -136,21 +136,17 @@ export function buildASTSchema(
         throw new Error('Nothing constructed for ' + typeName);
       }
       innerTypeMap[typeName] = innerTypeDef;
-      if (astMap[typeName].kind === INTERFACE_DEFINITION) {
-        // Now that we've created and cached our interface, ensure
-        // we create all implementations to point to it.
-        makeInterfaceImplementations(astMap[typeName]);
-      }
       return buildWrappedType(innerTypeDef, typeAST);
     };
   }
-
 
   var produceTypeDef = getTypeDefProducer(ast);
 
   if (isNullish(astMap[queryTypeName])) {
     throw new Error(`Type ${queryTypeName} not found in document`);
   }
+
+  ast.definitions.forEach(produceTypeDef);
 
   var queryType = produceTypeDef(astMap[queryTypeName]);
   var schema;
@@ -214,16 +210,6 @@ export function buildASTSchema(
 
   function makeImplementedInterfaces(def: TypeDefinition) {
     return def.interfaces.map(inter => produceTypeDef(inter));
-  }
-
-  function makeInterfaceImplementations(inter: InterfaceDefinition) {
-    var interName = inter.name.value;
-    var types = ast.definitions.filter(def => def.kind === TYPE_DEFINITION);
-    var implementingTypes = types.filter(def => {
-      var names = def.interfaces.map(namedType => namedType.name.value);
-      return names.indexOf(interName) !== -1;
-    });
-    implementingTypes.forEach(produceTypeDef);
   }
 
   function makeInputValues(values: Array<InputValueDefinition>) {


### PR DESCRIPTION
Ensures that if a type isn't referenced directly, but implements an interface that is references, that type is included in the schema, with a unit test to verify.