### PR TITLE
parse comments beginning with `##` as descriptions on schema definitions

### DIFF
--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -426,6 +426,19 @@ describe('Lexer', () => {
     );
   });
 
+  it('lexes description comments', () => {
+
+    expect(
+      lexOne('## test description')
+    ).to.deep.equal({
+      kind: TokenKind.DESCRIPTION,
+      start: 0,
+      end: 19,
+      value: 'test description'
+    });
+
+  });
+
   it('lexes punctuation', () => {
 
     expect(

--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -10,8 +10,13 @@ schema {
   mutation: MutationType
 }
 
+## description of 'Foo'
+## with multiple lines
 type Foo implements Bar {
+
+  ## description of field 'one'
   one: Type
+
   two(argument: InputType!): Type
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
@@ -19,56 +24,77 @@ type Foo implements Bar {
   six(argument: InputType = {key: "value"}): Type
 }
 
+## description of 'AnnotatedObject'
 type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
 
+## description of 'Bar'
 interface Bar {
   one: Type
+  ## description of field 'four'
   four(argument: String = "string"): String
 }
 
+## description of 'AnnotatedInterface'
 interface AnnotatedInterface @onInterface {
   annotatedField(arg: Type @onArg): Type @onField
 }
 
+## description of 'Feed'
 union Feed = Story | Article | Advert
 
+## description of 'AnnotatedUnion'
 union AnnotatedUnion @onUnion = A | B
 
+## description of 'CustomScalar'
 scalar CustomScalar
 
+## description of 'AnnotatedScalar'
 scalar AnnotatedScalar @onScalar
 
+## description of 'Site'
 enum Site {
   DESKTOP
+
+  ## description of enum value 'MOBILE'
   MOBILE
 }
 
+## description of 'AnnotatedEnum'
 enum AnnotatedEnum @onEnum {
+  ## description of enum value 'ANNOTATED_VALUE'
   ANNOTATED_VALUE @onEnumValue
+  ## description of enum value 'OTHER_VALUE'
   OTHER_VALUE
 }
 
+## description of 'InputType'
 input InputType {
   key: String!
+  ## description of field 'answer'
   answer: Int = 42
 }
 
+## description of 'AnnotatedInput'
 input AnnotatedInput @onInputObjectType {
   annotatedField: Type @onField
 }
 
 extend type Foo {
+  ## description of field 'seven'
   seven(argument: [String]): Type
 }
 
 extend type Foo @onType {}
 
+## description of 'NoFields'
 type NoFields {}
 
+## description of '@skip'
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+## description of '@include'
 directive @include(if: Boolean!)
   on FIELD
    | FRAGMENT_SPREAD

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -56,7 +56,10 @@ describe('Printer', () => {
   mutation: MutationType
 }
 
+## description of 'Foo'
+## with multiple lines
 type Foo implements Bar {
+  ## description of field 'one'
   one: Type
   two(argument: InputType!): Type
   three(argument: InputType, other: String): Int
@@ -65,56 +68,76 @@ type Foo implements Bar {
   six(argument: InputType = {key: "value"}): Type
 }
 
+## description of 'AnnotatedObject'
 type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
 
+## description of 'Bar'
 interface Bar {
   one: Type
+  ## description of field 'four'
   four(argument: String = "string"): String
 }
 
+## description of 'AnnotatedInterface'
 interface AnnotatedInterface @onInterface {
   annotatedField(arg: Type @onArg): Type @onField
 }
 
+## description of 'Feed'
 union Feed = Story | Article | Advert
 
+## description of 'AnnotatedUnion'
 union AnnotatedUnion @onUnion = A | B
 
+## description of 'CustomScalar'
 scalar CustomScalar
 
+## description of 'AnnotatedScalar'
 scalar AnnotatedScalar @onScalar
 
+## description of 'Site'
 enum Site {
   DESKTOP
+  ## description of enum value 'MOBILE'
   MOBILE
 }
 
+## description of 'AnnotatedEnum'
 enum AnnotatedEnum @onEnum {
+  ## description of enum value 'ANNOTATED_VALUE'
   ANNOTATED_VALUE @onEnumValue
+  ## description of enum value 'OTHER_VALUE'
   OTHER_VALUE
 }
 
+## description of 'InputType'
 input InputType {
   key: String!
+  ## description of field 'answer'
   answer: Int = 42
 }
 
+## description of 'AnnotatedInput'
 input AnnotatedInput @onInputObjectType {
   annotatedField: Type @onField
 }
 
 extend type Foo {
+  ## description of field 'seven'
   seven(argument: [String]): Type
 }
 
 extend type Foo @onType {}
 
+## description of 'NoFields'
 type NoFields {}
 
+## description of '@skip'
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+## description of '@include'
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 `);
 

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -25,6 +25,7 @@ export type Location = {
  * The list of all possible AST node types.
  */
 export type Node = Name
+                 | Description
                  | Document
                  | OperationDefinition
                  | VariableDefinition
@@ -65,6 +66,14 @@ export type Node = Name
 
 export type Name = {
   kind: 'Name';
+  loc?: ?Location;
+  value: string;
+}
+
+// Description
+
+export type Description = {
+  kind: 'Description';
   loc?: ?Location;
   value: string;
 }
@@ -290,6 +299,7 @@ export type ScalarTypeDefinition = {
   kind: 'ScalarTypeDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   directives?: ?Array<Directive>;
 }
 
@@ -297,6 +307,7 @@ export type ObjectTypeDefinition = {
   kind: 'ObjectTypeDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   interfaces?: ?Array<NamedType>;
   directives?: ?Array<Directive>;
   fields: Array<FieldDefinition>;
@@ -306,6 +317,7 @@ export type FieldDefinition = {
   kind: 'FieldDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   arguments: Array<InputValueDefinition>;
   type: Type;
   directives?: ?Array<Directive>;
@@ -315,6 +327,7 @@ export type InputValueDefinition = {
   kind: 'InputValueDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   type: Type;
   defaultValue?: ?Value;
   directives?: ?Array<Directive>;
@@ -324,6 +337,7 @@ export type InterfaceTypeDefinition = {
   kind: 'InterfaceTypeDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   directives?: ?Array<Directive>;
   fields: Array<FieldDefinition>;
 }
@@ -332,6 +346,7 @@ export type UnionTypeDefinition = {
   kind: 'UnionTypeDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   directives?: ?Array<Directive>;
   types: Array<NamedType>;
 }
@@ -340,6 +355,7 @@ export type EnumTypeDefinition = {
   kind: 'EnumTypeDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   directives?: ?Array<Directive>;
   values: Array<EnumValueDefinition>;
 }
@@ -348,6 +364,7 @@ export type EnumValueDefinition = {
   kind: 'EnumValueDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   directives?: ?Array<Directive>;
 }
 
@@ -355,6 +372,7 @@ export type InputObjectTypeDefinition = {
   kind: 'InputObjectTypeDefinition';
   loc?: ?Location;
   name: Name;
+  description?: ?Description;
   directives?: ?Array<Directive>;
   fields: Array<InputValueDefinition>;
 }

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -11,6 +11,10 @@
 
 export const NAME = 'Name';
 
+// Description
+
+export const DESCRIPTION = 'Description';
+
 // Document
 
 export const DOCUMENT = 'Document';

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -14,6 +14,7 @@ import { lex, TokenKind, getTokenKindDesc, getTokenDesc } from './lexer';
 import type { Token } from './lexer';
 import type {
   Name,
+  Description,
   Variable,
 
   Document,
@@ -64,6 +65,7 @@ import type {
 
 import {
   NAME,
+  DESCRIPTION,
   VARIABLE,
 
   DOCUMENT,
@@ -171,6 +173,21 @@ function parseName(parser: Parser): Name {
   };
 }
 
+/**
+ * Converts one or more description lex tokens into a description parse node.
+ */
+function parseDescription(parser: Parser): Description {
+  const tokens = [];
+  do {
+    tokens.push(expect(parser, TokenKind.DESCRIPTION));
+  } while (peek(parser, TokenKind.DESCRIPTION));
+  return {
+    kind: DESCRIPTION,
+    value: tokens.map(token => token.value).join('\n'),
+    loc: loc(parser, tokens[0].start)
+  };
+}
+
 // Implements the parsing rules in the Document section.
 
 /**
@@ -202,6 +219,11 @@ function parseDefinition(parser: Parser): Definition {
     return parseOperationDefinition(parser);
   }
 
+  let description = null;
+  if (peek(parser, TokenKind.DESCRIPTION)) {
+    description = parseDescription(parser);
+  }
+
   if (peek(parser, TokenKind.NAME)) {
     switch (parser.token.value) {
       // Note: subscription is an experimental non-spec addition.
@@ -221,7 +243,7 @@ function parseDefinition(parser: Parser): Definition {
       case 'enum':
       case 'input':
       case 'extend':
-      case 'directive': return parseTypeSystemDefinition(parser);
+      case 'directive': return parseTypeSystemDefinition(parser, description);
     }
   }
 
@@ -683,18 +705,30 @@ export function parseNamedType(parser: Parser): NamedType {
  *   - EnumTypeDefinition
  *   - InputObjectTypeDefinition
  */
-function parseTypeSystemDefinition(parser: Parser): TypeSystemDefinition {
+function parseTypeSystemDefinition(
+  parser: Parser,
+  description: ?Description
+): TypeSystemDefinition {
   if (peek(parser, TokenKind.NAME)) {
     switch (parser.token.value) {
-      case 'schema': return parseSchemaDefinition(parser);
-      case 'scalar': return parseScalarTypeDefinition(parser);
-      case 'type': return parseObjectTypeDefinition(parser);
-      case 'interface': return parseInterfaceTypeDefinition(parser);
-      case 'union': return parseUnionTypeDefinition(parser);
-      case 'enum': return parseEnumTypeDefinition(parser);
-      case 'input': return parseInputObjectTypeDefinition(parser);
-      case 'extend': return parseTypeExtensionDefinition(parser);
-      case 'directive': return parseDirectiveDefinition(parser);
+      case 'schema':
+        return parseSchemaDefinition(parser, description);
+      case 'scalar':
+        return parseScalarTypeDefinition(parser, description);
+      case 'type':
+        return parseObjectTypeDefinition(parser, description);
+      case 'interface':
+        return parseInterfaceTypeDefinition(parser, description);
+      case 'union':
+        return parseUnionTypeDefinition(parser, description);
+      case 'enum':
+        return parseEnumTypeDefinition(parser, description);
+      case 'input':
+        return parseInputObjectTypeDefinition(parser, description);
+      case 'directive':
+        return parseDirectiveDefinition(parser, description);
+      case 'extend':
+        return parseTypeExtensionDefinition(parser, description);
     }
   }
 
@@ -740,7 +774,10 @@ function parseOperationTypeDefinition(parser: Parser): OperationTypeDefinition {
 /**
  * ScalarTypeDefinition : scalar Name Directives?
  */
-function parseScalarTypeDefinition(parser: Parser): ScalarTypeDefinition {
+function parseScalarTypeDefinition(
+  parser: Parser,
+  description: ?Description
+): ScalarTypeDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'scalar');
   const name = parseName(parser);
@@ -748,6 +785,7 @@ function parseScalarTypeDefinition(parser: Parser): ScalarTypeDefinition {
   return {
     kind: SCALAR_TYPE_DEFINITION,
     name,
+    description,
     directives,
     loc: loc(parser, start),
   };
@@ -757,7 +795,10 @@ function parseScalarTypeDefinition(parser: Parser): ScalarTypeDefinition {
  * ObjectTypeDefinition :
  *   - type Name ImplementsInterfaces? Directives? { FieldDefinition+ }
  */
-function parseObjectTypeDefinition(parser: Parser): ObjectTypeDefinition {
+function parseObjectTypeDefinition(
+  parser: Parser,
+  description: ?Description
+): ObjectTypeDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'type');
   const name = parseName(parser);
@@ -772,6 +813,7 @@ function parseObjectTypeDefinition(parser: Parser): ObjectTypeDefinition {
   return {
     kind: OBJECT_TYPE_DEFINITION,
     name,
+    description,
     interfaces,
     directives,
     fields,
@@ -797,6 +839,10 @@ function parseImplementsInterfaces(parser: Parser): Array<NamedType> {
  * FieldDefinition : Name ArgumentsDefinition? : Type Directives?
  */
 function parseFieldDefinition(parser: Parser): FieldDefinition {
+  let description = null;
+  if (peek(parser, TokenKind.DESCRIPTION)) {
+    description = parseDescription(parser);
+  }
   const start = parser.token.start;
   const name = parseName(parser);
   const args = parseArgumentDefs(parser);
@@ -806,6 +852,7 @@ function parseFieldDefinition(parser: Parser): FieldDefinition {
   return {
     kind: FIELD_DEFINITION,
     name,
+    description,
     arguments: args,
     type,
     directives,
@@ -827,6 +874,10 @@ function parseArgumentDefs(parser: Parser): Array<InputValueDefinition> {
  * InputValueDefinition : Name : Type DefaultValue? Directives?
  */
 function parseInputValueDef(parser: Parser): InputValueDefinition {
+  let description = null;
+  if (peek(parser, TokenKind.DESCRIPTION)) {
+    description = parseDescription(parser);
+  }
   const start = parser.token.start;
   const name = parseName(parser);
   expect(parser, TokenKind.COLON);
@@ -839,6 +890,7 @@ function parseInputValueDef(parser: Parser): InputValueDefinition {
   return {
     kind: INPUT_VALUE_DEFINITION,
     name,
+    description,
     type,
     defaultValue,
     directives,
@@ -849,7 +901,10 @@ function parseInputValueDef(parser: Parser): InputValueDefinition {
 /**
  * InterfaceTypeDefinition : interface Name Directives? { FieldDefinition+ }
  */
-function parseInterfaceTypeDefinition(parser: Parser): InterfaceTypeDefinition {
+function parseInterfaceTypeDefinition(
+  parser: Parser,
+  description: ?Description
+): InterfaceTypeDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'interface');
   const name = parseName(parser);
@@ -863,6 +918,7 @@ function parseInterfaceTypeDefinition(parser: Parser): InterfaceTypeDefinition {
   return {
     kind: INTERFACE_TYPE_DEFINITION,
     name,
+    description,
     directives,
     fields,
     loc: loc(parser, start),
@@ -872,7 +928,10 @@ function parseInterfaceTypeDefinition(parser: Parser): InterfaceTypeDefinition {
 /**
  * UnionTypeDefinition : union Name Directives? = UnionMembers
  */
-function parseUnionTypeDefinition(parser: Parser): UnionTypeDefinition {
+function parseUnionTypeDefinition(
+  parser: Parser,
+  description: ?Description
+): UnionTypeDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'union');
   const name = parseName(parser);
@@ -882,6 +941,7 @@ function parseUnionTypeDefinition(parser: Parser): UnionTypeDefinition {
   return {
     kind: UNION_TYPE_DEFINITION,
     name,
+    description,
     directives,
     types,
     loc: loc(parser, start),
@@ -902,9 +962,12 @@ function parseUnionMembers(parser: Parser): Array<NamedType> {
 }
 
 /**
- * EnumTypeDefinition : enum Name Directives? { EnumValueDefinition+ }
+ * EnumTypeDefinition : enum Name { EnumValueDefinition+ }
  */
-function parseEnumTypeDefinition(parser: Parser): EnumTypeDefinition {
+function parseEnumTypeDefinition(
+  parser: Parser,
+  description: ?Description
+): EnumTypeDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'enum');
   const name = parseName(parser);
@@ -918,6 +981,7 @@ function parseEnumTypeDefinition(parser: Parser): EnumTypeDefinition {
   return {
     kind: ENUM_TYPE_DEFINITION,
     name,
+    description,
     directives,
     values,
     loc: loc(parser, start),
@@ -930,12 +994,17 @@ function parseEnumTypeDefinition(parser: Parser): EnumTypeDefinition {
  * EnumValue : Name
  */
 function parseEnumValueDefinition(parser: Parser) : EnumValueDefinition {
+  let description = null;
+  if (peek(parser, TokenKind.DESCRIPTION)) {
+    description = parseDescription(parser);
+  }
   const start = parser.token.start;
   const name = parseName(parser);
   const directives = parseDirectives(parser);
   return {
     kind: ENUM_VALUE_DEFINITION,
     name,
+    description,
     directives,
     loc: loc(parser, start),
   };
@@ -945,7 +1014,8 @@ function parseEnumValueDefinition(parser: Parser) : EnumValueDefinition {
  * InputObjectTypeDefinition : input Name Directives? { InputValueDefinition+ }
  */
 function parseInputObjectTypeDefinition(
-  parser: Parser
+  parser: Parser,
+  description: ?Description
 ): InputObjectTypeDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'input');
@@ -960,6 +1030,7 @@ function parseInputObjectTypeDefinition(
   return {
     kind: INPUT_OBJECT_TYPE_DEFINITION,
     name,
+    description,
     directives,
     fields,
     loc: loc(parser, start),
@@ -969,10 +1040,20 @@ function parseInputObjectTypeDefinition(
 /**
  * TypeExtensionDefinition : extend ObjectTypeDefinition
  */
-function parseTypeExtensionDefinition(parser: Parser): TypeExtensionDefinition {
+function parseTypeExtensionDefinition(
+  parser: Parser,
+  description: ?Description
+): TypeExtensionDefinition {
+  if (description) {
+    throw syntaxError(
+      parser.source,
+      parser.token.start,
+      'Description on type extension definition is not allowed'
+    );
+  }
   const start = parser.token.start;
   expectKeyword(parser, 'extend');
-  const definition = parseObjectTypeDefinition(parser);
+  const definition = parseObjectTypeDefinition(parser, null);
   return {
     kind: TYPE_EXTENSION_DEFINITION,
     definition,
@@ -984,7 +1065,10 @@ function parseTypeExtensionDefinition(parser: Parser): TypeExtensionDefinition {
  * DirectiveDefinition :
  *   - directive @ Name ArgumentsDefinition? on DirectiveLocations
  */
-function parseDirectiveDefinition(parser: Parser): DirectiveDefinition {
+function parseDirectiveDefinition(
+  parser: Parser,
+  description: ?Description
+): DirectiveDefinition {
   const start = parser.token.start;
   expectKeyword(parser, 'directive');
   expect(parser, TokenKind.AT);
@@ -995,6 +1079,7 @@ function parseDirectiveDefinition(parser: Parser): DirectiveDefinition {
   return {
     kind: DIRECTIVE_DEFINITION,
     name,
+    description,
     arguments: args,
     locations,
     loc: loc(parser, start)

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -104,10 +104,18 @@ const printDocASTReducer = {
   OperationTypeDefinition: ({ operation, type }) =>
     operation + ': ' + type,
 
-  ScalarTypeDefinition: ({ name, directives }) =>
+  ScalarTypeDefinition: ({ name, description, directives }) =>
+    descriptionComment(description) +
     join([ 'scalar', name, join(directives, ' ') ], ' '),
 
-  ObjectTypeDefinition: ({ name, interfaces, directives, fields }) =>
+  ObjectTypeDefinition: ({
+    name,
+    description,
+    interfaces,
+    directives,
+    fields
+  }) =>
+    descriptionComment(description) +
     join([
       'type',
       name,
@@ -116,20 +124,29 @@ const printDocASTReducer = {
       block(fields)
     ], ' '),
 
-  FieldDefinition: ({ name, arguments: args, type, directives }) =>
+  FieldDefinition: ({ name, description, arguments: args, type, directives }) =>
+    descriptionComment(description) +
     name +
     wrap('(', join(args, ', '), ')') +
     ': ' + type +
     wrap(' ', join(directives, ' ')),
 
-  InputValueDefinition: ({ name, type, defaultValue, directives }) =>
+  InputValueDefinition: ({
+    name,
+    description,
+    type,
+    defaultValue,
+    directives
+  }) =>
+    descriptionComment(description) +
     join([
       name + ': ' + type,
       wrap('= ', defaultValue),
       join(directives, ' ')
     ], ' '),
 
-  InterfaceTypeDefinition: ({ name, directives, fields }) =>
+  InterfaceTypeDefinition: ({ name, description, directives, fields }) =>
+    descriptionComment(description) +
     join([
       'interface',
       name,
@@ -137,7 +154,8 @@ const printDocASTReducer = {
       block(fields)
     ], ' '),
 
-  UnionTypeDefinition: ({ name, directives, types }) =>
+  UnionTypeDefinition: ({ name, description, directives, types }) =>
+    descriptionComment(description) +
     join([
       'union',
       name,
@@ -145,7 +163,8 @@ const printDocASTReducer = {
       '= ' + join(types, ' | ')
     ], ' '),
 
-  EnumTypeDefinition: ({ name, directives, values }) =>
+  EnumTypeDefinition: ({ name, description, directives, values }) =>
+    descriptionComment(description) +
     join([
       'enum',
       name,
@@ -153,10 +172,12 @@ const printDocASTReducer = {
       block(values)
     ], ' '),
 
-  EnumValueDefinition: ({ name, directives }) =>
+  EnumValueDefinition: ({ name, description, directives }) =>
+    descriptionComment(description) +
     join([ name, join(directives, ' ') ], ' '),
 
-  InputObjectTypeDefinition: ({ name, directives, fields }) =>
+  InputObjectTypeDefinition: ({ name, description, directives, fields }) =>
+    descriptionComment(description) +
     join([
       'input',
       name,
@@ -166,10 +187,24 @@ const printDocASTReducer = {
 
   TypeExtensionDefinition: ({ definition }) => `extend ${definition}`,
 
-  DirectiveDefinition: ({ name, arguments: args, locations }) =>
+  DirectiveDefinition: ({ name, description, arguments: args, locations }) =>
+    descriptionComment(description) +
     'directive @' + name + wrap('(', join(args, ', '), ')') +
     ' on ' + join(locations, ' | '),
 };
+
+/**
+ * Given description, print it as a description comment, possibly spanning
+ * multiple lines
+ */
+function descriptionComment(description) {
+  if (description) {
+    return description.value.split('\n').reduce(
+      (memo, line) => `${memo}## ${line}\n`
+    , '');
+  }
+  return '';
+}
 
 /**
  * Given maybeArray, print an empty string if it is null or empty, otherwise

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -348,8 +348,10 @@ export function buildASTSchema(ast: Document): GraphQLSchema {
 
   function makeTypeDef(def: ObjectTypeDefinition) {
     const typeName = def.name.value;
+    const description = def.description && def.description.value;
     const config = {
       name: typeName,
+      description,
       fields: () => makeFieldDefMap(def),
       interfaces: () => makeImplementedInterfaces(def),
     };
@@ -365,7 +367,8 @@ export function buildASTSchema(ast: Document): GraphQLSchema {
       field => ({
         type: produceOutputType(field.type),
         args: makeInputValues(field.arguments),
-        deprecationReason: getDeprecationReason(field.directives)
+        deprecationReason: getDeprecationReason(field.directives),
+        description: field.description && field.description.value,
       })
     );
   }


### PR DESCRIPTION
This pull adds a comment syntax for descriptions to the schema definition language as discussed in https://github.com/facebook/graphql/pull/90.

The details of the comment syntax have not been worked out in that thread - if there is something you prefer vs these 'double hash' comments, I'm happy to update.

As this pull stands, comments beginning with a second hash mark (`##`) will be parsed as description AST nodes and attached to the following type or field definition.

for example:
```graphql
## description of type 'User'
type User {
  ## description of field 'firstName'
  firstName: String
}
```

changes to lexer:

- when the lexer encounters a `#` character, it checks the next char - if that is also a `#`, it takes text from the current position to the end of the line and produces a `DESCRIPTION` token.

changes to parser:

- when parsing top level definitions, before looking at the initial keyword, the parser first takes any number of `DESCRIPTION` tokens, joins their values, and creates a description AST node.  Then it takes the keyword - if the definition is an `OperationDefinition` or `FragmentDefinition` the description is discarded.  If the definition is a `TypeSystemDefinition` the description node is attached to the definition node.

- when parsing field, input value, or enum value definitions, if there are any leading `DESCRIPTION` tokens, the parser creates a `Description` node and attaches it to the final `FieldDefinition`, `InputValueDefinition`, or `EnumValueDefinition` node.

changes to buildASTSchema.js:

- descriptions on AST nodes are attached to Type objects.