### PR TITLE
fix: inherit descriptor properties from the original error

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -80,15 +80,15 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   // Include (non-enumerable) stack trace.
   if (originalError && originalError.stack) {
     Object.defineProperty(this, 'stack', {
-      value: originalError.stack,
-      writable: true
+      ...Object.getOwnPropertyDescriptor(this, 'stack'),
+      value: originalError.stack
     });
   } else if (Error.captureStackTrace) {
     Error.captureStackTrace(this, GraphQLError);
   } else {
     Object.defineProperty(this, 'stack', {
-      value: Error().stack,
-      writable: true
+      ...Object.getOwnPropertyDescriptor(this, 'stack'),
+      value: Error().stack
     });
   }
 


### PR DESCRIPTION
The the default values for `{writable,configurable}` are `false`.
Therefore, when you defineProperty without explicitly setting
`{configurable}` to `true`, it defaults to `false`. As a result,
the stack cannot be overwritten by a latter program, e.g.
Bluebird will attempt to add [longStackTraces](http://bluebirdjs.com/docs/api/promise.longstacktraces.html).

Instead of explicitly setting property descriptor settings,
inherit descriptor properties of the original error object.