### PR TITLE
support customType for buildSchema

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -17,6 +17,8 @@ import {
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
+  Kind,
+  GraphQLScalarType,
 } from '../../';
 
 /**
@@ -802,4 +804,49 @@ fragment Foo on Type { field }
       .to.throw('Specified query type "Foo" not found in document.');
   });
 
+});
+
+describe('customTypeMap', () => {
+
+  const Url = new GraphQLScalarType({
+    name: 'Url',
+    serialize: String,
+    parseValue: String,
+    parseLiteral(ast) {
+      return ast.kind === Kind.STRING || ast.kind === Kind.INT ?
+        ast.value :
+        null;
+    }
+  });
+
+  it('Unknown type referenced', () => {
+    const body = `
+schema {
+  query: Hello
+}
+
+type Hello {
+  bar: Url
+}
+`;
+    const doc = parse(body);
+    expect(() => buildASTSchema(doc))
+      .to.throw('Type "Url" not found in document.');
+  });
+
+  it('Unknown type by customTypeMap', async () => {
+    const schema = buildASTSchema(parse(`
+      schema { query: Query }
+      type Query {
+        str(url: Url): Url
+      }
+    `), {Url});
+
+    const result = await graphql(
+      schema,
+      '{ str(url: "http://example.com") }',
+      { str: ({ url }) => url }
+    );
+    expect(result.data).to.deep.equal({ str: 'http://example.com' });
+  });
 });

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -135,7 +135,10 @@ function getNamedTypeNode(typeNode: TypeNode): NamedTypeNode {
  * Given that AST it constructs a GraphQLSchema. The resulting schema
  * has no resolve methods, so execution will use default resolvers.
  */
-export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
+export function buildASTSchema(
+    ast: DocumentNode,
+    customTypeMap: {[name: string]: GraphQLNamedType}
+): GraphQLSchema {
   if (!ast || ast.kind !== DOCUMENT) {
     throw new Error('Must provide a document ast.');
   }
@@ -325,6 +328,10 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
   function typeDefNamed(typeName: string): GraphQLNamedType {
     if (innerTypeMap[typeName]) {
       return innerTypeMap[typeName];
+    }
+
+    if (customTypeMap && customTypeMap[typeName]) {
+      return customTypeMap[typeName];
     }
 
     if (!nodeMap[typeName]) {
@@ -517,8 +524,11 @@ export function getDescription(node: { loc?: Location }): ?string {
  * A helper function to build a GraphQLSchema directly from a source
  * document.
  */
-export function buildSchema(source: string | Source): GraphQLSchema {
-  return buildASTSchema(parse(source));
+export function buildSchema(
+    source: string | Source,
+    customTypeMap: {[name: string]: GraphQLNamedType}
+): GraphQLSchema {
+  return buildASTSchema(parse(source), customTypeMap);
 }
 
 // Count the number of spaces on the starting side of a string.


### PR DESCRIPTION
let us can add custom type
```javascript
  const Url = new GraphQLScalarType({
    name: 'Url',
    serialize: String,
    parseValue: String,
    parseLiteral(ast) {
      return ast.kind === Kind.STRING || ast.kind === Kind.INT ?
        ast.value :
        null;
    }
  });

    const schema = buildASTSchema(parse(`
      schema { query: Query }
      type Query {
        str(url: Url): Url
      }
    `), {Url});

```