### PR TITLE
Type checking under GraphQLList is too strict.

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -695,7 +695,7 @@ function completeValue(
   // If field type is List, complete each item in the list with the inner type
   if (returnType instanceof GraphQLList) {
     invariant(
-      Array.isArray(result),
+      typeof result.map === 'function',
       'User Error: expected iterable, but did not find one ' +
       `for field ${info.parentType}.${info.fieldName}.`
     );

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -138,8 +138,7 @@ function coerceValue(type: GraphQLInputType, value: mixed): mixed {
 
   if (type instanceof GraphQLList) {
     const itemType = type.ofType;
-    // TODO: support iterable input
-    if (Array.isArray(_value)) {
+    if (typeof _value.map === 'function') {
       return _value.map(item => coerceValue(itemType, item));
     }
     return [ coerceValue(itemType, _value) ];


### PR DESCRIPTION
`Array.isArray` is being used before running `map`. This precludes, for example, [Backbone](http://backbonejs.org/)-style Collections from being considered valid iterables despite them having the required array-like functionality.