### PR TITLE
Make input objects and lists return better errors

### DIFF
--- a/src/execution/__tests__/variables.js
+++ b/src/execution/__tests__/variables.js
@@ -248,9 +248,9 @@ describe('Execute: Handles inputs', () => {
         expect(caughtError).to.containSubset({
           locations: [ { line: 2, column: 17 } ],
           message:
-            'Variable "$input" expected value of type "TestInputObject" but ' +
-            'got: {"a":"foo","b":"bar","c":null}. ' +
-            'In field c: Expected non-null value.'
+            'Variable "$input" got invalid value ' +
+            '{"a":"foo","b":"bar","c":null}.' +
+            '\nIn field "c": Expected "String!", found null.'
         });
       });
 
@@ -267,8 +267,8 @@ describe('Execute: Handles inputs', () => {
         expect(caughtError).to.containSubset({
           locations: [ { line: 2, column: 17 } ],
           message:
-            'Variable "$input" expected value of type "TestInputObject" but ' +
-            'got: "foo bar". Not an object.'
+            'Variable "$input" got invalid value "foo bar".' +
+            '\nExpected "TestInputObject", found not an object.'
         });
       });
 
@@ -285,8 +285,8 @@ describe('Execute: Handles inputs', () => {
         expect(caughtError).to.containSubset({
           locations: [ { line: 2, column: 17 } ],
           message:
-            'Variable "$input" expected value of type "TestInputObject" but ' +
-            'got: {"a":"foo","b":"bar"}. In field c: Expected non-null value.'
+            'Variable "$input" got invalid value {"a":"foo","b":"bar"}.' +
+            '\nIn field "c": Expected "String!", found null.'
         });
       });
 
@@ -309,10 +309,9 @@ describe('Execute: Handles inputs', () => {
         expect(caughtError).to.containSubset({
           locations: [ { line: 2, column: 19 } ],
           message:
-            'Variable "$input" expected value of type "TestNestedInputObject" but ' +
-            'got: {"na":{"a":"foo"}}.' +
-            ' In field na: In field c: Expected non-null value.' +
-            ' In field nb: Expected non-null value.'
+            'Variable "$input" got invalid value {"na":{"a":"foo"}}.' +
+            '\nIn field "na": In field "c": Expected "String!", found null.' +
+            '\nIn field "nb": Expected "String!", found null.'
         });
 
       });
@@ -330,8 +329,10 @@ describe('Execute: Handles inputs', () => {
         expect(caughtError).to.containSubset({
           locations: [ { line: 2, column: 17 } ],
           message:
-            'Variable "$input" expected value of type "TestInputObject" but ' +
-            'got: {"a":"foo","b":"bar","c":"baz","d":"dog"}.'
+            'Variable "$input" got invalid value ' +
+             '{"a":"foo","b":"bar","c":"baz","d":"dog"}.' +
+             '\nIn field "d": Expected type "ComplexScalar", found "dog".'
+
         });
       });
 
@@ -687,8 +688,8 @@ describe('Execute: Handles inputs', () => {
       expect(caughtError).to.containSubset({
         locations: [ { line: 2, column: 17 } ],
         message:
-          'Variable "$input" expected value of type "[String!]" but got: ' +
-          '["A",null,"B"]. In element #1: Expected non-null value.'
+          'Variable "$input" got invalid value ["A",null,"B"].' +
+          '\nIn element #1: Expected "String!", found null.'
       });
     });
 
@@ -750,8 +751,8 @@ describe('Execute: Handles inputs', () => {
       expect(caughtError).to.containSubset({
         locations: [ { line: 2, column: 17 } ],
         message:
-          'Variable "$input" expected value of type "[String!]!" but got: ' +
-          '["A",null,"B"]. In element #1: Expected non-null value.'
+          'Variable "$input" got invalid value ["A",null,"B"].' +
+          '\nIn element #1: Expected "String!", found null.'
       });
     });
 

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -113,9 +113,8 @@ function getVariableValue(
   }
   var message = errors ? '\n' + errors.join('\n') : '';
   throw new GraphQLError(
-    `Variable "$${variable.name.value}" expected value of type ` +
-    `"${print(definitionAST.type)}" but got: ${JSON.stringify(input)}.` +
-    `${message}`,
+    `Variable "$${variable.name.value}" got invalid value ` +
+    `${JSON.stringify(input)}.${message}`,
     [ definitionAST ]
   );
 }

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -94,7 +94,8 @@ function getVariableValue(
     );
   }
   var inputType: GraphQLInputType = (type: any);
-  if (isValidJSValue(input, inputType)) {
+  var errors = isValidJSValue(input, inputType);
+  if (!errors.length) {
     if (isNullish(input)) {
       var defaultValue = definitionAST.defaultValue;
       if (defaultValue) {
@@ -110,9 +111,11 @@ function getVariableValue(
       [ definitionAST ]
     );
   }
+  var message = errors ? '\n' + errors.join('\n') : '';
   throw new GraphQLError(
     `Variable "$${variable.name.value}" expected value of type ` +
-    `"${print(definitionAST.type)}" but got: ${JSON.stringify(input)}.`,
+    `"${print(definitionAST.type)}" but got: ${JSON.stringify(input)}.` +
+    `${message}`,
     [ definitionAST ]
   );
 }

--- a/src/type/__tests__/enumType.js
+++ b/src/type/__tests__/enumType.js
@@ -107,8 +107,10 @@ describe('Type System: Enum Values', () => {
       await graphql(schema, '{ colorEnum(fromEnum: "GREEN") }')
     ).to.deep.equal({
       errors: [
-        { message:
-            'Argument "fromEnum" expected type "Color" but got: "GREEN".' }
+        {
+          message: 'Argument "fromEnum" has invalid value "GREEN".' +
+            '\nExpected type \"Color\", found "GREEN".'
+        }
       ]
     });
   });
@@ -128,7 +130,8 @@ describe('Type System: Enum Values', () => {
       await graphql(schema, '{ colorEnum(fromEnum: 1) }')
     ).to.deep.equal({
       errors: [
-        { message: 'Argument "fromEnum" expected type "Color" but got: 1.' }
+        { message: 'Argument "fromEnum" has invalid value 1.' +
+            '\nExpected type "Color", found 1.' }
       ]
     });
   });
@@ -138,7 +141,8 @@ describe('Type System: Enum Values', () => {
       await graphql(schema, '{ colorEnum(fromInt: GREEN) }')
     ).to.deep.equal({
       errors: [
-        { message: 'Argument "fromInt" expected type "Int" but got: GREEN.' }
+        { message: 'Argument "fromInt" has invalid value GREEN.' +
+            '\nExpected type "Int", found GREEN.' }
       ]
     });
   });
@@ -183,8 +187,11 @@ describe('Type System: Enum Values', () => {
       )
     ).to.deep.equal({
       errors: [
-        { message:
-            'Variable "$color" expected value of type "Color!" but got: 2.' }
+        {
+          message:
+            'Variable "\$color" got invalid value 2.' +
+            '\nExpected type "Color", found 2.'
+        }
       ]
     });
   });

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -28,11 +28,14 @@ import type { GraphQLInputType } from '../type/definition';
 export function isValidJSValue(value: any, type: GraphQLInputType): [ string ] {
   // A value must be provided if the type is non-null.
   if (type instanceof GraphQLNonNull) {
+    var ofType: GraphQLInputType = (type.ofType: any);
     if (isNullish(value)) {
-      return [ 'Expected non-null value.' ];
+      if (ofType.name) {
+        return [ `Expected "${ofType.name}!", found null.` ];
+      }
+      return [ 'Expected non-null value, found null.' ];
     }
-    var nullableType: GraphQLInputType = (type.ofType: any);
-    return isValidJSValue(value, nullableType);
+    return isValidJSValue(value, ofType);
   }
 
   if (isNullish(value)) {
@@ -56,7 +59,7 @@ export function isValidJSValue(value: any, type: GraphQLInputType): [ string ] {
   // Input objects check each defined field.
   if (type instanceof GraphQLInputObjectType) {
     if (typeof value !== 'object') {
-      return [ 'Not an object.' ];
+      return [ `Expected "${type.name}", found not an object.` ];
     }
     var fields = type.getFields();
 
@@ -88,7 +91,9 @@ export function isValidJSValue(value: any, type: GraphQLInputType): [ string ] {
   // a non-null value.
   var parseResult = type.parseValue(value);
   if (isNullish(parseResult)) {
-    return [ `Expected type "${type.name}", found "{JSON.strigify(value)}".` ];
+    return [
+      `Expected type "${type.name}", found ${JSON.stringify(value)}.`
+    ];
   }
 
   return [];

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -68,7 +68,7 @@ export function isValidJSValue(value: any, type: GraphQLInputType): [ string ] {
     // Ensure every provided field is defined.
     for (var providedField of Object.keys(value)) {
       if (!fields[providedField]) {
-        errors.push('Unknown field "${providedField}".');
+        errors.push('In field "${providedField}": Unknown field.');
       }
     }
 

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -25,25 +25,30 @@ import type { GraphQLInputType } from '../type/definition';
  * accepted for that type. This is primarily useful for validating the
  * runtime values of query variables.
  */
-export function isValidJSValue(value: any, type: GraphQLInputType): boolean {
+export function isValidJSValue(value: any, type: GraphQLInputType): [ string ] {
   // A value must be provided if the type is non-null.
   if (type instanceof GraphQLNonNull) {
     if (isNullish(value)) {
-      return false;
+      return [ 'Expected non-null value.' ];
     }
     var nullableType: GraphQLInputType = (type.ofType: any);
     return isValidJSValue(value, nullableType);
   }
 
   if (isNullish(value)) {
-    return true;
+    return [];
   }
 
   // Lists accept a non-list value as a list of one.
   if (type instanceof GraphQLList) {
     var itemType: GraphQLInputType = (type.ofType: any);
     if (Array.isArray(value)) {
-      return value.every(item => isValidJSValue(item, itemType));
+      return value.reduce((acc, item, index) => {
+        var errors = isValidJSValue(item, itemType);
+        return acc.concat(errors.map(error =>
+          `In element #${index}: ${error}`
+        ));
+      }, []);
     }
     return isValidJSValue(value, itemType);
   }
@@ -51,19 +56,27 @@ export function isValidJSValue(value: any, type: GraphQLInputType): boolean {
   // Input objects check each defined field.
   if (type instanceof GraphQLInputObjectType) {
     if (typeof value !== 'object') {
-      return false;
+      return [ 'Not an object.' ];
     }
     var fields = type.getFields();
 
+    var errors = [];
+
     // Ensure every provided field is defined.
-    if (Object.keys(value).some(fieldName => !fields[fieldName])) {
-      return false;
+    for (var providedField of Object.keys(value)) {
+      if (!fields[providedField]) {
+        errors.push('Unknown field "${providedField}".');
+      }
     }
 
     // Ensure every defined field is valid.
-    return Object.keys(fields).every(
-      fieldName => isValidJSValue(value[fieldName], fields[fieldName].type)
-    );
+    for (var fieldName of Object.keys(fields)) {
+      var newErrors = isValidJSValue(value[fieldName], fields[fieldName].type);
+      errors.push(...(newErrors.map(error =>
+        `In field "${fieldName}": ${error}`
+      )));
+    }
+    return errors;
   }
 
   invariant(
@@ -73,5 +86,10 @@ export function isValidJSValue(value: any, type: GraphQLInputType): boolean {
 
   // Scalar/Enum input checks to ensure the type can parse the value to
   // a non-null value.
-  return !isNullish(type.parseValue(value));
+  var parseResult = type.parseValue(value);
+  if (isNullish(parseResult)) {
+    return [ `Expected type "${type.name}", found "{JSON.strigify(value)}".` ];
+  }
+
+  return [];
 }

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -41,10 +41,13 @@ export function isValidLiteralValue(
 ): [ string ] {
   // A value must be provided if the type is non-null.
   if (type instanceof GraphQLNonNull) {
-    if (!valueAST) {
-      return [ 'Expected non-null value.' ];
-    }
     var ofType: GraphQLInputType = (type.ofType: any);
+    if (!valueAST) {
+      if (ofType.name) {
+        return [ `Expected "${ofType.name}!", found null.` ];
+      }
+      return [ 'Expected non-null value, found null.' ];
+    }
     return isValidLiteralValue(ofType, valueAST);
   }
 
@@ -75,7 +78,7 @@ export function isValidLiteralValue(
   // Input objects check each defined field and look for undefined fields.
   if (type instanceof GraphQLInputObjectType) {
     if (valueAST.kind !== OBJECT) {
-      return [ 'Not an object.' ];
+      return [ `Expected "${type.name}", found not an object.` ];
     }
     var fields = type.getFields();
 

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -88,7 +88,9 @@ export function isValidLiteralValue(
     var fieldASTs = (valueAST: ObjectValue).fields;
     for (var providedFieldAST of fieldASTs) {
       if (!fields[providedFieldAST.name.value]) {
-        errors.push(`Unknown field "${providedFieldAST.name.value}".`);
+        errors.push(
+          `In field "${providedFieldAST.name.value}": Unknown field.`
+        );
       }
     }
 

--- a/src/validation/__tests__/ArgumentsOfCorrectType.js
+++ b/src/validation/__tests__/ArgumentsOfCorrectType.js
@@ -15,9 +15,9 @@ import {
 } from '../rules/ArgumentsOfCorrectType';
 
 
-function badValue(argName, typeName, value, line, column) {
+function badValue(argName, typeName, value, line, column, errors) {
   return {
-    message: badValueMessage(argName, typeName, value),
+    message: badValueMessage(argName, typeName, value, errors),
     locations: [ { line, column } ],
   };
 }
@@ -725,7 +725,9 @@ describe('Validate: Argument values of correct type', () => {
           }
         }
       `, [
-        badValue('complexArg', 'ComplexInput', '{intField: 4}', 4, 41),
+        badValue('complexArg', 'ComplexInput', '{intField: 4}', 4, 41, [
+          'In field requiredField: Expected non-null value.'
+        ]),
       ]);
     });
 
@@ -766,7 +768,8 @@ describe('Validate: Argument values of correct type', () => {
           'ComplexInput',
           '{requiredField: true, unknownField: "value"}',
           4,
-          41
+          41,
+          [ 'Unknown field unknownField.' ]
         ),
       ]);
     });

--- a/src/validation/__tests__/ArgumentsOfCorrectType.js
+++ b/src/validation/__tests__/ArgumentsOfCorrectType.js
@@ -16,11 +16,20 @@ import {
 
 
 function badValue(argName, typeName, value, line, column, errors) {
+  var realErrors;
+  if (!errors) {
+    realErrors = [
+      `Expected type "${typeName}", found ${value}.`
+    ];
+  } else {
+    realErrors = errors;
+  }
   return {
-    message: badValueMessage(argName, typeName, value, errors),
+    message: badValueMessage(argName, typeName, value, realErrors),
     locations: [ { line, column } ],
   };
 }
+
 
 describe('Validate: Argument values of correct type', () => {
 
@@ -484,7 +493,9 @@ describe('Validate: Argument values of correct type', () => {
           }
         }
       `, [
-        badValue('stringListArg', '[String]', '["one", 2]', 4, 47),
+        badValue('stringListArg', '[String]', '["one", 2]', 4, 47, [
+          'In element #1: Expected type "String", found 2.'
+        ]),
       ]);
     });
 
@@ -496,7 +507,7 @@ describe('Validate: Argument values of correct type', () => {
           }
         }
       `, [
-        badValue('stringListArg', '[String]', '1', 4, 47),
+        badValue('stringListArg', 'String', '1', 4, 47),
       ]);
     });
 
@@ -618,8 +629,8 @@ describe('Validate: Argument values of correct type', () => {
           }
         }
       `, [
-        badValue('req2', 'Int!', '"two"', 4, 32),
-        badValue('req1', 'Int!', '"one"', 4, 45),
+        badValue('req2', 'Int', '"two"', 4, 32),
+        badValue('req1', 'Int', '"one"', 4, 45),
       ]);
     });
 
@@ -631,7 +642,7 @@ describe('Validate: Argument values of correct type', () => {
           }
         }
       `, [
-        badValue('req1', 'Int!', '"one"', 4, 32),
+        badValue('req1', 'Int', '"one"', 4, 32),
       ]);
     });
 
@@ -726,7 +737,7 @@ describe('Validate: Argument values of correct type', () => {
         }
       `, [
         badValue('complexArg', 'ComplexInput', '{intField: 4}', 4, 41, [
-          'In field requiredField: Expected non-null value.'
+          'In field "requiredField": Expected "Boolean!", found null.'
         ]),
       ]);
     });
@@ -747,7 +758,9 @@ describe('Validate: Argument values of correct type', () => {
           'ComplexInput',
           '{stringListField: ["one", 2], requiredField: true}',
           4,
-          41
+          41,
+          [ 'In field "stringListField": In element #1: ' +
+            'Expected type "String", found 2.' ]
         ),
       ]);
     });
@@ -769,7 +782,7 @@ describe('Validate: Argument values of correct type', () => {
           '{requiredField: true, unknownField: "value"}',
           4,
           41,
-          [ 'Unknown field unknownField.' ]
+          [ 'Unknown field "unknownField".' ]
         ),
       ]);
     });
@@ -799,8 +812,8 @@ describe('Validate: Argument values of correct type', () => {
           }
         }
       `, [
-        badValue('if', 'Boolean!', '"yes"', 3, 28),
-        badValue('if', 'Boolean!', 'ENUM', 4, 28),
+        badValue('if', 'Boolean', '"yes"', 3, 28),
+        badValue('if', 'Boolean', 'ENUM', 4, 28),
       ]);
     });
 

--- a/src/validation/__tests__/ArgumentsOfCorrectType.js
+++ b/src/validation/__tests__/ArgumentsOfCorrectType.js
@@ -782,7 +782,7 @@ describe('Validate: Argument values of correct type', () => {
           '{requiredField: true, unknownField: "value"}',
           4,
           41,
-          [ 'Unknown field "unknownField".' ]
+          [ 'In field "unknownField": Unknown field.' ]
         ),
       ]);
     });

--- a/src/validation/__tests__/DefaultValuesOfCorrectType.js
+++ b/src/validation/__tests__/DefaultValuesOfCorrectType.js
@@ -23,9 +23,9 @@ function defaultForNonNullArg(varName, typeName, guessTypeName, line, column) {
   };
 }
 
-function badValue(varName, typeName, val, line, column) {
+function badValue(varName, typeName, val, line, column, errors) {
   return {
-    message: badValueForDefaultArgMessage(varName, typeName, val),
+    message: badValueForDefaultArgMessage(varName, typeName, val, errors),
     locations: [ { line, column } ],
   };
 }
@@ -83,7 +83,9 @@ describe('Validate: Variable default values of correct type', () => {
     `, [
       badValue('a', 'Int', '"one"', 3, 19),
       badValue('b', 'String', '4', 4, 22),
-      badValue('c', 'ComplexInput', '"notverycomplex"', 5, 28)
+      badValue('c', 'ComplexInput', '"notverycomplex"', 5, 28, [
+        'Not an object.'
+      ])
     ]);
   });
 
@@ -93,7 +95,9 @@ describe('Validate: Variable default values of correct type', () => {
         dog { name }
       }
     `, [
-      badValue('a', 'ComplexInput', '{intField: 3}', 2, 53)
+      badValue('a', 'ComplexInput', '{intField: 3}', 2, 53, [
+        'In field requiredField: Expected non-null value.'
+      ])
     ]);
   });
 

--- a/src/validation/__tests__/DefaultValuesOfCorrectType.js
+++ b/src/validation/__tests__/DefaultValuesOfCorrectType.js
@@ -24,8 +24,16 @@ function defaultForNonNullArg(varName, typeName, guessTypeName, line, column) {
 }
 
 function badValue(varName, typeName, val, line, column, errors) {
+  var realErrors;
+  if (!errors) {
+    realErrors = [
+      `Expected type "${typeName}", found ${val}.`
+    ];
+  } else {
+    realErrors = errors;
+  }
   return {
-    message: badValueForDefaultArgMessage(varName, typeName, val, errors),
+    message: badValueForDefaultArgMessage(varName, typeName, val, realErrors),
     locations: [ { line, column } ],
   };
 }
@@ -81,10 +89,14 @@ describe('Validate: Variable default values of correct type', () => {
         dog { name }
       }
     `, [
-      badValue('a', 'Int', '"one"', 3, 19),
-      badValue('b', 'String', '4', 4, 22),
+      badValue('a', 'Int', '"one"', 3, 19, [
+        'Expected type "Int", found "one".'
+      ]),
+      badValue('b', 'String', '4', 4, 22, [
+        'Expected type "String", found 4.'
+      ]),
       badValue('c', 'ComplexInput', '"notverycomplex"', 5, 28, [
-        'Not an object.'
+        'Expected "ComplexInput", found not an object.'
       ])
     ]);
   });
@@ -96,7 +108,7 @@ describe('Validate: Variable default values of correct type', () => {
       }
     `, [
       badValue('a', 'ComplexInput', '{intField: 3}', 2, 53, [
-        'In field requiredField: Expected non-null value.'
+        'In field "requiredField": Expected "Boolean!", found null.'
       ])
     ]);
   });
@@ -107,7 +119,9 @@ describe('Validate: Variable default values of correct type', () => {
         dog { name }
       }
     `, [
-      badValue('a', '[String]', '["one", 2]', 2, 40)
+      badValue('a', '[String]', '["one", 2]', 2, 40, [
+        'In element #1: Expected type "String", found 2.'
+      ])
     ]);
   });
 

--- a/src/validation/rules/ArgumentsOfCorrectType.js
+++ b/src/validation/rules/ArgumentsOfCorrectType.js
@@ -14,8 +14,16 @@ import { print } from '../../language/printer';
 import { isValidLiteralValue } from '../../utilities/isValidLiteralValue';
 
 
-export function badValueMessage(argName: any, type: any, value: any): string {
-  return `Argument "${argName}" expected type "${type}" but got: ${value}.`;
+export function badValueMessage(
+  argName: any,
+  type: any,
+  value: any,
+  verboseErrors?: [any]
+): string {
+  var message = verboseErrors ? '\n' + verboseErrors.join('\n') : '';
+  return (
+    `Argument "${argName}" has invalid value ${value}.${message}`
+  );
 }
 
 /**
@@ -28,12 +36,16 @@ export function ArgumentsOfCorrectType(context: ValidationContext): any {
   return {
     Argument(argAST) {
       var argDef = context.getArgument();
-      if (argDef && !isValidLiteralValue(argDef.type, argAST.value)) {
+      if (argDef) {
+        var errors = isValidLiteralValue(argDef.type, argAST.value);
+      }
+      if (errors.length) {
         return new GraphQLError(
           badValueMessage(
             argAST.name.value,
             argDef.type,
-            print(argAST.value)
+            print(argAST.value),
+            errors
           ),
           [ argAST.value ]
         );

--- a/src/validation/rules/ArgumentsOfCorrectType.js
+++ b/src/validation/rules/ArgumentsOfCorrectType.js
@@ -38,17 +38,17 @@ export function ArgumentsOfCorrectType(context: ValidationContext): any {
       var argDef = context.getArgument();
       if (argDef) {
         var errors = isValidLiteralValue(argDef.type, argAST.value);
-      }
-      if (errors.length) {
-        return new GraphQLError(
-          badValueMessage(
-            argAST.name.value,
-            argDef.type,
-            print(argAST.value),
-            errors
-          ),
-          [ argAST.value ]
-        );
+        if (errors.length) {
+          return new GraphQLError(
+            badValueMessage(
+              argAST.name.value,
+              argDef.type,
+              print(argAST.value),
+              errors
+            ),
+            [ argAST.value ]
+          );
+        }
       }
     }
   };

--- a/src/validation/rules/DefaultValuesOfCorrectType.js
+++ b/src/validation/rules/DefaultValuesOfCorrectType.js
@@ -27,10 +27,11 @@ export function defaultForNonNullArgMessage(
 export function badValueForDefaultArgMessage(
   varName: any,
   type: any,
-  value: any
+  value: any,
+  verboseErrors?: [any]
 ): string {
-  return `Variable "$${varName}" of type "${type}" has invalid default ` +
-    `value: ${value}.`;
+  var message = verboseErrors ? '\n' + verboseErrors.join('\n') : '';
+  return `Variable "$${varName} has invalid default value ${value}.${message}`;
 }
 
 /**
@@ -51,9 +52,13 @@ export function DefaultValuesOfCorrectType(context: ValidationContext): any {
           [ defaultValue ]
         );
       }
-      if (type && defaultValue && !isValidLiteralValue(type, defaultValue)) {
+      var errors;
+      if (type && defaultValue) {
+        errors = isValidLiteralValue(type, defaultValue);
+      }
+      if (errors && errors.length) {
         return new GraphQLError(
-          badValueForDefaultArgMessage(name, type, print(defaultValue)),
+          badValueForDefaultArgMessage(name, type, print(defaultValue), errors),
           [ defaultValue ]
         );
       }


### PR DESCRIPTION
Add index of invalid element or field of invalid field and make it recurse
into children until faulty place is found.