### PR TITLE
Add a concept of annotations to GraphQL

### DIFF
--- a/src/__tests__/starWarsIntrospectionTests.js
+++ b/src/__tests__/starWarsIntrospectionTests.js
@@ -67,6 +67,12 @@ describe('Star Wars Introspection Tests', () => {
               name: '__InputValue'
             },
             {
+              name: '__Annotation'
+            },
+            {
+              name: '__AnnotationArgument'
+            },
+            {
               name: '__EnumValue'
             },
             {

--- a/src/language/__tests__/kitchen-sink.graphql
+++ b/src/language/__tests__/kitchen-sink.graphql
@@ -55,3 +55,8 @@ fragment frag on Friend {
   unnamed(truthy: true, falsey: false),
   query
 }
+
+extend type User {
+  @iAmAnAnnotation(default: "Foo")
+  name: String
+}

--- a/src/language/__tests__/printer.js
+++ b/src/language/__tests__/printer.js
@@ -97,6 +97,11 @@ fragment frag on Friend {
   unnamed(truthy: true, falsey: false)
   query
 }
+
+extend type User {
+  @iAmAnAnnotation(default: "Foo")
+  name: String
+}
 `);
 
   });

--- a/src/language/__tests__/visitor.js
+++ b/src/language/__tests__/visitor.js
@@ -547,7 +547,42 @@ describe('Visitor', () => {
       [ 'leave', 'Field', 1, undefined ],
       [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
       [ 'leave', 'OperationDefinition', 4, undefined ],
-      [ 'leave', 'Document', undefined, undefined ] ]);
+      [ 'enter', 'TypeExtensionDefinition', 5, undefined ],
+      [
+        'enter',
+        'ObjectTypeDefinition',
+        'definition',
+        'TypeExtensionDefinition',
+      ],
+      [ 'enter', 'Name', 'name', 'ObjectTypeDefinition' ],
+      [ 'leave', 'Name', 'name', 'ObjectTypeDefinition' ],
+      [ 'enter', 'FieldDefinition', 0, undefined ],
+      [ 'enter', 'Name', 'name', 'FieldDefinition' ],
+      [ 'leave', 'Name', 'name', 'FieldDefinition' ],
+      [ 'enter', 'NamedType', 'type', 'FieldDefinition' ],
+      [ 'enter', 'Name', 'name', 'NamedType' ],
+      [ 'leave', 'Name', 'name', 'NamedType' ],
+      [ 'leave', 'NamedType', 'type', 'FieldDefinition' ],
+      [ 'enter', 'Annotation', 0, undefined ],
+      [ 'enter', 'Name', 'name', 'Annotation' ],
+      [ 'leave', 'Name', 'name', 'Annotation' ],
+      [ 'enter', 'Argument', 0, undefined ],
+      [ 'enter', 'Name', 'name', 'Argument' ],
+      [ 'leave', 'Name', 'name', 'Argument' ],
+      [ 'enter', 'StringValue', 'value', 'Argument' ],
+      [ 'leave', 'StringValue', 'value', 'Argument' ],
+      [ 'leave', 'Argument', 0, undefined ],
+      [ 'leave', 'Annotation', 0, undefined ],
+      [ 'leave', 'FieldDefinition', 0, undefined ],
+      [
+        'leave',
+        'ObjectTypeDefinition',
+        'definition',
+        'TypeExtensionDefinition',
+      ],
+      [ 'leave', 'TypeExtensionDefinition', 5, undefined ],
+      [ 'leave', 'Document', undefined, undefined ],
+    ]);
   });
 
   describe('visitInParallel', () => {

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -44,6 +44,7 @@ export type Node = Name
                  | ObjectValue
                  | ObjectField
                  | Directive
+                 | Annotation
                  | ListType
                  | NonNullType
                  | ObjectTypeDefinition
@@ -227,6 +228,14 @@ export type Directive = {
   arguments?: ?Array<Argument>;
 }
 
+// Annotation
+
+export type Annotation = {
+  kind: 'Annotation';
+  loc?: ?Location;
+  name: Name;
+  arguments?: ?Array<Argument>;
+}
 
 // Type Reference
 
@@ -276,6 +285,7 @@ export type FieldDefinition = {
   name: Name;
   arguments: Array<InputValueDefinition>;
   type: Type;
+  annotations?: ?Array<Annotation>;
 }
 
 export type InputValueDefinition = {

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -42,6 +42,10 @@ export const OBJECT_FIELD = 'ObjectField';
 
 export const DIRECTIVE = 'Directive';
 
+// Annotation
+
+export const ANNOTATION = 'Annotation';
+
 // Types
 
 export const NAMED_TYPE = 'NamedType';

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -34,6 +34,7 @@ import type {
   ObjectField,
 
   Directive,
+  Annotation,
 
   Type,
   NamedType,
@@ -77,6 +78,7 @@ import {
   OBJECT_FIELD,
 
   DIRECTIVE,
+  ANNOTATION,
 
   NAMED_TYPE,
   LIST_TYPE,
@@ -589,6 +591,33 @@ function parseDirective(parser): Directive {
   };
 }
 
+// Implements the parsing rules in the Annotations section.
+
+/**
+ * Annotations : Annotation+
+ */
+function parseAnnotations(parser): Array<Annotation> {
+  var annotations = [];
+  while (peek(parser, TokenKind.AT)) {
+    annotations.push(parseAnnotation(parser));
+  }
+  return annotations;
+}
+
+/**
+ * Annotation : @ Name Arguments?
+ */
+function parseAnnotation(parser): Annotation {
+  var start = parser.token.start;
+  expect(parser, TokenKind.AT);
+  return {
+    kind: ANNOTATION,
+    name: parseName(parser),
+    arguments: parseArguments(parser),
+    loc: loc(parser, start)
+  };
+}
+
 
 // Implements the parsing rules in the Types section.
 
@@ -709,10 +738,11 @@ function parseImplementsInterfaces(parser): Array<NamedType> {
 }
 
 /**
- * FieldDefinition : Name ArgumentsDefinition? : Type
+ * FieldDefinition : Annotations? Name ArgumentsDefinition? : Type
  */
 function parseFieldDefinition(parser): FieldDefinition {
   var start = parser.token.start;
+  var annotations = parseAnnotations(parser);
   var name = parseName(parser);
   var args = parseArgumentDefs(parser);
   expect(parser, TokenKind.COLON);
@@ -723,6 +753,7 @@ function parseFieldDefinition(parser): FieldDefinition {
     arguments: args,
     type,
     loc: loc(parser, start),
+    annotations,
   };
 }
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -83,6 +83,11 @@ var printDocASTReducer = {
   Directive: ({ name, arguments: args }) =>
     '@' + name + wrap('(', join(args, ', '), ')'),
 
+  // Annotation
+
+  Annotation: ({ name, arguments: args }) =>
+    '@' + name + wrap('(', join(args, ', '), ')'),
+
   // Type
 
   NamedType: ({ name }) => name,
@@ -96,8 +101,10 @@ var printDocASTReducer = {
     wrap('implements ', join(interfaces, ', '), ' ') +
     block(fields),
 
-  FieldDefinition: ({ name, arguments: args, type }) =>
-    name + wrap('(', join(args, ', '), ')') + ': ' + type,
+  FieldDefinition: ({ name, arguments: args, type, annotations }) =>
+    wrap('', join(annotations, '\n'), '\n') +
+    name + wrap('(', join(args, ', '), ')') + ': ' +
+    type,
 
   InputValueDefinition: ({ name, type, defaultValue }) =>
     name + ': ' + type + wrap(' = ', defaultValue),

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -33,13 +33,14 @@ export var QueryDocumentKeys = {
   ObjectField: [ 'name', 'value' ],
 
   Directive: [ 'name', 'arguments' ],
+  Annotation: [ 'name', 'arguments' ],
 
   NamedType: [ 'name' ],
   ListType: [ 'type' ],
   NonNullType: [ 'type' ],
 
   ObjectTypeDefinition: [ 'name', 'interfaces', 'fields' ],
-  FieldDefinition: [ 'name', 'arguments', 'type' ],
+  FieldDefinition: [ 'name', 'arguments', 'type', 'annotations' ],
   InputValueDefinition: [ 'name', 'type', 'defaultValue' ],
   InterfaceTypeDefinition: [ 'name', 'fields' ],
   UnionTypeDefinition: [ 'name', 'types' ],

--- a/src/type/__tests__/introspection.js
+++ b/src/type/__tests__/introspection.js
@@ -1294,4 +1294,75 @@ describe('Introspection', () => {
     });
   });
 
+  it('introspection of directives on fields', async () => {
+    var TestType = new GraphQLObjectType({
+      name: 'TestType',
+      fields: {
+        testString: {
+          type: GraphQLString,
+          annotations: {
+            iAmAnAnnotation: { a: '10' },
+            annotationWithTwoArguments: { arg1: 'a', arg2: 'b' }
+          },
+        },
+      }
+    });
+
+    var schema = new GraphQLSchema({ query: TestType });
+    var request = `
+      {
+        __type(name: "TestType") {
+          name
+          fields {
+            name
+            annotations {
+              name
+              args {
+                name
+                value
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    return expect(
+      await graphql(schema, request)
+    ).to.deep.equal({
+      data: {
+        __type: {
+          name: 'TestType',
+          fields: [ {
+            name: 'testString',
+            annotations: [
+              {
+                name: 'iAmAnAnnotation',
+                args: [
+                  {
+                    name: 'a',
+                    value: '10',
+                  },
+                ],
+              },
+              {
+                name: 'annotationWithTwoArguments',
+                args: [
+                  {
+                    name: 'arg1',
+                    value: 'a',
+                  },
+                  {
+                    name: 'arg2',
+                    value: 'b',
+                  },
+                ],
+              },
+            ]
+          } ]
+        }
+      }
+    });
+  });
+
 });

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -479,6 +479,22 @@ export type GraphQLFieldConfig = {
   resolve?: GraphQLFieldResolveFn;
   deprecationReason?: string;
   description?: ?string;
+  annotations?: GraphQLAnnotationsMap
+}
+
+export type GraphQLAnnotationArgumentMap = {
+  // TODO: not sure if this should be any, or we
+  // need to restrict it to be only a string
+  [argName: string]: any
+}
+
+export type GraphQLAnnotation = {
+  name: string,
+  args?: GraphQLAnnotationArgumentMap
+}
+
+export type GraphQLAnnotationsMap = {
+  [directiveName: string]: GraphQLAnnotation
 }
 
 export type GraphQLFieldConfigArgumentMap = {
@@ -502,6 +518,7 @@ export type GraphQLFieldDefinition = {
   args: Array<GraphQLArgument>;
   resolve?: GraphQLFieldResolveFn;
   deprecationReason?: ?string;
+  annotations?: GraphQLAnnotationsMap
 }
 
 export type GraphQLArgument = {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -89,6 +89,39 @@ var __Directive = new GraphQLObjectType({
   }),
 });
 
+var __AnnotationArgument = new GraphQLObjectType({
+  name: '__AnnotationArgument',
+  description:
+    'Arguments provided to annotations are represented as ' +
+    '__AnnotationArgument',
+  fields: () => ({
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    // TODO: value's type here could be any scalar I guess,
+    // is there any way we can encode that? If not, maybe
+    // we can restrict this to be a string.
+    value: { type: new GraphQLNonNull(GraphQLString) },
+  }),
+});
+
+var __Annotation = new GraphQLObjectType({
+  name: '__Annotation',
+  description:
+    'An Annotation provides a way to add metadata to ' +
+    'field definitions in the schema',
+  fields: () => ({
+    name: { type: new GraphQLNonNull(GraphQLString) },
+    args: {
+      type:
+        new GraphQLNonNull(new GraphQLList(
+          new GraphQLNonNull(__AnnotationArgument)
+        )),
+      resolve: annotation => Object.keys(annotation.args).map(
+        name => ({name, value: annotation.args[name]})
+      ) || []
+    },
+  }),
+});
+
 var __Type = new GraphQLObjectType({
   name: '__Type',
   description:
@@ -210,7 +243,13 @@ var __Field = new GraphQLObjectType({
     },
     deprecationReason: {
       type: GraphQLString,
-    }
+    },
+    annotations: {
+      type: new GraphQLNonNull(new GraphQLList(__Annotation)),
+      resolve: field => Object.keys(field.annotations).map(
+        name => ({name, args: field.annotations[name]})
+      ) || []
+    },
   })
 });
 

--- a/src/utilities/__tests__/extendSchema.js
+++ b/src/utilities/__tests__/extendSchema.js
@@ -534,6 +534,51 @@ type Subscription {
 `);
   });
 
+  it('type extension\'s fields can have directives', () => {
+    const ast = parse(`
+      extend type Foo {
+        @iAmAnAnnotation(a: 10, b: "c")
+        newField: String
+      }
+    `);
+    const originalPrint = printSchema(testSchema);
+    const extendedSchema = extendSchema(testSchema, ast);
+    expect(extendSchema).to.not.equal(testSchema);
+    expect(printSchema(testSchema)).to.equal(originalPrint);
+    expect(printSchema(extendedSchema)).to.equal(
+`type Bar implements SomeInterface {
+  name: String
+  some: SomeInterface
+  foo: Foo
+}
+
+type Biz {
+  fizz: String
+}
+
+type Foo implements SomeInterface {
+  name: String
+  some: SomeInterface
+  tree: [Foo]!
+  @iAmAnAnnotation(a: 10, b: "c")
+  newField: String
+}
+
+type Query {
+  foo: Foo
+  someUnion: SomeUnion
+  someInterface(id: ID!): SomeInterface
+}
+
+interface SomeInterface {
+  name: String
+  some: SomeInterface
+}
+
+union SomeUnion = Foo | Biz
+`);
+  });
+
   it('does not allow replacing an existing type', () => {
     const ast = parse(`
       type Bar {

--- a/src/utilities/__tests__/schemaPrinter.js
+++ b/src/utilities/__tests__/schemaPrinter.js
@@ -508,6 +508,16 @@ type Root {
     var Schema = new GraphQLSchema({ query: Root });
     var output = '\n' + printIntrospectionSchema(Schema);
     var introspectionSchema = `
+type __Annotation {
+  name: String!
+  args: [__AnnotationArgument!]!
+}
+
+type __AnnotationArgument {
+  name: String!
+  value: String!
+}
+
 type __Directive {
   name: String!
   description: String
@@ -531,6 +541,7 @@ type __Field {
   type: __Type!
   isDeprecated: Boolean!
   deprecationReason: String
+  annotations: [__Annotation]!
 }
 
 type __InputValue {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -323,6 +323,8 @@ export function extendSchema(
         type: extendFieldType(field.type),
         args: keyMap(field.args, arg => arg.name),
         resolve: throwClientSchemaExecutionError,
+        annotations: field.annotations &&
+          keyMap(field.annotations, annotation => annotation.name),
       };
     });
 
@@ -342,6 +344,7 @@ export function extendSchema(
           newFieldMap[fieldName] = {
             type: buildFieldType(field.type),
             args: buildInputValues(field.arguments),
+            annotations: buildAnnotations(field.annotations),
             resolve: throwClientSchemaExecutionError,
           };
         });
@@ -452,6 +455,27 @@ export function extendSchema(
       }
     );
   }
+
+  function buildAnnotations(annotations: Array<InputValueDefinition>) {
+    var wrap = function (left, str, right, condition) {
+      return condition ? `${left}${str}${right}` : str;
+    };
+    return keyValMap(
+      annotations,
+      annotation => annotation.name.value,
+      annotation => keyValMap(
+        annotation.arguments,
+        argument => argument.name.value,
+        argument => wrap(
+          '"',
+          argument.value.value,
+          '"',
+          argument.value.kind === 'StringValue'
+        )
+      )
+    );
+  }
+
 
   function buildFieldType(typeAST: Type): GraphQLType {
     if (typeAST.kind === LIST_TYPE) {

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -120,7 +120,8 @@ function printFields(type) {
   var fieldMap = type.getFields();
   var fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
   return fields.map(
-    f => `  ${f.name}${printArgs(f)}: ${f.type}`
+    f => `${printAnnotations(f.annotations)}` +
+         `  ${f.name}${printArgs(f)}: ${f.type}`
   ).join('\n');
 }
 
@@ -137,4 +138,21 @@ function printInputValue(arg) {
     argDecl += ` = ${print(astFromValue(arg.defaultValue, arg.type))}`;
   }
   return argDecl;
+}
+
+function printAnnotations(annotations) {
+  if (!annotations || Object.keys(annotations).length === 0) {
+    return '';
+  }
+  var printAnnotationArgs = function (args) {
+    if (args.length === 0) {
+      return '';
+    }
+    return '(' +
+      Object.keys(args).map(name => `${name}: ${args[name]}`).join(', ') +
+      ')';
+  };
+  return Object.keys(annotations).map(
+    name => `  @${name}${printAnnotationArgs(annotations[name])}`
+  ).join('\n') + '\n';
 }


### PR DESCRIPTION
This pull requests adds a new feature to the language -- annotations for fields in type definitions and extensions. For example, now you're able to do this:

    type Hello {
      @mock(value: "hello")
       world: String
    }

We need annotations to enable the mock functionality we're building -- we'd like product developers to quickly specify some mock data on top of which they can build UI. That way we decouple building UI and server endpoints.
