### PR TITLE
Make executor throw if no document is provided

### DIFF
--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -23,6 +23,21 @@ import {
 } from '../../type';
 
 describe('Execute: Handles basic execution tasks', () => {
+  it('throws if no document is provided', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Type',
+        fields: {
+          a: { type: GraphQLString },
+        }
+      })
+    });
+
+    expect(() => execute(schema, null)).to.throw(
+      'Must provide document'
+    );
+  });
+
   it('executes arbitrary code', async () => {
     const data = {
       a() { return 'Apple'; },

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -121,6 +121,7 @@ export function execute(
   operationName?: ?string
 ): Promise<ExecutionResult> {
   invariant(schema, 'Must provide schema');
+  invariant(document, 'Must provide document');
   invariant(
     schema instanceof GraphQLSchema,
     'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +


### PR DESCRIPTION
Currently, `buildExecutionContext` throws a null reference error

`Cannot read property 'definitions' of null`

when `document` is undefined. Instead, we should throw a friendlier error message.

Also fixes apollostack/graphql-server#112

🍺 