### PR TITLE
Add utility functions to compare schemas

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -203,4 +203,12 @@ export {
 
   // Asserts a string is a valid GraphQL name.
   assertValidName,
+
+  // Helpful functions to compare two GraphQLSchemas and detect breaking
+  // changes.
+  findRemovedTypes,
+  findTypesThatChangedType,
+  findBreakingFieldChanges,
+  findTypesRemovedFromUnions,
+  findValuesRemovedFromEnums,
 } from './utilities';

--- a/src/index.js
+++ b/src/index.js
@@ -204,12 +204,6 @@ export {
   // Asserts a string is a valid GraphQL name.
   assertValidName,
 
-  // Helpful functions to compare two GraphQLSchemas and detect breaking
-  // changes.
+  // Compares two GraphQLSchemas and detects breaking changes.
   findBreakingChanges,
-  findRemovedTypes,
-  findTypesThatChangedKind,
-  findFieldsThatChangedType,
-  findTypesRemovedFromUnions,
-  findValuesRemovedFromEnums,
 } from './utilities';

--- a/src/index.js
+++ b/src/index.js
@@ -206,6 +206,7 @@ export {
 
   // Helpful functions to compare two GraphQLSchemas and detect breaking
   // changes.
+  findBreakingChanges,
   findRemovedTypes,
   findTypesThatChangedType,
   findBreakingFieldChanges,

--- a/src/index.js
+++ b/src/index.js
@@ -208,8 +208,8 @@ export {
   // changes.
   findBreakingChanges,
   findRemovedTypes,
-  findTypesThatChangedType,
-  findBreakingFieldChanges,
+  findTypesThatChangedKind,
+  findFieldsThatChangedType,
   findTypesRemovedFromUnions,
   findValuesRemovedFromEnums,
 } from './utilities';

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -223,6 +223,8 @@ export class GraphQLScalarType {
 
   _scalarConfig: GraphQLScalarTypeConfig<*, *>;
 
+  static prettyName: string = 'Scalar';
+
   constructor(config: GraphQLScalarTypeConfig<*, *>) {
     invariant(config.name, 'Type must be named.');
     assertValidName(config.name);
@@ -323,6 +325,8 @@ export class GraphQLObjectType {
   _typeConfig: GraphQLObjectTypeConfig<*>;
   _fields: GraphQLFieldDefinitionMap;
   _interfaces: Array<GraphQLInterfaceType>;
+
+  static prettyName: string = 'Object';
 
   constructor(config: GraphQLObjectTypeConfig<*>) {
     invariant(config.name, 'Type must be named.');
@@ -570,6 +574,8 @@ export class GraphQLInterfaceType {
   _typeConfig: GraphQLInterfaceTypeConfig;
   _fields: GraphQLFieldDefinitionMap;
 
+  static prettyName: string = 'Interface';
+
   constructor(config: GraphQLInterfaceTypeConfig) {
     invariant(config.name, 'Type must be named.');
     assertValidName(config.name);
@@ -640,6 +646,8 @@ export class GraphQLUnionType {
   _typeConfig: GraphQLUnionTypeConfig;
   _types: Array<GraphQLObjectType>;
   _possibleTypeNames: {[typeName: string]: boolean};
+
+  static prettyName: string = 'Union';
 
   constructor(config: GraphQLUnionTypeConfig) {
     invariant(config.name, 'Type must be named.');
@@ -741,6 +749,8 @@ export class GraphQLEnumType/* <T> */ {
   _values: Array<GraphQLEnumValueDefinition/* <T> */>;
   _valueLookup: Map<any/* T */, GraphQLEnumValueDefinition>;
   _nameLookup: { [valueName: string]: GraphQLEnumValueDefinition };
+
+  static prettyName: string = 'Enum';
 
   constructor(config: GraphQLEnumTypeConfig/* <T> */) {
     this.name = config.name;
@@ -892,6 +902,8 @@ export class GraphQLInputObjectType {
 
   _typeConfig: InputObjectConfig;
   _fields: InputObjectFieldMap;
+
+  static prettyName: string = 'InputObject';
 
   constructor(config: InputObjectConfig) {
     invariant(config.name, 'Type must be named.');

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -218,7 +218,7 @@ export class GraphQLSchema {
   }
 }
 
-type TypeMap = { [typeName: string]: GraphQLNamedType }
+export type TypeMap = { [typeName: string]: GraphQLNamedType }
 
 type GraphQLSchemaConfig = {
   query: GraphQLObjectType;

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -218,7 +218,7 @@ export class GraphQLSchema {
   }
 }
 
-export type TypeMap = { [typeName: string]: GraphQLNamedType }
+type TypeMap = { [typeName: string]: GraphQLNamedType }
 
 type GraphQLSchemaConfig = {
   query: GraphQLObjectType;

--- a/src/utilities/__tests__/schemaComparisons-test.js
+++ b/src/utilities/__tests__/schemaComparisons-test.js
@@ -19,6 +19,7 @@ import {
   GraphQLUnionType,
 } from '../../type';
 import {
+  BreakingChangeType,
   findBreakingChanges,
   findFieldsThatChangedType,
   findRemovedTypes,
@@ -62,9 +63,12 @@ describe('CheckSchemaBackwardsCompatibility', () => {
         type2,
       ]
     });
-    expect(findRemovedTypes(oldSchema, newSchema)).to.eql(
-      [ 'Type1 was removed' ]
-    );
+    expect(findRemovedTypes(oldSchema, newSchema)).to.eql([
+      {
+        type: BreakingChangeType.TYPE_REMOVED,
+        description: 'Type1 was removed',
+      }
+    ]);
     expect(findRemovedTypes(oldSchema, oldSchema)).to.eql([]);
   });
 
@@ -100,9 +104,13 @@ describe('CheckSchemaBackwardsCompatibility', () => {
         unionType1,
       ]
     });
-    expect(findTypesThatChangedKind(oldSchema, newSchema)).to.eql(
-      [ 'Type1 changed from a GraphQLInterfaceType to a GraphQLUnionType' ]
-    );
+    expect(findTypesThatChangedKind(oldSchema, newSchema)).to.eql([
+      {
+        type: BreakingChangeType.TYPE_CHANGED_KIND,
+        description:
+          'Type1 changed from a GraphQLInterfaceType to a GraphQLUnionType',
+      }
+    ]);
   });
 
   it('should detect if a field on a type was deleted or changed type', () => {
@@ -160,9 +168,18 @@ describe('CheckSchemaBackwardsCompatibility', () => {
     });
 
     const expectedFieldChanges = [
-      'Type1.field2 was removed',
-      'Type1.field3 changed type from String to Boolean',
-      'Type1.field4 changed type from TypeA to TypeB',
+      {
+        type: BreakingChangeType.FIELD_REMOVED,
+        description: 'Type1.field2 was removed',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description: 'Type1.field3 changed type from String to Boolean',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description: 'Type1.field4 changed type from TypeA to TypeB',
+      },
     ];
     expect(findFieldsThatChangedType(oldSchema, newSchema)).to.eql(
       expectedFieldChanges
@@ -221,9 +238,12 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       ]
     });
 
-    expect(findTypesRemovedFromUnions(oldSchema, newSchema)).to.eql(
-      [ 'Type2 was removed from union type UnionType1' ]
-    );
+    expect(findTypesRemovedFromUnions(oldSchema, newSchema)).to.eql([
+      {
+        type: BreakingChangeType.TYPE_REMOVED_FROM_UNION,
+        description: 'Type2 was removed from union type UnionType1',
+      },
+    ]);
   });
 
   it('should detect if a value was removed from an enum type', () => {
@@ -257,9 +277,12 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       ]
     });
 
-    expect(findValuesRemovedFromEnums(oldSchema, newSchema)).to.eql(
-      [ 'VALUE1 was removed from enum type EnumType1' ]
-    );
+    expect(findValuesRemovedFromEnums(oldSchema, newSchema)).to.eql([
+      {
+        type: BreakingChangeType.VALUE_REMOVED_FROM_ENUM,
+        description: 'VALUE1 was removed from enum type EnumType1',
+      },
+    ]);
   });
 
   it('should detect all breaking changes', () => {
@@ -357,17 +380,39 @@ describe('CheckSchemaBackwardsCompatibility', () => {
     });
 
     const expectedBreakingChanges = [
-      'TypeThatGetsRemoved was removed',
-      'TypeInUnion2 was removed',
-      'TypeThatChangesType changed from a GraphQLObjectType ' +
-        'to a GraphQLInterfaceType',
-      'TypeThatHasBreakingFieldChanges.field1 was removed',
-      'TypeThatHasBreakingFieldChanges.field2 changed type ' +
-        'from String to Boolean',
-      'TypeInUnion2 was removed from union type UnionTypeThatLosesAType',
-      'VALUE0 was removed from enum type EnumTypeThatLosesAValue',
+      {
+        type: BreakingChangeType.TYPE_REMOVED,
+        description: 'TypeThatGetsRemoved was removed',
+      },
+      {
+        type: BreakingChangeType.TYPE_REMOVED,
+        description: 'TypeInUnion2 was removed',
+      },
+      {
+        type: BreakingChangeType.TYPE_CHANGED_KIND,
+        description: 'TypeThatChangesType changed from a GraphQLObjectType ' +
+          'to a GraphQLInterfaceType',
+      },
+      {
+        type: BreakingChangeType.FIELD_REMOVED,
+        description: 'TypeThatHasBreakingFieldChanges.field1 was removed',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description: 'TypeThatHasBreakingFieldChanges.field2 changed type ' +
+          'from String to Boolean',
+      },
+      {
+        type: BreakingChangeType.TYPE_REMOVED_FROM_UNION,
+        description: 'TypeInUnion2 was removed from union type ' +
+          'UnionTypeThatLosesAType',
+      },
+      {
+        type: BreakingChangeType.VALUE_REMOVED_FROM_ENUM,
+        description: 'VALUE0 was removed from enum type ' +
+          'EnumTypeThatLosesAValue',
+      },
     ];
-
     expect(findBreakingChanges(oldSchema, newSchema)).to.eql(
       expectedBreakingChanges
     );

--- a/src/utilities/__tests__/schemaComparisons-test.js
+++ b/src/utilities/__tests__/schemaComparisons-test.js
@@ -107,8 +107,7 @@ describe('CheckSchemaBackwardsCompatibility', () => {
     expect(findTypesThatChangedKind(oldSchema, newSchema)).to.eql([
       {
         type: BreakingChangeType.TYPE_CHANGED_KIND,
-        description:
-          'Type1 changed from a GraphQLInterfaceType to a GraphQLUnionType',
+        description: 'Type1 changed from an Interface type to a Union type',
       }
     ]);
   });
@@ -390,8 +389,8 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       },
       {
         type: BreakingChangeType.TYPE_CHANGED_KIND,
-        description: 'TypeThatChangesType changed from a GraphQLObjectType ' +
-          'to a GraphQLInterfaceType',
+        description: 'TypeThatChangesType changed from an Object type to an ' +
+          'Interface type',
       },
       {
         type: BreakingChangeType.FIELD_REMOVED,

--- a/src/utilities/__tests__/schemaComparisons-test.js
+++ b/src/utilities/__tests__/schemaComparisons-test.js
@@ -1,0 +1,259 @@
+/**
+ *  Copyright (c) 2016, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+  GraphQLUnionType,
+} from '../../type';
+import {
+  findBreakingFieldChanges,
+  findRemovedTypes,
+  findTypesRemovedFromUnions,
+  findTypesThatChangedType,
+  findValuesRemovedFromEnums,
+} from '../schemaComparisons';
+
+describe('CheckSchemaBackwardsCompatibility', () => {
+  const queryType = new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      field1: { type: GraphQLString },
+    }
+  });
+
+  it('should detect if a type was removed or not', () => {
+    const type1 = new GraphQLObjectType({
+      name: 'Type1',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    const type2 = new GraphQLObjectType({
+      name: 'Type2',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        type1,
+        type2,
+      ]
+    });
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        type2,
+      ]
+    });
+    expect(Array.from(findRemovedTypes(oldSchema, newSchema)))
+      .to.eql([ 'Type1 was removed' ]);
+    expect(Array.from(findRemovedTypes(oldSchema, oldSchema))).to.eql([]);
+  });
+
+  it('should detect if a type changed its type', () => {
+    const objectType = new GraphQLObjectType({
+      name: 'ObjectType',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+
+    const interfaceType1 = new GraphQLInterfaceType({
+      name: 'Type1',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    const unionType1 = new GraphQLUnionType({
+      name: 'Type1',
+      types: [ objectType ],
+      resolveType: () => null,
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        interfaceType1,
+      ]
+    });
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        unionType1,
+      ]
+    });
+    expect(Array.from(findTypesThatChangedType(oldSchema, newSchema))).to.eql(
+      [ 'Type1 changed from a GraphQLInterfaceType to a GraphQLUnionType' ]
+    );
+  });
+
+  it('should detect if a field on a type was deleted or changed type', () => {
+    const TypeA = new GraphQLObjectType({
+      name: 'TypeA',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    // logically equivalent to TypeA; findBreakingFieldChanges shouldn't
+    // treat this as differnt than TypeA
+    const TypeA2 = new GraphQLObjectType({
+      name: 'TypeA',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    const TypeB = new GraphQLObjectType({
+      name: 'TypeB',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+
+    const oldType1 = new GraphQLInterfaceType({
+      name: 'Type1',
+      fields: {
+        field1: { type: TypeA },
+        field2: { type: GraphQLString },
+        field3: { type: GraphQLString },
+        field4: { type: TypeA },
+      }
+    });
+    const newType1 = new GraphQLInterfaceType({
+      name: 'Type1',
+      fields: {
+        field1: { type: TypeA2 },
+        field3: { type: GraphQLBoolean },
+        field4: { type: TypeB },
+        field5: { type: GraphQLString },
+      }
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        oldType1,
+      ]
+    });
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        newType1,
+      ]
+    });
+
+    const expectedFieldChanges = [
+      'Type1.field2 was removed',
+      'Type1.field3 changed type from String to Boolean',
+      'Type1.field4 changed type from TypeA to TypeB',
+    ];
+    expect(Array.from(findBreakingFieldChanges(oldSchema, newSchema)))
+      .to.eql(expectedFieldChanges);
+  });
+
+  it('should detect if a type was removed from a union type', () => {
+    const type1 = new GraphQLObjectType({
+      name: 'Type1',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    // logially equivalent to type1; findTypesRemovedFromUnions should not
+    // treat this as different than type1
+    const type1a = new GraphQLObjectType({
+      name: 'Type1',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    const type2 = new GraphQLObjectType({
+      name: 'Type2',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+    const type3 = new GraphQLObjectType({
+      name: 'Type3',
+      fields: {
+        field1: { type: GraphQLString },
+      }
+    });
+
+    const oldUnionType = new GraphQLUnionType({
+      name: 'UnionType1',
+      types: [ type1, type2 ],
+      resolveType: () => null,
+    });
+    const newUnionType = new GraphQLUnionType({
+      name: 'UnionType1',
+      types: [ type1a, type3 ],
+      resolveType: () => null,
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        oldUnionType,
+      ]
+    });
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        newUnionType,
+      ]
+    });
+
+    expect(Array.from(findTypesRemovedFromUnions(oldSchema, newSchema)))
+      .to.eql([ 'Type2 was removed from union type UnionType1' ]);
+  });
+
+  it('should detect if a value was removed from an enum type', () => {
+    const oldEnumType = new GraphQLEnumType({
+      name: 'EnumType1',
+      values: {
+        VALUE0: { value: 0 },
+        VALUE1: { value: 1 },
+        VALUE2: { value: 2 },
+      }
+    });
+    const newEnumType = new GraphQLEnumType({
+      name: 'EnumType1',
+      values: {
+        VALUE0: { value: 0 },
+        VALUE2: { value: 2 },
+        VALUE3: { value: 3 },
+      }
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        oldEnumType,
+      ]
+    });
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        newEnumType,
+      ]
+    });
+
+    expect(Array.from(findValuesRemovedFromEnums(oldSchema, newSchema)))
+      .to.eql([ 'VALUE1 was removed from enum type EnumType1' ]);
+  });
+});

--- a/src/utilities/__tests__/schemaComparisons-test.js
+++ b/src/utilities/__tests__/schemaComparisons-test.js
@@ -20,10 +20,10 @@ import {
 } from '../../type';
 import {
   findBreakingChanges,
-  findBreakingFieldChanges,
+  findFieldsThatChangedType,
   findRemovedTypes,
   findTypesRemovedFromUnions,
-  findTypesThatChangedType,
+  findTypesThatChangedKind,
   findValuesRemovedFromEnums,
 } from '../schemaComparisons';
 
@@ -62,9 +62,10 @@ describe('CheckSchemaBackwardsCompatibility', () => {
         type2,
       ]
     });
-    expect(Array.from(findRemovedTypes(oldSchema, newSchema)))
-      .to.eql([ 'Type1 was removed' ]);
-    expect(Array.from(findRemovedTypes(oldSchema, oldSchema))).to.eql([]);
+    expect(findRemovedTypes(oldSchema, newSchema)).to.eql(
+      [ 'Type1 was removed' ]
+    );
+    expect(findRemovedTypes(oldSchema, oldSchema)).to.eql([]);
   });
 
   it('should detect if a type changed its type', () => {
@@ -99,7 +100,7 @@ describe('CheckSchemaBackwardsCompatibility', () => {
         unionType1,
       ]
     });
-    expect(Array.from(findTypesThatChangedType(oldSchema, newSchema))).to.eql(
+    expect(findTypesThatChangedKind(oldSchema, newSchema)).to.eql(
       [ 'Type1 changed from a GraphQLInterfaceType to a GraphQLUnionType' ]
     );
   });
@@ -163,8 +164,9 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       'Type1.field3 changed type from String to Boolean',
       'Type1.field4 changed type from TypeA to TypeB',
     ];
-    expect(Array.from(findBreakingFieldChanges(oldSchema, newSchema)))
-      .to.eql(expectedFieldChanges);
+    expect(findFieldsThatChangedType(oldSchema, newSchema)).to.eql(
+      expectedFieldChanges
+    );
   });
 
   it('should detect if a type was removed from a union type', () => {
@@ -219,8 +221,9 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       ]
     });
 
-    expect(Array.from(findTypesRemovedFromUnions(oldSchema, newSchema)))
-      .to.eql([ 'Type2 was removed from union type UnionType1' ]);
+    expect(findTypesRemovedFromUnions(oldSchema, newSchema)).to.eql(
+      [ 'Type2 was removed from union type UnionType1' ]
+    );
   });
 
   it('should detect if a value was removed from an enum type', () => {
@@ -254,8 +257,9 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       ]
     });
 
-    expect(Array.from(findValuesRemovedFromEnums(oldSchema, newSchema)))
-      .to.eql([ 'VALUE1 was removed from enum type EnumType1' ]);
+    expect(findValuesRemovedFromEnums(oldSchema, newSchema)).to.eql(
+      [ 'VALUE1 was removed from enum type EnumType1' ]
+    );
   });
 
   it('should detect all breaking changes', () => {
@@ -364,7 +368,8 @@ describe('CheckSchemaBackwardsCompatibility', () => {
       'VALUE0 was removed from enum type EnumTypeThatLosesAValue',
     ];
 
-    expect(Array.from(findBreakingChanges(oldSchema, newSchema)))
-      .to.eql(expectedBreakingChanges);
+    expect(findBreakingChanges(oldSchema, newSchema)).to.eql(
+      expectedBreakingChanges
+    );
   });
 });

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -63,6 +63,7 @@ export { assertValidName } from './assertValidName';
 
 // Helpful functions to compare two GraphQLSchemas and detect breaking changes.
 export {
+  findBreakingChanges,
   findRemovedTypes,
   findTypesThatChangedType,
   findBreakingFieldChanges,

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -61,12 +61,5 @@ export {
 // Asserts that a string is a valid GraphQL name
 export { assertValidName } from './assertValidName';
 
-// Helpful functions to compare two GraphQLSchemas and detect breaking changes.
-export {
-  findBreakingChanges,
-  findRemovedTypes,
-  findTypesThatChangedKind,
-  findFieldsThatChangedType,
-  findTypesRemovedFromUnions,
-  findValuesRemovedFromEnums,
-} from './schemaComparisons';
+// Compares two GraphQLSchemas and detects breaking changes.
+export { findBreakingChanges } from './schemaComparisons';

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -65,8 +65,8 @@ export { assertValidName } from './assertValidName';
 export {
   findBreakingChanges,
   findRemovedTypes,
-  findTypesThatChangedType,
-  findBreakingFieldChanges,
+  findTypesThatChangedKind,
+  findFieldsThatChangedType,
   findTypesRemovedFromUnions,
   findValuesRemovedFromEnums,
 } from './schemaComparisons';

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -60,3 +60,12 @@ export {
 
 // Asserts that a string is a valid GraphQL name
 export { assertValidName } from './assertValidName';
+
+// Helpful functions to compare two GraphQLSchemas and detect breaking changes.
+export {
+  findRemovedTypes,
+  findTypesThatChangedType,
+  findBreakingFieldChanges,
+  findTypesRemovedFromUnions,
+  findValuesRemovedFromEnums,
+} from './schemaComparisons';

--- a/src/utilities/schemaComparisons.js
+++ b/src/utilities/schemaComparisons.js
@@ -62,12 +62,10 @@ export function findRemovedTypes(
   const oldTypes = Object.keys(oldSchema.getTypeMap());
   const newTypes = new Set(Object.keys(newSchema.getTypeMap()));
   return oldTypes.filter(typeName => !newTypes.has(typeName)).map(
-    type => {
-      return {
-        type: BreakingChangeType.TYPE_REMOVED,
-        description: `${type} was removed`,
-      };
-    }
+    type => ({
+      type: BreakingChangeType.TYPE_REMOVED,
+      description: `${type} was removed`,
+    })
   );
 }
 
@@ -82,7 +80,7 @@ export function findTypesThatChangedKind(
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
 
-  const typesThatChangedType = [];
+  const breakingChanges = [];
   Object.keys(oldTypeMap).forEach(typeName => {
     if (!newTypeMap[typeName]) {
       return;
@@ -90,16 +88,23 @@ export function findTypesThatChangedKind(
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!(oldType instanceof newType.constructor)) {
-      typesThatChangedType.push(
+      breakingChanges.push(
         {
           type: BreakingChangeType.TYPE_CHANGED_KIND,
-          description: `${typeName} changed from a ` +
-            `${oldType.constructor.name} to a ${newType.constructor.name}`,
+          description: `${typeName} changed from ` +
+            `${prettifyTypeKind(oldType.constructor.name)} type to ` +
+            `${prettifyTypeKind(newType.constructor.name)} type`,
         }
       );
     }
   });
-  return typesThatChangedType;
+  return breakingChanges;
+}
+
+function prettifyTypeKind(typeKind: string): string {
+  const kind = typeKind.replace('GraphQL', '').replace('Type', '');
+  const article = [ 'A','E','I','O' ].includes(kind.charAt(0)) ? 'an' : 'a';
+  return article + ' ' + kind;
 }
 
 /**

--- a/src/utilities/schemaComparisons.js
+++ b/src/utilities/schemaComparisons.js
@@ -59,9 +59,9 @@ export function findRemovedTypes(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema
 ): Array<BreakingChange> {
-  const oldTypes = Object.keys(oldSchema.getTypeMap());
-  const newTypes = new Set(Object.keys(newSchema.getTypeMap()));
-  return oldTypes.filter(typeName => !newTypes.has(typeName)).map(
+  const oldTypeNames = Object.keys(oldSchema.getTypeMap());
+  const newTypes = newSchema.getTypeMap();
+  return oldTypeNames.filter(typeName => !newTypes[typeName]).map(
     type => ({
       type: BreakingChangeType.TYPE_REMOVED,
       description: `${type} was removed`,
@@ -92,8 +92,8 @@ export function findTypesThatChangedKind(
         {
           type: BreakingChangeType.TYPE_CHANGED_KIND,
           description: `${typeName} changed from ` +
-            `${prettifyTypeKind(oldType.constructor.name)} type to ` +
-            `${prettifyTypeKind(newType.constructor.name)} type`,
+            `${addArticle(oldType.constructor.prettyName)} type to ` +
+            `${addArticle(newType.constructor.prettyName)} type`,
         }
       );
     }
@@ -101,10 +101,9 @@ export function findTypesThatChangedKind(
   return breakingChanges;
 }
 
-function prettifyTypeKind(typeKind: string): string {
-  const kind = typeKind.replace('GraphQL', '').replace('Type', '');
-  const article = [ 'A','E','I','O' ].includes(kind.charAt(0)) ? 'an' : 'a';
-  return article + ' ' + kind;
+function addArticle(typeKind: string): string {
+  const article = [ 'A','E','I','O' ].includes(typeKind.charAt(0)) ? 'an' : 'a';
+  return article + ' ' + typeKind;
 }
 
 /**

--- a/src/utilities/schemaComparisons.js
+++ b/src/utilities/schemaComparisons.js
@@ -16,161 +16,142 @@ import {
   GraphQLObjectType,
   GraphQLUnionType,
 } from '../type/definition';
-import type {
-  GraphQLFieldDefinitionMap,
-  GraphQLNamedType,
-  GraphQLType,
-  InputObjectFieldMap,
-} from '../type/definition';
 import {
   GraphQLSchema,
 } from '../type/schema';
-import type {
-  TypeMap,
-} from '../type/schema';
 
 /**
- * Given two schemas, returns a Set containing descriptions of all the types of
- * breaking changes covered by the other functions down below.
+ * Given two schemas, returns an Array containing descriptions of all the types
+ * of breaking changes covered by the other functions down below.
  */
 export function findBreakingChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema
-): Set<string> {
-  return new Set([
-    ...Array.from(findRemovedTypes(oldSchema, newSchema)),
-    ...Array.from(findTypesThatChangedType(oldSchema, newSchema)),
-    ...Array.from(findBreakingFieldChanges(oldSchema, newSchema)),
-    ...Array.from(findTypesRemovedFromUnions(oldSchema, newSchema)),
-    ...Array.from(findValuesRemovedFromEnums(oldSchema, newSchema))
-  ]);
+): Array<string> {
+  return [
+    ...findRemovedTypes(oldSchema, newSchema),
+    ...findTypesThatChangedKind(oldSchema, newSchema),
+    ...findFieldsThatChangedType(oldSchema, newSchema),
+    ...findTypesRemovedFromUnions(oldSchema, newSchema),
+    ...findValuesRemovedFromEnums(oldSchema, newSchema)
+  ];
 }
 
 /**
-* Given two schemas, returns a Set containing descriptions of any breaking
-* changes in the newSchema related to removing an entire type.
-*/
+ * Given two schemas, returns an Array containing descriptions of any breaking
+ * changes in the newSchema related to removing an entire type.
+ */
 export function findRemovedTypes(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema
-): Set<string> {
-  const oldTypes: Set<string> = new Set(Object.keys(oldSchema.getTypeMap()));
-  const newTypes: Set<string> = new Set(Object.keys(newSchema.getTypeMap()));
-  const removedTypes: Set<string> = new Set(
-    Array.from(oldTypes).filter(typeName => !newTypes.has(typeName)).map(
-     type => `${type} was removed`
-    )
+): Array<string> {
+  const oldTypes = Object.keys(oldSchema.getTypeMap());
+  const newTypes = new Set(Object.keys(newSchema.getTypeMap()));
+  return oldTypes.filter(typeName => !newTypes.has(typeName)).map(
+    type => `${type} was removed`
   );
-  return removedTypes;
 }
 
 /**
-* Given two schemas, returns a Set containing descriptions of any breaking
-* changes in the newSchema related to changing the type of a type.
-*/
-export function findTypesThatChangedType(
+ * Given two schemas, returns an Array containing descriptions of any breaking
+ * changes in the newSchema related to changing the type of a type.
+ */
+export function findTypesThatChangedKind(
  oldSchema: GraphQLSchema,
  newSchema: GraphQLSchema
-): Set<string> {
-  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
-  const newTypeMap: TypeMap = newSchema.getTypeMap();
+): Array<string> {
+  const oldTypeMap = oldSchema.getTypeMap();
+  const newTypeMap = newSchema.getTypeMap();
 
-  const typesThatChangedType: Array<string> = [];
-  for (const typeName: string in oldTypeMap) {
+  const typesThatChangedType = [];
+  Object.keys(oldTypeMap).forEach(typeName => {
     if (!newTypeMap[typeName]) {
-      continue;
+      return;
     }
-    const oldType: GraphQLType = oldTypeMap[typeName];
-    const newType: GraphQLType = newTypeMap[typeName];
+    const oldType = oldTypeMap[typeName];
+    const newType = newTypeMap[typeName];
     if (!(oldType instanceof newType.constructor)) {
       typesThatChangedType.push(`${typeName} changed from a ` +
         `${oldType.constructor.name} to a ${newType.constructor.name}`);
     }
-  }
-  return new Set(typesThatChangedType);
+  });
+  return typesThatChangedType;
 }
 
 /**
-* Given two schemas, returns a Set containing descriptions of any breaking
-* changes in the newSchema related to the fields on a type. This includes if
-* a field has been removed from a type or if a field has changed type.
-*/
-export function findBreakingFieldChanges(
+ * Given two schemas, returns an Array containing descriptions of any breaking
+ * changes in the newSchema related to the fields on a type. This includes if
+ * a field has been removed from a type or if a field has changed type.
+ */
+export function findFieldsThatChangedType(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema
-): Set<string> {
-  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
-  const newTypeMap: TypeMap = newSchema.getTypeMap();
+): Array<string> {
+  const oldTypeMap = oldSchema.getTypeMap();
+  const newTypeMap = newSchema.getTypeMap();
 
-  const breakingFieldChanges: Array<string> = [];
-  for (const typeName: string in oldTypeMap) {
-    if (!{}.hasOwnProperty.call(oldTypeMap,typeName)) {
-      continue;
-    }
-    const oldType:GraphQLType = oldTypeMap[typeName];
-    const newType:GraphQLType = newTypeMap[typeName];
+  const breakingFieldChanges = [];
+  Object.keys(oldTypeMap).forEach(typeName => {
+    const oldType = oldTypeMap[typeName];
+    const newType = newTypeMap[typeName];
     if (
       !(oldType instanceof GraphQLObjectType ||
         oldType instanceof GraphQLInterfaceType ||
         oldType instanceof GraphQLInputObjectType) ||
       !(newType instanceof oldType.constructor)
     ) {
-      continue;
+      return;
     }
 
-    const oldTypeFieldsDef: InputObjectFieldMap | GraphQLFieldDefinitionMap =
-      oldType.getFields();
-    const newTypeFieldsDef: InputObjectFieldMap | GraphQLFieldDefinitionMap =
-      newType.getFields();
-    for (const fieldName: string in oldTypeFieldsDef) {
+    const oldTypeFieldsDef = oldType.getFields();
+    const newTypeFieldsDef = newType.getFields();
+    Object.keys(oldTypeFieldsDef).forEach(fieldName => {
       // Check if the field is missing on the type in the new schema.
       if (!(fieldName in newTypeFieldsDef)) {
         breakingFieldChanges.push(`${typeName}.${fieldName} was removed`);
       } else {
         // Check if the field's type has changed in the new schema.
-        const oldFieldType: ?GraphQLNamedType =
-          getNamedType(oldTypeFieldsDef[fieldName].type);
-        const newFieldType: ?GraphQLNamedType =
-          getNamedType(newTypeFieldsDef[fieldName].type);
+        const oldFieldType = getNamedType(oldTypeFieldsDef[fieldName].type);
+        const newFieldType = getNamedType(newTypeFieldsDef[fieldName].type);
         if (
           oldFieldType && newFieldType &&
           (oldFieldType.name !== newFieldType.name)
         ) {
-          breakingFieldChanges.push(`${typeName}.${fieldName} changed type ` +
-            `from ${oldFieldType.name} to ${newFieldType.name}`);
+          breakingFieldChanges.push(
+            `${typeName}.${fieldName} changed type from ${oldFieldType.name} ` +
+            `to ${newFieldType.name}`
+          );
         }
       }
-    }
-  }
-  return new Set(breakingFieldChanges);
+    });
+  });
+  return breakingFieldChanges;
 }
 
 /**
-* Given two schemas, returns a Set containing descriptions of any breaking
-* changes in the newSchema related to removing types from a union type.
-*/
+ * Given two schemas, returns an Array containing descriptions of any breaking
+ * changes in the newSchema related to removing types from a union type.
+ */
 export function findTypesRemovedFromUnions(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema
-): Set<string> {
-  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
-  const newTypeMap: TypeMap = newSchema.getTypeMap();
+): Array<string> {
+  const oldTypeMap = oldSchema.getTypeMap();
+  const newTypeMap = newSchema.getTypeMap();
 
-  const typesRemovedFromUnion: Array<string> = [];
-  for (const typeName: string in oldTypeMap) {
-    if (!{}.hasOwnProperty.call(oldTypeMap,typeName)) {
-      continue;
-    }
-    const oldType: GraphQLType = oldTypeMap[typeName];
-    const newType: GraphQLType = newTypeMap[typeName];
+  const typesRemovedFromUnion = [];
+  Object.keys(oldTypeMap).forEach(typeName => {
+    const oldType = oldTypeMap[typeName];
+    const newType = newTypeMap[typeName];
     if (
       !(oldType instanceof GraphQLUnionType) ||
       !(newType instanceof GraphQLUnionType)
     ) {
-      continue;
+      return;
     }
-    const typeNamesInNewUnion: Set<string> =
-      new Set(newType.getTypes().map(type => type.name));
+    const typeNamesInNewUnion = new Set(
+      newType.getTypes().map(type => type.name)
+    );
     oldType.getTypes().forEach(typeInOldUnion => {
       if (!typeNamesInNewUnion.has(typeInOldUnion.name)) {
         typesRemovedFromUnion.push(
@@ -178,36 +159,34 @@ export function findTypesRemovedFromUnions(
         );
       }
     });
-  }
-  return new Set(typesRemovedFromUnion);
+  });
+  return typesRemovedFromUnion;
 }
 
 /**
-* Given two schemas, returns a Set containing descriptions of any breaking
-* changes in the newSchema related to removing values from an enum type.
-*/
+ * Given two schemas, returns an Array containing descriptions of any breaking
+ * changes in the newSchema related to removing values from an enum type.
+ */
 export function findValuesRemovedFromEnums(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema
-): Set<string> {
-  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
-  const newTypeMap: TypeMap = newSchema.getTypeMap();
+): Array<string> {
+  const oldTypeMap = oldSchema.getTypeMap();
+  const newTypeMap = newSchema.getTypeMap();
 
-  const valuesRemovedFromEnums: Array<string> = [];
-  for (const typeName: string in oldTypeMap) {
-    if (!{}.hasOwnProperty.call(oldTypeMap,typeName)) {
-      continue;
-    }
-    const oldType: GraphQLType = oldTypeMap[typeName];
-    const newType: GraphQLType = newTypeMap[typeName];
+  const valuesRemovedFromEnums = [];
+  Object.keys(oldTypeMap).forEach(typeName => {
+    const oldType = oldTypeMap[typeName];
+    const newType = newTypeMap[typeName];
     if (
       !(oldType instanceof GraphQLEnumType) ||
       !(newType instanceof GraphQLEnumType)
     ) {
-      continue;
+      return;
     }
-    const valuesInNewEnum: Set<string> =
-      new Set(newType.getValues().map(value => value.name));
+    const valuesInNewEnum = new Set(
+      newType.getValues().map(value => value.name)
+    );
     oldType.getValues().forEach(valueInOldEnum => {
       if (!valuesInNewEnum.has(valueInOldEnum.name)) {
         valuesRemovedFromEnums.push(
@@ -215,6 +194,6 @@ export function findValuesRemovedFromEnums(
         );
       }
     });
-  }
-  return new Set(valuesRemovedFromEnums);
+  });
+  return valuesRemovedFromEnums;
 }

--- a/src/utilities/schemaComparisons.js
+++ b/src/utilities/schemaComparisons.js
@@ -30,6 +30,23 @@ import type {
 } from '../type/schema';
 
 /**
+ * Given two schemas, returns a Set containing descriptions of all the types of
+ * breaking changes covered by the other functions down below.
+ */
+export function findBreakingChanges(
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema
+): Set<string> {
+  return new Set([
+    ...Array.from(findRemovedTypes(oldSchema, newSchema)),
+    ...Array.from(findTypesThatChangedType(oldSchema, newSchema)),
+    ...Array.from(findBreakingFieldChanges(oldSchema, newSchema)),
+    ...Array.from(findTypesRemovedFromUnions(oldSchema, newSchema)),
+    ...Array.from(findValuesRemovedFromEnums(oldSchema, newSchema))
+  ]);
+}
+
+/**
 * Given two schemas, returns a Set containing descriptions of any breaking
 * changes in the newSchema related to removing an entire type.
 */

--- a/src/utilities/schemaComparisons.js
+++ b/src/utilities/schemaComparisons.js
@@ -1,0 +1,203 @@
+/* @flow */
+/**
+ *  Copyright (c) 2016, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import {
+  getNamedType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from '../type/definition';
+import type {
+  GraphQLFieldDefinitionMap,
+  GraphQLNamedType,
+  GraphQLType,
+  InputObjectFieldMap,
+} from '../type/definition';
+import {
+  GraphQLSchema,
+} from '../type/schema';
+import type {
+  TypeMap,
+} from '../type/schema';
+
+/**
+* Given two schemas, returns a Set containing descriptions of any breaking
+* changes in the newSchema related to removing an entire type.
+*/
+export function findRemovedTypes(
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema
+): Set<string> {
+  const oldTypes: Set<string> = new Set(Object.keys(oldSchema.getTypeMap()));
+  const newTypes: Set<string> = new Set(Object.keys(newSchema.getTypeMap()));
+  const removedTypes: Set<string> = new Set(
+    Array.from(oldTypes).filter(typeName => !newTypes.has(typeName)).map(
+     type => `${type} was removed`
+    )
+  );
+  return removedTypes;
+}
+
+/**
+* Given two schemas, returns a Set containing descriptions of any breaking
+* changes in the newSchema related to changing the type of a type.
+*/
+export function findTypesThatChangedType(
+ oldSchema: GraphQLSchema,
+ newSchema: GraphQLSchema
+): Set<string> {
+  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
+  const newTypeMap: TypeMap = newSchema.getTypeMap();
+
+  const typesThatChangedType: Array<string> = [];
+  for (const typeName: string in oldTypeMap) {
+    if (!newTypeMap[typeName]) {
+      continue;
+    }
+    const oldType: GraphQLType = oldTypeMap[typeName];
+    const newType: GraphQLType = newTypeMap[typeName];
+    if (!(oldType instanceof newType.constructor)) {
+      typesThatChangedType.push(`${typeName} changed from a ` +
+        `${oldType.constructor.name} to a ${newType.constructor.name}`);
+    }
+  }
+  return new Set(typesThatChangedType);
+}
+
+/**
+* Given two schemas, returns a Set containing descriptions of any breaking
+* changes in the newSchema related to the fields on a type. This includes if
+* a field has been removed from a type or if a field has changed type.
+*/
+export function findBreakingFieldChanges(
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema
+): Set<string> {
+  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
+  const newTypeMap: TypeMap = newSchema.getTypeMap();
+
+  const breakingFieldChanges: Array<string> = [];
+  for (const typeName: string in oldTypeMap) {
+    if (!{}.hasOwnProperty.call(oldTypeMap,typeName)) {
+      continue;
+    }
+    const oldType:GraphQLType = oldTypeMap[typeName];
+    const newType:GraphQLType = newTypeMap[typeName];
+    if (
+      !(oldType instanceof GraphQLObjectType ||
+        oldType instanceof GraphQLInterfaceType ||
+        oldType instanceof GraphQLInputObjectType) ||
+      !(newType instanceof oldType.constructor)
+    ) {
+      continue;
+    }
+
+    const oldTypeFieldsDef: InputObjectFieldMap | GraphQLFieldDefinitionMap =
+      oldType.getFields();
+    const newTypeFieldsDef: InputObjectFieldMap | GraphQLFieldDefinitionMap =
+      newType.getFields();
+    for (const fieldName: string in oldTypeFieldsDef) {
+      // Check if the field is missing on the type in the new schema.
+      if (!(fieldName in newTypeFieldsDef)) {
+        breakingFieldChanges.push(`${typeName}.${fieldName} was removed`);
+      } else {
+        // Check if the field's type has changed in the new schema.
+        const oldFieldType: ?GraphQLNamedType =
+          getNamedType(oldTypeFieldsDef[fieldName].type);
+        const newFieldType: ?GraphQLNamedType =
+          getNamedType(newTypeFieldsDef[fieldName].type);
+        if (
+          oldFieldType && newFieldType &&
+          (oldFieldType.name !== newFieldType.name)
+        ) {
+          breakingFieldChanges.push(`${typeName}.${fieldName} changed type ` +
+            `from ${oldFieldType.name} to ${newFieldType.name}`);
+        }
+      }
+    }
+  }
+  return new Set(breakingFieldChanges);
+}
+
+/**
+* Given two schemas, returns a Set containing descriptions of any breaking
+* changes in the newSchema related to removing types from a union type.
+*/
+export function findTypesRemovedFromUnions(
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema
+): Set<string> {
+  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
+  const newTypeMap: TypeMap = newSchema.getTypeMap();
+
+  const typesRemovedFromUnion: Array<string> = [];
+  for (const typeName: string in oldTypeMap) {
+    if (!{}.hasOwnProperty.call(oldTypeMap,typeName)) {
+      continue;
+    }
+    const oldType: GraphQLType = oldTypeMap[typeName];
+    const newType: GraphQLType = newTypeMap[typeName];
+    if (
+      !(oldType instanceof GraphQLUnionType) ||
+      !(newType instanceof GraphQLUnionType)
+    ) {
+      continue;
+    }
+    const typeNamesInNewUnion: Set<string> =
+      new Set(newType.getTypes().map(type => type.name));
+    oldType.getTypes().forEach(typeInOldUnion => {
+      if (!typeNamesInNewUnion.has(typeInOldUnion.name)) {
+        typesRemovedFromUnion.push(
+          `${typeInOldUnion.name} was removed from union type ${typeName}`
+        );
+      }
+    });
+  }
+  return new Set(typesRemovedFromUnion);
+}
+
+/**
+* Given two schemas, returns a Set containing descriptions of any breaking
+* changes in the newSchema related to removing values from an enum type.
+*/
+export function findValuesRemovedFromEnums(
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema
+): Set<string> {
+  const oldTypeMap: TypeMap = oldSchema.getTypeMap();
+  const newTypeMap: TypeMap = newSchema.getTypeMap();
+
+  const valuesRemovedFromEnums: Array<string> = [];
+  for (const typeName: string in oldTypeMap) {
+    if (!{}.hasOwnProperty.call(oldTypeMap,typeName)) {
+      continue;
+    }
+    const oldType: GraphQLType = oldTypeMap[typeName];
+    const newType: GraphQLType = newTypeMap[typeName];
+    if (
+      !(oldType instanceof GraphQLEnumType) ||
+      !(newType instanceof GraphQLEnumType)
+    ) {
+      continue;
+    }
+    const valuesInNewEnum: Set<string> =
+      new Set(newType.getValues().map(value => value.name));
+    oldType.getValues().forEach(valueInOldEnum => {
+      if (!valuesInNewEnum.has(valueInOldEnum.name)) {
+        valuesRemovedFromEnums.push(
+          `${valueInOldEnum.name} was removed from enum type ${typeName}`
+        );
+      }
+    });
+  }
+  return new Set(valuesRemovedFromEnums);
+}


### PR DESCRIPTION
This PR introduces some checks that can be used to help verify if changes to a schema are "safe". The idea is that you generate a `GraphQLSchema` object that represents the schema before and after a schema change (for example by using `buildClientSchema`). You can then pass the `oldSchema` and `newSchema` into these utility functions. The functions each check for different types of breaking changes, i.e. changes in the `newSchema` that are not backwards compatible with `oldSchema`. They can be used to help prevent regressions caused by unsafe schema changes that would break older versions of clients.