### PR TITLE
[RFC] Add flag to tolerate additional properties on input objects.

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -859,6 +859,7 @@ export type GraphQLEnumValueDefinition/* <T> */ = {
 export class GraphQLInputObjectType {
   name: string;
   description: ?string;
+  tolerateAdditionalProps: ?boolean;
 
   _typeConfig: InputObjectConfig;
   _fields: InputObjectFieldMap;
@@ -868,6 +869,7 @@ export class GraphQLInputObjectType {
     assertValidName(config.name);
     this.name = config.name;
     this.description = config.description;
+    this.tolerateAdditionalProps = config.tolerateAdditionalProps;
     this._typeConfig = config;
   }
 
@@ -914,6 +916,7 @@ export type InputObjectConfig = {
   name: string;
   fields: InputObjectConfigFieldMapThunk | InputObjectConfigFieldMap;
   description?: ?string;
+  tolerateAdditionalProps?: ?boolean;
 }
 
 type InputObjectConfigFieldMapThunk = () => InputObjectConfigFieldMap;

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -65,9 +65,11 @@ export function isValidJSValue(value: mixed, type: GraphQLInputType): [string] {
     const errors = [];
 
     // Ensure every provided field is defined.
-    for (const providedField of Object.keys(value)) {
-      if (!fields[providedField]) {
-        errors.push(`In field "${providedField}": Unknown field.`);
+    if (!type.tolerateAdditionalProps) {
+      for (const providedField of Object.keys(value)) {
+        if (!fields[providedField]) {
+          errors.push(`In field "${providedField}": Unknown field.`);
+        }
       }
     }
 


### PR DESCRIPTION
Adding `tolerateAdditionalProps` property to a GraphQLInputObjectType schema will allow that type to tolerate additional properties which are not specified in the schema.

Example:

``` js
new GraphQLInputObjectType({
  name: 'TestFlexInputObject',
  tolerateAdditionalProps: true,
  fields: {
    a: { type: GraphQLString },
    b: { type: new GraphQLList(GraphQLString) },
    c: { type: new GraphQLNonNull(GraphQLString) },
    d: { type: TestComplexScalar },
  }
});
```

Will accept:

```
{a: "foo", b: ["bar"], c: "baz", dog: "dog"}
```

Note that the additional properties will still get filtered out but we will not get an error.
