### PR TITLE
express-graphql Issue #54 fix: only 1 case tested

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -174,7 +174,7 @@ function buildExecutionContext(
             'Must provide operation name if query contains multiple operations.'
           );
         }
-        if (!operationName ||
+        if (operationName ||
             definition.name && definition.name.value === operationName) {
           operation = definition;
         }


### PR DESCRIPTION
adding an operation name of 'mutation' for a mutation query in a post request