### PR TITLE
Improve perf of separateOperations

### DIFF
--- a/src/utilities/separateOperations.js
+++ b/src/utilities/separateOperations.js
@@ -11,6 +11,7 @@
 import { visit } from '../language/visitor';
 import type {
   DocumentNode,
+  FragmentDefinitionNode,
   OperationDefinitionNode,
 } from '../language/ast';
 
@@ -24,18 +25,22 @@ export function separateOperations(
   documentAST: DocumentNode
 ): { [operationName: string]: DocumentNode } {
 
-  const operations = [];
+  const definitions: DefinitionMap = Object.create(null);
   const depGraph: DepGraph = Object.create(null);
   let fromName;
+  let idx = 0;
 
-  // Populate the list of operations and build a dependency graph.
+  // Populate the list of definitions and build a dependency graph.
   visit(documentAST, {
     OperationDefinition(node) {
-      operations.push(node);
       fromName = opName(node);
+      definitions[fromName] = { idx, node };
+      ++idx;
     },
     FragmentDefinition(node) {
       fromName = node.name.value;
+      definitions[fromName] = { idx, node };
+      ++idx;
     },
     FragmentSpread(node) {
       const toName = node.name.value;
@@ -47,23 +52,32 @@ export function separateOperations(
   // For each operation, produce a new synthesized AST which includes only what
   // is necessary for completing that operation.
   const separatedDocumentASTs = Object.create(null);
-  operations.forEach(operation => {
-    const operationName = opName(operation);
+  const operationNames = Object.keys(definitions).filter(defName =>
+    definitions[defName].node.kind === 'OperationDefinition'
+  );
+  operationNames.forEach(operationName => {
     const dependencies = Object.create(null);
     collectTransitiveDependencies(dependencies, depGraph, operationName);
+    dependencies[operationName] = true;
 
     separatedDocumentASTs[operationName] = {
       kind: 'Document',
-      definitions: documentAST.definitions.filter(def =>
-        def === operation ||
-        def.kind === 'FragmentDefinition' && dependencies[def.name.value]
-      )
+      definitions: Object.keys(dependencies)
+        .map(defName => definitions[defName])
+        .sort((def1, def2) => def1.idx - def2.idx)
+        .map(def => def.node)
     };
   });
 
   return separatedDocumentASTs;
 }
 
+type DefinitionMap = {
+  [defName: string]: {
+    idx: number,
+    node: OperationDefinitionNode | FragmentDefinitionNode
+  }
+};
 type DepGraph = {[from: string]: {[to: string]: boolean}};
 
 // Provides the empty string for anonymous operations.

--- a/src/utilities/separateOperations.js
+++ b/src/utilities/separateOperations.js
@@ -62,7 +62,7 @@ export function separateOperations(
     // to retain the same order as the original document.
     const definitions = [ operation ];
     Object.keys(dependencies).forEach(name => {
-      definitions.push(fragments[name])
+      definitions.push(fragments[name]);
     });
     definitions.sort(
       (n1, n2) => (positions.get(n1) || 0) - (positions.get(n2) || 0)


### PR DESCRIPTION
The separateOperations function does a pass over all definitions of a document for each operation in the document. This is painful for big documents. Since the function already visits each definition node, we can cache the visited nodes. Then instead of passing over all top-level definitions in the document and removing those not in an operation's depgraph, we can pass over the (often much smaller) list of definition names in the depgraph and retrieve the definitions by name from the cache.

Ran flow check and separateOperations-test.js