### PR TITLE
Allow graphql() to accept a Source instance.

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -8,10 +8,10 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
-import { Source } from './language/source';
 import { parse } from './language/parser';
 import { validate } from './validation/validate';
 import { execute } from './execution/execute';
+import type { Source } from './language/source';
 import type { GraphQLFieldResolver } from './type/definition';
 import type { GraphQLSchema } from './type/schema';
 import type { ExecutionResult } from './execution/execute';
@@ -28,7 +28,7 @@ import type { ExecutionResult } from './execution/execute';
  *
  * schema:
  *    The GraphQL type system to use when validating and executing a query.
- * requestString:
+ * source:
  *    A GraphQL language formatted string representing the requested operation.
  * rootValue:
  *    The value provided as the first argument to resolver functions on the top
@@ -47,7 +47,7 @@ import type { ExecutionResult } from './execution/execute';
  */
 export function graphql(
   schema: GraphQLSchema,
-  requestString: string,
+  source: string | Source,
   rootValue?: mixed,
   contextValue?: mixed,
   variableValues?: ?{[key: string]: mixed},
@@ -55,7 +55,6 @@ export function graphql(
   fieldResolver?: ?GraphQLFieldResolver<any, any>
 ): Promise<ExecutionResult> {
   return new Promise(resolve => {
-    const source = new Source(requestString || '', 'GraphQL request');
     const documentAST = parse(source);
     const validationErrors = validate(schema, documentAST);
     if (validationErrors.length > 0) {

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -17,13 +17,15 @@ function lexOne(str) {
   return lexer.advance();
 }
 
+/* eslint-disable max-len */
+
 describe('Lexer', () => {
 
   it('disallows uncommon control characters', () => {
 
     expect(() => lexOne('\u0007')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) ' +
+      'Syntax Error GraphQL request (1:1) ' +
       'Cannot contain the invalid character "\\u0007"'
     );
 
@@ -107,7 +109,7 @@ describe('Lexer', () => {
 
 `)
     ).to.throw(
-      'Syntax Error GraphQL (3:5) ' +
+      'Syntax Error GraphQL request (3:5) ' +
       'Cannot parse the unexpected character "?".\n' +
       '\n' +
       '2: \n' +
@@ -180,79 +182,79 @@ describe('Lexer', () => {
 
     expect(
       () => lexOne('"')
-    ).to.throw('Syntax Error GraphQL (1:2) Unterminated string.');
+    ).to.throw('Syntax Error GraphQL request (1:2) Unterminated string.');
 
     expect(
       () => lexOne('"no end quote')
-    ).to.throw('Syntax Error GraphQL (1:14) Unterminated string.');
+    ).to.throw('Syntax Error GraphQL request (1:14) Unterminated string.');
 
     expect(
       () => lexOne('\'single quotes\'')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) Unexpected single quote character (\'), ' +
+      'Syntax Error GraphQL request (1:1) Unexpected single quote character (\'), ' +
       'did you mean to use a double quote (")?'
     );
 
     expect(
       () => lexOne('"contains unescaped \u0007 control char"')
     ).to.throw(
-      'Syntax Error GraphQL (1:21) Invalid character within String: "\\u0007".'
+      'Syntax Error GraphQL request (1:21) Invalid character within String: "\\u0007".'
     );
 
     expect(
       () => lexOne('"null-byte is not \u0000 end of file"')
     ).to.throw(
-      'Syntax Error GraphQL (1:19) Invalid character within String: "\\u0000".'
+      'Syntax Error GraphQL request (1:19) Invalid character within String: "\\u0000".'
     );
 
     expect(
       () => lexOne('"multi\nline"')
-    ).to.throw('Syntax Error GraphQL (1:7) Unterminated string');
+    ).to.throw('Syntax Error GraphQL request (1:7) Unterminated string');
 
     expect(
       () => lexOne('"multi\rline"')
-    ).to.throw('Syntax Error GraphQL (1:7) Unterminated string');
+    ).to.throw('Syntax Error GraphQL request (1:7) Unterminated string');
 
     expect(
       () => lexOne('"bad \\z esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\z.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\z.'
     );
 
     expect(
       () => lexOne('"bad \\x esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\x.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\x.'
     );
 
     expect(
       () => lexOne('"bad \\u1 esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\u1 es.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\u1 es.'
     );
 
     expect(
       () => lexOne('"bad \\u0XX1 esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\u0XX1.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\u0XX1.'
     );
 
     expect(
       () => lexOne('"bad \\uXXXX esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uXXXX.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uXXXX.'
     );
 
     expect(
       () => lexOne('"bad \\uFXXX esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uFXXX.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uFXXX.'
     );
 
     expect(
       () => lexOne('"bad \\uXXXF esc"')
     ).to.throw(
-      'Syntax Error GraphQL (1:7) Invalid character escape sequence: \\uXXXF.'
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uXXXF.'
     );
   });
 
@@ -409,53 +411,53 @@ describe('Lexer', () => {
     expect(
       () => lexOne('00')
     ).to.throw(
-      'Syntax Error GraphQL (1:2) Invalid number, ' +
+      'Syntax Error GraphQL request (1:2) Invalid number, ' +
       'unexpected digit after 0: "0".'
     );
 
     expect(
       () => lexOne('+1')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) Cannot parse the unexpected character "+".'
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character "+".'
     );
 
     expect(
       () => lexOne('1.')
     ).to.throw(
-      'Syntax Error GraphQL (1:3) Invalid number, ' +
+      'Syntax Error GraphQL request (1:3) Invalid number, ' +
       'expected digit but got: <EOF>.'
     );
 
     expect(
       () => lexOne('.123')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) Cannot parse the unexpected character ".".'
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character ".".'
     );
 
     expect(
       () => lexOne('1.A')
     ).to.throw(
-      'Syntax Error GraphQL (1:3) Invalid number, ' +
+      'Syntax Error GraphQL request (1:3) Invalid number, ' +
       'expected digit but got: "A".'
     );
 
     expect(
       () => lexOne('-A')
     ).to.throw(
-      'Syntax Error GraphQL (1:2) Invalid number, ' +
+      'Syntax Error GraphQL request (1:2) Invalid number, ' +
       'expected digit but got: "A".'
     );
 
     expect(
       () => lexOne('1.0e')
     ).to.throw(
-      'Syntax Error GraphQL (1:5) Invalid number, ' +
+      'Syntax Error GraphQL request (1:5) Invalid number, ' +
       'expected digit but got: <EOF>.');
 
     expect(
       () => lexOne('1.0eA')
     ).to.throw(
-      'Syntax Error GraphQL (1:5) Invalid number, ' +
+      'Syntax Error GraphQL request (1:5) Invalid number, ' +
       'expected digit but got: "A".'
     );
   });
@@ -586,26 +588,26 @@ describe('Lexer', () => {
     expect(
       () => lexOne('..')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) Cannot parse the unexpected character ".".'
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character ".".'
     );
 
     expect(
       () => lexOne('?')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) Cannot parse the unexpected character "?".'
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character "?".'
     );
 
     expect(
       () => lexOne('\u203B')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) ' +
+      'Syntax Error GraphQL request (1:1) ' +
       'Cannot parse the unexpected character "\\u203B".'
     );
 
     expect(
       () => lexOne('\u200b')
     ).to.throw(
-      'Syntax Error GraphQL (1:1) ' +
+      'Syntax Error GraphQL request (1:1) ' +
       'Cannot parse the unexpected character "\\u200B".'
     );
   });
@@ -623,7 +625,7 @@ describe('Lexer', () => {
     expect(
       () => lexer.advance()
     ).to.throw(
-      'Syntax Error GraphQL (1:3) Invalid number, expected digit but got: "b".'
+      'Syntax Error GraphQL request (1:3) Invalid number, expected digit but got: "b".'
     );
   });
 

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -27,7 +27,7 @@ describe('Parser', () => {
     }
 
     expect(caughtError.message).to.equal(
-      `Syntax Error GraphQL (1:2) Expected Name, found <EOF>
+      `Syntax Error GraphQL request (1:2) Expected Name, found <EOF>
 
 1: {
     ^
@@ -45,19 +45,23 @@ describe('Parser', () => {
 `{ ...MissingOn }
 fragment MissingOn Type
 `)
-    ).to.throw('Syntax Error GraphQL (2:20) Expected "on", found Name "Type"');
+    ).to.throw(
+      'Syntax Error GraphQL request (2:20) Expected "on", found Name "Type"'
+    );
 
     expect(
       () => parse('{ field: {} }')
-    ).to.throw('Syntax Error GraphQL (1:10) Expected Name, found {');
+    ).to.throw('Syntax Error GraphQL request (1:10) Expected Name, found {');
 
     expect(
       () => parse('notanoperation Foo { field }')
-    ).to.throw('Syntax Error GraphQL (1:1) Unexpected Name "notanoperation"');
+    ).to.throw(
+      'Syntax Error GraphQL request (1:1) Unexpected Name "notanoperation"'
+    );
 
     expect(
       () => parse('...')
-    ).to.throw('Syntax Error GraphQL (1:1) Unexpected ...');
+    ).to.throw('Syntax Error GraphQL request (1:1) Unexpected ...');
 
   });
 
@@ -76,19 +80,19 @@ fragment MissingOn Type
   it('parses constant default values', () => {
     expect(
       () => parse('query Foo($x: Complex = { a: { b: [ $var ] } }) { field }')
-    ).to.throw('Syntax Error GraphQL (1:37) Unexpected $');
+    ).to.throw('Syntax Error GraphQL request (1:37) Unexpected $');
   });
 
   it('does not accept fragments named "on"', () => {
     expect(
       () => parse('fragment on on on { on }')
-    ).to.throw('Syntax Error GraphQL (1:10) Unexpected Name "on"');
+    ).to.throw('Syntax Error GraphQL request (1:10) Unexpected Name "on"');
   });
 
   it('does not accept fragments spread of "on"', () => {
     expect(
       () => parse('{ ...on }')
-    ).to.throw('Syntax Error GraphQL (1:9) Expected Name, found }');
+    ).to.throw('Syntax Error GraphQL request (1:9) Expected Name, found }');
   });
 
   it('parses multi-byte characters', async () => {

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -20,6 +20,6 @@ export class Source {
 
   constructor(body: string, name?: string): void {
     this.body = body;
-    this.name = name || 'GraphQL';
+    this.name = name || 'GraphQL request';
   }
 }


### PR DESCRIPTION
This fixes a use case when using named graphql files as a source of truth when calling the graphql() function, using those names in reporting.

Potentially unit-test breaking: may change the error message content from using parse() directly.