### PR TITLE
Allow `isTypeOf` and `resolveType` to return a Promise

### DIFF
--- a/src/execution/__tests__/abstract-promise-test.js
+++ b/src/execution/__tests__/abstract-promise-test.js
@@ -168,15 +168,18 @@ describe('Execute: Handles execution of abstract types with promises', () => {
 
     expect(result).to.deep.equal({
       data: {
-        pets: [
-          null,
-          { name: 'Garfield',
-            meows: false } ] },
+        pets: [ null, null ]
+      },
       errors: [
         {
           message: 'We are testing this error',
           locations: [ { line: 2, column: 7 } ],
           path: [ 'pets', 0 ]
+        },
+        {
+          message: 'We are testing this error',
+          locations: [ { line: 2, column: 7 } ],
+          path: [ 'pets', 1 ]
         }
       ]
     });

--- a/src/execution/__tests__/abstract-promise-test.js
+++ b/src/execution/__tests__/abstract-promise-test.js
@@ -1,0 +1,433 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import {
+  graphql,
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLList,
+  GraphQLString,
+  GraphQLBoolean,
+} from '../../';
+
+class Dog {
+  constructor(name, woofs) {
+    this.name = name;
+    this.woofs = woofs;
+  }
+}
+
+class Cat {
+  constructor(name, meows) {
+    this.name = name;
+    this.meows = meows;
+  }
+}
+
+class Human {
+  constructor(name) {
+    this.name = name;
+  }
+}
+
+describe('Execute: Handles execution of abstract types with promises', () => {
+
+  it('isTypeOf used to resolve runtime type for Interface', async () => {
+    const PetType = new GraphQLInterfaceType({
+      name: 'Pet',
+      fields: {
+        name: { type: GraphQLString }
+      }
+    });
+
+    const DogType = new GraphQLObjectType({
+      name: 'Dog',
+      interfaces: [ PetType ],
+      isTypeOf: obj => Promise.resolve(obj instanceof Dog),
+      fields: {
+        name: { type: GraphQLString },
+        woofs: { type: GraphQLBoolean },
+      }
+    });
+
+    const CatType = new GraphQLObjectType({
+      name: 'Cat',
+      interfaces: [ PetType ],
+      isTypeOf: obj => Promise.resolve(obj instanceof Cat),
+      fields: {
+        name: { type: GraphQLString },
+        meows: { type: GraphQLBoolean },
+      }
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          pets: {
+            type: new GraphQLList(PetType),
+            resolve() {
+              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
+            }
+          }
+        }
+      }),
+      types: [ CatType, DogType ]
+    });
+
+    const query = `{
+      pets {
+        name
+        ... on Dog {
+          woofs
+        }
+        ... on Cat {
+          meows
+        }
+      }
+    }`;
+
+    const result = await graphql(schema, query);
+
+    expect(result).to.deep.equal({
+      data: {
+        pets: [
+          { name: 'Odie',
+            woofs: true },
+          { name: 'Garfield',
+            meows: false } ] }
+    });
+  });
+
+  it('isTypeOf used to resolve runtime type for Union', async () => {
+    const DogType = new GraphQLObjectType({
+      name: 'Dog',
+      isTypeOf: obj => Promise.resolve(obj instanceof Dog),
+      fields: {
+        name: { type: GraphQLString },
+        woofs: { type: GraphQLBoolean },
+      }
+    });
+
+    const CatType = new GraphQLObjectType({
+      name: 'Cat',
+      isTypeOf: obj => Promise.resolve(obj instanceof Cat),
+      fields: {
+        name: { type: GraphQLString },
+        meows: { type: GraphQLBoolean },
+      }
+    });
+
+    const PetType = new GraphQLUnionType({
+      name: 'Pet',
+      types: [ DogType, CatType ]
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          pets: {
+            type: new GraphQLList(PetType),
+            resolve() {
+              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
+            }
+          }
+        }
+      })
+    });
+
+    const query = `{
+      pets {
+        ... on Dog {
+          name
+          woofs
+        }
+        ... on Cat {
+          name
+          meows
+        }
+      }
+    }`;
+
+    const result = await graphql(schema, query);
+
+    expect(result).to.deep.equal({
+      data: {
+        pets: [
+          { name: 'Odie',
+            woofs: true },
+          { name: 'Garfield',
+            meows: false } ] }
+    });
+  });
+
+  it('resolveType on Interface yields useful error', async () => {
+    const PetType = new GraphQLInterfaceType({
+      name: 'Pet',
+      resolveType(obj) {
+        return Promise.resolve(obj instanceof Dog ? DogType :
+          obj instanceof Cat ? CatType :
+          obj instanceof Human ? HumanType :
+          null);
+      },
+      fields: {
+        name: { type: GraphQLString }
+      }
+    });
+
+    const HumanType = new GraphQLObjectType({
+      name: 'Human',
+      fields: {
+        name: { type: GraphQLString },
+      }
+    });
+
+    const DogType = new GraphQLObjectType({
+      name: 'Dog',
+      interfaces: [ PetType ],
+      fields: {
+        name: { type: GraphQLString },
+        woofs: { type: GraphQLBoolean },
+      }
+    });
+
+    const CatType = new GraphQLObjectType({
+      name: 'Cat',
+      interfaces: [ PetType ],
+      fields: {
+        name: { type: GraphQLString },
+        meows: { type: GraphQLBoolean },
+      }
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          pets: {
+            type: new GraphQLList(PetType),
+            resolve() {
+              return Promise.resolve([
+                new Dog('Odie', true),
+                new Cat('Garfield', false),
+                new Human('Jon')
+              ]);
+            }
+          }
+        }
+      }),
+      types: [ CatType, DogType ]
+    });
+
+    const query = `{
+      pets {
+        name
+        ... on Dog {
+          woofs
+        }
+        ... on Cat {
+          meows
+        }
+      }
+    }`;
+
+    const result = await graphql(schema, query);
+
+    expect(result).to.jsonEqual({
+      data: {
+        pets: [
+          { name: 'Odie',
+            woofs: true },
+          { name: 'Garfield',
+            meows: false },
+          null
+        ]
+      },
+      errors: [
+        {
+          message:
+            'Runtime Object type "Human" is not a possible type for "Pet".',
+          locations: [ { line: 2, column: 7 } ],
+          path: [ 'pets', 2 ]
+        }
+      ]
+    });
+  });
+
+  it('resolveType on Union yields useful error', async () => {
+    const HumanType = new GraphQLObjectType({
+      name: 'Human',
+      fields: {
+        name: { type: GraphQLString },
+      }
+    });
+
+    const DogType = new GraphQLObjectType({
+      name: 'Dog',
+      fields: {
+        name: { type: GraphQLString },
+        woofs: { type: GraphQLBoolean },
+      }
+    });
+
+    const CatType = new GraphQLObjectType({
+      name: 'Cat',
+      fields: {
+        name: { type: GraphQLString },
+        meows: { type: GraphQLBoolean },
+      }
+    });
+
+    const PetType = new GraphQLUnionType({
+      name: 'Pet',
+      resolveType(obj) {
+        return Promise.resolve(obj instanceof Dog ? DogType :
+          obj instanceof Cat ? CatType :
+          obj instanceof Human ? HumanType :
+          null);
+      },
+      types: [ DogType, CatType ]
+    });
+
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          pets: {
+            type: new GraphQLList(PetType),
+            resolve() {
+              return [
+                new Dog('Odie', true),
+                new Cat('Garfield', false),
+                new Human('Jon')
+              ];
+            }
+          }
+        }
+      })
+    });
+
+    const query = `{
+      pets {
+        ... on Dog {
+          name
+          woofs
+        }
+        ... on Cat {
+          name
+          meows
+        }
+      }
+    }`;
+
+    const result = await graphql(schema, query);
+
+    expect(result).to.jsonEqual({
+      data: {
+        pets: [
+          { name: 'Odie',
+            woofs: true },
+          { name: 'Garfield',
+            meows: false },
+          null
+        ]
+      },
+      errors: [
+        {
+          message:
+            'Runtime Object type "Human" is not a possible type for "Pet".',
+          locations: [ { line: 2, column: 7 } ],
+          path: [ 'pets', 2 ]
+        }
+      ]
+    });
+  });
+
+  it('resolveType allows resolving with type name', async () => {
+    const PetType = new GraphQLInterfaceType({
+      name: 'Pet',
+      resolveType(obj) {
+        return Promise.resolve(obj instanceof Dog ? 'Dog' :
+          obj instanceof Cat ? 'Cat' :
+          null);
+      },
+      fields: {
+        name: { type: GraphQLString }
+      }
+    });
+
+    const DogType = new GraphQLObjectType({
+      name: 'Dog',
+      interfaces: [ PetType ],
+      fields: {
+        name: { type: GraphQLString },
+        woofs: { type: GraphQLBoolean },
+      }
+    });
+
+    const CatType = new GraphQLObjectType({
+      name: 'Cat',
+      interfaces: [ PetType ],
+      fields: {
+        name: { type: GraphQLString },
+        meows: { type: GraphQLBoolean },
+      }
+    });
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          pets: {
+            type: new GraphQLList(PetType),
+            resolve() {
+              return [
+                new Dog('Odie', true),
+                new Cat('Garfield', false)
+              ];
+            }
+          }
+        }
+      }),
+      types: [ CatType, DogType ]
+    });
+
+    const query = `{
+      pets {
+        name
+        ... on Dog {
+          woofs
+        }
+        ... on Cat {
+          meows
+        }
+      }
+    }`;
+
+    const result = await graphql(schema, query);
+
+    expect(result).to.jsonEqual({
+      data: {
+        pets: [
+          { name: 'Odie',
+            woofs: true },
+          { name: 'Garfield',
+            meows: false },
+        ]
+      }
+    });
+  });
+
+});

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -949,47 +949,55 @@ function completeAbstractValue(
     const runtimeTypePromise: Promise<GraphQLObjectType | string> = 
       (runtimeType: any);
     return runtimeTypePromise.then(resolvedRuntimeType =>
-      validateRuntimeTypeAndCompleteObjectValue(
+      completeObjectValue(
         exeContext,
         returnType,
         fieldNodes,
         info,
         path,
-        ensureType(exeContext.schema, resolvedRuntimeType),
+        ensureValidRuntimeType(
+          resolvedRuntimeType,
+          exeContext, 
+          returnType, 
+          fieldNodes,
+          info,
+          result
+        ),
         result
       )
     );
   }
 
-  return validateRuntimeTypeAndCompleteObjectValue(
+  return completeObjectValue(
     exeContext,
     returnType,
     fieldNodes,
     info,
     path,
-    ensureType(exeContext.schema, runtimeType),
+    ensureValidRuntimeType(
+      resolvedRuntimeType,
+      exeContext,
+      returnType, 
+      fieldNodes,
+      info,
+      result
+    ),
     result
   );
 }
 
-function ensureType(
-  schema: GraphQLSchema, 
-  typeOrName: string | GraphQLObjectType
-): GraphQLObjectType {
-  return typeof typeOrName === 'string' ? 
-    schema.getType(typeOrName) : 
-    typeOrName;
-}
-
-function validateRuntimeTypeAndCompleteObjectValue(
+function ensureValidRuntimeType(
+  runtimeTypeOrName: string | GraphQLObjectType | void
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
-  path: ResponsePath,
-  runtimeType: GraphQLObjectType,
   result: mixed
-): mixed {
+): GraphQLObjectType {
+  const runtimeType = typeof runtimeTypeOrName === 'string' ? 
+    exeContext.schema.getType(runtimeTypeOrName) : 
+    runtimeTypeOrName;
+
   if (!(runtimeType instanceof GraphQLObjectType)) {
     throw new GraphQLError(
       `Abstract type ${returnType.name} must resolve to an Object type at ` +
@@ -1007,14 +1015,7 @@ function validateRuntimeTypeAndCompleteObjectValue(
     );
   }
 
-  return completeObjectValue(
-    exeContext,
-    runtimeType,
-    fieldNodes,
-    info,
-    path,
-    result
-  );
+  return runtimeType;
 }
 
 /**

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -951,10 +951,6 @@ function completeAbstractValue(
     return runtimeTypePromise.then(resolvedRuntimeType =>
       completeObjectValue(
         exeContext,
-        returnType,
-        fieldNodes,
-        info,
-        path,
         ensureValidRuntimeType(
           resolvedRuntimeType,
           exeContext, 
@@ -963,6 +959,9 @@ function completeAbstractValue(
           info,
           result
         ),
+        fieldNodes,
+        info,
+        path,
         result
       )
     );
@@ -970,10 +969,6 @@ function completeAbstractValue(
 
   return completeObjectValue(
     exeContext,
-    returnType,
-    fieldNodes,
-    info,
-    path,
     ensureValidRuntimeType(
       resolvedRuntimeType,
       exeContext,
@@ -982,6 +977,9 @@ function completeAbstractValue(
       info,
       result
     ),
+    fieldNodes,
+    info,
+    path,
     result
   );
 }

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -985,7 +985,7 @@ function completeAbstractValue(
 }
 
 function ensureValidRuntimeType(
-  runtimeTypeOrName: string | GraphQLObjectType | void
+  runtimeTypeOrName: string | GraphQLObjectType | void,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
   fieldNodes: Array<FieldNode>,

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -946,15 +946,15 @@ function completeAbstractValue(
 
   if (isThenable(runtimeType)) {
     // Cast to Promise
-    const runtimeTypePromise: Promise<GraphQLObjectType | string> = 
+    const runtimeTypePromise: Promise<?GraphQLObjectType | string> =
       (runtimeType: any);
     return runtimeTypePromise.then(resolvedRuntimeType =>
       completeObjectValue(
         exeContext,
         ensureValidRuntimeType(
           resolvedRuntimeType,
-          exeContext, 
-          returnType, 
+          exeContext,
+          returnType,
           fieldNodes,
           info,
           result
@@ -970,9 +970,9 @@ function completeAbstractValue(
   return completeObjectValue(
     exeContext,
     ensureValidRuntimeType(
-      resolvedRuntimeType,
+      ((runtimeType: any): ?GraphQLObjectType | string),
       exeContext,
-      returnType, 
+      returnType,
       fieldNodes,
       info,
       result
@@ -985,15 +985,15 @@ function completeAbstractValue(
 }
 
 function ensureValidRuntimeType(
-  runtimeTypeOrName: string | GraphQLObjectType | void,
+  runtimeTypeOrName: ?GraphQLObjectType | string,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   result: mixed
 ): GraphQLObjectType {
-  const runtimeType = typeof runtimeTypeOrName === 'string' ? 
-    exeContext.schema.getType(runtimeTypeOrName) : 
+  const runtimeType = typeof runtimeTypeOrName === 'string' ?
+    exeContext.schema.getType(runtimeTypeOrName) :
     runtimeTypeOrName;
 
   if (!(runtimeType instanceof GraphQLObjectType)) {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -553,13 +553,13 @@ export type GraphQLTypeResolver<TSource, TContext> = (
   value: TSource,
   context: TContext,
   info: GraphQLResolveInfo
-) => ?GraphQLObjectType | ?string;
+) => ?GraphQLObjectType | ?string | ?Promise<?GraphQLObjectType | ?string>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
   source: TSource,
   context: TContext,
   info: GraphQLResolveInfo
-) => boolean;
+) => boolean | Promise<boolean>;
 
 export type GraphQLFieldResolver<TSource, TContext> = (
   source: TSource,


### PR DESCRIPTION
Hello, 

The idea behind this PR is to allow `GraphQLObjectType#isTypeOf`, `GraphQLInterfaceType#resolveType` and `GraphQLUnionType#resolveType` to return a Promise.

The PR consists of:
- Changes to `execute.js` to support the new promise feature.
- New tests: Promise.resolve duplicates of the existing ones about `isTypeOf` and `resolveType` + new ones to test the cases where the promise is rejected.

This relates to issue #398. Use case is the following: 
For some projects fetching data can be expensive. To prevent that, the 'source' passed to resolveFns can be thought as an ID string referencing remote data, so the fields resolve only what is needed based on that ID. It works fine, except when abstract types require a sync resolving of the type behind an ID string.
The use case at my company: We create our GraphQL schema based on our RDF ontology, query with SPARQL, etc... (see this almost open-sourced project: [semantic-graphql](https://www.npmjs.com/package/semantic-graphql))

