### PR TITLE
fix flow errors from turning on const_params experimental flag

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,3 +9,4 @@
 [libs]
 
 [options]
+experimental.const_params=true

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -143,17 +143,36 @@ export function execute(
   // Extract arguments from object args if provided.
   const args = arguments.length === 1 ? argsOrSchema : undefined;
   const schema = args ? args.schema : argsOrSchema;
-  if (args) {
-    /* eslint-disable no-param-reassign */
-    document = args.document;
-    rootValue = args.rootValue;
-    contextValue = args.contextValue;
-    variableValues = args.variableValues;
-    operationName = args.operationName;
-    fieldResolver = args.fieldResolver;
-    /* eslint-enable no-param-reassign, no-redeclare */
-  }
+  return args ?
+    executeImpl(
+      schema,
+      args.document,
+      args.rootValue,
+      args.contextValue,
+      args.variableValues,
+      args.operationName,
+      args.fieldResolver,
+    ) :
+    executeImpl(
+      schema,
+      document,
+      rootValue,
+      contextValue,
+      variableValues,
+      operationName,
+      fieldResolver,
+    );
+}
 
+function executeImpl(
+  schema,
+  document,
+  rootValue,
+  contextValue,
+  variableValues,
+  operationName,
+  fieldResolver
+) {
   // If arguments are missing or incorrect, throw an error.
   assertValidExecutionArguments(
     schema,

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -77,17 +77,36 @@ export function graphql(
   // Extract arguments from object args if provided.
   const args = arguments.length === 1 ? argsOrSchema : undefined;
   const schema = args ? args.schema : argsOrSchema;
-  if (args) {
-    /* eslint-disable no-param-reassign */
-    source = args.source;
-    rootValue = args.rootValue;
-    contextValue = args.contextValue;
-    variableValues = args.variableValues;
-    operationName = args.operationName;
-    fieldResolver = args.fieldResolver;
-    /* eslint-enable no-param-reassign, no-redeclare */
-  }
+  return args ?
+    graphqlImpl(
+      schema,
+      args.source,
+      args.rootValue,
+      args.contextValue,
+      args.variableValues,
+      args.operationName,
+      args.fieldResolver,
+    ) :
+    graphqlImpl(
+      schema,
+      source,
+      rootValue,
+      contextValue,
+      variableValues,
+      operationName,
+      fieldResolver,
+    );
+}
 
+function graphqlImpl(
+  schema,
+  source,
+  rootValue,
+  contextValue,
+  variableValues,
+  operationName,
+  fieldResolver
+) {
   return new Promise(resolve => {
     // Parse
     let document;

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -73,18 +73,39 @@ export function subscribe(
   // Extract arguments from object args if provided.
   const args = arguments.length === 1 ? argsOrSchema : undefined;
   const schema = args ? args.schema : argsOrSchema;
-  if (args) {
-    /* eslint-disable no-param-reassign */
-    document = args.document;
-    rootValue = args.rootValue;
-    contextValue = args.contextValue;
-    variableValues = args.variableValues;
-    operationName = args.operationName;
-    fieldResolver = args.fieldResolver;
-    subscribeFieldResolver = args.subscribeFieldResolver;
-    /* eslint-enable no-param-reassign, no-redeclare */
-  }
+  return args ?
+    subscribeImpl(
+      schema,
+      args.document,
+      args.rootValue,
+      args.contextValue,
+      args.variableValues,
+      args.operationName,
+      args.fieldResolver,
+      args.subscribeFieldResolver,
+    ) :
+    subscribeImpl(
+      schema,
+      document,
+      rootValue,
+      contextValue,
+      variableValues,
+      operationName,
+      fieldResolver,
+      subscribeFieldResolver,
+    );
+}
 
+function subscribeImpl(
+  schema,
+  document,
+  rootValue,
+  contextValue,
+  variableValues,
+  operationName,
+  fieldResolver,
+  subscribeFieldResolver
+) {
   const subscription = createSourceEventStream(
     schema,
     document,


### PR DESCRIPTION
Fixed a bunch of flow errors observed after turning on `const_params` experimental flag, by delegating the correct arguments to another function (`Impl` functions).