### PR TITLE
Fix bug where @include directive is ignored if @skip is present.

### DIFF
--- a/src/execution/__tests__/directives-test.js
+++ b/src/execution/__tests__/directives-test.js
@@ -312,4 +312,30 @@ describe('Execute: handles directives', () => {
       });
     });
   });
+
+  describe('works with skip and include directives', () => {
+    it('include and no skip', async () => {
+      return expect(
+        await executeTestQuery('{ a, b @include(if: true) @skip(if: false) }')
+      ).to.deep.equal({
+        data: { a: 'a', b: 'b' }
+      });
+    });
+
+    it('include and skip', async () => {
+      return expect(
+        await executeTestQuery('{ a, b @include(if: true) @skip(if: true) }')
+      ).to.deep.equal({
+        data: { a: 'a' }
+      });
+    });
+
+    it('no include or skip', async () => {
+      return expect(
+        await executeTestQuery('{ a, b @include(if: false) @skip(if: false) }')
+      ).to.deep.equal({
+        data: { a: 'a' }
+      });
+    });
+  });
 });

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -444,7 +444,9 @@ function shouldIncludeNode(
       skipAST.arguments,
       exeContext.variableValues
     );
-    return !skipIf;
+    if (skipIf) {
+      return false;
+    }
   }
 
   const includeAST = directives && find(


### PR DESCRIPTION
## Problem

The GraphQL spec has the following paragraph in the [`@include` section](http://facebook.github.io/graphql/#sec--include):

> In the case that both the `@skip` and `@include` directives are provided in the same context, the field or fragment must be queried only if the `@skip` condition is false *and* the `@include` condition is true. Stated conversely, the field/fragment must *not* be queried if either the `@skip` condition is true or the `@include` condition is false.

However, a field or fragment with `@skip(if: false) @include(if: false)` would be queried even though `@include(if: false)` should cause it to not be queried.

## Solution

Only do an early return when checking the skip directive if its argument is `true`.