### PR TITLE
[RFC] Allows use of generated schemas for execution.

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -704,7 +704,7 @@ export type GraphQLUnionTypeConfig = {
    * the default implementation will call `isTypeOf` on each implementing
    * Object type.
    */
-  resolveType?: GraphQLTypeResolveFn;
+  resolveType?: ?GraphQLTypeResolveFn;
   description?: ?string;
 };
 

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -13,10 +13,11 @@ import { parse } from '../../language';
 import { printSchema } from '../schemaPrinter';
 import { buildASTSchema } from '../buildASTSchema';
 import {
+  graphql,
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
-} from '../../type/directives';
+} from '../../';
 
 /**
  * This function does a full cycle of going from a
@@ -32,6 +33,23 @@ function cycleOutput(body) {
 }
 
 describe('Schema Builder', () => {
+
+  it('can use built schema for limited execution', async () => {
+    const schema = buildASTSchema(parse(`
+      schema { query: Query }
+      type Query {
+        str: String
+      }
+    `));
+
+    const result = await graphql(
+      schema,
+      '{ str }',
+      { str: 123 }
+    );
+    expect(result.data).to.deep.equal({ str: '123' });
+  });
+
   it('Simple type', () => {
     const body = `
 schema {

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -644,7 +644,7 @@ describe('Type System: build schema from introspection', () => {
     await testSchema(schema);
   });
 
-  it('cannot use client schema for general execution', async () => {
+  it('can use client schema for limited execution', async () => {
     const customScalar = new GraphQLScalarType({
       name: 'CustomScalar',
       serialize: () => null,
@@ -670,20 +670,13 @@ describe('Type System: build schema from introspection', () => {
 
     const result = await graphql(
       clientSchema,
-      'query NoNo($v: CustomScalar) { foo(custom1: 123, custom2: $v) }',
-      { foo: 'bar' },
+      'query Limited($v: CustomScalar) { foo(custom1: 123, custom2: $v) }',
+      { foo: 'bar', unused: 'value' },
       null,
       { v: 'baz' }
     );
-    expect(result).to.containSubset({
-      data: {
-        foo: null,
-      },
-      errors: [
-        { message: 'Client Schema cannot be used for execution.',
-          locations: [ { line: 1, column: 32 } ] }
-      ]
-    });
+
+    expect(result.data).to.deep.equal({ foo: 'bar' });
   });
 
   describe('throws when given incomplete introspection', () => {

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -115,7 +115,7 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.not.contain('newField');
   });
 
-  it('cannot be used for execution', async () => {
+  it('can be used for limited execution', async () => {
     const ast = parse(`
       extend type Query {
         newField: String
@@ -124,11 +124,12 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(testSchema, ast);
     const clientQuery = parse('{ newField }');
 
-    const result = await execute(extendedSchema, clientQuery);
-    expect(result.data.newField).to.equal(null);
-    expect(result.errors).to.containSubset([ {
-      message: 'Client Schema cannot be used for execution.'
-    } ]);
+    const result = await execute(
+      extendedSchema,
+      clientQuery,
+      { newField: 123 }
+    );
+    expect(result.data).to.deep.equal({ newField: '123' });
   });
 
   it('can describe the extended fields', async () => {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -398,8 +398,8 @@ export function buildASTSchema(ast: Document): GraphQLSchema {
     return new GraphQLInterfaceType({
       name: typeName,
       description: getDescription(def),
-      resolveType: () => null,
       fields: () => makeFieldDefMap(def),
+      resolveType: cannotExecuteSchema,
     });
   }
 
@@ -424,8 +424,8 @@ export function buildASTSchema(ast: Document): GraphQLSchema {
     return new GraphQLUnionType({
       name: def.name.value,
       description: getDescription(def),
-      resolveType: () => null,
       types: def.types.map(t => produceObjectType(t)),
+      resolveType: cannotExecuteSchema,
     });
   }
 
@@ -509,4 +509,10 @@ function leadingSpaces(str) {
     }
   }
   return i;
+}
+
+function cannotExecuteSchema() {
+  throw new Error(
+    'Generated Schema cannot use Interface or Union types for execution.'
+  );
 }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -226,7 +226,7 @@ export function buildClientSchema(
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
-      serialize: () => null,
+      serialize: id => id,
       // Note: validation calls the parse functions to determine if a
       // literal value is correct. Returning null would cause use of custom
       // scalars to always fail validation. Returning false causes them to
@@ -305,7 +305,6 @@ export function buildClientSchema(
         deprecationReason: fieldIntrospection.deprecationReason,
         type: getOutputType(fieldIntrospection.type),
         args: buildInputValueDefMap(fieldIntrospection.args),
-        resolve: cannotExecuteClientSchema,
       })
     );
   }
@@ -393,5 +392,7 @@ export function buildClientSchema(
 }
 
 function cannotExecuteClientSchema() {
-  throw new Error('Client Schema cannot be used for execution.');
+  throw new Error(
+    'Client Schema cannot use Interface or Union types for execution.'
+  );
 }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -350,6 +350,7 @@ export function extendSchema(
       description: type.description,
       interfaces: () => extendImplementedInterfaces(type),
       fields: () => extendFieldMap(type),
+      isTypeOf: type.isTypeOf,
     });
   }
 
@@ -360,7 +361,7 @@ export function extendSchema(
       name: type.name,
       description: type.description,
       fields: () => extendFieldMap(type),
-      resolveType: cannotExecuteClientSchema,
+      resolveType: type.resolveType,
     });
   }
 
@@ -369,7 +370,7 @@ export function extendSchema(
       name: type.name,
       description: type.description,
       types: type.getTypes().map(getTypeFromDef),
-      resolveType: cannotExecuteClientSchema,
+      resolveType: type.resolveType,
     });
   }
 
@@ -409,7 +410,7 @@ export function extendSchema(
         deprecationReason: field.deprecationReason,
         type: extendFieldType(field.type),
         args: keyMap(field.args, arg => arg.name),
-        resolve: cannotExecuteClientSchema,
+        resolve: field.resolve,
       };
     });
 
@@ -430,7 +431,6 @@ export function extendSchema(
             description: getDescription(field),
             type: buildOutputFieldType(field.type),
             args: buildInputValues(field.arguments),
-            resolve: cannotExecuteClientSchema,
           };
         });
       });
@@ -475,7 +475,7 @@ export function extendSchema(
       name: typeAST.name.value,
       description: getDescription(typeAST),
       fields: () => buildFieldMap(typeAST),
-      resolveType: cannotExecuteClientSchema,
+      resolveType: cannotExecuteExtendedSchema,
     });
   }
 
@@ -484,7 +484,7 @@ export function extendSchema(
       name: typeAST.name.value,
       description: getDescription(typeAST),
       types: typeAST.types.map(getObjectTypeFromAST),
-      resolveType: cannotExecuteClientSchema,
+      resolveType: cannotExecuteExtendedSchema,
     });
   }
 
@@ -492,7 +492,7 @@ export function extendSchema(
     return new GraphQLScalarType({
       name: typeAST.name.value,
       description: getDescription(typeAST),
-      serialize: () => null,
+      serialize: id => id,
       // Note: validation calls the parse functions to determine if a
       // literal value is correct. Returning null would cause use of custom
       // scalars to always fail validation. Returning false causes them to
@@ -543,7 +543,6 @@ export function extendSchema(
         type: buildOutputFieldType(field.type),
         description: getDescription(field),
         args: buildInputValues(field.arguments),
-        resolve: cannotExecuteClientSchema,
       })
     );
   }
@@ -588,6 +587,8 @@ export function extendSchema(
   }
 }
 
-function cannotExecuteClientSchema() {
-  throw new Error('Client Schema cannot be used for execution.');
+function cannotExecuteExtendedSchema() {
+  throw new Error(
+    'Extended Schema cannot use Interface or Union types for execution.'
+  );
 }


### PR DESCRIPTION
Right now our generated schemas (built from introspection, built from AST) explicitly do not allow their use in execution. They throw as soon as any resolver function is called. This conservative behavior was appropriate for early versions where we wanted to limit the surface area under use. Today it's becoming more clear that there are immediately valuable use cases for using generated schema in execution.

The ability to execute will still be somewhat limited: generated schema do not contain enough information to resolve Interface and Union types, and coerce values for custom Scalars.

Case 1: Resolvers live in your domain models, AST schema is useful:

```js
const schema = buildASTSchema(parse(`type MyTypeSystem { ... }`));
class MyObject { ... }
class MyQueryRoot { ... }
const response = graphql(schema, query, new MyQueryRoot())
```

This is pretty compelling for simpler schema. You can define your schema entirely in AST and allow resolvers to completely exist outside the GraphQL type domain. This approach is now immediately useful thanks to @lacker's #468.

Case 2: Querying your local cache:

```js
const schema = buildClientSchema(introspection);
const response = graphql(schema, query, myGraphQLCache);
```

I admit that this use case is more experimental and less thought through, but I believe that contributors & community may take this idea further. Conceptually it's compelling: given a query I want to submit and my local cache of results, what partial results can I use right away before the server returns? I'm absolutely sure there are missing pieces to truly enable this, but this should be a first step.