### PR TITLE
Allow buildASTSchema to throw errors with source locations.

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -86,6 +86,33 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   path?: ?Array<string | number>,
   originalError?: ?Error
 ) {
+  // Define message so it can be captured in stack trace.
+  Object.defineProperty(this, 'message', {
+    value: message,
+    // By being enumerable, JSON.stringify will include `message` in the
+    // resulting output. This ensures that the simplist possible GraphQL
+    // service adheres to the spec.
+    enumerable: true,
+    writable: true
+  });
+
+  // Include (non-enumerable) stack trace.
+  if (originalError && originalError.stack) {
+    Object.defineProperty(this, 'stack', {
+      value: originalError.stack,
+      writable: true,
+      configurable: true
+    });
+  } else if (Error.captureStackTrace) {
+    Error.captureStackTrace(this, GraphQLError);
+  } else {
+    Object.defineProperty(this, 'stack', {
+      value: Error().stack,
+      writable: true,
+      configurable: true
+    });
+  }
+
   // Compute locations in the source for the given nodes/positions.
   let _source = source;
   if (!_source && nodes && nodes.length > 0) {
@@ -109,14 +136,6 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   }
 
   Object.defineProperties(this, {
-    message: {
-      value: message,
-      // By being enumerable, JSON.stringify will include `message` in the
-      // resulting output. This ensures that the simplest possible GraphQL
-      // service adheres to the spec.
-      enumerable: true,
-      writable: true
-    },
     locations: {
       // Coercing falsey values to undefined ensures they will not be included
       // in JSON.stringify() when not provided.

--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -90,7 +90,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   Object.defineProperty(this, 'message', {
     value: message,
     // By being enumerable, JSON.stringify will include `message` in the
-    // resulting output. This ensures that the simplist possible GraphQL
+    // resulting output. This ensures that the simplest possible GraphQL
     // service adheres to the spec.
     enumerable: true,
     writable: true

--- a/src/error/syntaxError.js
+++ b/src/error/syntaxError.js
@@ -58,9 +58,9 @@ export function syntaxError(
  * returns an error containing the message, without context.
  */
 export function validationError(
+  source: ?Source,
+  node: ?ASTNode,
   message: string,
-  node?: ASTNode,
-  source?: Source
 ): GraphQLError {
   const position = node ? (node.loc ? node.loc.start : null) : null;
   if (position == null || source == null) {

--- a/src/jsutils/invariant.js
+++ b/src/jsutils/invariant.js
@@ -8,8 +8,11 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-export default function invariant(condition: mixed, message: string) {
+export default function invariant(condition: mixed, message: string | Error) {
   if (!condition) {
+    if (message instanceof Error) {
+      throw message;
+    }
     throw new Error(message);
   }
 }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -92,9 +92,9 @@ export function assertInputType(
 ): GraphQLInputType {
   invariant(isInputType(type),
     validationError(
-      `Expected ${String(type)} to be a GraphQL input type.`,
+      source,
       typeNode,
-      source));
+      `Expected ${String(type)} to be a GraphQL input type.`));
   return type;
 }
 
@@ -136,9 +136,9 @@ export function assertOutputType(
 ): GraphQLOutputType {
   invariant(isOutputType(type),
     validationError(
-      `Expected ${String(type)} to be a GraphQL output type.`,
+      source,
       typeNode,
-      source));
+      `Expected ${String(type)} to be a GraphQL output type.`));
   return type;
 }
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -19,7 +19,10 @@ import type {
   ValueNode,
 } from '../language/ast';
 import type { GraphQLSchema } from './schema';
+import { validationError } from '../error/syntaxError';
 
+import type { Source } from '../language/source';
+import type { ASTNode } from '../language/ast';
 
 // Predicates & Assertions
 
@@ -82,11 +85,16 @@ export function isInputType(type: ?GraphQLType): boolean %checks {
   );
 }
 
-export function assertInputType(type: ?GraphQLType): GraphQLInputType {
-  invariant(
-    isInputType(type),
-    `Expected ${String(type)} to be a GraphQL input type.`
-  );
+export function assertInputType(
+  type: ?GraphQLType,
+  typeNode?: ASTNode,
+  source?: Source
+): GraphQLInputType {
+  invariant(isInputType(type),
+    validationError(
+      `Expected ${String(type)} to be a GraphQL input type.`,
+      typeNode,
+      source));
   return type;
 }
 
@@ -121,11 +129,16 @@ export function isOutputType(type: ?GraphQLType): boolean %checks {
   );
 }
 
-export function assertOutputType(type: ?GraphQLType): GraphQLOutputType {
-  invariant(
-    isOutputType(type),
-    `Expected ${String(type)} to be a GraphQL output type.`,
-  );
+export function assertOutputType(
+  type: ?GraphQLType,
+  typeNode?: ASTNode,
+  source?: Source
+): GraphQLOutputType {
+  invariant(isOutputType(type),
+    validationError(
+      `Expected ${String(type)} to be a GraphQL output type.`,
+      typeNode,
+      source));
   return type;
 }
 

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -17,6 +17,7 @@ import {
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
+  Source,
 } from '../../';
 
 /**
@@ -819,5 +820,30 @@ type Repeated {
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Type "Repeated" was defined more than once.');
+
+  it('warns with a location where validation errors occur', () => {
+    const body = new Source(`type OutputType {
+      value: String
+    }
+
+    input InputType {
+      value: String
+    }
+
+    type Query {
+      output: [OutputType]
+    }
+
+    type Mutation {
+      signup (password: OutputType): OutputType
+    }`);
+    const doc = parse(body);
+    expect(() => buildASTSchema(doc, body))
+      .to.throw(`GraphQLError: Validation Error: Expected Input type (14:25)
+
+13:     type Mutation {
+14:       signup (password: OutputType): OutputType
+                            ^
+15:     }`);
   });
 });

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -317,14 +317,14 @@ export function buildASTSchema(
   function produceObjectType(typeNode: TypeNode): GraphQLObjectType {
     const type = produceType(typeNode);
     invariant(type instanceof GraphQLObjectType,
-      validationError('Expected Object type', typeNode, source));
+      validationError(source, typeNode, 'Expected Object type'));
     return type;
   }
 
   function produceInterfaceType(typeNode: TypeNode): GraphQLInterfaceType {
     const type = produceType(typeNode);
     invariant(type instanceof GraphQLInterfaceType,
-      validationError('Expected Interface type', typeNode, source));
+      validationError(source, typeNode, 'Expected Interface type'));
     return type;
   }
 


### PR DESCRIPTION
See #546 for context. This patch is one possible implementation of having type errors in a schema list their source location. Given the following code:

```js
const { graphql, buildSchema } = require('graphql');

const schema = buildSchema(`
  type OutputType {
    value: String
  }

  input InputType {
    value: String
  }

  type Query {
    output: [OutputType]
  }

  type Mutation {
    signup (password: OutputType): OutputType
  }
`)
```

Instead of this error:

```sh
$ node schema.js
/Users/trim/github/graphql-js/dist/jsutils/invariant.js:19
    throw new Error(message);
    ^

Error: Expected Input type
    at invariant (/Users/trim/github/graphql-js/dist/jsutils/invariant.js:19:11)
    ...
```

It would throw this:

```sh
$ node schema.js
/Users/trim/github/graphql-js/dist/jsutils/invariant.js:19
    throw new Error(message);
    ^

Error: Expected Input type (15:23)

14:   type Mutation {
15:     signup (password: OutputType): OutputType
                          ^
16:   }

    at invariant (/Users/trim/github/graphql-js/dist/jsutils/invariant.js:19:11)
    ....
```

Caveats:

* We'd have to thread the Source object through buildASTSchema in order to have content for line numbers and the source error itself. In this implementation, I made this optional so buildASTSchema just uses it as context for the error if it's provided.
* In order to avoid recreating the `Source` object many times in `invariantError`, `buildASTSchema` now does so explicitly. But is this necessary?
* This makes our invariant calls more costly, because it constructs the error message and deduces the line numbers & syntax highlighting whether or not it's thrown.
* We have to give the `syntaxError` module knowledge of the AST, though with a bit of work this implementation could pass in a position instead.
* The implementation `invariantError` I chose here is pretty weak, there's probably a better pattern for wrapping `invariant(...)` we could use.
* Can we merge the formatting logic of `syntaxError` to use `invariantError`?
* Lastly, I didn't apply the invariantError to all functions, just a handful. That would have to be finished before merge.