### PR TITLE
fix all errors with flow 0.28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ npm-debug.log
 node_modules
 coverage
 dist
+.vscode

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-babel": "3.2.0",
     "eslint-plugin-flow-vars": "^0.4.0",
     "eslint-plugin-flowtype": "2.2.7",
-    "flow-bin": "0.26.0",
+    "flow-bin": "^0.28.0",
     "isparta": "4.0.0",
     "mocha": "2.5.3",
     "sane": "1.3.4"

--- a/src/jsutils/typecast.js
+++ b/src/jsutils/typecast.js
@@ -1,0 +1,42 @@
+/* @flow */
+/**
+ *  Copyright (c) 2016, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// import invariant from './invariant';
+import {
+  castToNamedType,
+  castToInputType,
+  castToOutputType,
+} from '../type/definition';
+
+/**
+ * These functions are Dynamic checks which will give the checked value
+ * a right Flow Type.
+**/
+
+let dev = {
+  castToNamedType,
+  castToInputType,
+  castToOutputType
+};
+
+if (process.env.NODE_ENV !== 'dev') {
+  dev = {
+    castToNamedType: (v: any): any => v,
+    castToInputType: (v: any): any => v,
+    castToOutputType: (v: any): any => v,
+  };
+}
+
+export {
+  castToNamedType,
+  castToInputType,
+  castToOutputType,
+  dev
+};

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -27,14 +27,9 @@ import type { GraphQLSchema } from './schema';
  * These are all of the possible kinds of types.
  */
 export type GraphQLType =
-  GraphQLScalarType |
-  GraphQLObjectType |
-  GraphQLInterfaceType |
-  GraphQLUnionType |
-  GraphQLEnumType |
-  GraphQLInputObjectType |
-  GraphQLList |
-  GraphQLNonNull;
+  GraphQLNamedType |
+  GraphQLList<any> |
+  GraphQLNonNull<any>;
 
 export function isType(type: mixed): boolean {
   return (
@@ -73,6 +68,23 @@ export function isInputType(type: ?GraphQLType): boolean {
   );
 }
 
+/*
+ * ToDo: should check inner type for GraphQLList|GraphQLNonNull later
+**/
+export function castToInputType(type: GraphQLType,eMsg?: string)
+: GraphQLInputType {
+  if (
+    type instanceof GraphQLScalarType ||
+    type instanceof GraphQLEnumType ||
+    type instanceof GraphQLInputObjectType ||
+    type instanceof GraphQLList ||
+    type instanceof GraphQLNonNull
+  ) {
+    return type;
+  }
+  invariant(false, eMsg ? eMsg : 'The given type is not a GraphQLInputType');
+}
+
 /**
  * These types may be used as output types as the result of fields.
  */
@@ -101,6 +113,24 @@ export function isOutputType(type: ?GraphQLType): boolean {
     namedType instanceof GraphQLUnionType ||
     namedType instanceof GraphQLEnumType
   );
+}
+
+/*
+ * ToDo: should check inner type for GraphQLList|GraphQLNonNull later
+**/
+export function castToOutputType(type: GraphQLType, eMsg?: string)
+: GraphQLOutputType {
+  if (type instanceof GraphQLScalarType ||
+      type instanceof GraphQLObjectType ||
+      type instanceof GraphQLInterfaceType ||
+      type instanceof GraphQLUnionType ||
+      type instanceof GraphQLEnumType ||
+      type instanceof GraphQLList ||
+      type instanceof GraphQLNonNull
+  ) {
+    return type;
+  }
+  invariant(false, eMsg ? eMsg : 'The given type is not a GraphQLOutputType');
 }
 
 /**
@@ -158,7 +188,7 @@ export type GraphQLNullableType =
   GraphQLUnionType |
   GraphQLEnumType |
   GraphQLInputObjectType |
-  GraphQLList;
+  GraphQLList<any>;
 
 export function getNullableType(type: ?GraphQLType): ?GraphQLNullableType {
   return type instanceof GraphQLNonNull ? type.ofType : type;
@@ -186,6 +216,19 @@ export function getNamedType(type: ?GraphQLType): ?GraphQLNamedType {
   return unmodifiedType;
 }
 
+export function castToNamedType(type: ?GraphQLType, eMsg?: string)
+: GraphQLNamedType {
+  if (type instanceof GraphQLScalarType ||
+      type instanceof GraphQLObjectType ||
+      type instanceof GraphQLInterfaceType ||
+      type instanceof GraphQLUnionType ||
+      type instanceof GraphQLEnumType ||
+      type instanceof GraphQLInputObjectType
+  ) {
+    return type;
+  }
+  invariant(false, eMsg ? eMsg : 'The given type is not a GraphQLNamedType');
+}
 
 /**
  * Used while defining GraphQL types to allow for circular references in

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -66,8 +66,6 @@ import {
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
-  isInputType,
-  isOutputType,
 } from '../type/definition';
 
 import type {
@@ -98,6 +96,11 @@ import {
   __EnumValue,
   __TypeKind,
 } from '../type/introspection';
+
+import {
+  castToInputType,
+  castToOutputType,
+} from '../jsutils/typecast';
 
 
 function buildWrappedType(
@@ -284,15 +287,13 @@ export function buildASTSchema(ast: Document): GraphQLSchema {
   }
 
   function produceInputType(typeAST: Type): GraphQLInputType {
-    const type = produceType(typeAST);
-    invariant(isInputType(type), 'Expected Input type.');
-    return (type: any);
+    return castToInputType(
+      produceType(typeAST), 'Expected Input type.');
   }
 
   function produceOutputType(typeAST: Type): GraphQLOutputType {
-    const type = produceType(typeAST);
-    invariant(isOutputType(type), 'Expected Output type.');
-    return (type: any);
+    return castToOutputType(
+      produceType(typeAST), 'Expected Output type.');
   }
 
   function produceObjectType(typeAST: Type): GraphQLObjectType {


### PR DESCRIPTION
Fix all errors(update Flow to 0.27), will write unit test later.(flow 0.27 errors motioned in #412 )
And keep `GraphQLType` to a normal type (not update it to a recursive type):
```
export type GraphQLType =
  GraphQLNamedType|
  GraphQLList |
  GraphQLNonNull;
```
cause in flow 0.27 `GraphQLList<GraphQLType>` was still resolved to `GraphQLList<any>`,seems its no difference between `GraphQLList` and  `GraphQLList<GraphQLType>`. I am asking this behaviors in [flow/issues/2024](https://github.com/facebook/flow/issues/2024), will test this tomorrow, the `any` type should be cleaned.