### PR TITLE
Allow passing custom TypeInfo to validate()

### DIFF
--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -11,7 +11,6 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { testSchema } from './harness';
 import { validate, specifiedRules } from '../';
-import { visitUsingRules } from '../validate';
 import { parse } from '../../language';
 import { TypeInfo } from '../../utilities/TypeInfo';
 
@@ -57,12 +56,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    const errors = visitUsingRules(
-      testSchema,
-      typeInfo,
-      ast,
-      specifiedRules
-    );
+    const errors = validate(testSchema, ast, specifiedRules, typeInfo);
 
     const errorMessages = errors.map(err => err.message);
 

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -45,11 +45,15 @@ import { specifiedRules } from './specifiedRules';
  * Each validation rules is a function which returns a visitor
  * (see the language/visitor API). Visitor methods are expected to return
  * GraphQLErrors, or Arrays of GraphQLErrors when invalid.
+ *
+ * Optionally a custom TypeInfo instance may be provided. If not provided, one
+ * will be created from the provided schema.
  */
 export function validate(
   schema: GraphQLSchema,
   ast: DocumentNode,
-  rules?: Array<any>
+  rules?: Array<any>,
+  typeInfo?: TypeInfo,
 ): Array<GraphQLError> {
   invariant(schema, 'Must provide schema');
   invariant(ast, 'Must provide document');
@@ -58,8 +62,12 @@ export function validate(
     'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
     'not multiple versions of GraphQL installed in your node_modules directory.'
   );
-  const typeInfo = new TypeInfo(schema);
-  return visitUsingRules(schema, typeInfo, ast, rules || specifiedRules);
+  return visitUsingRules(
+    schema,
+    typeInfo || new TypeInfo(schema),
+    ast,
+    rules || specifiedRules
+  );
 }
 
 /**


### PR DESCRIPTION
This is motivated by cases where you want to supply a custom TypeInfo instance when validating a document.