### PR TITLE
[RFC] RequestDocument

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -40,8 +40,8 @@ import {
   GraphQLSkipDirective
 } from '../type/directives';
 import type {
+  RequestDocument,
   Directive,
-  Document,
   OperationDefinition,
   SelectionSet,
   Field,
@@ -105,7 +105,7 @@ type ExecutionResult = {
  */
 export function execute(
   schema: GraphQLSchema,
-  documentAST: Document,
+  documentAST: RequestDocument,
   rootValue?: any,
   variableValues?: ?{[key: string]: any},
   operationName?: ?string
@@ -158,7 +158,7 @@ export function execute(
  */
 function buildExecutionContext(
   schema: GraphQLSchema,
-  documentAST: Document,
+  documentAST: RequestDocument,
   rootValue: any,
   rawVariableValues: ?{[key: string]: any},
   operationName: ?string

--- a/src/language/__tests__/parser.js
+++ b/src/language/__tests__/parser.js
@@ -19,7 +19,7 @@ describe('Parser', () => {
 
   it('accepts option to not include source', () => {
     expect(parse(`{ field }`, { noSource: true })).to.deep.equal({
-      kind: 'Document',
+      kind: 'RequestDocument',
       loc: { start: 0, end: 9 },
       definitions:
        [ { kind: 'OperationDefinition',
@@ -180,7 +180,7 @@ fragment ${fragmentName} on Type {
     var result = parse(source);
 
     expect(result).to.deep.equal(
-      { kind: Kind.DOCUMENT,
+      { kind: Kind.REQUEST_DOCUMENT,
         loc: { start: 0, end: 41, source },
         definitions:
          [ { kind: Kind.OPERATION_DEFINITION,

--- a/src/language/__tests__/visitor.js
+++ b/src/language/__tests__/visitor.js
@@ -103,7 +103,7 @@ describe('Visitor', () => {
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined ],
+      [ 'enter', 'RequestDocument', undefined ],
       [ 'enter', 'OperationDefinition', undefined ],
       [ 'enter', 'SelectionSet', undefined ],
       [ 'enter', 'Field', undefined ],
@@ -117,7 +117,7 @@ describe('Visitor', () => {
       [ 'leave', 'Field', undefined ],
       [ 'leave', 'SelectionSet', undefined ],
       [ 'leave', 'OperationDefinition', undefined ],
-      [ 'leave', 'Document', undefined ],
+      [ 'leave', 'RequestDocument', undefined ],
     ]);
   });
 
@@ -140,7 +140,7 @@ describe('Visitor', () => {
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined ],
+      [ 'enter', 'RequestDocument', undefined ],
       [ 'enter', 'OperationDefinition', undefined ],
       [ 'enter', 'SelectionSet', undefined ],
       [ 'enter', 'Field', undefined ],
@@ -210,7 +210,7 @@ describe('Visitor', () => {
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined, undefined ],
+      [ 'enter', 'RequestDocument', undefined, undefined ],
       [ 'enter', 'OperationDefinition', 0, undefined ],
       [ 'enter', 'Name', 'name', 'OperationDefinition' ],
       [ 'leave', 'Name', 'name', 'OperationDefinition' ],
@@ -423,7 +423,7 @@ describe('Visitor', () => {
       [ 'leave', 'Field', 1, undefined ],
       [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
       [ 'leave', 'OperationDefinition', 3, undefined ],
-      [ 'leave', 'Document', undefined, undefined ]
+      [ 'leave', 'RequestDocument', undefined, undefined ]
     ]);
   });
 });

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -25,7 +25,7 @@ export type Location = {
  * The list of all possible AST node types.
  */
 export type Node = Name
-                 | Document
+                 | RequestDocument
                  | OperationDefinition
                  | VariableDefinition
                  | Variable
@@ -55,16 +55,16 @@ export type Name = {
   value: string;
 }
 
-// Document
+// RequestDocument
 
-export type Document = {
-  kind: 'Document';
+export type RequestDocument = {
+  kind: 'RequestDocument';
   loc?: ?Location;
-  definitions: Array<Definition>;
+  definitions: Array<RequestDefinition>;
 }
 
-export type Definition = OperationDefinition
-                       | FragmentDefinition
+export type RequestDefinition = OperationDefinition
+                              | FragmentDefinition
 
 export type OperationDefinition = {
   kind: 'OperationDefinition';

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -11,9 +11,9 @@
 
 export const NAME = 'Name';
 
-// Document
+// Request Document
 
-export const DOCUMENT = 'Document';
+export const REQUEST_DOCUMENT = 'RequestDocument';
 export const OPERATION_DEFINITION = 'OperationDefinition';
 export const VARIABLE_DEFINITION = 'VariableDefinition';
 export const VARIABLE = 'Variable';

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -14,7 +14,7 @@ import type {
   Name,
   Variable,
 
-  Document,
+  RequestDocument,
   OperationDefinition,
   VariableDefinition,
   SelectionSet,
@@ -41,7 +41,7 @@ import {
   NAME,
   VARIABLE,
 
-  DOCUMENT,
+  REQUEST_DOCUMENT,
   OPERATION_DEFINITION,
   VARIABLE_DEFINITION,
   SELECTION_SET,
@@ -83,16 +83,16 @@ import {
 } from './parserCore';
 
 /**
- * Given a GraphQL source, parses it into a Document.
+ * Given a GraphQL source, parses it into a RequestDocument.
  * Throws GraphQLError if a syntax error is encountered.
  */
 export function parse(
   source: Source | string,
   options?: ParseOptions
-): Document {
+): RequestDocument {
   var sourceObj = source instanceof Source ? source : new Source(source);
   var parser = makeParser(sourceObj, options || {});
-  return parseDocument(parser);
+  return parseRequestDocument(parser);
 }
 
 /**
@@ -123,9 +123,9 @@ export function parseName(parser): Name {
   };
 }
 
-// Implements the parsing rules in the Document section.
+// Implements the parsing rules in the RequestDocument section.
 
-function parseDocument(parser): Document {
+function parseRequestDocument(parser): RequestDocument {
   var start = parser.token.start;
   var definitions = [];
   do {
@@ -144,7 +144,7 @@ function parseDocument(parser): Document {
     }
   } while (!skip(parser, TokenKind.EOF));
   return {
-    kind: DOCUMENT,
+    kind: REQUEST_DOCUMENT,
     definitions,
     loc: loc(parser, start)
   };

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -21,9 +21,9 @@ export var printDocASTReducer = {
   Name: node => node.value,
   Variable: node => '$' + node.name,
 
-  // Document
+  // RequestDocument
 
-  Document: node => join(node.definitions, '\n\n') + '\n',
+  RequestDocument: node => join(node.definitions, '\n\n') + '\n',
 
   OperationDefinition(node) {
     var op = node.operation;

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -10,7 +10,7 @@
 export var QueryDocumentKeys = {
   Name: [],
 
-  Document: [ 'definitions' ],
+  RequestDocument: [ 'definitions' ],
   OperationDefinition:
     [ 'name', 'variableDefinitions', 'directives', 'selectionSet' ],
   VariableDefinition: [ 'variable', 'type', 'defaultValue' ],

--- a/src/validation/rules/LoneAnonymousOperation.js
+++ b/src/validation/rules/LoneAnonymousOperation.js
@@ -24,7 +24,7 @@ export function anonOperationNotAloneMessage(): string {
 export function LoneAnonymousOperation(): any {
   var operationCount = 0;
   return {
-    Document(node) {
+    RequestDocument(node) {
       operationCount = node.definitions.filter(
         definition => definition.kind === 'OperationDefinition'
       ).length;

--- a/src/validation/rules/NoUnusedFragments.js
+++ b/src/validation/rules/NoUnusedFragments.js
@@ -40,7 +40,7 @@ export function NoUnusedFragments(): any {
     FragmentSpread(spread) {
       spreadNames[spread.name.value] = true;
     },
-    Document: {
+    RequestDocument: {
       leave() {
         var fragmentNameUsed = {};
         var reduceSpreadFragments = function (spreads) {

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -13,7 +13,7 @@ import { GraphQLError } from '../error';
 import { visit, getVisitFn } from '../language/visitor';
 import * as Kind from '../language/kinds';
 import type {
-  Document,
+  RequestDocument,
   FragmentDefinition,
 } from '../language/ast';
 import { GraphQLSchema } from '../type/schema';
@@ -48,7 +48,7 @@ import { specifiedRules } from './specifiedRules';
  */
 export function validate(
   schema: GraphQLSchema,
-  ast: Document,
+  ast: RequestDocument,
   rules?: Array<any>
 ): Array<GraphQLError> {
   invariant(schema, 'Must provide schema');
@@ -67,7 +67,7 @@ export function validate(
  */
 function visitUsingRules(
   schema: GraphQLSchema,
-  documentAST: Document,
+  documentAST: RequestDocument,
   rules: Array<any>
 ): Array<GraphQLError> {
   var typeInfo = new TypeInfo(schema);
@@ -175,11 +175,11 @@ function append(arr, items) {
  */
 export class ValidationContext {
   _schema: GraphQLSchema;
-  _ast: Document;
+  _ast: RequestDocument;
   _typeInfo: TypeInfo;
   _fragments: {[name: string]: FragmentDefinition};
 
-  constructor(schema: GraphQLSchema, ast: Document, typeInfo: TypeInfo) {
+  constructor(schema: GraphQLSchema, ast: RequestDocument, typeInfo: TypeInfo) {
     this._schema = schema;
     this._ast = ast;
     this._typeInfo = typeInfo;
@@ -189,7 +189,7 @@ export class ValidationContext {
     return this._schema;
   }
 
-  getDocument(): Document {
+  getDocument(): RequestDocument {
     return this._ast;
   }
 


### PR DESCRIPTION
This proposes renaming `Document` to `RequestDocument` - change in spec would follow - to make room for a `ClientDocument` which contains references that have no executable semantic but do have code-gen or other client-side utility.