### PR TITLE
RFC: Define custom scalars in terms of built-in scalars.

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -41,6 +41,8 @@ union AnnotatedUnionTwo @onUnion = | A | B
 
 scalar CustomScalar
 
+scalar StringEncodedCustomScalar = String
+
 scalar AnnotatedScalar @onScalar
 
 enum Site {

--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -41,7 +41,7 @@ union AnnotatedUnionTwo @onUnion = | A | B
 
 scalar CustomScalar
 
-scalar StringEncodedCustomScalar = String
+scalar StringEncodedCustomScalar as String
 
 scalar AnnotatedScalar @onScalar
 

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -530,6 +530,7 @@ type Hello {
         {
           kind: 'ScalarTypeDefinition',
           name: nameNode('Hello', { start: 7, end: 12 }),
+          type: null,
           directives: [],
           loc: { start: 0, end: 12 },
         }

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -87,6 +87,8 @@ union AnnotatedUnionTwo @onUnion = A | B
 
 scalar CustomScalar
 
+scalar StringEncodedCustomScalar = String
+
 scalar AnnotatedScalar @onScalar
 
 enum Site {

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -87,7 +87,7 @@ union AnnotatedUnionTwo @onUnion = A | B
 
 scalar CustomScalar
 
-scalar StringEncodedCustomScalar = String
+scalar StringEncodedCustomScalar as String
 
 scalar AnnotatedScalar @onScalar
 

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -397,6 +397,7 @@ export type ScalarTypeDefinitionNode = {
   kind: 'ScalarTypeDefinition';
   loc?: Location;
   name: NameNode;
+  type?: ?NamedTypeNode;
   directives?: ?Array<DirectiveNode>;
 };
 

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -784,14 +784,14 @@ function parseOperationTypeDefinition(
 }
 
 /**
- * ScalarTypeDefinition : scalar Name ScalarOfType? Directives?
- * ScalarOfType : = NamedType
+ * ScalarTypeDefinition : scalar Name SerializeAsType? Directives?
+ * SerializeAsType : as NamedType
  */
 function parseScalarTypeDefinition(lexer: Lexer<*>): ScalarTypeDefinitionNode {
   const start = lexer.token;
   expectKeyword(lexer, 'scalar');
   const name = parseName(lexer);
-  const type = skip(lexer, TokenKind.EQUALS) ? parseNamedType(lexer) : null;
+  const type = skipKeyword(lexer, 'as') ? parseNamedType(lexer) : null;
   const directives = parseDirectives(lexer);
   return {
     kind: SCALAR_TYPE_DEFINITION,
@@ -1133,9 +1133,23 @@ function expect(lexer: Lexer<*>, kind: string): Token {
 }
 
 /**
- * If the next token is a keyword with the given value, return that token after
+ * If the next token is a keyword with the given value, return true after
  * advancing the lexer. Otherwise, do not change the parser state and return
  * false.
+ */
+function skipKeyword(lexer: Lexer<*>, value: string): boolean {
+  const token = lexer.token;
+  const match = token.kind === TokenKind.NAME && token.value === value;
+  if (match) {
+    lexer.advance();
+  }
+  return match;
+}
+
+/**
+ * If the next token is a keyword with the given value, return that token after
+ * advancing the lexer. Otherwise, do not change the parser state and throw
+ * an error.
  */
 function expectKeyword(lexer: Lexer<*>, value: string): Token {
   const token = lexer.token;

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -784,16 +784,19 @@ function parseOperationTypeDefinition(
 }
 
 /**
- * ScalarTypeDefinition : scalar Name Directives?
+ * ScalarTypeDefinition : scalar Name ScalarOfType? Directives?
+ * ScalarOfType : = NamedType
  */
 function parseScalarTypeDefinition(lexer: Lexer<*>): ScalarTypeDefinitionNode {
   const start = lexer.token;
   expectKeyword(lexer, 'scalar');
   const name = parseName(lexer);
+  const type = skip(lexer, TokenKind.EQUALS) ? parseNamedType(lexer) : null;
   const directives = parseDirectives(lexer);
   return {
     kind: SCALAR_TYPE_DEFINITION,
     name,
+    type,
     directives,
     loc: loc(lexer, start),
   };

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -105,8 +105,8 @@ const printDocASTReducer = {
   OperationTypeDefinition: ({ operation, type }) =>
     operation + ': ' + type,
 
-  ScalarTypeDefinition: ({ name, directives }) =>
-    join([ 'scalar', name, join(directives, ' ') ], ' '),
+  ScalarTypeDefinition: ({ name, type, directives }) =>
+    join([ 'scalar', name, wrap('= ', type), join(directives, ' ') ], ' '),
 
   ObjectTypeDefinition: ({ name, interfaces, directives, fields }) =>
     join([

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -106,7 +106,7 @@ const printDocASTReducer = {
     operation + ': ' + type,
 
   ScalarTypeDefinition: ({ name, type, directives }) =>
-    join([ 'scalar', name, wrap('= ', type), join(directives, ' ') ], ' '),
+    join([ 'scalar', name, wrap('as ', type), join(directives, ' ') ], ' '),
 
   ObjectTypeDefinition: ({ name, interfaces, directives, fields }) =>
     join([

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -42,7 +42,7 @@ export const QueryDocumentKeys = {
   SchemaDefinition: [ 'directives', 'operationTypes' ],
   OperationTypeDefinition: [ 'type' ],
 
-  ScalarTypeDefinition: [ 'name', 'directives' ],
+  ScalarTypeDefinition: [ 'name', 'type', 'directives' ],
   ObjectTypeDefinition: [ 'name', 'interfaces', 'directives', 'fields' ],
   FieldDefinition: [ 'name', 'arguments', 'type', 'directives' ],
   InputValueDefinition: [ 'name', 'type', 'defaultValue', 'directives' ],

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1313,8 +1313,9 @@ describe('Introspection', () => {
             'An enum describing what kind of type a given `__Type` is.',
           enumValues: [
             {
-              description: 'Indicates this type is a scalar. ' +
-                           '`ofType` is a valid field.',
+              description:
+                'Indicates this type is a scalar. ' +
+                  '`ofType` may represent how this scalar is serialized.',
               name: 'SCALAR'
             },
             {

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1313,7 +1313,8 @@ describe('Introspection', () => {
             'An enum describing what kind of type a given `__Type` is.',
           enumValues: [
             {
-              description: 'Indicates this type is a scalar.',
+              description: 'Indicates this type is a scalar. ' +
+                           '`ofType` is a valid field.',
               name: 'SCALAR'
             },
             {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -207,8 +207,8 @@ export const __Type = new GraphQLObjectType({
     'The fundamental unit of any GraphQL Schema is the type. There are ' +
     'many kinds of types in GraphQL as represented by the `__TypeKind` enum.' +
     '\n\nDepending on the kind of a type, certain fields describe ' +
-    'information about that type. Scalar types provide no information ' +
-    'beyond a name and description, while Enum types provide their values. ' +
+    'information about that type. Scalar types provide a name, description' +
+    'and how they serialize, while Enum types provide their possible values. ' +
     'Object and Interface types provide the fields they describe. Abstract ' +
     'types, Union and Interface, provide the Object types possible ' +
     'at runtime. List and NonNull types compose other types.',
@@ -382,7 +382,7 @@ export const __TypeKind = new GraphQLEnumType({
     SCALAR: {
       value: TypeKind.SCALAR,
       description: 'Indicates this type is a scalar. ' +
-                   '`ofType` is a valid field.'
+                   '`ofType` may represent how this scalar is serialized.'
     },
     OBJECT: {
       value: TypeKind.OBJECT,

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -381,7 +381,8 @@ export const __TypeKind = new GraphQLEnumType({
   values: {
     SCALAR: {
       value: TypeKind.SCALAR,
-      description: 'Indicates this type is a scalar.'
+      description: 'Indicates this type is a scalar. ' +
+                   '`ofType` is a valid field.'
     },
     OBJECT: {
       value: TypeKind.OBJECT,

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -571,7 +571,7 @@ schema {
   query: Root
 }
 
-scalar Even = Int
+scalar Even as Int
 
 scalar Odd
 
@@ -783,10 +783,10 @@ type __Schema {
 # types in GraphQL as represented by the \`__TypeKind\` enum.
 #
 # Depending on the kind of a type, certain fields describe information about that
-# type. Scalar types provide no information beyond a name and description, while
-# Enum types provide their values. Object and Interface types provide the fields
-# they describe. Abstract types, Union and Interface, provide the Object types
-# possible at runtime. List and NonNull types compose other types.
+# type. Scalar types provide a name, descriptionand how they serialize, while Enum
+# types provide their possible values. Object and Interface types provide the
+# fields they describe. Abstract types, Union and Interface, provide the Object
+# types possible at runtime. List and NonNull types compose other types.
 type __Type {
   description: String
   enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
@@ -801,7 +801,7 @@ type __Type {
 
 # An enum describing what kind of type a given \`__Type\` is.
 enum __TypeKind {
-  # Indicates this type is a scalar. \`ofType\` is a valid field.
+  # Indicates this type is a scalar. \`ofType\` may represent how this scalar is serialized.
   SCALAR
 
   # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -540,8 +540,17 @@ type Root {
   });
 
   it('Custom Scalar', () => {
+    const EvenType = new GraphQLScalarType({
+      name: 'Even',
+      ofType: GraphQLInt,
+      serialize(value) {
+        return value % 2 === 1 ? value : null;
+      }
+    });
+
     const OddType = new GraphQLScalarType({
       name: 'Odd',
+      // No ofType in this test case.
       serialize(value) {
         return value % 2 === 1 ? value : null;
       }
@@ -550,6 +559,7 @@ type Root {
     const Root = new GraphQLObjectType({
       name: 'Root',
       fields: {
+        even: { type: EvenType },
         odd: { type: OddType },
       },
     });
@@ -561,9 +571,12 @@ schema {
   query: Root
 }
 
+scalar Even = Int
+
 scalar Odd
 
 type Root {
+  even: Even
   odd: Odd
 }
 `
@@ -788,7 +801,7 @@ type __Type {
 
 # An enum describing what kind of type a given \`__Type\` is.
 enum __TypeKind {
-  # Indicates this type is a scalar.
+  # Indicates this type is a scalar. \`ofType\` is a valid field.
   SCALAR
 
   # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -194,6 +194,14 @@ export function buildClientSchema(
     return type;
   }
 
+  function getScalarType(typeRef: IntrospectionTypeRef): GraphQLScalarType {
+    const type = getType(typeRef);
+    invariant(
+      type instanceof GraphQLScalarType,
+      'Introspection must provide scalar type for custom scalars.'
+    );
+    return type;
+  }
 
   // Given a type's introspection result, construct the correct
   // GraphQLType instance.
@@ -223,16 +231,20 @@ export function buildClientSchema(
   function buildScalarDef(
     scalarIntrospection: IntrospectionScalarType
   ): GraphQLScalarType {
+    const ofType = scalarIntrospection.ofType ?
+      getScalarType(scalarIntrospection.ofType) :
+      undefined;
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
+      ofType,
       serialize: id => id,
       // Note: validation calls the parse functions to determine if a
       // literal value is correct. Returning null would cause use of custom
       // scalars to always fail validation. Returning false causes them to
       // always pass validation.
-      parseValue: () => false,
-      parseLiteral: () => false,
+      parseValue: ofType ? null : () => false,
+      parseLiteral: ofType ? null : () => false,
     });
   }
 

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -285,6 +285,12 @@ export function extendSchema(
     return type;
   }
 
+  function getScalarTypeFromAST(node: NamedTypeNode): GraphQLScalarType {
+    const type = getTypeFromAST(node);
+    invariant(type instanceof GraphQLScalarType, 'Must be Scalar type.');
+    return type;
+  }
+
   function getInputTypeFromAST(node: NamedTypeNode): GraphQLInputType {
     return assertInputType(getTypeFromAST(node));
   }
@@ -478,16 +484,18 @@ export function extendSchema(
   }
 
   function buildScalarType(typeNode: ScalarTypeDefinitionNode) {
+    const ofType = typeNode.type && getScalarTypeFromAST(typeNode.type);
     return new GraphQLScalarType({
       name: typeNode.name.value,
       description: getDescription(typeNode),
+      ofType,
       serialize: id => id,
       // Note: validation calls the parse functions to determine if a
       // literal value is correct. Returning null would cause use of custom
       // scalars to always fail validation. Returning false causes them to
       // always pass validation.
-      parseValue: () => false,
-      parseLiteral: () => false,
+      parseValue: ofType ? null : () => false,
+      parseLiteral: ofType ? null : () => false,
     });
   }
 

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -135,6 +135,20 @@ export function findTypesThatChangedKind(
         description: `${typeName} changed from ` +
           `${typeKindName(oldType)} to ${typeKindName(newType)}.`
       });
+    } else if (
+      oldType instanceof GraphQLScalarType &&
+      newType instanceof GraphQLScalarType
+    ) {
+      const oldOfType = oldType.ofType;
+      const newOfType = newType.ofType;
+      if (oldOfType && newOfType && oldOfType !== newOfType) {
+        breakingChanges.push({
+          type: BreakingChangeType.TYPE_CHANGED_KIND,
+          description: `${typeName} changed from ` +
+            `${typeKindName(oldType)} serialized as ${oldOfType.name} ` +
+            `to ${typeKindName(newType)} serialized as ${newOfType.name}.`
+        });
+      }
     }
   });
   return breakingChanges;

--- a/src/utilities/introspectionQuery.js
+++ b/src/utilities/introspectionQuery.js
@@ -129,6 +129,7 @@ export type IntrospectionScalarType = {
   kind: 'SCALAR';
   name: string;
   description: ?string;
+  ofType: ?IntrospectionNamedTypeRef;
 };
 
 export type IntrospectionObjectType = {

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -153,9 +153,9 @@ export function printType(type: GraphQLType): string {
 }
 
 function printScalar(type: GraphQLScalarType): string {
-  const ofType = type.ofType ? ` = ${type.ofType.name}` : '';
+  const serializeAsType = type.ofType ? ` as ${type.ofType.name}` : '';
   return printDescription(type) +
-    `scalar ${type.name}${ofType}`;
+    `scalar ${type.name}${serializeAsType}`;
 }
 
 function printObject(type: GraphQLObjectType): string {

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -153,8 +153,9 @@ export function printType(type: GraphQLType): string {
 }
 
 function printScalar(type: GraphQLScalarType): string {
+  const ofType = type.ofType ? ` = ${type.ofType.name}` : '';
   return printDescription(type) +
-    `scalar ${type.name}`;
+    `scalar ${type.name}${ofType}`;
 }
 
 function printObject(type: GraphQLObjectType): string {


### PR DESCRIPTION
This proposes an additive change which allows custom scalars to be defined in terms of the built-in scalars. The motivation is for client-side code generators to understand how to map between the GraphQL type system and a native type system. As an example, a `URL` custom type may be defined in terms of the built-in scalar `String`. It could define additional serialization and parsing logic, however client tools can know to treat `URL` values as `String`. Presently, we do this by defining these mappings manually on the client, which is difficult to scale, or by giving up and making no assumptions of how the custom types serialize.

Another real use case of giving client tools this information is GraphiQL: this change will allow GraphiQL to show more useful errors when a literal of an incorrect kind is provided to a custom scalar. Currently GraphiQL simply accepts all values.

To accomplish this, this proposes adding the following:

* A new property when defining `GraphQLScalarType` (`ofType`) which asserts that only built-in scalar types are provided.

* A second type coercion to guarantee to a client that the serialized values match the `ofType`.

* Delegating the `parseLiteral` and `parseValue` functions to those in `ofType` (this enables downstream validation / GraphiQL features)

* Exposing `ofType` in the introspection system, and consuming that introspection in `buildClientSchema`.

* Adding optional syntax to the SDL, and consuming that in `buildASTSchema` and `extendSchema` as well as in `schemaPrinter`.

* Adding a case to `findBreakingChanges` which looks for a scalar's ofType changing.