### PR TITLE
Fix input coercion to allow null-valued Enums as arguments

### DIFF
--- a/src/utilities/__tests__/valueFromAST-test.js
+++ b/src/utilities/__tests__/valueFromAST-test.js
@@ -66,7 +66,13 @@ describe('valueFromAST', () => {
 
   const testEnum = new GraphQLEnumType({
     name: 'TestColor',
-    values: { RED: { value: 1 }, GREEN: { value: 2 }, BLUE: { value: 3 } }
+    values: {
+      RED: { value: 1 },
+      GREEN: { value: 2 },
+      BLUE: { value: 3 },
+      NULL: { value: null },
+      UNDEFINED: { value: undefined }
+    }
   });
 
   it('converts enum values according to input coercion rules', () => {
@@ -75,6 +81,8 @@ describe('valueFromAST', () => {
     testCase(testEnum, '3', undefined);
     testCase(testEnum, '"BLUE"', undefined);
     testCase(testEnum, 'null', null);
+    testCase(testEnum, 'NULL', null);
+    testCase(testEnum, 'UNDEFINED', undefined);
   });
 
   // Boolean!

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -115,10 +115,11 @@ export function isValidLiteralValue(
     'Must be input type'
   );
 
-  // Scalar/Enum input checks to ensure the type can parse the value to
-  // a non-null value.
+  // Scalars must parse to a non-null value, Enums may be null but must
+  // serialize back to a named value.
   const parseResult = type.parseLiteral(valueNode);
-  if (isNullish(parseResult)) {
+  if (type instanceof GraphQLEnumType ?
+      !type.serialize(parseResult) : isNullish(parseResult)) {
     return [ `Expected type "${type.name}", found ${print(valueNode)}.` ];
   }
 

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -152,9 +152,11 @@ export function valueFromAST(
   );
 
   const parsed = type.parseLiteral(valueNode);
-  if (isNullish(parsed)) {
-    // null or invalid values represent a failure to parse correctly,
-    // in which case no value is returned.
+  if (type instanceof GraphQLEnumType ?
+      !type.serialize(parsed) : isNullish(parsed)) {
+    // null or invalid values represent a failure to parse correctly (unless
+    // we have a legitimately null-valued Enum), in which case no value is
+    // returned.
     return;
   }
 


### PR DESCRIPTION
This fixes my issue from #840 where null-valued Enums (supported since 0.9.5) were rejected when provided as arguments.

This reveals some minor code duplication in `isValidLiteralValue` and `valueFromAST`.

There are likely other places in the code where null-valued Enums cause problems; for example, in `isValidJSValue`: if a type is `GraphQLNonNull(EnumWithNullValue)`, then `null` should probably be accepted, since it should end up resolving to a name in the Enum and not actually `null`. But I didn't attempt to chase down all those edge cases; these changes are enough to get my test suite to pass.

Fixes #840.