### PR TITLE
Logging support

### DIFF
--- a/src/__tests__/starWarsQuery-test.js
+++ b/src/__tests__/starWarsQuery-test.js
@@ -574,9 +574,7 @@ describe('Star Wars Query Tests', () => {
         null,
         null,
         (tag, payload) => {
-          const path =
-          tag === TAG.SUBTREE_ERROR || tag === TAG.RESOLVER_ERROR ?
-          payload.executionPath : payload;
+          const { path } = payload;
           logged.push([ tag, path ]);
         });
 

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -598,6 +598,7 @@ function resolveField(
           error: reason,
           path,
         }, info);
+        logFn(TAG.RESOLVER_END, { path });
         return Promise.reject(reason);
       });
   } else {

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -591,7 +591,7 @@ function resolveField(
   let result = resolveOrError(resolveFn, source, args, context, info);
 
   if (isThenable(result)) {
-    result = ((result: any): Promise).then(
+    result = ((result: any): Promise<*>).then(
       passThroughResultAndLog(logFn, TAG.RESOLVER_END, { path }, info),
       reason => {
         logFn(TAG.RESOLVER_ERROR, {
@@ -665,7 +665,7 @@ function completeValueCatchingError(
     );
 
     if (isThenable(completed)) {
-      return ((completed: any): Promise).then(
+      return ((completed: any): Promise<*>).then(
         passThroughResultAndLog(logFn, TAG.SUBTREE_END, { path }, info),
         reason => {
           logFn(TAG.SUBTREE_ERROR, {

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -584,7 +584,7 @@ function resolveField(
   };
 
   const logFn = exeContext.logFn || (() => {});
-  logFn(TAG.RESOLVER_START, path, info);
+  logFn(TAG.RESOLVER_START, { path }, info);
 
   // Get the resolve function, regardless of if its result is normal
   // or abrupt (error).
@@ -592,11 +592,11 @@ function resolveField(
 
   if (isThenable(result)) {
     result = ((result: any): Promise).then(
-      passThroughResultAndLog(logFn, TAG.RESOLVER_END, path, info),
+      passThroughResultAndLog(logFn, TAG.RESOLVER_END, { path }, info),
       reason => {
         logFn(TAG.RESOLVER_ERROR, {
           error: reason,
-          executionPath: path,
+          path,
         }, info);
         return Promise.reject(reason);
       });
@@ -604,10 +604,10 @@ function resolveField(
     if (result instanceof Error) {
       logFn(TAG.RESOLVER_ERROR, {
         error: result,
-        executionPath: path,
+        path,
       }, info);
     }
-    logFn(TAG.RESOLVER_END, path, info);
+    logFn(TAG.RESOLVER_END, { path }, info);
   }
 
   return completeValueCatchingError(
@@ -649,7 +649,7 @@ function completeValueCatchingError(
   result: mixed
 ): mixed {
   const logFn = exeContext.logFn || (() => {});
-  logFn(TAG.SUBTREE_START, path, info);
+  logFn(TAG.SUBTREE_START, { path }, info);
 
   // If the field type is non-nullable, then it is resolved without any
   // protection from errors.
@@ -665,18 +665,18 @@ function completeValueCatchingError(
 
     if (isThenable(completed)) {
       return ((completed: any): Promise).then(
-        passThroughResultAndLog(logFn, TAG.SUBTREE_END, path, info),
+        passThroughResultAndLog(logFn, TAG.SUBTREE_END, { path }, info),
         reason => {
           logFn(TAG.SUBTREE_ERROR, {
             error: reason,
-            executionPath: path
+            path,
           }, info);
-          logFn(TAG.SUBTREE_END, path, info);
+          logFn(TAG.SUBTREE_END, { path }, info);
           return Promise.reject(reason);
         });
     }
 
-    logFn(TAG.SUBTREE_END, path, info);
+    logFn(TAG.SUBTREE_END, { path }, info);
     return completed;
   }
 
@@ -697,20 +697,20 @@ function completeValueCatchingError(
       // Note: we don't rely on a `catch` method, but we do expect "thenable"
       // to take a second callback for the error case.
       return ((completed: any): Promise<*>).then(
-        passThroughResultAndLog(logFn, TAG.SUBTREE_END, path, info),
+        passThroughResultAndLog(logFn, TAG.SUBTREE_END, { path }, info),
         error => {
           exeContext.errors.push(error);
           logFn(TAG.SUBTREE_ERROR, {
             error,
-            executionPath: path
+            path
           }, info);
-          logFn(TAG.SUBTREE_END, path, info);
+          logFn(TAG.SUBTREE_END, { path }, info);
 
           return Promise.resolve(null);
         });
     }
 
-    logFn(TAG.SUBTREE_END, path, info);
+    logFn(TAG.SUBTREE_END, { path }, info);
 
     return completed;
   } catch (error) {
@@ -720,9 +720,9 @@ function completeValueCatchingError(
 
     logFn(TAG.SUBTREE_ERROR, {
       error,
-      executionPath: path
+      path
     }, info);
-    logFn(TAG.SUBTREE_END, path, info);
+    logFn(TAG.SUBTREE_END, { path }, info);
 
     return null;
   }

--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -8,3 +8,4 @@
  */
 
 export { execute } from './execute';
+export { TAG } from './logging';

--- a/src/execution/logging.js
+++ b/src/execution/logging.js
@@ -1,0 +1,32 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+export const TAG = {
+  SUBTREE_START: 'SUBTREE_START',
+  SUBTREE_END: 'SUBTREE_END',
+  SUBTREE_ERROR: 'SUBTREE_ERROR',
+  RESOLVER_START: 'RESOLVER_START',
+  RESOLVER_END: 'RESOLVER_END',
+  RESOLVER_ERROR: 'RESOLVER_ERROR',
+};
+
+export type GraphQLLoggingTagType = $Keys<typeof TAG>; // eslint-disable-line
+
+export function passThroughResultAndLog(
+  logFn: any,
+  tag: GraphQLLoggingTagType,
+  payload: any,
+  info: any
+): any {
+  return function (result) {
+    logFn(tag, payload, info);
+    return result;
+  };
+}

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -39,6 +39,10 @@ import type { GraphQLSchema } from './type/schema';
  *    The name of the operation to use if requestString contains multiple
  *    possible operations. Can be omitted if requestString contains only
  *    one operation.
+ * logFn:
+ *    The function that is called with a tag of an event, an event payload
+ *    and other execution information.
+ *    The examples include: errors thrown, before and after the resolver call.
  */
 export function graphql(
   schema: GraphQLSchema,
@@ -46,7 +50,8 @@ export function graphql(
   rootValue?: mixed,
   contextValue?: mixed,
   variableValues?: ?{[key: string]: mixed},
-  operationName?: ?string
+  operationName?: ?string,
+  logFn?: (tag: string, payload: mixed, info: mixed) => void
 ): Promise<GraphQLResult> {
   return new Promise(resolve => {
     const source = new Source(requestString || '', 'GraphQL request');
@@ -62,7 +67,8 @@ export function graphql(
           rootValue,
           contextValue,
           variableValues,
-          operationName
+          operationName,
+          logFn
         )
       );
     }

--- a/src/index.js
+++ b/src/index.js
@@ -128,6 +128,7 @@ export {
 // Execute GraphQL queries.
 export {
   execute,
+  TAG
 } from './execution';
 
 


### PR DESCRIPTION
This PR builds on top of #396 and provides a new option `logFn` that is called by GraphQL.js with the following events:
- Resolver starts execution
- Resolver finished execution
- Resolver threw an error
- Resolver's subtree starts execution (for a compound type)
- Resolver's subtree finished execution
- Resolver's subtree threw an error

This logging allows external users of the `graphql` module to tap into the execution time-line for profiling or logging/debugging.

Note that this is not intended to be a logging system available from resolver's code. For that, we expect users of the library to pass their logging mechanism through the `context` property.
