### PR TITLE
Forbid duplicate type definitions

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -802,4 +802,22 @@ fragment Foo on Type { field }
       .to.throw('Specified query type "Foo" not found in document.');
   });
 
+  it('Forbids duplicate type definitions', () => {
+    const body = `
+schema {
+  query: Repeated
+}
+
+type Repeated {
+  id: Int
+}
+
+type Repeated {
+  id: String
+}
+`;
+    const doc = parse(body);
+    expect(() => buildASTSchema(doc))
+      .to.throw('Type "Repeated" was defined more than once.');
+  });
 });

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -160,8 +160,12 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
       case ENUM_TYPE_DEFINITION:
       case UNION_TYPE_DEFINITION:
       case INPUT_OBJECT_TYPE_DEFINITION:
+        const typeName = d.name.value;
+        if (nodeMap[typeName]) {
+          throw new Error(`Type "${typeName}" was defined more than once.`);
+        }
         typeDefs.push(d);
-        nodeMap[d.name.value] = d;
+        nodeMap[typeName] = d;
         break;
       case DIRECTIVE_DEFINITION:
         directiveDefs.push(d);


### PR DESCRIPTION
A GraphQL schema can't have more than one definition of the same type.

Facebook runs an integration test to prevent this:
https://github.com/graphql/graphql-js/issues/223#issuecomment-265366200

With this PR the `buildASTSchema` step throws, causing any tests that load the schema to fail.
