### PR TITLE
Use the Error base class stack property

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -46,13 +46,15 @@ export class GraphQLError extends Error {
       writable: true,
     });
 
-    Object.defineProperty(this, 'stack', {
-      value: stack || message,
-      // Note: stack should not really be writable, but some libraries (such
-      // as bluebird) use Error brand-checking which specifically looks to see
-      // if stack is a writable property.
-      writable: true,
-    });
+    if (stack) {
+      Object.defineProperty(this, 'stack', {
+        value: stack,
+        // Note: stack should not really be writable, but some libraries (such
+        // as bluebird) use Error brand-checking which specifically looks to see
+        // if stack is a writable property.
+        writable: true,
+      });
+    }
 
     Object.defineProperty(this, 'nodes', { value: nodes });
 


### PR DESCRIPTION
Many libraries (such as https://github.com/PolymerLabs/stacky) expect an error's stack to be of a certain format. Currently this code sets it to the message, which causes exceptions in formatters. 

It also obscures the actual location of where the error is thrown, since it overwrites the stack property of the inherited Error.