### PR TITLE
Relaxing `getNamedType` method for accepting ConnectionType

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -179,10 +179,7 @@ export type GraphQLNamedType =
 
 export function getNamedType(type: ?GraphQLType): ?GraphQLNamedType {
   let unmodifiedType = type;
-  while (
-    unmodifiedType instanceof GraphQLList ||
-    unmodifiedType instanceof GraphQLNonNull
-  ) {
+  while (unmodifiedType.ofType) {
     unmodifiedType = unmodifiedType.ofType;
   }
   return unmodifiedType;


### PR DESCRIPTION
Relay's ConnectionType should have `ofType` property, like `GraphQLNonNull` and `GraphQLList`. ConnectoionType is some kind of wrapper under NamedType.

So for any other wrappers, I offer to relax `getNamedType` for accepting any object with `ofType` property.

Cross PR with Relay: https://github.com/graphql/graphql-relay-js/pull/98