### PR TITLE
Make the default resolver use args and context

### DIFF
--- a/src/execution/__tests__/resolve-test.js
+++ b/src/execution/__tests__/resolve-test.js
@@ -66,6 +66,34 @@ describe('Execute: resolve function', () => {
     });
   });
 
+  it('default function passes args and context', async () => {
+    const schema = testSchema({
+      type: GraphQLInt,
+      args: {
+        addend1: { type: GraphQLInt },
+      },
+    });
+
+    class Adder {
+      constructor(num) {
+        this._num = num;
+      }
+
+      test({addend1}, context) {
+        return this._num + addend1 + context.addend2;
+      }
+    }
+    const source = new Adder(700);
+
+    expect(
+      await graphql(schema, '{ test(addend1: 80) }', source, { addend2: 9 })
+    ).to.deep.equal({
+      data: {
+        test: 789
+      }
+    });
+  });
+
   it('uses provided resolve function', async () => {
     const schema = testSchema({
       type: GraphQLString,

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -990,13 +990,16 @@ function defaultResolveTypeFn(
  * If a resolve function is not given, then a default resolve behavior is used
  * which takes the property of the source object of the same name as the field
  * and returns it as the result, or if it's a function, returns the result
- * of calling that function.
+ * of calling that function while passing along args and context.
  */
 function defaultResolveFn(source: any, args, context, { fieldName }) {
   // ensure source is a value for which property access is acceptable.
   if (typeof source === 'object' || typeof source === 'function') {
     const property = source[fieldName];
-    return typeof property === 'function' ? source[fieldName]() : property;
+    if (typeof property === 'function') {
+      return source[fieldName](args, context);
+    }
+    return property;
   }
 }
 


### PR DESCRIPTION
Right now the default resolver is really handy in some cases. If you have a field that uses args and/or context, though, you can't use a default resolver because the default resolver just throws them away, even if there's a function hanging off the source object. There's no real benefit to that behavior, so this PR passes args and context along to the function hanging off the source object if there is one. This makes it easier to use es6 classes in conjunction with graphql.js.

This is backward compatible unless you happened to use a default resolver method which relied on not receiving any arguments despite the schema allowing arguments, which seems perverse enough that we can ignore that case.