### PR TITLE
[RFC] Expose more information to field resolver functions.

### DIFF
--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -52,11 +52,11 @@ export function getVariableValues(
  * definitions and list of argument AST nodes.
  */
 export function getArgumentValues(
-  argDefs: Array<GraphQLArgument>,
+  argDefs: ?Array<GraphQLArgument>,
   argASTs: ?Array<Argument>,
   variables: { [key: string]: any }
 ): { [key: string]: any } {
-  if (!argASTs) {
+  if (!argDefs || !argASTs) {
     return {};
   }
   var argASTMap = keyMap(argASTs, arg => arg.name.value);

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -10,7 +10,12 @@
 
 import invariant from '../jsutils/invariant';
 import { ENUM } from '../language/kinds';
-import type { Value } from '../language/ast';
+import type {
+  OperationDefinition,
+  Field,
+  FragmentDefinition,
+  Value,
+} from '../language/ast';
 import type { GraphQLSchema } from './schema';
 
 
@@ -350,18 +355,28 @@ type GraphQLInterfacesThunk = () => Array<GraphQLInterfaceType>;
 
 type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 
+export type GraphQLFieldResolveFn = (
+  source?: any,
+  args?: {[argName: string]: any},
+  info?: GraphQLFieldExeInfo
+) => any
+
+export type GraphQLFieldExeInfo = {
+  fieldName: string,
+  fieldASTs: Array<Field>,
+  returnType: GraphQLOutputType,
+  parentType: GraphQLCompositeType,
+  schema: GraphQLSchema,
+  fragments: { [fragmentName: string]: FragmentDefinition },
+  rootValue: any,
+  operation: OperationDefinition,
+  variables: { [variableName: string]: any },
+}
+
 export type GraphQLFieldConfig = {
   type: GraphQLOutputType;
   args?: GraphQLFieldConfigArgumentMap;
-    resolve?: (
-    source?: any,
-    args?: ?{[argName: string]: any},
-    context?: any,
-    fieldAST?: any,
-    fieldType?: any,
-    parentType?: any,
-    schema?: GraphQLSchema
-  ) => any;
+  resolve?: GraphQLFieldResolveFn;
   deprecationReason?: string;
   description?: ?string;
 }
@@ -384,15 +399,7 @@ export type GraphQLFieldDefinition = {
   description: ?string;
   type: GraphQLOutputType;
   args: Array<GraphQLArgument>;
-  resolve?: (
-    source?: any,
-    args?: ?{[argName: string]: any},
-    context?: any,
-    fieldAST?: any,
-    fieldType?: any,
-    parentType?: any,
-    schema?: GraphQLSchema
-  ) => any;
+  resolve?: GraphQLFieldResolveFn;
   deprecationReason?: ?string;
 }
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -288,15 +288,7 @@ export var SchemaMetaFieldDef: GraphQLFieldDefinition = {
   type: new GraphQLNonNull(__Schema),
   description: 'Access the current type schema of this server.',
   args: [],
-  resolve: (
-    source,
-    args,
-    root,
-    fieldAST,
-    fieldType,
-    parentType,
-    schema
-  ) => schema
+  resolve: (source, args, { schema }) => schema
 };
 
 export var TypeMetaFieldDef: GraphQLFieldDefinition = {
@@ -306,15 +298,7 @@ export var TypeMetaFieldDef: GraphQLFieldDefinition = {
   args: [
     { name: 'name', type: new GraphQLNonNull(GraphQLString) }
   ],
-  resolve: (
-    source,
-    { name },
-    root,
-    fieldAST,
-    fieldType,
-    parentType,
-    schema
-  ) => schema.getType(name)
+  resolve: (source, { name }, { schema }) => schema.getType(name)
 };
 
 export var TypeNameMetaFieldDef: GraphQLFieldDefinition = {
@@ -322,12 +306,5 @@ export var TypeNameMetaFieldDef: GraphQLFieldDefinition = {
   type: new GraphQLNonNull(GraphQLString),
   description: 'The name of the current Object type at runtime.',
   args: [],
-  resolve: (
-    source,
-    args,
-    root,
-    fieldAST,
-    fieldType,
-    parentType
-  ) => parentType.name
+  resolve: (source, args, { parentType }) => parentType.name
 };


### PR DESCRIPTION
This exposes more info to field resolvers, but reduces the arity of these functions to a fixed 3 arguments: source, arguments, execution info.

This along with ES6 argument destructuring makes accessing this information more natural.