### PR TITLE
Add parseVariable and move from coerce terminology

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -451,7 +451,7 @@ function getFieldEntryKey(node: Field): string {
 /**
  * Resolves the field on the given source object. In particular, this
  * figures out the value that the field returns by calling its resolve function,
- * then calls completeValue to complete promises, coerce scalars, or execute
+ * then calls completeValue to complete promises, serialize scalars, or execute
  * the sub-selection-set for objects.
  */
 function resolveField(
@@ -547,7 +547,8 @@ function completeValueCatchingError(
  * for the inner type on each item in the list.
  *
  * If the field type is a Scalar or Enum, ensures the completed value is a legal
- * value of the type by calling the `coerce` method of GraphQL type definition.
+ * value of the type by calling the `serialize` method of GraphQL type
+ * definition.
  *
  * Otherwise, the field type expects a sub-selection set, and will complete the
  * value by evaluating all sub-selections.
@@ -613,13 +614,13 @@ function completeValue(
     return containsPromise ? Promise.all(completedResults) : completedResults;
   }
 
-  // If field type is Scalar or Enum, coerce to a valid value, returning null
-  // if coercion is not possible.
+  // If field type is Scalar or Enum, serialize to a valid value, returning
+  // null if serialization is not possible.
   if (fieldType instanceof GraphQLScalarType ||
       fieldType instanceof GraphQLEnumType) {
-    invariant(fieldType.coerce, 'Missing coerce method on type');
-    var coercedResult = fieldType.coerce(result);
-    return isNullish(coercedResult) ? null : coercedResult;
+    invariant(fieldType.serialize, 'Missing serialize method on type');
+    var serializedResult = fieldType.serialize(result);
+    return isNullish(serializedResult) ? null : serializedResult;
   }
 
   // Field type must be Object, Interface or Union and expect sub-selections.

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -31,7 +31,7 @@ import type { Argument, VariableDefinition } from '../language/ast';
 
 /**
  * Prepares an object map of variables of the correct type based on the provided
- * variable definitions and arbitrary input. If the input cannot be coerced
+ * variable definitions and arbitrary input. If the input cannot be parsed
  * to match the variable definitions, a GraphQLError will be thrown.
  */
 export function getVariableValues(
@@ -142,8 +142,8 @@ function coerceValue(type: GraphQLInputType, value: any): any {
     'Must be input type'
   );
 
-  var coerced = type.coerce(value);
-  if (!isNullish(coerced)) {
-    return coerced;
+  var parsed = type.parseVariable(value);
+  if (!isNullish(parsed)) {
+    return parsed;
   }
 }

--- a/src/type/__tests__/serialization.js
+++ b/src/type/__tests__/serialization.js
@@ -19,125 +19,125 @@ import { expect } from 'chai';
 
 
 describe('Type System: Scalar coercion', () => {
-  it('coerces output int', () => {
+  it('serializes output int', () => {
     expect(
-      GraphQLInt.coerce(1)
+      GraphQLInt.serialize(1)
     ).to.equal(1);
     expect(
-      GraphQLInt.coerce(0)
+      GraphQLInt.serialize(0)
     ).to.equal(0);
     expect(
-      GraphQLInt.coerce(-1)
+      GraphQLInt.serialize(-1)
     ).to.equal(-1);
     expect(
-      GraphQLInt.coerce(0.1)
+      GraphQLInt.serialize(0.1)
     ).to.equal(0);
     expect(
-      GraphQLInt.coerce(1.1)
+      GraphQLInt.serialize(1.1)
     ).to.equal(1);
     expect(
-      GraphQLInt.coerce(-1.1)
+      GraphQLInt.serialize(-1.1)
     ).to.equal(-1);
     expect(
-      GraphQLInt.coerce(1e5)
+      GraphQLInt.serialize(1e5)
     ).to.equal(100000);
     // Bigger than 2^32, but still representable as an Int
     expect(
-      GraphQLInt.coerce(9876504321)
+      GraphQLInt.serialize(9876504321)
     ).to.equal(9876504321);
     expect(
-      GraphQLInt.coerce(-9876504321)
+      GraphQLInt.serialize(-9876504321)
     ).to.equal(-9876504321);
     // Too big to represent as an Int
     expect(
-      GraphQLInt.coerce(1e100)
+      GraphQLInt.serialize(1e100)
     ).to.equal(null);
     expect(
-      GraphQLInt.coerce(-1e100)
+      GraphQLInt.serialize(-1e100)
     ).to.equal(null);
     expect(
-      GraphQLInt.coerce('-1.1')
+      GraphQLInt.serialize('-1.1')
     ).to.equal(-1);
     expect(
-      GraphQLInt.coerce('one')
+      GraphQLInt.serialize('one')
     ).to.equal(null);
     expect(
-      GraphQLInt.coerce(false)
+      GraphQLInt.serialize(false)
     ).to.equal(0);
     expect(
-      GraphQLInt.coerce(true)
+      GraphQLInt.serialize(true)
     ).to.equal(1);
   });
 
-  it('coerces output float', () => {
+  it('serializes output float', () => {
     expect(
-      GraphQLFloat.coerce(1)
+      GraphQLFloat.serialize(1)
     ).to.equal(1.0);
     expect(
-      GraphQLFloat.coerce(0)
+      GraphQLFloat.serialize(0)
     ).to.equal(0.0);
     expect(
-      GraphQLFloat.coerce(-1)
+      GraphQLFloat.serialize(-1)
     ).to.equal(-1.0);
     expect(
-      GraphQLFloat.coerce(0.1)
+      GraphQLFloat.serialize(0.1)
     ).to.equal(0.1);
     expect(
-      GraphQLFloat.coerce(1.1)
+      GraphQLFloat.serialize(1.1)
     ).to.equal(1.1);
     expect(
-      GraphQLFloat.coerce(-1.1)
+      GraphQLFloat.serialize(-1.1)
     ).to.equal(-1.1);
     expect(
-      GraphQLFloat.coerce('-1.1')
+      GraphQLFloat.serialize('-1.1')
     ).to.equal(-1.1);
     expect(
-      GraphQLFloat.coerce('one')
+      GraphQLFloat.serialize('one')
     ).to.equal(null);
     expect(
-      GraphQLFloat.coerce(false)
+      GraphQLFloat.serialize(false)
     ).to.equal(0.0);
     expect(
-      GraphQLFloat.coerce(true)
+      GraphQLFloat.serialize(true)
     ).to.equal(1.0);
   });
 
-  it('coerces output strings', () => {
+  it('serializes output strings', () => {
     expect(
-      GraphQLString.coerce('string')
+      GraphQLString.serialize('string')
     ).to.equal('string');
     expect(
-      GraphQLString.coerce(1)
+      GraphQLString.serialize(1)
     ).to.equal('1');
     expect(
-      GraphQLString.coerce(-1.1)
+      GraphQLString.serialize(-1.1)
     ).to.equal('-1.1');
     expect(
-      GraphQLString.coerce(true)
+      GraphQLString.serialize(true)
     ).to.equal('true');
     expect(
-      GraphQLString.coerce(false)
+      GraphQLString.serialize(false)
     ).to.equal('false');
   });
 
-  it('coerces output boolean', () => {
+  it('serializes output boolean', () => {
     expect(
-      GraphQLBoolean.coerce('string')
+      GraphQLBoolean.serialize('string')
     ).to.equal(true);
     expect(
-      GraphQLBoolean.coerce('')
+      GraphQLBoolean.serialize('')
     ).to.equal(false);
     expect(
-      GraphQLBoolean.coerce(1)
+      GraphQLBoolean.serialize(1)
     ).to.equal(true);
     expect(
-      GraphQLBoolean.coerce(0)
+      GraphQLBoolean.serialize(0)
     ).to.equal(false);
     expect(
-      GraphQLBoolean.coerce(true)
+      GraphQLBoolean.serialize(true)
     ).to.equal(true);
     expect(
-      GraphQLBoolean.coerce(false)
+      GraphQLBoolean.serialize(false)
     ).to.equal(false);
   });
 });

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -17,16 +17,21 @@ import { Kind } from '../language';
 var MAX_INT = 9007199254740991;
 var MIN_INT = -9007199254740991;
 
+function coerceInt(value) {
+  var num = Number(value);
+  if (num === num && num <= MAX_INT && num >= MIN_INT) {
+    return (num < 0 ? Math.ceil : Math.floor)(num);
+  }
+  return null;
+
+}
+
 export var GraphQLInt = new GraphQLScalarType({
   name: 'Int',
-  coerce(value) {
-    var num = Number(value);
-    if (num === num && num <= MAX_INT && num >= MIN_INT) {
-      return (num < 0 ? Math.ceil : Math.floor)(num);
-    }
-    return null;
+  serialize(value) {
+    return coerceInt(value);
   },
-  coerceLiteral(ast) {
+  parseLiteral(ast) {
     if (ast.kind === Kind.INT) {
       var num = parseInt(ast.value, 10);
       if (num <= MAX_INT && num >= MIN_INT) {
@@ -34,44 +39,57 @@ export var GraphQLInt = new GraphQLScalarType({
       }
     }
     return null;
+  },
+  parseVariable(value) {
+    return coerceInt(value);
   }
 });
 
+function coerceFloat(value) {
+  var num = Number(value);
+  return num === num ? num : null;
+}
+
 export var GraphQLFloat = new GraphQLScalarType({
   name: 'Float',
-  coerce(value) {
-    var num = Number(value);
-    return num === num ? num : null;
+  serialize(value) {
+    return coerceFloat(value);
   },
-  coerceLiteral(ast) {
+  parseLiteral(ast) {
     return ast.kind === Kind.FLOAT || ast.kind === Kind.INT ?
       parseFloat(ast.value) :
       null;
+  },
+  parseVariable(value) {
+    return coerceFloat(value);
   }
 });
 
 export var GraphQLString = new GraphQLScalarType({
   name: 'String',
-  coerce: value => String(value),
-  coerceLiteral(ast) {
+  serialize: value => String(value),
+  parseLiteral(ast) {
     return ast.kind === Kind.STRING ? ast.value : null;
-  }
+  },
+  parseVariable: value => String(value),
 });
 
 export var GraphQLBoolean = new GraphQLScalarType({
   name: 'Boolean',
-  coerce: value => Boolean(value),
-  coerceLiteral(ast) {
+  serialize: value => Boolean(value),
+  parseLiteral(ast) {
     return ast.kind === Kind.BOOLEAN ? ast.value : null;
-  }
+  },
+  parseVariable: value => Boolean(value),
 });
 
 export var GraphQLID = new GraphQLScalarType({
   name: 'ID',
-  coerce: value => String(value),
-  coerceLiteral(ast) {
+  serialize: value => String(value),
+  parseLiteral(ast) {
     return ast.kind === Kind.STRING || ast.kind === Kind.INT ?
       ast.value :
       null;
-  }
+  },
+  parseVariable: value => String(value),
 });

--- a/src/utilities/__tests__/schemaPrinter.js
+++ b/src/utilities/__tests__/schemaPrinter.js
@@ -437,7 +437,7 @@ type Root {
   it('Custom Scalar', () => {
     var OddType = new GraphQLScalarType({
       name: 'Odd',
-      coerce(value) {
+      serialize(value) {
         return value % 2 === 1 ? value : null;
       }
     });

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -66,8 +66,8 @@ import type {
  * Given the result of a client running the introspection query, creates and
  * returns a GraphQLSchema instance which can be then used with all graphql-js
  * tools, but cannot be used to execute a query, as introspection does not
- * represent the "resolver" or "coerce" functions or any other server-internal
- * mechanisms.
+ * represent the "resolver", "parse" or "serialize" functions or any other
+ * server-internal mechanisms.
  */
 export function buildClientSchema(
   introspection: IntrospectionQuery
@@ -200,12 +200,13 @@ export function buildClientSchema(
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
-      // Note: validation calls the coerce functions to determine if a
+      // Note: validation calls the serialize functions to determine if a
       // query value is correct. Returning null would cause use of custom
       // scalars to always fail validation. Returning false causes them to
       // always pass validation.
-      coerce: () => false,
-      coerceLiteral: () => false,
+      serialize: () => false,
+      parseLiteral: () => false,
+      parseVariable: () => false,
     });
   }
 

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -71,7 +71,7 @@ export function isValidJSValue(value: any, type: GraphQLInputType): boolean {
     'Must be input type'
   );
 
-  // Scalar/Enum input checks to ensure the type can coerce the value to
+  // Scalar/Enum input checks to ensure the type can parse the value to
   // a non-null value.
-  return !isNullish(type.coerce(value));
+  return !isNullish(type.parseVariable(value));
 }

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -94,7 +94,7 @@ export function isValidLiteralValue(
     'Must be input type'
   );
 
-  // Scalar/Enum input checks to ensure the type can coerce the value to
+  // Scalar/Enum input checks to ensure the type can parse the value to
   // a non-null value.
-  return !isNullish(type.coerceLiteral(valueAST));
+  return !isNullish(type.parseLiteral(valueAST));
 }

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -105,8 +105,8 @@ export function valueFromAST(
     'Must be input type'
   );
 
-  var coerced = type.coerceLiteral(valueAST);
-  if (!isNullish(coerced)) {
-    return coerced;
+  var parsed = type.parseLiteral(valueAST);
+  if (!isNullish(parsed)) {
+    return parsed;
   }
 }


### PR DESCRIPTION
* Add parseVariable to scalar, to separate parsing of values from
  their serialization
* Rename coerce to serialize and coerceLiteral to parseLiteral

As per #115. I am not 100% sure anymore about terminology change, needs more discussion.