### PR TITLE
Improved error message for undefined field config

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -330,6 +330,19 @@ describe('Type System: Objects must have fields', () => {
     );
   });
 
+  it('rejects an Object type field with undefined config', () => {
+    expect(
+      () => schemaWithFieldType(new GraphQLObjectType({
+        name: 'SomeObject',
+        fields: {
+          f: undefined
+        }
+      }))
+    ).to.throw(
+      'SomeObject.f field config must be an object'
+    );
+  });
+
   it('rejects an Object type with incorrectly named fields', () => {
     expect(
       () => schemaWithFieldType(new GraphQLObjectType({

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -491,6 +491,10 @@ function defineFieldMap<TSource, TContext>(
     assertValidName(fieldName);
     const fieldConfig = fieldMap[fieldName];
     invariant(
+      isPlainObj(fieldConfig),
+      `${type.name}.${fieldName} field config must be an object`
+    );
+    invariant(
       !fieldConfig.hasOwnProperty('isDeprecated'),
       `${type.name}.${fieldName} should provide "deprecationReason" instead ` +
       'of "isDeprecated".'


### PR DESCRIPTION
Context: a circular dependency problem while using graphql-relay caused `nodeField` to be undefined.

Unfortunately, when a field config is undefined you don't get a useful stack trace:

```sh
/Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/definition.js:330
    (0, _invariant2.default)(!fieldConfig.hasOwnProperty('isDeprecated'), type.name + '.' + fieldName + ' should provide "deprecationReason" instead ' + 'of "isDeprecated".');
                                         ^

TypeError: Cannot read property 'hasOwnProperty' of undefined
    at /Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/definition.js:330:42
    at Array.forEach (native)
    at defineFieldMap (/Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/definition.js:327:14)
    at GraphQLObjectType.getFields (/Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/definition.js:285:44)
    at /Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/schema.js:207:27
    at typeMapReducer (/Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/schema.js:219:7)
    at Array.reduce (native)
    at new GraphQLSchema (/Users/cesarandreu/Developer/graphql-project/node_modules/graphql/type/schema.js:95:34)
    at Object.<anonymous> (/Users/cesarandreu/Developer/graphql-project/src/schema/index.js:5:23)
```
