### PR TITLE
[Proposal] POC "JSON/Raw/Unchecked/Free/WhateverYouWantAsName" Field Objects

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -663,8 +663,10 @@ function completeValue(
     var serializedResult = returnType.serialize(result);
     return isNullish(serializedResult) ? null : serializedResult;
   }
-  
-  if (returnType instanceof GraphQLRawObjectType) return result;
+
+  if (returnType instanceof GraphQLRawObjectType) {
+    return result;
+  }
 
   // Field type must be Object, Interface or Union and expect sub-selections.
   var objectType: ?GraphQLObjectType;

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -18,6 +18,7 @@ import { getVariableValues, getArgumentValues } from './values';
 import {
   GraphQLScalarType,
   GraphQLObjectType,
+  GraphQLRawObjectType,
   GraphQLEnumType,
   GraphQLList,
   GraphQLNonNull,
@@ -662,6 +663,8 @@ function completeValue(
     var serializedResult = returnType.serialize(result);
     return isNullish(serializedResult) ? null : serializedResult;
   }
+  
+  if (returnType instanceof GraphQLRawObjectType) return result;
 
   // Field type must be Object, Interface or Union and expect sub-selections.
   var objectType: ?GraphQLObjectType;

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ export { GraphQLSchema } from './type/schema';
 export {
   GraphQLScalarType,
   GraphQLObjectType,
+  GraphQLRawObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -87,7 +87,8 @@ export function isOutputType(type: ?GraphQLType): boolean {
     namedType instanceof GraphQLObjectType ||
     namedType instanceof GraphQLInterfaceType ||
     namedType instanceof GraphQLUnionType ||
-    namedType instanceof GraphQLEnumType
+    namedType instanceof GraphQLEnumType ||
+    namedType instanceof GraphQLRawObjectType
   );
 }
 
@@ -102,6 +103,7 @@ export function isLeafType(type: ?GraphQLType): boolean {
   var namedType = getNamedType(type);
   return (
     namedType instanceof GraphQLScalarType ||
+    namedType instanceof GraphQLRawObjectType ||
     namedType instanceof GraphQLEnumType
   );
 }
@@ -174,6 +176,22 @@ export function getNamedType(type: ?GraphQLType): ?GraphQLNamedType {
   return unmodifiedType;
 }
 
+export class GraphQLRawObjectType {
+  name: string;
+  description: ?string;
+
+
+  constructor(config: GraphQLObjectTypeConfig) {
+    invariant(config.name, 'Type must be named.');
+    assertValidName(config.name);
+    this.name = config.name;
+    this.description = config.description;
+  }
+
+  toString(): string {
+    return this.name;
+  }
+}
 
 /**
  * Scalar Type Definition

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -34,7 +34,8 @@ export type GraphQLType =
   GraphQLEnumType |
   GraphQLInputObjectType |
   GraphQLList |
-  GraphQLNonNull;
+  GraphQLNonNull |
+  GraphQLRawObjectType;
 
 export function isType(type: any): boolean {
   return (
@@ -163,7 +164,8 @@ export type GraphQLNamedType =
   GraphQLInterfaceType |
   GraphQLUnionType |
   GraphQLEnumType |
-  GraphQLInputObjectType;
+  GraphQLInputObjectType |
+  GraphQLRawObjectType;
 
 export function getNamedType(type: ?GraphQLType): ?GraphQLNamedType {
   var unmodifiedType = type;

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -27,6 +27,7 @@ export {
   // Definitions
   GraphQLScalarType,
   GraphQLObjectType,
+  GraphQLRawObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,


### PR DESCRIPTION
Hello,

Here is an implementation of a concept that doesn't exists in specs... The idea is to be able to use raw objects as leaf type.

Sometimes your server has to handle data that it doesn't care of, and sometimes theses data are objects... Either your client has to serialize/deserialize it himself, or Raw objects allow that...

This PR allow things like that :

```javascript
import gql, {
  graphql,
  GraphQLString,
  GraphQLSchema,
  GraphQLObjectType,
  GraphQLRawObjectType
} from './src';

var test = new GraphQLRawObjectType({
  name: 'Hello',
});

var Queries = new GraphQLObjectType({
  name: 'Query',
  fields: () => ({
    foo: {
      type: GraphQLString,
      resolve: () => ('Ho !')
    },
    bar: {
      type: test,
      resolve: () => {
        return { val:'Hi !'}
      }
    }
  }),
});

var Schema = new GraphQLSchema({
  query: Queries,
});

graphql(Schema, '{ foo, bar }').then(r => {
  console.log(r);
  // this prints { data: { foo: 'Ho !', bar: { val: 'Hi !' } } }
});
```

/!\ This is only a POC to discuss the subject ! Not an "as it is" Pull Request.

Another way could be to serialize the object on a scalar type, but this would be much less pretty! :D

Let's talk !!

