### PR TITLE
Convert error to warning for non-compliant use of __

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -341,15 +341,26 @@ describe('Type System: Objects must have fields', () => {
     );
   });
 
-  it('rejects an Object type with reserved named fields', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
+  it('warns about an Object type with reserved named fields', () => {
+    /* eslint-disable no-console */
+    const realConsoleError = console.error;
+    const calls = [];
+    console.error = function () {
+      calls.push(Array.prototype.slice.call(arguments));
+    };
+    try {
+      schemaWithFieldType(new GraphQLObjectType({
         name: 'SomeObject',
         fields: { __notPartOfIntrospection: { type: GraphQLString } }
-      }))
-    ).to.throw(
-      'Name "__notPartOfIntrospection" must not begin with "__", which is reserved by GraphQL introspection.'
-    );
+      }));
+
+      expect(calls[0][0]).contains(
+        'Name "__notPartOfIntrospection" must not begin with "__", which is reserved by GraphQL introspection.'
+      );
+    } finally {
+      console.error = realConsoleError;
+    }
+    /* eslint-enable no-console */
   });
 
   it('rejects an Object type with incorrectly typed fields', () => {

--- a/src/utilities/assertValidName.js
+++ b/src/utilities/assertValidName.js
@@ -10,6 +10,9 @@
 
 const NAME_RX = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
 
+// Ensures console warnings are only issued once.
+let hasWarnedAboutDunder = false;
+
 /**
  * Upholds the spec rules about naming.
  */
@@ -22,11 +25,17 @@ export function assertValidName(
       `Must be named. Unexpected name: ${name}.`
     );
   }
-  if (!isIntrospection && name.slice(0, 2) === '__') {
-    throw new Error(
-      `Name "${name}" must not begin with "__", which is reserved by ` +
-      'GraphQL introspection.'
-    );
+  if (!isIntrospection && name.slice(0, 2) === '__' && !hasWarnedAboutDunder) {
+    hasWarnedAboutDunder = true;
+    /* eslint-disable no-console */
+    if (console && console.error) {
+      const error = new Error(
+        `Name "${name}" must not begin with "__", which is reserved by ` +
+        'GraphQL introspection.'
+      );
+      console.error(error.stack || String(error));
+    }
+    /* eslint-enable no-console */
   }
   if (!NAME_RX.test(name)) {
     throw new Error(


### PR DESCRIPTION
This unbreaks various uses of graphql-js which were defining fields with __ while retaining some form of reporting warning for non-compliant use.

Fixes #690