### PR TITLE
Add isNamedType and assertNamedType helpers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,7 @@ export {
   isLeafType,
   isCompositeType,
   isAbstractType,
+  isNamedType,
 
   // Assertions
   assertType,
@@ -105,6 +106,7 @@ export {
   assertLeafType,
   assertCompositeType,
   assertAbstractType,
+  assertNamedType,
 
   // Un-modifiers
   getNullableType,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -225,6 +225,25 @@ export type GraphQLNamedType =
   GraphQLEnumType |
   GraphQLInputObjectType;
 
+export function isNamedType(type: ?GraphQLType): boolean {
+  return (
+    type instanceof GraphQLScalarType ||
+    type instanceof GraphQLObjectType ||
+    type instanceof GraphQLInterfaceType ||
+    type instanceof GraphQLUnionType ||
+    type instanceof GraphQLEnumType ||
+    type instanceof GraphQLInputObjectType
+  );
+}
+
+export function assertNamedType(type: ?GraphQLType): GraphQLNamedType {
+  invariant(
+    isNamedType(type),
+    `Expected ${String(type)} to be a GraphQL named type.`,
+  );
+  return (type: any);
+}
+
 export function getNamedType(type: ?GraphQLType): ?GraphQLNamedType {
   let unmodifiedType = type;
   while (

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -19,6 +19,7 @@ export {
   isLeafType,
   isCompositeType,
   isAbstractType,
+  isNamedType,
 
   // Assertions
   assertType,
@@ -27,6 +28,7 @@ export {
   assertLeafType,
   assertCompositeType,
   assertAbstractType,
+  assertNamedType,
 
   // Un-modifiers
   getNullableType,


### PR DESCRIPTION
Completes the set of isXxxType/assertXxxType helpers. Useful for building type repositories and the like.