### PR TITLE
Add constructor to GraphQLError class flow type

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "3.19.0",
     "eslint-plugin-babel": "4.1.1",
     "eslint-plugin-flowtype": "2.32.1",
-    "flow-bin": "0.44.2",
+    "flow-bin": "0.45.0",
     "isparta": "4.0.0",
     "mocha": "3.3.0",
     "sane": "1.6.0"

--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -20,12 +20,21 @@ import type { Source } from '../language/source';
  */
 declare class GraphQLError extends Error {
 
+  constructor(
+    message: string,
+    nodes?: ?Array<*>,
+    source?: ?Source,
+    positions?: ?Array<number>,
+    path?: ?Array<string | number>,
+    originalError?: ?Error
+  ): void;
+
   /**
    * A message describing the Error for debugging purposes.
    *
    * Enumerable, and appears in the result of JSON.stringify().
    */
-  message: string,
+  message: string;
 
   /**
    * An array of { line, column } locations within the source GraphQL document

--- a/yarn.lock
+++ b/yarn.lock
@@ -770,13 +770,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.0:
+debug@2.6.0, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
 
-debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
+debug@^2.1.1, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1099,9 +1099,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.44.2:
-  version "0.44.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.44.2.tgz#3893c7db5de043ed82674f327a04b1309db208b5"
+flow-bin@0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
 
 for-in@^0.1.5:
   version "0.1.6"


### PR DESCRIPTION
Since GraphQLError is declared then defined separately, Flow might infer that the constructor is not being used correctly via wrong arity, or might not detect improper use if an incorrect type is provided. This fixes that by adding a contructor to the declared type.

Also bumped the version of flow to ensure this change passes both the existing and most recent flow version