### PR TITLE
Provide a Scalar type to support raw JSON values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,8 @@ export {
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLID
+  GraphQLID,
+  GraphQLJson
 } from './type/scalars';
 
 // Format GraphQL errors.

--- a/src/type/__tests__/introspection.js
+++ b/src/type/__tests__/introspection.js
@@ -20,6 +20,7 @@ import {
   GraphQLList,
   GraphQLInputObjectType,
   GraphQLString,
+  GraphQLJson,
   GraphQLEnumType,
 } from '../../';
 
@@ -1294,4 +1295,229 @@ describe('Introspection', () => {
     });
   });
 
+  describe('JSON type', async () => {
+    // Schema that provide the argument as a value
+    var JsonWithArgRoot = new GraphQLObjectType({
+      name: 'JsonWithArgRoot',
+      fields: {
+        jsonField: {
+          type: GraphQLJson,
+          args: {
+            jsonArg: {
+              type: GraphQLJson
+            }
+          },
+          resolve(_, args) {
+            return args.jsonArg;
+          }
+        }
+      }
+    });
+    it('Resolve Type with JSON field', async () => {
+
+      var ObjectType = new GraphQLObjectType({
+        name: 'ObjectType',
+        fields: {
+          key: {
+            type: GraphQLString,
+          },
+          name: {
+            type: GraphQLString,
+          },
+          config: {
+            type: GraphQLJson,
+          }
+        }
+      });
+      var QueryRoot = new GraphQLObjectType({
+        name: 'QueryRoot',
+        fields: {
+          object: {
+            type: ObjectType,
+            resolve() {
+              return {
+                key: 'ffff-acde-876678',
+                name: 'Object Name',
+                config: {
+                  key1: 1,
+                  key2: 'value1',
+                  key3: [ 1, '2', true ]
+                }
+              };
+            }
+          }
+        }
+      });
+
+      var schema = new GraphQLSchema({ query: QueryRoot });
+      var request = `
+        {
+          object {
+            key,
+            name,
+            config
+          }
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          object: {
+            key: 'ffff-acde-876678',
+            name: 'Object Name',
+            config: {
+              key1: 1,
+              key2: 'value1',
+              key3: [ 1, '2', true ]
+            }
+          }
+        }
+      });
+    });
+
+    it('Arguments with String value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: "arg string")
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: 'arg string'
+        }
+      });
+    });
+    it('Arguments with Int value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: 127)
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: 127
+        }
+      });
+    });
+    it('Arguments with Float value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: 3.14155962)
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: 3.14155962
+        }
+      });
+    });
+    it('Arguments with Boolean value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: true)
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: true
+        }
+      });
+    });
+    it('Arguments with Enum value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: SOME_ENUM)
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: 'SOME_ENUM'
+        }
+      });
+    });
+    it('Arguments with Array value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: [ 1, 2, 3 ])
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: [ 1, 2, 3 ]
+        }
+      });
+    });
+    it('Arguments with Object value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField(jsonArg: {
+            stringValue: "some string"
+            arrayValue: [ 1, 2, 3 ]
+          })
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: {
+            stringValue: 'some string',
+            arrayValue: [ 1, 2, 3 ]
+          }
+        }
+      });
+    });
+    it('Arguments with null value', async () => {
+
+      var schema = new GraphQLSchema({ query: JsonWithArgRoot });
+      var request = `
+        {
+          jsonField
+        }
+      `;
+
+      return expect(
+        await graphql(schema, request)
+      ).to.deep.equal({
+        data: {
+          jsonField: null
+        }
+      });
+    });
+  });
 });

--- a/src/type/__tests__/serialization.js
+++ b/src/type/__tests__/serialization.js
@@ -11,7 +11,8 @@ import {
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
-  GraphQLBoolean
+  GraphQLBoolean,
+  GraphQLJson
 } from '../';
 
 import { describe, it } from 'mocha';
@@ -139,5 +140,30 @@ describe('Type System: Scalar coercion', () => {
     expect(
       GraphQLBoolean.serialize(false)
     ).to.equal(false);
+  });
+
+  it('serializes output JSON', () => {
+    expect(
+      GraphQLJson.serialize('string')
+    ).to.equal('string');
+    expect(
+      GraphQLJson.serialize(127)
+    ).to.equal(127);
+    expect(
+      GraphQLJson.serialize(Math.PI)
+    ).to.equal(Math.PI);
+    expect(
+      GraphQLJson.serialize(true)
+    ).to.equal(true);
+    expect(
+      GraphQLJson.serialize([ 1, 2, 3 ])
+    ).to.deep.equal([ 1, 2, 3 ]);
+    expect(
+      GraphQLJson.serialize({
+        foo: 'bar'
+      })
+    ).to.deep.equal({
+      foo: 'bar'
+    });
   });
 });

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -42,4 +42,5 @@ export {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
+  GraphQLJson
 } from './scalars';

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -105,3 +105,35 @@ export var GraphQLID = new GraphQLScalarType({
       null;
   }
 });
+
+var astToJson = {};
+astToJson[Kind.INT] = ast => GraphQLInt.parseLiteral(ast);
+astToJson[Kind.FLOAT] = ast => GraphQLFloat.parseLiteral(ast);
+astToJson[Kind.BOOLEAN] = ast => GraphQLBoolean.parseLiteral(ast);
+astToJson[Kind.STRING] = ast => GraphQLString.parseLiteral(ast);
+astToJson[Kind.ENUM] = ast => String(ast.value);
+astToJson[Kind.LIST] = ast => ast.values.map(astItem => {
+  return GraphQLJson.parseLiteral(astItem);
+});
+astToJson[Kind.OBJECT] = ast => {
+  var obj = {};
+  ast.fields.forEach(field => {
+    obj[field.name.value] = GraphQLJson.parseLiteral(field.value);
+  });
+  return obj;
+};
+
+function jsonValue(value) {
+  return value;
+}
+
+export var GraphQLJson = new GraphQLScalarType({
+  name: 'JSON',
+  description: 'The `JSON` scalar type represents raw JSON as values.',
+  serialize: jsonValue,
+  parseValue: jsonValue,
+  parseLiteral(ast) {
+    var parser = astToJson[ast.kind];
+    return parser ? parser.call(this, ast) : null;
+  }
+});


### PR DESCRIPTION
Hi,

Based on the idea of https://github.com/graphql/graphql-js/pull/172, that a "JSON Value" could be a Scalar value. I create this code to provide this functionality.

Now it's possible to provide leaf values that is a JavaScript Object :)

```js
var ObjectType = new GraphQLObjectType({
  name: 'ObjectType',
  fields: () => ({
    key: {
      type: GraphQLString,
      resolve: () => ('CAFE12345678')
    },
    name: {
      type: GraphQLString,
      resolve: () => ('Object Name')
    },
    config: {
      type: GraphQLJson,
      resolve: () => ({
        num: 1,
        str: 'str key2',
        array: [ 1, 2, 3 ],
        obj: {
          prop: 'value'
        }
      })
    }
  })
});

var Schema = new GraphQLSchema({
  query: ObjectType,
});

graphql(Schema, '{ key, name, config }').then(result => {
  console.log(JSON.stringify(result.data, null, 2));
  // Should print:
  // {
  //   "key": "CAFE12345678",
  //   "name": "Object Name",
  //   "config": {
  //     "num": 1,
  //     "str": "str key2",
  //     "array": [
  //       1,
  //       2,
  //       3
  //     ],
  //     "obj": {
  //       "prop": "value"
  //     }
  //   }
  // }
});
```

The other functionality is the ability to provide raw Objects as an argument.
```js
var FilteredObjectType = new GraphQLObjectType({
  name: 'FilteredObjectType',
  fields: () => ({
    config: {
      type: GraphQLJson,
      args: {
        filter: {
          type: GraphQLJson
        }
      },
      resolve: (_, { filter }) => filter
    }
  })
});

var FilteredSchema = new GraphQLSchema({
  query: FilteredObjectType,
});

graphql(FilteredSchema, '{ config( filter: 1 ) }').then(result => {
  console.log(JSON.stringify(result.data, null, 2));
  // Should print:
  // {
  //   "config": 1
  // }
});
graphql(FilteredSchema, '{ config( filter: "Filter String" ) }').then(result => {
  console.log(JSON.stringify(result.data, null, 2));
  // Should print:
  // {
  //   "config": "Filter String"
  // }
});
graphql(FilteredSchema, '{ config( filter: { foo: ENUM_BAR, bar: "Bar Str" } ) }').then(result => {
  console.log(JSON.stringify(result.data, null, 2));
  // Should print:
  // {
  //   "config": {
  //     "foo": "ENUM_BAR",
  //     "bar": "Bar Str"
  //   }
  // }
});
```

What do you think about that?