### PR TITLE
Fix the error message for unknown field

### DIFF
--- a/src/execution/__tests__/variables.js
+++ b/src/execution/__tests__/variables.js
@@ -317,7 +317,7 @@ describe('Execute: Handles inputs', () => {
       });
 
       it('errors on addition of unknown input field', async () => {
-        var params = { input: { a: 'foo', b: 'bar', c: 'baz', d: 'dog' } };
+        var params = { input: { a: 'foo', b: 'bar', c: 'baz', extra: 'dog' } };
 
         var caughtError;
         try {
@@ -330,9 +330,8 @@ describe('Execute: Handles inputs', () => {
           locations: [ { line: 2, column: 17 } ],
           message:
             'Variable "$input" got invalid value ' +
-             '{"a":"foo","b":"bar","c":"baz","d":"dog"}.' +
-             '\nIn field "d": Expected type "ComplexScalar", found "dog".'
-
+             '{"a":"foo","b":"bar","c":"baz","extra":"dog"}.' +
+             '\nIn field \"extra\": Unknown field.'
         });
       });
 

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -68,7 +68,7 @@ export function isValidJSValue(value: any, type: GraphQLInputType): [ string ] {
     // Ensure every provided field is defined.
     for (var providedField of Object.keys(value)) {
       if (!fields[providedField]) {
-        errors.push('In field "${providedField}": Unknown field.');
+        errors.push(`In field "${providedField}": Unknown field.`);
       }
     }
 


### PR DESCRIPTION
The error message for unknown field was literal:
"In field "${providedField}": Unknown field."

Add necessary back ticks to the template literal so the message
includes the actual field name. Also change the test that claims to
test this case to actually test it.