### PR TITLE
Add printFineSchema() for printing hierarchy ordered types.

### DIFF
--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -26,6 +26,7 @@ import {
   GraphQLBoolean,
   GraphQLList,
   GraphQLNonNull,
+  GraphQLID,
 } from '../../';
 
 
@@ -547,8 +548,7 @@ scalar Odd
 type Root {
   odd: Odd
 }
-`
-     );
+`);
   });
 
   it('Enum', () => {
@@ -693,5 +693,886 @@ enum __TypeKind {
 }
 `;
     expect(output).to.equal(introspectionSchema);
+  });
+
+
+});
+
+function printFineForTest(schema) {
+  return '\n' + printSchema(schema, 'hierarchy');
+}
+
+function printFineSingleFieldSchema(fieldConfig) {
+  const Root = new GraphQLObjectType({
+    name: 'Root',
+    fields: { singleField: fieldConfig },
+  });
+  return printFineForTest(new GraphQLSchema({ query: Root }));
+}
+
+describe('Type System Printer [printFineSchema]:',() => {
+  it('Prints String Field', () => {
+    const output = printFineSingleFieldSchema({
+      type: GraphQLString
+    });
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField: String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints [String] Field', () => {
+    const output = printFineSingleFieldSchema({
+      type: listOf(GraphQLString)
+    });
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField: [String]
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String! Field', () => {
+    const output = printFineSingleFieldSchema({
+      type: nonNull(GraphQLString)
+    });
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField: String!
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints [String]! Field', () => {
+    const output = printFineSingleFieldSchema({
+      type: nonNull(listOf(GraphQLString))
+    });
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField: [String]!
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints [String!] Field', () => {
+    const output = printFineSingleFieldSchema({
+      type: listOf(nonNull(GraphQLString))
+    });
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField: [String!]
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints [String!]! Field', () => {
+    const output = printFineSingleFieldSchema({
+      type: nonNull(listOf(nonNull(GraphQLString)))
+    });
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField: [String!]!
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Print Object Field', () => {
+    const FooType = new GraphQLObjectType({
+      name: 'Foo',
+      fields: { str: { type: GraphQLString } }
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: { foo: { type: FooType } },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+type Foo {
+  str: String
+}
+
+type Root {
+  foo: Foo
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Int Arg', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: { argOne: { type: GraphQLInt } },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Int Arg With Default', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: { argOne: { type: GraphQLInt, defaultValue: 2 } },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int = 2): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Int! Arg', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: { argOne: { type: nonNull(GraphQLInt) } },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int!): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt },
+          argTwo: { type: GraphQLString },
+        },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int, argTwo: String): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args, First is Default', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt, defaultValue: 1 },
+          argTwo: { type: GraphQLString },
+          argThree: { type: GraphQLBoolean },
+        },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args, Second is Default', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt },
+          argTwo: { type: GraphQLString, defaultValue: 'foo' },
+          argThree: { type: GraphQLBoolean },
+        },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Prints String Field With Multiple Args, Last is Default', () => {
+    const output = printFineSingleFieldSchema(
+      {
+        type: GraphQLString,
+        args: {
+          argOne: { type: GraphQLInt },
+          argTwo: { type: GraphQLString },
+          argThree: { type: GraphQLBoolean, defaultValue: false },
+        },
+      }
+    );
+    expect(output).to.equal(`\n\n
+type Root {
+  singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  // below is multipul type objects test,
+  // results are different from printSchema
+  it('Print Interface', () => {
+    const FooType = new GraphQLInterfaceType({
+      name: 'Foo',
+      resolveType: () => null,
+      fields: { str: { type: GraphQLString } },
+    });
+
+    const BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: { str: { type: GraphQLString } },
+      interfaces: [ FooType ],
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: { bar: { type: BarType } },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+interface Foo {
+  str: String
+}
+
+type Bar implements Foo {
+  str: String
+}
+
+type Root {
+  bar: Bar
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Print Multiple Interface', () => {
+    const FooType = new GraphQLInterfaceType({
+      name: 'Foo',
+      resolveType: () => null,
+      fields: { str: { type: GraphQLString } },
+    });
+
+    const BaazType = new GraphQLInterfaceType({
+      name: 'Baaz',
+      resolveType: () => null,
+      fields: { int: { type: GraphQLInt } },
+    });
+
+    const BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: {
+        str: { type: GraphQLString },
+        int: { type: GraphQLInt },
+      },
+      interfaces: [ FooType, BaazType ],
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: { bar: { type: BarType } },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+interface Baaz {
+  int: Int
+}
+
+interface Foo {
+  str: String
+}
+
+type Bar implements Foo, Baaz {
+  str: String
+  int: Int
+}
+
+type Root {
+  bar: Bar
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Print Unions', () => {
+    const FooType = new GraphQLObjectType({
+      name: 'Foo',
+      fields: {
+        bool: { type: GraphQLBoolean },
+      },
+    });
+
+    const BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: {
+        str: { type: GraphQLString },
+      },
+    });
+
+    const SingleUnion = new GraphQLUnionType({
+      name: 'SingleUnion',
+      resolveType: () => null,
+      types: [ FooType ],
+    });
+
+    const MultipleUnion = new GraphQLUnionType({
+      name: 'MultipleUnion',
+      resolveType: () => null,
+      types: [ FooType, BarType ],
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        single: { type: SingleUnion },
+        multiple: { type: MultipleUnion },
+      },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+type Bar {
+  str: String
+}
+
+type Foo {
+  bool: Boolean
+}
+
+union MultipleUnion = Foo | Bar
+
+union SingleUnion = Foo
+
+type Root {
+  single: SingleUnion
+  multiple: MultipleUnion
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Print Input Type', () => {
+    const InputType = new GraphQLInputObjectType({
+      name: 'InputType',
+      fields: {
+        int: { type: GraphQLInt },
+      },
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        str: {
+          type: GraphQLString,
+          args: { argOne: { type: InputType } },
+        },
+      },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+input InputType {
+  int: Int
+}
+
+type Root {
+  str(argOne: InputType): String
+}
+
+schema {
+  query: Root
+}
+`);
+  });
+
+  it('Custom Scalar', () => {
+    const OddType = new GraphQLScalarType({
+      name: 'Odd',
+      serialize(value) {
+        return value % 2 === 1 ? value : null;
+      }
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        odd: { type: OddType },
+      },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+scalar Odd
+
+type Root {
+  odd: Odd
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+
+  it('Enum', () => {
+    const RGBType = new GraphQLEnumType({
+      name: 'RGB',
+      values: {
+        RED: { value: 0 },
+        GREEN: { value: 1 },
+        BLUE: { value: 2 }
+      }
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        rgb: { type: RGBType },
+      },
+    });
+
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+enum RGB {
+  RED
+  GREEN
+  BLUE
+}
+
+type Root {
+  rgb: RGB
+}
+
+schema {
+  query: Root
+}
+`);
+  });
+
+  it('Circle reference between type', () => {
+    const nodeType = new GraphQLInterfaceType({
+      name: 'Node',
+      resolveType: () => null,
+      fields: () => ({
+        id: {type: GraphQLString},
+        best: {type: dogType},
+      }),
+    });
+
+    const dogType = new GraphQLObjectType({
+      name: 'Dog',
+      fields: () => ({
+        id: {type: GraphQLString},
+        best: {type: dogType},
+        look: {type: catType},
+      }),
+      interfaces: [ nodeType ],
+    });
+
+    const mouseType = new GraphQLObjectType({
+      name: 'Mouse',
+      fields: () => ({
+        id: {type: GraphQLString},
+        best: {type: dogType},
+        find: {type: cowType},
+      }),
+      interfaces: [ nodeType ],
+    });
+
+    const catType = new GraphQLObjectType({
+      name: 'Cat',
+      fields: () => ({
+        id: {type: GraphQLString},
+        best: {type: dogType},
+        eat: {type: mouseType},
+      }),
+      interfaces: [ nodeType ],
+    });
+
+    const cowType = new GraphQLObjectType({
+      name: 'Cow',
+      fields: () => ({
+        id: {type: GraphQLString},
+        best: {type: dogType},
+        feed: {type: listOf(nodeType)},
+      }),
+      interfaces: [ nodeType ],
+    });
+
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        dog: { type: dogType },
+        mouse: { type: mouseType },
+      },
+    });
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+interface Node {
+  id: String
+  best: Dog
+}
+
+type Cow implements Node {
+  id: String
+  best: Dog
+  feed: [Node]
+}
+
+type Mouse implements Node {
+  id: String
+  best: Dog
+  find: Cow
+}
+
+type Cat implements Node {
+  id: String
+  best: Dog
+  eat: Mouse
+}
+
+type Dog implements Node {
+  id: String
+  best: Dog
+  look: Cat
+}
+
+type Root {
+  dog: Dog
+  mouse: Mouse
+}
+
+schema {
+  query: Root
+}
+`
+    );
+  });
+  it('relay style types to check right type order', () => {
+
+    const nodeType = new GraphQLInterfaceType({
+      name: 'Node',
+      resolveType: () => null,
+      fields: () => ({
+        id: {type: nonNull(GraphQLString)},
+      }),
+    });
+
+    const newPostInputType = new GraphQLInputObjectType({
+      name: 'NewPostInput',
+      fields: {
+        user: { type: nonNull(GraphQLString) },
+        content: { type: nonNull(GraphQLString) },
+        clientMutationId: { type: nonNull(GraphQLString) },
+      }
+    });
+
+    const newPostPayloadType = new GraphQLObjectType({
+      name: 'NewPostPayload',
+      fields: () => ({
+        postEdge: {type: postEdgeType},
+        web: {type: webType},
+        clientMutationId: { type: nonNull(GraphQLString) },
+      }),
+    });
+
+    const commentConnectionType = new GraphQLObjectType({
+      name: 'CommentConnection',
+      fields: () => ({
+        pageInfo: {type: nonNull(pageInfoType)},
+        edges: {type: listOf(commentEdgeType)},
+      }),
+    });
+
+    const postConnectionType = new GraphQLObjectType({
+      name: 'PostConnection',
+      fields: () => ({
+        pageInfo: {type: nonNull(pageInfoType)},
+        edges: {type: listOf(postEdgeType)},
+      }),
+    });
+
+    const pageInfoType = new GraphQLObjectType({
+      name: 'PageInfo',
+      fields: () => ({
+        hasNextPage: {type: nonNull(GraphQLBoolean)},
+        hasPreviousPage: {type: nonNull(GraphQLBoolean)},
+        startCursor: {type: GraphQLString},
+        endCursor: {type: GraphQLString},
+      }),
+    });
+
+    const commentEdgeType = new GraphQLObjectType({
+      name: 'CommentEdge',
+      fields: () => ({
+        node: {type: commentType},
+        cursor: {type: nonNull(GraphQLString)},
+      }),
+    });
+
+    const postEdgeType = new GraphQLObjectType({
+      name: 'PostEdge',
+      fields: () => ({
+        node: {type: postType},
+        cursor: {type: nonNull(GraphQLString)},
+      }),
+    });
+
+    const postSearchType = new GraphQLObjectType({
+      name: 'PostSearch',
+      fields: () => ({
+        postCount: {type: GraphQLInt},
+        cursor: {type: postConnectionType},
+      }),
+    });
+
+    const postType = new GraphQLObjectType({
+      name: 'Post',
+      fields: () => ({
+        id: {type: nonNull(GraphQLString)},
+        user: {type: GraphQLString},
+        content: {type: GraphQLString},
+        comments: {type: commentConnectionType},
+      }),
+      interfaces: [ nodeType ],
+    });
+
+    const commentType = new GraphQLObjectType({
+      name: 'Comment',
+      fields: () => ({
+        id: {type: nonNull(GraphQLString)},
+        user: {type: GraphQLString},
+        content: {type: GraphQLString},
+        replyTo: {type: postType},
+      }),
+      interfaces: [ nodeType ],
+    });
+
+    const webType = new GraphQLObjectType({
+      name: 'Web',
+      fields: () => ({
+        id: {type: nonNull(GraphQLString)},
+        postSearch: {
+          type: postSearchType,
+          args: {
+            text: {type: GraphQLString},
+          },
+        },
+        allPosts: {
+          type: postConnectionType,
+        },
+      }),
+    });
+
+    const queryType = new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        web: { type: webType },
+        node: {
+          type: nodeType,
+          args: {
+            id: {type: nonNull( GraphQLID)}
+          },
+          resolve: () => null,
+        },
+      },
+    });
+    const mutationType = new GraphQLObjectType({
+      name: 'Mutation',
+      fields: () => ({
+        newPost: {
+          type: newPostPayloadType,
+          args: {
+            input: {
+              type: nonNull(newPostInputType),
+            },
+          },
+          resolve: () => null,
+        },
+      }),
+    });
+    const Schema = new GraphQLSchema({
+      query: queryType ,mutation: mutationType });
+    const output = printFineForTest(Schema);
+    expect(output).to.equal(`\n\n
+interface Node {
+  id: String!
+}
+
+type Comment implements Node {
+  id: String!
+  user: String
+  content: String
+  replyTo: Post
+}
+
+type CommentEdge {
+  node: Comment
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  hasPreviousPage: Boolean!
+  startCursor: String
+  endCursor: String
+}
+
+type CommentConnection {
+  pageInfo: PageInfo!
+  edges: [CommentEdge]
+}
+
+type Post implements Node {
+  id: String!
+  user: String
+  content: String
+  comments: CommentConnection
+}
+
+type PostEdge {
+  node: Post
+  cursor: String!
+}
+
+type PostConnection {
+  pageInfo: PageInfo!
+  edges: [PostEdge]
+}
+
+type PostSearch {
+  postCount: Int
+  cursor: PostConnection
+}
+
+type Web {
+  id: String!
+  postSearch(text: String): PostSearch
+  allPosts: PostConnection
+}
+
+type Query {
+  web: Web
+  node(id: ID!): Node
+}
+
+input NewPostInput {
+  user: String!
+  content: String!
+  clientMutationId: String!
+}
+
+type NewPostPayload {
+  postEdge: PostEdge
+  web: Web
+  clientMutationId: String!
+}
+
+type Mutation {
+  newPost(input: NewPostInput!): NewPostPayload
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}
+`
+    );
   });
 });

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -26,9 +26,9 @@ import { GraphQLString } from '../type/scalars';
 import { DEFAULT_DEPRECATION_REASON } from '../type/directives';
 
 
-// type printStyle = 'alphabet' | 'hierarchy';
+type printStyle = 'alphabet' | 'hierarchy';
 export function printSchema(
-  schema: GraphQLSchema,style: string = 'alphabet'): string {
+  schema: GraphQLSchema,style: printStyle = 'alphabet'): string {
   switch (style) {
     case 'hierarchy':
       return printFineSchema(schema, n => !isSpecDirective(n));
@@ -256,7 +256,7 @@ function getOrderedNamesBySchema(schema) {
   return orderedNames;
 }
 
-function flatNamesMapToArray(leveledNamesMap:Map):Array<string> {
+function flatNamesMapToArray(leveledNamesMap: Map<*, *>): Array<string> {
   const levelToNamesMap = flipMap(leveledNamesMap);
   const nameLevels = Array.from(levelToNamesMap.keys());
   nameLevels.sort((pre,next) => ( next - pre ));
@@ -276,13 +276,13 @@ function flatNamesMapToArray(leveledNamesMap:Map):Array<string> {
 }
 
 type NamesMap = {
-  leveledNamesMap:Map,
-  unLeveledNamesMap:Map,
+  leveledNamesMap:Map<*, *>,
+  unLeveledNamesMap:Map<*, *>,
 };
 
 // calculate level values for each type names by their reference to each other
-function levelTypeNames(rootName:string,namesMapToBeLeveled:Map,
-                        schema:GraphQLSchema):NamesMap {
+function levelTypeNames(rootName: string,namesMapToBeLeveled: Map<*, *>,
+                        schema: GraphQLSchema): NamesMap {
   const typeMap = schema.getTypeMap();
   const unLeveledNamesMap = new Map(namesMapToBeLeveled);
   const leveledNamesMap = new Map();
@@ -322,7 +322,7 @@ function levelTypeNames(rootName:string,namesMapToBeLeveled:Map,
 // always return an array ,if get none,just return []
 // three sources of reference from a type.
 // field itself, args of a fields,interface
-function getRefedTypes(type:any):Array<string> {
+function getRefedTypes(type: any): Array<string> {
   let refedTypeNames = [];
   if (!isDefinedType(type.name) ||
       // as i known ~_~,if there is no Fields
@@ -358,8 +358,8 @@ function getRefedTypes(type:any):Array<string> {
 
 }
 
-function arrayToMap(_array:Array<string>,
-                    defaultValue:number):Map<string,number> {
+function arrayToMap(_array: Array<string>,
+                    defaultValue: number): Map<string, number> {
   const _map = new Map();
   for (const v of _array) {
     _map.set(v,defaultValue);
@@ -367,7 +367,7 @@ function arrayToMap(_array:Array<string>,
   return _map;
 }
 
-function flipMap(_srcMap:Map<string,number>):Map<number,Array<string>> {
+function flipMap(_srcMap: Map<string, number>): Map<number, Array<string>> {
   const _outMap = new Map();
   for (const [ oldKey,vToKey ] of _srcMap) {
     const subArray = _outMap.get(vToKey);
@@ -380,7 +380,7 @@ function flipMap(_srcMap:Map<string,number>):Map<number,Array<string>> {
   return _outMap;
 }
 
-function getTypeName(type:any):string {
+function getTypeName(type: any): string {
   const typeString = type.constructor.name;
   let name = type.name;
   if (typeString === 'GraphQLNonNull' || typeString === 'GraphQLList' ) {
@@ -395,7 +395,7 @@ function getTypeName(type:any):string {
   return name;
 }
 
-function getDefinedTypeNameByType(TypeObj:GraphQLType):?string {
+function getDefinedTypeNameByType(TypeObj: GraphQLType): ?string {
   const typeName = getTypeName(TypeObj);
   if (isDefinedType(typeName)) {
     return typeName;

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -26,8 +26,17 @@ import { GraphQLString } from '../type/scalars';
 import { DEFAULT_DEPRECATION_REASON } from '../type/directives';
 
 
-export function printSchema(schema: GraphQLSchema): string {
-  return printFilteredSchema(schema, n => !isSpecDirective(n), isDefinedType);
+// type printStyle = 'alphabet' | 'hierarchy';
+export function printSchema(
+  schema: GraphQLSchema,style: string = 'alphabet'): string {
+  switch (style) {
+    case 'hierarchy':
+      return printFineSchema(schema, n => !isSpecDirective(n));
+    case 'alphabet':
+    default:
+      return printFilteredSchema(schema, n => !isSpecDirective(n),
+      isDefinedType);
+  }
 }
 
 export function printIntrospectionSchema(schema: GraphQLSchema): string {
@@ -195,4 +204,201 @@ function printInputValue(arg) {
 function printDirective(directive) {
   return 'directive @' + directive.name + printArgs(directive) +
     ' on ' + directive.locations.join(' | ');
+}
+
+function printFineSchema(
+  schema: GraphQLSchema,
+  directiveFilter: (type: string) => boolean = (n => !isSpecDirective(n))
+): string {
+  const directives = schema.getDirectives()
+  .filter(directive => directiveFilter(directive.name));
+  const typeMap = schema.getTypeMap();
+  const orderedNames = getOrderedNamesBySchema(schema);
+  const types = orderedNames.map(orderedName => typeMap[orderedName]);
+  return [ directives.map(printDirective) ].concat(
+    types.map(printType),
+    printSchemaDefinition(schema)
+  ).join('\n\n') + '\n';
+}
+
+function getOrderedNamesBySchema(schema) {
+  const typeMap = schema.getTypeMap();
+  const rootQuery = schema.getQueryType();
+  const definedTypeNames = Object.keys(typeMap).filter(isDefinedType);
+
+  // use a big number 999999 to save some condition operator ~_~
+  // todo should modify the magic 999999
+  const typeNamesMap = arrayToMap(definedTypeNames,99999);
+  // give each type used by 'Query' a level number
+  const queryMaps = levelTypeNames(rootQuery.name,typeNamesMap,schema);
+  let unLeveledNamesMap = queryMaps.unLeveledNamesMap;
+  const leveledNamesMap = queryMaps.leveledNamesMap;
+  let orderedNames = flatNamesMapToArray(leveledNamesMap);
+
+  const rootMutation = schema.getMutationType();
+  if (rootMutation) {
+    // give level number to the rest unLeveled type
+    // which used by Mutations
+    const restNamesMap = levelTypeNames(rootMutation.name,
+      unLeveledNamesMap,schema);
+    const orderedMutations =
+      flatNamesMapToArray(restNamesMap.leveledNamesMap);
+
+    orderedNames = [ ...orderedNames,...orderedMutations ];
+    unLeveledNamesMap = restNamesMap.unLeveledNamesMap;
+  }
+
+  // todo throw a error .. should have none unknown type
+  const theNamesIDontKnown = flatNamesMapToArray(unLeveledNamesMap);
+  if (theNamesIDontKnown.length > 0) {
+    orderedNames = [ ...theNamesIDontKnown,...orderedNames ];
+  }
+  return orderedNames;
+}
+
+function flatNamesMapToArray(leveledNamesMap:Map):Array<string> {
+  const levelToNamesMap = flipMap(leveledNamesMap);
+  const nameLevels = Array.from(levelToNamesMap.keys());
+  nameLevels.sort((pre,next) => ( next - pre ));
+  let orderedNames = [];
+  for (const level of nameLevels) {
+    const levelNames = levelToNamesMap.get(level);
+    if (levelNames) {
+      // sort the same level names . to get a certainly order.
+      levelNames.sort((name1, name2) => name1.localeCompare(name2));
+      orderedNames = orderedNames.concat(levelNames);
+    } else {
+      throw new Error(`printFineSchema.getOrderedNamesFromMap:
+      level[${level}] have no names,it should have`);
+    }
+  }
+  return orderedNames;
+}
+
+type NamesMap = {
+  leveledNamesMap:Map,
+  unLeveledNamesMap:Map,
+};
+
+// calculate level values for each type names by their reference to each other
+function levelTypeNames(rootName:string,namesMapToBeLeveled:Map,
+                        schema:GraphQLSchema):NamesMap {
+  const typeMap = schema.getTypeMap();
+  const unLeveledNamesMap = new Map(namesMapToBeLeveled);
+  const leveledNamesMap = new Map();
+  // use a map to watch circle ref,Depth-first search
+  const circleRef = new Map();
+
+  unLeveledNamesMap.delete(rootName);
+  leveledNamesMap.set(rootName,0);
+  _levelTypeNames(rootName,1);
+  function _levelTypeNames(thisName,childLevel) {
+    const childrenNames = getRefedTypes(typeMap[thisName]);
+    for (const childName of childrenNames) {
+      const currentLevel = leveledNamesMap.get(childName);
+      if (// meet a circle ref,skip
+      circleRef.get(childName) ||
+        // this type is not belong to current process,skip
+      namesMapToBeLeveled.get(childName) === undefined ||
+        //  if [the level of leveled Name] >= [current level]
+        // must skip,level is always up~ no downgrade
+      (currentLevel && currentLevel >= childLevel)
+      ) {
+        continue;
+      }
+      circleRef.set(childName,childLevel);
+
+      leveledNamesMap.set(childName,childLevel);
+      unLeveledNamesMap.delete(childName);
+      _levelTypeNames(childName,childLevel + 1);
+
+      circleRef.delete(childName);
+    }
+  }
+
+  return {unLeveledNamesMap,leveledNamesMap};
+}
+
+// always return an array ,if get none,just return []
+// three sources of reference from a type.
+// field itself, args of a fields,interface
+function getRefedTypes(type:any):Array<string> {
+  let refedTypeNames = [];
+  if (!isDefinedType(type.name) ||
+      // as i known ~_~,if there is no Fields
+      // this type can not ref other types inside
+    !(type.getFields instanceof Function)
+  ) {
+    return refedTypeNames;
+  }
+
+  const fields = type.getFields();
+  // 1/2 get refed type name from fields
+  Object.keys(fields).map( fieldKey => fields[fieldKey])
+    .filter(field => isDefinedType(getTypeName(field.type) ) )
+    .map(field => {
+      refedTypeNames = refedTypeNames.concat(
+        // 1. get type name from args of a field
+        // in javascript, can not use instanceof to check a String type!
+        // must use typeof!
+        field.args.map(arg => getDefinedTypeNameByType(arg.type))
+          .filter(value => (typeof value === 'string')) ,
+        // 2. get type name from field itself
+        getDefinedTypeNameByType(field.type) || []
+      );
+    });
+
+  // 3. get type name from interfaces
+  if (type.getInterfaces instanceof Function) {
+    for (const interfaceType of type.getInterfaces()) {
+      refedTypeNames.push(interfaceType.name);
+    }
+  }
+  return refedTypeNames;
+
+}
+
+function arrayToMap(_array:Array<string>,
+                    defaultValue:number):Map<string,number> {
+  const _map = new Map();
+  for (const v of _array) {
+    _map.set(v,defaultValue);
+  }
+  return _map;
+}
+
+function flipMap(_srcMap:Map<string,number>):Map<number,Array<string>> {
+  const _outMap = new Map();
+  for (const [ oldKey,vToKey ] of _srcMap) {
+    const subArray = _outMap.get(vToKey);
+    if ( subArray ) {
+      subArray.push(oldKey);
+    } else {
+      _outMap.set(vToKey,[ oldKey ]);
+    }
+  }
+  return _outMap;
+}
+
+function getTypeName(type:any):string {
+  const typeString = type.constructor.name;
+  let name = type.name;
+  if (typeString === 'GraphQLNonNull' || typeString === 'GraphQLList' ) {
+    name = getTypeName(type.ofType);
+  }
+  if ( name === undefined && isDefinedType(type)) {
+    // if still can not get name,
+    // this type must be something i dont known ,throw to learn
+    throw new Error(`Unknown type its javascript class is
+      [ [${type.constructor.name}] ${type.ofType.constructor.name}]`);
+  }
+  return name;
+}
+
+function getDefinedTypeNameByType(TypeObj:GraphQLType):?string {
+  const typeName = getTypeName(TypeObj);
+  if (isDefinedType(typeName)) {
+    return typeName;
+  }
+  return null;
 }


### PR DESCRIPTION
Add printFineSchema() for printing hierarchy ordered types,the ranks are determined by reference/extends between each type.
Not modify the original printSchema.
Something like :
```
C {  a:A }
B {  c:C }
A {}
```
will be ordered to their hierarchy , more details is in __tests__
```
A {}
C {  a:A }
B {  c:C }
```