### PR TITLE
Quotes reserved literals when used in properties.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -21,5 +21,6 @@
     "transform-es2015-block-scoping",
     "transform-es2015-modules-commonjs",
     "transform-regenerator",
+    "transform-es3-property-literals",
   ]
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-plugin-transform-es2015-shorthand-properties": "6.22.0",
     "babel-plugin-transform-es2015-spread": "6.22.0",
     "babel-plugin-transform-es2015-template-literals": "6.22.0",
+    "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "babel-plugin-transform-object-rest-spread": "6.22.0",
     "babel-plugin-transform-regenerator": "6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -446,6 +446,12 @@ babel-plugin-transform-es2015-template-literals@6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-es3-property-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz#b2078d5842e22abf40f73e8cde9cd3711abd5758"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-flow-strip-types@6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
@@ -923,9 +929,9 @@ eslint-plugin-flowtype@2.30.0:
   dependencies:
     lodash "^4.15.0"
 
-eslint@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.14.0.tgz#2c617e5f782fda5cbee5bc8be7ef5053af8e63a3"
+eslint@3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.14.1.tgz#8a62175f2255109494747a1b25128d97b8eb3d97"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"


### PR DESCRIPTION
This is primarily getting hit when using graphql-js in weird or old environments where ES6 exports end up using `default` a bunch. Better safe.