### PR TITLE
Attempt to fix the context test

### DIFF
--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -198,7 +198,7 @@ describe('Execute: Handles basic execution tasks', () => {
         fields: {
           a: {
             type: GraphQLString,
-            resolve(context) {
+            resolve(rootValue, args, context) {
               resolvedContext = context;
             }
           }
@@ -206,7 +206,7 @@ describe('Execute: Handles basic execution tasks', () => {
       })
     });
 
-    await execute(schema, parse(doc), data);
+    await execute(schema, parse(doc), null, data);
 
     expect(resolvedContext.contextThing).to.equal('thing');
   });


### PR DESCRIPTION
It looks like the context test is testing the rootValue field if I interpret the test correctly. The fix is simply to pass and access the context field instead of the rootValue field. I might be wrongly interpreting the test since I am new to GraphQL.