### PR TITLE
Quotes preserved `if` literal when used in properties

### DIFF
--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -112,7 +112,7 @@ export const GraphQLIncludeDirective = new GraphQLDirective({
     DirectiveLocation.INLINE_FRAGMENT,
   ],
   args: {
-    if: {
+    'if': {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Included when true.'
     }
@@ -133,7 +133,7 @@ export const GraphQLSkipDirective = new GraphQLDirective({
     DirectiveLocation.INLINE_FRAGMENT,
   ],
   args: {
-    if: {
+    'if': {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: 'Skipped when true.'
     }


### PR DESCRIPTION
Related to 080e281f97470a309be70e5edbc9bf5107bc4e21, but for `if` case.