### PR TITLE
Provides a correct OperationType without name in GraphQLPrinter

### DIFF
--- a/src/language/__tests__/printer.js
+++ b/src/language/__tests__/printer.js
@@ -34,6 +34,44 @@ describe('Printer', () => {
     );
   });
 
+  it('correctly prints non-query operations without name', () => {
+    const queryAstShorthanded = parse(`query { id, name }`);
+    expect(print(queryAstShorthanded)).to.equal(
+`{
+  id
+  name
+}
+`);
+
+    const mutationAst = parse(`mutation { id, name }`);
+    expect(print(mutationAst)).to.equal(
+`mutation {
+  id
+  name
+}
+`);
+
+    const queryAstWithArtifacts = parse(
+`query ($foo: TestType) @testDirective { id, name }`
+);
+    expect(print(queryAstWithArtifacts)).to.equal(
+`query ($foo: TestType) @testDirective {
+  id
+  name
+}
+`);
+
+    const mutationAstWithArtifacts = parse(
+`mutation ($foo: TestType) @testDirective { id, name }`
+);
+    expect(print(mutationAstWithArtifacts)).to.equal(
+`mutation ($foo: TestType) @testDirective {
+  id
+  name
+}
+`);
+  });
+
 
   const kitchenSink = readFileSync(
     join(__dirname, '/kitchen-sink.graphql'),

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -28,11 +28,14 @@ const printDocASTReducer = {
   OperationDefinition(node) {
     const op = node.operation;
     const name = node.name;
-    const defs = wrap('(', join(node.variableDefinitions, ', '), ')');
+    const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
     const directives = join(node.directives, ' ');
     const selectionSet = node.selectionSet;
-    return !name ? selectionSet :
-      join([ op, join([ name, defs ]), directives, selectionSet ], ' ');
+    // Anonymous queries with no directives or variable definitions can use
+    // the query short form.
+    return !name && !directives && !varDefs && op === 'query' ?
+      selectionSet :
+      join([ op, join([ name, varDefs ]), directives, selectionSet ], ' ');
   },
 
   VariableDefinition: ({ variable, type, defaultValue }) =>


### PR DESCRIPTION
Addresses #288. Simply inserts another check to see OperationType is `query` and only omit the keyword in that case. For `mutation` (and `subscription`) the query string should still contain OperationType.