### PR TITLE
[RFC] Add directives to field definitions

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -11,6 +11,7 @@ type Foo implements Bar {
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
+  @meta(value: 6)
   six(argument: InputType = {key: "value"}): Type
 }
 

--- a/src/language/__tests__/schema-parser.js
+++ b/src/language/__tests__/schema-parser.js
@@ -47,11 +47,16 @@ function fieldNode(name, type, loc) {
 }
 
 function fieldNodeWithArgs(name, type, args, loc) {
+  return fieldNodeWithDirectives(name, type, args, [], loc);
+}
+
+function fieldNodeWithDirectives(name, type, args, directives, loc) {
   return {
     kind: 'FieldDefinition',
     name,
     arguments: args,
     type,
+    directives,
     loc,
   };
 }
@@ -441,6 +446,56 @@ type Hello {
         }
       ],
       loc: loc(1, 61),
+    };
+    expect(printJson(doc)).to.equal(printJson(expected));
+  });
+
+  it('Simple field with a directive', () => {
+    var body = `
+type Hello {
+  @relatedField(name: "hellos")
+  world: World
+}`;
+    var doc = parse(body);
+    var loc = createLocFn(body);
+    var expected = {
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'ObjectTypeDefinition',
+          name: nameNode('Hello', loc(6, 11)),
+          interfaces: [],
+          fields: [
+            fieldNodeWithDirectives(
+              nameNode('world', loc(48, 53)),
+              typeNode('World', loc(55, 60)),
+              [],
+              [
+                {
+                  kind: 'Directive',
+                  name: nameNode('relatedField', loc(17, 29)),
+                  arguments: [
+                    {
+                      kind: 'Argument',
+                      name: nameNode('name', loc(30, 34)),
+                      value: {
+                        kind: 'StringValue',
+                        value: 'hellos',
+                        loc: loc(36, 44),
+                      },
+                      loc: loc(30, 44)
+                    },
+                  ],
+                  loc: loc(16, 45),
+                },
+              ],
+              loc(16, 60)
+            )
+          ],
+          loc: loc(1, 62),
+        }
+      ],
+      loc: loc(1, 62),
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -276,6 +276,7 @@ export type FieldDefinition = {
   name: Name;
   arguments: Array<InputValueDefinition>;
   type: Type;
+  directives?: ?Array<Directive>;
 }
 
 export type InputValueDefinition = {

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -719,6 +719,7 @@ function parseImplementsInterfaces(parser): Array<NamedType> {
  */
 function parseFieldDefinition(parser): FieldDefinition {
   var start = parser.token.start;
+  var directives = parseDirectives(parser);
   var name = parseName(parser);
   var args = parseArgumentDefs(parser);
   expect(parser, TokenKind.COLON);
@@ -728,6 +729,7 @@ function parseFieldDefinition(parser): FieldDefinition {
     name,
     arguments: args,
     type,
+    directives,
     loc: loc(parser, start),
   };
 }


### PR DESCRIPTION
This proposal extends the GraphQL IDL syntax to support directives for fields in types. Directives can be used to add custom metadata / annotations to fields.

Being able to add tool specific metadata to fields opens up new possibilities for tools that use the GraphQL IDL to bootstrap the schema. For example, we are planning to use the definition language for specifying a schema in our [GraphQL BaaS](https://www.reindex.io/) and doing so requires a way to add metadata to fields. E.g. to create a relationship between types, a `@connection` directive could be used like this:
```graphql
type TvSeason implements Node {
  @connection(relatedField: "season")
  episodes: TvEpisodeConnection
  id: ID!
}
```