### PR TITLE
Allow providing directives to GraphQLSchema

### DIFF
--- a/src/type/__tests__/validation.js
+++ b/src/type/__tests__/validation.js
@@ -189,6 +189,17 @@ describe('Type System: A Schema must have Object root types', () => {
     );
   });
 
+  it('rejects a Schema whose directives are incorrectly typed', () => {
+    expect(
+      () => new GraphQLSchema({
+        query: SomeObjectType,
+        directives: [ 'somedirective' ]
+      })
+    ).to.throw(
+      'Schema directives must be Array<GraphQLDirective> if provided but got: somedirective.'
+    );
+  });
+
 });
 
 describe('Type System: A Schema must contain uniquely named types', () => {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -488,6 +488,7 @@ export type GraphQLFieldConfigArgumentMap = {
 export type GraphQLArgumentConfig = {
   type: GraphQLInputType;
   defaultValue?: any;
+  description?: ?string;
 }
 
 export type GraphQLFieldConfigMap = {

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -28,20 +28,20 @@ export class GraphQLDirective {
   constructor(config: GraphQLDirectiveConfig) {
     this.name = config.name;
     this.description = config.description;
-    this.args = config.args;
-    this.onOperation = config.onOperation;
-    this.onFragment = config.onFragment;
-    this.onField = config.onField;
+    this.args = config.args || [];
+    this.onOperation = Boolean(config.onOperation);
+    this.onFragment = Boolean(config.onFragment);
+    this.onField = Boolean(config.onField);
   }
 }
 
 type GraphQLDirectiveConfig = {
   name: string;
-  description?: string;
-  args: Array<GraphQLArgument>;
-  onOperation: boolean;
-  onFragment: boolean;
-  onField: boolean;
+  description?: ?string;
+  args?: ?Array<GraphQLArgument>;
+  onOperation?: ?boolean;
+  onFragment?: ?boolean;
+  onField?: ?boolean;
 }
 
 /**

--- a/src/utilities/__tests__/buildClientSchema.js
+++ b/src/utilities/__tests__/buildClientSchema.js
@@ -28,6 +28,7 @@ import {
   GraphQLBoolean,
   GraphQLID,
 } from '../../';
+import { GraphQLDirective } from '../../type/directives';
 
 
 // Test property:
@@ -472,6 +473,31 @@ describe('Type System: build schema from introspection', () => {
           }
         }
       })
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with custom directives', async () => {
+
+    var schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Simple',
+        description: 'This is a simple type',
+        fields: {
+          string: {
+            type: GraphQLString,
+            description: 'This is a string field'
+          }
+        }
+      }),
+      directives: [
+        new GraphQLDirective({
+          name: 'customDirective',
+          description: 'This is a custom directive',
+          onField: true,
+        })
+      ]
     });
 
     await testSchema(schema);

--- a/src/validation/__tests__/KnownDirectives.js
+++ b/src/validation/__tests__/KnownDirectives.js
@@ -104,11 +104,13 @@ describe('Validate: Known directives', () => {
   it('with misplaced directives', () => {
     expectFailsRule(KnownDirectives, `
       query Foo @include(if: true) {
-        name
-        ...Frag
+        name @operationOnly
+        ...Frag @operationOnly
       }
     `, [
-      misplacedDirective('include', 'operation', 2, 17)
+      misplacedDirective('include', 'operation', 2, 17),
+      misplacedDirective('operationOnly', 'field', 3, 14),
+      misplacedDirective('operationOnly', 'fragment', 4, 17),
     ]);
   });
 

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -26,6 +26,11 @@ import {
   GraphQLBoolean,
   GraphQLID
 } from '../../type';
+import {
+  GraphQLDirective,
+  GraphQLIncludeDirective,
+  GraphQLSkipDirective,
+} from '../../type/directives';
 
 
 var Being = new GraphQLInterfaceType({
@@ -288,7 +293,15 @@ var QueryRoot = new GraphQLObjectType({
 });
 
 var defaultSchema = new GraphQLSchema({
-  query: QueryRoot
+  query: QueryRoot,
+  directives: [
+    new GraphQLDirective({
+      name: 'operationOnly',
+      onOperation: true
+    }),
+    GraphQLIncludeDirective,
+    GraphQLSkipDirective,
+  ]
 });
 
 function expectValid(schema, rules, queryString) {


### PR DESCRIPTION
This allows GraphQLSchema to represent different sets of directives than those graphql-js is able to use
during execution. Critically, this allows GraphQLSchema to be used against servers which support different sets of directives and still use validation utilities.