### PR TITLE
Forbid object to declare that it implements same interface twice.

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -559,6 +559,30 @@ describe('Type System: Object interfaces must be array', () => {
     );
   });
 
+  it('rejects an Object that declare it implements same interface more than once', () => {
+    expect(() => {
+      const NonUniqInterface = new GraphQLInterfaceType({
+        name: 'NonUniqInterface',
+        resolveType: () => null,
+        fields: { f: { type: GraphQLString } },
+      });
+
+      const AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        resolveType: () => null,
+        fields: { f: { type: GraphQLString } },
+      });
+
+      schemaWithFieldType(new GraphQLObjectType({
+        name: 'SomeObject',
+        interfaces: () => [ NonUniqInterface, AnotherInterface, NonUniqInterface ],
+        fields: { f: { type: GraphQLString } }
+      }));
+    }).to.throw(
+      'SomeObject may declare it implements NonUniqInterface only once.'
+    );
+  });
+
   it('rejects an Object type with interfaces as a function returning an incorrect type', () => {
     expect(
       () => schemaWithFieldType(new GraphQLObjectType({

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -450,7 +450,7 @@ function defineInterfaces(
     'an Array.'
   );
 
-  const seenInterfaceNames = [];
+  const implementedTypeNames = {};
   interfaces.forEach(iface => {
     invariant(
       iface instanceof GraphQLInterfaceType,
@@ -458,10 +458,10 @@ function defineInterfaces(
       `implement: ${String(iface)}.`
     );
     invariant(
-      seenInterfaceNames.indexOf(iface.name) === -1,
+      !implementedTypeNames[iface.name],
       `${type.name} may declare it implements ${iface.name} only once.`
     );
-    seenInterfaceNames.push(iface.name);
+    implementedTypeNames[iface.name] = true;
     if (typeof iface.resolveType !== 'function') {
       invariant(
         typeof type.isTypeOf === 'function',

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -449,12 +449,19 @@ function defineInterfaces(
     `${type.name} interfaces must be an Array or a function which returns ` +
     'an Array.'
   );
+
+  const seenInterfaceNames = [];
   interfaces.forEach(iface => {
     invariant(
       iface instanceof GraphQLInterfaceType,
       `${type.name} may only implement Interface types, it cannot ` +
       `implement: ${String(iface)}.`
     );
+    invariant(
+      seenInterfaceNames.indexOf(iface.name) === -1,
+      `${type.name} may declare it implements ${iface.name} only once.`
+    );
+    seenInterfaceNames.push(iface.name);
     if (typeof iface.resolveType !== 'function') {
       invariant(
         typeof type.isTypeOf === 'function',


### PR DESCRIPTION
For details please see this PR: https://github.com/facebook/graphql/pull/262