### PR TITLE
Deprecated directive

### DIFF
--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -54,7 +54,7 @@ export function getVariableValues(
 export function getArgumentValues(
   argDefs: ?Array<GraphQLArgument>,
   argASTs: ?Array<Argument>,
-  variableValues: { [key: string]: mixed }
+  variableValues?: ?{ [key: string]: mixed }
 ): { [key: string]: mixed } {
   if (!argDefs || !argASTs) {
     return {};

--- a/src/index.js
+++ b/src/index.js
@@ -66,9 +66,14 @@ export {
   GraphQLBoolean,
   GraphQLID,
 
-  // Built-in Directives
+  // Built-in Directives defined by the Spec
+  specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeprecatedDirective,
+
+  // Constant Deprecation Reason
+  DEFAULT_DEPRECATION_REASON,
 
   // Meta-field definitions.
   SchemaMetaFieldDef,

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -13,7 +13,7 @@ import type {
   GraphQLFieldConfigArgumentMap,
   GraphQLArgument
 } from './definition';
-import { GraphQLBoolean } from './scalars';
+import { GraphQLString, GraphQLBoolean } from './scalars';
 import invariant from '../jsutils/invariant';
 import { assertValidName } from '../utilities/assertValidName';
 
@@ -99,7 +99,7 @@ type GraphQLDirectiveConfig = {
 }
 
 /**
- * Used to conditionally include fields or fragments
+ * Used to conditionally include fields or fragments.
  */
 export const GraphQLIncludeDirective = new GraphQLDirective({
   name: 'include',
@@ -120,7 +120,7 @@ export const GraphQLIncludeDirective = new GraphQLDirective({
 });
 
 /**
- * Used to conditionally skip (exclude) fields or fragments
+ * Used to conditionally skip (exclude) fields or fragments.
  */
 export const GraphQLSkipDirective = new GraphQLDirective({
   name: 'skip',
@@ -139,3 +139,40 @@ export const GraphQLSkipDirective = new GraphQLDirective({
     }
   },
 });
+
+/**
+ * Constant string used for default reason for a deprecation.
+ */
+export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
+
+/**
+ * Used to declare element of a GraphQL schema as deprecated.
+ */
+export const GraphQLDeprecatedDirective = new GraphQLDirective({
+  name: 'deprecated',
+  description:
+    'Marks an element of a GraphQL schema as no longer supported.',
+  locations: [
+    DirectiveLocation.FIELD_DEFINITION,
+    DirectiveLocation.ENUM_VALUE,
+  ],
+  args: {
+    reason: {
+      type: GraphQLString,
+      description:
+        'Explains why this element was deprecated, usually also including a ' +
+        'suggestion for how to access supported similar data. Formatted' +
+        'in [Markdown](https://daringfireball.net/projects/markdown/).',
+      defaultValue: DEFAULT_DEPRECATION_REASON
+    }
+  },
+});
+
+/**
+ * The full list of specified directives.
+ */
+export const specifiedDirectives: Array<GraphQLDirective> = [
+  GraphQLIncludeDirective,
+  GraphQLSkipDirective,
+  GraphQLDeprecatedDirective,
+];

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -42,9 +42,14 @@ export {
   // Directives Definition
   GraphQLDirective,
 
-  // Built-in Directives
+  // Built-in Directives defined by the Spec
+  specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeprecatedDirective,
+
+  // Constant Deprecation Reason
+  DEFAULT_DEPRECATION_REASON,
 } from './directives';
 
 // Common built-in scalar instances.

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -17,11 +17,7 @@ import {
   GraphQLNonNull
 } from './definition';
 import type { GraphQLType, GraphQLAbstractType } from './definition';
-import {
-  GraphQLDirective,
-  GraphQLIncludeDirective,
-  GraphQLSkipDirective
-} from './directives';
+import { GraphQLDirective, specifiedDirectives } from './directives';
 import { __Schema } from './introspection';
 import find from '../jsutils/find';
 import invariant from '../jsutils/invariant';
@@ -38,21 +34,20 @@ import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators';
  * Example:
  *
  *     const MyAppSchema = new GraphQLSchema({
- *       query: MyAppQueryRootType
- *       mutation: MyAppMutationRootType
- *     });
+ *       query: MyAppQueryRootType,
+ *       mutation: MyAppMutationRootType,
+ *     })
  *
  * Note: If an array of `directives` are provided to GraphQLSchema, that will be
  * the exact list of directives represented and allowed. If `directives` is not
- * provided then a default set of the built-in `[ @include, @skip ]` directives
- * will be used. If you wish to provide *additional* directives to these
- * built-ins, you must explicitly declare them. Example:
+ * provided then a default set of the specified directives (e.g. @include and
+ * @skip) will be used. If you wish to provide *additional* directives to these
+ * specified directives, you must explicitly declare them. Example:
  *
- *     directives: [
- *       myCustomDirective,
- *       GraphQLIncludeDirective,
- *       GraphQLSkipDirective
- *     ]
+ *     const MyAppSchema = new GraphQLSchema({
+ *       ...
+ *       directives: specifiedDirectives.concat([ myCustomDirective ]),
+ *     })
  *
  */
 export class GraphQLSchema {
@@ -104,11 +99,8 @@ export class GraphQLSchema {
       `Schema directives must be Array<GraphQLDirective> if provided but got: ${
         config.directives}.`
     );
-    // Provide `@include() and `@skip()` directives by default.
-    this._directives = config.directives || [
-      GraphQLIncludeDirective,
-      GraphQLSkipDirective
-    ];
+    // Provide specified directives (e.g. @include and @skip) by default.
+    this._directives = config.directives || specifiedDirectives;
 
     // Build type map now to detect any errors within this schema.
     let initialTypes: Array<?GraphQLType> = [

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -7,6 +7,9 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+// 80+ char lines are useful in describe/it, so ignore in this file.
+/* eslint-disable max-len */
+
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { printSchema, printIntrospectionSchema } from '../schemaPrinter';
@@ -602,14 +605,16 @@ directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
+
 type __Directive {
   name: String!
   description: String
   locations: [__DirectiveLocation!]!
   args: [__InputValue!]!
-  onOperation: Boolean!
-  onFragment: Boolean!
-  onField: Boolean!
+  onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
+  onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+  onField: Boolean! @deprecated(reason: "Use \`locations\`.")
 }
 
 enum __DirectiveLocation {


### PR DESCRIPTION
This adds a new directive as part of the experimental schema language:

```
directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ENUM_VALUE
```

It also adds support for this directive in the schemaPrinter and buildASTSchema.

Additionally exports a new helper `specifiedDirectives` which is encoured to be used when addressing the collection of all directives defined by the spec. The `@deprecated` directive is optimistically added to this collection. While it's currently experimental, it will become part of the schema definition language RFC.