### PR TITLE
add ‘GraphQL’ prefix to input object types

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -891,7 +891,7 @@ export class GraphQLInputObjectType {
   description: ?string;
 
   _typeConfig: GraphQLInputObjectTypeConfig;
-  _fields: GraphQLInputFieldMap;
+  _fields: GraphQLInputFieldDefinitionMap;
 
   constructor(config: GraphQLInputObjectTypeConfig) {
     invariant(config.name, 'Type must be named.');

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -890,10 +890,10 @@ export class GraphQLInputObjectType {
   name: string;
   description: ?string;
 
-  _typeConfig: GraphQLInputObjectConfig;
-  _fields: GraphQLInputObjectFieldMap;
+  _typeConfig: GraphQLInputObjectTypeConfig;
+  _fields: GraphQLInputFieldMap;
 
-  constructor(config: GraphQLInputObjectConfig) {
+  constructor(config: GraphQLInputObjectTypeConfig) {
     invariant(config.name, 'Type must be named.');
     assertValidName(config.name);
     this.name = config.name;
@@ -901,11 +901,11 @@ export class GraphQLInputObjectType {
     this._typeConfig = config;
   }
 
-  getFields(): GraphQLInputObjectFieldMap {
+  getFields(): GraphQLInputFieldDefinitionMap {
     return this._fields || (this._fields = this._defineFieldMap());
   }
 
-  _defineFieldMap(): GraphQLInputObjectFieldMap {
+  _defineFieldMap(): GraphQLInputFieldDefinitionMap {
     const fieldMap: any = resolveThunk(this._typeConfig.fields);
     invariant(
       isPlainObj(fieldMap),
@@ -940,31 +940,31 @@ export class GraphQLInputObjectType {
   }
 }
 
-export type GraphQLInputObjectConfig = {
+export type GraphQLInputObjectTypeConfig = {
   name: string;
-  fields: Thunk<GraphQLInputObjectConfigFieldMap>;
+  fields: Thunk<GraphQLInputFieldConfigMap>;
   description?: ?string;
 };
 
-export type GraphQLInputObjectFieldConfig = {
+export type GraphQLInputFieldConfig = {
   type: GraphQLInputType;
   defaultValue?: mixed;
   description?: ?string;
 };
 
-export type GraphQLInputObjectConfigFieldMap = {
-  [fieldName: string]: GraphQLInputObjectFieldConfig;
+export type GraphQLInputFieldConfigMap = {
+  [fieldName: string]: GraphQLInputFieldConfig;
 };
 
-export type GraphQLInputObjectField = {
+export type GraphQLInputFieldDefinition = {
   name: string;
   type: GraphQLInputType;
   defaultValue?: mixed;
   description?: ?string;
 };
 
-export type GraphQLInputObjectFieldMap = {
-  [fieldName: string]: GraphQLInputObjectField;
+export type GraphQLInputFieldDefinitionMap = {
+  [fieldName: string]: GraphQLInputFieldDefinition;
 };
 
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -890,10 +890,10 @@ export class GraphQLInputObjectType {
   name: string;
   description: ?string;
 
-  _typeConfig: InputObjectConfig;
-  _fields: InputObjectFieldMap;
+  _typeConfig: GraphQLInputObjectConfig;
+  _fields: GraphQLInputObjectFieldMap;
 
-  constructor(config: InputObjectConfig) {
+  constructor(config: GraphQLInputObjectConfig) {
     invariant(config.name, 'Type must be named.');
     assertValidName(config.name);
     this.name = config.name;
@@ -901,11 +901,11 @@ export class GraphQLInputObjectType {
     this._typeConfig = config;
   }
 
-  getFields(): InputObjectFieldMap {
+  getFields(): GraphQLInputObjectFieldMap {
     return this._fields || (this._fields = this._defineFieldMap());
   }
 
-  _defineFieldMap(): InputObjectFieldMap {
+  _defineFieldMap(): GraphQLInputObjectFieldMap {
     const fieldMap: any = resolveThunk(this._typeConfig.fields);
     invariant(
       isPlainObj(fieldMap),
@@ -940,31 +940,31 @@ export class GraphQLInputObjectType {
   }
 }
 
-export type InputObjectConfig = {
+export type GraphQLInputObjectConfig = {
   name: string;
-  fields: Thunk<InputObjectConfigFieldMap>;
+  fields: Thunk<GraphQLInputObjectConfigFieldMap>;
   description?: ?string;
 };
 
-export type InputObjectFieldConfig = {
+export type GraphQLInputObjectFieldConfig = {
   type: GraphQLInputType;
   defaultValue?: mixed;
   description?: ?string;
 };
 
-export type InputObjectConfigFieldMap = {
-  [fieldName: string]: InputObjectFieldConfig;
+export type GraphQLInputObjectConfigFieldMap = {
+  [fieldName: string]: GraphQLInputObjectFieldConfig;
 };
 
-export type InputObjectField = {
+export type GraphQLInputObjectField = {
   name: string;
   type: GraphQLInputType;
   defaultValue?: mixed;
   description?: ?string;
 };
 
-export type InputObjectFieldMap = {
-  [fieldName: string]: InputObjectField;
+export type GraphQLInputObjectFieldMap = {
+  [fieldName: string]: GraphQLInputObjectField;
 };
 
 


### PR DESCRIPTION
Types with names like `InputObjectConfig` are inconsistent with all other type names. This makes the types awkward to import and use. This may be considered a breaking change (although I’d venture to believe very few people if any are importing this specific file to get at the types). If you’d like to mitigate breakage we could re-export aliases like so:

```js
export type InputObjectConfig = GraphQLInputObjectTypeConfig
```