### PR TITLE
Do not mutate passed field map in ObjectType and ObjectInput

### DIFF
--- a/src/type/__tests__/definition.js
+++ b/src/type/__tests__/definition.js
@@ -310,4 +310,69 @@ describe('Type System: Example', () => {
       );
     });
   });
+
+  it('does not mutate passed field definitions', () => {
+    const fields = {
+      field1: {
+        type: GraphQLString,
+      },
+      field2: {
+        type: GraphQLString,
+        args: {
+          id: {
+            type: GraphQLString
+          }
+        }
+      }
+    };
+    const testObject1 = new GraphQLObjectType({
+      name: 'Test1',
+      fields,
+    });
+    const testObject2 = new GraphQLObjectType({
+      name: 'Test2',
+      fields,
+    });
+
+    expect(testObject1.getFields()).to.deep.equal(testObject2.getFields());
+    expect(fields).to.deep.equal({
+      field1: {
+        type: GraphQLString,
+      },
+      field2: {
+        type: GraphQLString,
+        args: {
+          id: {
+            type: GraphQLString
+          }
+        }
+      }
+    });
+
+    const testInputObject1 = new GraphQLInputObjectType({
+      name: 'Test1',
+      fields
+    });
+    const testInputObject2 = new GraphQLInputObjectType({
+      name: 'Test2',
+      fields
+    });
+
+    expect(testInputObject1.getFields()).to.deep.equal(
+      testInputObject2.getFields()
+    );
+    expect(fields).to.deep.equal({
+      field1: {
+        type: GraphQLString,
+      },
+      field2: {
+        type: GraphQLString,
+        args: {
+          id: {
+            type: GraphQLString
+          }
+        }
+      }
+    });
+  });
 });

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -371,15 +371,20 @@ function defineFieldMap(
     `${type} fields must be an object with field names as keys or a ` +
     `function which returns such an object.`
   );
+
   var fieldNames = Object.keys(fieldMap);
   invariant(
     fieldNames.length > 0,
     `${type} fields must be an object with field names as keys or a ` +
     `function which returns such an object.`
   );
+
+  var resultFieldMap = {};
   fieldNames.forEach(fieldName => {
-    var field = fieldMap[fieldName];
-    field.name = fieldName;
+    var field = {
+      ...fieldMap[fieldName],
+      name: fieldName
+    };
     invariant(
       isOutputType(field.type),
       `${type}.${fieldName} field type must be Output Type but ` +
@@ -408,8 +413,9 @@ function defineFieldMap(
         };
       });
     }
+    resultFieldMap[fieldName] = field;
   });
-  return fieldMap;
+  return resultFieldMap;
 }
 
 function isPlainObj(obj) {
@@ -897,16 +903,20 @@ export class GraphQLInputObjectType {
       `${this} fields must be an object with field names as keys or a ` +
       `function which returns such an object.`
     );
+    var resultFieldMap = {};
     fieldNames.forEach(fieldName => {
-      var field = fieldMap[fieldName];
-      field.name = fieldName;
+      var field = {
+        ...fieldMap[fieldName],
+        name: fieldName
+      };
       invariant(
         isInputType(field.type),
         `${this}.${fieldName} field type must be Input Type but ` +
         `got: ${field.type}.`
       );
+      resultFieldMap[fieldName] = field;
     });
-    return fieldMap;
+    return resultFieldMap;
   }
 
   toString(): string {


### PR DESCRIPTION
Types used to mutate the fields passed to it, which can be very confusing and prevents reuse (parts) of field definitions between multiple types. Changed it so that fields is first shallow copied and new object is returned as a field map.