### PR TITLE
Use Math.trunc for Int coercion

### DIFF
--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -20,10 +20,9 @@ var MIN_INT = -9007199254740991;
 function coerceInt(value) {
   var num = Number(value);
   if (num === num && num <= MAX_INT && num >= MIN_INT) {
-    return (num < 0 ? Math.ceil : Math.floor)(num);
+    return Math.trunc(num);
   }
   return null;
-
 }
 
 export var GraphQLInt = new GraphQLScalarType({


### PR DESCRIPTION
ES6 support truncate without polyfilling:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc