### PR TITLE
Allow providing custom default field resolver.

### DIFF
--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -935,4 +935,34 @@ describe('Execute: Handles basic execution tasks', () => {
     });
   });
 
+  it('uses a custom field resolver', async () => {
+    const query = parse('{ foo }');
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          foo: { type: GraphQLString }
+        }
+      })
+    });
+
+    // For the purposes of test, just return the name of the field!
+    function customResolver(source, args, context, info) {
+      return info.fieldName;
+    }
+
+    const result = await execute(
+      schema,
+      query,
+      null,
+      null,
+      null,
+      null,
+      customResolver
+    );
+
+    expect(result).to.jsonEqual({ data: { foo: 'foo' } });
+  });
+
 });

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -87,6 +87,7 @@ export type ExecutionContext = {
   contextValue: mixed;
   operation: OperationDefinitionNode;
   variableValues: {[key: string]: mixed};
+  fieldResolver: GraphQLFieldResolver<any, any>;
   errors: Array<GraphQLError>;
 };
 
@@ -115,7 +116,8 @@ export function execute(
   rootValue?: mixed,
   contextValue?: mixed,
   variableValues?: ?{[key: string]: mixed},
-  operationName?: ?string
+  operationName?: ?string,
+  fieldResolver?: ?GraphQLFieldResolver<any, any>
 ): Promise<ExecutionResult> {
   // If a valid context cannot be created due to incorrect arguments,
   // this will throw an error.
@@ -125,7 +127,8 @@ export function execute(
     rootValue,
     contextValue,
     variableValues,
-    operationName
+    operationName,
+    fieldResolver
   );
 
   // Return a Promise that will eventually resolve to the data described by
@@ -187,7 +190,8 @@ export function buildExecutionContext(
   rootValue: mixed,
   contextValue: mixed,
   rawVariableValues: ?{[key: string]: mixed},
-  operationName: ?string
+  operationName: ?string,
+  fieldResolver: ?GraphQLFieldResolver<any, any>
 ): ExecutionContext {
   invariant(schema, 'Must provide schema');
   invariant(document, 'Must provide document');
@@ -251,7 +255,8 @@ export function buildExecutionContext(
     contextValue,
     operation,
     variableValues,
-    errors
+    fieldResolver: fieldResolver || defaultFieldResolver,
+    errors,
   };
 }
 
@@ -580,7 +585,7 @@ function resolveField(
     return;
   }
 
-  const resolveFn = fieldDef.resolve || defaultFieldResolver;
+  const resolveFn = fieldDef.resolve || exeContext.fieldResolver;
 
   const info = buildResolveInfo(
     exeContext,

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -12,6 +12,7 @@ import { Source } from './language/source';
 import { parse } from './language/parser';
 import { validate } from './validation/validate';
 import { execute } from './execution/execute';
+import type { GraphQLFieldResolver } from './type/definition';
 import type { GraphQLSchema } from './type/schema';
 import type { ExecutionResult } from './execution/execute';
 
@@ -39,6 +40,10 @@ import type { ExecutionResult } from './execution/execute';
  *    The name of the operation to use if requestString contains multiple
  *    possible operations. Can be omitted if requestString contains only
  *    one operation.
+ * fieldResolver:
+ *    A resolver function to use when one is not provided by the schema.
+ *    If not provided, the default field resolver is used (which looks for a
+ *    value or method on the source value with the field's name).
  */
 export function graphql(
   schema: GraphQLSchema,
@@ -46,7 +51,8 @@ export function graphql(
   rootValue?: mixed,
   contextValue?: mixed,
   variableValues?: ?{[key: string]: mixed},
-  operationName?: ?string
+  operationName?: ?string,
+  fieldResolver?: ?GraphQLFieldResolver<any, any>
 ): Promise<ExecutionResult> {
   return new Promise(resolve => {
     const source = new Source(requestString || '', 'GraphQL request');
@@ -62,7 +68,8 @@ export function graphql(
           rootValue,
           contextValue,
           variableValues,
-          operationName
+          operationName,
+          fieldResolver
         )
       );
     }


### PR DESCRIPTION
This adds an argument to `execute()`, `createSourceEventStream()` and `subscribe()` which allows for providing a custom field resolver. For subscriptions, this allows for externalizing the resolving of event streams to a separate function (mentioned in #846) or to provide a custom function for externalizing the resolving of values (mentioned in #733)

cc @stubailo @helfer