### PR TITLE
Fix tests by updating babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "babel": "5.8.21",
     "babel-core": "5.8.22",
-    "babel-eslint": "4.0.10",
+    "babel-eslint": "4.1.5",
     "bluebird": "2.9.34",
     "chai": "3.2.0",
     "chai-subset": "1.0.1",


### PR DESCRIPTION
Tests started failing a few days ago, when escope (eslint dependency) updated v3.2.0 to v3.2.1, with updated dependencies. There may still be fixes coming in babel-eslint, escope, and their dependencies, but pumping babel-eslint for now seems to fix the tests.