### PR TITLE
TypeInfo.getEnumValue() and EnumType.getValue(name)

### DIFF
--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -354,13 +354,22 @@ describe('Type System: Enum Values', () => {
     });
   });
 
-  it('may present a values API for complex enums ', () => {
+  it('presents a getValues() API for complex enums', () => {
     const values = ComplexEnum.getValues();
     expect(values.length).to.equal(2);
     expect(values[0].name).to.equal('ONE');
     expect(values[0].value).to.equal(Complex1);
     expect(values[1].name).to.equal('TWO');
     expect(values[1].value).to.equal(Complex2);
+  });
+
+  it('presents a getValue() API for complex enums', () => {
+    const oneValue = ComplexEnum.getValue('ONE');
+    expect(oneValue.name).to.equal('ONE');
+    expect(oneValue.value).to.equal(Complex1);
+
+    const badUsage = ComplexEnum.getValue(Complex1);
+    expect(badUsage).to.equal(undefined);
   });
 
   it('may be internally represented with complex values', async () => {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -852,6 +852,10 @@ export class GraphQLEnumType/* <T> */ {
     return this._values;
   }
 
+  getValue(name: string): ?GraphQLEnumValue {
+    return this._getNameLookup()[name];
+  }
+
   serialize(value: any/* T */): ?string {
     const enumValue = this._getValueLookup().get(value);
     return enumValue ? enumValue.name : null;

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -17,6 +17,7 @@ import {
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLInputObjectType,
+  GraphQLEnumType,
   GraphQLList,
 } from '../type/definition';
 import type {
@@ -25,7 +26,8 @@ import type {
   GraphQLOutputType,
   GraphQLCompositeType,
   GraphQLField,
-  GraphQLArgument
+  GraphQLArgument,
+  GraphQLEnumValue,
 } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';
 import {
@@ -52,6 +54,7 @@ export class TypeInfo {
   _fieldDefStack: Array<?GraphQLField<*, *>>;
   _directive: ?GraphQLDirective;
   _argument: ?GraphQLArgument;
+  _enumValue: ?GraphQLEnumValue;
   _getFieldDef: typeof getFieldDef;
 
   constructor(
@@ -68,6 +71,7 @@ export class TypeInfo {
     this._fieldDefStack = [];
     this._directive = null;
     this._argument = null;
+    this._enumValue = null;
     this._getFieldDef = getFieldDefFn || getFieldDef;
   }
 
@@ -101,6 +105,10 @@ export class TypeInfo {
 
   getArgument(): ?GraphQLArgument {
     return this._argument;
+  }
+
+  getEnumValue(): ?GraphQLEnumValue {
+    return this._enumValue;
   }
 
   // Flow does not yet handle this case.
@@ -182,6 +190,14 @@ export class TypeInfo {
         }
         this._inputTypeStack.push(fieldType);
         break;
+      case Kind.ENUM:
+        const enumType = getNamedType(this.getInputType());
+        let enumValue;
+        if (enumType instanceof GraphQLEnumType) {
+          enumValue = enumType.getValue(node.value);
+        }
+        this._enumValue = enumValue;
+        break;
     }
   }
 
@@ -212,6 +228,9 @@ export class TypeInfo {
       case Kind.LIST:
       case Kind.OBJECT_FIELD:
         this._inputTypeStack.pop();
+        break;
+      case Kind.ENUM:
+        this._enumValue = null;
         break;
     }
   }


### PR DESCRIPTION
This adds two new APIs to the schema utilities. One is for `TypeInfo` which is typically used alongside an AST visitor - now you can call `getEnumValue()` to get the GraphQLEnumValue instance referred to by the EnumValue ast node under visit.

Also, `EnumType.getValue(name)` accepts the name of an enum value and returns the GraphQLEnumValue instance associated with it. Beats running a `getValues().find(...)`.