### PR TITLE
Spec compliance: Validation error on multi-field subscription

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -271,6 +271,7 @@ export {
   PossibleFragmentSpreadsRule,
   ProvidedNonNullArgumentsRule,
   ScalarLeafsRule,
+  SingleFieldSubscriptionsRule,
   UniqueArgumentNamesRule,
   UniqueDirectivesPerLocationRule,
   UniqueFragmentNamesRule,

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -158,10 +158,6 @@ export function createSourceEventStream(
     Object.create(null)
   );
   const responseNames = Object.keys(fields);
-  invariant(
-    responseNames.length === 1,
-    'A subscription operation must contain exactly one root field.'
-  );
   const responseName = responseNames[0];
   const fieldNodes = fields[responseName];
   const fieldNode = fieldNodes[0];

--- a/src/validation/__tests__/SingleFieldSubscriptions-test.js
+++ b/src/validation/__tests__/SingleFieldSubscriptions-test.js
@@ -1,0 +1,81 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { describe, it } from 'mocha';
+import { expectPassesRule, expectFailsRule } from './harness';
+import {
+  SingleFieldSubscriptions,
+  singleFieldOnlyMessage,
+} from '../rules/SingleFieldSubscriptions';
+
+
+describe('Validate: Subscriptions with single field', () => {
+
+  it('valid subscription', () => {
+    expectPassesRule(SingleFieldSubscriptions, `
+      subscription ImportantEmails {
+        importantEmails
+      }
+    `);
+  });
+
+  it('fails with more than one root field', () => {
+    expectFailsRule(SingleFieldSubscriptions, `
+      subscription ImportantEmails {
+        importantEmails
+        notImportantEmails
+      }
+    `, [ {
+      message: singleFieldOnlyMessage('ImportantEmails'),
+      locations: [ { line: 4, column: 9 } ],
+      path: undefined,
+    } ]);
+  });
+
+  it('fails with more than one root field including introspection', () => {
+    expectFailsRule(SingleFieldSubscriptions, `
+      subscription ImportantEmails {
+        importantEmails
+        __typename
+      }
+    `, [ {
+      message: singleFieldOnlyMessage('ImportantEmails'),
+      locations: [ { line: 4, column: 9 } ],
+      path: undefined,
+    } ]);
+  });
+
+  it('fails with many more than one root field', () => {
+    expectFailsRule(SingleFieldSubscriptions, `
+      subscription ImportantEmails {
+        importantEmails
+        notImportantEmails
+        spamEmails
+      }
+    `, [ {
+      message: singleFieldOnlyMessage('ImportantEmails'),
+      locations: [ { line: 4, column: 9 }, { line: 5, column: 9 } ],
+      path: undefined,
+    } ]);
+  });
+
+  it('fails with more than one root field in anonymous subscriptions', () => {
+    expectFailsRule(SingleFieldSubscriptions, `
+      subscription {
+        importantEmails
+        notImportantEmails
+      }
+    `, [ {
+      message: singleFieldOnlyMessage(null),
+      locations: [ { line: 4, column: 9 } ],
+      path: undefined,
+    } ]);
+  });
+
+});

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -96,6 +96,11 @@ export {
   ScalarLeafs as ScalarLeafsRule
 } from './rules/ScalarLeafs';
 
+// Spec Section: "Subscriptions with Single Root Field"
+export {
+  SingleFieldSubscriptions as SingleFieldSubscriptionsRule
+} from './rules/SingleFieldSubscriptions';
+
 // Spec Section: "Argument Uniqueness"
 export {
   UniqueArgumentNames as UniqueArgumentNamesRule

--- a/src/validation/rules/SingleFieldSubscriptions.js
+++ b/src/validation/rules/SingleFieldSubscriptions.js
@@ -1,0 +1,39 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import type { ValidationContext } from '../index';
+import { GraphQLError } from '../../error';
+import type { OperationDefinitionNode } from '../../language/ast';
+
+
+export function singleFieldOnlyMessage(name: ?string): string {
+  return (name ? `Subscription "${name}" ` : 'Anonymous Subscription ') +
+    'must select only one top level field.';
+}
+
+/**
+ * Subscriptions must only include one field.
+ *
+ * A GraphQL subscription is valid only if it contains a single root field.
+ */
+export function SingleFieldSubscriptions(context: ValidationContext): any {
+  return {
+    OperationDefinition(node: OperationDefinitionNode) {
+      if (node.operation === 'subscription') {
+        if (node.selectionSet.selections.length !== 1) {
+          context.reportError(new GraphQLError(
+            singleFieldOnlyMessage(node.name && node.name.value),
+            node.selectionSet.selections.slice(1)
+          ));
+        }
+      }
+    }
+  };
+}

--- a/src/validation/specifiedRules.js
+++ b/src/validation/specifiedRules.js
@@ -14,6 +14,9 @@ import { UniqueOperationNames } from './rules/UniqueOperationNames';
 // Spec Section: "Lone Anonymous Operation"
 import { LoneAnonymousOperation } from './rules/LoneAnonymousOperation';
 
+// Spec Section: "Subscriptions with Single Root Field"
+import { SingleFieldSubscriptions } from './rules/SingleFieldSubscriptions';
+
 // Spec Section: "Fragment Spread Type Existence"
 import { KnownTypeNames } from './rules/KnownTypeNames';
 
@@ -98,6 +101,7 @@ import type { ValidationContext } from './index';
 export const specifiedRules: Array<(context: ValidationContext) => any> = [
   UniqueOperationNames,
   LoneAnonymousOperation,
+  SingleFieldSubscriptions,
   KnownTypeNames,
   FragmentsOnCompositeTypes,
   VariablesAreInputTypes,


### PR DESCRIPTION
As per the spec, a subscription should simply use the first field defined, and not make any other assertions during the Subscribe operation. Instead, a validation rule should detect this and report it.