### PR TITLE
Docs: remove outdated language/schema from readme.

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -12,7 +12,6 @@ var GraphQL = require('graphql'); // CommonJS
 Each sub directory within is a sub-module of graphql-js:
 
 * `graphql/language`: Parse and operate on the GraphQL language.
-* `graphql/language/schema`: Parsing and operate on the GraphQL Schema language.
 * `graphql/type`: Define GraphQL types and schema.
 * `graphql/validation`: The Validation phase of fulfilling a GraphQL result.
 * `graphql/execution`: The Execution phase of fulfilling a GraphQL request.


### PR DESCRIPTION
`graphql/language/schema` was merged with `graphql/language` in v0.4.3.