### PR TITLE
[RFC] Support iterable values as inputs and outputs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,7 +3,6 @@
 .*/dist/.*
 .*/coverage/.*
 .*/resources/.*
-.*/node_modules/.*
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
     "preversion": ". ./resources/checkgit.sh && npm test",
     "prepublish": ". ./resources/prepublish.sh"
   },
+  "dependencies": {
+    "iterall": "1.0.2"
+  },
   "devDependencies": {
     "babel-cli": "6.10.1",
     "babel-eslint": "6.1.0",

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -8,6 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import { forEach, isCollection } from 'iterall';
+
 import { GraphQLError, locatedError } from '../error';
 import find from '../jsutils/find';
 import invariant from '../jsutils/invariant';
@@ -829,8 +831,8 @@ function completeListValue(
   result: mixed
 ): mixed {
   invariant(
-    Array.isArray(result),
-    `User Error: expected iterable, but did not find one for field ${
+    isCollection(result),
+    `Expected Iterable, but did not find one for field ${
       info.parentType.name}.${info.fieldName}.`
   );
 
@@ -838,7 +840,8 @@ function completeListValue(
   // where the list contains no Promises by avoiding creating another Promise.
   const itemType = returnType.ofType;
   let containsPromise = false;
-  const completedResults = result.map((item, index) => {
+  const completedResults = [];
+  forEach((result: any), (item, index) => {
     // No need to modify the info object containing the path,
     // since from here on it is not ever accessed by resolver functions.
     const fieldPath = path.concat([ index ]);
@@ -854,7 +857,7 @@ function completeListValue(
     if (!containsPromise && isThenable(completedItem)) {
       containsPromise = true;
     }
-    return completedItem;
+    completedResults.push(completedItem);
   });
 
   return containsPromise ? Promise.all(completedResults) : completedResults;

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -8,6 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import { forEach, isCollection } from 'iterall';
+
 import { GraphQLError } from '../error';
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
@@ -138,9 +140,12 @@ function coerceValue(type: GraphQLInputType, value: mixed): mixed {
 
   if (type instanceof GraphQLList) {
     const itemType = type.ofType;
-    // TODO: support iterable input
-    if (Array.isArray(_value)) {
-      return _value.map(item => coerceValue(itemType, item));
+    if (isCollection(_value)) {
+      const coercedValues = [];
+      forEach((_value: any), item => {
+        coercedValues.push(coerceValue(itemType, item));
+      });
+      return coercedValues;
     }
     return [ coerceValue(itemType, _value) ];
   }

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -8,6 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import { forEach, isCollection } from 'iterall';
+
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
 import type {
@@ -79,9 +81,9 @@ export function astFromValue(
   // the value is not an array, convert the value using the list's item type.
   if (type instanceof GraphQLList) {
     const itemType = type.ofType;
-    if (Array.isArray(_value)) {
+    if (isCollection(_value)) {
       const valuesASTs = [];
-      _value.forEach(item => {
+      forEach((_value: any), item => {
         const itemAST = astFromValue(item, itemType);
         if (itemAST) {
           valuesASTs.push(itemAST);

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -8,6 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import { forEach, isCollection } from 'iterall';
+
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
 import {
@@ -44,13 +46,14 @@ export function isValidJSValue(value: mixed, type: GraphQLInputType): [string] {
   // Lists accept a non-list value as a list of one.
   if (type instanceof GraphQLList) {
     const itemType = type.ofType;
-    if (Array.isArray(value)) {
-      return value.reduce((acc, item, index) => {
-        const errors = isValidJSValue(item, itemType);
-        return acc.concat(errors.map(error =>
+    if (isCollection(value)) {
+      const errors = [];
+      forEach((value: any), (item, index) => {
+        errors.push.apply(errors, isValidJSValue(item, itemType).map(error =>
           `In element #${index}: ${error}`
         ));
-      }, []);
+      });
+      return errors;
     }
     return isValidJSValue(value, itemType);
   }


### PR DESCRIPTION
This adds support for returning any Iterable from a resolver function expecting a List type, rather than only Arrays, by using the `iterall` library.

This also adds support for accepting any Iterable as input for arguments or variable values which expect a List type.

Fixes #300 