### PR TITLE
Export rest graphql flow types

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -451,9 +451,9 @@ export type GraphQLObjectTypeConfig = {
   description?: ?string
 }
 
-type GraphQLInterfacesThunk = () => Array<GraphQLInterfaceType>;
+export type GraphQLInterfacesThunk = () => Array<GraphQLInterfaceType>;
 
-type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
+export type GraphQLFieldConfigMapThunk = () => GraphQLFieldConfigMap;
 
 export type GraphQLFieldResolveFn = (
   source?: any,
@@ -952,7 +952,7 @@ export type InputObjectConfig = {
   description?: ?string;
 }
 
-type InputObjectConfigFieldMapThunk = () => InputObjectConfigFieldMap;
+export type InputObjectConfigFieldMapThunk = () => InputObjectConfigFieldMap;
 
 export type InputObjectFieldConfig = {
   type: GraphQLInputType;


### PR DESCRIPTION
Exported types:
* GraphQLInterfacesThunk
* GraphQLFieldConfigMapThunk
* InputObjectConfigFieldMapThunk