### PR TITLE
Avoid new Flow errors with v0.47.0

### DIFF
--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -29,19 +29,19 @@ import type { GraphQLSchema } from '../type/schema';
  * found in the schema, then undefined will be returned.
  */
 /* eslint-disable no-redeclare */
-declare function typeFromAST(
+declare function typeFromASTType(
   schema: GraphQLSchema,
   typeNode: NamedTypeNode
 ): void | GraphQLNamedType;
-declare function typeFromAST(
+declare function typeFromASTType(
   schema: GraphQLSchema,
   typeNode: ListTypeNode
 ): void | GraphQLList<*>;
-declare function typeFromAST(
+declare function typeFromASTType(
   schema: GraphQLSchema,
   typeNode: NonNullTypeNode
 ): void | GraphQLNonNull<*>;
-export function typeFromAST(schema, typeNode) {
+function typeFromASTImpl(schema, typeNode) {
 /* eslint-enable no-redeclare */
   let innerType;
   if (typeNode.kind === LIST_TYPE) {
@@ -55,3 +55,7 @@ export function typeFromAST(schema, typeNode) {
   invariant(typeNode.kind === NAMED_TYPE, 'Must be a named type.');
   return schema.getType(typeNode.name.value);
 }
+// This will export typeFromAST with the correct type, but currently exposes
+// ~26 errors: https://gist.github.com/4a29403a99a8186fcb15064d69c5f3ae
+// export var typeFromAST: typeof typeFromASTType = typeFromASTImpl;
+export const typeFromAST: $FlowFixMe = typeFromASTImpl;


### PR DESCRIPTION
Flow v0.47.0 finds 3 errors in master. This is important to fix, because the graphql npm 
module ships with types, so anyone who uses the graphql npm module will get errors 
when upgrading to Flow v0.47.0. The new errors [look like this](https://gist.github.com/85d7f03510760dd223e968d2e92e7712).

When investigating, I found that `typeFromAST()` was doing something a little
odd. I believe it was trying to declare itself as an overloaded function, but
instead it was declaring an overloaded function and then shadowing it with the
exported function.

When it's properly fixed, it exposes 26 errors, which is a little much for me
to fix right now. So instead, I'm sabotaging its type completely, which will avoid errors in 
either v0.46.0 or v0.47.0