### PR TITLE
Expose 'getArgumentValues' method

### DIFF
--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -7,6 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+export { getArgumentValues } from './values';
 export { execute, defaultFieldResolver, responsePathAsArray } from './execute';
 
 export type { ExecutionResult } from './execute';

--- a/src/index.js
+++ b/src/index.js
@@ -236,6 +236,7 @@ export {
   execute,
   defaultFieldResolver,
   responsePathAsArray,
+  getArgumentValues,
 } from './execution';
 
 export type {


### PR DESCRIPTION
Currently, it's the only method that allows parsing directives with Type Safety.
We are already using this method in multiple projects by importing from `graphql/execution/values.js` directly but it is not convenient (+ typings doesn't work).