### PR TITLE
unnecessary call throwing errors

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -869,7 +869,7 @@ function defaultResolveFn(source, args, { fieldName }) {
   // ensure source is a value for which property access is acceptable.
   if (typeof source !== 'number' && typeof source !== 'string' && source) {
     const property = (source: any)[fieldName];
-    return typeof property === 'function' ? property.call(source) : property;
+    return typeof property === 'function' ? property(source) : property;
   }
 }
 


### PR DESCRIPTION
Somehow it appears that `call` is becoming unbound, resulting in errors being thrown by `defaultResolveFn`.

Why not just call the function directly?

Affects mattkrick/meatier#123 and [trace can be seen on ci](https://circleci.com/gh/wenzowski/meatier/15)