### PR TITLE
Refactors tokenizer to emit a Token double-linked-list

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ export {
   visitInParallel,
   visitWithTypeInfo,
   Kind,
+  TokenKind,
   BREAK,
 } from './language';
 

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -17,9 +17,9 @@ import { join } from 'path';
 describe('Printer', () => {
   it('does not alter ast', () => {
     const ast = parse(kitchenSink);
-    const astCopy = JSON.parse(JSON.stringify(ast));
+    const astBefore = JSON.stringify(ast);
     print(ast);
-    expect(ast).to.deep.equal(astCopy);
+    expect(JSON.stringify(ast)).to.equal(astBefore);
   });
 
   it('prints minimal ast', () => {

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -11,17 +11,6 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { parse } from '../parser';
 
-function createLocFn(body) {
-  return (start, end) => ({
-    start,
-    end,
-    source: {
-      body,
-      name: 'GraphQL',
-    },
-  });
-}
-
 function printJson(obj) {
   return JSON.stringify(obj, null, 2);
 }
@@ -84,26 +73,25 @@ type Hello {
   world: String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           interfaces: [],
           directives: [],
           fields: [
             fieldNode(
-              nameNode('world', loc(16, 21)),
-              typeNode('String', loc(23, 29)),
-              loc(16, 29)
+              nameNode('world', { start: 16, end: 21 }),
+              typeNode('String', { start: 23, end: 29 }),
+              { start: 16, end: 29 }
             )
           ],
-          loc: loc(1, 31),
+          loc: { start: 1, end: 31 },
         }
       ],
-      loc: loc(1, 31),
+      loc: { start: 0, end: 31 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -112,9 +100,9 @@ type Hello {
     const body = `
 extend type Hello {
   world: String
-}`;
+}
+`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
@@ -122,22 +110,22 @@ extend type Hello {
           kind: 'TypeExtensionDefinition',
           definition: {
             kind: 'ObjectTypeDefinition',
-            name: nameNode('Hello', loc(13, 18)),
+            name: nameNode('Hello', { start: 13, end: 18 }),
             interfaces: [],
             directives: [],
             fields: [
               fieldNode(
-                nameNode('world', loc(23, 28)),
-                typeNode('String', loc(30, 36)),
-                loc(23, 36)
+                nameNode('world', { start: 23, end: 28 }),
+                typeNode('String', { start: 30, end: 36 }),
+                { start: 23, end: 36 }
               )
             ],
-            loc: loc(8, 38),
+            loc: { start: 8, end: 38 },
           },
-          loc: loc(1, 38),
+          loc: { start: 1, end: 38 },
         }
       ],
-      loc: loc(1, 38)
+      loc: { start: 0, end: 39 }
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -147,31 +135,30 @@ extend type Hello {
 type Hello {
   world: String!
 }`;
-    const loc = createLocFn(body);
     const doc = parse(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           interfaces: [],
           directives: [],
           fields: [
             fieldNode(
-              nameNode('world', loc(16, 21)),
+              nameNode('world', { start: 16, end: 21 }),
               {
                 kind: 'NonNullType',
-                type: typeNode('String', loc(23, 29)),
-                loc: loc(23, 30),
+                type: typeNode('String', { start: 23, end: 29 }),
+                loc: { start: 23, end: 30 },
               },
-              loc(16, 30)
+              { start: 16, end: 30 }
             )
           ],
-          loc: loc(1, 32),
+          loc: { start: 1, end: 32 },
         }
       ],
-      loc: loc(1, 32),
+      loc: { start: 0, end: 32 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -179,88 +166,84 @@ type Hello {
 
   it('Simple type inheriting interface', () => {
     const body = 'type Hello implements World { }';
-    const loc = createLocFn(body);
     const doc = parse(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(5, 10)),
-          interfaces: [ typeNode('World', loc(22, 27)) ],
+          name: nameNode('Hello', { start: 5, end: 10 }),
+          interfaces: [ typeNode('World', { start: 22, end: 27 }) ],
           directives: [],
           fields: [],
-          loc: loc(0, 31),
+          loc: { start: 0, end: 31 },
         }
       ],
-      loc: loc(0, 31),
+      loc: { start: 0, end: 31 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
 
   it('Simple type inheriting multiple interfaces', () => {
     const body = 'type Hello implements Wo, rld { }';
-    const loc = createLocFn(body);
     const doc = parse(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(5, 10)),
+          name: nameNode('Hello', { start: 5, end: 10 }),
           interfaces: [
-            typeNode('Wo', loc(22, 24)),
-            typeNode('rld', loc(26, 29))
+            typeNode('Wo', { start: 22, end: 24 }),
+            typeNode('rld', { start: 26, end: 29 })
           ],
           directives: [],
           fields: [],
-          loc: loc(0, 33),
+          loc: { start: 0, end: 33 },
         }
       ],
-      loc: loc(0, 33),
+      loc: { start: 0, end: 33 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
 
   it('Single value enum', () => {
     const body = 'enum Hello { WORLD }';
-    const loc = createLocFn(body);
     const doc = parse(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'EnumTypeDefinition',
-          name: nameNode('Hello', loc(5, 10)),
+          name: nameNode('Hello', { start: 5, end: 10 }),
           directives: [],
-          values: [ enumValueNode('WORLD', loc(13, 18)) ],
-          loc: loc(0, 20),
+          values: [ enumValueNode('WORLD', { start: 13, end: 18 }) ],
+          loc: { start: 0, end: 20 },
         }
       ],
-      loc: loc(0, 20),
+      loc: { start: 0, end: 20 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
 
   it('Double value enum', () => {
     const body = 'enum Hello { WO, RLD }';
-    const loc = createLocFn(body);
     const doc = parse(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'EnumTypeDefinition',
-          name: nameNode('Hello', loc(5, 10)),
+          name: nameNode('Hello', { start: 5, end: 10 }),
           directives: [],
           values: [
-            enumValueNode('WO', loc(13, 15)),
-            enumValueNode('RLD', loc(17, 20)),
+            enumValueNode('WO', { start: 13, end: 15 }),
+            enumValueNode('RLD', { start: 17, end: 20 }),
           ],
-          loc: loc(0, 22),
+          loc: { start: 0, end: 22 },
         }
       ],
-      loc: loc(0, 22),
+      loc: { start: 0, end: 22 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -271,25 +254,24 @@ interface Hello {
   world: String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'InterfaceTypeDefinition',
-          name: nameNode('Hello', loc(11, 16)),
+          name: nameNode('Hello', { start: 11, end: 16 }),
           directives: [],
           fields: [
             fieldNode(
-              nameNode('world', loc(21, 26)),
-              typeNode('String', loc(28, 34)),
-              loc(21, 34)
+              nameNode('world', { start: 21, end: 26 }),
+              typeNode('String', { start: 28, end: 34 }),
+              { start: 21, end: 34 }
             )
           ],
-          loc: loc(1, 36),
+          loc: { start: 1, end: 36 },
         }
       ],
-      loc: loc(1, 36),
+      loc: { start: 0, end: 36 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -300,34 +282,33 @@ type Hello {
   world(flag: Boolean): String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           interfaces: [],
           directives: [],
           fields: [
             fieldNodeWithArgs(
-              nameNode('world', loc(16, 21)),
-              typeNode('String', loc(38, 44)),
+              nameNode('world', { start: 16, end: 21 }),
+              typeNode('String', { start: 38, end: 44 }),
               [
                 inputValueNode(
-                  nameNode('flag', loc(22, 26)),
-                  typeNode('Boolean', loc(28, 35)),
+                  nameNode('flag', { start: 22, end: 26 }),
+                  typeNode('Boolean', { start: 28, end: 35 }),
                   null,
-                  loc(22, 35)
+                  { start: 22, end: 35 }
                 )
               ],
-              loc(16, 44)
+              { start: 16, end: 44 }
             )
           ],
-          loc: loc(1, 46),
+          loc: { start: 1, end: 46 },
         }
       ],
-      loc: loc(1, 46),
+      loc: { start: 0, end: 46 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -338,38 +319,37 @@ type Hello {
   world(flag: Boolean = true): String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           interfaces: [],
           directives: [],
           fields: [
             fieldNodeWithArgs(
-              nameNode('world', loc(16, 21)),
-              typeNode('String', loc(45, 51)),
+              nameNode('world', { start: 16, end: 21 }),
+              typeNode('String', { start: 45, end: 51 }),
               [
                 inputValueNode(
-                  nameNode('flag', loc(22, 26)),
-                  typeNode('Boolean', loc(28, 35)),
+                  nameNode('flag', { start: 22, end: 26 }),
+                  typeNode('Boolean', { start: 28, end: 35 }),
                   {
                     kind: 'BooleanValue',
                     value: true,
-                    loc: loc(38, 42),
+                    loc: { start: 38, end: 42 },
                   },
-                  loc(22, 42)
+                  { start: 22, end: 42 }
                 )
               ],
-              loc(16, 51)
+              { start: 16, end: 51 }
             )
           ],
-          loc: loc(1, 53),
+          loc: { start: 1, end: 53 },
         }
       ],
-      loc: loc(1, 53),
+      loc: { start: 0, end: 53 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -380,38 +360,37 @@ type Hello {
   world(things: [String]): String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           interfaces: [],
           directives: [],
           fields: [
             fieldNodeWithArgs(
-              nameNode('world', loc(16, 21)),
-              typeNode('String', loc(41, 47)),
+              nameNode('world', { start: 16, end: 21 }),
+              typeNode('String', { start: 41, end: 47 }),
               [
                 inputValueNode(
-                  nameNode('things', loc(22, 28)),
+                  nameNode('things', { start: 22, end: 28 }),
                   {
                     kind: 'ListType',
-                    type: typeNode('String', loc(31, 37)),
-                    loc: loc(30, 38)
+                    type: typeNode('String', { start: 31, end: 37 }),
+                    loc: { start: 30, end: 38 }
                   },
                   null,
-                  loc(22, 38)
+                  { start: 22, end: 38 }
                 )
               ],
-              loc(16, 47)
+              { start: 16, end: 47 }
             )
           ],
-          loc: loc(1, 49),
+          loc: { start: 1, end: 49 },
         }
       ],
-      loc: loc(1, 49),
+      loc: { start: 0, end: 49 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -422,40 +401,39 @@ type Hello {
   world(argOne: Boolean, argTwo: Int): String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ObjectTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           interfaces: [],
           directives: [],
           fields: [
             fieldNodeWithArgs(
-              nameNode('world', loc(16, 21)),
-              typeNode('String', loc(53, 59)),
+              nameNode('world', { start: 16, end: 21 }),
+              typeNode('String', { start: 53, end: 59 }),
               [
                 inputValueNode(
-                  nameNode('argOne', loc(22, 28)),
-                  typeNode('Boolean', loc(30, 37)),
+                  nameNode('argOne', { start: 22, end: 28 }),
+                  typeNode('Boolean', { start: 30, end: 37 }),
                   null,
-                  loc(22, 37)
+                  { start: 22, end: 37 }
                 ),
                 inputValueNode(
-                  nameNode('argTwo', loc(39, 45)),
-                  typeNode('Int', loc(47, 50)),
+                  nameNode('argTwo', { start: 39, end: 45 }),
+                  typeNode('Int', { start: 47, end: 50 }),
                   null,
-                  loc(39, 50)
+                  { start: 39, end: 50 }
                 ),
               ],
-              loc(16, 59)
+              { start: 16, end: 59 }
             )
           ],
-          loc: loc(1, 61),
+          loc: { start: 1, end: 61 },
         }
       ],
-      loc: loc(1, 61),
+      loc: { start: 0, end: 61 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -463,19 +441,18 @@ type Hello {
   it('Simple union', () => {
     const body = 'union Hello = World';
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'UnionTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           directives: [],
-          types: [ typeNode('World', loc(14, 19)) ],
-          loc: loc(0, 19),
+          types: [ typeNode('World', { start: 14, end: 19 }) ],
+          loc: { start: 0, end: 19 },
         }
       ],
-      loc: loc(0, 19),
+      loc: { start: 0, end: 19 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -483,22 +460,21 @@ type Hello {
   it('Union with two types', () => {
     const body = 'union Hello = Wo | Rld';
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'UnionTypeDefinition',
-          name: nameNode('Hello', loc(6, 11)),
+          name: nameNode('Hello', { start: 6, end: 11 }),
           directives: [],
           types: [
-            typeNode('Wo', loc(14, 16)),
-            typeNode('Rld', loc(19, 22)),
+            typeNode('Wo', { start: 14, end: 16 }),
+            typeNode('Rld', { start: 19, end: 22 }),
           ],
-          loc: loc(0, 22),
+          loc: { start: 0, end: 22 },
         }
       ],
-      loc: loc(0, 22),
+      loc: { start: 0, end: 22 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -506,18 +482,17 @@ type Hello {
   it('Scalar', () => {
     const body = 'scalar Hello';
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'ScalarTypeDefinition',
-          name: nameNode('Hello', loc(7, 12)),
+          name: nameNode('Hello', { start: 7, end: 12 }),
           directives: [],
-          loc: loc(0, 12),
+          loc: { start: 0, end: 12 },
         }
       ],
-      loc: loc(0, 12),
+      loc: { start: 0, end: 12 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -528,26 +503,25 @@ input Hello {
   world: String
 }`;
     const doc = parse(body);
-    const loc = createLocFn(body);
     const expected = {
       kind: 'Document',
       definitions: [
         {
           kind: 'InputObjectTypeDefinition',
-          name: nameNode('Hello', loc(7, 12)),
+          name: nameNode('Hello', { start: 7, end: 12 }),
           directives: [],
           fields: [
             inputValueNode(
-              nameNode('world', loc(17, 22)),
-              typeNode('String', loc(24, 30)),
+              nameNode('world', { start: 17, end: 22 }),
+              typeNode('String', { start: 24, end: 30 }),
               null,
-              loc(17, 30)
+              { start: 17, end: 30 }
             )
           ],
-          loc: loc(1, 32),
+          loc: { start: 1, end: 32 },
         }
       ],
-      loc: loc(1, 32),
+      loc: { start: 0, end: 32 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -38,9 +38,9 @@ describe('Printer', () => {
 
   it('does not alter ast', () => {
     const ast = parse(kitchenSink);
-    const astCopy = JSON.parse(JSON.stringify(ast));
+    const astBefore = JSON.stringify(ast);
     print(ast);
-    expect(ast).to.deep.equal(astCopy);
+    expect(JSON.stringify(ast)).to.equal(astBefore);
   });
 
   it('prints kitchen sink', () => {

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -12,14 +12,100 @@ import type { Source } from './source';
 
 
 /**
- * Contains a range of UTF-8 character offsets that identify
- * the region of the source from which the AST derived.
+ * Contains a range of UTF-8 character offsets and token references that
+ * identify the region of the source from which the AST derived.
  */
 export type Location = {
+
+  /**
+   * The character offset at which this Node begins.
+   */
   start: number;
+
+  /**
+   * The character offset at which this Node ends.
+   */
   end: number;
-  source?: ?Source
-}
+
+  /**
+   * The Token at which this Node begins.
+   */
+  startToken: Token;
+
+  /**
+   * The Token at which this Node ends.
+   */
+  endToken: Token;
+
+  /**
+   * The Source document the AST represents.
+   */
+  source: Source;
+};
+
+/**
+ * Represents a range of characters represented by a lexical token
+ * within a Source.
+ */
+export type Token = {
+
+  /**
+   * The kind of Token.
+   */
+  kind: '<SOF>'
+      | '<EOF>'
+      | '!'
+      | '$'
+      | '('
+      | ')'
+      | '...'
+      | ':'
+      | '='
+      | '@'
+      | '['
+      | ']'
+      | '{'
+      | '|'
+      | '}'
+      | 'Name'
+      | 'Int'
+      | 'Float'
+      | 'String'
+      | 'Comment';
+
+  /**
+   * The character offset at which this Node begins.
+   */
+  start: number;
+
+  /**
+   * The character offset at which this Node ends.
+   */
+  end: number;
+
+  /**
+   * The 1-indexed line number on which this Token appears.
+   */
+  line: number;
+
+  /**
+   * The 1-indexed column number at which this Token begins.
+   */
+  column: number;
+
+  /**
+   * For non-punctuation tokens, represents the interpreted value of the token.
+   */
+  value: string | void;
+
+  /**
+   * Tokens exist as nodes in a double-linked-list amongst all tokens
+   * including ignored tokens. <SOF> is always the first node and <EOF>
+   * the last.
+   */
+  prev: Token | null;
+  next: Token | null;
+};
 
 /**
  * The list of all possible AST node types.
@@ -65,7 +151,7 @@ export type Node = Name
 
 export type Name = {
   kind: 'Name';
-  loc?: ?Location;
+  loc?: Location;
   value: string;
 }
 
@@ -73,7 +159,7 @@ export type Name = {
 
 export type Document = {
   kind: 'Document';
-  loc?: ?Location;
+  loc?: Location;
   definitions: Array<Definition>;
 }
 
@@ -83,7 +169,7 @@ export type Definition = OperationDefinition
 
 export type OperationDefinition = {
   kind: 'OperationDefinition';
-  loc?: ?Location;
+  loc?: Location;
   operation: OperationType;
   name?: ?Name;
   variableDefinitions?: ?Array<VariableDefinition>;
@@ -96,7 +182,7 @@ export type OperationType = 'query' | 'mutation' | 'subscription';
 
 export type VariableDefinition = {
   kind: 'VariableDefinition';
-  loc?: ?Location;
+  loc?: Location;
   variable: Variable;
   type: Type;
   defaultValue?: ?Value;
@@ -104,13 +190,13 @@ export type VariableDefinition = {
 
 export type Variable = {
   kind: 'Variable';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
 }
 
 export type SelectionSet = {
   kind: 'SelectionSet';
-  loc?: ?Location;
+  loc?: Location;
   selections: Array<Selection>;
 }
 
@@ -120,7 +206,7 @@ export type Selection = Field
 
 export type Field = {
   kind: 'Field';
-  loc?: ?Location;
+  loc?: Location;
   alias?: ?Name;
   name: Name;
   arguments?: ?Array<Argument>;
@@ -130,7 +216,7 @@ export type Field = {
 
 export type Argument = {
   kind: 'Argument';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   value: Value;
 }
@@ -140,14 +226,14 @@ export type Argument = {
 
 export type FragmentSpread = {
   kind: 'FragmentSpread';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
 }
 
 export type InlineFragment = {
   kind: 'InlineFragment';
-  loc?: ?Location;
+  loc?: Location;
   typeCondition?: ?NamedType;
   directives?: ?Array<Directive>;
   selectionSet: SelectionSet;
@@ -155,7 +241,7 @@ export type InlineFragment = {
 
 export type FragmentDefinition = {
   kind: 'FragmentDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   typeCondition: NamedType;
   directives?: ?Array<Directive>;
@@ -176,49 +262,49 @@ export type Value = Variable
 
 export type IntValue = {
   kind: 'IntValue';
-  loc?: ?Location;
+  loc?: Location;
   value: string;
 }
 
 export type FloatValue = {
   kind: 'FloatValue';
-  loc?: ?Location;
+  loc?: Location;
   value: string;
 }
 
 export type StringValue = {
   kind: 'StringValue';
-  loc?: ?Location;
+  loc?: Location;
   value: string;
 }
 
 export type BooleanValue = {
   kind: 'BooleanValue';
-  loc?: ?Location;
+  loc?: Location;
   value: boolean;
 }
 
 export type EnumValue = {
   kind: 'EnumValue';
-  loc?: ?Location;
+  loc?: Location;
   value: string;
 }
 
 export type ListValue = {
   kind: 'ListValue';
-  loc?: ?Location;
+  loc?: Location;
   values: Array<Value>;
 }
 
 export type ObjectValue = {
   kind: 'ObjectValue';
-  loc?: ?Location;
+  loc?: Location;
   fields: Array<ObjectField>;
 }
 
 export type ObjectField = {
   kind: 'ObjectField';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   value: Value;
 }
@@ -228,7 +314,7 @@ export type ObjectField = {
 
 export type Directive = {
   kind: 'Directive';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   arguments?: ?Array<Argument>;
 }
@@ -242,19 +328,19 @@ export type Type = NamedType
 
 export type NamedType = {
   kind: 'NamedType';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
 };
 
 export type ListType = {
   kind: 'ListType';
-  loc?: ?Location;
+  loc?: Location;
   type: Type;
 }
 
 export type NonNullType = {
   kind: 'NonNullType';
-  loc?: ?Location;
+  loc?: Location;
   type: NamedType | ListType;
 }
 
@@ -267,14 +353,14 @@ export type TypeSystemDefinition = SchemaDefinition
 
 export type SchemaDefinition = {
   kind: 'SchemaDefinition';
-  loc?: ?Location;
+  loc?: Location;
   directives: Array<Directive>;
   operationTypes: Array<OperationTypeDefinition>;
 }
 
 export type OperationTypeDefinition = {
   kind: 'OperationTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   operation: OperationType;
   type: NamedType;
 }
@@ -288,14 +374,14 @@ export type TypeDefinition = ScalarTypeDefinition
 
 export type ScalarTypeDefinition = {
   kind: 'ScalarTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
 }
 
 export type ObjectTypeDefinition = {
   kind: 'ObjectTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   interfaces?: ?Array<NamedType>;
   directives?: ?Array<Directive>;
@@ -304,7 +390,7 @@ export type ObjectTypeDefinition = {
 
 export type FieldDefinition = {
   kind: 'FieldDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   arguments: Array<InputValueDefinition>;
   type: Type;
@@ -313,7 +399,7 @@ export type FieldDefinition = {
 
 export type InputValueDefinition = {
   kind: 'InputValueDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   type: Type;
   defaultValue?: ?Value;
@@ -322,7 +408,7 @@ export type InputValueDefinition = {
 
 export type InterfaceTypeDefinition = {
   kind: 'InterfaceTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
   fields: Array<FieldDefinition>;
@@ -330,7 +416,7 @@ export type InterfaceTypeDefinition = {
 
 export type UnionTypeDefinition = {
   kind: 'UnionTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
   types: Array<NamedType>;
@@ -338,7 +424,7 @@ export type UnionTypeDefinition = {
 
 export type EnumTypeDefinition = {
   kind: 'EnumTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
   values: Array<EnumValueDefinition>;
@@ -346,14 +432,14 @@ export type EnumTypeDefinition = {
 
 export type EnumValueDefinition = {
   kind: 'EnumValueDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
 }
 
 export type InputObjectTypeDefinition = {
   kind: 'InputObjectTypeDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   directives?: ?Array<Directive>;
   fields: Array<InputValueDefinition>;
@@ -361,13 +447,13 @@ export type InputObjectTypeDefinition = {
 
 export type TypeExtensionDefinition = {
   kind: 'TypeExtensionDefinition';
-  loc?: ?Location;
+  loc?: Location;
   definition: ObjectTypeDefinition;
 }
 
 export type DirectiveDefinition = {
   kind: 'DirectiveDefinition';
-  loc?: ?Location;
+  loc?: Location;
   name: Name;
   arguments?: ?Array<InputValueDefinition>;
   locations: Array<Name>;

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -10,7 +10,7 @@
 export { getLocation } from './location';
 import * as Kind from './kinds';
 export { Kind };
-export { lex } from './lexer';
+export { createLexer, TokenKind } from './lexer';
 export { parse, parseValue } from './parser';
 export { print } from './printer';
 export { Source } from './source';

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -8,67 +8,126 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import type { Token } from './ast';
 import type { Source } from './source';
 import { syntaxError } from '../error';
 
 /**
- * A representation of a lexed Token. Value only appears for non-punctuation
- * tokens: NAME, INT, FLOAT, and STRING.
- */
-export type Token = {
-  kind: number;
-  start: number;
-  end: number;
-  value: ?string;
-};
-
-type Lexer = (resetPosition?: number) => Token;
-
-/**
  * Given a Source object, this returns a Lexer for that source.
- * A Lexer is a function that acts like a generator in that every time
- * it is called, it returns the next token in the Source. Assuming the
+ * A Lexer is a stateful stream generator in that every time
+ * it is advanced, it returns the next token in the Source. Assuming the
  * source lexes, the final Token emitted by the lexer will be of kind
- * EOF, after which the lexer will repeatedly return EOF tokens whenever
- * called.
- *
- * The argument to the lexer function is optional, and can be used to
- * rewind or fast forward the lexer to a new position in the source.
+ * EOF, after which the lexer will repeatedly return the same EOF token
+ * whenever called.
  */
-export function lex(source: Source): Lexer {
-  let prevPosition = 0;
-  return function nextToken(resetPosition) {
-    const token = readToken(
-      source,
-      resetPosition === undefined ? prevPosition : resetPosition
-    );
-    prevPosition = token.end;
-    return token;
+export function createLexer<TOptions>(
+  source: Source,
+  options: TOptions
+): Lexer<TOptions> {
+  const startOfFileToken = new Tok(SOF, 0, 0, 0, 0, null);
+  const lexer: Lexer<TOptions> = {
+    source,
+    options,
+    lastToken: startOfFileToken,
+    token: startOfFileToken,
+    line: 1,
+    lineStart: 0,
+    advance: advanceLexer
   };
+  return lexer;
+}
+
+function advanceLexer() {
+  let token = this.lastToken = this.token;
+  if (token.kind !== EOF) {
+    do {
+      token = token.next = readToken(this, token);
+    } while (token.kind === COMMENT);
+    this.token = token;
+  }
+  return token;
 }
 
 /**
- * An enum describing the different kinds of tokens that the lexer emits.
+ * The return type of createLexer.
+ */
+export type Lexer<TOptions> = {
+  source: Source;
+  options: TOptions;
+
+  /**
+   * The previously focused non-ignored token.
+   */
+  lastToken: Token;
+
+  /**
+   * The currently focused non-ignored token.
+   */
+  token: Token;
+
+  /**
+   * The (1-indexed) line containing the current token.
+   */
+  line: number;
+
+  /**
+   * The character offset at which the current line begins.
+   */
+  lineStart: number;
+
+  /**
+   * Advances the token stream to the next non-ignored token.
+   */
+  advance(): Token;
+};
+
+// Each kind of token.
+const SOF = '<SOF>';
+const EOF = '<EOF>';
+const BANG = '!';
+const DOLLAR = '$';
+const PAREN_L = '(';
+const PAREN_R = ')';
+const SPREAD = '...';
+const COLON = ':';
+const EQUALS = '=';
+const AT = '@';
+const BRACKET_L = '[';
+const BRACKET_R = ']';
+const BRACE_L = '{';
+const PIPE = '|';
+const BRACE_R = '}';
+const NAME = 'Name';
+const INT = 'Int';
+const FLOAT = 'Float';
+const STRING = 'String';
+const COMMENT = 'Comment';
+
+/**
+ * An exported enum describing the different kinds of tokens that the
+ * lexer emits.
  */
 export const TokenKind = {
-  EOF: 1,
-  BANG: 2,
-  DOLLAR: 3,
-  PAREN_L: 4,
-  PAREN_R: 5,
-  SPREAD: 6,
-  COLON: 7,
-  EQUALS: 8,
-  AT: 9,
-  BRACKET_L: 10,
-  BRACKET_R: 11,
-  BRACE_L: 12,
-  PIPE: 13,
-  BRACE_R: 14,
-  NAME: 15,
-  INT: 16,
-  FLOAT: 17,
-  STRING: 18,
+  SOF,
+  EOF,
+  BANG,
+  DOLLAR,
+  PAREN_L,
+  PAREN_R,
+  SPREAD,
+  COLON,
+  EQUALS,
+  AT,
+  BRACKET_L,
+  BRACKET_R,
+  BRACE_L,
+  PIPE,
+  BRACE_R,
+  NAME,
+  INT,
+  FLOAT,
+  STRING,
+  COMMENT
 };
 
 /**
@@ -76,37 +135,8 @@ export const TokenKind = {
  */
 export function getTokenDesc(token: Token): string {
   const value = token.value;
-  return value ?
-    `${getTokenKindDesc(token.kind)} "${value}"` :
-    getTokenKindDesc(token.kind);
+  return value ? `${token.kind} "${value}"` : token.kind;
 }
-
-/**
- * A helper function to describe a token kind as a string for debugging
- */
-export function getTokenKindDesc(kind: number): string {
-  return tokenDescription[kind];
-}
-
-const tokenDescription = {};
-tokenDescription[TokenKind.EOF] = 'EOF';
-tokenDescription[TokenKind.BANG] = '!';
-tokenDescription[TokenKind.DOLLAR] = '$';
-tokenDescription[TokenKind.PAREN_L] = '(';
-tokenDescription[TokenKind.PAREN_R] = ')';
-tokenDescription[TokenKind.SPREAD] = '...';
-tokenDescription[TokenKind.COLON] = ':';
-tokenDescription[TokenKind.EQUALS] = '=';
-tokenDescription[TokenKind.AT] = '@';
-tokenDescription[TokenKind.BRACKET_L] = '[';
-tokenDescription[TokenKind.BRACKET_R] = ']';
-tokenDescription[TokenKind.BRACE_L] = '{';
-tokenDescription[TokenKind.PIPE] = '|';
-tokenDescription[TokenKind.BRACE_R] = '}';
-tokenDescription[TokenKind.NAME] = 'Name';
-tokenDescription[TokenKind.INT] = 'Int';
-tokenDescription[TokenKind.FLOAT] = 'Float';
-tokenDescription[TokenKind.STRING] = 'String';
 
 const charCodeAt = String.prototype.charCodeAt;
 const slice = String.prototype.slice;
@@ -114,19 +144,39 @@ const slice = String.prototype.slice;
 /**
  * Helper function for constructing the Token object.
  */
-function makeToken(
-  kind: number,
+function Tok(
+  kind,
   start: number,
   end: number,
+  line: number,
+  column: number,
+  prev: Token | null,
   value?: string
-): Token {
-  return { kind, start, end, value };
+) {
+  this.kind = kind;
+  this.start = start;
+  this.end = end;
+  this.line = line;
+  this.column = column;
+  this.value = value;
+  this.prev = prev;
+  this.next = null;
 }
+
+// Print a simplified form when appearing in JSON/util.inspect.
+Tok.prototype.toJSON = Tok.prototype.inspect = function toJSON() {
+  return {
+    kind: this.kind,
+    value: this.value,
+    line: this.line,
+    column: this.column
+  };
+};
 
 function printCharCode(code) {
   return (
     // NaN/undefined represents access beyond the end of the file.
-    isNaN(code) ? '<EOF>' :
+    isNaN(code) ? EOF :
     // Trust JSON for ASCII.
     code < 0x007F ? JSON.stringify(String.fromCharCode(code)) :
     // Otherwise print the escaped form.
@@ -141,14 +191,17 @@ function printCharCode(code) {
  * token, then lexes punctuators immediately or calls the appropriate helper
  * function for more complicated tokens.
  */
-function readToken(source: Source, fromPosition: number): Token {
+function readToken(lexer: Lexer<*>, prev: Token): Token {
+  const source = lexer.source;
   const body = source.body;
   const bodyLength = body.length;
 
-  const position = positionAfterWhitespace(body, fromPosition);
+  const position = positionAfterWhitespace(body, prev.end, lexer);
+  const line = lexer.line;
+  const col = 1 + position - lexer.lineStart;
 
   if (position >= bodyLength) {
-    return makeToken(TokenKind.EOF, position, position);
+    return new Tok(EOF, bodyLength, bodyLength, line, col, prev);
   }
 
   const code = charCodeAt.call(body, position);
@@ -164,36 +217,42 @@ function readToken(source: Source, fromPosition: number): Token {
 
   switch (code) {
     // !
-    case 33: return makeToken(TokenKind.BANG, position, position + 1);
+    case 33: return new Tok(BANG, position, position + 1, line, col, prev);
+    // #
+    case 35: return readComment(source, position, line, col, prev);
     // $
-    case 36: return makeToken(TokenKind.DOLLAR, position, position + 1);
+    case 36: return new Tok(DOLLAR, position, position + 1, line, col, prev);
     // (
-    case 40: return makeToken(TokenKind.PAREN_L, position, position + 1);
+    case 40: return new Tok(PAREN_L, position, position + 1, line, col, prev);
     // )
-    case 41: return makeToken(TokenKind.PAREN_R, position, position + 1);
+    case 41: return new Tok(PAREN_R, position, position + 1, line, col, prev);
     // .
     case 46:
       if (charCodeAt.call(body, position + 1) === 46 &&
           charCodeAt.call(body, position + 2) === 46) {
-        return makeToken(TokenKind.SPREAD, position, position + 3);
+        return new Tok(SPREAD, position, position + 3, line, col, prev);
       }
       break;
     // :
-    case 58: return makeToken(TokenKind.COLON, position, position + 1);
+    case 58: return new Tok(COLON, position, position + 1, line, col, prev);
     // =
-    case 61: return makeToken(TokenKind.EQUALS, position, position + 1);
+    case 61: return new Tok(EQUALS, position, position + 1, line, col, prev);
     // @
-    case 64: return makeToken(TokenKind.AT, position, position + 1);
+    case 64: return new Tok(AT, position, position + 1, line, col, prev);
     // [
-    case 91: return makeToken(TokenKind.BRACKET_L, position, position + 1);
+    case 91:
+      return new Tok(BRACKET_L, position, position + 1, line, col, prev);
     // ]
-    case 93: return makeToken(TokenKind.BRACKET_R, position, position + 1);
+    case 93:
+      return new Tok(BRACKET_R, position, position + 1, line, col, prev);
     // {
-    case 123: return makeToken(TokenKind.BRACE_L, position, position + 1);
+    case 123:
+      return new Tok(BRACE_L, position, position + 1, line, col, prev);
     // |
-    case 124: return makeToken(TokenKind.PIPE, position, position + 1);
+    case 124: return new Tok(PIPE, position, position + 1, line, col, prev);
     // }
-    case 125: return makeToken(TokenKind.BRACE_R, position, position + 1);
+    case 125:
+      return new Tok(BRACE_R, position, position + 1, line, col, prev);
     // A-Z _ a-z
     case 65: case 66: case 67: case 68: case 69: case 70: case 71: case 72:
     case 73: case 74: case 75: case 76: case 77: case 78: case 79: case 80:
@@ -204,14 +263,14 @@ function readToken(source: Source, fromPosition: number): Token {
     case 105: case 106: case 107: case 108: case 109: case 110: case 111:
     case 112: case 113: case 114: case 115: case 116: case 117: case 118:
     case 119: case 120: case 121: case 122:
-      return readName(source, position);
+      return readName(source, position, line, col, prev);
     // - 0-9
     case 45:
     case 48: case 49: case 50: case 51: case 52:
     case 53: case 54: case 55: case 56: case 57:
-      return readNumber(source, position, code);
+      return readNumber(source, position, code, line, col, prev);
     // "
-    case 34: return readString(source, position);
+    case 34: return readString(source, position, line, col, prev);
   }
 
   throw syntaxError(
@@ -226,41 +285,64 @@ function readToken(source: Source, fromPosition: number): Token {
  * or commented character, then returns the position of that character for
  * lexing.
  */
-function positionAfterWhitespace(body: string, startPosition: number): number {
+function positionAfterWhitespace(
+  body: string,
+  startPosition: number,
+  lexer: Lexer<*>
+): number {
   const bodyLength = body.length;
   let position = startPosition;
   while (position < bodyLength) {
-    let code = charCodeAt.call(body, position);
-    // Skip Ignored
-    if (
-      // BOM
-      code === 0xFEFF ||
-      // White Space
-      code === 0x0009 || // tab
-      code === 0x0020 || // space
-      // Line Terminator
-      code === 0x000A || // new line
-      code === 0x000D || // carriage return
-      // Comma
-      code === 0x002C
-    ) {
+    const code = charCodeAt.call(body, position);
+    // tab | space | comma | BOM
+    if (code === 9 || code === 32 || code === 44 || code === 0xFEFF) {
       ++position;
-    // Skip comments
-    } else if (code === 35) { // #
+    } else if (code === 10) { // new line
       ++position;
-      while (
-        position < bodyLength &&
-        (code = charCodeAt.call(body, position)) !== null &&
-        // SourceCharacter but not LineTerminator
-        (code > 0x001F || code === 0x0009) && code !== 0x000A && code !== 0x000D
-      ) {
+      ++lexer.line;
+      lexer.lineStart = position;
+    } else if (code === 13) { // carriage return
+      if (charCodeAt.call(body, position + 1) === 10) {
+        position += 2;
+      } else {
         ++position;
       }
+      ++lexer.line;
+      lexer.lineStart = position;
     } else {
       break;
     }
   }
   return position;
+}
+
+/**
+ * Reads a comment token from the source file.
+ *
+ * #[\u0009\u0020-\uFFFF]*
+ */
+function readComment(source, start, line, col, prev): Token {
+  const body = source.body;
+  let code;
+  let position = start;
+
+  do {
+    code = charCodeAt.call(body, ++position);
+  } while (
+    code !== null &&
+    // SourceCharacter but not LineTerminator
+    (code > 0x001F || code === 0x0009)
+  );
+
+  return new Tok(
+    COMMENT,
+    start,
+    position,
+    line,
+    col,
+    prev,
+    slice.call(body, start + 1, position)
+  );
 }
 
 /**
@@ -270,7 +352,7 @@ function positionAfterWhitespace(body: string, startPosition: number): number {
  * Int:   -?(0|[1-9][0-9]*)
  * Float: -?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(+|-)?[0-9]+)?
  */
-function readNumber(source, start, firstCode) {
+function readNumber(source, start, firstCode, line, col, prev): Token {
   const body = source.body;
   let code = firstCode;
   let position = start;
@@ -312,10 +394,13 @@ function readNumber(source, start, firstCode) {
     position = readDigits(source, position, code);
   }
 
-  return makeToken(
-    isFloat ? TokenKind.FLOAT : TokenKind.INT,
+  return new Tok(
+    isFloat ? FLOAT : INT,
     start,
     position,
+    line,
+    col,
+    prev,
     slice.call(body, start, position)
   );
 }
@@ -345,7 +430,7 @@ function readDigits(source, start, firstCode) {
  *
  * "([^"\\\u000A\u000D]|(\\(u[0-9a-fA-F]{4}|["\\/bfnrt])))*"
  */
-function readString(source, start) {
+function readString(source, start, line, col, prev): Token {
   const body = source.body;
   let position = start + 1;
   let chunkStart = position;
@@ -417,7 +502,7 @@ function readString(source, start) {
   }
 
   value += slice.call(body, chunkStart, position);
-  return makeToken(TokenKind.STRING, start, position + 1, value);
+  return new Tok(STRING, start, position + 1, line, col, prev, value);
 }
 
 /**
@@ -456,7 +541,7 @@ function char2hex(a) {
  *
  * [_A-Za-z][_0-9A-Za-z]*
  */
-function readName(source, position) {
+function readName(source, position, line, col, prev): Token {
   const body = source.body;
   const bodyLength = body.length;
   let end = position + 1;
@@ -473,10 +558,13 @@ function readName(source, position) {
   ) {
     ++end;
   }
-  return makeToken(
-    TokenKind.NAME,
+  return new Tok(
+    NAME,
     position,
     end,
+    line,
+    col,
+    prev,
     slice.call(body, position, end)
   );
 }


### PR DESCRIPTION
This refactors the tokenizer, simplifying both tokenizer and parser code slightly (fewer utility functions) and returns tokens as part of the AST's `loc` information. 

Location info is now created as an Object with non-writable defined properties, only `start` and `end` are enumerable. That removes the need for the `noSource` option, which was really only added to not choke JSON.stringify/util.inspect on the full source. Location info now also includes the `startToken` and `endToken` associated with every node in the AST, providing easy access to the token stream from any point.

Tokens also have gained a few new properties: `line` for the 1-indexed line they appear on and `prev`/`next` to navigate the dll of Tokens.

Finally, this introduces three new Token types: `<SOF>` for the empty token at beginning of the file stream, `,` for ignored comma tokens, and `Comment` for ignored comment tokens.

These tokens are *included* in the Token list allowing for easier navigation of the parsed document in GraphQL tools and as a basis for parsing comment descriptions in the schema language.