### PR TITLE
Check for valid field arg names

### DIFF
--- a/src/type/__tests__/validation.js
+++ b/src/type/__tests__/validation.js
@@ -353,6 +353,47 @@ describe('Type System: Objects must have fields', () => {
 });
 
 
+describe('Type System: Fields args must be properly named', () => {
+
+  it('accepts field args with valid names', () => {
+    expect(
+      () => schemaWithFieldType(new GraphQLObjectType({
+        name: 'SomeObject',
+        fields: {
+          goodField: {
+            type: GraphQLString,
+            args: {
+              goodArg: { type: GraphQLString }
+            }
+          }
+        }
+      }))
+    ).not.to.throw();
+  });
+
+  it('rejects field arg with invalid names', () => {
+    expect(
+      () => {
+        var QueryType = new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {
+            badField: {
+              type: GraphQLString,
+              args: {
+                'bad-name-with-dashes': { type: GraphQLString }
+              }
+            }
+          }
+        });
+        return new GraphQLSchema({ query: QueryType });
+      }).to.throw(
+      'Field arg names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.'
+    );
+  });
+
+});
+
+
 describe('Type System: Fields args must be objects', () => {
 
   it('accepts an Object type with field args', () => {

--- a/src/type/__tests__/validation.js
+++ b/src/type/__tests__/validation.js
@@ -296,6 +296,17 @@ describe('Type System: Objects must have fields', () => {
     );
   });
 
+  it('rejects an Object type with incorrectly named fields', () => {
+    expect(
+      () => schemaWithFieldType(new GraphQLObjectType({
+        name: 'SomeObject',
+        fields: { 'bad-name-with-dashes': { type: GraphQLString } }
+      }))
+    ).to.throw(
+      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.'
+    );
+  });
+
   it('rejects an Object type with incorrectly typed fields', () => {
     expect(
       () => schemaWithFieldType(new GraphQLObjectType({
@@ -387,7 +398,7 @@ describe('Type System: Fields args must be properly named', () => {
         });
         return new GraphQLSchema({ query: QueryType });
       }).to.throw(
-      'Field arg names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.'
+      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.'
     );
   });
 

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -149,6 +149,14 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
       var field = fieldMap[fieldName];
       if (field.args) {
         var fieldArgTypes = field.args.map(arg => arg.type);
+
+        field.args.forEach(arg =>
+          invariant(
+            /^[_a-zA-Z][_a-zA-Z0-9]*$/.test(arg.name),
+            `Field arg names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ ` +
+            `but "${arg.name}" does not.`
+        ));
+
         reducedMap = fieldArgTypes.reduce(typeMapReducer, reducedMap);
       }
       reducedMap = typeMapReducer(reducedMap, field.type);

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -147,15 +147,12 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
     var fieldMap = type.getFields();
     Object.keys(fieldMap).forEach(fieldName => {
       var field = fieldMap[fieldName];
+      assertValidName(fieldName);
+
       if (field.args) {
         var fieldArgTypes = field.args.map(arg => arg.type);
 
-        field.args.forEach(arg =>
-          invariant(
-            /^[_a-zA-Z][_a-zA-Z0-9]*$/.test(arg.name),
-            `Field arg names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ ` +
-            `but "${arg.name}" does not.`
-        ));
+        field.args.forEach(arg => assertValidName(arg.name));
 
         reducedMap = fieldArgTypes.reduce(typeMapReducer, reducedMap);
       }
@@ -164,6 +161,13 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   }
 
   return reducedMap;
+}
+
+function assertValidName(name: string): void {
+  invariant(
+  /^[_a-zA-Z][_a-zA-Z0-9]*$/.test(name),
+  `Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ ` +
+  `but "${name}" does not.`);
 }
 
 function assertObjectImplementsInterface(


### PR DESCRIPTION
If I've understood the intent of https://facebook.github.io/graphql/#sec-Names, field arg names are restricted to `/^[_a-zA-Z][_a-zA-Z0-9]*$/`.

Currently the js implementation allows the creation of non-conformant field arg names, which means you can create a field arg that a client can't actually reference in a query.

This PR adds a test for field arg name validity.