### PR TITLE
Split up the completeValue function

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -25,6 +25,7 @@ import {
 } from '../type/definition';
 import type {
   GraphQLType,
+  GraphQLLeafType,
   GraphQLAbstractType,
   GraphQLFieldDefinition,
   GraphQLResolveInfo,
@@ -701,9 +702,7 @@ function completeValue(
   // null if serialization is not possible.
   if (returnType instanceof GraphQLScalarType ||
       returnType instanceof GraphQLEnumType) {
-    invariant(returnType.serialize, 'Missing serialize method on type');
-    const serializedResult = returnType.serialize(result);
-    return isNullish(serializedResult) ? null : serializedResult;
+    return completeLeafValue(exeContext, returnType, fieldASTs, info, result);
   }
 
   // Field type must be Object, Interface or Union and expect sub-selections.
@@ -787,6 +786,22 @@ function completeListValue(
   });
 
   return containsPromise ? Promise.all(completedResults) : completedResults;
+}
+
+/**
+ * Complete a Scalar or Enum by serializing to a valid value, returning
+ * null if serialization is not possible.
+ */
+function completeLeafValue(
+  exeContext: ExecutionContext,
+  returnType: GraphQLLeafType,
+  fieldASTs: Array<Field>,
+  info: GraphQLResolveInfo,
+  result: mixed
+): mixed {
+  invariant(returnType.serialize, 'Missing serialize method on type');
+  const serializedResult = returnType.serialize(result);
+  return isNullish(serializedResult) ? null : serializedResult;
 }
 
 /**

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -732,7 +732,10 @@ function completeValue(
   }
 
   // Not reachable
-  return null;
+  invariant(
+    false,
+    `Cannot complete value of unexpected type "${returnType}".`
+  );
 }
 
 /**


### PR DESCRIPTION
The completeValue function is fairly large and took me a while to understand.  This PR extracts out the logic that is different based on the type of the value being completed.  Four new functions are added:

- completeListValue
- completeLeafValue
- completeObjectValue
- completeAbstractValue

The code in each function is identical except i inlined one isAbstractType call to avoid having to add an invariant.

I did add an invariant for an unreachable condition that also exists in the current logic in master, but ends on a return null.

This is a change that I did as part of #304.  I'm submitting it as a separate PR. I think its a good change regardless of whether #304 is accepted.

Note that the names in this PR do not match #304.  I tried to match the spec more closely with the names here and I will change the other to comply.

The exception to this is using the term leaf to refer to Scalar or Enum, which is established in type/definition.js, but not defined in the spec.