### PR TITLE
 `GraphQLObjectTypeConfig<TSource>` to `GraphQLFieldResolveFn<TSource, TResult>`

### DIFF
--- a/src/__tests__/starWarsData.js
+++ b/src/__tests__/starWarsData.js
@@ -1,10 +1,12 @@
+/* @flow */
+/* eslint quote-props: ["error", "as-needed",
+{ "keywords": true, "unnecessary": false }]*/
 /**
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
  *  LICENSE file in the root directory of this source tree. An additional grant
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
-
 /**
  * This defines a basic set of data for our Star Wars Schema.
  *
@@ -12,6 +14,8 @@
  * fetching this data from a backend service rather than from hardcoded
  * JSON objects in a more complex demo.
  */
+
+import invariant from '../jsutils/invariant';
 
 const luke = {
   id: '1000',
@@ -81,9 +85,37 @@ const droidData = {
 };
 
 /**
+ * These are data types corresponding to the schema design.
+ * They represent what the input and output datas should be
+ * in schema's resolving hierarchy.
+ * If the schema is re-designed,these types should be re-designed too.
+ */
+export type Character = {
+  id: string,
+  name?: string,
+  friends?: Array<string>,
+  appearsIn?: Array<number>,
+};
+
+export type Human = {
+  id: string,
+  name?: string,
+  friends?: Array<string>,
+  appearsIn?: Array<number>,
+  homePlanet?: string,
+};
+
+export type Droid = {
+  id: string,
+  name?: string,
+  friends?: Array<string>,
+  appearsIn?: Array<number>,
+  primaryFunction?: string
+};
+/**
  * Helper function to get a character by ID.
  */
-function getCharacter(id) {
+function getCharacter(id): Promise<*> {
   // Returning a promise just to illustrate GraphQL.js's support.
   return Promise.resolve(humanData[id] || droidData[id]);
 }
@@ -91,14 +123,20 @@ function getCharacter(id) {
 /**
  * Allows us to query for a character's friends.
  */
-export function getFriends(character) {
+export function getFriends(character: Character): Array<*> {
+  // as you can see,with Flow
+  // If you choose a schema structure like {friends?: Array<*>}.
+  // You must check it ,or re-design your schema.
+  // Flow will keep you away from hiden bugs.
+  invariant(character.friends !== undefined,
+    'Character.friends should not be undefined');
   return character.friends.map(id => getCharacter(id));
 }
 
 /**
  * Allows us to fetch the undisputed hero of the Star Wars trilogy, R2-D2.
  */
-export function getHero(episode) {
+export function getHero(episode: number): Character {
   if (episode === 5) {
     // Luke is the hero of Episode V.
     return luke;
@@ -110,13 +148,13 @@ export function getHero(episode) {
 /**
  * Allows us to query for the human with the given id.
  */
-export function getHuman(id) {
+export function getHuman(id: string): Human {
   return humanData[id];
 }
 
 /**
  * Allows us to query for the droid with the given id.
  */
-export function getDroid(id) {
+export function getDroid(id: string): Droid {
   return droidData[id];
 }

--- a/src/__tests__/starWarsData.js
+++ b/src/__tests__/starWarsData.js
@@ -1,6 +1,4 @@
 /* @flow */
-/* eslint quote-props: ["error", "as-needed",
-{ "keywords": true, "unnecessary": false }]*/
 /**
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
@@ -115,7 +113,7 @@ export type Droid = {
 /**
  * Helper function to get a character by ID.
  */
-function getCharacter(id): Promise<*> {
+function getCharacter(id) {
   // Returning a promise just to illustrate GraphQL.js's support.
   return Promise.resolve(humanData[id] || droidData[id]);
 }
@@ -123,7 +121,7 @@ function getCharacter(id): Promise<*> {
 /**
  * Allows us to query for a character's friends.
  */
-export function getFriends(character: Character): Array<*> {
+export function getFriends(character: Character): Array<Promise<Character>> {
   // as you can see,with Flow
   // If you choose a schema structure like {friends?: Array<*>}.
   // You must check it ,or re-design your schema.

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -1,3 +1,4 @@
+/* @flow */
 /**
  *  Copyright (c) 2015, Facebook, Inc.
  *  All rights reserved.
@@ -18,6 +19,8 @@ import {
 } from '../type';
 
 import { getFriends, getHero, getHuman, getDroid } from './starWarsData.js';
+
+import type {Character, Human, Droid} from './starWarsData.js';
 
 /**
  * This is designed to be an end-to-end test, demonstrating
@@ -132,7 +135,7 @@ const characterInterface = new GraphQLInterfaceType({
     },
   }),
   resolveType: character => {
-    return getHuman(character.id) ? humanType : droidType;
+    return getHuman((character: any).id) ? humanType : droidType;
   }
 });
 
@@ -164,7 +167,7 @@ const humanType = new GraphQLObjectType({
       type: new GraphQLList(characterInterface),
       description: 'The friends of the human, or an empty list if they ' +
                    'have none.',
-      resolve: human => getFriends(human),
+      resolve: (human: Human): Array<Promise<Character>> => getFriends(human),
     },
     appearsIn: {
       type: new GraphQLList(episodeEnum),
@@ -214,7 +217,7 @@ const droidType = new GraphQLObjectType({
       type: new GraphQLList(characterInterface),
       description: 'The friends of the droid, or an empty list if they ' +
                    'have none.',
-      resolve: droid => getFriends(droid),
+      resolve: (droid: Droid): Array<Promise<Character>> => getFriends(droid),
     },
     appearsIn: {
       type: new GraphQLList(episodeEnum),
@@ -261,7 +264,7 @@ const queryType = new GraphQLObjectType({
           type: episodeEnum
         }
       },
-      resolve: (root, { episode }) => getHero(episode),
+      resolve: (root, { episode }): Character => getHero((episode: any)),
     },
     human: {
       type: humanType,
@@ -271,7 +274,7 @@ const queryType = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLString)
         }
       },
-      resolve: (root, { id }) => getHuman(id),
+      resolve: (root, { id }): Human => getHuman((id: any)),
     },
     droid: {
       type: droidType,
@@ -281,7 +284,7 @@ const queryType = new GraphQLObjectType({
           type: new GraphQLNonNull(GraphQLString)
         }
       },
-      resolve: (root, { id }) => getDroid(id),
+      resolve: (root, { id }): Droid => getDroid((id: any)),
     },
   })
 });

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -20,7 +20,7 @@ import {
 
 import { getFriends, getHero, getHuman, getDroid } from './starWarsData.js';
 
-import type {Character, Human, Droid} from './starWarsData.js';
+import type { Character, Human, Droid } from './starWarsData.js';
 
 /**
  * This is designed to be an end-to-end test, demonstrating

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -596,7 +596,7 @@ function resolveField(
 // Isolates the "ReturnOrAbrupt" behavior to not de-opt the `resolveField`
 // function. Returns the result of resolveFn or the abrupt-return Error object.
 function resolveOrError(
-  resolveFn: GraphQLFieldResolveFn<*>,
+  resolveFn: GraphQLFieldResolveFn<*, *>,
   source: mixed,
   args: { [key: string]: mixed },
   context: mixed,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -478,12 +478,12 @@ export type GraphQLIsTypeOfFn = (
   info: GraphQLResolveInfo
 ) => boolean
 
-export type GraphQLFieldResolveFn<TSource> = (
+export type GraphQLFieldResolveFn<TSource, TResult> = (
   source: TSource,
   args: {[argName: string]: mixed},
   context: mixed,
   info: GraphQLResolveInfo
-) => mixed
+) => TResult
 
 export type GraphQLResolveInfo = {
   fieldName: string;
@@ -501,7 +501,7 @@ export type GraphQLResolveInfo = {
 export type GraphQLFieldConfig<TSource> = {
   type: GraphQLOutputType;
   args?: GraphQLFieldConfigArgumentMap;
-  resolve?: GraphQLFieldResolveFn<TSource>;
+  resolve?: GraphQLFieldResolveFn<TSource, *>;
   deprecationReason?: ?string;
   description?: ?string;
 }
@@ -525,7 +525,7 @@ export type GraphQLFieldDefinition = {
   description: ?string;
   type: GraphQLOutputType;
   args: Array<GraphQLArgument>;
-  resolve?: GraphQLFieldResolveFn<*>;
+  resolve?: GraphQLFieldResolveFn<*, *>;
   deprecationReason?: ?string;
 }
 


### PR DESCRIPTION
 `GraphQLObjectTypeConfig<TSource>` to `GraphQLFieldResolveFn<TSource, TResult>`
Make user can do a whole top-bottom Flow check between their resolvers.
With the Flow typed feature, user can ensure his data structure is correspond to schema . ex: [starWarsData.js L103](https://github.com/graphql/graphql-js/commit/046cbba2732be8bbbef74f988fffd04294b583c2#diff-e6e81fa96fbb4bdccb4e3f0042b5f1a3R103)

More details see the [src/**tests**/starWarsSchema.js
](https://github.com/graphql/graphql-js/commit/046cbba2732be8bbbef74f988fffd04294b583c2#diff-14d97c822b45992f98d875d53ca45626R112)
A simple demonstration:

```
  type DCPost;
  type DComment;
  type DUser;
  const Post = new GraphQLObjectType({
    name: 'Post',
    fields: () => ({
      ...
      comment: {
        type: new GraphQLList(Comment),
        resolve: (src:DPost):DComment[] => { // Flow check DPost -> DComment[]
          return ...;
        } }
    }),
  });

  const Comment = new GraphQLObjectType({
    name: 'Comment',
    fields: () => ({
      ...
      user: {
        type: User,
        resolve: (src:DComment):DUser => { // DComment -> DUser
          return ...;
        }
      },
    }),
  });

  const User = new GraphQLObjectType({
      ...
  });
```

Note: Because in v0.61 ,in source code use a `any` type to force cast `TSource`. So it is user's responsibility to check the Data Type is not typo. In above code , if `resolve: (src:DPost):DComment[]` is typo to `resolve: (src:DPost):DSomeAnotherType[]`(and user return a wrong data), Flow will still pass. Flow will not check `DSomeAnotherType` is `DComment`,cause of `DSomeAnotherType` -> `any` ->  `DComment`
