### PR TITLE
Remove all 'instanceof GraphQLSchema' checks

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -117,11 +117,6 @@ export function execute(
   operationName?: ?string
 ): Promise<ExecutionResult> {
   invariant(schema, 'Must provide schema');
-  invariant(
-    schema instanceof GraphQLSchema,
-    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
-    'not multiple versions of GraphQL installed in your node_modules directory.'
-  );
 
   // If a valid context cannot be created due to incorrect arguments,
   // this will throw an error.

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -94,10 +94,6 @@ export function extendSchema(
   schema: GraphQLSchema,
   documentAST: Document
 ): GraphQLSchema {
-  invariant(
-    schema instanceof GraphQLSchema,
-    'Must provide valid GraphQLSchema'
-  );
 
   invariant(
     documentAST && documentAST.kind === DOCUMENT,

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -53,11 +53,6 @@ export function validate(
 ): Array<GraphQLError> {
   invariant(schema, 'Must provide schema');
   invariant(ast, 'Must provide document');
-  invariant(
-    schema instanceof GraphQLSchema,
-    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
-    'not multiple versions of GraphQL installed in your node_modules directory.'
-  );
   const typeInfo = new TypeInfo(schema);
   return visitUsingRules(schema, typeInfo, ast, rules || specifiedRules);
 }


### PR DESCRIPTION
This change removes the instanceof GraphQLSchema checks in validate and execute. This makes graphql-js play more nicely with schemas generated by other libraries, or even schemas created by other versions of graphql-js as long as they are compatible (a common issue with npm v2).

@leebyron Right now I just removed the checks and didn't replace them with anything, because it turned out that no tests were affected by the change. Let me know if you think we should have some duck typing checks in there, such as checking that getTypeMap, get Type, getQueryType, getDirectives etc. are functions.