### PR TITLE
Export default resolve function

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -1006,7 +1006,7 @@ function defaultResolveTypeFn(
  * and returns it as the result, or if it's a function, returns the result
  * of calling that function while passing along args and context.
  */
-function defaultResolveFn(source: any, args, context, { fieldName }) {
+export function defaultResolveFn(source: any, args, context, { fieldName }) {
   // ensure source is a value for which property access is acceptable.
   if (typeof source === 'object' || typeof source === 'function') {
     const property = source[fieldName];

--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -7,4 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-export { execute } from './execute';
+export {
+  execute,
+  defaultResolveFn,
+} from './execute';

--- a/src/index.js
+++ b/src/index.js
@@ -130,6 +130,7 @@ export {
 // Execute GraphQL queries.
 export {
   execute,
+  defaultResolveFn,
 } from './execution';
 
 


### PR DESCRIPTION
Right now we have several tools which wrap resolvers in some way, and they currently need to have a local copy of the default resolve function. It would be great to be able to use the one from inside this package instead!
