### PR TITLE
Fix: OverlappingFieldsCanBeMerged on js keyword named fields

### DIFF
--- a/src/jsutils/keyMap.js
+++ b/src/jsutils/keyMap.js
@@ -35,5 +35,8 @@ export default function keyMap<T>(
   list: Array<T>,
   keyFn: (item: T) => string
 ): {[key: string]: T} {
-  return list.reduce((map, item) => ((map[keyFn(item)] = item), map), {});
+  return list.reduce(
+    (map, item) => ((map[keyFn(item)] = item), map),
+    Object.create(null)
+  );
 }

--- a/src/jsutils/keyValMap.js
+++ b/src/jsutils/keyValMap.js
@@ -32,6 +32,6 @@ export default function keyValMap<T, V>(
 ): {[key: string]: V} {
   return list.reduce(
     (map, item) => ((map[keyFn(item)] = valFn(item)), map),
-    {}
+    Object.create(null)
   );
 }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -470,7 +470,7 @@ function defineInterfaces(
     'an Array.'
   );
 
-  const implementedTypeNames = {};
+  const implementedTypeNames = Object.create(null);
   interfaces.forEach(iface => {
     invariant(
       iface instanceof GraphQLInterfaceType,
@@ -513,7 +513,7 @@ function defineFieldMap<TSource, TContext>(
     'function which returns such an object.'
   );
 
-  const resultFieldMap = {};
+  const resultFieldMap = Object.create(null);
   fieldNames.forEach(fieldName => {
     assertValidName(fieldName);
     const fieldConfig = fieldMap[fieldName];
@@ -818,7 +818,7 @@ function defineTypes(
     'Must provide Array of types or a function which returns ' +
     `such an array for Union ${unionType.name}.`
   );
-  const includedTypeNames = {};
+  const includedTypeNames = Object.create(null);
   types.forEach(objType => {
     invariant(
       objType instanceof GraphQLObjectType,
@@ -1091,7 +1091,7 @@ export class GraphQLInputObjectType {
       `${this.name} fields must be an object with field names as keys or a ` +
       'function which returns such an object.'
     );
-    const resultFieldMap = {};
+    const resultFieldMap = Object.create(null);
     fieldNames.forEach(fieldName => {
       assertValidName(fieldName);
       const field = {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -123,8 +123,8 @@ export function extendSchema(
   );
 
   // Collect the type definitions and extensions found in the document.
-  const typeDefinitionMap = {};
-  const typeExtensionsMap = {};
+  const typeDefinitionMap = Object.create(null);
+  const typeExtensionsMap = Object.create(null);
 
   // New directives and types are separate because a directives and types can
   // have the same name. For example, a type named "skip".
@@ -400,7 +400,7 @@ export function extendSchema(
   }
 
   function extendFieldMap(type: GraphQLObjectType | GraphQLInterfaceType) {
-    const newFieldMap = {};
+    const newFieldMap = Object.create(null);
     const oldFieldMap = type.getFields();
     Object.keys(oldFieldMap).forEach(fieldName => {
       const field = oldFieldMap[fieldName];

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -936,6 +936,35 @@ describe('Validate: Overlapping fields can be merged', () => {
       );
     });
 
+    it('works for field names that are JS keywords', () => {
+      const FooType = new GraphQLObjectType({
+        name: 'Foo',
+        fields: {
+          constructor: {
+            type: GraphQLString
+          },
+        }
+      });
+
+      const schemaWithKeywords = new GraphQLSchema({
+        query: new GraphQLObjectType({
+          name: 'Query',
+          fields: () => ({
+            foo: { type: FooType },
+          })
+        }),
+      });
+
+      expectPassesRuleWithSchema(
+        schemaWithKeywords,
+        OverlappingFieldsCanBeMerged,
+        `{
+          foo {
+            constructor
+          }
+        }`
+      );
+    });
   });
 
 });

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -665,8 +665,8 @@ function getFieldsAndFragmentNames(
 ): [ NodeAndDefCollection, Array<string> ] {
   let cached = cachedFieldsAndFragmentNames.get(selectionSet);
   if (!cached) {
-    const nodeAndDefs = {};
-    const fragmentNames = {};
+    const nodeAndDefs = Object.create(null);
+    const fragmentNames = Object.create(null);
     _collectFieldsAndFragmentNames(
       context,
       parentType,

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -151,7 +151,7 @@ export class ValidationContext {
             frags[statement.name.value] = statement;
           }
           return frags;
-        }, {});
+        }, Object.create(null));
     }
     return fragments[name];
   }


### PR DESCRIPTION
Replaces all places where `{}` is used as an empty string map with `Object.create(null)`.