### PR TITLE
Sort fields before printing to get a more stable diff

### DIFF
--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -585,7 +585,7 @@ describe('Subscribe', () => {
         invalidEmailSchema,
         ast
       );
-    }).to.throw('Subscription must return AsyncIterable. Received: test');
+    }).to.throw('Subscription must return Async Iterable. Received: test');
   });
 
   it('expects to have subscribe on type definition with iterator', () => {

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -68,11 +68,11 @@ schema {
 }
 
 type HelloScalars {
-  str: String
-  int: Int
+  bool: Boolean
   float: Float
   id: ID
-  bool: Boolean
+  int: Int
+  str: String
 }
 `;
     const output = cycleOutput(body);
@@ -196,11 +196,11 @@ schema {
 }
 
 type HelloScalars {
-  nonNullStr: String!
-  listOfStrs: [String]
   listOfNonNullStrs: [String!]
-  nonNullListOfStrs: [String]!
+  listOfStrs: [String]
   nonNullListOfNonNullStrs: [String!]!
+  nonNullListOfStrs: [String]!
+  nonNullStr: String!
 }
 `;
     const output = cycleOutput(body);
@@ -215,8 +215,8 @@ schema {
 }
 
 type Recurse {
-  str: String
   recurse: Recurse
+  str: String
 }
 `;
     const output = cycleOutput(body);
@@ -250,10 +250,10 @@ schema {
 }
 
 type Hello {
-  str(int: Int): String
+  booleanToStr(bool: Boolean): String
   floatToStr(float: Float): String
   idToStr(id: ID): String
-  booleanToStr(bool: Boolean): String
+  str(int: Int): String
   strToStr(bool: String): String
 }
 `;
@@ -450,9 +450,9 @@ schema {
 }
 
 type HelloScalars {
-  str: String
-  int: Int
   bool: Boolean
+  int: Int
+  str: String
 }
 
 type Mutation {
@@ -471,9 +471,9 @@ schema {
 }
 
 type HelloScalars {
-  str: String
-  int: Int
   bool: Boolean
+  int: Int
+  str: String
 }
 
 type Subscription {
@@ -527,9 +527,9 @@ enum MyEnum {
 }
 
 type Query {
+  enum: MyEnum
   field1: String @deprecated
   field2: Int @deprecated(reason: "Because I said so")
-  enum: MyEnum
 }
 `;
     const output = cycleOutput(body);

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -158,9 +158,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz {
@@ -169,16 +169,16 @@ type Biz {
 
 type Foo implements SomeInterface {
   name: String
+  newField: String
   some: SomeInterface
   tree: [Foo]!
-  newField: String
 }
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -251,9 +251,9 @@ union SomeUnion = Foo | Biz
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz {
@@ -268,9 +268,9 @@ type Foo implements SomeInterface {
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -309,9 +309,9 @@ type Unused {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz {
@@ -320,9 +320,9 @@ type Biz {
 
 type Foo implements SomeInterface {
   name: String
+  newField(arg1: String, arg2: NewInputObj!): String
   some: SomeInterface
   tree: [Foo]!
-  newField(arg1: String, arg2: NewInputObj!): String
 }
 
 input NewInputObj {
@@ -333,9 +333,9 @@ input NewInputObj {
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -364,9 +364,9 @@ union SomeUnion = Foo | Biz
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz {
@@ -375,16 +375,16 @@ type Biz {
 
 type Foo implements SomeInterface {
   name: String
+  newField(arg1: SomeEnum!): SomeEnum
   some: SomeInterface
   tree: [Foo]!
-  newField(arg1: SomeEnum!): SomeEnum
 }
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -414,9 +414,9 @@ union SomeUnion = Foo | Biz
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz implements SomeInterface {
@@ -433,9 +433,9 @@ type Foo implements SomeInterface {
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -490,9 +490,9 @@ union SomeUnion = Foo | Biz
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz {
@@ -501,14 +501,14 @@ type Biz {
 
 type Foo implements SomeInterface {
   name: String
+  newEnum: NewEnum
+  newInterface: NewInterface
+  newObject: NewObject
+  newScalar: NewScalar
+  newTree: [Foo]!
+  newUnion: NewUnion
   some: SomeInterface
   tree: [Foo]!
-  newObject: NewObject
-  newInterface: NewInterface
-  newUnion: NewUnion
-  newScalar: NewScalar
-  newEnum: NewEnum
-  newTree: [Foo]!
 }
 
 enum NewEnum {
@@ -534,9 +534,9 @@ union NewUnion = NewObject | NewOtherObject
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -569,9 +569,9 @@ union SomeUnion = Foo | Biz
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz {
@@ -579,10 +579,10 @@ type Biz {
 }
 
 type Foo implements SomeInterface, NewInterface {
+  baz: String
   name: String
   some: SomeInterface
   tree: [Foo]!
-  baz: String
 }
 
 interface NewInterface {
@@ -591,9 +591,9 @@ interface NewInterface {
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -637,18 +637,18 @@ union SomeUnion = Foo | Biz
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(
 `type Bar implements SomeInterface {
+  foo: Foo
   name: String
   some: SomeInterface
-  foo: Foo
 }
 
 type Biz implements NewInterface, SomeInterface {
-  fizz: String
   buzz: String
+  fizz: String
   name: String
-  some: SomeInterface
   newFieldA: Int
   newFieldB: Float
+  some: SomeInterface
 }
 
 type Foo implements SomeInterface {
@@ -663,9 +663,9 @@ interface NewInterface {
 
 type Query {
   foo: Foo
-  someUnion: SomeUnion
   someEnum: SomeEnum
   someInterface(id: ID!): SomeInterface
+  someUnion: SomeUnion
 }
 
 enum SomeEnum {
@@ -728,13 +728,13 @@ union SomeUnion = Foo | Biz
 }
 
 type Query {
-  queryField: String
   newQueryField: Int
+  queryField: String
 }
 
 type Subscription {
-  subscriptionField: String
   newSubscriptionField: Int
+  subscriptionField: String
 }
 `);
   });

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -427,8 +427,8 @@ interface Baaz {
 }
 
 type Bar implements Foo, Baaz {
-  str: String
   int: Int
+  str: String
 }
 
 interface Foo {
@@ -495,8 +495,8 @@ type Foo {
 union MultipleUnion = Foo | Bar
 
 type Root {
-  single: SingleUnion
   multiple: MultipleUnion
+  single: SingleUnion
 }
 
 union SingleUnion = Foo
@@ -647,13 +647,13 @@ directive @deprecated(
 # skipping a field. Directives provide this by describing additional information
 # to the executor.
 type __Directive {
-  name: String!
+  args: [__InputValue!]!
   description: String
   locations: [__DirectiveLocation!]!
-  args: [__InputValue!]!
-  onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
-  onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+  name: String!
   onField: Boolean! @deprecated(reason: "Use \`locations\`.")
+  onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+  onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
 }
 
 # A Directive can be adjacent to many parts of the GraphQL language, a
@@ -718,53 +718,52 @@ enum __DirectiveLocation {
 # placeholder for a string or numeric value. However an Enum value is returned in
 # a JSON response as a string.
 type __EnumValue {
-  name: String!
+  deprecationReason: String
   description: String
   isDeprecated: Boolean!
-  deprecationReason: String
+  name: String!
 }
 
 # Object and Interface types are described by a list of Fields, each of which has
 # a name, potentially a list of arguments, and a return type.
 type __Field {
-  name: String!
-  description: String
   args: [__InputValue!]!
-  type: __Type!
-  isDeprecated: Boolean!
   deprecationReason: String
+  description: String
+  isDeprecated: Boolean!
+  name: String!
+  type: __Type!
 }
 
 # Arguments provided to Fields or Directives and the input fields of an
 # InputObject are represented as Input Values which describe their type and
 # optionally a default value.
 type __InputValue {
-  name: String!
-  description: String
-  type: __Type!
-
   # A GraphQL-formatted string representing the default value for this input value.
   defaultValue: String
+  description: String
+  name: String!
+  type: __Type!
 }
 
 # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
 # available types and directives on the server, as well as the entry points for
 # query, mutation, and subscription operations.
 type __Schema {
-  # A list of all types supported by this server.
-  types: [__Type!]!
-
-  # The type that query operations will be rooted at.
-  queryType: __Type!
+  # A list of all directives supported by this server.
+  directives: [__Directive!]!
 
   # If this server supports mutation, the type that mutation operations will be rooted at.
   mutationType: __Type
 
+  # The type that query operations will be rooted at.
+  queryType: __Type!
+
   # If this server support subscription, the type that subscription operations will be rooted at.
   subscriptionType: __Type
 
-  # A list of all directives supported by this server.
-  directives: [__Directive!]!
+  # A list of all types supported by this server.
+  types: [__Type!]!
 }
 
 # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
@@ -776,15 +775,15 @@ type __Schema {
 # they describe. Abstract types, Union and Interface, provide the Object types
 # possible at runtime. List and NonNull types compose other types.
 type __Type {
+  description: String
+  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+  fields(includeDeprecated: Boolean = false): [__Field!]
+  inputFields: [__InputValue!]
+  interfaces: [__Type!]
   kind: __TypeKind!
   name: String
-  description: String
-  fields(includeDeprecated: Boolean = false): [__Field!]
-  interfaces: [__Type!]
-  possibleTypes: [__Type!]
-  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-  inputFields: [__InputValue!]
   ofType: __Type
+  possibleTypes: [__Type!]
 }
 
 # An enum describing what kind of type a given \`__Type\` is.

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -195,7 +195,9 @@ function printEnumValues(values): string {
 
 function printInputObject(type: GraphQLInputObjectType): string {
   const fieldMap = type.getFields();
-  const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
+  const fields = Object.keys(fieldMap)
+    .sort((name1, name2) => name1.localeCompare(name2))
+    .map(fieldName => fieldMap[fieldName]);
   return printDescription(type) +
     `input ${type.name} {\n` +
       fields.map((f, i) =>
@@ -206,7 +208,9 @@ function printInputObject(type: GraphQLInputObjectType): string {
 
 function printFields(type) {
   const fieldMap = type.getFields();
-  const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
+  const fields = Object.keys(fieldMap)
+    .sort((name1, name2) => name1.localeCompare(name2))
+    .map(fieldName => fieldMap[fieldName]);
   return fields.map((f, i) =>
     printDescription(f, '  ', !i) + '  ' +
     f.name + printArgs(f.args, '  ') + ': ' +


### PR DESCRIPTION
Sort the fields of an object similar to how types are being sorted.