### PR TITLE
buildSchema helper function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,6 +160,9 @@ export {
   // Build a GraphQLSchema from a parsed GraphQL Schema language AST.
   buildASTSchema,
 
+  // Build a GraphQLSchema from a GraphQL schema language document.
+  buildSchema,
+
   // Extends an existing GraphQLSchema from a parsed GraphQL Schema
   // language AST.
   extendSchema,

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -11,7 +11,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { parse } from '../../language';
 import { printSchema } from '../schemaPrinter';
-import { buildASTSchema } from '../buildASTSchema';
+import { buildASTSchema, buildSchema } from '../buildASTSchema';
 import {
   graphql,
   GraphQLSkipDirective,
@@ -48,6 +48,17 @@ describe('Schema Builder', () => {
       { str: 123 }
     );
     expect(result.data).to.deep.equal({ str: '123' });
+  });
+
+  it('can build a schema directly from the source', async () => {
+    const schema = buildSchema(`
+      type Query {
+        add(x: Int, y: Int): Int
+      }
+    `);
+    expect(await graphql(
+      schema, '{ add(x: 34, y: 55) }', { add: ({x, y}) => x + y }
+    )).to.deep.equal({ data: { add: 89 }});
   });
 
   it('Simple type', () => {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -13,6 +13,8 @@ import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
 import { valueFromAST } from './valueFromAST';
 import { TokenKind } from '../language/lexer';
+import { parse } from '../language/parser';
+import { Source } from '../language/source';
 import { getArgumentValues } from '../execution/values';
 
 import {
@@ -130,9 +132,8 @@ function getNamedTypeAST(typeAST: Type): NamedType {
  * If no schema definition is provided, then it will look for types named Query
  * and Mutation.
  *
- * Given that AST it constructs a GraphQLSchema. As constructed
- * they are not particularly useful for non-introspection queries
- * since they have no resolve methods.
+ * Given that AST it constructs a GraphQLSchema. The resulting schema
+ * has no resolve methods, so execution will use default resolvers.
  */
 export function buildASTSchema(ast: Document): GraphQLSchema {
   if (!ast || ast.kind !== DOCUMENT) {
@@ -505,6 +506,14 @@ export function getDescription(node: { loc?: Location }): ?string {
     .reverse()
     .map(comment => comment.slice(minSpaces))
     .join('\n');
+}
+
+/**
+ * A helper function to build a GraphQLSchema directly from a source
+ * document.
+ */
+export function buildSchema(source: string | Source): GraphQLSchema {
+  return buildASTSchema(parse(source));
 }
 
 // Count the number of spaces on the starting side of a string.

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -14,7 +14,7 @@ import keyValMap from '../jsutils/keyValMap';
 import { valueFromAST } from './valueFromAST';
 import { TokenKind } from '../language/lexer';
 import { parse } from '../language/parser';
-import { Source } from '../language/source';
+import type { Source } from '../language/source';
 import { getArgumentValues } from '../execution/values';
 
 import {

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -17,8 +17,8 @@ export { getOperationAST } from './getOperationAST';
 // Build a GraphQLSchema from an introspection result.
 export { buildClientSchema } from './buildClientSchema';
 
-// Build a GraphQLSchema from a parsed GraphQL Schema language AST.
-export { buildASTSchema } from './buildASTSchema';
+// Build a GraphQLSchema from GraphQL Schema language.
+export { buildASTSchema, buildSchema } from './buildASTSchema';
 
 // Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
 export { extendSchema } from './extendSchema';


### PR DESCRIPTION
Pretty simple - this just adds a `buildSchema` function that composes `buildASTSchema` and `parse`, as mentioned in the discussion on https://github.com/graphql/graphql-js/pull/469 . This makes a "hello world" experience one notch simpler; product developers can use this mechanism to build their schemas while ignoring the intermediate ast format altogether.