### PR TITLE
differentiate between input values with no default and with default = null

### DIFF
--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -825,7 +825,8 @@ describe('Introspection', () => {
       name: 'TestInputObject',
       fields: {
         a: { type: GraphQLString, defaultValue: 'foo' },
-        b: { type: new GraphQLList(GraphQLString) }
+        b: { type: new GraphQLList(GraphQLString) },
+        c: { type: GraphQLString, defaultValue: null }
       }
     });
 
@@ -897,7 +898,13 @@ describe('Introspection', () => {
             { kind: 'SCALAR',
               name: 'String',
               ofType: null } },
-          defaultValue: null } ] } ] } }
+          defaultValue: null },
+        { name: 'c',
+          type:
+          { kind: 'SCALAR',
+            name: 'String',
+            ofType: null },
+          defaultValue: 'null' } ] } ] } }
     });
   });
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -8,7 +8,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import isNullish from '../jsutils/isNullish';
+import isInvalid from '../jsutils/isInvalid';
 import { astFromValue } from '../utilities/astFromValue';
 import { print } from '../language/printer';
 import {
@@ -333,7 +333,7 @@ export const __InputValue = new GraphQLObjectType({
       description:
         'A GraphQL-formatted string representing the default value for this ' +
         'input value.',
-      resolve: inputVal => isNullish(inputVal.defaultValue) ?
+      resolve: inputVal => isInvalid(inputVal.defaultValue) ?
         null :
         print(astFromValue(inputVal.defaultValue, inputVal.type))
     }

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -509,6 +509,23 @@ describe('Type System: build schema from introspection', () => {
                 defaultValue: { lat: 37.485, lon: -122.148 }
               }
             }
+          },
+          defaultNull: {
+            type: GraphQLString,
+            args: {
+              intArg: {
+                type: GraphQLInt,
+                defaultValue: null
+              }
+            }
+          },
+          noDefault: {
+            type: GraphQLString,
+            args: {
+              intArg: {
+                type: GraphQLInt
+              }
+            }
           }
         }
       })

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -321,7 +321,7 @@ export function buildClientSchema(
     const type = getInputType(inputValueIntrospection.type);
     const defaultValue = inputValueIntrospection.defaultValue ?
       valueFromAST(parseValue(inputValueIntrospection.defaultValue), type) :
-      null;
+      undefined;
     return {
       name: inputValueIntrospection.name,
       description: inputValueIntrospection.description,


### PR DESCRIPTION
- introspection should return null if there is no default value and the string "null" if there is a default value that is null
- buildClientSchema should translate defaultValue "null" to null (as it already does) and null to undefined (fixed here)