### PR TITLE
Fix GraphQLError missing positions/locations when node.loc.start === 0

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -101,7 +101,8 @@ export function GraphQLError( // eslint-disable-line no-redeclare
 
   let _positions = positions;
   if (!_positions && nodes) {
-    _positions = nodes.map(node => node.loc && node.loc.start).filter(Boolean);
+    _positions = nodes.filter(node => node.loc !== null)
+      .map(node => node.loc.start);
   }
   if (_positions && _positions.length === 0) {
     _positions = undefined;

--- a/src/error/__tests__/GraphQLError-test.js
+++ b/src/error/__tests__/GraphQLError-test.js
@@ -72,6 +72,19 @@ describe('GraphQLError', () => {
     expect(e.locations).to.deep.equal([ { line: 2, column: 7 } ]);
   });
 
+  it('converts node with loc.start === 0 to positions and locations', () => {
+    const source = new Source(`{
+      field
+    }`);
+    const ast = parse(source);
+    const operationAST = ast.definitions[0];
+    const e = new GraphQLError('msg', [ operationAST ]);
+    expect(e.nodes).to.deep.equal([ operationAST ]);
+    expect(e.source).to.equal(source);
+    expect(e.positions).to.deep.equal([ 0 ]);
+    expect(e.locations).to.deep.equal([ { line: 1, column: 1 } ]);
+  });
+
   it('converts source and positions to locations', () => {
     const source = new Source(`{
       field


### PR DESCRIPTION
Because the GraphQLError constructor filtered out falsy values for
node.loc.start, that would also filter out 0.