### PR TITLE
Validate Input Types do not define resolvers

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -726,6 +726,97 @@ describe('Type System: Input Objects must have fields', () => {
 });
 
 
+describe('Type System: Input Object fields must not have resolvers', () => {
+
+  function schemaWithInputObject(inputObjectType) {
+    return new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          f: {
+            type: GraphQLString,
+            args: {
+              input: { type: inputObjectType }
+            }
+          }
+        }
+      })
+    });
+  }
+
+  it('accepts an Input Object type with no resolver', () => {
+    expect(
+      () => schemaWithInputObject(new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: GraphQLString,
+          }
+        }
+      }))
+    ).not.to.throw();
+  });
+
+  it('accepts an Input Object type with null resolver', () => {
+    expect(
+      () => schemaWithInputObject(new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: GraphQLString,
+            resolve: null,
+          }
+        }
+      }))
+    ).not.to.throw();
+  });
+
+  it('accepts an Input Object type with undefined resolver', () => {
+    expect(
+      () => schemaWithInputObject(new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: GraphQLString,
+            resolve: undefined,
+          }
+        }
+      }))
+    ).not.to.throw();
+  });
+
+  it('rejects an Input Object type with resolver function', () => {
+    expect(
+      () => schemaWithInputObject(new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: GraphQLString,
+            resolve: () => { return 0; },
+          }
+        }
+      }))
+    ).to.throw('SomeInputObject.f field type has a resolve property,' +
+    ' but Input Types cannot define resolvers.');
+  });
+
+  it('rejects an Input Object type with resolver constant', () => {
+    expect(
+      () => schemaWithInputObject(new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: GraphQLString,
+            resolve: {},
+          }
+        }
+      }))
+    ).to.throw('SomeInputObject.f field type has a resolve property,' +
+    ' but Input Types cannot define resolvers.');
+  });
+});
+
+
 describe('Type System: Object types must be assertable', () => {
 
   it('accepts an Object type with an isTypeOf function', () => {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -1050,6 +1050,11 @@ export class GraphQLInputObjectType {
         `${this.name}.${fieldName} field type must be Input Type but ` +
         `got: ${String(field.type)}.`
       );
+      invariant(
+        field.resolve == null,
+        `${this.name}.${fieldName} field type has a resolve property, but ` +
+        'Input Types cannot define resolvers.'
+      );
       resultFieldMap[fieldName] = field;
     });
     return resultFieldMap;


### PR DESCRIPTION
GraphQLInputObjectTypes are confusing to new users of GraphQL. One general distinction between GraphQLObjectType and GraphQLInputObjectType is the use of resolvers: I can't think of a valid case for them to be present on GraphQLInputObjectType. Let's validate this during schema construction and throw a helpful error. 