### PR TITLE
Declare total war on misuse of "it's"

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -131,7 +131,7 @@ export function execute(
   // The "Response" section of the GraphQL specification.
   //
   // If errors are encountered while executing a GraphQL field, only that
-  // field and it's descendents will be omitted, and sibling fields will still
+  // field and its descendants will be omitted, and sibling fields will still
   // be executed. An execution which encounters errors will still result in a
   // resolved Promise.
   return new Promise(resolve => {
@@ -517,7 +517,7 @@ function resolveField(
     variableValues: exeContext.variableValues,
   };
 
-  // Get the resolve function, regardless of if it's result is normal
+  // Get the resolve function, regardless of if its result is normal
   // or abrupt (error).
   var result = resolveOrError(resolveFn, source, args, info);
 

--- a/src/jsutils/README.md
+++ b/src/jsutils/README.md
@@ -4,6 +4,6 @@ JavaScript Utils
 This directory contains dependency-free JavaScript utility functions used
 throughout the codebase.
 
-Each utility should belong in it's own file and be the default export.
+Each utility should belong in its own file and be the default export.
 
 These functions are not part of the module interface and are subject to change.

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -132,7 +132,7 @@ function join(maybeArray, separator) {
 
 /**
  * Given maybeArray, print an empty string if it is null or empty, otherwise
- * print each item on it's own line, wrapped in an indented "{ }" block.
+ * print each item on its own line, wrapped in an indented "{ }" block.
  */
 function block(maybeArray) {
   return length(maybeArray) ?

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -55,7 +55,7 @@ export const BREAK = {};
 /**
  * visit() will walk through an AST using a depth first traversal, calling
  * the visitor's enter function at each node in the traversal, and calling the
- * leave function after visiting that node and all of it's child nodes.
+ * leave function after visiting that node and all of its child nodes.
  *
  * By returning different values from the enter and leave functions, the
  * behavior of the visitor can be altered, including skipping over a sub-tree of

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -740,7 +740,7 @@ export type GraphQLUnionTypeConfig = {
  *     });
  *
  * Note: If a value is not provided in a definition, the name of the enum value
- * will be used as it's internal value.
+ * will be used as its internal value.
  */
 export class GraphQLEnumType/* <T> */ {
   name: string;


### PR DESCRIPTION
Also fixed one use of "descendents" that happened to be on one of the
touched lines.