### PR TITLE
Add void returns to constructors

### DIFF
--- a/src/language/source.js
+++ b/src/language/source.js
@@ -18,7 +18,7 @@ export class Source {
   body: string;
   name: string;
 
-  constructor(body: string, name?: string) {
+  constructor(body: string, name?: string): void {
     this.body = body;
     this.name = name || 'GraphQL';
   }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -297,7 +297,7 @@ export class GraphQLScalarType {
 
   _scalarConfig: GraphQLScalarTypeConfig<*, *>;
 
-  constructor(config: GraphQLScalarTypeConfig<*, *>) {
+  constructor(config: GraphQLScalarTypeConfig<*, *>): void {
     assertValidName(config.name);
     this.name = config.name;
     this.description = config.description;
@@ -417,7 +417,7 @@ export class GraphQLObjectType {
   _fields: GraphQLFieldMap<*, *>;
   _interfaces: Array<GraphQLInterfaceType>;
 
-  constructor(config: GraphQLObjectTypeConfig<*, *>) {
+  constructor(config: GraphQLObjectTypeConfig<*, *>): void {
     assertValidName(config.name, config.isIntrospection);
     this.name = config.name;
     this.description = config.description;
@@ -696,7 +696,7 @@ export class GraphQLInterfaceType {
   _typeConfig: GraphQLInterfaceTypeConfig<*, *>;
   _fields: GraphQLFieldMap<*, *>;
 
-  constructor(config: GraphQLInterfaceTypeConfig<*, *>) {
+  constructor(config: GraphQLInterfaceTypeConfig<*, *>): void {
     assertValidName(config.name);
     this.name = config.name;
     this.description = config.description;
@@ -774,7 +774,7 @@ export class GraphQLUnionType {
   _types: Array<GraphQLObjectType>;
   _possibleTypeNames: {[typeName: string]: boolean};
 
-  constructor(config: GraphQLUnionTypeConfig<*, *>) {
+  constructor(config: GraphQLUnionTypeConfig<*, *>): void {
     assertValidName(config.name);
     this.name = config.name;
     this.description = config.description;
@@ -888,7 +888,7 @@ export class GraphQLEnumType/* <T> */ {
   _valueLookup: Map<any/* T */, GraphQLEnumValue>;
   _nameLookup: { [valueName: string]: GraphQLEnumValue };
 
-  constructor(config: GraphQLEnumTypeConfig/* <T> */) {
+  constructor(config: GraphQLEnumTypeConfig/* <T> */): void {
     this.name = config.name;
     assertValidName(config.name, config.isIntrospection);
     this.description = config.description;
@@ -1067,7 +1067,7 @@ export class GraphQLInputObjectType {
   _typeConfig: GraphQLInputObjectTypeConfig;
   _fields: GraphQLInputFieldMap;
 
-  constructor(config: GraphQLInputObjectTypeConfig) {
+  constructor(config: GraphQLInputObjectTypeConfig): void {
     assertValidName(config.name);
     this.name = config.name;
     this.description = config.description;
@@ -1176,7 +1176,7 @@ export type GraphQLInputFieldMap = {
 export class GraphQLList<T: GraphQLType> {
   ofType: T;
 
-  constructor(type: T) {
+  constructor(type: T): void {
     invariant(
       isType(type),
       `Can only create List of a GraphQLType but got: ${String(type)}.`
@@ -1221,7 +1221,7 @@ GraphQLList.prototype.toJSON =
 export class GraphQLNonNull<T: GraphQLNullableType> {
   ofType: T;
 
-  constructor(type: T) {
+  constructor(type: T): void {
     invariant(
       isType(type) && !(type instanceof GraphQLNonNull),
       'Can only create NonNull of a Nullable GraphQLType but got: ' +

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -53,7 +53,7 @@ export class GraphQLDirective {
   locations: Array<DirectiveLocationEnum>;
   args: Array<GraphQLArgument>;
 
-  constructor(config: GraphQLDirectiveConfig) {
+  constructor(config: GraphQLDirectiveConfig): void {
     invariant(config.name, 'Directive must be named.');
     assertValidName(config.name);
     invariant(

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -65,7 +65,7 @@ export class GraphQLSchema {
     [abstractName: string]: { [possibleName: string]: boolean }
   };
 
-  constructor(config: GraphQLSchemaConfig) {
+  constructor(config: GraphQLSchemaConfig): void {
     invariant(
       typeof config === 'object',
       'Must provide configuration object.'

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -64,7 +64,7 @@ export class TypeInfo {
     // to support non-spec-compliant codebases. You should never need to use it.
     // It may disappear in the future.
     getFieldDefFn?: typeof getFieldDef
-  ) {
+  ): void {
     this._schema = schema;
     this._typeStack = [];
     this._parentTypeStack = [];

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -441,10 +441,10 @@ export function extendSchema(
 
   function extendFieldType<T: GraphQLType>(typeDef: T): T {
     if (typeDef instanceof GraphQLList) {
-      return new GraphQLList(extendFieldType(typeDef.ofType));
+      return (new GraphQLList(extendFieldType(typeDef.ofType)): any);
     }
     if (typeDef instanceof GraphQLNonNull) {
-      return new GraphQLNonNull(extendFieldType(typeDef.ofType));
+      return (new GraphQLNonNull(extendFieldType(typeDef.ofType)): any);
     }
     return getTypeFromDef(typeDef);
   }

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -776,7 +776,7 @@ function subfieldConflicts(
 class PairSet {
   _data: {[a: string]: {[b: string]: boolean}};
 
-  constructor() {
+  constructor(): void {
     this._data = Object.create(null);
   }
 

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -111,7 +111,11 @@ export class ValidationContext {
   _variableUsages: Map<NodeWithSelectionSet, Array<VariableUsage>>;
   _recursiveVariableUsages: Map<OperationDefinitionNode, Array<VariableUsage>>;
 
-  constructor(schema: GraphQLSchema, ast: DocumentNode, typeInfo: TypeInfo) {
+  constructor(
+    schema: GraphQLSchema,
+    ast: DocumentNode,
+    typeInfo: TypeInfo
+  ): void {
     this._schema = schema;
     this._ast = ast;
     this._typeInfo = typeInfo;


### PR DESCRIPTION
Fixes #857

This fixes an issue where flow implicitly types new Class as `any` if the constructor is not typed to return `void` (https://github.com/facebook/flow/issues/2748).