### PR TITLE
Add sanity checks for schema in buildASTschema

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -446,6 +446,68 @@ type Hello {
       .to.throw('Must provide schema definition with query type.');
   });
 
+  it('Allows only a single query type', () => {
+    const body = `
+schema {
+  query: Hello
+  query: Yellow
+}
+
+type Hello {
+  bar: Bar
+}
+
+type Yellow {
+  isColor: Boolean
+}
+`;
+    const doc = parse(body);
+    expect(() => buildASTSchema(doc))
+      .to.throw('Must provide only one query type in schema.');
+  });
+
+  it('Allows only a single mutation type', () => {
+    const body = `
+schema {
+  query: Hello
+  mutation: Hello
+  mutation: Yellow
+}
+
+type Hello {
+  bar: Bar
+}
+
+type Yellow {
+  isColor: Boolean
+}
+`;
+    const doc = parse(body);
+    expect(() => buildASTSchema(doc))
+      .to.throw('Must provide only one mutation type in schema.');
+  });
+
+  it('Allows only a single subscription type', () => {
+    const body = `
+schema {
+  query: Hello
+  subscription: Hello
+  subscription: Yellow
+}
+
+type Hello {
+  bar: Bar
+}
+
+type Yellow {
+  isColor: Boolean
+}
+`;
+    const doc = parse(body);
+    expect(() => buildASTSchema(doc))
+      .to.throw('Must provide only one subscription type in schema.');
+  });
+
   it('Unknown type referenced', () => {
     const body = `
 schema {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -111,8 +111,8 @@ function getNamedTypeAST(typeAST: Type): NamedType {
 }
 
 /**
- * This takes the ast of a schema document produced by parseSchema in
- * src/language/schema/parser.js.
+ * This takes the ast of a schema document produced by the parse function in
+ * src/language/parser.js.
  *
  * Given that AST it constructs a GraphQLSchema. As constructed
  * they are not particularly useful for non-introspection queries
@@ -160,10 +160,19 @@ export function buildASTSchema(ast: Document): GraphQLSchema {
   schemaDef.operationTypes.forEach(operationType => {
     const typeName = operationType.type.name.value;
     if (operationType.operation === 'query') {
+      if (queryTypeName) {
+        throw new Error('Must provide only one query type in schema.');
+      }
       queryTypeName = typeName;
     } else if (operationType.operation === 'mutation') {
+      if (mutationTypeName) {
+        throw new Error('Must provide only one mutation type in schema.');
+      }
       mutationTypeName = typeName;
     } else if (operationType.operation === 'subscription') {
+      if (subscriptionTypeName) {
+        throw new Error('Must provide only one subscription type in schema.');
+      }
       subscriptionTypeName = typeName;
     }
   });


### PR DESCRIPTION
Adds checks to make sure the AST contains exactly one query, and at most one mutation and subscription operation.

Here's the original pull-request: https://github.com/graphql/graphql-js/pull/340