### PR TITLE
Use only ASCII characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The reference implementation provides base libraries in JavaScript that would
 provide the basis for full GraphQL implementations and tools. It is not a fully
 standalone GraphQL server that a client developer could use to start
 manipulating and querying data. Most importantly, it provides no mapping to a
-functioning, production-ready backend. The only “backend” we have targeted for
+functioning, production-ready backend. The only "backend" we have targeted for
 this early preview are in-memory stubs in test cases.
 
 We are releasing this now because after GraphQL was first discussed publicly,

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -518,7 +518,7 @@ function promiseForObject<T>(
 }
 
 /**
- * Implements the logic to compute the key of a given field’s entry
+ * Implements the logic to compute the key of a given field's entry
  */
 function getFieldEntryKey(node: Field): string {
   return node.alias ? node.alias.value : node.name.value;

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -72,7 +72,7 @@ export const __Directive = new GraphQLObjectType({
   description:
     'A Directive provides a way to describe alternate runtime execution and ' +
     'type validation behavior in a GraphQL document.' +
-    '\n\nIn some cases, you need to provide options to alter GraphQL’s ' +
+    '\n\nIn some cases, you need to provide options to alter GraphQL\'s ' +
     'execution behavior in ways field arguments will not suffice, such as ' +
     'conditionally including or skipping a field. Directives provide this by ' +
     'describing additional information to the executor.',


### PR DESCRIPTION
In some environments it's preferable to only use ASCII characters. This changes
all non-ASCII characters to ASCII alternatives.