### PR TITLE
Expose `printType` for test/debug purposes.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -274,6 +274,9 @@ export {
   // Print a GraphQLSchema to GraphQL Schema language.
   printSchema,
 
+  // Print a GraphQLType to GraphQL Schema language.
+  printType,
+
   // Create a GraphQLType from a GraphQL language AST.
   typeFromAST,
 

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -43,7 +43,11 @@ export { buildASTSchema, buildSchema } from './buildASTSchema';
 export { extendSchema } from './extendSchema';
 
 // Print a GraphQLSchema to GraphQL Schema language.
-export { printSchema, printIntrospectionSchema } from './schemaPrinter';
+export {
+  printSchema,
+  printType,
+  printIntrospectionSchema,
+} from './schemaPrinter';
 
 // Create a GraphQLType from a GraphQL language AST.
 export { typeFromAST } from './typeFromAST';

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -136,7 +136,7 @@ function isSchemaOfCommonNames(schema: GraphQLSchema): boolean {
   return true;
 }
 
-function printType(type: GraphQLType): string {
+export function printType(type: GraphQLType): string {
   if (type instanceof GraphQLScalarType) {
     return printScalar(type);
   } else if (type instanceof GraphQLObjectType) {


### PR DESCRIPTION
Users may generate graphql types from some models (eg. from [mongoose](https://github.com/nodkz/graphql-compose-mongoose)). And want to have ability to see what they got in human view.

My several related issues:
https://github.com/nodkz/graphql-compose/issues/27#issuecomment-258618998
https://github.com/nodkz/graphql-compose/issues/17