### PR TITLE
[RFC] Add explicit context arg to graphql execution

### DIFF
--- a/src/__tests__/starWarsQueryTests.js
+++ b/src/__tests__/starWarsQueryTests.js
@@ -181,7 +181,7 @@ describe('Star Wars Query Tests', () => {
           name: 'Luke Skywalker'
         }
       };
-      const result = await graphql(StarWarsSchema, query, null, params);
+      const result = await graphql(StarWarsSchema, query, null, null, params);
       expect(result).to.deep.equal({ data: expected });
     });
 
@@ -201,7 +201,7 @@ describe('Star Wars Query Tests', () => {
           name: 'Han Solo'
         }
       };
-      const result = await graphql(StarWarsSchema, query, null, params);
+      const result = await graphql(StarWarsSchema, query, null, null, params);
       expect(result).to.deep.equal({ data: expected });
     });
 
@@ -219,7 +219,7 @@ describe('Star Wars Query Tests', () => {
       const expected = {
         human: null
       };
-      const result = await graphql(StarWarsSchema, query, null, params);
+      const result = await graphql(StarWarsSchema, query, null, null, params);
       expect(result).to.deep.equal({ data: expected });
     });
   });

--- a/src/execution/__tests__/executor.js
+++ b/src/execution/__tests__/executor.js
@@ -137,7 +137,7 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     expect(
-      await execute(schema, ast, data, { size: 100 }, 'Example')
+      await execute(schema, ast, data, null, { size: 100 }, 'Example')
     ).to.deep.equal(expected);
   });
 
@@ -427,7 +427,7 @@ describe('Execute: Handles basic execution tasks', () => {
       })
     });
 
-    const result = await execute(schema, ast, data, null, 'OtherExample');
+    const result = await execute(schema, ast, data, null, null, 'OtherExample');
 
     expect(result).to.deep.equal({ data: { second: 'b' } });
   });
@@ -481,7 +481,9 @@ describe('Execute: Handles basic execution tasks', () => {
       })
     });
 
-    expect(() => execute(schema, ast, data, null, 'UnknownExample')).to.throw(
+    expect(() =>
+      execute(schema, ast, data, null, null, 'UnknownExample')
+    ).to.throw(
       'Unknown operation named "UnknownExample".'
     );
   });
@@ -511,7 +513,7 @@ describe('Execute: Handles basic execution tasks', () => {
       })
     });
 
-    const queryResult = await execute(schema, ast, data, {}, 'Q');
+    const queryResult = await execute(schema, ast, data, null, {}, 'Q');
 
     expect(queryResult).to.deep.equal({ data: { a: 'b' } });
   });
@@ -535,7 +537,7 @@ describe('Execute: Handles basic execution tasks', () => {
       })
     });
 
-    const mutationResult = await execute(schema, ast, data, {}, 'M');
+    const mutationResult = await execute(schema, ast, data, null, {}, 'M');
 
     expect(mutationResult).to.deep.equal({ data: { c: 'd' } });
   });
@@ -559,7 +561,7 @@ describe('Execute: Handles basic execution tasks', () => {
       })
     });
 
-    const subscriptionResult = await execute(schema, ast, data, {}, 'S');
+    const subscriptionResult = await execute(schema, ast, data, null, {}, 'S');
 
     expect(subscriptionResult).to.deep.equal({ data: { a: 'b' } });
   });
@@ -644,7 +646,7 @@ describe('Execute: Handles basic execution tasks', () => {
       }),
     });
 
-    const queryResult = await execute(schema, ast, data, {}, 'Q');
+    const queryResult = await execute(schema, ast, data, null, {}, 'Q');
 
     expect(queryResult).to.deep.equal({ data: { a: 'b' } });
   });

--- a/src/execution/__tests__/union-interface.js
+++ b/src/execution/__tests__/union-interface.js
@@ -349,6 +349,7 @@ describe('Execute: Union and intersection types', () => {
   });
 
   it('gets execution info in resolver', async () => {
+    let encounteredContext;
     let encounteredSchema;
     let encounteredRootValue;
 
@@ -357,9 +358,10 @@ describe('Execute: Union and intersection types', () => {
       fields: {
         name: { type: GraphQLString }
       },
-      resolveType(obj, { schema: infoSchema, rootValue: infoRootValue }) {
-        encounteredSchema = infoSchema;
-        encounteredRootValue = infoRootValue;
+      resolveType(obj, context, { schema: _schema, rootValue }) {
+        encounteredContext = context;
+        encounteredSchema = _schema;
+        encounteredRootValue = rootValue;
         return PersonType2;
       }
     });
@@ -379,14 +381,17 @@ describe('Execute: Union and intersection types', () => {
 
     const john2 = new Person('John', [], [ liz ]);
 
+    const context = { authToken: '123abc' };
+
     const ast = parse('{ name, friends { name } }');
 
     expect(
-      await execute(schema2, ast, john2)
+      await execute(schema2, ast, john2, context)
     ).to.deep.equal({
       data: { name: 'John', friends: [ { name: 'Liz' } ] }
     });
 
+    expect(encounteredContext).to.equal(context);
     expect(encounteredSchema).to.equal(schema2);
     expect(encounteredRootValue).to.equal(john2);
   });

--- a/src/execution/__tests__/variables.js
+++ b/src/execution/__tests__/variables.js
@@ -204,7 +204,7 @@ describe('Execute: Handles inputs', () => {
 
       it('executes with complex input', async () => {
         const params = { input: { a: 'foo', b: [ 'bar' ], c: 'baz' } };
-        const result = await execute(schema, ast, null, params);
+        const result = await execute(schema, ast, null, null, params);
 
         return expect(result).to.deep.equal({
           data: {
@@ -231,7 +231,7 @@ describe('Execute: Handles inputs', () => {
 
       it('properly parses single value to list', async () => {
         const params = { input: { a: 'foo', b: 'bar', c: 'baz' } };
-        const result = await execute(schema, ast, null, params);
+        const result = await execute(schema, ast, null, null, params);
 
         return expect(result).to.deep.equal({
           data: {
@@ -242,7 +242,7 @@ describe('Execute: Handles inputs', () => {
 
       it('executes with complex scalar input', async () => {
         const params = { input: { c: 'foo', d: 'SerializedValue' } };
-        const result = await execute(schema, ast, null, params);
+        const result = await execute(schema, ast, null, null, params);
 
         return expect(result).to.deep.equal({
           data: {
@@ -256,7 +256,7 @@ describe('Execute: Handles inputs', () => {
 
         let caughtError;
         try {
-          execute(schema, ast, null, params);
+          execute(schema, ast, null, null, params);
         } catch (error) {
           caughtError = error;
         }
@@ -275,7 +275,7 @@ describe('Execute: Handles inputs', () => {
 
         let caughtError;
         try {
-          execute(schema, ast, null, params);
+          execute(schema, ast, null, null, params);
         } catch (error) {
           caughtError = error;
         }
@@ -293,7 +293,7 @@ describe('Execute: Handles inputs', () => {
 
         let caughtError;
         try {
-          execute(schema, ast, null, params);
+          execute(schema, ast, null, null, params);
         } catch (error) {
           caughtError = error;
         }
@@ -317,7 +317,7 @@ describe('Execute: Handles inputs', () => {
 
         let caughtError;
         try {
-          execute(schema, nestedAst, null, params);
+          execute(schema, nestedAst, null, null, params);
         } catch (error) {
           caughtError = error;
         }
@@ -339,7 +339,7 @@ describe('Execute: Handles inputs', () => {
 
         let caughtError;
         try {
-          execute(schema, ast, null, params);
+          execute(schema, ast, null, null, params);
         } catch (error) {
           caughtError = error;
         }
@@ -411,7 +411,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { value: null })
+        await execute(schema, ast, null, null, { value: null })
       ).to.deep.equal({
         data: {
           fieldWithNullableStringInput: null
@@ -428,7 +428,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { value: 'a' })
+        await execute(schema, ast, null, null, { value: 'a' })
       ).to.deep.equal({
         data: {
           fieldWithNullableStringInput: '"a"'
@@ -484,7 +484,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, { value: null });
+        execute(schema, ast, null, null, { value: null });
       } catch (error) {
         caughtError = error;
       }
@@ -505,7 +505,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { value: 'a' })
+        await execute(schema, ast, null, null, { value: 'a' })
       ).to.deep.equal({
         data: {
           fieldWithNonNullableStringInput: '"a"'
@@ -554,7 +554,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: null })
+        await execute(schema, ast, null, null, { input: null })
       ).to.deep.equal({
         data: {
           list: null
@@ -571,7 +571,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: [ 'A' ] })
       ).to.deep.equal({
         data: {
           list: '["A"]'
@@ -588,7 +588,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: [ 'A', null, 'B' ] })
+        await execute(schema, ast, null, null, { input: [ 'A', null, 'B' ] })
       ).to.deep.equal({
         data: {
           list: '["A",null,"B"]'
@@ -606,7 +606,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, { input: null });
+        execute(schema, ast, null, null, { input: null });
       } catch (error) {
         caughtError = error;
       }
@@ -627,7 +627,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: [ 'A' ] })
       ).to.deep.equal({
         data: {
           nnList: '["A"]'
@@ -644,7 +644,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: [ 'A', null, 'B' ] })
+        await execute(schema, ast, null, null, { input: [ 'A', null, 'B' ] })
       ).to.deep.equal({
         data: {
           nnList: '["A",null,"B"]'
@@ -661,7 +661,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: null })
+        await execute(schema, ast, null, null, { input: null })
       ).to.deep.equal({
         data: {
           listNN: null
@@ -678,7 +678,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: [ 'A' ] })
       ).to.deep.equal({
         data: {
           listNN: '["A"]'
@@ -697,7 +697,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, vars);
+        execute(schema, ast, null, null, vars);
       } catch (error) {
         caughtError = error;
       }
@@ -720,7 +720,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, { input: null });
+        execute(schema, ast, null, null, { input: null });
       } catch (error) {
         caughtError = error;
       }
@@ -741,7 +741,7 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       return expect(
-        await execute(schema, ast, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: [ 'A' ] })
       ).to.deep.equal({
         data: {
           nnListNN: '["A"]'
@@ -760,7 +760,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, vars);
+        execute(schema, ast, null, null, vars);
       } catch (error) {
         caughtError = error;
       }
@@ -784,7 +784,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, vars);
+        execute(schema, ast, null, null, vars);
       } catch (error) {
         caughtError = error;
       }
@@ -808,7 +808,7 @@ describe('Execute: Handles inputs', () => {
 
       let caughtError;
       try {
-        execute(schema, ast, null, vars);
+        execute(schema, ast, null, null, vars);
       } catch (error) {
         caughtError = error;
       }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -44,6 +44,7 @@ export function graphql(
   schema: GraphQLSchema,
   requestString: string,
   rootValue?: mixed,
+  contextValue?: mixed,
   variableValues?: ?{[key: string]: mixed},
   operationName?: ?string
 ): Promise<GraphQLResult> {
@@ -59,6 +60,7 @@ export function graphql(
           schema,
           documentAST,
           rootValue,
+          contextValue,
           variableValues,
           operationName
         )

--- a/src/type/__tests__/enumType.js
+++ b/src/type/__tests__/enumType.js
@@ -172,6 +172,7 @@ describe('Type System: Enum Values', () => {
         schema,
         'query test($color: Color!) { colorEnum(fromEnum: $color) }',
         null,
+        null,
         { color: 'BLUE' }
       )
     ).to.deep.equal({
@@ -186,6 +187,7 @@ describe('Type System: Enum Values', () => {
       await graphql(
         schema,
         'mutation x($color: Color!) { favoriteEnum(color: $color) }',
+        null,
         null,
         { color: 'GREEN' }
       )
@@ -202,6 +204,7 @@ describe('Type System: Enum Values', () => {
         schema,
         'subscription x($color: Color!) { subscribeToEnum(color: $color) }',
         null,
+        null,
         { color: 'GREEN' }
       )
     ).to.deep.equal({
@@ -216,6 +219,7 @@ describe('Type System: Enum Values', () => {
       await graphql(
         schema,
         'query test($color: Color!) { colorEnum(fromEnum: $color) }',
+        null,
         null,
         { color: 2 }
       )
@@ -235,6 +239,7 @@ describe('Type System: Enum Values', () => {
         schema,
         'query test($color: String!) { colorEnum(fromEnum: $color) }',
         null,
+        null,
         { color: 'BLUE' }
       )
     ).to.deep.equal({
@@ -252,6 +257,7 @@ describe('Type System: Enum Values', () => {
       await graphql(
         schema,
         'query test($color: Int!) { colorEnum(fromEnum: $color) }',
+        null,
         null,
         { color: 2 }
       )

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -456,17 +456,20 @@ type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 
 export type GraphQLTypeResolveFn = (
   value: mixed,
+  context: mixed,
   info: GraphQLResolveInfo
 ) => ?GraphQLObjectType
 
 export type GraphQLIsTypeOfFn = (
   value: mixed,
+  context: mixed,
   info: GraphQLResolveInfo
 ) => boolean
 
 export type GraphQLFieldResolveFn = (
   source: mixed,
   args: {[argName: string]: mixed},
+  context: mixed,
   info: GraphQLResolveInfo
 ) => mixed
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -218,7 +218,7 @@ export const __Type = new GraphQLObjectType({
     },
     possibleTypes: {
       type: new GraphQLList(new GraphQLNonNull(__Type)),
-      resolve(type, args, { schema }) {
+      resolve(type, args, context, { schema }) {
         if (type instanceof GraphQLInterfaceType ||
             type instanceof GraphQLUnionType) {
           return schema.getPossibleTypes(type);
@@ -385,7 +385,7 @@ export const SchemaMetaFieldDef: GraphQLFieldDefinition = {
   type: new GraphQLNonNull(__Schema),
   description: 'Access the current type schema of this server.',
   args: [],
-  resolve: (source, args, { schema }) => schema
+  resolve: (source, args, context, { schema }) => schema
 };
 
 export const TypeMetaFieldDef: GraphQLFieldDefinition = {
@@ -395,7 +395,7 @@ export const TypeMetaFieldDef: GraphQLFieldDefinition = {
   args: [
     { name: 'name', type: new GraphQLNonNull(GraphQLString) }
   ],
-  resolve: (source, { name }: { name: string }, { schema }) =>
+  resolve: (source, { name }: { name: string }, context, { schema }) =>
     schema.getType(name)
 };
 
@@ -404,5 +404,5 @@ export const TypeNameMetaFieldDef: GraphQLFieldDefinition = {
   type: new GraphQLNonNull(GraphQLString),
   description: 'The name of the current Object type at runtime.',
   args: [],
-  resolve: (source, args, { parentType }) => parentType.name
+  resolve: (source, args, context, { parentType }) => parentType.name
 };

--- a/src/utilities/__tests__/buildClientSchema.js
+++ b/src/utilities/__tests__/buildClientSchema.js
@@ -672,6 +672,7 @@ describe('Type System: build schema from introspection', () => {
       clientSchema,
       'query NoNo($v: CustomScalar) { foo(custom1: 123, custom2: $v) }',
       { foo: 'bar' },
+      null,
       { v: 'baz' }
     );
     expect(result).to.containSubset({


### PR DESCRIPTION
This *BREAKING* change introduces a new argument to the GraphQL execution API which is presented to resolution functions: `context`.

This solves a long-standing point of confusion about the correct way to represent authentication or a "viewer context" in which a query is executed.

Previously, we suggested that the `rootValue` contain any authentication tokens, however this led to awkward code:

```
resolve: (val, args, { rootValue: { authToken } }) { ... }
```

Which can now be written as:

```
resolve: (val, args, authToken) { ... }
```

The `info` object is still created and provided to resolution functions, and the `rootValue` is still provided within it, however it is now the *fourth* argument rather than the *third*.