### PR TITLE
chore(circ-dep): fixed circular dependancies

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -8,7 +8,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import { getLocation } from '../language';
+import { getLocation } from '../language/location';
 import type { ASTNode } from '../language/ast';
 import type { Source } from '../language/source';
 


### PR DESCRIPTION
Fix circular dependency that fails the code after compiling the library with Rollup (because of https://github.com/rollup/rollup-plugin-commonjs/issues/105)