### PR TITLE
Add test for parseLiteral on ComplexScalar

### DIFF
--- a/src/execution/__tests__/variables.js
+++ b/src/execution/__tests__/variables.js
@@ -175,6 +175,22 @@ describe('Execute: Handles inputs', () => {
           }
         });
       });
+
+      it('properly runs parseLiteral on complex scalar types', async () => {
+        const doc = `
+        {
+          fieldWithObjectInput(input: {a: "foo", d: "SerializedValue"})
+        }
+        `;
+        const ast = parse(doc);
+
+        return expect(await execute(schema, ast)).to.deep.equal({
+          data: {
+            fieldWithObjectInput: '{"a":"foo","d":"DeserializedValue"}',
+          }
+        });
+      });
+
     });
 
     describe('using variables', () => {


### PR DESCRIPTION
I was looking through to get a sense for how `parseLiteral` was used and realized there wasn't a test for its use here, so I added one.