### PR TITLE
Make 'errors' top property in the response object.

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -96,12 +96,12 @@ type ExecutionContext = {
 /**
  * The result of GraphQL execution.
  *
- *   - `data` is the result of a successful execution of the query.
  *   - `errors` is included when any errors occurred as a non-empty array.
+ *   - `data` is the result of a successful execution of the query.
  */
 export type ExecutionResult = {
-  data?: ?{[key: string]: mixed};
   errors?: Array<GraphQLError>;
+  data?: ?{[key: string]: mixed};
 };
 
 /**
@@ -166,7 +166,7 @@ export function execute(
     if (!context.errors.length) {
       return { data };
     }
-    return { data, errors: context.errors };
+    return { errors: context.errors, data };
   });
 }
 


### PR DESCRIPTION
It’s hard to notice `errors` property if it is hidden under multiple screens of JSON.
For example, if you run [this query](http://graphql.org/swapi-graphql/?query=%7B%0A%20%20allPeople%20%7B%0A%20%20%20%20people%20%7B%0A%20%20%20%20%20%20height%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A) you will see the following:
![image](https://cloud.githubusercontent.com/assets/8336157/25564240/972540c6-2db7-11e7-91b0-86dde88466ee.png)
And only if you scroll a couple pages down you will see an error what is bad DX.
To fix this I just changed the order of `errors` and `data` fields so result of the same query look like this:
![image](https://cloud.githubusercontent.com/assets/8336157/25564254/f5bba0bc-2db7-11e7-97d6-06f5a1fba598.png)