### PR TITLE
Carry context up to parseValue scalar resolver

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -216,7 +216,8 @@ function buildExecutionContext(
   const variableValues = getVariableValues(
     schema,
     operation.variableDefinitions || [],
-    rawVariableValues || {}
+    rawVariableValues || {},
+    contextValue || {},
   );
 
   return {


### PR DESCRIPTION
The goal of this PR is to be able to get the resolution context into the Scalar's resolver (useful for instance to create "FileUpload" scalars). It's not quite done yet but if I can get an early review to check if I'm going in an overall right direction with this and know if this has any chance to get merged, that would actually be super cool 😉 !

**TODO**:
- [x] `parseValue` gets the context injected
- [ ] `parseLiteral` gets the context injected
- [ ] TESTS!
