### PR TITLE
Better error for GraphQLList

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -680,7 +680,7 @@ function completeValue(
     invariant(
       Array.isArray(result),
       'User Error: expected iterable, but did not find one ' +
-      `for field ${info.parentType}.${info.fieldName}.
+      `for field ${info.parentType}.${info.fieldName}.`
     );
 
     // This is specified as a simple map, however we're optimizing the path

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -679,7 +679,8 @@ function completeValue(
   if (returnType instanceof GraphQLList) {
     invariant(
       Array.isArray(result),
-      'User Error: expected iterable, but did not find one.'
+      'User Error: expected iterable, but did not find one ' +
+      `for field ${info.parentType}.${info.fieldName}.
     );
 
     // This is specified as a simple map, however we're optimizing the path


### PR DESCRIPTION
<img width="764" alt="screen shot 2016-01-15 at 12 15 14" src="https://cloud.githubusercontent.com/assets/1946920/12346782/c9ac31fc-bb81-11e5-8f51-35b74d8a37ac.png">

In my Object about 8 list fields, and it is not possible to determine which exactly produces an error.

--- 

Error message now contains field name 
`User Error: expected iterable, but did not find one for field Resume.experience.`  