### PR TITLE
[validation] Fix infinite loop on invalid queries in OverlappingFields

### DIFF
--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -938,4 +938,55 @@ describe('Validate: Overlapping fields can be merged', () => {
 
   });
 
+  it('does not infinite loop on recursive fragment', () => {
+    expectPassesRule(OverlappingFieldsCanBeMerged, `
+      fragment fragA on Human {name relatives { name ...fragA } },
+    `);
+  });
+
+  it('does not infinite loop on immediately spread fragment', () => {
+    expectPassesRule(OverlappingFieldsCanBeMerged, `
+      fragment fragA on Human {name ...fragA },
+    `);
+  });
+
+  it('finds invalid case even with immediately spread fragment', () => {
+    // You would not expect this to have three error messages, and you would be
+    // right. The trickiness here is that we don't detect the immediate spread
+    // on first spreading, because it's in the context of the selection set. So
+    // by the time we detect and eliminate it, we've already spread it in once,
+    // and hence we get multiple error messages. We could change the algorithm
+    // to track that we're in an immediate fragment spread, but that would add
+    // complexity that only is needed in this error case.
+
+    // Because this is an invalid query by another rule (NoFragmentCycles), I'm
+    // not too worried about this case... and since we used to infinite loop,
+    // this is strictly better.
+    expectFailsRule(OverlappingFieldsCanBeMerged, `
+      fragment sameAliasesWithDifferentFieldTargets on Dog {
+        ...sameAliasesWithDifferentFieldTargets
+        fido: name
+        fido: nickname
+      }
+    `, [
+      { message: fieldsConflictMessage(
+          'fido',
+          'name and nickname are different fields'
+        ),
+        locations: [ { line: 4, column: 9 }, { line: 5, column: 9 } ],
+        path: undefined },
+      { message: fieldsConflictMessage(
+          'fido',
+          'name and nickname are different fields'
+        ),
+        locations: [ { line: 4, column: 9 }, { line: 5, column: 9 } ],
+        path: undefined },
+      { message: fieldsConflictMessage(
+          'fido',
+          'nickname and name are different fields'
+        ),
+        locations: [ { line: 5, column: 9 }, { line: 4, column: 9 } ],
+        path: undefined }
+    ]);
+  });
 });

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -239,6 +239,12 @@ function collectConflictsBetweenFieldsAndFragment(
     fragment
   );
 
+  if (fragmentNames2.indexOf(fragmentName) !== -1) {
+    // This means a fragment spread in itself. We're going to infinite loop
+    // if we try and collect all fields. Pretend we did not index that fragment
+    fragmentNames2.splice(fragmentNames2.indexOf(fragmentName));
+  }
+
   // (D) First collect any conflicts between the provided collection of fields
   // and the collection of fields represented by the given fragment.
   collectConflictsBetween(


### PR DESCRIPTION
`OverlappingFieldsCanBeMerged` would infinite loop when passed something like

```graphql
fragment A on User {
  name
  ...A
}
```

It's not `OverlappingFieldsCanBeMerged`'s responsibility to detect that validation error, but we still would ideally avoid infinite looping.

This detects that case, and pretends that the infinite spread wasn't there for the purposes of this validation step.