### PR TITLE
Add source filepath information to formatted errors

### DIFF
--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -18,10 +18,13 @@ import type { GraphQLError } from './GraphQLError';
  */
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   invariant(error, 'Received null or undefined error.');
+  // Pick location associated with the first AST node
+  const loc = error.nodes && error.nodes[0] && error.nodes[0].loc;
   return {
     message: error.message,
     locations: error.locations,
-    path: error.path
+    path: error.path,
+    origin: loc && loc.source.name,
   };
 }
 

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -1076,7 +1076,11 @@ function loc(lexer: Lexer<*>, startToken: Token): Location | void {
   }
 }
 
-function Loc(startToken: Token, endToken: Token, source: Source) {
+function Loc(
+  startToken: Token,
+  endToken: Token,
+  source: Source
+) {
   this.start = startToken.start;
   this.end = endToken.end;
   this.startToken = startToken;
@@ -1086,7 +1090,7 @@ function Loc(startToken: Token, endToken: Token, source: Source) {
 
 // Print a simplified form when appearing in JSON/util.inspect.
 Loc.prototype.toJSON = Loc.prototype.inspect = function toJSON() {
-  return { start: this.start, end: this.end };
+  return { start: this.start, end: this.end, origin: this.source.name };
 };
 
 /**


### PR DESCRIPTION
Working on Relay Compiler, I noticed that the origin of the error messages is difficult to track.
This PR adds additional information about the source filepath if such is passed into the compiler.

I wasn't sure if it is better to add additional arguments or pass it as an option in the options object.