### PR TITLE
Visitor does not support `enter` and `leave` for the root node

### DIFF
--- a/src/language/__tests__/visitor.js
+++ b/src/language/__tests__/visitor.js
@@ -20,6 +20,63 @@ import { getNamedType, isCompositeType } from '../../type';
 
 
 describe('Visitor', () => {
+
+  it('allows editing a node both on enter and on leave', () => {
+
+    const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
+
+    let selectionSet;
+
+    const editedAst = visit(ast, {
+      OperationDefinition: {
+        enter(node) {
+          selectionSet = node.selectionSet;
+          return {
+            ...node,
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: []
+            },
+          };
+        },
+        leave(node) {
+          return {
+            ...node,
+            selectionSet,
+          };
+        }
+      }
+    });
+
+    expect(editedAst).to.deep.equal(ast);
+  });
+
+  it('allows editing the root node on enter and on leave', () => {
+
+    const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
+
+    const { definitions } = ast;
+
+    const editedAst = visit(ast, {
+      Document: {
+        enter(node) {
+          return {
+            ...node,
+            definitions: []
+          };
+        },
+        leave(node) {
+          return {
+            ...node,
+            definitions,
+          };
+        }
+      }
+    });
+
+    expect(editedAst).to.deep.equal(ast);
+  });
+
   it('allows for editing on enter', () => {
 
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -254,7 +254,7 @@ export function visit(root, visitor, keyMap) {
   } while (stack !== undefined);
 
   if (edits.length !== 0) {
-    newRoot = edits[0][1];
+    newRoot = edits[edits.length - 1][1];
   }
 
   return newRoot;


### PR DESCRIPTION
Opening an issue to discuss this apparent problem.