### PR TITLE
Allow object types without fields.

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -355,38 +355,12 @@ describe('Type System: Objects must have fields', () => {
     );
   });
 
-  it('rejects an Object type with empty fields', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {}
-      }))
-    ).to.throw(
-      'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
-    );
-  });
-
   it('rejects an Object type with a field function that returns nothing', () => {
     expect(
       () => schemaWithFieldType(new GraphQLObjectType({
         name: 'SomeObject',
         fields() {
           return;
-        }
-      }))
-    ).to.throw(
-      'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
-    );
-  });
-
-  it('rejects an Object type with a field function that returns empty', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields() {
-          return {};
         }
       }))
     ).to.throw(

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -385,15 +385,8 @@ function defineFieldMap(
     'function which returns such an object.'
   );
 
-  const fieldNames = Object.keys(fieldMap);
-  invariant(
-    fieldNames.length > 0,
-    `${type} fields must be an object with field names as keys or a ` +
-    'function which returns such an object.'
-  );
-
   const resultFieldMap = {};
-  fieldNames.forEach(fieldName => {
+  Object.keys(fieldMap).forEach(fieldName => {
     assertValidName(fieldName);
     const field = {
       ...fieldMap[fieldName],


### PR DESCRIPTION
## Problem

graphql-js has an invariant that prevents the object type from having no fields, which could be useful for the result of mutation fields.  Using an object type allows fields to be added to the result later, so an object type would provide forward compatibility.  I would also like to remove the requirement for relay mutation payloads from having to include a clientMutationId, since I don't see a reason why it needs to be sent over the network.

The GraphQL specification has an [Object type validation](http://facebook.github.io/graphql/#sec-Object-type-validation) section, but doesn't have a restriction that prevents an object type from having no field.

The GraphQL specification does validate that a selection set on an object type must not be empty, but the __typename field can still be selected on an object type without any fields.  That field wouldn't be necessary for the mutation use case, but would be useful if an object type without fields was used in a union.

## Solution

Remove the invariant, since it doesn't seem necessary.

## Question

There is another invariant that prevents an input object type from being empty.  That is also a restriction that doesn't seem to be imposed by the GraphQL spec.  Should that be removed as well?