### PR TITLE
Allow resolveType to return a type name string

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -903,9 +903,14 @@ function completeAbstractValue(
   path: Array<string | number>,
   result: mixed
 ): mixed {
-  const runtimeType = returnType.resolveType ?
+  let runtimeType = returnType.resolveType ?
     returnType.resolveType(result, exeContext.contextValue, info) :
     defaultResolveTypeFn(result, exeContext.contextValue, info, returnType);
+
+  // If resolveType returns a string, we assume it's a GraphQLObjectType name.
+  if (typeof runtimeType === 'string') {
+    runtimeType = exeContext.schema.getType(runtimeType);
+  }
 
   if (!(runtimeType instanceof GraphQLObjectType)) {
     throw new GraphQLError(

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -471,7 +471,7 @@ export type GraphQLTypeResolveFn = (
   value: mixed,
   context: mixed,
   info: GraphQLResolveInfo
-) => ?GraphQLObjectType;
+) => ?GraphQLObjectType | ?string;
 
 export type GraphQLIsTypeOfFn = (
   source: mixed,


### PR DESCRIPTION
This change permits `resolveType` functions to return the "name" string of a type definition rather than the concrete `GraphQLObjectType` instance. 

This is particularly useful when the `resolveType` function doesn't have access to the type instances in the immediate closure scope. While it's possible to accomplish the same with `info.schema.getType` in the resolve function, being able to return a string and have the executor figure it out felt a bit nicer.

Example:
```js
const PetType = new GraphQLInterfaceType({
  name: 'Pet',
  resolveType(obj) {
    return obj instanceof Dog ? 'Dog' :
      obj instanceof Cat ? 'Cat' :
      null;
  },
  fields: {
    name: { type: GraphQLString }
  }
});
```

