### PR TITLE
Advantage common convention for naming root types.

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -457,10 +457,6 @@ type Subscription {
 
   it('Unreferenced type implementing referenced interface', () => {
     const body = `
-schema {
-  query: Query
-}
-
 type Concrete implements Iface {
   key: String
 }
@@ -479,10 +475,6 @@ type Query {
 
   it('Unreferenced type implementing referenced union', () => {
     const body = `
-schema {
-  query: Query
-}
-
 type Concrete {
   key: String
 }
@@ -499,10 +491,6 @@ union Union = Concrete
 
   it('Supports @deprecated', () => {
     const body = `
-schema {
-  query: Query
-}
-
 enum MyEnum {
   VALUE
   OLD_VALUE @deprecated
@@ -522,15 +510,16 @@ type Query {
 
 describe('Failures', () => {
 
-  it('Requires a schema definition', () => {
+  it('Requires a schema definition or Query type', () => {
     const body = `
 type Hello {
   bar: Bar
 }
 `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Must provide a schema definition.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Must provide schema definition with query type or a type named Query.'
+    );
   });
 
   it('Allows only a single schema definition', () => {
@@ -563,8 +552,9 @@ type Hello {
 }
 `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Must provide schema definition with query type.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Must provide schema definition with query type or a type named Query.'
+    );
   });
 
   it('Allows only a single query type', () => {

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -156,11 +156,7 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -209,11 +205,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -271,11 +263,7 @@ type Unused {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -330,11 +318,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -384,11 +368,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -464,11 +444,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -547,11 +523,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -619,11 +591,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-}
-
-type Bar implements SomeInterface {
+`type Bar implements SomeInterface {
   name: String
   some: SomeInterface
   foo: Foo
@@ -709,13 +677,7 @@ union SomeUnion = Foo | Biz
     expect(extendedSchema).to.not.equal(mutationSchema);
     expect(printSchema(mutationSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
-`schema {
-  query: Query
-  mutation: Mutation
-  subscription: Subscription
-}
-
-type Mutation {
+`type Mutation {
   mutationField: String
   newMutationField: Int
 }


### PR DESCRIPTION
This is a result of a conversation I had with @lacker that we should provide a stronger opinion on what to name the root types, and then advantage that opinion. Here's the result of that:

If you use the type names `Query` and `Mutation` for your root types, then printing the schema or parsing a schema IDL can omit the `schema { query: Query, mutation: Mutation }` boilerplate. If your root type names are anything other than these, then you have to include it.

There doesn't seem to be a significant downside to this except for the relative complication of understanding why sometimes a `schema {}` description is included and sometimes it isn't.

**Note: It's okay to make these changes now since the IDL is still technically experimental (It's not in the spec) but we want to nail down the spec'd behavior of the IDL pretty soon, and this would be behavior the spec would need to describe.**