### PR TITLE
[RFC] Add Schema Definition to IDL.

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+schema {
+  query: QueryType
+  mutation: MutationType
+}
+
 type Foo implements Bar {
   one: Type
   two(argument: InputType!): Type

--- a/src/language/__tests__/schema-printer.js
+++ b/src/language/__tests__/schema-printer.js
@@ -51,7 +51,12 @@ describe('Printer', () => {
 
     /* eslint-disable max-len */
     expect(printed).to.equal(
-`type Foo implements Bar {
+`schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+type Foo implements Bar {
   one: Type
   two(argument: InputType!): Type
   three(argument: InputType, other: String): Int

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -47,12 +47,14 @@ export type Node = Name
                  | NamedType
                  | ListType
                  | NonNullType
+                 | SchemaDefinition
+                 | OperationTypeDefinition
+                 | ScalarTypeDefinition
                  | ObjectTypeDefinition
                  | FieldDefinition
                  | InputValueDefinition
                  | InterfaceTypeDefinition
                  | UnionTypeDefinition
-                 | ScalarTypeDefinition
                  | EnumTypeDefinition
                  | EnumValueDefinition
                  | InputObjectTypeDefinition
@@ -77,18 +79,20 @@ export type Document = {
 
 export type Definition = OperationDefinition
                        | FragmentDefinition
-                       | TypeSystemDefinition
+                       | TypeSystemDefinition // experimental non-spec addition.
 
 export type OperationDefinition = {
   kind: 'OperationDefinition';
   loc?: ?Location;
-  // Note: subscription is an experimental non-spec addition.
-  operation: 'query' | 'mutation' | 'subscription';
+  operation: OperationType;
   name?: ?Name;
   variableDefinitions?: ?Array<VariableDefinition>;
   directives?: ?Array<Directive>;
   selectionSet: SelectionSet;
 }
+
+// Note: subscription is an experimental non-spec addition.
+export type OperationType = 'query' | 'mutation' | 'subscription';
 
 export type VariableDefinition = {
   kind: 'VariableDefinition';
@@ -256,9 +260,23 @@ export type NonNullType = {
 
 // Type System Definition
 
-export type TypeSystemDefinition = TypeDefinition
+export type TypeSystemDefinition = SchemaDefinition
+                                 | TypeDefinition
                                  | TypeExtensionDefinition
                                  | DirectiveDefinition
+
+export type SchemaDefinition = {
+  kind: 'SchemaDefinition';
+  loc?: ?Location;
+  operationTypes: Array<OperationTypeDefinition>;
+}
+
+export type OperationTypeDefinition = {
+  kind: 'OperationTypeDefinition';
+  loc?: ?Location;
+  operation: OperationType;
+  type: NamedType;
+}
 
 export type TypeDefinition = ScalarTypeDefinition
                            | ObjectTypeDefinition

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -50,6 +50,9 @@ export const NON_NULL_TYPE = 'NonNullType';
 
 // Type System Definitions
 
+export const SCHEMA_DEFINITION = 'SchemaDefinition';
+export const OPERATION_TYPE_DEFINITION = 'OperationTypeDefinition';
+
 // Type Definitions
 
 export const SCALAR_TYPE_DEFINITION = 'ScalarTypeDefinition';

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -94,6 +94,12 @@ const printDocASTReducer = {
 
   // Type System Definitions
 
+  SchemaDefinition: ({ operationTypes }) =>
+    'schema ' + block(operationTypes),
+
+  OperationTypeDefinition: ({ operation, type }) =>
+    operation + ': ' + type,
+
   ScalarTypeDefinition: ({ name }) =>
     `scalar ${name}`,
 

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -38,16 +38,21 @@ export const QueryDocumentKeys = {
   ListType: [ 'type' ],
   NonNullType: [ 'type' ],
 
+  SchemaDefinition: [ 'operationTypes' ],
+  OperationTypeDefinition: [ 'type' ],
+
+  ScalarTypeDefinition: [ 'name' ],
   ObjectTypeDefinition: [ 'name', 'interfaces', 'fields' ],
   FieldDefinition: [ 'name', 'arguments', 'type' ],
   InputValueDefinition: [ 'name', 'type', 'defaultValue' ],
   InterfaceTypeDefinition: [ 'name', 'fields' ],
   UnionTypeDefinition: [ 'name', 'types' ],
-  ScalarTypeDefinition: [ 'name' ],
   EnumTypeDefinition: [ 'name', 'values' ],
   EnumValueDefinition: [ 'name' ],
   InputObjectTypeDefinition: [ 'name', 'fields' ],
+
   TypeExtensionDefinition: [ 'definition' ],
+
   DirectiveDefinition: [ 'name', 'arguments', 'locations' ],
 };
 

--- a/src/utilities/__tests__/extendSchema.js
+++ b/src/utilities/__tests__/extendSchema.js
@@ -133,7 +133,11 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
+`schema {
+  query: Query
+}
+
+type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -182,7 +186,11 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
+`schema {
+  query: Query
+}
+
+type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -232,7 +240,11 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
+`schema {
+  query: Query
+}
+
+type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -302,7 +314,11 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
+`schema {
+  query: Query
+}
+
+type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -375,7 +391,11 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
+`schema {
+  query: Query
+}
+
+type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -437,7 +457,11 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
+`schema {
+  query: Query
+}
+
+type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -517,7 +541,13 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(mutationSchema);
     expect(printSchema(mutationSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`type Mutation {
+`schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+type Mutation {
   mutationField: String
   newMutationField: Int
 }

--- a/src/utilities/__tests__/schemaPrinter.js
+++ b/src/utilities/__tests__/schemaPrinter.js
@@ -52,6 +52,10 @@ describe('Type System Printer', () => {
       type: GraphQLString
     });
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField: String
 }
@@ -64,6 +68,10 @@ type Root {
       type: listOf(GraphQLString)
     });
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField: [String]
 }
@@ -76,6 +84,10 @@ type Root {
       type: nonNull(GraphQLString)
     });
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField: String!
 }
@@ -88,6 +100,10 @@ type Root {
       type: nonNull(listOf(GraphQLString))
     });
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField: [String]!
 }
@@ -100,6 +116,10 @@ type Root {
       type: listOf(nonNull(GraphQLString))
     });
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField: [String!]
 }
@@ -112,6 +132,10 @@ type Root {
       type: nonNull(listOf(nonNull(GraphQLString)))
     });
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField: [String!]!
 }
@@ -133,6 +157,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Foo {
   str: String
 }
@@ -152,6 +180,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int): String
 }
@@ -167,6 +199,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int = 2): String
 }
@@ -182,6 +218,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int!): String
 }
@@ -200,6 +240,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int, argTwo: String): String
 }
@@ -219,6 +263,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
 }
@@ -238,6 +286,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
 }
@@ -257,6 +309,10 @@ type Root {
       }
     );
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Root {
   singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
 }
@@ -285,6 +341,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Bar implements Foo {
   str: String
 }
@@ -330,6 +390,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 interface Baaz {
   int: Int
 }
@@ -388,6 +452,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 type Bar {
   str: String
 }
@@ -429,6 +497,10 @@ union SingleUnion = Foo
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 input InputType {
   int: Int
 }
@@ -457,6 +529,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 scalar Odd
 
 type Root {
@@ -486,6 +562,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
     expect(output).to.equal(`
+schema {
+  query: Root
+}
+
 enum RGB {
   RED
   GREEN
@@ -508,6 +588,10 @@ type Root {
     const Schema = new GraphQLSchema({ query: Root });
     const output = '\n' + printIntrospectionSchema(Schema);
     const introspectionSchema = `
+schema {
+  query: Root
+}
+
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -66,9 +66,31 @@ function printFilteredSchema(
     .filter(typeFilter)
     .sort((name1, name2) => name1.localeCompare(name2))
     .map(typeName => typeMap[typeName]);
-  return directives.map(printDirective).concat(
+  return [ printSchemaDefinition(schema) ].concat(
+    directives.map(printDirective),
     types.map(printType)
   ).join('\n\n') + '\n';
+}
+
+function printSchemaDefinition(schema: GraphQLSchema): string {
+  const operationTypes = [];
+
+  const queryType = schema.getQueryType();
+  if (queryType) {
+    operationTypes.push(`  query: ${queryType}`);
+  }
+
+  const mutationType = schema.getMutationType();
+  if (mutationType) {
+    operationTypes.push(`  mutation: ${mutationType}`);
+  }
+
+  const subscriptionType = schema.getSubscriptionType();
+  if (subscriptionType) {
+    operationTypes.push(`  subscription: ${subscriptionType}`);
+  }
+
+  return `schema {\n${operationTypes.join('\n')}\n}`;
 }
 
 function printType(type: GraphQLType): string {


### PR DESCRIPTION
This implements the schema definition in the spec proposal in https://github.com/facebook/graphql/pull/90

Adjusts AST, parser, printer, visitor, but also changes the API of buildASTSchema to require a schema definition instead of passing the type names into the function.