### PR TITLE
Moving from raw instance check to name checks in `findBreakingArgChanges`

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -392,6 +392,54 @@ describe('findBreakingChanges', () => {
     ]);
   });
 
+  it('should not flag args with the same type signature as breaking', () => {
+    const oldType = new GraphQLObjectType({
+      name: 'Type1',
+      fields: {
+        field1: {
+          type: GraphQLInt,
+          args: {
+            id: {
+              type: new GraphQLNonNull(GraphQLInt),
+            },
+          },
+        },
+      },
+    });
+
+    const newType = new GraphQLObjectType({
+      name: 'Type1',
+      fields: {
+        field1: {
+          type: GraphQLInt,
+          args: {
+            id: {
+              type: new GraphQLNonNull(GraphQLInt),
+            },
+          },
+        },
+      },
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        oldType,
+      ]
+    });
+
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [
+        newType,
+      ]
+    });
+
+    expect(
+      findArgChanges(oldSchema, newSchema).breakingChanges
+    ).to.eql([]);
+  });
+
   it('should consider args that move away from NonNull as non-breaking', () => {
     const oldType = new GraphQLObjectType({
       name: 'Type1',

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -16,7 +16,6 @@ import {
   GraphQLInterfaceType,
   GraphQLObjectType,
   GraphQLUnionType,
-  getNullableType,
 } from '../type/definition';
 
 import type { GraphQLNamedType, GraphQLFieldMap } from '../type/definition';
@@ -175,8 +174,7 @@ export function findArgChanges(
         );
         const newArgDef = newArgs[newTypeArgIndex];
 
-        const oldArgNullableType = getNullableType(oldArgDef.type);
-        const oldArgNullableTypeName = getNamedType(oldArgNullableType);
+        const oldArgTypeName = getNamedType(oldArgDef.type);
         const newArgTypeName = newArgDef ?
           getNamedType(newArgDef.type) :
           null;
@@ -191,7 +189,8 @@ export function findArgChanges(
 
         // Arg changed type in a breaking way
         } else if (
-          oldArgNullableTypeName.name !== newArgTypeName.name
+          oldArgTypeName && newArgTypeName &&
+          oldArgTypeName.name !== newArgTypeName.name
         ) {
           breakingChanges.push({
             type: BreakingChangeType.ARG_CHANGED_KIND,

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -179,8 +179,12 @@ export function findArgChanges(
           getNamedType(newArgDef.type) :
           null;
 
+        if (!oldArgTypeName) {
+          return;
+        }
+
         // Arg not present
-        if (newTypeArgIndex < 0) {
+        if (!newArgTypeName) {
           breakingChanges.push({
             type: BreakingChangeType.ARG_REMOVED,
             description: `${oldType.name}.${fieldName} arg ` +
@@ -189,7 +193,6 @@ export function findArgChanges(
 
         // Arg changed type in a breaking way
         } else if (
-          oldArgTypeName && newArgTypeName &&
           oldArgTypeName.name !== newArgTypeName.name
         ) {
           breakingChanges.push({

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -175,6 +175,12 @@ export function findArgChanges(
         );
         const newArgDef = newArgs[newTypeArgIndex];
 
+        const oldArgNullableType = getNullableType(oldArgDef.type);
+        const oldArgNullableTypeName = getNamedType(oldArgNullableType);
+        const newArgTypeName = newArgDef ?
+          getNamedType(newArgDef.type) :
+          null;
+
         // Arg not present
         if (newTypeArgIndex < 0) {
           breakingChanges.push({
@@ -185,8 +191,7 @@ export function findArgChanges(
 
         // Arg changed type in a breaking way
         } else if (
-          oldArgDef.type !== newArgDef.type &&
-          getNullableType(oldArgDef.type) !== newArgDef.type
+          oldArgNullableTypeName.name !== newArgTypeName.name
         ) {
           breakingChanges.push({
             type: BreakingChangeType.ARG_CHANGED_KIND,


### PR DESCRIPTION
Addresses https://github.com/graphql/graphql-js/issues/783. When I initially wrote the `findBreakingArgChanges`, doing comparison checks on the arg instances themselves was the state-of-the-art. It looks like the `findFieldsThatChangedType` now references the `name` property of the types to check if changes happened in a breaking way, which is what I've done in this PR.

Not sure how I can assert this correction in unit-tests... would be happy for feedback