### PR TITLE
Add buildASTSchemaComponents function

### DIFF
--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -224,13 +224,20 @@ export class GraphQLSchema {
 
 type TypeMap = { [typeName: string]: GraphQLNamedType };
 
-type GraphQLSchemaConfig = {
-  query: GraphQLObjectType;
+type GraphQLSchemaConfigBase = {
   mutation?: ?GraphQLObjectType;
   subscription?: ?GraphQLObjectType;
   types?: ?Array<GraphQLNamedType>;
   directives?: ?Array<GraphQLDirective>;
   astNode?: ?SchemaDefinitionNode;
+};
+
+type GraphQLSchemaConfig = GraphQLSchemaConfigBase & {
+  query: GraphQLObjectType;
+};
+
+export type GraphQLSchemaComponents = GraphQLSchemaConfigBase & {
+  query?: ?GraphQLObjectType;
 };
 
 function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -11,7 +11,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { parse, print } from '../../language';
 import { printSchema } from '../schemaPrinter';
-import { buildASTSchema, buildSchema } from '../buildASTSchema';
+import {
+  buildASTSchemaComponents,
+  buildASTSchema,
+  buildSchema
+} from '../buildASTSchema';
 import dedent from '../../jsutils/dedent';
 import {
   graphql,
@@ -34,6 +38,18 @@ function cycleOutput(body) {
 }
 
 describe('Schema Builder', () => {
+
+  it('can build schema config for IDL with missing query type', async () => {
+    const config = buildASTSchemaComponents(parse(`
+      scalar TestType
+      directive @testDirective(testArg: TestType, testArg2: Float) on FIELD
+    `));
+
+    expect(config.types.length).to.equal(1);
+    expect(config.types[0].name).to.equal('TestType');
+    expect(config.directives.length).to.equal(1);
+    expect(config.directives[0].name).to.equal('testDirective');
+  });
 
   it('can use built schema for limited execution', async () => {
     const schema = buildASTSchema(parse(`


### PR DESCRIPTION
At the moment you can use IDL only to describe entire Schema.
But in a few our projects we need to build only directives and associated types from IDL.
We work around this by appending following to the IDL:
```
 type Query {
    dummy: String
 }
```
This PR splits out the major part of `buildASTSchema` function code and allows to get types and directives before they are passed to `GraphQLSchema` constructor.