### PR TITLE
[FIX] astFromValue uses `serialize()` and requires type.

### DIFF
--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -17,6 +17,7 @@ import {
   GraphQLInt,
   GraphQLString,
   GraphQLBoolean,
+  introspectionQuery,
 } from '../../';
 
 
@@ -31,8 +32,8 @@ describe('Type System: Enum Values', () => {
     }
   });
 
-  const Complex1 = { someRandomObject: 1 };
-  const Complex2 = { someOtherRandomObject: 2 };
+  const Complex1 = { someRandomFunction: () => {} };
+  const Complex2 = { someRandomValue: 123 };
 
   const ComplexEnum = new GraphQLEnumType({
     name: 'Complex',
@@ -88,8 +89,8 @@ describe('Type System: Enum Values', () => {
           }
           if (provideBadValue) {
             // Note: similar shape, but not the same *reference*
-            // as Complex1 above. Enum internal values require === equality.
-            return { someRandomObject: 1 };
+            // as Complex2 above. Enum internal values require === equality.
+            return { someRandomValue: 123 };
           }
           return fromEnum;
         }
@@ -362,6 +363,11 @@ describe('Type System: Enum Values', () => {
         bad: null
       }
     });
+  });
+
+  it('can be introspected without error', async () => {
+    const result = await graphql(schema, introspectionQuery);
+    expect(result).to.not.have.property('errors');
   });
 
 });

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -245,7 +245,7 @@ export class GraphQLScalarType {
     this._scalarConfig = config;
   }
 
-  // Serializes an internal value to include an a response.
+  // Serializes an internal value to include in a response.
   serialize(value: mixed): mixed {
     const serializer = this._scalarConfig.serialize;
     return serializer(value);

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -338,7 +338,7 @@ export const __InputValue = new GraphQLObjectType({
         'input value.',
       resolve: inputVal => isNullish(inputVal.defaultValue) ?
         null :
-        print(astFromValue(inputVal.defaultValue, inputVal))
+        print(astFromValue(inputVal.defaultValue, inputVal.type))
     }
   })
 });

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -22,6 +22,7 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
 } from '../type/definition';
+import { GraphQLString } from '../type/scalars';
 import { DEFAULT_DEPRECATION_REASON } from '../type/directives';
 
 
@@ -172,7 +173,8 @@ function printDeprecated(fieldOrEnumVal) {
   ) {
     return ' @deprecated';
   }
-  return ' @deprecated(reason: ' + print(astFromValue(reason)) + ')';
+  return ' @deprecated(reason: ' +
+    print(astFromValue(reason, GraphQLString)) + ')';
 }
 
 function printArgs(fieldOrDirectives) {

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -39,8 +39,9 @@ import type {
  * | Input Object         | Object        |
  * | List                 | Array         |
  * | Boolean              | Boolean       |
- * | String / Enum Value  | String        |
+ * | String               | String        |
  * | Int / Float          | Number        |
+ * | Enum Value           | Mixed         |
  *
  */
 export function valueFromAST(
@@ -81,10 +82,10 @@ export function valueFromAST(
   }
 
   if (type instanceof GraphQLInputObjectType) {
-    const fields = type.getFields();
     if (valueAST.kind !== Kind.OBJECT) {
       return null;
     }
+    const fields = type.getFields();
     const fieldASTs = keyMap(
       (valueAST: ObjectValue).fields,
       field => field.name.value


### PR DESCRIPTION
A bug was reported in #435 and reproduced in #438 which illustrates an issue where defaultValue would serialize incorrectly or even throw an invariant violation when working with input objects or enums backed by values other than their names.

The root of the issue is that astFromValue accepts an *internal* value, but then produces an AST directly from that value without serializing it to an *external* value first via calling `type.serialize(value)`. This critical missing step is responsible for the reported issue.

In order to fix correctly, this refactored this method to be a closer dual to [`valueFromAST`](https://github.com/graphql/graphql-js/blob/master/src/utilities/valueFromAST.js), relying on the GraphQL type rather than the JavaScript type to guide coercion. As a consequence, `astFromValue` now *requires* a type rather than accepting one optionally.