### PR TITLE
[FIX] Include locations for errors related to failed value completion.

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -17,10 +17,10 @@ export class GraphQLError extends Error {
   message: string;
   stack: string;
   nodes: ?Array<Node>;
-  source: Source;
-  positions: Array<number>;
-  locations: any;
-  path: Array<string | number>;
+  source: ?Source;
+  positions: ?Array<number>;
+  locations: ?Array<{ line: number, column: number }>;
+  path: ?Array<string | number>;
   originalError: ?Error;
 
   constructor(
@@ -28,8 +28,10 @@ export class GraphQLError extends Error {
     // A flow bug keeps us from declaring nodes as an array of Node
     nodes?: Array<any/* Node */>,
     stack?: ?string,
-    source?: Source,
-    positions?: Array<number>
+    source?: ?Source,
+    positions?: ?Array<number>,
+    path?: ?Array<string|number>,
+    originalError?: ?Error
   ) {
     super(message);
 
@@ -94,5 +96,17 @@ export class GraphQLError extends Error {
       // service adheres to the spec.
       enumerable: true,
     }: any));
+
+    Object.defineProperty(this, 'path', {
+      value: path,
+      // By being enumerable, JSON.stringify will include `path` in the
+      // resulting output. This ensures that the simplist possible GraphQL
+      // service adheres to the spec.
+      enumerable: true
+    });
+
+    Object.defineProperty(this, 'originalError', {
+      value: originalError
+    });
   }
 }

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -21,12 +21,23 @@ export function locatedError(
   nodes: Array<any>,
   path: Array<string | number>
 ): GraphQLError {
+  // Note: this uses a brand-check to support GraphQL errors originating from
+  // other contexts.
+  if (originalError && originalError.hasOwnProperty('locations')) {
+    return (originalError: any);
+  }
+
   const message = originalError ?
     originalError.message || String(originalError) :
     'An unknown error occurred.';
   const stack = originalError ? originalError.stack : null;
-  const error = new GraphQLError(message, nodes, stack);
-  error.path = path;
-  error.originalError = originalError;
-  return error;
+  return new GraphQLError(
+    message,
+    nodes,
+    stack,
+    null,
+    null,
+    path,
+    originalError
+  );
 }

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -363,8 +363,6 @@ describe('Execute: Handles basic execution tasks', () => {
         locations: [ { line: 6, column: 7 } ] },
       { message: 'Error getting syncReturnErrorList3',
         locations: [ { line: 6, column: 7 } ] },
-      { message: 'Error getting asyncReturnError',
-        locations: [ { line: 13, column: 7 } ] },
       { message: 'Error getting asyncReject',
         locations: [ { line: 8, column: 7 } ] },
       { message: 'Error getting asyncRawReject',
@@ -375,6 +373,8 @@ describe('Execute: Handles basic execution tasks', () => {
         locations: [ { line: 11, column: 7 } ] },
       { message: 'Error getting asyncRawError',
         locations: [ { line: 12, column: 7 } ] },
+      { message: 'Error getting asyncReturnError',
+        locations: [ { line: 13, column: 7 } ] },
     ]);
   });
 

--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -174,10 +174,14 @@ describe('Type System: Enum Values', () => {
   it('does not accept incorrect internal value', async () => {
     expect(
       await graphql(schema, '{ colorEnum(fromString: "GREEN") }')
-    ).to.jsonEqual({
+    ).to.containSubset({
       data: {
         colorEnum: null
-      }
+      },
+      errors: [
+        { message: 'Expected a value of type "Color" but received: GREEN',
+          locations: [ { line: 1, column: 3 } ] }
+      ]
     });
   });
 
@@ -367,13 +371,18 @@ describe('Type System: Enum Values', () => {
         good: complexEnum(provideGoodValue: true)
         bad: complexEnum(provideBadValue: true)
       }`)
-    ).to.jsonEqual({
+    ).to.containSubset({
       data: {
         first: 'ONE',
         second: 'TWO',
         good: 'TWO',
         bad: null
-      }
+      },
+      errors: [ {
+        message:
+          'Expected a value of type "Complex" but received: [object Object]',
+        locations: [ { line: 5, column: 9 } ]
+      } ]
     });
   });
 


### PR DESCRIPTION
Error locations were previously only being added due to async value resolution and not during value completion. This meant if an error was raised due to an incorrect response from a resolver function that it would not have gotten wrapped in a location-aware GraphQLError object.

This includes a new intermediate phase which catches and assigns these locations before further propogating the error.

This also assigns non-enumable property for `originalError` so it is not included during JSON.stringify.