### PR TITLE
Use linked-list to represent response path.

### DIFF
--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -225,7 +225,7 @@ describe('Execute: Handles basic execution tasks', () => {
     );
     expect(info.returnType).to.equal(GraphQLString);
     expect(info.parentType).to.equal(schema.getQueryType());
-    expect(info.path).to.deep.equal([ 'result' ]);
+    expect(info.path).to.deep.equal({ prev: undefined, key: 'result' });
     expect(info.schema).to.equal(schema);
     expect(info.rootValue).to.equal(rootValue);
     expect(info.operation).to.equal(ast.definitions[0]);

--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -7,6 +7,6 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-export { execute, defaultFieldResolver } from './execute';
+export { execute, defaultFieldResolver, responsePathAsArray } from './execute';
 
 export type { ExecutionResult } from './execute';

--- a/src/index.js
+++ b/src/index.js
@@ -137,6 +137,7 @@ export type {
   GraphQLIsTypeOfFn,
   GraphQLObjectTypeConfig,
   GraphQLResolveInfo,
+  ResponsePath,
   GraphQLScalarTypeConfig,
   GraphQLTypeResolver,
   GraphQLUnionTypeConfig,
@@ -224,6 +225,7 @@ export type {
 export {
   execute,
   defaultFieldResolver,
+  responsePathAsArray,
 } from './execution';
 
 export type {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -491,13 +491,15 @@ export type GraphQLResolveInfo = {
   fieldNodes: Array<FieldNode>;
   returnType: GraphQLOutputType;
   parentType: GraphQLCompositeType;
-  path: Array<string | number>;
+  path: ResponsePath;
   schema: GraphQLSchema;
   fragments: { [fragmentName: string]: FragmentDefinitionNode };
   rootValue: mixed;
   operation: OperationDefinitionNode;
   variableValues: { [variableName: string]: mixed };
 };
+
+export type ResponsePath = { prev: ResponsePath, key: string | number } | void;
 
 export type GraphQLFieldConfig<TSource> = {
   type: GraphQLOutputType;

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -114,6 +114,7 @@ export type {
   GraphQLIsTypeOfFn,
   GraphQLObjectTypeConfig,
   GraphQLResolveInfo,
+  ResponsePath,
   GraphQLScalarTypeConfig,
   GraphQLTypeResolver,
   GraphQLUnionTypeConfig,


### PR DESCRIPTION
This is a performance improvement to the execution path that removes the need for creating a new array to represent the response path for each resolved field in the response. Instead this creates a single-linked-list which is naturally persistently immutable.

This exposes a breaking change: if you relied on `resolve(_, _, _, { path }) {` then you'll find `path` in this linked list format instead of an array.