### PR TITLE
Unify how 'kinds' are imported

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -10,7 +10,7 @@
 
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
-import { ENUM } from '../language/kinds';
+import * as Kind from '../language/kinds';
 import { assertValidName } from '../utilities/assertValidName';
 import type {
   OperationDefinitionNode,
@@ -924,12 +924,12 @@ export class GraphQLEnumType/* <T> */ {
   }
 
   isValidLiteral(valueNode: ValueNode): boolean {
-    return valueNode.kind === ENUM &&
+    return valueNode.kind === Kind.ENUM &&
       this._getNameLookup()[valueNode.value] !== undefined;
   }
 
   parseLiteral(valueNode: ValueNode): ?any/* T */ {
-    if (valueNode.kind === ENUM) {
+    if (valueNode.kind === Kind.ENUM) {
       const enumValue = this._getNameLookup()[valueNode.value];
       if (enumValue) {
         return enumValue.value;

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -24,18 +24,7 @@ import type {
   ListValueNode,
   ObjectValueNode,
 } from '../language/ast';
-import {
-  NAME,
-  INT,
-  FLOAT,
-  STRING,
-  BOOLEAN,
-  NULL,
-  ENUM,
-  LIST,
-  OBJECT,
-  OBJECT_FIELD,
-} from '../language/kinds';
+import * as Kind from '../language/kinds';
 import type { GraphQLInputType } from '../type/definition';
 import {
   GraphQLScalarType,
@@ -73,7 +62,7 @@ export function astFromValue(
 
   if (type instanceof GraphQLNonNull) {
     const astValue = astFromValue(_value, type.ofType);
-    if (astValue && astValue.kind === NULL) {
+    if (astValue && astValue.kind === Kind.NULL) {
       return null;
     }
     return astValue;
@@ -81,7 +70,7 @@ export function astFromValue(
 
   // only explicit null, not undefined, NaN
   if (_value === null) {
-    return ({ kind: NULL }: NullValueNode);
+    return ({ kind: Kind.NULL }: NullValueNode);
   }
 
   // undefined, NaN
@@ -101,7 +90,7 @@ export function astFromValue(
           valuesNodes.push(itemNode);
         }
       });
-      return ({ kind: LIST, values: valuesNodes }: ListValueNode);
+      return ({ kind: Kind.LIST, values: valuesNodes }: ListValueNode);
     }
     return astFromValue(_value, itemType);
   }
@@ -119,13 +108,13 @@ export function astFromValue(
       const fieldValue = astFromValue(_value[fieldName], fieldType);
       if (fieldValue) {
         fieldNodes.push({
-          kind: OBJECT_FIELD,
-          name: { kind: NAME, value: fieldName },
+          kind: Kind.OBJECT_FIELD,
+          name: { kind: Kind.NAME, value: fieldName },
           value: fieldValue
         });
       }
     });
-    return ({ kind: OBJECT, fields: fieldNodes }: ObjectValueNode);
+    return ({ kind: Kind.OBJECT, fields: fieldNodes }: ObjectValueNode);
   }
 
   invariant(
@@ -142,32 +131,32 @@ export function astFromValue(
 
   // Others serialize based on their corresponding JavaScript scalar types.
   if (typeof serialized === 'boolean') {
-    return ({ kind: BOOLEAN, value: serialized }: BooleanValueNode);
+    return ({ kind: Kind.BOOLEAN, value: serialized }: BooleanValueNode);
   }
 
   // JavaScript numbers can be Int or Float values.
   if (typeof serialized === 'number') {
     const stringNum = String(serialized);
     return /^[0-9]+$/.test(stringNum) ?
-      ({ kind: INT, value: stringNum }: IntValueNode) :
-      ({ kind: FLOAT, value: stringNum }: FloatValueNode);
+      ({ kind: Kind.INT, value: stringNum }: IntValueNode) :
+      ({ kind: Kind.FLOAT, value: stringNum }: FloatValueNode);
   }
 
   if (typeof serialized === 'string') {
     // Enum types use Enum literals.
     if (type instanceof GraphQLEnumType) {
-      return ({ kind: ENUM, value: serialized }: EnumValueNode);
+      return ({ kind: Kind.ENUM, value: serialized }: EnumValueNode);
     }
 
     // ID types can use Int literals.
     if (type === GraphQLID && /^[0-9]+$/.test(serialized)) {
-      return ({ kind: INT, value: serialized }: IntValueNode);
+      return ({ kind: Kind.INT, value: serialized }: IntValueNode);
     }
 
     // Use JSON stringify, which uses the same string encoding as GraphQL,
     // then remove the quotes.
     return ({
-      kind: STRING,
+      kind: Kind.STRING,
       value: JSON.stringify(serialized).slice(1, -1)
     }: StringValueNode);
   }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -55,19 +55,7 @@ import {
   GraphQLID,
 } from '../type/scalars';
 
-import {
-  DOCUMENT,
-  LIST_TYPE,
-  NON_NULL_TYPE,
-  OBJECT_TYPE_DEFINITION,
-  INTERFACE_TYPE_DEFINITION,
-  ENUM_TYPE_DEFINITION,
-  UNION_TYPE_DEFINITION,
-  SCALAR_TYPE_DEFINITION,
-  INPUT_OBJECT_TYPE_DEFINITION,
-  TYPE_EXTENSION_DEFINITION,
-  DIRECTIVE_DEFINITION,
-} from '../language/kinds';
+import * as Kind from '../language/kinds';
 
 import type {
   GraphQLType,
@@ -118,7 +106,7 @@ export function extendSchema(
   );
 
   invariant(
-    documentAST && documentAST.kind === DOCUMENT,
+    documentAST && documentAST.kind === Kind.DOCUMENT,
     'Must provide valid Document AST'
   );
 
@@ -133,12 +121,12 @@ export function extendSchema(
   for (let i = 0; i < documentAST.definitions.length; i++) {
     const def = documentAST.definitions[i];
     switch (def.kind) {
-      case OBJECT_TYPE_DEFINITION:
-      case INTERFACE_TYPE_DEFINITION:
-      case ENUM_TYPE_DEFINITION:
-      case UNION_TYPE_DEFINITION:
-      case SCALAR_TYPE_DEFINITION:
-      case INPUT_OBJECT_TYPE_DEFINITION:
+      case Kind.OBJECT_TYPE_DEFINITION:
+      case Kind.INTERFACE_TYPE_DEFINITION:
+      case Kind.ENUM_TYPE_DEFINITION:
+      case Kind.UNION_TYPE_DEFINITION:
+      case Kind.SCALAR_TYPE_DEFINITION:
+      case Kind.INPUT_OBJECT_TYPE_DEFINITION:
         // Sanity check that none of the defined types conflict with the
         // schema's existing types.
         const typeName = def.name.value;
@@ -151,7 +139,7 @@ export function extendSchema(
         }
         typeDefinitionMap[typeName] = def;
         break;
-      case TYPE_EXTENSION_DEFINITION:
+      case Kind.TYPE_EXTENSION_DEFINITION:
         // Sanity check that this type extension exists within the
         // schema's existing types.
         const extendedTypeName = def.definition.name.value;
@@ -177,7 +165,7 @@ export function extendSchema(
         }
         typeExtensionsMap[extendedTypeName] = extensions;
         break;
-      case DIRECTIVE_DEFINITION:
+      case Kind.DIRECTIVE_DEFINITION:
         const directiveName = def.name.value;
         const existingDirective = schema.getDirective(directiveName);
         if (existingDirective) {
@@ -451,12 +439,13 @@ export function extendSchema(
 
   function buildType(typeNode: TypeDefinitionNode): GraphQLNamedType {
     switch (typeNode.kind) {
-      case OBJECT_TYPE_DEFINITION: return buildObjectType(typeNode);
-      case INTERFACE_TYPE_DEFINITION: return buildInterfaceType(typeNode);
-      case UNION_TYPE_DEFINITION: return buildUnionType(typeNode);
-      case SCALAR_TYPE_DEFINITION: return buildScalarType(typeNode);
-      case ENUM_TYPE_DEFINITION: return buildEnumType(typeNode);
-      case INPUT_OBJECT_TYPE_DEFINITION: return buildInputObjectType(typeNode);
+      case Kind.OBJECT_TYPE_DEFINITION: return buildObjectType(typeNode);
+      case Kind.INTERFACE_TYPE_DEFINITION: return buildInterfaceType(typeNode);
+      case Kind.UNION_TYPE_DEFINITION: return buildUnionType(typeNode);
+      case Kind.SCALAR_TYPE_DEFINITION: return buildScalarType(typeNode);
+      case Kind.ENUM_TYPE_DEFINITION: return buildEnumType(typeNode);
+      case Kind.INPUT_OBJECT_TYPE_DEFINITION:
+        return buildInputObjectType(typeNode);
     }
     throw new TypeError('Unknown type kind ' + typeNode.kind);
   }
@@ -572,10 +561,10 @@ export function extendSchema(
   }
 
   function buildInputFieldType(typeNode: TypeNode): GraphQLInputType {
-    if (typeNode.kind === LIST_TYPE) {
+    if (typeNode.kind === Kind.LIST_TYPE) {
       return new GraphQLList(buildInputFieldType(typeNode.type));
     }
-    if (typeNode.kind === NON_NULL_TYPE) {
+    if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const nullableType = buildInputFieldType(typeNode.type);
       invariant(!(nullableType instanceof GraphQLNonNull), 'Must be nullable');
       return new GraphQLNonNull(nullableType);
@@ -584,10 +573,10 @@ export function extendSchema(
   }
 
   function buildOutputFieldType(typeNode: TypeNode): GraphQLOutputType {
-    if (typeNode.kind === LIST_TYPE) {
+    if (typeNode.kind === Kind.LIST_TYPE) {
       return new GraphQLList(buildOutputFieldType(typeNode.type));
     }
-    if (typeNode.kind === NON_NULL_TYPE) {
+    if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const nullableType = buildOutputFieldType(typeNode.type);
       invariant(!(nullableType instanceof GraphQLNonNull), 'Must be nullable');
       return new GraphQLNonNull(nullableType);

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -14,12 +14,7 @@ import type {
   ListValueNode,
   ObjectValueNode
 } from '../language/ast';
-import {
-  NULL,
-  VARIABLE,
-  LIST,
-  OBJECT
-} from '../language/kinds';
+import * as Kind from '../language/kinds';
 import {
   GraphQLScalarType,
   GraphQLEnumType,
@@ -45,26 +40,26 @@ export function isValidLiteralValue(
 ): Array<string> {
   // A value must be provided if the type is non-null.
   if (type instanceof GraphQLNonNull) {
-    if (!valueNode || (valueNode.kind === NULL)) {
+    if (!valueNode || (valueNode.kind === Kind.NULL)) {
       return [ `Expected "${String(type)}", found null.` ];
     }
     return isValidLiteralValue(type.ofType, valueNode);
   }
 
-  if (!valueNode || (valueNode.kind === NULL)) {
+  if (!valueNode || (valueNode.kind === Kind.NULL)) {
     return [];
   }
 
   // This function only tests literals, and assumes variables will provide
   // values of the correct type.
-  if (valueNode.kind === VARIABLE) {
+  if (valueNode.kind === Kind.VARIABLE) {
     return [];
   }
 
   // Lists accept a non-list value as a list of one.
   if (type instanceof GraphQLList) {
     const itemType = type.ofType;
-    if (valueNode.kind === LIST) {
+    if (valueNode.kind === Kind.LIST) {
       return (valueNode: ListValueNode).values.reduce((acc, item, index) => {
         const errors = isValidLiteralValue(itemType, item);
         return acc.concat(errors.map(error =>
@@ -77,7 +72,7 @@ export function isValidLiteralValue(
 
   // Input objects check each defined field and look for undefined fields.
   if (type instanceof GraphQLInputObjectType) {
-    if (valueNode.kind !== OBJECT) {
+    if (valueNode.kind !== Kind.OBJECT) {
       return [ `Expected "${type.name}", found not an object.` ];
     }
     const fields = type.getFields();

--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -9,7 +9,7 @@
  */
 
 import invariant from '../jsutils/invariant';
-import { NAMED_TYPE, LIST_TYPE, NON_NULL_TYPE } from '../language/kinds';
+import * as Kind from '../language/kinds';
 import type {
   NamedTypeNode,
   ListTypeNode,
@@ -44,15 +44,15 @@ declare function typeFromASTType(
 function typeFromASTImpl(schema, typeNode) {
 /* eslint-enable no-redeclare */
   let innerType;
-  if (typeNode.kind === LIST_TYPE) {
+  if (typeNode.kind === Kind.LIST_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);
     return innerType && new GraphQLList(innerType);
   }
-  if (typeNode.kind === NON_NULL_TYPE) {
+  if (typeNode.kind === Kind.NON_NULL_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);
     return innerType && new GraphQLNonNull(innerType);
   }
-  invariant(typeNode.kind === NAMED_TYPE, 'Must be a named type.');
+  invariant(typeNode.kind === Kind.NAMED_TYPE, 'Must be a named type.');
   return schema.getType(typeNode.name.value);
 }
 // This will export typeFromAST with the correct type, but currently exposes

--- a/src/validation/rules/KnownArgumentNames.js
+++ b/src/validation/rules/KnownArgumentNames.js
@@ -14,10 +14,7 @@ import find from '../../jsutils/find';
 import invariant from '../../jsutils/invariant';
 import suggestionList from '../../jsutils/suggestionList';
 import quotedOrList from '../../jsutils/quotedOrList';
-import {
-  FIELD,
-  DIRECTIVE
-} from '../../language/kinds';
+import * as Kind from '../../language/kinds';
 import type { GraphQLType } from '../../type/definition';
 
 
@@ -58,7 +55,7 @@ export function KnownArgumentNames(context: ValidationContext): any {
   return {
     Argument(node, key, parent, path, ancestors) {
       const argumentOf = ancestors[ancestors.length - 1];
-      if (argumentOf.kind === FIELD) {
+      if (argumentOf.kind === Kind.FIELD) {
         const fieldDef = context.getFieldDef();
         if (fieldDef) {
           const fieldArgDef = find(
@@ -82,7 +79,7 @@ export function KnownArgumentNames(context: ValidationContext): any {
             ));
           }
         }
-      } else if (argumentOf.kind === DIRECTIVE) {
+      } else if (argumentOf.kind === Kind.DIRECTIVE) {
         const directive = context.getDirective();
         if (directive) {
           const directiveArgDef = find(

--- a/src/validation/rules/KnownDirectives.js
+++ b/src/validation/rules/KnownDirectives.js
@@ -11,23 +11,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import find from '../../jsutils/find';
-import {
-  FIELD,
-  FRAGMENT_DEFINITION,
-  FRAGMENT_SPREAD,
-  INLINE_FRAGMENT,
-  OPERATION_DEFINITION,
-  SCHEMA_DEFINITION,
-  SCALAR_TYPE_DEFINITION,
-  OBJECT_TYPE_DEFINITION,
-  FIELD_DEFINITION,
-  INPUT_VALUE_DEFINITION,
-  INTERFACE_TYPE_DEFINITION,
-  UNION_TYPE_DEFINITION,
-  ENUM_TYPE_DEFINITION,
-  ENUM_VALUE_DEFINITION,
-  INPUT_OBJECT_TYPE_DEFINITION,
-} from '../../language/kinds';
+import * as Kind from '../../language/kinds';
 import { DirectiveLocation } from '../../type/directives';
 
 
@@ -81,29 +65,30 @@ export function KnownDirectives(context: ValidationContext): any {
 function getDirectiveLocationForASTPath(ancestors) {
   const appliedTo = ancestors[ancestors.length - 1];
   switch (appliedTo.kind) {
-    case OPERATION_DEFINITION:
+    case Kind.OPERATION_DEFINITION:
       switch (appliedTo.operation) {
         case 'query': return DirectiveLocation.QUERY;
         case 'mutation': return DirectiveLocation.MUTATION;
         case 'subscription': return DirectiveLocation.SUBSCRIPTION;
       }
       break;
-    case FIELD: return DirectiveLocation.FIELD;
-    case FRAGMENT_SPREAD: return DirectiveLocation.FRAGMENT_SPREAD;
-    case INLINE_FRAGMENT: return DirectiveLocation.INLINE_FRAGMENT;
-    case FRAGMENT_DEFINITION: return DirectiveLocation.FRAGMENT_DEFINITION;
-    case SCHEMA_DEFINITION: return DirectiveLocation.SCHEMA;
-    case SCALAR_TYPE_DEFINITION: return DirectiveLocation.SCALAR;
-    case OBJECT_TYPE_DEFINITION: return DirectiveLocation.OBJECT;
-    case FIELD_DEFINITION: return DirectiveLocation.FIELD_DEFINITION;
-    case INTERFACE_TYPE_DEFINITION: return DirectiveLocation.INTERFACE;
-    case UNION_TYPE_DEFINITION: return DirectiveLocation.UNION;
-    case ENUM_TYPE_DEFINITION: return DirectiveLocation.ENUM;
-    case ENUM_VALUE_DEFINITION: return DirectiveLocation.ENUM_VALUE;
-    case INPUT_OBJECT_TYPE_DEFINITION: return DirectiveLocation.INPUT_OBJECT;
-    case INPUT_VALUE_DEFINITION:
+    case Kind.FIELD: return DirectiveLocation.FIELD;
+    case Kind.FRAGMENT_SPREAD: return DirectiveLocation.FRAGMENT_SPREAD;
+    case Kind.INLINE_FRAGMENT: return DirectiveLocation.INLINE_FRAGMENT;
+    case Kind.FRAGMENT_DEFINITION: return DirectiveLocation.FRAGMENT_DEFINITION;
+    case Kind.SCHEMA_DEFINITION: return DirectiveLocation.SCHEMA;
+    case Kind.SCALAR_TYPE_DEFINITION: return DirectiveLocation.SCALAR;
+    case Kind.OBJECT_TYPE_DEFINITION: return DirectiveLocation.OBJECT;
+    case Kind.FIELD_DEFINITION: return DirectiveLocation.FIELD_DEFINITION;
+    case Kind.INTERFACE_TYPE_DEFINITION: return DirectiveLocation.INTERFACE;
+    case Kind.UNION_TYPE_DEFINITION: return DirectiveLocation.UNION;
+    case Kind.ENUM_TYPE_DEFINITION: return DirectiveLocation.ENUM;
+    case Kind.ENUM_VALUE_DEFINITION: return DirectiveLocation.ENUM_VALUE;
+    case Kind.INPUT_OBJECT_TYPE_DEFINITION:
+      return DirectiveLocation.INPUT_OBJECT;
+    case Kind.INPUT_VALUE_DEFINITION:
       const parentNode = ancestors[ancestors.length - 3];
-      return parentNode.kind === INPUT_OBJECT_TYPE_DEFINITION ?
+      return parentNode.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ?
         DirectiveLocation.INPUT_FIELD_DEFINITION :
         DirectiveLocation.ARGUMENT_DEFINITION;
   }

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -17,7 +17,7 @@ import type {
   ArgumentNode,
   FragmentDefinitionNode,
 } from '../../language/ast';
-import { FIELD, INLINE_FRAGMENT, FRAGMENT_SPREAD } from '../../language/kinds';
+import * as Kind from '../../language/kinds';
 import { print } from '../../language/printer';
 import {
   getNamedType,
@@ -712,7 +712,7 @@ function _collectFieldsAndFragmentNames(
   for (let i = 0; i < selectionSet.selections.length; i++) {
     const selection = selectionSet.selections[i];
     switch (selection.kind) {
-      case FIELD:
+      case Kind.FIELD:
         const fieldName = selection.name.value;
         let fieldDef;
         if (parentType instanceof GraphQLObjectType ||
@@ -726,10 +726,10 @@ function _collectFieldsAndFragmentNames(
         }
         nodeAndDefs[responseName].push([ parentType, selection, fieldDef ]);
         break;
-      case FRAGMENT_SPREAD:
+      case Kind.FRAGMENT_SPREAD:
         fragmentNames[selection.name.value] = true;
         break;
-      case INLINE_FRAGMENT:
+      case Kind.INLINE_FRAGMENT:
         const typeCondition = selection.typeCondition;
         const inlineFragmentType = typeCondition ?
           typeFromAST(context.getSchema(), typeCondition) :


### PR DESCRIPTION
At the moment there are two ways 'kinds' are imported:
```js
import * as Kind from '../language/kinds';
```
and
```js
import {
  NULL,
  ENUM,
  // ...
} from '../language/kinds';
```

This PR unifies this by using the first approach. IMHO this PR not only shaves a few lines of code but also improves readability. For example `NULL` as the name is confusing (especially for someone who used C language) and `Kind.NULL` solves this problem.