### PR TITLE
Add resolver validation, check if value is a function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,7 +69,7 @@
     "dot-location": [2, "property"],
     "dot-notation": 0,
     "eol-last": 2,
-    "eqeqeq": 2,
+    "eqeqeq": ["error", "smart"],
     "func-names": 0,
     "func-style": 0,
     "generator-star-spacing": [2, {"before": true, "after": false}],

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -1119,6 +1119,49 @@ describe('Type System: Object fields must have output types', () => {
 });
 
 
+describe('Type System: Object fields must have valid resolve values', () => {
+
+  function schemaWithObjectWithFieldResolver(resolveValue) {
+    const BadResolverType = new GraphQLObjectType({
+      name: 'BadResolver',
+      fields: {
+        badField: {
+          type: GraphQLString,
+          resolve: resolveValue
+        }
+      }
+    });
+
+    return new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          f: { type: BadResolverType }
+        }
+      })
+    });
+  }
+
+  it('accepts a lambda as an Object field resolver', () => {
+    expect(() => schemaWithObjectWithFieldResolver(() => ({}))).not.to.throw();
+  });
+
+  it('rejects an empty Object field resolver', () => {
+    expect(() => schemaWithObjectWithFieldResolver({})).to.throw(
+      'BadResolver.badField field resolver must be function or null/undefined' +
+      ', but got: [object Object].'
+    );
+  });
+
+  it('rejects a constant scalar value resolver', () => {
+    expect(() => schemaWithObjectWithFieldResolver(0)).to.throw(
+      'BadResolver.badField field resolver must be function or null/undefined' +
+      ', but got: 0.'
+    );
+  });
+});
+
+
 describe('Type System: Objects can only implement interfaces', () => {
 
   function schemaWithObjectImplementingType(implementedType) {

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -1148,15 +1148,15 @@ describe('Type System: Object fields must have valid resolve values', () => {
 
   it('rejects an empty Object field resolver', () => {
     expect(() => schemaWithObjectWithFieldResolver({})).to.throw(
-      'BadResolver.badField field resolver must be function or null/undefined' +
-      ', but got: [object Object].'
+      'BadResolver.badField field resolver must be a function if provided, ' +
+      'but got: [object Object].'
     );
   });
 
   it('rejects a constant scalar value resolver', () => {
     expect(() => schemaWithObjectWithFieldResolver(0)).to.throw(
-      'BadResolver.badField field resolver must be function or null/undefined' +
-      ', but got: 0.'
+      'BadResolver.badField field resolver must be a function if provided, ' +
+      'but got: 0.'
     );
   });
 });

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -508,8 +508,8 @@ function defineFieldMap<TSource, TContext>(
     );
     invariant(
       isValidResolver(field.resolve),
-      `${type.name}.${fieldName} field resolver must be function or null/` +
-      `undefined, but got: ${String(field.resolve)}.`
+      `${type.name}.${fieldName} field resolver must be a function if ` +
+      `provided, but got: ${String(field.resolve)}.`
     );
     const argsConfig = fieldConfig.args;
     if (!argsConfig) {
@@ -547,10 +547,7 @@ function isPlainObj(obj) {
 
 // If a resolver is defined, it must be a function.
 function isValidResolver(resolver: any): boolean {
-  if (resolver === null || resolver === undefined) {
-    return true;
-  }
-  return typeof resolver === 'function';
+  return (resolver == null || typeof resolver === 'function');
 }
 
 export type GraphQLObjectTypeConfig<TSource, TContext> = {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -506,6 +506,11 @@ function defineFieldMap<TSource, TContext>(
       `${type.name}.${fieldName} field type must be Output Type but ` +
       `got: ${String(field.type)}.`
     );
+    invariant(
+      isValidResolver(field.resolve),
+      `${type.name}.${fieldName} field resolver must be function or null/` +
+      `undefined, but got: ${String(field.resolve)}.`
+    );
     const argsConfig = fieldConfig.args;
     if (!argsConfig) {
       field.args = [];
@@ -538,6 +543,14 @@ function defineFieldMap<TSource, TContext>(
 
 function isPlainObj(obj) {
   return obj && typeof obj === 'object' && !Array.isArray(obj);
+}
+
+// If a resolver is defined, it must be a function.
+function isValidResolver(resolver: any): boolean {
+  if (resolver === null || resolver === undefined) {
+    return true;
+  }
+  return typeof resolver === 'function';
 }
 
 export type GraphQLObjectTypeConfig<TSource, TContext> = {


### PR DESCRIPTION
If a field's resolver is set to a constant value like "{}" we get a runtime error, "resolveFn is not a function". We can easily detect this case when we validate fields during schema creation. This PR adds a new validation rule to check that the resolve definition is a function. 