### PR TITLE
Add 'configurable: true' to GraphQLError stack property

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -81,14 +81,16 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   if (originalError && originalError.stack) {
     Object.defineProperty(this, 'stack', {
       value: originalError.stack,
-      writable: true
+      writable: true,
+      configurable: true
     });
   } else if (Error.captureStackTrace) {
     Error.captureStackTrace(this, GraphQLError);
   } else {
     Object.defineProperty(this, 'stack', {
       value: Error().stack,
-      writable: true
+      writable: true,
+      configurable: true
     });
   }
 


### PR DESCRIPTION
Bluebird will throw an error if an error used to reject a promise has `writable: true` but not `configurable: true`

See: 
https://github.com/graphql/graphql-js/issues/439
https://github.com/petkaantonov/bluebird/pull/1238

Fixes #488 