### PR TITLE
[test] [minor] Make test name unique

### DIFF
--- a/src/validation/__tests__/NoUnusedVariables-test.js
+++ b/src/validation/__tests__/NoUnusedVariables-test.js
@@ -155,7 +155,7 @@ describe('Validate: No unused variables', () => {
     ]);
   });
 
-  it('multiple variables not used', () => {
+  it('multiple variables not used in fragments', () => {
     expectFailsRule(NoUnusedVariables, `
       query Foo($a: String, $b: String, $c: String) {
         ...FragA


### PR DESCRIPTION
There is already a `it('multiple variables not used'` earlier in the test for a plain graph. Clarifying that this test is about a graph with fragments.