### PR TITLE
Fix a bug where KnownTypeNames rule incorrectly fails

### DIFF
--- a/src/validation/__tests__/KnownTypeNames.js
+++ b/src/validation/__tests__/KnownTypeNames.js
@@ -8,7 +8,9 @@
  */
 
 import { describe, it } from 'mocha';
-import { expectPassesRule, expectFailsRule } from './harness';
+import { expectPassesRule, expectFailsRule, expectPassesRuleWithSchema, testSchema } from './harness';
+import { extendSchema } from '../../utilities/extendSchema';
+import { parse } from '../../language';
 import {
   KnownTypeNames,
   unknownTypeMessage,
@@ -53,6 +55,16 @@ describe('Validate: Known type names', () => {
       unknownType('Badger', 5, 25),
       unknownType('Peettt', 8, 29)
     ]);
+  });
+
+  it('types that are not in the schema don\'t need to be checked', () => {
+    // both types A and B are not part of the schema because nobody is
+    // referencing them
+    var clientSideTypes = `
+        type A { name: String }
+        type B { a: A }`;
+    var schema = extendSchema(testSchema, parse(clientSideTypes));
+    expectPassesRuleWithSchema(schema, KnownTypeNames, clientSideTypes);
   });
 
 });

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -315,6 +315,10 @@ function expectInvalid(schema, rules, queryString, expectedErrors) {
   expect(errors.map(formatError)).to.deep.equal(expectedErrors);
 }
 
+export function expectPassesRuleWithSchema(schema, rule, queryString) {
+  expectValid(schema, rule, queryString);
+}
+
 export function expectPassesRule(rule, queryString) {
   return expectValid(testSchema, [ rule ], queryString);
 }

--- a/src/validation/rules/KnownTypeNames.js
+++ b/src/validation/rules/KnownTypeNames.js
@@ -21,9 +21,22 @@ export function unknownTypeMessage(type: any): string {
  *
  * A GraphQL document is only valid if referenced types (specifically
  * variable definitions and fragment conditions) are defined by the type schema.
+ *
+ * We ignore the types that are referenced by types that are not part of the
+ * schema.
  */
 export function KnownTypeNames(context: ValidationContext): any {
   return {
+    ObjectTypeDefinition(node) {
+      var typeName = node.name.value;
+      var type = context.getSchema().getType(typeName);
+      if (!type) {
+        // If a type is not part of the schema, there's no reason to visit the
+        // sub-tree. This might happen when extendSchema() doesn't pick up the
+        // client-side type because it's never referenced by any of the queries.
+        return false;
+      }
+    },
     NamedType(node) {
       var typeName = node.name.value;
       var type = context.getSchema().getType(typeName);

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -77,7 +77,12 @@ export function visitUsingRules(
   const context = new ValidationContext(schema, documentAST, typeInfo);
   const visitors = rules.map(rule => rule(context));
   // Visit the whole document with each instance of all provided rules.
-  visit(documentAST, visitWithTypeInfo(typeInfo, visitInParallel(visitors)));
+  // TODO -- use visitInParallel() once
+  // https://github.com/graphql/graphql-js/pull/254 is fixed
+  //visit(documentAST, visitWithTypeInfo(typeInfo, visitInParallel(visitors)));
+  visitors.forEach(function (visitor) {
+    visit(documentAST, visitWithTypeInfo(typeInfo, visitor));
+  });
   return context.getErrors();
 }
 


### PR DESCRIPTION
To better understand the bug, check out the new test in __tests__/KnownTypeNames.js.

What happens is some part of our client-side schema might be left
non-imported, because it's not referenced (since expandSchema works by
continiously expanding root queryTypes). However, when a non-imported
type refrences another non-imported type KnownTypeNames reports a failure.
To fix this, I added a rule to skip a subtree of a non-imported type in
KnownTypeNames.

I also had to fix validate.js because visitInParallel() doesn't support
skipping the subtree when enter() returns false. See bug report #254.