### PR TITLE
Improve validation error message when field names conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-plugin-transform-runtime": "6.6.0",
     "babel-preset-es2015": "6.6.0",
     "chai": "3.5.0",
+    "chai-string": "1.2.0",
     "chai-subset": "1.2.2",
     "coveralls": "2.11.9",
     "eslint": "2.7.0",

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import {
   expectPassesRule,
@@ -28,7 +29,10 @@ import {
   GraphQLString,
   GraphQLID,
 } from '../../type';
+import chai from 'chai';
+import chaiString from 'chai-string';
 
+chai.use(chaiString);
 
 describe('Validate: Overlapping fields can be merged', () => {
 
@@ -751,6 +755,15 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       `);
+    });
+
+    it('error message contains hint for alias conflict', () => {
+      // The error template should end with a hint for the user to try using
+      // different aliases.
+      const error = fieldsConflictMessage('x', 'a and b are different fields');
+      const hint = 'Use different aliases on the fields to fetch both ' +
+                   'if this was intentional.';
+      expect(error).to.endsWith(hint);
     });
 
   });

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -40,15 +40,15 @@ export function fieldsConflictMessage(
   reason: ConflictReasonMessage
 ): string {
   return `Fields "${responseName}" conflict because ${reasonMessage(reason)}` +
-    '. Use aliases on the fields to fetch both if this was intentional.';
+    '. Use different aliases on the fields to fetch both if this was ' +
+    'intentional.';
 }
 
 function reasonMessage(reason: ConflictReasonMessage): string {
   if (Array.isArray(reason)) {
     return reason.map(([ responseName, subreason ]) =>
       `subfields "${responseName}" conflict because ${reasonMessage(subreason)}`
-    ).join(' and ') +
-      '. Use aliases on the fields to fetch both if this was intentional.';
+    ).join(' and ');
   }
   return reason;
 }

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -39,14 +39,16 @@ export function fieldsConflictMessage(
   responseName: string,
   reason: ConflictReasonMessage
 ): string {
-  return `Fields "${responseName}" conflict because ${reasonMessage(reason)}.`;
+  return `Fields "${responseName}" conflict because ${reasonMessage(reason)}` +
+    '. Use aliases on the fields to fetch both if this was intentional.';
 }
 
 function reasonMessage(reason: ConflictReasonMessage): string {
   if (Array.isArray(reason)) {
     return reason.map(([ responseName, subreason ]) =>
       `subfields "${responseName}" conflict because ${reasonMessage(subreason)}`
-    ).join(' and ');
+    ).join(' and ') +
+      '. Use aliases on the fields to fetch both if this was intentional.';
   }
   return reason;
 }


### PR DESCRIPTION
When I submit a query with overlapping field names like so:

_node {
          echo(val: "test"),
          echo(val: "foo")
        }_

I get the following validation error: 
**"Fields \"echo\" conflict because they have differing arguments."**

This PR modifies the error message to suggest using aliases when this occurs: 
**"Fields \"echo\" conflict because they have differing arguments. Use aliases on the fields to fetch both if this was intentional."**