### PR TITLE
Use flow %checks to reduce occurance of :any

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -18,14 +18,11 @@ import { typeFromAST } from '../utilities/typeFromAST';
 import * as Kind from '../language/kinds';
 import { getVariableValues, getArgumentValues } from './values';
 import {
-  GraphQLScalarType,
   GraphQLObjectType,
-  GraphQLEnumType,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
-  isAbstractType
+  isAbstractType,
+  isLeafType,
 } from '../type/definition';
 import type {
   GraphQLType,
@@ -527,8 +524,7 @@ function doesFragmentConditionMatch(
     return true;
   }
   if (isAbstractType(conditionalType)) {
-    const abstractType = ((conditionalType: any): GraphQLAbstractType);
-    return exeContext.schema.isPossibleType(abstractType, type);
+    return exeContext.schema.isPossibleType(conditionalType, type);
   }
   return false;
 }
@@ -831,15 +827,13 @@ function completeValue(
 
   // If field type is a leaf type, Scalar or Enum, serialize to a valid value,
   // returning null if serialization is not possible.
-  if (returnType instanceof GraphQLScalarType ||
-      returnType instanceof GraphQLEnumType) {
+  if (isLeafType(returnType)) {
     return completeLeafValue(returnType, result);
   }
 
   // If field type is an abstract type, Interface or Union, determine the
   // runtime Object type and complete for that type.
-  if (returnType instanceof GraphQLInterfaceType ||
-      returnType instanceof GraphQLUnionType) {
+  if (isAbstractType(returnType)) {
     return completeAbstractValue(
       exeContext,
       returnType,

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -57,7 +57,7 @@ export function getVariableValues(
   for (let i = 0; i < varDefNodes.length; i++) {
     const varDefNode = varDefNodes[i];
     const varName = varDefNode.variable.name.value;
-    let varType = typeFromAST(schema, varDefNode.type);
+    const varType = typeFromAST(schema, varDefNode.type);
     if (!isInputType(varType)) {
       throw new GraphQLError(
         `Variable "$${varName}" expected value of type ` +
@@ -65,7 +65,6 @@ export function getVariableValues(
         [ varDefNode.type ]
       );
     }
-    varType = ((varType: any): GraphQLInputType);
 
     const value = inputs[varName];
     if (isInvalid(value)) {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -20,6 +20,7 @@ import {
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
+  isAbstractType,
 } from './definition';
 import { GraphQLString, GraphQLBoolean } from './scalars';
 import { DirectiveLocation } from './directives';
@@ -267,8 +268,7 @@ export const __Type = new GraphQLObjectType({
     possibleTypes: {
       type: new GraphQLList(new GraphQLNonNull(__Type)),
       resolve(type, args, context, { schema }) {
-        if (type instanceof GraphQLInterfaceType ||
-            type instanceof GraphQLUnionType) {
+        if (isAbstractType(type)) {
           return schema.getPossibleTypes(type);
         }
       }

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -17,7 +17,6 @@ import {
   getNamedType,
   GraphQLObjectType,
   GraphQLInterfaceType,
-  GraphQLUnionType,
   GraphQLInputObjectType,
   GraphQLEnumType,
   GraphQLList,
@@ -120,9 +119,7 @@ export class TypeInfo {
       case Kind.SELECTION_SET:
         const namedType = getNamedType(this.getType());
         this._parentTypeStack.push(
-          isCompositeType(namedType) ?
-            ((namedType: any): GraphQLCompositeType) :
-            undefined
+          isCompositeType(namedType) ? namedType : undefined
         );
         break;
       case Kind.FIELD:
@@ -155,17 +152,13 @@ export class TypeInfo {
           typeFromAST(schema, typeConditionAST) :
           this.getType();
         this._typeStack.push(
-          isOutputType(outputType) ?
-            ((outputType: any): GraphQLOutputType) :
-            undefined
+          isOutputType(outputType) ? outputType : undefined
         );
         break;
       case Kind.VARIABLE_DEFINITION:
         const inputType = typeFromAST(schema, node.type);
         this._inputTypeStack.push(
-          isInputType(inputType) ?
-            ((inputType: any): GraphQLInputType) :
-            undefined
+          isInputType(inputType) ? inputType : undefined
         );
         break;
       case Kind.ARGUMENT:
@@ -264,11 +257,7 @@ function getFieldDef(
       schema.getQueryType() === parentType) {
     return TypeMetaFieldDef;
   }
-  if (name === TypeNameMetaFieldDef.name &&
-      (parentType instanceof GraphQLObjectType ||
-       parentType instanceof GraphQLInterfaceType ||
-       parentType instanceof GraphQLUnionType)
-  ) {
+  if (name === TypeNameMetaFieldDef.name && isCompositeType(parentType)) {
     return TypeNameMetaFieldDef;
   }
   if (parentType instanceof GraphQLObjectType ||

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -68,8 +68,8 @@ import {
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
-  isInputType,
-  isOutputType,
+  assertInputType,
+  assertOutputType,
 } from '../type/definition';
 
 import type {
@@ -299,15 +299,11 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
   }
 
   function produceInputType(typeNode: TypeNode): GraphQLInputType {
-    const type = produceType(typeNode);
-    invariant(isInputType(type), 'Expected Input type.');
-    return (type: any);
+    return assertInputType(produceType(typeNode));
   }
 
   function produceOutputType(typeNode: TypeNode): GraphQLOutputType {
-    const type = produceType(typeNode);
-    invariant(isOutputType(type), 'Expected Output type.');
-    return (type: any);
+    return assertOutputType(produceType(typeNode));
   }
 
   function produceObjectType(typeNode: TypeNode): GraphQLObjectType {

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -162,7 +162,7 @@ export function buildClientSchema(
       isInputType(type),
       'Introspection must provide input type for arguments.'
     );
-    return (type: any);
+    return type;
   }
 
   function getOutputType(typeRef: IntrospectionTypeRef): GraphQLOutputType {
@@ -171,7 +171,7 @@ export function buildClientSchema(
       isOutputType(type),
       'Introspection must provide output type for fields.'
     );
-    return (type: any);
+    return type;
   }
 
   function getObjectType(typeRef: IntrospectionTypeRef): GraphQLObjectType {
@@ -180,7 +180,7 @@ export function buildClientSchema(
       type instanceof GraphQLObjectType,
       'Introspection must provide object type for possibleTypes.'
     );
-    return (type: any);
+    return type;
   }
 
   function getInterfaceType(
@@ -191,7 +191,7 @@ export function buildClientSchema(
       type instanceof GraphQLInterfaceType,
       'Introspection must provide interface type for interfaces.'
     );
-    return (type: any);
+    return type;
   }
 
 

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -28,8 +28,8 @@ import {
   GraphQLScalarType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  isInputType,
-  isOutputType,
+  assertInputType,
+  assertOutputType,
 } from '../type/definition';
 
 import {
@@ -298,15 +298,11 @@ export function extendSchema(
   }
 
   function getInputTypeFromAST(node: NamedTypeNode): GraphQLInputType {
-    const type = getTypeFromAST(node);
-    invariant(isInputType(type), 'Must be Input type.');
-    return (type: any);
+    return assertInputType(getTypeFromAST(node));
   }
 
   function getOutputTypeFromAST(node: NamedTypeNode): GraphQLOutputType {
-    const type = getTypeFromAST(node);
-    invariant(isOutputType(type), 'Must be Output type.');
-    return (type: any);
+    return assertOutputType(getTypeFromAST(node));
   }
 
   // Given a name, returns a type from either the existing schema or an
@@ -445,10 +441,10 @@ export function extendSchema(
 
   function extendFieldType<T: GraphQLType>(typeDef: T): T {
     if (typeDef instanceof GraphQLList) {
-      return (new GraphQLList(extendFieldType(typeDef.ofType)): any);
+      return new GraphQLList(extendFieldType(typeDef.ofType));
     }
     if (typeDef instanceof GraphQLNonNull) {
-      return (new GraphQLNonNull(extendFieldType(typeDef.ofType)): any);
+      return new GraphQLNonNull(extendFieldType(typeDef.ofType));
     }
     return getTypeFromDef(typeDef);
   }

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -281,9 +281,7 @@ export function findFieldsThatChangedType(
         // Check if the field's type has changed in the new schema.
         const oldFieldType = getNamedType(oldTypeFieldsDef[fieldName].type);
         const newFieldType = getNamedType(newTypeFieldsDef[fieldName].type);
-        if (oldFieldType &&
-            newFieldType &&
-            oldFieldType.name !== newFieldType.name) {
+        if (oldFieldType.name !== newFieldType.name) {
           breakingFieldChanges.push({
             type: BreakingChangeType.FIELD_CHANGED_KIND,
             description: `${typeName}.${fieldName} changed type from ` +

--- a/src/utilities/typeComparators.js
+++ b/src/utilities/typeComparators.js
@@ -11,15 +11,12 @@
 import {
   isAbstractType,
   GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
   GraphQLList,
   GraphQLNonNull,
 } from '../type/definition';
 import type {
   GraphQLType,
-  GraphQLCompositeType,
-  GraphQLAbstractType
+  GraphQLCompositeType
 } from '../type/definition';
 import type {
   GraphQLSchema
@@ -89,10 +86,7 @@ export function isTypeSubTypeOf(
   // possible object type.
   if (isAbstractType(superType) &&
       maybeSubType instanceof GraphQLObjectType &&
-      schema.isPossibleType(
-        ((superType: any): GraphQLAbstractType),
-        maybeSubType
-      )) {
+      schema.isPossibleType(superType, maybeSubType)) {
     return true;
   }
 
@@ -122,10 +116,8 @@ export function doTypesOverlap(
     return true;
   }
 
-  if (typeA instanceof GraphQLInterfaceType ||
-      typeA instanceof GraphQLUnionType) {
-    if (_typeB instanceof GraphQLInterfaceType ||
-        _typeB instanceof GraphQLUnionType) {
+  if (isAbstractType(typeA)) {
+    if (isAbstractType(_typeB)) {
       // If both types are abstract, then determine if there is any intersection
       // between possible concrete types of each.
       return schema.getPossibleTypes(typeA).some(
@@ -136,8 +128,7 @@ export function doTypesOverlap(
     return schema.isPossibleType(typeA, _typeB);
   }
 
-  if (_typeB instanceof GraphQLInterfaceType ||
-      _typeB instanceof GraphQLUnionType) {
+  if (isAbstractType(_typeB)) {
     // Determine if the former type is a possible concrete type of the latter.
     return schema.isPossibleType(_typeB, typeA);
   }

--- a/src/validation/rules/FieldsOnCorrectType.js
+++ b/src/validation/rules/FieldsOnCorrectType.js
@@ -18,7 +18,7 @@ import type { GraphQLOutputType } from '../../type/definition';
 import {
   GraphQLObjectType,
   GraphQLInterfaceType,
-  GraphQLUnionType,
+  isAbstractType,
 } from '../../type/definition';
 
 
@@ -89,8 +89,7 @@ function getSuggestedTypeNames(
   type: GraphQLOutputType,
   fieldName: string
 ): Array<string> {
-  if (type instanceof GraphQLInterfaceType ||
-      type instanceof GraphQLUnionType) {
+  if (isAbstractType(type)) {
     const suggestedObjectTypes = [];
     const interfaceUsageCount = Object.create(null);
     schema.getPossibleTypes(type).forEach(possibleType => {

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -697,7 +697,7 @@ function getReferencedFieldsAndFragmentNames(
   return getFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
-    ((fragmentType: any): GraphQLNamedType),
+    fragmentType,
     fragment.selectionSet
   );
 }
@@ -736,7 +736,7 @@ function _collectFieldsAndFragmentNames(
           parentType;
         _collectFieldsAndFragmentNames(
           context,
-          ((inlineFragmentType: any): GraphQLNamedType),
+          inlineFragmentType,
           selection.selectionSet,
           nodeAndDefs,
           fragmentNames


### PR DESCRIPTION
This uses a pre-release flow feature to provide predicate functions with more type checking power. It also breaks apart some functions into multiple declare function statements for cases where more specific input types result in more specific output types.