### PR TITLE
Revert "Remove all 'instanceof GraphQLSchema' checks"

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -117,6 +117,11 @@ export function execute(
   operationName?: ?string
 ): Promise<ExecutionResult> {
   invariant(schema, 'Must provide schema');
+  invariant(
+    schema instanceof GraphQLSchema,
+    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
+    'not multiple versions of GraphQL installed in your node_modules directory.'
+  );
 
   // If a valid context cannot be created due to incorrect arguments,
   // this will throw an error.

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -94,6 +94,10 @@ export function extendSchema(
   schema: GraphQLSchema,
   documentAST: Document
 ): GraphQLSchema {
+  invariant(
+    schema instanceof GraphQLSchema,
+    'Must provide valid GraphQLSchema'
+  );
 
   invariant(
     documentAST && documentAST.kind === DOCUMENT,

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -53,6 +53,11 @@ export function validate(
 ): Array<GraphQLError> {
   invariant(schema, 'Must provide schema');
   invariant(ast, 'Must provide document');
+  invariant(
+    schema instanceof GraphQLSchema,
+    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
+    'not multiple versions of GraphQL installed in your node_modules directory.'
+  );
   const typeInfo = new TypeInfo(schema);
   return visitUsingRules(schema, typeInfo, ast, rules || specifiedRules);
 }


### PR DESCRIPTION
Reverts graphql/graphql-js#371

Now have a better understanding of why those invariants were there - because `instanceof` is used in many other places, removing these doesn't allow the use of GraphQLSchema defined by other versions of graphql-js because eventually checks like `instanceof GraphQLList` or `instanceof GraphQLObjectType` will fail for the same reasons - but at that point the produced errors may be far more mysterious. These invariants were added to at least give a clear error message early on.

If we want to enable this, we'll have to completely remove `instanceof`.