### PR TITLE
add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "Daniel Schafer <dschafer@fb.com>"
   ],
   "license": "BSD-3-Clause",
+  "main": "index.js",
   "homepage": "https://github.com/graphql/graphql-js",
   "bugs": {
     "url": "https://github.com/graphql/graphql-js/issues"


### PR DESCRIPTION
Adding main to package.json tells consumers what is the main eatery point (as im sure you all know) [https://docs.npmjs.com/files/package.json#main](https://docs.npmjs.com/files/package.json#main). I know consumers should fallback to index.js, but its is still nice to have. I should probably add this case on the thing I am building as well.