### PR TITLE
allow deprecated fields/values to be extended

### DIFF
--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -465,7 +465,13 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
   }
 }
 
-function getDeprecationReason(directives: ?Array<DirectiveNode>): ?string {
+/**
+ * Given a collection of directives, returns the string value for the
+ * deprecation reason.
+ */
+export function getDeprecationReason(
+  directives: ?Array<DirectiveNode>,
+): ?string {
   const deprecatedAST = directives && find(
     directives,
     directive => directive.name.value === GraphQLDeprecatedDirective.name

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -11,7 +11,10 @@
 import invariant from '../jsutils/invariant';
 import keyMap from '../jsutils/keyMap';
 import keyValMap from '../jsutils/keyValMap';
-import { getDescription } from './buildASTSchema';
+import {
+  getDescription,
+  getDeprecationReason,
+} from './buildASTSchema';
 import { valueFromAST } from './valueFromAST';
 import { GraphQLError } from '../error/GraphQLError';
 import { GraphQLSchema } from '../type/schema';
@@ -431,6 +434,7 @@ export function extendSchema(
             description: getDescription(field),
             type: buildOutputFieldType(field.type),
             args: buildInputValues(field.arguments),
+            deprecationReason: getDeprecationReason(field.directives),
           };
         });
       });
@@ -506,7 +510,14 @@ export function extendSchema(
     return new GraphQLEnumType({
       name: typeNode.name.value,
       description: getDescription(typeNode),
-      values: keyValMap(typeNode.values, v => v.name.value, () => ({})),
+      values: keyValMap(
+        typeNode.values,
+        enumValue => enumValue.name.value,
+        enumValue => ({
+          description: getDescription(enumValue),
+          deprecationReason: getDeprecationReason(enumValue.directives),
+        }),
+      ),
     });
   }
 
@@ -544,6 +555,7 @@ export function extendSchema(
         type: buildOutputFieldType(field.type),
         description: getDescription(field),
         args: buildInputValues(field.arguments),
+        deprecationReason: getDeprecationReason(field.directives),
       })
     );
   }


### PR DESCRIPTION
There isn't a way to extend a schema with types that contains deprecated fields/enum values as `extendSchema` util function ignores the `@deprecated` directive. This fixes it.