### PR TITLE
Test schema instead of function

### DIFF
--- a/src/utilities/__tests__/extendSchema.js
+++ b/src/utilities/__tests__/extendSchema.js
@@ -100,7 +100,7 @@ describe('extendSchema', () => {
     `);
     const originalPrint = printSchema(testSchema);
     const extendedSchema = extendSchema(testSchema, ast);
-    expect(extendSchema).to.not.equal(testSchema);
+    expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.contain('newField');
     expect(printSchema(testSchema)).to.not.contain('newField');


### PR DESCRIPTION
The test was run against the function instead of the schema, a simple typo omission.