### PR TITLE
[RFC] schema enforced interface adherance.

### DIFF
--- a/src/type/__tests__/validation.js
+++ b/src/type/__tests__/validation.js
@@ -1175,3 +1175,288 @@ describe('Type System: NonNull must accept GraphQL types', () => {
   });
 
 });
+
+
+describe('Objects must adhere to Interface they implement', () => {
+
+  it('accepts an Object which implements an Interface', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString }
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString }
+            }
+          }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).not.to.throw();
+  });
+
+  it('accepts an Object which implements an Interface along with more fields', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          },
+          anotherfield: { type: GraphQLString }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).not.to.throw();
+  });
+
+  it('rejects an Object which implements an Interface field along with more arguments', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+              anotherInput: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).to.throw(
+      'AnotherInterface.field does not define argument "anotherInput" but ' +
+      'AnotherObject.field provides it.'
+    );
+  });
+
+  it('rejects an Object missing an Interface field', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          anotherfield: { type: GraphQLString }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).to.throw(
+      '"AnotherInterface" expects field "field" but ' +
+      '"AnotherObject" does not provide it.'
+    );
+  });
+
+  it('rejects an Object with an incorrectly typed Interface field', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: {
+            type: SomeScalarType,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).to.throw(
+      'AnotherInterface.field expects type "String" but ' +
+      'AnotherObject.field provides type "SomeScalar".'
+    );
+  });
+
+  it('rejects an Object missing an Interface argument', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: {
+            type: GraphQLString,
+          }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).to.throw(
+      'AnotherInterface.field expects argument "input" but ' +
+      'AnotherObject.field does not provide it.'
+    );
+  });
+
+  it('rejects an Object with an incorrectly typed Interface argument', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: GraphQLString },
+            }
+          }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              input: { type: SomeScalarType },
+            }
+          }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).to.throw(
+      'AnotherInterface.field(input:) expects type "String" but ' +
+      'AnotherObject.field(input:) provides type "SomeScalar".'
+    );
+  });
+
+  it('accepts an Object with an equivalently modified Interface field type', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).not.to.throw();
+  });
+
+  it('rejects an Object with a differently modified Interface field type', () => {
+    expect(() => {
+      var AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: {
+          field: { type: GraphQLString }
+        }
+      });
+
+      var AnotherObject = new GraphQLObjectType({
+        name: 'AnotherObject',
+        interfaces: [ AnotherInterface ],
+        fields: {
+          field: { type: new GraphQLNonNull(GraphQLString) }
+        }
+      });
+
+      return schemaWithFieldType(AnotherObject);
+    }).to.throw(
+      'AnotherInterface.field expects type "String" but ' +
+      'AnotherObject.field provides type "String!".'
+    );
+  });
+
+});

--- a/src/validation/__tests__/KnownArgumentNames.js
+++ b/src/validation/__tests__/KnownArgumentNames.js
@@ -148,21 +148,4 @@ describe('Validate: Known argument names', () => {
     ]);
   });
 
-  it('args may be on object but not interface', () => {
-    expectFailsRule(KnownArgumentNames, `
-      fragment nameSometimesHasArg on Being {
-        name(surname: true)
-        ... on Human {
-          name(surname: true)
-        }
-        ... on Dog {
-          name(surname: true)
-        }
-      }
-    `, [
-      unknownArg('surname', 'name', 'Being', 3, 14),
-      unknownArg('surname', 'name', 'Dog', 8, 16)
-    ]);
-  });
-
 });

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -31,14 +31,20 @@ import {
 var Being = new GraphQLInterfaceType({
   name: 'Being',
   fields: () => ({
-    name: { type: GraphQLString }
+    name: {
+      type: GraphQLString,
+      args: { surname: { type: GraphQLBoolean } },
+    }
   }),
 });
 
 var Pet = new GraphQLInterfaceType({
   name: 'Pet',
   fields: () => ({
-    name: { type: GraphQLString }
+    name: {
+      type: GraphQLString,
+      args: { surname: { type: GraphQLBoolean } },
+    }
   }),
 });
 
@@ -55,7 +61,10 @@ var Dog = new GraphQLObjectType({
   name: 'Dog',
   isTypeOf: () => true,
   fields: () => ({
-    name: { type: GraphQLString },
+    name: {
+      type: GraphQLString,
+      args: { surname: { type: GraphQLBoolean } },
+    },
     nickname: { type: GraphQLString },
     barkVolume: { type: GraphQLInt },
     barks: { type: GraphQLBoolean },
@@ -86,7 +95,10 @@ var Cat = new GraphQLObjectType({
   name: 'Cat',
   isTypeOf: () => true,
   fields: () => ({
-    name: { type: GraphQLString },
+    name: {
+      type: GraphQLString,
+      args: { surname: { type: GraphQLBoolean } },
+    },
     nickname: { type: GraphQLString },
     meows: { type: GraphQLBoolean },
     meowVolume: { type: GraphQLInt },
@@ -116,8 +128,8 @@ var Human = new GraphQLObjectType({
   interfaces: [ Being, Intelligent ],
   fields: () => ({
     name: {
+      type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
-      type: GraphQLString
     },
     pets: { type: new GraphQLList(Pet) },
     relatives: { type: new GraphQLList(Human) },
@@ -131,6 +143,10 @@ var Alien = new GraphQLObjectType({
   interfaces: [ Being, Intelligent ],
   fields: {
     iq: { type: GraphQLInt },
+    name: {
+      type: GraphQLString,
+      args: { surname: { type: GraphQLBoolean } },
+    },
     numEyes: { type: GraphQLInt },
   }
 });


### PR DESCRIPTION
This adds an invariant step in the Schema ctor for enforcing that all Object types in the Schema properly adhere to the Interface types they claim to implement.

This effectively implements http://facebook.github.io/graphql/#sec-Object-type-validation