### PR TITLE
add test cases to check support of negative floats and ints

### DIFF
--- a/src/validation/__tests__/ArgumentsOfCorrectType-test.js
+++ b/src/validation/__tests__/ArgumentsOfCorrectType-test.js
@@ -46,6 +46,16 @@ describe('Validate: Argument values of correct type', () => {
       `);
     });
 
+    it('Good negative int value', () => {
+      expectPassesRule(ArgumentsOfCorrectType, `
+        {
+          complicatedArgs {
+            intArgField(intArg: -2)
+          }
+        }
+      `);
+    });
+
     it('Good boolean value', () => {
       expectPassesRule(ArgumentsOfCorrectType, `
         {
@@ -71,6 +81,16 @@ describe('Validate: Argument values of correct type', () => {
         {
           complicatedArgs {
             floatArgField(floatArg: 1.1)
+          }
+        }
+      `);
+    });
+
+    it('Good negative float value', () => {
+      expectPassesRule(ArgumentsOfCorrectType, `
+        {
+          complicatedArgs {
+            floatArgField(floatArg: -1.1)
           }
         }
       `);


### PR DESCRIPTION
This tests are used to generate json with test cases for alternative realization of graphql (https://github.com/neelance/graphql-go). 
As for this repo pull request will add test case for addional variants of int and float values (such cases was not supported by alternative one).