### PR TITLE
[RFC] Do not format errors from graphql()

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -12,8 +12,7 @@ import { Source } from './language/source';
 import { parse } from './language/parser';
 import { validate } from './validation/validate';
 import { execute } from './execution/execute';
-import { formatError } from './error';
-import type { GraphQLFormattedError } from './error/formatError';
+import type { GraphQLError } from './error/GraphQLError';
 import type { GraphQLSchema } from './type/schema';
 
 
@@ -38,9 +37,7 @@ export function graphql(
     var documentAST = parse(source);
     var validationErrors = validate(schema, documentAST);
     if (validationErrors.length > 0) {
-      resolve({
-        errors: validationErrors.map(formatError)
-      });
+      resolve({ errors: validationErrors });
     } else {
       resolve(
         execute(
@@ -49,19 +46,11 @@ export function graphql(
           rootValue,
           variableValues,
           operationName
-        ).then(result => {
-          if (result.errors) {
-            return {
-              data: result.data,
-              errors: result.errors.map(formatError)
-            };
-          }
-          return result;
-        })
+        )
       );
     }
   }).catch(error => {
-    return { errors: [ formatError(error) ] };
+    return { errors: [ error ] };
   });
 }
 
@@ -73,5 +62,5 @@ export function graphql(
  */
 type GraphQLResult = {
   data?: ?Object;
-  errors?: Array<GraphQLFormattedError>;
+  errors?: Array<GraphQLError>;
 }

--- a/src/type/__tests__/introspection.js
+++ b/src/type/__tests__/introspection.js
@@ -1135,7 +1135,7 @@ describe('Introspection', () => {
 
     return expect(
       await graphql(schema, request)
-    ).to.deep.equal({
+    ).to.containSubset({
       errors: [
         { message: missingFieldArgMessage('__type', 'name', 'String!'),
           locations: [ { line: 3, column: 9 } ] }

--- a/src/utilities/__tests__/buildClientSchema.js
+++ b/src/utilities/__tests__/buildClientSchema.js
@@ -501,7 +501,7 @@ describe('Type System: build schema from introspection', () => {
       { foo: 'bar' },
       { v: 'baz' }
     );
-    expect(result).to.deep.equal({
+    expect(result).to.containSubset({
       data: {
         foo: null,
       },


### PR DESCRIPTION
This changes the implementation of `graphql()` to not format any returned errors. Most importantly, this allows access to the `stack` property of each error, along with richer information contained in GraphQLError like the affected AST nodes and source document.

This means that the responsibility for formatting errors must be handled elsewhere, likely by an HTTP service like `express-graphql`.