### PR TITLE
Fix test assertions for validation test when using custom TypeInfo

### DIFF
--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -64,10 +64,15 @@ describe('Validate: Supports full validation', () => {
       specifiedRules
     );
 
-    expect(errors).to.deep.equal([
-      new Error('Cannot query field "catOrDog" on type "QueryRoot".'),
-      new Error('Cannot query field "furColor" on type "Cat".'),
-      new Error('Cannot query field "isHousetrained" on type "Dog".'),
+    const errorMessages = errors.map(err => err.message);
+
+    expect(errorMessages).to.deep.equal([
+      'Cannot query field "catOrDog" on type "QueryRoot". ' +
+      'Did you mean "catOrDog"?',
+      'Cannot query field "furColor" on type "Cat". ' +
+      'Did you mean "furColor"?',
+      'Cannot query field "isHousetrained" on type "Dog". ' +
+      'Did you mean "isHousetrained"?'
     ]);
   });
 


### PR DESCRIPTION
- Changes in #355, which improved validation messages, should had broken the test.
- But `expect().to.deep.equal()` checks for the right number of errors  but does not check for equality of error messages.

Notes:
- `npm run check` complained that the error messages were too long; broke each error into 2 lines.

PS: Can someone with travis access re-run the build? It failed for only one of the environment `nodejs 4`, seems like `flow` didn't get installed properly (`ENOENT` error)
