### PR TITLE
Add check for unknown mutation type

### DIFF
--- a/src/utilities/__tests__/buildASTSchema.js
+++ b/src/utilities/__tests__/buildASTSchema.js
@@ -320,7 +320,6 @@ type Hello { testUnion: TestUnion }
       .to.throw('Type Bar not found in document');
   });
 
-
   it('Unknown query type', () => {
     var body = `
 type Hello {
@@ -330,5 +329,16 @@ type Hello {
     var doc = parseSchemaIntoAST(body);
     expect(() => buildASTSchema(doc, 'Wat'))
       .to.throw('Specified query type Wat not found in document');
+  });
+
+  it('Unknown mutation type', () => {
+    var body = `
+type Hello {
+  str: String
+}
+`;
+    var doc = parseSchemaIntoAST(body);
+    expect(() => buildASTSchema(doc, 'Hello', 'Wat'))
+      .to.throw('Specified mutation type Wat not found in document');
   });
 });

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -105,6 +105,11 @@ export function buildASTSchema(
       ' not found in document.');
   }
 
+  if (!isNullish(mutationTypeName) && isNullish(astMap[mutationTypeName])) {
+    throw new Error('Specified mutation type ' + mutationTypeName +
+      ' not found in document.');
+  }
+
   /**
    * This generates a function that allows you to produce
    * type definitions on demand. We produce the function
@@ -141,10 +146,6 @@ export function buildASTSchema(
   }
 
   var produceTypeDef = getTypeDefProducer(ast);
-
-  if (isNullish(astMap[queryTypeName])) {
-    throw new Error(`Type ${queryTypeName} not found in document`);
-  }
 
   ast.definitions.forEach(produceTypeDef);
 


### PR DESCRIPTION
We weren't checking unknown mutation types (and we were double checking unknown query types).