### PR TITLE
[RFC] Type extension syntax

### DIFF
--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -55,6 +55,7 @@ export type Node = Name
                  | EnumTypeDefinition
                  | EnumValueDefinition
                  | InputObjectTypeDefinition
+                 | TypeExtensionDefinition
 
 // Name
 
@@ -75,6 +76,7 @@ export type Document = {
 export type Definition = OperationDefinition
                        | FragmentDefinition
                        | TypeDefinition
+                       | TypeExtensionDefinition
 
 export type OperationDefinition = {
   kind: 'OperationDefinition';
@@ -322,4 +324,12 @@ export type InputObjectTypeDefinition = {
   loc?: ?Location;
   name: Name;
   fields: Array<InputValueDefinition>;
+}
+
+// Type Extention
+
+export type TypeExtensionDefinition = {
+  kind: 'TypeExtensionDefinition';
+  loc?: ?Location;
+  definition: ObjectTypeDefinition;
 }

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -59,3 +59,7 @@ export const SCALAR_TYPE_DEFINITION = 'ScalarTypeDefinition';
 export const ENUM_TYPE_DEFINITION = 'EnumTypeDefinition';
 export const ENUM_VALUE_DEFINITION = 'EnumValueDefinition';
 export const INPUT_OBJECT_TYPE_DEFINITION = 'InputObjectTypeDefinition';
+
+// Type Extension Definitions
+
+export const TYPE_EXTENSION_DEFINITION = 'TypeExtensionDefinition';

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -48,6 +48,8 @@ import type {
   EnumTypeDefinition,
   EnumValueDefinition,
   InputObjectTypeDefinition,
+
+  TypeExtensionDefinition,
 } from './ast';
 
 import {
@@ -89,6 +91,8 @@ import {
   ENUM_TYPE_DEFINITION,
   ENUM_VALUE_DEFINITION,
   INPUT_OBJECT_TYPE_DEFINITION,
+
+  TYPE_EXTENTION_DEFINITION,
 } from './kinds';
 
 
@@ -177,6 +181,7 @@ function parseDocument(parser): Document {
  *   - OperationDefinition
  *   - FragmentDefinition
  *   - TypeDefinition
+ *   - TypeExtensionDefinition
  */
 function parseDefinition(parser): Definition {
   if (peek(parser, TokenKind.BRACE_L)) {
@@ -196,6 +201,8 @@ function parseDefinition(parser): Definition {
       case 'scalar':
       case 'enum':
       case 'input': return parseTypeDefinition(parser);
+
+      case 'extend': return parseTypeExtensionDefinition(parser);
     }
   }
 
@@ -878,6 +885,23 @@ function parseInputObjectTypeDefinition(parser): InputObjectTypeDefinition {
     kind: INPUT_OBJECT_TYPE_DEFINITION,
     name,
     fields,
+    loc: loc(parser, start),
+  };
+}
+
+
+// Implements the parsing rules for Type Extension
+
+/**
+ * TypeExtensionDefinition : extend ObjectTypeDefinition
+ */
+function parseTypeExtensionDefinition(parser): TypeExtensionDefinition {
+  var start = parser.token.start;
+  expectKeyword(parser, 'extend');
+  var definition = parseObjectTypeDefinition(parser);
+  return {
+    kind: TYPE_EXTENTION_DEFINITION,
+    definition,
     loc: loc(parser, start),
   };
 }

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -115,6 +115,10 @@ var printDocASTReducer = {
 
   InputObjectTypeDefinition: ({ name, fields }) =>
     `input ${name} ${block(fields)}`,
+
+  // Type Extension Definition
+
+  TypeExtensionDefinition: ({ definition }) => `extend ${definition}`,
 };
 
 /**

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -47,6 +47,8 @@ export var QueryDocumentKeys = {
   EnumTypeDefinition: [ 'name', 'values' ],
   EnumValueDefinition: [ 'name' ],
   InputObjectTypeDefinition: [ 'name', 'fields' ],
+
+  TypeExtensionDefinition: [ 'definition' ],
 };
 
 export const BREAK = {};


### PR DESCRIPTION
This proposal introduces a syntactic addition for client-side tools that perform code generation. It allows those tools to describe "extensions" to the server-supplied GraphQL schema. Tools may then use this information to generate types/classes/objects in the client language which include these client-side-only extensions.

The syntax I'm proposing is:

```
TypeExtensionDefinition : `extend` ObjectDefinition
```

An example of this might look like:

```
type User {
  name: String
  birthday: Int
}

extend type User {
  age: Int
}
```

While I could have proposed simply `extend User { ... }`, I chose to fully reuse the ObjectDefinition rule to preserve the future ability to expand this syntax to include extending interfaces, enums, and other types.