### PR TITLE
Remove unnecessary optionality in type resolve parameters

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -470,12 +470,12 @@ type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 
 export type GraphQLTypeResolveFn = (
   value: mixed,
-  info?: GraphQLResolveInfo
+  info: GraphQLResolveInfo
 ) => ?GraphQLObjectType
 
 export type GraphQLIsTypeOfFn = (
   value: mixed,
-  info?: GraphQLResolveInfo
+  info: GraphQLResolveInfo
 ) => boolean
 
 export type GraphQLFieldResolveFn = (


### PR DESCRIPTION
What does it mean that the GraphQLResolveInfo parameter is optional for GraphQLTypeResolveFn and GraphQLIsTypeOfFn?  Does that mean when I'm implementing an execution engine I don't have to pass it?  Does that mean if I'm implementing a resolve function I might receive null?

info is not optional for GraphQLFieldResolveFn, so lets make the function signatures symmetric by making it required for GraphQLTypeResolveFn and GraphQLIsTypeOfFn.  The value can be ignored, but will clearly always be sent.