### PR TITLE
Add directives to FieldDefinition

### DIFF
--- a/src/language/__tests__/kitchen-sink.graphql
+++ b/src/language/__tests__/kitchen-sink.graphql
@@ -55,3 +55,8 @@ fragment frag on Friend {
   unnamed(truthy: true, falsey: false),
   query
 }
+
+extend type User {
+  @iAmAnAnnotation(default: "Foo")
+  name: String
+}

--- a/src/language/__tests__/printer.js
+++ b/src/language/__tests__/printer.js
@@ -97,6 +97,11 @@ fragment frag on Friend {
   unnamed(truthy: true, falsey: false)
   query
 }
+
+extend type User {
+  @iAmAnAnnotation(default: "Foo")
+  name: String
+}
 `);
 
   });

--- a/src/language/__tests__/visitor.js
+++ b/src/language/__tests__/visitor.js
@@ -547,7 +547,42 @@ describe('Visitor', () => {
       [ 'leave', 'Field', 1, undefined ],
       [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
       [ 'leave', 'OperationDefinition', 4, undefined ],
-      [ 'leave', 'Document', undefined, undefined ] ]);
+      [ 'enter', 'TypeExtensionDefinition', 5, undefined ],
+      [
+        'enter',
+        'ObjectTypeDefinition',
+        'definition',
+        'TypeExtensionDefinition',
+      ],
+      [ 'enter', 'Name', 'name', 'ObjectTypeDefinition' ],
+      [ 'leave', 'Name', 'name', 'ObjectTypeDefinition' ],
+      [ 'enter', 'FieldDefinition', 0, undefined ],
+      [ 'enter', 'Name', 'name', 'FieldDefinition' ],
+      [ 'leave', 'Name', 'name', 'FieldDefinition' ],
+      [ 'enter', 'NamedType', 'type', 'FieldDefinition' ],
+      [ 'enter', 'Name', 'name', 'NamedType' ],
+      [ 'leave', 'Name', 'name', 'NamedType' ],
+      [ 'leave', 'NamedType', 'type', 'FieldDefinition' ],
+      [ 'enter', 'Annotation', 0, undefined ],
+      [ 'enter', 'Name', 'name', 'Annotation' ],
+      [ 'leave', 'Name', 'name', 'Annotation' ],
+      [ 'enter', 'Argument', 0, undefined ],
+      [ 'enter', 'Name', 'name', 'Argument' ],
+      [ 'leave', 'Name', 'name', 'Argument' ],
+      [ 'enter', 'StringValue', 'value', 'Argument' ],
+      [ 'leave', 'StringValue', 'value', 'Argument' ],
+      [ 'leave', 'Argument', 0, undefined ],
+      [ 'leave', 'Annotation', 0, undefined ],
+      [ 'leave', 'FieldDefinition', 0, undefined ],
+      [
+        'leave',
+        'ObjectTypeDefinition',
+        'definition',
+        'TypeExtensionDefinition',
+      ],
+      [ 'leave', 'TypeExtensionDefinition', 5, undefined ],
+      [ 'leave', 'Document', undefined, undefined ],
+    ]);
   });
 
   describe('visitInParallel', () => {

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -44,6 +44,7 @@ export type Node = Name
                  | ObjectValue
                  | ObjectField
                  | Directive
+                 | Annotation
                  | ListType
                  | NonNullType
                  | ObjectTypeDefinition
@@ -227,6 +228,14 @@ export type Directive = {
   arguments?: ?Array<Argument>;
 }
 
+// Annotation
+
+export type Annotation = {
+  kind: 'Annotation';
+  loc?: ?Location;
+  name: Name;
+  arguments?: ?Array<Argument>;
+}
 
 // Type Reference
 
@@ -276,6 +285,7 @@ export type FieldDefinition = {
   name: Name;
   arguments: Array<InputValueDefinition>;
   type: Type;
+  annotations?: ?Array<Annotation>;
 }
 
 export type InputValueDefinition = {

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -42,6 +42,10 @@ export const OBJECT_FIELD = 'ObjectField';
 
 export const DIRECTIVE = 'Directive';
 
+// Annotation
+
+export const ANNOTATION = 'Annotation';
+
 // Types
 
 export const NAMED_TYPE = 'NamedType';

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -34,6 +34,7 @@ import type {
   ObjectField,
 
   Directive,
+  Annotation,
 
   Type,
   NamedType,
@@ -77,6 +78,7 @@ import {
   OBJECT_FIELD,
 
   DIRECTIVE,
+  ANNOTATION,
 
   NAMED_TYPE,
   LIST_TYPE,
@@ -589,6 +591,33 @@ function parseDirective(parser): Directive {
   };
 }
 
+// Implements the parsing rules in the Annotations section.
+
+/**
+ * Annotations : Annotation+
+ */
+function parseAnnotations(parser): Array<Annotation> {
+  var annotations = [];
+  while (peek(parser, TokenKind.AT)) {
+    annotations.push(parseAnnotation(parser));
+  }
+  return annotations;
+}
+
+/**
+ * Annotation : @ Name Arguments?
+ */
+function parseAnnotation(parser): Annotation {
+  var start = parser.token.start;
+  expect(parser, TokenKind.AT);
+  return {
+    kind: ANNOTATION,
+    name: parseName(parser),
+    arguments: parseArguments(parser),
+    loc: loc(parser, start)
+  };
+}
+
 
 // Implements the parsing rules in the Types section.
 
@@ -709,10 +738,11 @@ function parseImplementsInterfaces(parser): Array<NamedType> {
 }
 
 /**
- * FieldDefinition : Name ArgumentsDefinition? : Type
+ * FieldDefinition : Annotations? Name ArgumentsDefinition? : Type
  */
 function parseFieldDefinition(parser): FieldDefinition {
   var start = parser.token.start;
+  var annotations = parseAnnotations(parser);
   var name = parseName(parser);
   var args = parseArgumentDefs(parser);
   expect(parser, TokenKind.COLON);
@@ -723,6 +753,7 @@ function parseFieldDefinition(parser): FieldDefinition {
     arguments: args,
     type,
     loc: loc(parser, start),
+    annotations,
   };
 }
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -83,6 +83,11 @@ var printDocASTReducer = {
   Directive: ({ name, arguments: args }) =>
     '@' + name + wrap('(', join(args, ', '), ')'),
 
+  // Annotation
+
+  Annotation: ({ name, arguments: args }) =>
+    '@' + name + wrap('(', join(args, ', '), ')'),
+
   // Type
 
   NamedType: ({ name }) => name,
@@ -96,8 +101,10 @@ var printDocASTReducer = {
     wrap('implements ', join(interfaces, ', '), ' ') +
     block(fields),
 
-  FieldDefinition: ({ name, arguments: args, type }) =>
-    name + wrap('(', join(args, ', '), ')') + ': ' + type,
+  FieldDefinition: ({ name, arguments: args, type, annotations }) =>
+    wrap('', join(annotations, '\n'), '\n') +
+    name + wrap('(', join(args, ', '), ')') + ': ' +
+    type,
 
   InputValueDefinition: ({ name, type, defaultValue }) =>
     name + ': ' + type + wrap(' = ', defaultValue),

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -33,13 +33,14 @@ export var QueryDocumentKeys = {
   ObjectField: [ 'name', 'value' ],
 
   Directive: [ 'name', 'arguments' ],
+  Annotation: [ 'name', 'arguments' ],
 
   NamedType: [ 'name' ],
   ListType: [ 'type' ],
   NonNullType: [ 'type' ],
 
   ObjectTypeDefinition: [ 'name', 'interfaces', 'fields' ],
-  FieldDefinition: [ 'name', 'arguments', 'type' ],
+  FieldDefinition: [ 'name', 'arguments', 'type', 'annotations' ],
   InputValueDefinition: [ 'name', 'type', 'defaultValue' ],
   InterfaceTypeDefinition: [ 'name', 'fields' ],
   UnionTypeDefinition: [ 'name', 'types' ],


### PR DESCRIPTION
This pull requests adds a new feature to the language -- directives for fields in type definitions and extensions. For example, now you're able to do this:

    type Hello {
       world: String @mock(value: "hello")
    }

We need directives for fields to enable the mock functionality we're building -- we'd like product developers to quickly specify some mock data on top of which they can build UI. That way we decouple building UI and server endpoints.

We could add directives to fields in a query, but if the platform is using type models, it's easier to add @mock to fields in a type definition -- the auto-generated type model just needs to override the default field getter.