### PR TITLE
Fix: isLeafType matches type definition.

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -135,10 +135,9 @@ export type GraphQLLeafType =
   GraphQLEnumType;
 
 export function isLeafType(type: ?GraphQLType): boolean {
-  const namedType = getNamedType(type);
   return (
-    namedType instanceof GraphQLScalarType ||
-    namedType instanceof GraphQLEnumType
+    type instanceof GraphQLScalarType ||
+    type instanceof GraphQLEnumType
   );
 }
 

--- a/src/validation/rules/ScalarLeafs.js
+++ b/src/validation/rules/ScalarLeafs.js
@@ -11,7 +11,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import type { FieldNode } from '../../language/ast';
-import { isLeafType } from '../../type/definition';
+import { getNamedType, isLeafType } from '../../type/definition';
 import type { GraphQLType } from '../../type/definition';
 
 
@@ -42,7 +42,7 @@ export function ScalarLeafs(context: ValidationContext): any {
     Field(node: FieldNode) {
       const type = context.getType();
       if (type) {
-        if (isLeafType(type)) {
+        if (isLeafType(getNamedType(type))) {
           if (node.selectionSet) {
             context.reportError(new GraphQLError(
               noSubselectionAllowedMessage(node.name.value, type),


### PR DESCRIPTION
This was ambiguous before. Other isCompositeType / isAbstractType checks below do not include named type unwrapping, and it did not match the type definition above. Only one callsite actually relied on named type unwrapping, so moved this check there.