### PR TITLE
Use the same babel options in npm published package

### DIFF
--- a/resources/prepublish.sh
+++ b/resources/prepublish.sh
@@ -21,4 +21,4 @@ fi;
 #
 #    var language = require('graphql/language');
 #
-babel src --ignore __tests__ --out-dir ./;
+babel --optional runtime src --ignore __tests__ --out-dir ./;


### PR DESCRIPTION
Followup commit to c61ccac where babel plugin options were inlined to command line. Brings npm published version and built version in sync.