### PR TITLE
Add internal names to input object fields and arguments

### DIFF
--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -70,7 +70,7 @@ export function getArgumentValues(
       value = argDef.defaultValue;
     }
     if (!isNullish(value)) {
-      result[name] = value;
+      result[argDef.internalName] = value;
     }
     return result;
   }, {});
@@ -162,7 +162,7 @@ function coerceValue(type: GraphQLInputType, value: mixed): mixed {
         fieldValue = field.defaultValue;
       }
       if (!isNullish(fieldValue)) {
-        obj[fieldName] = fieldValue;
+        obj[field.internalName] = fieldValue;
       }
       return obj;
     }, {});

--- a/src/jsutils/__tests__/isDistinct-test.js
+++ b/src/jsutils/__tests__/isDistinct-test.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import isDistinct from '../isDistinct';
+
+describe('isDistinct', () => {
+
+  it('will determine whether all items in an array are distinct', () => {
+    const obj = {};
+    expect(isDistinct([ 1, 2, 3 ])).to.equal(true);
+    expect(isDistinct([ 1, 2, 3, 2, 1 ])).to.equal(false);
+    expect(isDistinct([ 1, 1 ])).to.equal(false);
+    expect(isDistinct([ 4, 5, 6 ])).to.equal(true);
+    expect(isDistinct([ {}, {}, {} ])).to.equal(true);
+    expect(isDistinct([ obj, obj, obj ])).to.equal(false);
+  });
+
+});

--- a/src/jsutils/isDistinct.js
+++ b/src/jsutils/isDistinct.js
@@ -1,0 +1,22 @@
+/* @flow */
+
+const ITERATOR_METHOD =
+  typeof Symbol === 'function' ? Symbol.iterator : '@@iterator';
+
+/**
+ * Returns true when all of the items in the iterable are distinct from one
+ * another. In other words checks for array uniqueness.
+ */
+export default function isDistinct <T>(iterable: Iterable<T>): boolean {
+  const set = new Set();
+  const iterator = (iterable: any)[ITERATOR_METHOD]();
+  let current = iterator.next();
+  while (!current.done) {
+    if (set.has(current.value)) {
+      return false;
+    }
+    set.add(current.value);
+    current = iterator.next();
+  }
+  return true;
+}

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -23,6 +23,7 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLString,
+  GraphQLDirective,
 } from '../../';
 
 
@@ -1907,6 +1908,154 @@ describe('Objects must adhere to Interface they implement', () => {
     ).to.throw(
       'SomeEnum.value should provide "deprecationReason" instead ' +
       'of "isDeprecated".'
+    );
+  });
+
+});
+
+describe('Type System: internal names cannot be repeated', () => {
+
+  it('does not allow duplicates in input object fields', () => {
+    expect(() =>
+      new GraphQLInputObjectType({
+        name: 'Foo',
+        fields: {
+          _a: { type: GraphQLString, internalName: 'a' },
+          _b: { type: GraphQLString, internalName: 'a' },
+          _c: { type: GraphQLString, internalName: 'c' },
+        }
+      }).getFields()
+    ).to.throw(
+      'Foo must not have two fields with the same internal name.'
+    );
+  });
+
+  it('does not allow duplicates in object field arguments', () => {
+    expect(() =>
+      new GraphQLObjectType({
+        name: 'Foo',
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              _a: { type: GraphQLString, internalName: 'a' },
+              _b: { type: GraphQLString, internalName: 'a' },
+              _c: { type: GraphQLString, internalName: 'c' },
+            }
+          }
+        }
+      }).getFields()
+    ).to.throw(
+      'Foo.field must not have two args with the same ' +
+      'internal name.'
+    );
+  });
+
+  it('does not allow duplicates in interface field arguments', () => {
+    expect(() =>
+      new GraphQLInterfaceType({
+        name: 'Foo',
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              _a: { type: GraphQLString, internalName: 'a' },
+              _b: { type: GraphQLString, internalName: 'a' },
+              _c: { type: GraphQLString, internalName: 'c' },
+            }
+          }
+        }
+      }).getFields()
+    ).to.throw(
+      'Foo.field must not have two args with the same ' +
+      'internal name.'
+    );
+  });
+
+  it('does not allow duplicates in directive arguments', () => {
+    expect(() =>
+      new GraphQLDirective({
+        name: 'Foo',
+        locations: [],
+        args: {
+          _a: { type: GraphQLString, internalName: 'a' },
+          _b: { type: GraphQLString, internalName: 'a' },
+          _c: { type: GraphQLString, internalName: 'c' },
+        }
+      })
+    ).to.throw(
+      'Foo must not have two args with the same ' +
+      'internal name.'
+    );
+  });
+
+  it('does not allow duplicates in input object fields when an internal name is implied', () => {
+    expect(() =>
+      new GraphQLInputObjectType({
+        name: 'Bar',
+        fields: {
+          _a: { type: GraphQLString },
+          _b: { type: GraphQLString, internalName: '_a' },
+        }
+      }).getFields()
+    ).to.throw(
+      'Bar must not have two fields with the same internal name.'
+    );
+  });
+
+  it('does not allow duplicates in object field arguments when an internal name is implied', () => {
+    expect(() =>
+      new GraphQLObjectType({
+        name: 'Bar',
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              _a: { type: GraphQLString },
+              _b: { type: GraphQLString, internalName: '_a' },
+            }
+          }
+        }
+      }).getFields()
+    ).to.throw(
+      'Bar.field must not have two args with the same ' +
+      'internal name.'
+    );
+  });
+
+  it('does not allow duplicates in interface field arguments when an internal name is implied', () => {
+    expect(() =>
+      new GraphQLInterfaceType({
+        name: 'Bar',
+        fields: {
+          field: {
+            type: GraphQLString,
+            args: {
+              _a: { type: GraphQLString },
+              _b: { type: GraphQLString, internalName: '_a' },
+            }
+          }
+        }
+      }).getFields()
+    ).to.throw(
+      'Bar.field must not have two args with the same ' +
+      'internal name.'
+    );
+  });
+
+  it('does not allow duplicates in directive arguments when an internal name is implied', () => {
+    expect(() =>
+      new GraphQLDirective({
+        name: 'Foo',
+        locations: [],
+        args: {
+          _a: { type: GraphQLString },
+          _b: { type: GraphQLString, internalName: '_a' },
+        }
+      })
+    ).to.throw(
+      'Foo must not have two args with the same ' +
+      'internal name.'
     );
   });
 

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -8,6 +8,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import isDistinct from '../jsutils/isDistinct';
 import { isInputType, GraphQLNonNull } from './definition';
 import type {
   GraphQLFieldConfigArgumentMap,
@@ -82,11 +83,17 @@ export class GraphQLDirective {
         );
         return {
           name: argName,
+          internalName:
+            typeof arg.internalName !== 'string' ? argName : arg.internalName,
           description: arg.description === undefined ? null : arg.description,
           type: arg.type,
           defaultValue: arg.defaultValue === undefined ? null : arg.defaultValue
         };
       });
+      invariant(
+        isDistinct(this.args.map(({ internalName }) => internalName)),
+        `@${config.name} must not have two args with the same internal name.`
+      );
     }
   }
 }

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -437,7 +437,11 @@ export const TypeMetaFieldDef: GraphQLFieldDefinition = {
   type: __Type,
   description: 'Request the type information of a single type.',
   args: [
-    { name: 'name', type: new GraphQLNonNull(GraphQLString) }
+    {
+      name: 'name',
+      internalName: 'name',
+      type: new GraphQLNonNull(GraphQLString)
+    }
   ],
   resolve: (source, { name }: { name: string }, context, { schema }) =>
     schema.getType(name)

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -220,4 +220,28 @@ describe('astFromValue', () => {
             value: { kind: 'EnumValue', value: 'HELLO' } } ] }
     );
   });
+
+  it('converts input objects with their internal names', () => {
+    const inputObj = new GraphQLInputObjectType({
+      name: 'MyInputObj',
+      fields: {
+        foo: { type: GraphQLFloat, internalName: '_foo' },
+        bar: { type: myEnum, internalName: '_bar' }
+      }
+    });
+
+    expect(astFromValue(
+      { _foo: 3, _bar: 'HELLO' },
+      inputObj
+    )).to.deep.equal(
+      { kind: 'ObjectValue',
+        fields: [
+          { kind: 'ObjectField',
+            name: { kind: 'Name', value: 'foo' },
+            value: { kind: 'IntValue', value: '3' } },
+          { kind: 'ObjectField',
+            name: { kind: 'Name', value: 'bar' },
+            value: { kind: 'EnumValue', value: 'HELLO' } } ] }
+    );
+  });
 });

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -103,8 +103,11 @@ export function astFromValue(
     const fields = type.getFields();
     const fieldASTs = [];
     Object.keys(fields).forEach(fieldName => {
-      const fieldType = fields[fieldName].type;
-      const fieldValue = astFromValue(_value[fieldName], fieldType);
+      const field = fields[fieldName];
+      const fieldValue = astFromValue(
+        _value[field.internalName],
+        field.type
+      );
       if (fieldValue) {
         fieldASTs.push({
           kind: OBJECT_FIELD,

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -99,7 +99,7 @@ export function valueFromAST(
         fieldValue = field.defaultValue;
       }
       if (!isNullish(fieldValue)) {
-        obj[fieldName] = fieldValue;
+        obj[field.internalName] = fieldValue;
       }
       return obj;
     }, {});


### PR DESCRIPTION
`GraphQLScalarType` gives us the ability to transform input data into an arbitrary form usable in our `resolve` functions. I’d like to see a similar functionality for `GraphQLInputObjectType`.

In my GraphQL schemas, I have a number of fairly complex input objects which must be in a different form by the time they reach my `resolve` function. One could manually parse the input objects in a `resolve` function, however doing so would require recursion and therefore type information making this case difficult to implement correctly. It would also require keeping this extra parsing information in a data structure parallel to both the value and the type system.

90% of the time, the transform I want to perform is renaming input object field names alone, having this feature baked into `graphql-js` would help ease this use case. Especially for users who may expect their input objects in `snake_case` but would like to expose a `camelCase` API.

This PR adds an `internalName` to input object fields and arguments which the executor will use as the key when building input objects or argument objects. This is the least powerful approach, but it addresses 90% of my use cases (maybe not others?). It’s also likely the least controversial option and easiest to implement.

<!--
## Exploration
Given my requirements above, here are the other attempts I explored. If you would prefer one of these implementations let me know.

### Move `parseValue` and `parseLiteral` to `GraphQLInputObjectType`
This was my first idea. By moving these two methods which provide so much utility and flexibility on `GraphQLScalarType` to `GraphQLInputObjectType` would allow the user to do completely custom parsing of the object. Roughly the implementation would be moving the [logic for `GraphQLInputObjectType` in `coerceValue`](https://github.com/graphql/graphql-js/blob/2406d3ab6569d6214f9ef9c9ecce3f6f4aa629be/src/execution/values.js#L154-L168) into a new `GraphQLInputObjectType` `parseValue` method. Similarly this could be done for `parseLiteral`.

I decided to not go down this approach because:

1. [The implementation depends on `coerceValue`](https://github.com/graphql/graphql-js/blob/2406d3ab6569d6214f9ef9c9ecce3f6f4aa629be/src/execution/values.js#L127) which is private to its containing module.
2. Updating the implementation of `astFromValue` would have been tricky.

### Adding an `assign` method to input object fields that is analogous to `resolve`
This was the next idea which didn’t clobber the entire object like the first one. In this users would define an `assign` method on fields which would act as a reducer on an object.
-->
