### PR TITLE
[RFC] Move input field uniqueness validator

### DIFF
--- a/src/language/__tests__/parser.js
+++ b/src/language/__tests__/parser.js
@@ -107,12 +107,6 @@ fragment MissingOn Type
     ).to.throw('Syntax Error GraphQL (1:37) Unexpected $');
   });
 
-  it('duplicate keys in input object is syntax error', () => {
-    expect(
-      () => parse('{ field(arg: { a: 1, a: 2 }) }')
-    ).to.throw('Syntax Error GraphQL (1:22) Duplicate input object field a.');
-  });
-
   it('does not accept fragments named "on"', () => {
     expect(
       () => parse('fragment on on on { on }')

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -528,10 +528,9 @@ function parseList(parser, isConst: boolean): ListValue {
 function parseObject(parser, isConst: boolean): ObjectValue {
   var start = parser.token.start;
   expect(parser, TokenKind.BRACE_L);
-  var fieldNames = {};
   var fields = [];
   while (!skip(parser, TokenKind.BRACE_R)) {
-    fields.push(parseObjectField(parser, isConst, fieldNames));
+    fields.push(parseObjectField(parser, isConst));
   }
   return {
     kind: OBJECT,
@@ -543,24 +542,11 @@ function parseObject(parser, isConst: boolean): ObjectValue {
 /**
  * ObjectField[Const] : Name : Value[?Const]
  */
-function parseObjectField(
-  parser,
-  isConst: boolean,
-  fieldNames: {[name: string]: boolean}
-): ObjectField {
+function parseObjectField(parser, isConst: boolean): ObjectField {
   var start = parser.token.start;
-  var name = parseName(parser);
-  if (fieldNames.hasOwnProperty(name.value)) {
-    throw syntaxError(
-      parser.source,
-      start,
-      `Duplicate input object field ${name.value}.`
-    );
-  }
-  fieldNames[name.value] = true;
   return {
     kind: OBJECT_FIELD,
-    name,
+    name: parseName(parser),
     value:
       (expect(parser, TokenKind.COLON), parseValueLiteral(parser, isConst)),
     loc: loc(parser, start)

--- a/src/validation/__tests__/UniqueInputFieldNames.js
+++ b/src/validation/__tests__/UniqueInputFieldNames.js
@@ -1,0 +1,72 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { describe, it } from 'mocha';
+import { expectPassesRule, expectFailsRule } from './harness';
+import {
+  UniqueInputFieldNames,
+  duplicateInputFieldMessage,
+} from '../rules/UniqueInputFieldNames';
+
+
+function duplicateField(name, l1, c1, l2, c2) {
+  return {
+    message: duplicateInputFieldMessage(name),
+    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+  };
+}
+
+describe('Validate: Unique input field names', () => {
+
+  it('input object with fields', () => {
+    expectPassesRule(UniqueInputFieldNames, `
+      {
+        field(arg: { f: true })
+      }
+    `);
+  });
+
+  it('same input object within two args', () => {
+    expectPassesRule(UniqueInputFieldNames, `
+      {
+        field(arg1: { f: true }, arg2: { f: true })
+      }
+    `);
+  });
+
+  it('multiple input object fields', () => {
+    expectPassesRule(UniqueInputFieldNames, `
+      {
+        field(arg: { f1: "value", f2: "value", f3: "value" })
+      }
+    `);
+  });
+
+  it('duplicate input object fields', () => {
+    expectFailsRule(UniqueInputFieldNames, `
+      {
+        field(arg: { f1: "value", f1: "value" })
+      }
+    `, [
+      duplicateField('f1', 3, 22, 3, 35)
+    ]);
+  });
+
+  it('many duplicate input object fields', () => {
+    expectFailsRule(UniqueInputFieldNames, `
+      {
+        field(arg: { f1: "value", f1: "value", f1: "value" })
+      }
+    `, [
+      duplicateField('f1', 3, 22, 3, 35),
+      duplicateField('f1', 3, 22, 3, 48)
+    ]);
+  });
+
+});

--- a/src/validation/rules/UniqueInputFieldNames.js
+++ b/src/validation/rules/UniqueInputFieldNames.js
@@ -1,0 +1,41 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { GraphQLError } from '../../error';
+
+
+export function duplicateInputFieldMessage(fieldName: any): string {
+  return `There can be only one input field named "${fieldName}".`;
+}
+
+/**
+ * Unique input field names
+ *
+ * A GraphQL input object value is only valid if all supplied fields are
+ * uniquely named.
+ */
+export function UniqueInputFieldNames(): any {
+  var knownNames = Object.create(null);
+  return {
+    ObjectValue() {
+      knownNames = Object.create(null);
+    },
+    ObjectField(node) {
+      var fieldName = node.name.value;
+      if (knownNames[fieldName]) {
+        return new GraphQLError(
+          duplicateInputFieldMessage(fieldName),
+          [ knownNames[fieldName], node.name ]
+        );
+      }
+      knownNames[fieldName] = node.name;
+    }
+  };
+}

--- a/src/validation/specifiedRules.js
+++ b/src/validation/specifiedRules.js
@@ -76,6 +76,9 @@ import {
   OverlappingFieldsCanBeMerged
 } from './rules/OverlappingFieldsCanBeMerged';
 
+// Spec Section: "Input Object Field Uniqueness"
+import { UniqueInputFieldNames } from './rules/UniqueInputFieldNames';
+
 
 /**
  * This set includes all validation rules defined by the GraphQL spec.
@@ -103,4 +106,5 @@ export var specifiedRules = [
   DefaultValuesOfCorrectType,
   VariablesInAllowedPosition,
   OverlappingFieldsCanBeMerged,
+  UniqueInputFieldNames,
 ];


### PR DESCRIPTION
This proposes moving input field uniqueness assertion from the parser to the validator. This simplifies the parser and allows these errors to be reported as part of the collection of validation errors which is actually more valuable.

Spec: https://github.com/facebook/graphql/pull/95