### PR TITLE
Added printIntrospectionSchema to exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -318,6 +318,10 @@ export {
 
   // Print a GraphQLSchema to GraphQL Schema language.
   printSchema,
+  
+  // Prints the built-in introspection schema in the Schema Language
+  // format.
+  printIntrospectionSchema,
 
   // Print a GraphQLType to GraphQL Schema language.
   printType,


### PR DESCRIPTION
Docs at http://graphql.org/graphql-js/utilities/ say "You can import either from the graphql/utilities module, or from the root graphql module" and lists printIntrospectionSchema, yet it is not exported via the root module.