### PR TITLE
Add GraphQLSchema types field

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -270,5 +270,6 @@ var queryType = new GraphQLObjectType({
  * type we defined above) and export it.
  */
 export var StarWarsSchema = new GraphQLSchema({
-  query: queryType
+  query: queryType,
+  types: [ humanType, droidType ]
 });

--- a/src/execution/__tests__/abstract.js
+++ b/src/execution/__tests__/abstract.js
@@ -87,7 +87,8 @@ describe('Execute: Handles execution of abstract types', () => {
             }
           }
         }
-      })
+      }),
+      types: [ CatType, DogType ]
     });
 
     var query = `{
@@ -231,7 +232,8 @@ describe('Execute: Handles execution of abstract types', () => {
             }
           }
         }
-      })
+      }),
+      types: [ CatType, DogType ]
     });
 
     var query = `{

--- a/src/execution/__tests__/union-interface.js
+++ b/src/execution/__tests__/union-interface.js
@@ -97,7 +97,8 @@ var PersonType = new GraphQLObjectType({
 });
 
 var schema = new GraphQLSchema({
-  query: PersonType
+  query: PersonType,
+  types: [ PetType ]
 });
 
 var garfield = new Cat('Garfield', false);
@@ -143,9 +144,9 @@ describe('Execute: Union and intersection types', () => {
           ],
           interfaces: null,
           possibleTypes: [
+            { name: 'Person' },
             { name: 'Dog' },
             { name: 'Cat' },
-            { name: 'Person' }
           ],
           enumValues: null,
           inputFields: null

--- a/src/type/__tests__/definition.js
+++ b/src/type/__tests__/definition.js
@@ -191,7 +191,8 @@ describe('Type System: Example', () => {
         fields: {
           iface: { type: SomeInterface }
         }
-      })
+      }),
+      types: [ SomeSubtype ]
     });
 
     expect(schema.getTypeMap().SomeSubtype).to.equal(SomeSubtype);
@@ -220,7 +221,8 @@ describe('Type System: Example', () => {
         fields: {
           iface: { type: SomeInterface }
         }
-      })
+      }),
+      types: [ SomeSubtype ]
     });
 
     expect(schema.getTypeMap().SomeSubtype).to.equal(SomeSubtype);

--- a/src/type/__tests__/validation.js
+++ b/src/type/__tests__/validation.js
@@ -104,11 +104,16 @@ var notInputTypes = withModifiers([
 ]).concat(String);
 
 function schemaWithFieldType(type) {
+  var types = (
+    type instanceof GraphQLObjectType ||
+    type instanceof GraphQLUnionType
+  ) ? [ type ] : [];
   return new GraphQLSchema({
     query: new GraphQLObjectType({
       name: 'Query',
       fields: { f: { type } }
-    })
+    }),
+    types
   });
 }
 
@@ -250,7 +255,10 @@ describe('Type System: A Schema must contain uniquely named types', () => {
         }
       });
 
-      return new GraphQLSchema({ query: QueryType });
+      return new GraphQLSchema({
+        query: QueryType,
+        types: [ FirstBadObject, SecondBadObject ]
+      });
     }).to.throw(
       'Schema must contain unique named types but contains multiple types ' +
       'named "BadObject".'
@@ -1078,7 +1086,8 @@ describe('Type System: Objects can only implement interfaces', () => {
         fields: {
           f: { type: BadObjectType }
         }
-      })
+      }),
+      types: [ BadObjectType ]
     });
   }
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -308,7 +308,6 @@ export class GraphQLObjectType {
     }
     this.isTypeOf = config.isTypeOf;
     this._typeConfig = config;
-    addImplementationToInterfaces(this);
   }
 
   getFields(): GraphQLFieldDefinitionMap {
@@ -431,18 +430,6 @@ function isPlainObj(obj) {
   return obj && typeof obj === 'object' && !Array.isArray(obj);
 }
 
-/**
- * Update the interfaces to know about this implementation.
- * This is an rare and unfortunate use of mutation in the type definition
- * implementations, but avoids an expensive "getPossibleTypes"
- * implementation for Interface types.
- */
-function addImplementationToInterfaces(impl) {
-  impl.getInterfaces().forEach(type => {
-    type._implementations.push(impl);
-  });
-}
-
 export type GraphQLObjectTypeConfig = {
   name: string;
   interfaces?: GraphQLInterfacesThunk | Array<GraphQLInterfaceType>;
@@ -542,7 +529,7 @@ export class GraphQLInterfaceType {
   _typeConfig: GraphQLInterfaceTypeConfig;
   _fields: GraphQLFieldDefinitionMap;
   _implementations: Array<GraphQLObjectType>;
-  _possibleTypes: { [typeName: string]: GraphQLObjectType };
+  _possibleTypes: ?{ [typeName: string]: GraphQLObjectType };
 
   constructor(config: GraphQLInterfaceTypeConfig) {
     invariant(config.name, 'Type must be named.');

--- a/src/utilities/__tests__/schemaPrinter.js
+++ b/src/utilities/__tests__/schemaPrinter.js
@@ -282,7 +282,10 @@ type Root {
       fields: { bar: { type: BarType } },
     });
 
-    var Schema = new GraphQLSchema({ query: Root });
+    var Schema = new GraphQLSchema({
+      query: Root,
+      types: [ BarType ]
+    });
     var output = printForTest(Schema);
     expect(output).to.equal(`
 type Bar implements Foo {
@@ -327,7 +330,10 @@ type Root {
       fields: { bar: { type: BarType } },
     });
 
-    var Schema = new GraphQLSchema({ query: Root });
+    var Schema = new GraphQLSchema({
+      query: Root,
+      types: [ BarType ]
+    });
     var output = printForTest(Schema);
     expect(output).to.equal(`
 interface Baaz {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -288,7 +288,8 @@ var QueryRoot = new GraphQLObjectType({
 });
 
 var defaultSchema = new GraphQLSchema({
-  query: QueryRoot
+  query: QueryRoot,
+  types: [ Cat, Dog, Human, Alien ]
 });
 
 function expectValid(schema, rules, queryString) {


### PR DESCRIPTION
Per discussion with @leebyron - adds a "types" field on the `GraphQLSchema` config, requiring all `GraphQLObjectType`s implementing interfaces be specified on the Schema definition. `GraphQLUnionType`s may be specified in place of their possible `ObjectType`s.

Moves the `InterfaceType` mutation of implementations from the `ObjectType` constructor to the definition of the Schema, properly deferring a thunk provided as the "interfaces" prop on ObjectType configuration.

This helps prevent the situation where where types are required lazily, thus making it possible an incomplete schema definition could be generated due to runtime mutation of the schema.