### PR TITLE
Define possibleTypes on InterfaceType

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -128,7 +128,8 @@ var characterInterface = new GraphQLInterfaceType({
   }),
   resolveType: character => {
     return getHuman(character.id) ? humanType : droidType;
-  }
+  },
+  possibleTypes: () => [ humanType, droidType ]
 });
 
 /**

--- a/src/execution/__tests__/abstract.js
+++ b/src/execution/__tests__/abstract.js
@@ -48,7 +48,8 @@ describe('Execute: Handles execution of abstract types', () => {
       name: 'Pet',
       fields: {
         name: { type: GraphQLString }
-      }
+      },
+      possibleTypes: () => [ DogType, CatType ]
     });
 
     // Added to interface type when defined
@@ -188,7 +189,8 @@ describe('Execute: Handles execution of abstract types', () => {
       },
       fields: {
         name: { type: GraphQLString }
-      }
+      },
+      possibleTypes: () => [ DogType, CatType ]
     });
 
     var HumanType = new GraphQLObjectType({

--- a/src/execution/__tests__/union-interface.js
+++ b/src/execution/__tests__/union-interface.js
@@ -49,7 +49,8 @@ var NamedType = new GraphQLInterfaceType({
   name: 'Named',
   fields: {
     name: { type: GraphQLString }
-  }
+  },
+  possibleTypes: () => [ PetType, PersonType ]
 });
 
 var DogType = new GraphQLObjectType({
@@ -360,7 +361,8 @@ describe('Execute: Union and intersection types', () => {
         encounteredSchema = infoSchema;
         encounteredRootValue = infoRootValue;
         return PersonType2;
-      }
+      },
+      possibleTypes: () => [ PersonType2 ]
     });
 
     var PersonType2 = new GraphQLObjectType({

--- a/src/type/__tests__/definition.js
+++ b/src/type/__tests__/definition.js
@@ -173,7 +173,8 @@ describe('Type System: Example', () => {
       name: 'SomeInterface',
       fields: {
         f: { type: GraphQLInt }
-      }
+      },
+      possibleTypes: () => [ SomeSubtype ]
     });
 
     var SomeSubtype = new GraphQLObjectType({
@@ -202,7 +203,8 @@ describe('Type System: Example', () => {
       name: 'SomeInterface',
       fields: {
         f: { type: GraphQLInt }
-      }
+      },
+      possibleTypes: () => [ SomeSubtype ]
     });
 
     var SomeSubtype = new GraphQLObjectType({

--- a/src/type/__tests__/validation.js
+++ b/src/type/__tests__/validation.js
@@ -223,6 +223,7 @@ describe('Type System: A Schema must contain uniquely named types', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: { f: { type: GraphQLString } },
+        possibleTypes: () => [ FirstBadObject, SecondBadObject ]
       });
 
       /* eslint-disable no-unused-vars */

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -23,7 +23,6 @@ import { __Schema } from './introspection';
 import find from '../jsutils/find';
 import invariant from '../jsutils/invariant';
 
-
 /**
  * Schema Definition
  *

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -237,8 +237,24 @@ export function buildASTSchema(
       name: typeName,
       resolveType: () => null,
       fields: () => makeFieldDefMap(def),
+      possibleTypes: () => extractPossibleTypes(typeName)
     };
     return new GraphQLInterfaceType(config);
+  }
+
+  function extractPossibleTypes(typeName) {
+    var possibleTypes = [];
+    Object.keys(astMap).forEach(type => {
+      var typeAST = astMap[type];
+      if (Array.isArray(typeAST.interfaces)) {
+        typeAST.interfaces.forEach(iface => {
+          if (iface.name.value === typeName) {
+            possibleTypes.push(produceTypeDef(typeAST));
+          }
+        });
+      }
+    });
+    return possibleTypes;
   }
 
   function makeEnumDef(def: EnumTypeDefinition) {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -36,6 +36,7 @@ var Being = new GraphQLInterfaceType({
       args: { surname: { type: GraphQLBoolean } },
     }
   }),
+  possibleTypes: () => [ Dog, Cat, Human, Alien ]
 });
 
 var Pet = new GraphQLInterfaceType({
@@ -46,6 +47,7 @@ var Pet = new GraphQLInterfaceType({
       args: { surname: { type: GraphQLBoolean } },
     }
   }),
+  possibleTypes: () => [ Dog, Cat ]
 });
 
 var DogCommand = new GraphQLEnumType({
@@ -119,7 +121,8 @@ var Intelligent = new GraphQLInterfaceType({
   name: 'Intelligent',
   fields: {
     iq: { type: GraphQLInt }
-  }
+  },
+  possibleTypes: () => [ Human, Alien ]
 });
 
 var Human = new GraphQLObjectType({


### PR DESCRIPTION
Mutation of interfaces in type definition is problematic, as it allows for incomplete schema generation if not all types are loaded at runtime.

This adds an optional `possibleTypes` property on the InterfaceType definition. It may be an Array or thunk, resolving with an Array of types an interface may implement.

It also allows a thunk for interfaces to act as intended (lazily). Currently it is immediately invoked as a side-effect of the `addImplementationToInterfaces` call in constructor.

It's a bit of a big change, so let me know if you have any questions or need me to clarify anything about where I ran into this as an issue.
