### PR TITLE
Move getTypeOf to execute.js and rename to defaultResolveTypeFn

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -600,27 +600,8 @@ export class GraphQLInterfaceType {
     return Boolean(possibleTypes[type.name]);
   }
 
-  getObjectType(value: mixed, info: GraphQLResolveInfo): ?GraphQLObjectType {
-    const resolver = this.resolveType;
-    return resolver ? resolver(value, info) : getTypeOf(value, info, this);
-  }
-
   toString(): string {
     return this.name;
-  }
-}
-
-function getTypeOf(
-  value: mixed,
-  info: GraphQLResolveInfo,
-  abstractType: GraphQLAbstractType
-): ?GraphQLObjectType {
-  const possibleTypes = abstractType.getPossibleTypes();
-  for (let i = 0; i < possibleTypes.length; i++) {
-    const type = possibleTypes[i];
-    if (typeof type.isTypeOf === 'function' && type.isTypeOf(value, info)) {
-      return type;
-    }
   }
 }
 
@@ -719,11 +700,6 @@ export class GraphQLUnionType {
         );
     }
     return possibleTypeNames[type.name] === true;
-  }
-
-  getObjectType(value: mixed, info: GraphQLResolveInfo): ?GraphQLObjectType {
-    const resolver = this._typeConfig.resolveType;
-    return resolver ? resolver(value, info) : getTypeOf(value, info, this);
   }
 
   toString(): string {


### PR DESCRIPTION
Default behavior for resolving fields is located in execute.js, while default behavior for resolving types is located in definition.js.  These two functions should be located in the same place.

Since type resolving is an execution phase activity, it more closely belongs in execute.js than in definition.js.  In #304, I ended up having to change this algorithm, also indicating that it changes when execution algorithms change and thus should be co-located with execution.

This also results in a cleaner definition.js for cases when execution is not needed.

getObjectType was removed, as field resolve has no such accessor. 

In more aggressive optimization experiments it turns out that knowing when the the default was to be used was valuable information.  The accessor for type resolving obscures this information.

I hope to eventually propose a similar change for serialize, except there the accessor method is doing more work and references "this," making symmetry harder to achieve.  The right approach for serialize eludes me at this time.  There is value in being able to know the underlying serialize function.  For example, `String` gets called a lot, cannot throw an error, cannot return null and cannot return a promise, all checks we must make for user defined serialization functions that are wasted effort for `String`.