### PR TITLE
Improve coercion error messages

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -818,7 +818,7 @@ function completeAbstractValue(
     defaultResolveTypeFn(result, exeContext.contextValue, info, returnType);
 
   invariant(
-    runtimeType,
+    !isNullish(runtimeType),
     `Could not determine runtime type of value "${result}" for field ${
       info.parentType}.${info.fieldName}.`
   );

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -822,7 +822,7 @@ function completeAbstractValue(
   }
 
   const schema = exeContext.schema;
-  if (runtimeType && !schema.isPossibleType(returnType, runtimeType)) {
+  if (!schema.isPossibleType(returnType, runtimeType)) {
     throw new GraphQLError(
       `Runtime Object type "${runtimeType}" is not a possible type ` +
       `for "${returnType}".`,

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -822,6 +822,11 @@ function completeAbstractValue(
     `Could not determine runtime type of value "${result}" for field ${
       info.parentType}.${info.fieldName}.`
   );
+  invariant(
+    runtimeType instanceof GraphQLObjectType,
+    `resolveType must return an instance of GraphQLObjectType for field ${
+      info.parentType}.${info.fieldName}, received "${runtimeType}".`
+  );
 
   const schema = exeContext.schema;
   if (!schema.isPossibleType(returnType, runtimeType)) {

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -817,9 +817,11 @@ function completeAbstractValue(
     returnType.resolveType(result, exeContext.contextValue, info) :
     defaultResolveTypeFn(result, exeContext.contextValue, info, returnType);
 
-  if (!runtimeType) {
-    return null;
-  }
+  invariant(
+    runtimeType,
+    `Could not determine runtime type of value "${result}" for field ${
+      info.parentType}.${info.fieldName}.`
+  );
 
   const schema = exeContext.schema;
   if (!schema.isPossibleType(returnType, runtimeType)) {


### PR DESCRIPTION
I had an error in my resolveType function which took me a long time to track down.  If resolveType returns null, even accidentally, completeAbstractValue just returns null and no error is noted.

It is reasonable for resolveType to return null if a type cannot be determined.  But, is it reasonable for execute to ignore when this happens?

This PR introduces an invariant to trigger an error message when the runtime type cannot be determined, or something weird is returned from resolveType.