### PR TITLE
Adds `isValidValue` and `isValidLiteral` to Scalar and Enum types.

### DIFF
--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -95,7 +95,7 @@ export function isValidJSValue(
   // a non-null value.
   try {
     const parseResult = type.parseValue(value);
-    if (isNullish(parseResult)) {
+    if (isNullish(parseResult) && !type.isValidValue(value)) {
       return [
         `Expected type "${type.name}", found ${JSON.stringify(value)}.`
       ];

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -30,7 +30,6 @@ import {
 import type { GraphQLInputType } from '../type/definition';
 import invariant from '../jsutils/invariant';
 import keyMap from '../jsutils/keyMap';
-import isNullish from '../jsutils/isNullish';
 
 
 /**
@@ -115,11 +114,8 @@ export function isValidLiteralValue(
     'Must be input type'
   );
 
-  // Scalars must parse to a non-null value, Enums may be null but must
-  // serialize back to a named value.
-  const parseResult = type.parseLiteral(valueNode);
-  if (type instanceof GraphQLEnumType ?
-      !type.serialize(parseResult) : isNullish(parseResult)) {
+  // Scalars determine if a literal values is valid.
+  if (!type.isValidLiteral(valueNode)) {
     return [ `Expected type "${type.name}", found ${print(valueNode)}.` ];
   }
 

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -152,11 +152,9 @@ export function valueFromAST(
   );
 
   const parsed = type.parseLiteral(valueNode);
-  if (type instanceof GraphQLEnumType ?
-      !type.serialize(parsed) : isNullish(parsed)) {
-    // null or invalid values represent a failure to parse correctly (unless
-    // we have a legitimately null-valued Enum), in which case no value is
-    // returned.
+  if (isNullish(parsed) && !type.isValidLiteral(valueNode)) {
+    // Invalid values represent a failure to parse correctly, in which case
+    // no value is returned.
     return;
   }
 


### PR DESCRIPTION
Used for more semantically correct validity checking after #848