### PR TITLE
Expose more info to serialize

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -721,7 +721,7 @@ function completeValue(
   if (returnType instanceof GraphQLScalarType ||
       returnType instanceof GraphQLEnumType) {
     invariant(returnType.serialize, 'Missing serialize method on type');
-    const serializedResult = returnType.serialize(result);
+    const serializedResult = returnType.serialize(result, info);
     return isNullish(serializedResult) ? null : serializedResult;
   }
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -231,9 +231,9 @@ export class GraphQLScalarType<InternalType> {
     this._scalarConfig = config;
   }
 
-  serialize(value: mixed): ?InternalType {
+  serialize(value: mixed, info?: GraphQLResolveInfo): ?InternalType {
     const serializer = this._scalarConfig.serialize;
-    return serializer(value);
+    return serializer(value, info);
   }
 
   parseValue(value: mixed): ?InternalType {
@@ -254,7 +254,7 @@ export class GraphQLScalarType<InternalType> {
 export type GraphQLScalarTypeConfig<InternalType> = {
   name: string;
   description?: ?string;
-  serialize: (value: mixed) => ?InternalType;
+  serialize: (value: mixed, info?: GraphQLResolveInfo) => ?InternalType;
   parseValue?: (value: mixed) => ?InternalType;
   parseLiteral?: (valueAST: Value) => ?InternalType;
 }


### PR DESCRIPTION
Similar to #103, this PR adds the `GraphQLResolveInfo` as a trailing argument to `serialize` on `GraphQLScalarType`.

The use case is that for a situation like Relay where you'd want to have a generated key based on a combination of the `id` property and the object type. You could just use a custom defined Scalar, which would now know which type it's being serialized on.

Test case included to illustrate this example.