### PR TITLE
Type field arg values as "any"

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -529,7 +529,7 @@ export type GraphQLIsTypeOfFn<TSource, TContext> = (
 
 export type GraphQLFieldResolver<TSource, TContext> = (
   source: TSource,
-  args: {[argName: string]: mixed},
+  args: { [argName: string]: any },
   context: TContext,
   info: GraphQLResolveInfo
 ) => mixed;

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -434,7 +434,7 @@ export const TypeMetaFieldDef: GraphQLField<*, *> = {
     { name: 'name', type: new GraphQLNonNull(GraphQLString) }
   ],
   resolve: (source, { name }, context, { schema }) =>
-    schema.getType(((name: any): string))
+    schema.getType(name)
 };
 
 export const TypeNameMetaFieldDef: GraphQLField<*, *> = {


### PR DESCRIPTION
This changes the flow types from an object of mixed values to an object of any values. This is explicitly less type safe, however is way more ergonomic and better matches the previous behavior before flow types were exported.

This was suggested in #554 and partially implements #574