### PR TITLE
Initial proposal for the experimental GraphQLDateTime scalar

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "prepublish": ". ./resources/prepublish.sh"
   },
   "dependencies": {
-    "iterall": "1.0.2",
-    "moment": "^2.15.2"
+    "iterall": "1.0.2"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "prepublish": ". ./resources/prepublish.sh"
   },
   "dependencies": {
-    "iterall": "1.0.2"
+    "iterall": "1.0.2",
+    "moment": "^2.15.2"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,7 @@ export {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
+  GraphQLDateTime,
 
   // Built-in Directives defined by the Spec
   specifiedDirectives,

--- a/src/type/__tests__/serialization-test.js
+++ b/src/type/__tests__/serialization-test.js
@@ -236,7 +236,7 @@ describe('Type System: Scalar coercion', () => {
       '2000-02-29',
       // Datetime with hours and minutes
       '2016-02-01T00:00Z',
-      '2016-02-01T24:00Z',
+      '2016-02-01T23:00Z',
       '2016-02-01T23:59Z',
       '2016-02-01T15:32Z',
       // Datetime with hours, minutes and seconds
@@ -280,6 +280,7 @@ describe('Type System: Scalar coercion', () => {
       '2016-02-01T00:0Z',
       '2015-02-29T00:00Z',
       '2016-02-01T0000',
+      '2016-02-02T24:00Z',
       // Datetime with hours, minutes and seconds
       '2016-02-01T000059Z',
       '2016-02-01T00:00:60Z',
@@ -355,7 +356,7 @@ describe('Type System: Scalar coercion', () => {
       [ '2000-02-29', new Date(Date.UTC(2000, 1, 29)) ],
       // Datetime with hours and minutes
       [ '2016-02-01T00:00Z', new Date(Date.UTC(2016, 1, 1, 0, 0)) ],
-      [ '2016-02-01T24:00Z', new Date(Date.UTC(2016, 1, 2, 0, 0)) ],
+      [ '2016-02-01T23:00Z', new Date(Date.UTC(2016, 1, 1, 23, 0)) ],
       [ '2016-02-01T23:59Z', new Date(Date.UTC(2016, 1, 1, 23, 59)) ],
       [ '2016-02-01T15:32Z', new Date(Date.UTC(2016, 1, 1, 15, 32)) ],
       // Datetime with hours, minutes and seconds
@@ -423,6 +424,7 @@ describe('Type System: Scalar coercion', () => {
       '2016-02-01T00:0Z',
       '2015-02-29T00:00Z',
       '2016-02-01T0000',
+      '2016-02-02T24:00Z',
       // Datetime with hours, minutes and seconds
       '2016-02-01T000059Z',
       '2016-02-01T00:00:60Z',
@@ -465,7 +467,7 @@ describe('Type System: Scalar coercion', () => {
       [ '2000-02-29', new Date(Date.UTC(2000, 1, 29)) ],
       // Datetime with hours and minutes
       [ '2016-02-01T00:00Z', new Date(Date.UTC(2016, 1, 1, 0, 0)) ],
-      [ '2016-02-01T24:00Z', new Date(Date.UTC(2016, 1, 2, 0, 0)) ],
+      [ '2016-02-01T23:00Z', new Date(Date.UTC(2016, 1, 1, 23, 0)) ],
       [ '2016-02-01T23:59Z', new Date(Date.UTC(2016, 1, 1, 23, 59)) ],
       [ '2016-02-01T15:32Z', new Date(Date.UTC(2016, 1, 1, 15, 32)) ],
       // Datetime with hours, minutes and seconds
@@ -520,6 +522,7 @@ describe('Type System: Scalar coercion', () => {
       '2016-02-01T00:0Z',
       '2015-02-29T00:00Z',
       '2016-02-01T0000',
+      '2016-02-02T24:00Z',
       // Datetime with hours, minutes and seconds
       '2016-02-01T000059Z',
       '2016-02-01T00:00:60Z',

--- a/src/type/__tests__/serialization-test.js
+++ b/src/type/__tests__/serialization-test.js
@@ -11,11 +11,13 @@ import {
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
-  GraphQLBoolean
+  GraphQLBoolean,
+  GraphQLDateTime
 } from '../';
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import * as Kind from '../../language/kinds';
 
 
 describe('Type System: Scalar coercion', () => {
@@ -176,5 +178,101 @@ describe('Type System: Scalar coercion', () => {
     expect(
       GraphQLBoolean.serialize(false)
     ).to.equal(false);
+  });
+
+  it('serializes output DateTime', () => {
+    expect(
+      GraphQLDateTime.serialize(new Date(Date.UTC(2016, 0, 1)))
+    ).to.equal('2016-01-01T00:00:00.000Z');
+    expect(
+      GraphQLDateTime.serialize(new Date(Date.UTC(2016, 0, 1, 14, 48, 10, 3)))
+    ).to.equal('2016-01-01T14:48:10.003Z');
+    expect(() =>
+      GraphQLDateTime.serialize('2016-01-01T14:48:10.003Z')
+    ).to.throw(
+      'DateTime cannot be serialized from a non Date ' +
+      'type 2016-01-01T14:48:10.003Z'
+    );
+    expect(() =>
+      GraphQLDateTime.serialize(75683393)
+    ).to.throw(
+      'DateTime cannot be serialized from a non Date type 75683393'
+    );
+    expect(() =>
+      GraphQLDateTime.serialize(new Date('wrong date'))
+    ).to.throw(
+      'DateTime cannot represent an invalid date'
+    );
+  });
+
+  it('parses input DateTime', () => {
+
+    [
+      [ '2016', new Date(Date.UTC(2016, 0)) ],
+      [ '2016-11', new Date(Date.UTC(2016, 10)) ],
+      [ '2016-11-05', new Date(Date.UTC(2016, 10, 5)) ],
+      [ '20161105', new Date(Date.UTC(2016, 10, 5)) ],
+      [ '2016-W44', new Date(Date.UTC(2016, 9, 31)) ],
+      [ '2016W44', new Date(Date.UTC(2016, 9, 31)) ],
+      [ '2016-W44-6', new Date(Date.UTC(2016, 10, 5)) ],
+      [ '2016W446', new Date(Date.UTC(2016, 10, 5)) ],
+      [ '2016-310', new Date(Date.UTC(2016, 10, 5)) ],
+      [ '2016310', new Date(Date.UTC(2016, 10, 5)) ],
+      [ '2016-01-01T10Z', new Date(Date.UTC(2016, 0, 1, 10)) ],
+      [ '2016-01-01T10:10Z', new Date(Date.UTC(2016, 0, 1, 10, 10)) ],
+      [ '2016-01-01T1010Z', new Date(Date.UTC(2016, 0, 1, 10, 10)) ],
+      [ '2016-01-01T10:10:10Z', new Date(Date.UTC(2016, 0, 1, 10, 10, 10)) ],
+      [ '2016-01-01T101010Z',
+        new Date(Date.UTC(2016, 0, 1, 10, 10, 10)) ],
+      [ '2016-01-01T10:10:10.321Z',
+        new Date(Date.UTC(2016, 0, 1, 10, 10, 10, 321)) ],
+      [ '2016-01-01T101010.321Z',
+        new Date(Date.UTC(2016, 0, 1, 10, 10, 10, 321)) ]
+    ].forEach(([ value, expected ]) => {
+      expect(
+        GraphQLDateTime.parseValue(value).getTime()
+      ).to.equal(expected.getTime());
+    });
+
+    expect(() =>
+      GraphQLDateTime.parseValue(75683393)
+    ).to.throw(
+      'DateTime cannot represent non string type 75683393'
+    );
+
+    [
+      '01-01-2016',
+      '201611',
+      '2016-W44-8',
+      '2015-02-29',
+      '2016-01-01T101010.321'
+    ].forEach(dateString => {
+      expect(() =>
+        GraphQLDateTime.parseValue(dateString)
+      ).to.throw(
+        'DateTime cannot represent an invalid ISO 8601 date ' + dateString
+      );
+    });
+  });
+
+  it('parses literal DateTime', () => {
+
+    expect(
+      GraphQLDateTime.parseLiteral({
+        kind: Kind.STRING, value: '2016-01-01T101010.321Z'
+      }).getTime()
+    ).to.equal(
+      new Date(Date.UTC(2016, 0, 1, 10, 10, 10, 321)).getTime()
+    );
+    expect(
+      GraphQLDateTime.parseLiteral({
+        kind: Kind.FLOAT, value: 5
+      })
+    ).to.equal(null);
+    expect(
+      GraphQLDateTime.parseLiteral({
+        kind: Kind.STRING, value: '2015-02-29'
+      })
+    ).to.equal(null);
   });
 });

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -59,6 +59,7 @@ export {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
+  GraphQLDateTime
 } from './scalars';
 
 export {

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -59,7 +59,7 @@ export {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
-  GraphQLDateTime
+  GraphQLDateTime,
 } from './scalars';
 
 export {

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -155,12 +155,25 @@ function isValidDate(datestring: string): boolean {
     return false;
   }
 
-  // Perform specific checks for dates. We need
+  // Perform specific checks for the hours in datetimes
+  // (i.e. datetimes that incude YYYY-MM-DDThh). We need
+  // to make sure that the number of hours in a day ranges
+  // from 0 to 23. This needs to be done because node v6 and above
+  // support the hour range 0-24 while other node versions only support
+  // range 0 to 23. We need to keep this consistent across node versions.
+  if (datestring.length >= 13) {
+    const hour = Number(datestring.substr(11,2));
+    if (hour > 23) {
+      return false;
+    }
+  }
+
+  // Perform specific checks for dates (i.e. that include
+  // YYYY-MM-DD). We need
   // to make sure that the date string has the correct
   // number of days for a given month. This check is required
   // because the javascript Date.parse() assumes every month has 31 days.
-  const regexYYYYMM = /\d{4}-\d{2}-\d{2}/;
-  if (regexYYYYMM.test(datestring)) {
+  if (datestring.length >= 10) {
     const year = Number(datestring.substr(0,4));
     const month = Number(datestring.substr(5,2));
     const day = Number(datestring.substr(8,2));
@@ -181,10 +194,9 @@ function isValidDate(datestring: string): boolean {
           return false;
         }
         break;
-      default:
-        return true;
     }
   }
+
   // Every year that is exactly divisible by four
   // is a leap year, except for years that are exactly
   // divisible by 100, but these centurial years are


### PR DESCRIPTION
This PR contains an initial proposal for a graphQL `DateTime` scalar following the discussion in issue #550. Let me know what you think:)

**The scalar has the following properties:**

- It follows the **ISO 8601** date specification. 
- All dates are represented in **UTC**.
- It **serializes javascript Date instances into ISO 8601 date strings** in the format `YYYY-MM-DDThh:mm:ss.sssZ`.
- It **parses date strings into javascript Date instances**. The following formats are supported for the date strings: 

```
'YYYY',
'YYYY-MM',
'YYYY-MM-DD',
'YYYYMMDD',
'YYYY-MM-DDThhZ',
'YYYY-MM-DDThh:mmZ',
'YYYY-MM-DDThhmmZ',
'YYYY-MM-DDThh:mm:ssZ',
'YYYY-MM-DDThhmmssZ',
'YYYY-MM-DDThh:mm:ss.sssZ',
'YYYY-MM-DDThhmmss.sssZ',
'YYYY-Www',
'YYYYWww',
'YYYY-Www-D',
'YYYYWwwD',
'YYYY-DDD',
'YYYYDDD'
```

- I had to include `moment` as a dependency in order to perform all the date operations.

> The list of supported date formats was retrieved from [wikipedia](https://en.wikipedia.org/wiki/ISO_8601).

> On wikipedia they mentioned that `±YYYYY` is used _"To represent years before 0000 or after 9999, the standard also permits the expansion of the year representation but only by prior agreement between the sender and the receiver."_. From this description I concluded that this format is not in the standard ISO 8601 spec so I did not include it in the scalar.