### PR TITLE
add public aliases for type configs

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -328,6 +328,10 @@ export class GraphQLScalarType {
     const parser = this._scalarConfig.parseLiteral;
     return parser ? parser(valueNode) : null;
   }
+  
+  get scalarConfig(): GraphQLScalarTypeConfig<*, *> {
+    return this._scalarConfig;
+  }
 
   toString(): string {
     return this.name;
@@ -422,6 +426,10 @@ export class GraphQLObjectType {
     return this._interfaces || (this._interfaces =
       defineInterfaces(this, this._typeConfig.interfaces)
     );
+  }
+
+  get typeConfig(): GraphQLObjectTypeConfig<*, *> {
+    return this._typeConfig;
   }
 
   toString(): string {
@@ -673,6 +681,10 @@ export class GraphQLInterfaceType {
       (this._fields = defineFieldMap(this, this._typeConfig.fields));
   }
 
+  get typeConfig(): GraphQLInterfaceTypeConfig<*, *> {
+    return this._typeConfig;
+  }
+
   toString(): string {
     return this.name;
   }
@@ -750,6 +762,10 @@ export class GraphQLUnionType {
     return this._types || (this._types =
       defineTypes(this, this._typeConfig.types)
     );
+  }
+
+  get typeConfig(): GraphQLUnionTypeConfig<*, *> {
+    return this._typeConfig;
   }
 
   toString(): string {
@@ -897,6 +913,10 @@ export class GraphQLEnumType/* <T> */ {
     return this._nameLookup;
   }
 
+  get enumConfig(): GraphQLEnumTypeConfig/* <T> */ {
+    return this._enumConfig;
+  }
+
   toString(): string {
     return this.name;
   }
@@ -1039,6 +1059,10 @@ export class GraphQLInputObjectType {
       resultFieldMap[fieldName] = field;
     });
     return resultFieldMap;
+  }
+
+  get typeConfig(): GraphQLInputObjectTypeConfig {
+    return this._typeConfig
   }
 
   toString(): string {


### PR DESCRIPTION
Having access to the type config is very useful for building type building utilities. Take for instance a function `implementNodeInterface(type: GraphQLObjectType)` which clones the `type._typeConfig` object and adds an interface, verifies an `isTypeOf` field exists, handles a special `nodeResolve` field (which can be used by a query level `node` field), and adds the global `id` field required by the interface.

As utilities around a GraphQL schema definition could benefit from the access to a type config I propose with this PR that we make the config field public by removing the underscore. From `_typeConfig` to `typeConfig`, `_scalarConfig` to `scalarConfig`, `_enumConfig` to `enumConfig`, and etc.

Currently this PR does not actually rename anything, instead it opts to add a getter alias which just returns the config with an underscore. This has the nice side effect of also disallowing assignment to the property as `type.typeConfig = null` would be illegal.