### PR TITLE
Deepen introspection query from 3 levels to 7

### DIFF
--- a/src/utilities/introspectionQuery.js
+++ b/src/utilities/introspectionQuery.js
@@ -83,6 +83,22 @@ export const introspectionQuery = `
         ofType {
           kind
           name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
# Problem

Certain use cases require deeply nested types, perhaps non-null lists inside non-null lists etc..

GraphQL (quite reasonably) doesn't support infinitely recursive queries, which would enable introspecting on arbitrarily nested structures like this. This limits introspection on deeply nested types.

This GraphQL implementation provides an introspection query that supports up to a finite depth, currently 3, e.g. `[Int!]!`. This is not enough for all use cases: imagine a fully non-null 3D matrix: `[[[Int!]!]!]!`.

In practice, I encountered this problem almost immediately with a modest type akin to `[[Int!]!]`.

# Solution

Deepen the introspection depth for nested types from 3 to 7. This is enough to support the examples above, and is likely to be enough for most reasonable cases, even with fairly heavy use of non-null types.

Tests now explicitly express the desired maximum depth.

# Result

It becomes easy to introspect on deeply nested types.