### PR TITLE
Unify wording in error messages.

### DIFF
--- a/src/validation/rules/UniqueFragmentNames.js
+++ b/src/validation/rules/UniqueFragmentNames.js
@@ -13,7 +13,7 @@ import { GraphQLError } from '../../error';
 
 
 export function duplicateFragmentNameMessage(fragName: string): string {
-  return `There can only be one fragment named "${fragName}".`;
+  return `There can be only one fragment named "${fragName}".`;
 }
 
 /**

--- a/src/validation/rules/UniqueOperationNames.js
+++ b/src/validation/rules/UniqueOperationNames.js
@@ -13,7 +13,7 @@ import { GraphQLError } from '../../error';
 
 
 export function duplicateOperationNameMessage(operationName: string): string {
-  return `There can only be one operation named "${operationName}".`;
+  return `There can be only one operation named "${operationName}".`;
 }
 
 /**


### PR DESCRIPTION
Before this change there was:
- There can be only one argument named ...
- There can be only one input field named ...
- There can be only one variable named ...
- There can only be one fragment named ...
- There can only be one operation named ...

Now the last two match the others.