### PR TITLE
Replaced validator kind strings with constants

### DIFF
--- a/src/validation/rules/KnownArgumentNames.js
+++ b/src/validation/rules/KnownArgumentNames.js
@@ -12,6 +12,10 @@ import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import find from '../../jsutils/find';
 import invariant from '../../jsutils/invariant';
+import {
+  FIELD,
+  DIRECTIVE
+} from '../../language/kinds';
 
 
 export function unknownArgMessage(
@@ -40,7 +44,7 @@ export function KnownArgumentNames(context: ValidationContext): any {
   return {
     Argument(node, key, parent, path, ancestors) {
       var argumentOf = ancestors[ancestors.length - 1];
-      if (argumentOf.kind === 'Field') {
+      if (argumentOf.kind === FIELD) {
         var fieldDef = context.getFieldDef();
         if (fieldDef) {
           var fieldArgDef = find(
@@ -60,7 +64,7 @@ export function KnownArgumentNames(context: ValidationContext): any {
             );
           }
         }
-      } else if (argumentOf.kind === 'Directive') {
+      } else if (argumentOf.kind === DIRECTIVE) {
         var directive = context.getDirective();
         if (directive) {
           var directiveArgDef = find(

--- a/src/validation/rules/LoneAnonymousOperation.js
+++ b/src/validation/rules/LoneAnonymousOperation.js
@@ -9,6 +9,7 @@
  */
 
 import { GraphQLError } from '../../error';
+import { OPERATION_DEFINITION } from '../../language/kinds';
 
 
 export function anonOperationNotAloneMessage(): string {
@@ -26,7 +27,7 @@ export function LoneAnonymousOperation(): any {
   return {
     Document(node) {
       operationCount = node.definitions.filter(
-        definition => definition.kind === 'OperationDefinition'
+        definition => definition.kind === OPERATION_DEFINITION
       ).length;
     },
     OperationDefinition(node) {


### PR DESCRIPTION
There were a few places in the validation rules that were not using the
constants found in `src/language/kinds.js`. This commit replaces those strings
with their respective constants.

This can be considered a cleanup.