### PR TITLE
Second pass after #907

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -76,3 +76,8 @@ directive @include(if: Boolean!)
   on FIELD
    | FRAGMENT_SPREAD
    | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on
+  | FIELD
+  | FRAGMENT_SPREAD
+  | INLINE_FRAGMENT

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -457,7 +457,29 @@ type Hello {
     expect(printJson(doc)).to.equal(printJson(expected));
   });
 
-  it('Union with two types and leading vertical bar', () => {
+  it('Union with two types', () => {
+    const body = 'union Hello = Wo | Rld';
+    const doc = parse(body);
+    const expected = {
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'UnionTypeDefinition',
+          name: nameNode('Hello', { start: 6, end: 11 }),
+          directives: [],
+          types: [
+            typeNode('Wo', { start: 14, end: 16 }),
+            typeNode('Rld', { start: 19, end: 22 }),
+          ],
+          loc: { start: 0, end: 22 },
+        }
+      ],
+      loc: { start: 0, end: 22 },
+    };
+    expect(printJson(doc)).to.equal(printJson(expected));
+  });
+
+  it('Union with two types and leading pipe', () => {
     const body = 'union Hello = | Wo | Rld';
     const doc = parse(body);
     const expected = {
@@ -479,56 +501,24 @@ type Hello {
     expect(printJson(doc)).to.equal(printJson(expected));
   });
 
-  it('Union with no types and leading vertical bar', () => {
+  it('Union fails with no types', () => {
     const body = 'union Hello = |';
     expect(() => parse(body)).to.throw();
   });
 
-  it('Union with types and ending vertical bar', () => {
-    const body = 'union Hello = Wo | Rld |';
-    expect(() => parse(body)).to.throw();
-  });
-
-  it('Union with types and double vertical bar at the beginning', () => {
+  it('Union fails with leading douple pipe', () => {
     const body = 'union Hello = || Wo | Rld';
     expect(() => parse(body)).to.throw();
   });
 
-  it('Union with types and double vertical bar in the middle', () => {
+  it('Union fails with double pipe', () => {
     const body = 'union Hello = Wo || Rld';
     expect(() => parse(body)).to.throw();
   });
 
-  it('Union with types and double vertical bar at the end', () => {
-    const body = 'union Hello = | Wo | Rld ||';
-    expect(() => parse(body)).to.throw();
-  });
-
-  it('Union with types , leanding and ending vertical bar', () => {
+  it('Union fails with trailing pipe', () => {
     const body = 'union Hello = | Wo | Rld |';
     expect(() => parse(body)).to.throw();
-  });
-
-  it('Union with two types', () => {
-    const body = 'union Hello = Wo | Rld';
-    const doc = parse(body);
-    const expected = {
-      kind: 'Document',
-      definitions: [
-        {
-          kind: 'UnionTypeDefinition',
-          name: nameNode('Hello', { start: 6, end: 11 }),
-          directives: [],
-          types: [
-            typeNode('Wo', { start: 14, end: 16 }),
-            typeNode('Rld', { start: 19, end: 22 }),
-          ],
-          loc: { start: 0, end: 22 },
-        }
-      ],
-      loc: { start: 0, end: 22 },
-    };
-    expect(printJson(doc)).to.equal(printJson(expected));
   });
 
   it('Scalar', () => {

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -119,6 +119,8 @@ type NoFields {}
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 `);
 
   });

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -938,14 +938,13 @@ function parseUnionTypeDefinition(lexer: Lexer<*>): UnionTypeDefinitionNode {
 
 /**
  * UnionMembers :
- *   - NamedType
+ *   - `|`? NamedType
  *   - UnionMembers | NamedType
  */
 function parseUnionMembers(lexer: Lexer<*>): Array<NamedTypeNode> {
+  // Optional leading pipe
+  skip(lexer, TokenKind.PIPE);
   const members = [];
-  if (peek(lexer, TokenKind.PIPE)) {
-    skip(lexer, TokenKind.PIPE);
-  }
   do {
     members.push(parseNamedType(lexer));
   } while (skip(lexer, TokenKind.PIPE));
@@ -1056,10 +1055,12 @@ function parseDirectiveDefinition(lexer: Lexer<*>): DirectiveDefinitionNode {
 
 /**
  * DirectiveLocations :
- *   - Name
+ *   - `|`? Name
  *   - DirectiveLocations | Name
  */
 function parseDirectiveLocations(lexer: Lexer<*>): Array<NameNode> {
+  // Optional leading pipe
+  skip(lexer, TokenKind.PIPE);
   const locations = [];
   do {
     locations.push(parseName(lexer));


### PR DESCRIPTION
This adds a bit of cleanup after #907 for post-commit review:

* Removes unnecessary `peek()`
* Adds leading pipe support to directive locations
* Removes some redundant tests
* Orders tests so similar tests remain together