### PR TITLE
Fix some input objects missing from the type map

### DIFF
--- a/src/type/__tests__/definition.js
+++ b/src/type/__tests__/definition.js
@@ -140,6 +140,31 @@ describe('Type System: Example', () => {
 
   });
 
+  it('includes nested input objects in the map', () => {
+    var NestedInputObject = new GraphQLInputObjectType({
+      name: 'NestedInputObject',
+      fields: { value: { type: GraphQLString } }
+    });
+    var SomeInputObject = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: { nested: { type: NestedInputObject } }
+    });
+    var SomeMutation = new GraphQLObjectType({
+      name: 'SomeMutation',
+      fields: {
+        mutateSomething: {
+          type: BlogArticle,
+          args: { input: { type: SomeInputObject } }
+        }
+      }
+    });
+    var schema = new GraphQLSchema({
+      query: BlogQuery,
+      mutation: SomeMutation,
+    });
+    expect(schema.getTypeMap().NestedInputObject).to.equal(NestedInputObject);
+  });
+
   it('includes interfaces\' subtypes in the type map', () => {
     var SomeInterface = new GraphQLInterfaceType({
       name: 'SomeInterface',

--- a/src/type/__tests__/validator.js
+++ b/src/type/__tests__/validator.js
@@ -218,13 +218,15 @@ describe('Rule: NoOutputTypesAsInputArgs', () => {
 
   it('accepts a schema with a list of input type as an input field arg', () => {
     testAcceptingFieldArgOfType(new GraphQLList(new GraphQLInputObjectType({
-      name: 'SomeInputType'
+      name: 'SomeInputType',
+      fields: {}
     })));
   });
 
   it('accepts a schema with a nonnull input type as an input field arg', () => {
     testAcceptingFieldArgOfType(new GraphQLNonNull(new GraphQLInputObjectType({
-      name: 'SomeInputType'
+      name: 'SomeInputType',
+      fields: {}
     })));
   });
 });

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -10,6 +10,7 @@
 
 import {
   GraphQLObjectType,
+  GraphQLInputObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLList,
@@ -106,12 +107,15 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   }
 
   if (type instanceof GraphQLObjectType ||
-      type instanceof GraphQLInterfaceType) {
+      type instanceof GraphQLInterfaceType ||
+      type instanceof GraphQLInputObjectType) {
     var fieldMap = type.getFields();
     Object.keys(fieldMap).forEach(fieldName => {
       var field = fieldMap[fieldName];
-      var fieldArgTypes = field.args.map(arg => arg.type);
-      reducedMap = fieldArgTypes.reduce(typeMapReducer, reducedMap);
+      if (field.args) {
+        var fieldArgTypes = field.args.map(arg => arg.type);
+        reducedMap = fieldArgTypes.reduce(typeMapReducer, reducedMap);
+      }
       reducedMap = typeMapReducer(reducedMap, field.type);
     });
   }


### PR DESCRIPTION
Input object types were not included in the type map when they were used as a field type in other input objects, because `typeMapReducer` did not recurse into those fields.

Modify `typeMapReducer` to also handle GraphQLInputObjectType and add a test case that checks also nested input object types are handled.