### PR TITLE
[RFC] Directives in schema language

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -36,3 +36,10 @@ input InputType {
 extend type Foo {
   seven(argument: [String]): Type
 }
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!)
+  on FIELD
+   | FRAGMENT_SPREAD
+   | INLINE_FRAGMENT

--- a/src/language/__tests__/schema-printer.js
+++ b/src/language/__tests__/schema-printer.js
@@ -49,6 +49,7 @@ describe('Printer', () => {
 
     const printed = print(ast);
 
+    /* eslint-disable max-len */
     expect(printed).to.equal(
 `type Foo implements Bar {
   one: Type
@@ -81,6 +82,10 @@ input InputType {
 extend type Foo {
   seven(argument: [String]): Type
 }
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 `);
 
   });

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -57,6 +57,7 @@ export type Node = Name
                  | EnumValueDefinition
                  | InputObjectTypeDefinition
                  | TypeExtensionDefinition
+                 | DirectiveDefinition
 
 // Name
 
@@ -78,6 +79,7 @@ export type Definition = OperationDefinition
                        | FragmentDefinition
                        | TypeDefinition
                        | TypeExtensionDefinition
+                       | DirectiveDefinition
 
 export type OperationDefinition = {
   kind: 'OperationDefinition';
@@ -331,4 +333,12 @@ export type TypeExtensionDefinition = {
   kind: 'TypeExtensionDefinition';
   loc?: ?Location;
   definition: ObjectTypeDefinition;
+}
+
+export type DirectiveDefinition = {
+  kind: 'DirectiveDefinition';
+  loc?: ?Location;
+  name: Name;
+  arguments?: ?Array<InputValueDefinition>;
+  locations: Array<Name>;
 }

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -59,4 +59,11 @@ export const SCALAR_TYPE_DEFINITION = 'ScalarTypeDefinition';
 export const ENUM_TYPE_DEFINITION = 'EnumTypeDefinition';
 export const ENUM_VALUE_DEFINITION = 'EnumValueDefinition';
 export const INPUT_OBJECT_TYPE_DEFINITION = 'InputObjectTypeDefinition';
+
+// Type Extensions
+
 export const TYPE_EXTENSION_DEFINITION = 'TypeExtensionDefinition';
+
+// Directive Definitions
+
+export const DIRECTIVE_DEFINITION = 'DirectiveDefinition';

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -51,6 +51,8 @@ import type {
   InputObjectTypeDefinition,
 
   TypeExtensionDefinition,
+
+  DirectiveDefinition,
 } from './ast';
 
 import {
@@ -94,6 +96,8 @@ import {
   INPUT_OBJECT_TYPE_DEFINITION,
 
   TYPE_EXTENSION_DEFINITION,
+
+  DIRECTIVE_DEFINITION,
 } from './kinds';
 
 
@@ -205,6 +209,7 @@ function parseDefinition(parser: Parser): Definition {
       case 'enum':
       case 'input': return parseTypeDefinition(parser);
       case 'extend': return parseTypeExtensionDefinition(parser);
+      case 'directive': return parseDirectiveDefinition(parser);
     }
   }
 
@@ -898,6 +903,39 @@ function parseTypeExtensionDefinition(parser: Parser): TypeExtensionDefinition {
   };
 }
 
+/**
+ * DirectiveDefinition :
+ *   - directive @ Name ArgumentsDefinition? on DirectiveLocations
+ */
+function parseDirectiveDefinition(parser: Parser): DirectiveDefinition {
+  const start = parser.token.start;
+  expectKeyword(parser, 'directive');
+  expect(parser, TokenKind.AT);
+  const name = parseName(parser);
+  const args = parseArgumentDefs(parser);
+  expectKeyword(parser, 'on');
+  const locations = parseDirectiveLocations(parser);
+  return {
+    kind: DIRECTIVE_DEFINITION,
+    name,
+    arguments: args,
+    locations,
+    loc: loc(parser, start)
+  };
+}
+
+/**
+ * DirectiveLocations :
+ *   - Name
+ *   - DirectiveLocations | Name
+ */
+function parseDirectiveLocations(parser: Parser): Array<Name> {
+  const locations = [];
+  do {
+    locations.push(parseName(parser));
+  } while (skip(parser, TokenKind.PIPE));
+  return locations;
+}
 
 // Core parsing utility functions
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -123,6 +123,10 @@ const printDocASTReducer = {
     `input ${name} ${block(fields)}`,
 
   TypeExtensionDefinition: ({ definition }) => `extend ${definition}`,
+
+  DirectiveDefinition: ({ name, arguments: args, locations }) =>
+    'directive @' + name + wrap('(', join(args, ', '), ')') +
+    ' on ' + join(locations, ' | '),
 };
 
 /**

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -48,6 +48,7 @@ export const QueryDocumentKeys = {
   EnumValueDefinition: [ 'name' ],
   InputObjectTypeDefinition: [ 'name', 'fields' ],
   TypeExtensionDefinition: [ 'definition' ],
+  DirectiveDefinition: [ 'name', 'arguments', 'locations' ],
 };
 
 export const BREAK = {};

--- a/src/utilities/__tests__/buildASTSchema.js
+++ b/src/utilities/__tests__/buildASTSchema.js
@@ -41,6 +41,18 @@ type HelloScalars {
     expect(output).to.equal(body);
   });
 
+  it('With directives', () => {
+    const body = `
+directive @foo(arg: Int) on FIELD
+
+type Hello {
+  str: String
+}
+`;
+    const output = cycleOutput(body, 'Hello');
+    expect(output).to.equal(body);
+  });
+
   it('Type modifiers', () => {
     const body = `
 type HelloScalars {

--- a/src/utilities/__tests__/schemaPrinter.js
+++ b/src/utilities/__tests__/schemaPrinter.js
@@ -508,6 +508,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = '\n' + printIntrospectionSchema(Schema);
     const introspectionSchema = `
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
 type __Directive {
   name: String!
   description: String

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -342,7 +342,7 @@ export function buildClientSchema(
       name: directiveIntrospection.name,
       description: directiveIntrospection.description,
       locations,
-      args: directiveIntrospection.args.map(buildInputValue),
+      args: buildInputValueDefMap(directiveIntrospection.args),
     });
   }
 


### PR DESCRIPTION
This adds directives to schema language and to the utilities that use it (schema parser, and buildASTSchema). Directives are one of the few missing pieces from representing a full schema in the schema language.

Note: the schema language is still experimental, so there is no corresponding change to the spec yet.

DirectiveDefinition :
  - `directive` `@` Name ArgumentsDefinition? `on` DirectiveLocations

DirectiveLocations :
  - Name
  - DirectiveLocations `|` Name

Example:

```
directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

# Suggested formatting when there are many valid locations
directive @include(if: Boolean!)
  on FIELD
   | FRAGMENT_SPREAD
   | INLINE_FRAGMENT
```

Note: this depends on #317