### PR TITLE
Improve error message on null-values for non-nullable fields

### DIFF
--- a/src/execution/__tests__/lists.js
+++ b/src/execution/__tests__/lists.js
@@ -162,7 +162,7 @@ describe('Execute: Handles list nullability', () => {
         null,
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -185,7 +185,7 @@ describe('Execute: Handles list nullability', () => {
         resolved(null),
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -240,7 +240,7 @@ describe('Execute: Handles list nullability', () => {
         [ 1, null, 2 ],
         { data: { nest: { test: null } },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -263,7 +263,7 @@ describe('Execute: Handles list nullability', () => {
         resolved([ 1, null, 2 ]),
         { data: { nest: { test: null } },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -295,7 +295,7 @@ describe('Execute: Handles list nullability', () => {
         [ resolved(1), resolved(null), resolved(2) ],
         { data: { nest: { test: null } },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -329,7 +329,7 @@ describe('Execute: Handles list nullability', () => {
         [ 1, null, 2 ],
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -338,7 +338,7 @@ describe('Execute: Handles list nullability', () => {
         null,
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -356,7 +356,7 @@ describe('Execute: Handles list nullability', () => {
         resolved([ 1, null, 2 ]),
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -365,7 +365,7 @@ describe('Execute: Handles list nullability', () => {
         resolved(null),
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));
@@ -392,7 +392,7 @@ describe('Execute: Handles list nullability', () => {
         [ resolved(1), resolved(null), resolved(2) ],
         { data: { nest: null },
           errors: [
-            { message: 'Cannot return null for non-nullable type.',
+            { message: 'Cannot return null for non-nullable field "test" of type "DataType".',
               locations: [ { line: 1, column: 10 } ] }
           ] }
       ));

--- a/src/execution/__tests__/nonnull.js
+++ b/src/execution/__tests__/nonnull.js
@@ -500,7 +500,7 @@ describe('Execute: handles non-nullable types', () => {
         nest: null
       },
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullSync" of type "DataType".',
           locations: [ { line: 4, column: 11 } ] }
       ]
     };
@@ -526,7 +526,7 @@ describe('Execute: handles non-nullable types', () => {
         nest: null
       },
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullPromise" of type "DataType".',
           locations: [ { line: 4, column: 11 } ] }
       ]
     };
@@ -552,7 +552,7 @@ describe('Execute: handles non-nullable types', () => {
         promiseNest: null
       },
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullSync" of type "DataType".',
           locations: [ { line: 4, column: 11 } ] }
       ]
     };
@@ -578,7 +578,7 @@ describe('Execute: handles non-nullable types', () => {
         promiseNest: null
       },
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullPromise" of type "DataType".',
           locations: [ { line: 4, column: 11 } ] }
       ]
     };
@@ -714,13 +714,13 @@ describe('Execute: handles non-nullable types', () => {
         anotherPromiseNest: null
       },
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullSync" of type "DataType".',
           locations: [ { line: 8, column: 19 } ] },
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullSync" of type "DataType".',
           locations: [ { line: 19, column: 19 } ] },
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullPromise" of type "DataType".',
           locations: [ { line: 30, column: 19 } ] },
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullPromise" of type "DataType".',
           locations: [ { line: 41, column: 19 } ] }
       ]
     };
@@ -774,7 +774,7 @@ describe('Execute: handles non-nullable types', () => {
     var expected = {
       data: null,
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullSync" of type "DataType".',
           locations: [ { line: 2, column: 17 } ] }
       ]
     };
@@ -792,7 +792,7 @@ describe('Execute: handles non-nullable types', () => {
     var expected = {
       data: null,
       errors: [
-        { message: 'Cannot return null for non-nullable type.',
+        { message: 'Cannot return null for non-nullable field "nonNullPromise" of type "DataType".',
           locations: [ { line: 2, column: 17 } ] }
       ]
     };

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -614,7 +614,8 @@ function completeValue(
     );
     if (completed === null) {
       throw new GraphQLError(
-        'Cannot return null for non-nullable type.',
+        `Cannot return null for non-nullable field "${info.fieldName}" ` +
+        `of type "${info.parentType.name}".`,
         fieldASTs
       );
     }


### PR DESCRIPTION
I was implementing a GraphQL schema today and encountered this error: `Cannot return null for non-nullable type.`

I thought it left something to be desired in terms of figuring out which field/type was causing this issue. This PR adds a more descriptive error message, including the field name and parent type name to make this easier to track down.

Let me know if this needs any changes.
