### PR TITLE
Update babel-cli and flow-bin package references

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "babel-runtime": ">=6.0.0"
   },
   "devDependencies": {
-    "babel-cli": "6.6.5",
+    "babel-cli": "6.7.7",
     "babel-eslint": "6.0.2",
     "babel-plugin-syntax-async-functions": "6.5.0",
     "babel-plugin-transform-class-properties": "6.6.0",
@@ -65,7 +65,7 @@
     "coveralls": "2.11.9",
     "eslint": "2.7.0",
     "eslint-plugin-babel": "3.2.0",
-    "flow-bin": "0.22.1",
+    "flow-bin": "0.24.2",
     "isparta": "4.0.0",
     "mocha": "2.4.5",
     "sane": "1.3.4"


### PR DESCRIPTION
We currently get a bunch of graceful-fs deprecated warnings when running "npm install". This change fixes two such warnings by updating babel-cli and flow-bin. 