### PR TITLE
Allow Travis CI's IRC bot to post without joining

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ notifications:
     use_notice: true
     on_success: change
     on_failure: change
+    skip_join: true
     channels:
       - "chat.freenode.net#graphql"
   slack:


### PR DESCRIPTION
This removes the `join` / `part` steps of this:

<img width="901" alt="screen shot 2016-10-11 at 13 27 18" src="https://cloud.githubusercontent.com/assets/113730/19294997/6eab6ed2-8fff-11e6-9fbb-41b306b22e1b.png">

See https://docs.travis-ci.com/user/notifications#IRC-notification for more information.

Note that this requires removing the `n` flag on the IRC channel.
See https://freenode.net/kb/answer/channelmodes

> n (prevent external send): Users outside the channel may not send messages to it. Keep in mind that bans and quiets will not apply to external users.

Apologies if this was already suggested and declined in the past, I did not find this on the closed PRs or issues.