### PR TITLE
[RFC] Export all validation rules directly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -247,7 +247,36 @@ export type {
 export {
   validate,
   ValidationContext,
+
+  // All validation rules in the GraphQL Specification.
   specifiedRules,
+
+  // Individual validation rules.
+  ArgumentsOfCorrectTypeRule,
+  DefaultValuesOfCorrectTypeRule,
+  FieldsOnCorrectTypeRule,
+  FragmentsOnCompositeTypesRule,
+  KnownArgumentNamesRule,
+  KnownDirectivesRule,
+  KnownFragmentNamesRule,
+  KnownTypeNamesRule,
+  LoneAnonymousOperationRule,
+  NoFragmentCyclesRule,
+  NoUndefinedVariablesRule,
+  NoUnusedFragmentsRule,
+  NoUnusedVariablesRule,
+  OverlappingFieldsCanBeMergedRule,
+  PossibleFragmentSpreadsRule,
+  ProvidedNonNullArgumentsRule,
+  ScalarLeafsRule,
+  UniqueArgumentNamesRule,
+  UniqueDirectivesPerLocationRule,
+  UniqueFragmentNamesRule,
+  UniqueInputFieldNamesRule,
+  UniqueOperationNamesRule,
+  UniqueVariableNamesRule,
+  VariablesAreInputTypesRule,
+  VariablesInAllowedPositionRule,
 } from './validation';
 
 

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -8,4 +8,130 @@
  */
 
 export { validate, ValidationContext } from './validate';
+
 export { specifiedRules } from './specifiedRules';
+
+// Spec Section: "Argument Values Type Correctness"
+export {
+  ArgumentsOfCorrectType as ArgumentsOfCorrectTypeRule
+} from './rules/ArgumentsOfCorrectType';
+
+// Spec Section: "Variable Default Values Are Correctly Typed"
+export {
+  DefaultValuesOfCorrectType as DefaultValuesOfCorrectTypeRule
+} from './rules/DefaultValuesOfCorrectType';
+
+// Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"
+export {
+  FieldsOnCorrectType as FieldsOnCorrectTypeRule
+} from './rules/FieldsOnCorrectType';
+
+// Spec Section: "Fragments on Composite Types"
+export {
+  FragmentsOnCompositeTypes as FragmentsOnCompositeTypesRule
+} from './rules/FragmentsOnCompositeTypes';
+
+// Spec Section: "Argument Names"
+export {
+  KnownArgumentNames as KnownArgumentNamesRule
+} from './rules/KnownArgumentNames';
+
+// Spec Section: "Directives Are Defined"
+export {
+  KnownDirectives as KnownDirectivesRule
+} from './rules/KnownDirectives';
+
+// Spec Section: "Fragment spread target defined"
+export {
+  KnownFragmentNames as KnownFragmentNamesRule
+} from './rules/KnownFragmentNames';
+
+// Spec Section: "Fragment Spread Type Existence"
+export {
+  KnownTypeNames as KnownTypeNamesRule
+} from './rules/KnownTypeNames';
+
+// Spec Section: "Lone Anonymous Operation"
+export {
+  LoneAnonymousOperation as LoneAnonymousOperationRule
+} from './rules/LoneAnonymousOperation';
+
+// Spec Section: "Fragments must not form cycles"
+export {
+  NoFragmentCycles as NoFragmentCyclesRule
+} from './rules/NoFragmentCycles';
+
+// Spec Section: "All Variable Used Defined"
+export {
+  NoUndefinedVariables as NoUndefinedVariablesRule
+} from './rules/NoUndefinedVariables';
+
+// Spec Section: "Fragments must be used"
+export {
+  NoUnusedFragments as NoUnusedFragmentsRule
+} from './rules/NoUnusedFragments';
+
+// Spec Section: "All Variables Used"
+export {
+  NoUnusedVariables as NoUnusedVariablesRule
+} from './rules/NoUnusedVariables';
+
+// Spec Section: "Field Selection Merging"
+export {
+  OverlappingFieldsCanBeMerged as OverlappingFieldsCanBeMergedRule
+} from './rules/OverlappingFieldsCanBeMerged';
+
+// Spec Section: "Fragment spread is possible"
+export {
+  PossibleFragmentSpreads as PossibleFragmentSpreadsRule
+} from './rules/PossibleFragmentSpreads';
+
+// Spec Section: "Argument Optionality"
+export {
+  ProvidedNonNullArguments as ProvidedNonNullArgumentsRule
+} from './rules/ProvidedNonNullArguments';
+
+// Spec Section: "Leaf Field Selections"
+export {
+  ScalarLeafs as ScalarLeafsRule
+} from './rules/ScalarLeafs';
+
+// Spec Section: "Argument Uniqueness"
+export {
+  UniqueArgumentNames as UniqueArgumentNamesRule
+} from './rules/UniqueArgumentNames';
+
+// Spec Section: "Directives Are Unique Per Location"
+export {
+  UniqueDirectivesPerLocation as UniqueDirectivesPerLocationRule
+} from './rules/UniqueDirectivesPerLocation';
+
+// Spec Section: "Fragment Name Uniqueness"
+export {
+  UniqueFragmentNames as UniqueFragmentNamesRule
+} from './rules/UniqueFragmentNames';
+
+// Spec Section: "Input Object Field Uniqueness"
+export {
+  UniqueInputFieldNames as UniqueInputFieldNamesRule
+} from './rules/UniqueInputFieldNames';
+
+// Spec Section: "Operation Name Uniqueness"
+export {
+  UniqueOperationNames as UniqueOperationNamesRule
+} from './rules/UniqueOperationNames';
+
+// Spec Section: "Variable Uniqueness"
+export {
+  UniqueVariableNames as UniqueVariableNamesRule
+} from './rules/UniqueVariableNames';
+
+// Spec Section: "Variables are Input Types"
+export {
+  VariablesAreInputTypes as VariablesAreInputTypesRule
+} from './rules/VariablesAreInputTypes';
+
+// Spec Section: "All Variable Usages Are Allowed"
+export {
+  VariablesInAllowedPosition as VariablesInAllowedPositionRule
+} from './rules/VariablesInAllowedPosition';

--- a/src/validation/specifiedRules.js
+++ b/src/validation/specifiedRules.js
@@ -91,6 +91,9 @@ import type { ValidationContext } from './index';
 
 /**
  * This set includes all validation rules defined by the GraphQL spec.
+ *
+ * The order of the rules in this list has been adjusted to lead to the
+ * most clear output when encountering multiple validation errors.
  */
 export const specifiedRules: Array<(context: ValidationContext) => any> = [
   UniqueOperationNames,


### PR DESCRIPTION
It's become relatively standard to create a whitelist or blacklist of validation rules, and reaching into the package per rule can get messy. This exports all the rules at the higher levels of submodule and module as well to make this easier.

For explaination of whitelist of blacklist:

```js
// Whitelist
import { specifiedRules, ScalarLeafsRule } from 'graphql';

// A ruleset which only runs one rule.
const whitelistRules = [ ScalarLeafsRule ];
```

```js
// Blacklist
import { specifiedRules, ScalarLeafsRule } from 'graphql';

// A ruleset which only runs all but one rule.
const blacklistRules = specifiedRules.filter(rule => rule !== ScalarLeafsRule);

// Note: the wrong way to do a blacklist would be to import and specify all
// but one rule. That's a whitelist and would fail to pick up any added
// validation rules that may be amended to spec in the future.
```