### PR TITLE
move babel config to the babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": [
+    "es2015"
+  ],
+  "plugins": [
+    "syntax-async-functions",
+    "transform-class-properties",
+    "transform-flow-strip-types",
+    "transform-object-rest-spread",
+    "transform-regenerator",
+    "transform-runtime"
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@
 .idea
 npm-debug.log
 
+.babelrc 
 CONTRIBUTING.md
 node_modules
 coverage

--- a/package.json
+++ b/package.json
@@ -20,19 +20,6 @@
   "options": {
     "mocha": "--require ./resources/mocha-bootload --check-leaks --full-trace src/**/__tests__/**/*-test.js"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ],
-    "plugins": [
-      "syntax-async-functions",
-      "transform-class-properties",
-      "transform-flow-strip-types",
-      "transform-object-rest-spread",
-      "transform-regenerator",
-      "transform-runtime"
-    ]
-  },
   "scripts": {
     "test": "npm run lint && npm run check && npm run testonly",
     "testonly": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",


### PR DESCRIPTION
This moves babel config to the babelrc and unincludes it from the npm module.

For most use cases, this shouldn't make any difference. But, some build tools will look through node_modules and barf if there is a package.json with a babel config in there. In particular, jest has a  react-native-specific hack that does this. In particular, any project using jest, react-native, and the graphql module doesn't work at the moment. E.g. we had to do a similar thing to fix enzyme. https://github.com/airbnb/enzyme/pull/311