### PR TITLE
Add named type for user defined resolveType and isTypeOf functions

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -301,7 +301,7 @@ export type GraphQLScalarTypeConfig<InternalType> = {
 export class GraphQLObjectType {
   name: string;
   description: ?string;
-  isTypeOf: ?(value: mixed, info?: GraphQLResolveInfo) => boolean;
+  isTypeOf: ?GraphQLIsTypeOfFn;
 
   _typeConfig: GraphQLObjectTypeConfig;
   _fields: GraphQLFieldDefinitionMap;
@@ -459,7 +459,7 @@ export type GraphQLObjectTypeConfig = {
   name: string;
   interfaces?: GraphQLInterfacesThunk | Array<GraphQLInterfaceType>;
   fields: GraphQLFieldConfigMapThunk | GraphQLFieldConfigMap;
-  isTypeOf?: (value: mixed, info?: GraphQLResolveInfo) => boolean;
+  isTypeOf?: GraphQLIsTypeOfFn;
   description?: ?string
 }
 
@@ -471,6 +471,11 @@ export type GraphQLTypeResolveFn = (
   value: mixed,
   info?: GraphQLResolveInfo
 ) => ?GraphQLObjectType
+
+export type GraphQLIsTypeOfFn = (
+  value: mixed,
+  info?: GraphQLResolveInfo
+) => boolean
 
 export type GraphQLFieldResolveFn = (
   source: mixed,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -467,6 +467,11 @@ type GraphQLInterfacesThunk = () => Array<GraphQLInterfaceType>;
 
 type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 
+export type GraphQLTypeResolveFn = (
+  value: mixed,
+  info?: GraphQLResolveInfo
+) => ?GraphQLObjectType
+
 export type GraphQLFieldResolveFn = (
   source: mixed,
   args: {[argName: string]: mixed},
@@ -550,7 +555,7 @@ export type GraphQLFieldDefinitionMap = {
 export class GraphQLInterfaceType {
   name: string;
   description: ?string;
-  resolveType: ?(value: mixed, info?: GraphQLResolveInfo) => ?GraphQLObjectType;
+  resolveType: ?GraphQLTypeResolveFn;
 
   _typeConfig: GraphQLInterfaceTypeConfig;
   _fields: GraphQLFieldDefinitionMap;
@@ -621,7 +626,7 @@ export type GraphQLInterfaceTypeConfig = {
    * the default implementation will call `isTypeOf` on each implementing
    * Object type.
    */
-  resolveType?: (value: mixed, info?: GraphQLResolveInfo) => ?GraphQLObjectType,
+  resolveType?: GraphQLTypeResolveFn,
   description?: ?string
 };
 
@@ -653,7 +658,7 @@ export type GraphQLInterfaceTypeConfig = {
 export class GraphQLUnionType {
   name: string;
   description: ?string;
-  resolveType: ?(value: mixed, info?: GraphQLResolveInfo) => ?GraphQLObjectType;
+  resolveType: ?GraphQLTypeResolveFn;
 
   _typeConfig: GraphQLUnionTypeConfig;
   _types: Array<GraphQLObjectType>;
@@ -728,7 +733,7 @@ export type GraphQLUnionTypeConfig = {
    * the default implementation will call `isTypeOf` on each implementing
    * Object type.
    */
-  resolveType?: (value: mixed, info?: GraphQLResolveInfo) => ?GraphQLObjectType;
+  resolveType?: GraphQLTypeResolveFn;
   description?: ?string;
 };
 


### PR DESCRIPTION
The definition file uses a named type GraphQLFieldResolveFn to describe the user provided field resolving function, but uses inline types to describe the resolveType and isTypeOf functions.

This change brings symmetry by defining a named types for the other two resolving functions: resolveType and isTypeOf.  This adds named types for those, too: GraphQLTypeResolveFn and GraphQLIsTypeOfFn.

This is in the #304 PR, but stands on its own.  In that PR, each function of the three functions is changed to have a different type for the info parameter.  Having symmetrical definitions makes that change easier to follow. 

This was not done for serialize, parseValue and parseLiteral because they are not exposed on their object and the named type would have only been referenced in one place.