### PR TITLE
Fix identation

### DIFF
--- a/src/jsutils/dedent.js
+++ b/src/jsutils/dedent.js
@@ -1,0 +1,50 @@
+/* @flow */
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+ /**
+  * fixes identation by removing leading spaces from each line
+  */
+function fixIdent(str: string): string {
+  const indent = /^\n?( *)/.exec(str)[1]; // figure out ident
+  return str
+    .replace(RegExp('^' + indent, 'mg'), '') // remove ident
+    .replace(/^\n*/m, '') //  remove leading newline
+    .replace(/ *$/, ''); // remove trailing spaces
+}
+
+/**
+ * An ES6 string tag that fixes identation. Also removes leading newlines
+ * but keeps trailing ones
+ *
+ * Example usage:
+ * const str = dedent`
+ *   {
+ *     test
+ *   }
+ * `
+ * str === "{\n  test\n}\n";
+ */
+export default function dedent(
+  strings: string | { raw: [string]},
+  ...values: Array<string>
+) {
+  const raw = typeof strings === 'string' ? [ strings ] : strings.raw;
+  let res = '';
+  // interpolation
+  for (let i = 0; i < raw.length; i++) {
+    res += raw[i].replace(/\\`/g, '`'); // handle escaped backticks
+
+    if (i < values.length) {
+      res += values[i];
+    }
+  }
+
+  return fixIdent(res);
+}

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -14,6 +14,7 @@ import { parse, parseValue, parseType } from '../parser';
 import { Source } from '../source';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import dedent from '../../jsutils/dedent';
 
 describe('Parser', () => {
 
@@ -36,12 +37,12 @@ describe('Parser', () => {
       caughtError = error;
     }
 
-    expect(caughtError.message).to.equal(
-      `Syntax Error GraphQL request (1:2) Expected Name, found <EOF>
+    expect(caughtError.message).to.equal(dedent`
+      Syntax Error GraphQL request (1:2) Expected Name, found <EOF>
 
-1: {
-    ^
-`
+      1: {
+          ^
+      `
     );
 
     expect(caughtError.positions).to.deep.equal([ 1 ]);
@@ -51,10 +52,10 @@ describe('Parser', () => {
     ]);
 
     expect(
-      () => parse(
-`{ ...MissingOn }
-fragment MissingOn Type
-`)
+      () => parse(dedent`
+        { ...MissingOn }
+        fragment MissingOn Type
+      `)
     ).to.throw(
       'Syntax Error GraphQL request (2:20) Expected "on", found Name "Type"'
     );
@@ -154,13 +155,15 @@ fragment MissingOn Type
         fragmentName = 'a';
       }
       expect(() => {
-        parse(`query ${keyword} {
-  ... ${fragmentName}
-  ... on ${keyword} { field }
-}
-fragment ${fragmentName} on Type {
-  ${keyword}(${keyword}: $${keyword}) @${keyword}(${keyword}: ${keyword})
-}`
+        parse(dedent`
+          query ${keyword} {
+            ... ${fragmentName}
+            ... on ${keyword} { field }
+          }
+          fragment ${fragmentName} on Type {
+            ${keyword}(${keyword}: $${keyword})
+              @${keyword}(${keyword}: ${keyword})
+          }`
         );
       }).to.not.throw();
     });

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -13,6 +13,7 @@ import { parse } from '../parser';
 import { readFileSync } from 'fs';
 import { print } from '../printer';
 import { join } from 'path';
+import dedent from '../../jsutils/dedent';
 
 describe('Printer', () => {
   it('does not alter ast', () => {
@@ -36,40 +37,40 @@ describe('Printer', () => {
 
   it('correctly prints non-query operations without name', () => {
     const queryAstShorthanded = parse('query { id, name }');
-    expect(print(queryAstShorthanded)).to.equal(
-`{
-  id
-  name
-}
-`);
+    expect(print(queryAstShorthanded)).to.equal(dedent`
+      {
+        id
+        name
+      }
+    `);
 
     const mutationAst = parse('mutation { id, name }');
-    expect(print(mutationAst)).to.equal(
-`mutation {
-  id
-  name
-}
-`);
+    expect(print(mutationAst)).to.equal(dedent`
+      mutation {
+        id
+        name
+      }
+    `);
 
     const queryAstWithArtifacts = parse(
       'query ($foo: TestType) @testDirective { id, name }'
     );
-    expect(print(queryAstWithArtifacts)).to.equal(
-`query ($foo: TestType) @testDirective {
-  id
-  name
-}
-`);
+    expect(print(queryAstWithArtifacts)).to.equal(dedent`
+      query ($foo: TestType) @testDirective {
+        id
+        name
+      }
+    `);
 
     const mutationAstWithArtifacts = parse(
       'mutation ($foo: TestType) @testDirective { id, name }'
     );
-    expect(print(mutationAstWithArtifacts)).to.equal(
-`mutation ($foo: TestType) @testDirective {
-  id
-  name
-}
-`);
+    expect(print(mutationAstWithArtifacts)).to.equal(dedent`
+      mutation ($foo: TestType) @testDirective {
+        id
+        name
+      }
+    `);
   });
 
 
@@ -84,58 +85,58 @@ describe('Printer', () => {
 
     const printed = print(ast);
 
-    expect(printed).to.equal(
-  `query queryName($foo: ComplexType, $site: Site = MOBILE) {
-  whoever123is: node(id: [123, 456]) {
-    id
-    ... on User @defer {
-      field2 {
-        id
-        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+    expect(printed).to.equal(dedent`
+      query queryName($foo: ComplexType, $site: Site = MOBILE) {
+        whoever123is: node(id: [123, 456]) {
           id
-          ...frag
+          ... on User @defer {
+            field2 {
+              id
+              alias: field1(first: 10, after: $foo) @include(if: $foo) {
+                id
+                ...frag
+              }
+            }
+          }
+          ... @skip(unless: $foo) {
+            id
+          }
+          ... {
+            id
+          }
         }
       }
-    }
-    ... @skip(unless: $foo) {
-      id
-    }
-    ... {
-      id
-    }
-  }
-}
 
-mutation likeStory {
-  like(story: 123) @defer {
-    story {
-      id
-    }
-  }
-}
-
-subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
-  storyLikeSubscribe(input: $input) {
-    story {
-      likers {
-        count
+      mutation likeStory {
+        like(story: 123) @defer {
+          story {
+            id
+          }
+        }
       }
-      likeSentence {
-        text
+
+      subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+        storyLikeSubscribe(input: $input) {
+          story {
+            likers {
+              count
+            }
+            likeSentence {
+              text
+            }
+          }
+        }
       }
-    }
-  }
-}
 
-fragment frag on Friend {
-  foo(size: $size, bar: $b, obj: {key: "value"})
-}
+      fragment frag on Friend {
+        foo(size: $size, bar: $b, obj: {key: "value"})
+      }
 
-{
-  unnamed(truthy: true, falsey: false, nullish: null)
-  query
-}
-`);
+      {
+        unnamed(truthy: true, falsey: false, nullish: null)
+        query
+      }
+    `);
 
   });
 });

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -12,6 +12,7 @@ import { describe, it } from 'mocha';
 import { parse } from '../../language';
 import { printSchema } from '../schemaPrinter';
 import { buildASTSchema, buildSchema } from '../buildASTSchema';
+import dedent from '../../jsutils/dedent';
 import {
   graphql,
   GraphQLSkipDirective,
@@ -29,7 +30,7 @@ import {
 function cycleOutput(body) {
   const ast = parse(body);
   const schema = buildASTSchema(ast);
-  return '\n' + printSchema(schema);
+  return printSchema(schema);
 }
 
 describe('Schema Builder', () => {
@@ -62,80 +63,80 @@ describe('Schema Builder', () => {
   });
 
   it('Simple type', () => {
-    const body = `
-schema {
-  query: HelloScalars
-}
+    const body = dedent`
+      schema {
+        query: HelloScalars
+      }
 
-type HelloScalars {
-  bool: Boolean
-  float: Float
-  id: ID
-  int: Int
-  str: String
-}
-`;
+      type HelloScalars {
+        bool: Boolean
+        float: Float
+        id: ID
+        int: Int
+        str: String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('With directives', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-directive @foo(arg: Int) on FIELD
+      directive @foo(arg: Int) on FIELD
 
-type Hello {
-  str: String
-}
-`;
+      type Hello {
+        str: String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Supports descriptions', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-# This is a directive
-directive @foo(
-  # It has an argument
-  arg: Int
-) on FIELD
+      # This is a directive
+      directive @foo(
+        # It has an argument
+        arg: Int
+      ) on FIELD
 
-# With an enum
-enum Color {
-  RED
+      # With an enum
+      enum Color {
+        RED
 
-  # Not a creative color
-  GREEN
-  BLUE
-}
+        # Not a creative color
+        GREEN
+        BLUE
+      }
 
-# What a great type
-type Hello {
-  # And a field to boot
-  str: String
-}
-`;
+      # What a great type
+      type Hello {
+        # And a field to boot
+        str: String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Maintains @skip & @include', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello {
-  str: String
-}
-`;
+      type Hello {
+        str: String
+      }
+    `;
     const schema = buildASTSchema(parse(body));
     expect(schema.getDirectives().length).to.equal(3);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
@@ -146,19 +147,19 @@ type Hello {
   });
 
   it('Overriding directives excludes specified', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-directive @skip on FIELD
-directive @include on FIELD
-directive @deprecated on FIELD_DEFINITION
+      directive @skip on FIELD
+      directive @include on FIELD
+      directive @deprecated on FIELD_DEFINITION
 
-type Hello {
-  str: String
-}
-`;
+      type Hello {
+        str: String
+      }
+    `;
     const schema = buildASTSchema(parse(body));
     expect(schema.getDirectives().length).to.equal(3);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
@@ -171,17 +172,17 @@ type Hello {
   });
 
   it('Adding directives maintains @skip & @include', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-directive @foo(arg: Int) on FIELD
+      directive @foo(arg: Int) on FIELD
 
-type Hello {
-  str: String
-}
-`;
+      type Hello {
+        str: String
+      }
+    `;
     const schema = buildASTSchema(parse(body));
     expect(schema.getDirectives().length).to.equal(4);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
@@ -190,348 +191,348 @@ type Hello {
   });
 
   it('Type modifiers', () => {
-    const body = `
-schema {
-  query: HelloScalars
-}
+    const body = dedent`
+      schema {
+        query: HelloScalars
+      }
 
-type HelloScalars {
-  listOfNonNullStrs: [String!]
-  listOfStrs: [String]
-  nonNullListOfNonNullStrs: [String!]!
-  nonNullListOfStrs: [String]!
-  nonNullStr: String!
-}
-`;
+      type HelloScalars {
+        listOfNonNullStrs: [String!]
+        listOfStrs: [String]
+        nonNullListOfNonNullStrs: [String!]!
+        nonNullListOfStrs: [String]!
+        nonNullStr: String!
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
 
   it('Recursive type', () => {
-    const body = `
-schema {
-  query: Recurse
-}
+    const body = dedent`
+      schema {
+        query: Recurse
+      }
 
-type Recurse {
-  recurse: Recurse
-  str: String
-}
-`;
+      type Recurse {
+        recurse: Recurse
+        str: String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Two types circular', () => {
-    const body = `
-schema {
-  query: TypeOne
-}
+    const body = dedent`
+      schema {
+        query: TypeOne
+      }
 
-type TypeOne {
-  str: String
-  typeTwo: TypeTwo
-}
+      type TypeOne {
+        str: String
+        typeTwo: TypeTwo
+      }
 
-type TypeTwo {
-  str: String
-  typeOne: TypeOne
-}
-`;
+      type TypeTwo {
+        str: String
+        typeOne: TypeOne
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Single argument field', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello {
-  booleanToStr(bool: Boolean): String
-  floatToStr(float: Float): String
-  idToStr(id: ID): String
-  str(int: Int): String
-  strToStr(bool: String): String
-}
-`;
+      type Hello {
+        booleanToStr(bool: Boolean): String
+        floatToStr(float: Float): String
+        idToStr(id: ID): String
+        str(int: Int): String
+        strToStr(bool: String): String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Simple type with multiple arguments', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello {
-  str(int: Int, bool: Boolean): String
-}
-`;
+      type Hello {
+        str(int: Int, bool: Boolean): String
+      }
+    `;
     const output = cycleOutput(body, 'Hello');
     expect(output).to.equal(body);
   });
 
   it('Simple type with interface', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello implements WorldInterface {
-  str: String
-}
+      type Hello implements WorldInterface {
+        str: String
+      }
 
-interface WorldInterface {
-  str: String
-}
-`;
+      interface WorldInterface {
+        str: String
+      }
+    `;
     const output = cycleOutput(body, 'Hello');
     expect(output).to.equal(body);
   });
 
   it('Simple output enum', () => {
-    const body = `
-schema {
-  query: OutputEnumRoot
-}
+    const body = dedent`
+      schema {
+        query: OutputEnumRoot
+      }
 
-enum Hello {
-  WORLD
-}
+      enum Hello {
+        WORLD
+      }
 
-type OutputEnumRoot {
-  hello: Hello
-}
-`;
+      type OutputEnumRoot {
+        hello: Hello
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Simple input enum', () => {
-    const body = `
-schema {
-  query: InputEnumRoot
-}
+    const body = dedent`
+      schema {
+        query: InputEnumRoot
+      }
 
-enum Hello {
-  WORLD
-}
+      enum Hello {
+        WORLD
+      }
 
-type InputEnumRoot {
-  str(hello: Hello): String
-}
-`;
+      type InputEnumRoot {
+        str(hello: Hello): String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Multiple value enum', () => {
-    const body = `
-schema {
-  query: OutputEnumRoot
-}
+    const body = dedent`
+      schema {
+        query: OutputEnumRoot
+      }
 
-enum Hello {
-  WO
-  RLD
-}
+      enum Hello {
+        WO
+        RLD
+      }
 
-type OutputEnumRoot {
-  hello: Hello
-}
-`;
+      type OutputEnumRoot {
+        hello: Hello
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Simple Union', () => {
-    const body = `
-schema {
-  query: Root
-}
+    const body = dedent`
+      schema {
+        query: Root
+      }
 
-union Hello = World
+      union Hello = World
 
-type Root {
-  hello: Hello
-}
+      type Root {
+        hello: Hello
+      }
 
-type World {
-  str: String
-}
-`;
+      type World {
+        str: String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Multiple Union', () => {
-    const body = `
-schema {
-  query: Root
-}
+    const body = dedent`
+      schema {
+        query: Root
+      }
 
-union Hello = WorldOne | WorldTwo
+      union Hello = WorldOne | WorldTwo
 
-type Root {
-  hello: Hello
-}
+      type Root {
+        hello: Hello
+      }
 
-type WorldOne {
-  str: String
-}
+      type WorldOne {
+        str: String
+      }
 
-type WorldTwo {
-  str: String
-}
-`;
+      type WorldTwo {
+        str: String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Custom Scalar', () => {
-    const body = `
-schema {
-  query: Root
-}
+    const body = dedent`
+      schema {
+        query: Root
+      }
 
-scalar CustomScalar
+      scalar CustomScalar
 
-type Root {
-  customScalar: CustomScalar
-}
-`;
+      type Root {
+        customScalar: CustomScalar
+      }
+    `;
 
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Input Object', async() => {
-    const body = `
-schema {
-  query: Root
-}
+    const body = dedent`
+      schema {
+        query: Root
+      }
 
-input Input {
-  int: Int
-}
+      input Input {
+        int: Int
+      }
 
-type Root {
-  field(in: Input): String
-}
-`;
+      type Root {
+        field(in: Input): String
+      }
+    `;
 
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Simple argument field with default', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello {
-  str(int: Int = 2): String
-}
-`;
+      type Hello {
+        str(int: Int = 2): String
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Simple type with mutation', () => {
-    const body = `
-schema {
-  query: HelloScalars
-  mutation: Mutation
-}
+    const body = dedent`
+      schema {
+        query: HelloScalars
+        mutation: Mutation
+      }
 
-type HelloScalars {
-  bool: Boolean
-  int: Int
-  str: String
-}
+      type HelloScalars {
+        bool: Boolean
+        int: Int
+        str: String
+      }
 
-type Mutation {
-  addHelloScalars(str: String, int: Int, bool: Boolean): HelloScalars
-}
-`;
+      type Mutation {
+        addHelloScalars(str: String, int: Int, bool: Boolean): HelloScalars
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Simple type with subscription', () => {
-    const body = `
-schema {
-  query: HelloScalars
-  subscription: Subscription
-}
+    const body = dedent`
+      schema {
+        query: HelloScalars
+        subscription: Subscription
+      }
 
-type HelloScalars {
-  bool: Boolean
-  int: Int
-  str: String
-}
+      type HelloScalars {
+        bool: Boolean
+        int: Int
+        str: String
+      }
 
-type Subscription {
-  subscribeHelloScalars(str: String, int: Int, bool: Boolean): HelloScalars
-}
-`;
+      type Subscription {
+        sbscribeHelloScalars(str: String, int: Int, bool: Boolean): HelloScalars
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Unreferenced type implementing referenced interface', () => {
-    const body = `
-type Concrete implements Iface {
-  key: String
-}
+    const body = dedent`
+      type Concrete implements Iface {
+        key: String
+      }
 
-interface Iface {
-  key: String
-}
+      interface Iface {
+        key: String
+      }
 
-type Query {
-  iface: Iface
-}
-`;
+      type Query {
+        iface: Iface
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Unreferenced type implementing referenced union', () => {
-    const body = `
-type Concrete {
-  key: String
-}
+    const body = dedent`
+      type Concrete {
+        key: String
+      }
 
-type Query {
-  union: Union
-}
+      type Query {
+        union: Union
+      }
 
-union Union = Concrete
-`;
+      union Union = Concrete
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
 
   it('Supports @deprecated', () => {
-    const body = `
-enum MyEnum {
-  VALUE
-  OLD_VALUE @deprecated
-  OTHER_VALUE @deprecated(reason: "Terrible reasons")
-}
+    const body = dedent`
+      enum MyEnum {
+        VALUE
+        OLD_VALUE @deprecated
+        OTHER_VALUE @deprecated(reason: "Terrible reasons")
+      }
 
-type Query {
-  enum: MyEnum
-  field1: String @deprecated
-  field2: Int @deprecated(reason: "Because I said so")
-}
-`;
+      type Query {
+        enum: MyEnum
+        field1: String @deprecated
+        field2: Int @deprecated(reason: "Because I said so")
+      }
+    `;
     const output = cycleOutput(body);
     expect(output).to.equal(body);
 
@@ -574,11 +575,11 @@ type Query {
 describe('Failures', () => {
 
   it('Requires a schema definition or Query type', () => {
-    const body = `
-type Hello {
-  bar: Bar
-}
-`;
+    const body = dedent`
+      type Hello {
+        bar: Bar
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc)).to.throw(
       'Must provide schema definition with query type or a type named Query.'
@@ -586,34 +587,34 @@ type Hello {
   });
 
   it('Allows only a single schema definition', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-schema {
-  query: Hello
-}
+      schema {
+        query: Hello
+      }
 
-type Hello {
-  bar: Bar
-}
-`;
+      type Hello {
+        bar: Bar
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Must provide only one schema definition.');
   });
 
   it('Requires a query type', () => {
-    const body = `
-schema {
-  mutation: Hello
-}
+    const body = dedent`
+      schema {
+        mutation: Hello
+      }
 
-type Hello {
-  bar: Bar
-}
-`;
+      type Hello {
+        bar: Bar
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc)).to.throw(
       'Must provide schema definition with query type or a type named Query.'
@@ -621,201 +622,201 @@ type Hello {
   });
 
   it('Allows only a single query type', () => {
-    const body = `
-schema {
-  query: Hello
-  query: Yellow
-}
+    const body = dedent`
+      schema {
+        query: Hello
+        query: Yellow
+      }
 
-type Hello {
-  bar: Bar
-}
+      type Hello {
+        bar: Bar
+      }
 
-type Yellow {
-  isColor: Boolean
-}
-`;
+      type Yellow {
+        isColor: Boolean
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Must provide only one query type in schema.');
   });
 
   it('Allows only a single mutation type', () => {
-    const body = `
-schema {
-  query: Hello
-  mutation: Hello
-  mutation: Yellow
-}
+    const body = dedent`
+      schema {
+        query: Hello
+        mutation: Hello
+        mutation: Yellow
+      }
 
-type Hello {
-  bar: Bar
-}
+      type Hello {
+        bar: Bar
+      }
 
-type Yellow {
-  isColor: Boolean
-}
-`;
+      type Yellow {
+        isColor: Boolean
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Must provide only one mutation type in schema.');
   });
 
   it('Allows only a single subscription type', () => {
-    const body = `
-schema {
-  query: Hello
-  subscription: Hello
-  subscription: Yellow
-}
+    const body = dedent`
+      schema {
+        query: Hello
+        subscription: Hello
+        subscription: Yellow
+      }
 
-type Hello {
-  bar: Bar
-}
+      type Hello {
+        bar: Bar
+      }
 
-type Yellow {
-  isColor: Boolean
-}
-`;
+      type Yellow {
+        isColor: Boolean
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Must provide only one subscription type in schema.');
   });
 
   it('Unknown type referenced', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello {
-  bar: Bar
-}
-`;
+      type Hello {
+        bar: Bar
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Type "Bar" not found in document.');
   });
 
   it('Unknown type in interface list', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-type Hello implements Bar { }
-`;
+      type Hello implements Bar { }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Type "Bar" not found in document.');
   });
 
   it('Unknown type in union list', () => {
-    const body = `
-schema {
-  query: Hello
-}
+    const body = dedent`
+      schema {
+        query: Hello
+      }
 
-union TestUnion = Bar
-type Hello { testUnion: TestUnion }
-`;
+      union TestUnion = Bar
+      type Hello { testUnion: TestUnion }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Type "Bar" not found in document.');
   });
 
   it('Unknown query type', () => {
-    const body = `
-schema {
-  query: Wat
-}
+    const body = dedent`
+      schema {
+        query: Wat
+      }
 
-type Hello {
-  str: String
-}
-`;
+      type Hello {
+        str: String
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Specified query type "Wat" not found in document.');
   });
 
   it('Unknown mutation type', () => {
-    const body = `
-schema {
-  query: Hello
-  mutation: Wat
-}
+    const body = dedent`
+      schema {
+        query: Hello
+        mutation: Wat
+      }
 
-type Hello {
-  str: String
-}
-`;
+      type Hello {
+        str: String
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Specified mutation type "Wat" not found in document.');
   });
 
   it('Unknown subscription type', () => {
-    const body = `
-schema {
-  query: Hello
-  mutation: Wat
-  subscription: Awesome
-}
+    const body = dedent`
+      schema {
+        query: Hello
+        mutation: Wat
+        subscription: Awesome
+      }
 
-type Hello {
-  str: String
-}
+      type Hello {
+        str: String
+      }
 
-type Wat {
-  str: String
-}
-`;
+      type Wat {
+        str: String
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Specified subscription type "Awesome" not found in document.');
   });
 
   it('Does not consider operation names', () => {
-    const body = `
-schema {
-  query: Foo
-}
+    const body = dedent`
+      schema {
+        query: Foo
+      }
 
-query Foo { field }
-`;
+      query Foo { field }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Specified query type "Foo" not found in document.');
   });
 
   it('Does not consider fragment names', () => {
-    const body = `
-schema {
-  query: Foo
-}
+    const body = dedent`
+      schema {
+        query: Foo
+      }
 
-fragment Foo on Type { field }
-`;
+      fragment Foo on Type { field }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Specified query type "Foo" not found in document.');
   });
 
   it('Forbids duplicate type definitions', () => {
-    const body = `
-schema {
-  query: Repeated
-}
+    const body = dedent`
+      schema {
+        query: Repeated
+      }
 
-type Repeated {
-  id: Int
-}
+      type Repeated {
+        id: Int
+      }
 
-type Repeated {
-  id: String
-}
-`;
+      type Repeated {
+        id: String
+      }
+    `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc))
       .to.throw('Type "Repeated" was defined more than once.');

--- a/src/utilities/__tests__/concatAST-test.js
+++ b/src/utilities/__tests__/concatAST-test.js
@@ -9,6 +9,7 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import dedent from '../../jsutils/dedent';
 import { concatAST } from '../concatAST';
 import { Source, parse, print } from '../../language';
 
@@ -30,17 +31,17 @@ describe('concatAST', () => {
     const astB = parse(sourceB);
     const astC = concatAST([ astA, astB ]);
 
-    expect(print(astC)).to.equal(
-`{
-  a
-  b
-  ...Frag
-}
+    expect(print(astC)).to.equal(dedent`
+      {
+        a
+        b
+        ...Frag
+      }
 
-fragment Frag on T {
-  c
-}
-`);
+      fragment Frag on T {
+        c
+      }
+    `);
   });
 
 });

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -9,6 +9,7 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import dedent from '../../jsutils/dedent';
 import { extendSchema } from '../extendSchema';
 import { execute } from '../../execution';
 import { parse } from '../../language';
@@ -156,43 +157,43 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz {
-  fizz: String
-}
+      type Biz {
+        fizz: String
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  newField: String
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        newField: String
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('builds types with deprecated fields/values', () => {
@@ -249,46 +250,46 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz {
-  fizz: String
-}
+      type Biz {
+        fizz: String
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
+      union SomeUnion = Foo | Biz
 
-type Unused {
-  someField: String
-}
-`);
+      type Unused {
+        someField: String
+      }
+    `);
   });
 
   it('extends objects by adding new fields with arguments', () => {
@@ -307,49 +308,49 @@ type Unused {
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz {
-  fizz: String
-}
+      type Biz {
+        fizz: String
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  newField(arg1: String, arg2: NewInputObj!): String
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        newField(arg1: String, arg2: NewInputObj!): String
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-input NewInputObj {
-  field1: Int
-  field2: [Float]
-  field3: String!
-}
+      input NewInputObj {
+        field1: Int
+        field2: [Float]
+        field3: String!
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('extends objects by adding new fields with existing types', () => {
@@ -362,43 +363,43 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz {
-  fizz: String
-}
+      type Biz {
+        fizz: String
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  newField(arg1: SomeEnum!): SomeEnum
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        newField(arg1: SomeEnum!): SomeEnum
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('extends objects by adding implemented interfaces', () => {
@@ -412,44 +413,44 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz implements SomeInterface {
-  fizz: String
-  name: String
-  some: SomeInterface
-}
+      type Biz implements SomeInterface {
+        fizz: String
+        name: String
+        some: SomeInterface
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('extends objects by including new types', () => {
@@ -488,69 +489,69 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz {
-  fizz: String
-}
+      type Biz {
+        fizz: String
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  newEnum: NewEnum
-  newInterface: NewInterface
-  newObject: NewObject
-  newScalar: NewScalar
-  newTree: [Foo]!
-  newUnion: NewUnion
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        newEnum: NewEnum
+        newInterface: NewInterface
+        newObject: NewObject
+        newScalar: NewScalar
+        newTree: [Foo]!
+        newUnion: NewUnion
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-enum NewEnum {
-  OPTION_A
-  OPTION_B
-}
+      enum NewEnum {
+        OPTION_A
+        OPTION_B
+      }
 
-interface NewInterface {
-  baz: String
-}
+      interface NewInterface {
+        baz: String
+      }
 
-type NewObject implements NewInterface {
-  baz: String
-}
+      type NewObject implements NewInterface {
+        baz: String
+      }
 
-type NewOtherObject {
-  fizz: Int
-}
+      type NewOtherObject {
+        fizz: Int
+      }
 
-scalar NewScalar
+      scalar NewScalar
 
-union NewUnion = NewObject | NewOtherObject
+      union NewUnion = NewObject | NewOtherObject
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('extends objects by adding implemented new interfaces', () => {
@@ -567,47 +568,47 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz {
-  fizz: String
-}
+      type Biz {
+        fizz: String
+      }
 
-type Foo implements SomeInterface, NewInterface {
-  baz: String
-  name: String
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface, NewInterface {
+        baz: String
+        name: String
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-interface NewInterface {
-  baz: String
-}
+      interface NewInterface {
+        baz: String
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('extends objects multiple times', () => {
@@ -635,51 +636,51 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(testSchema, ast);
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Bar implements SomeInterface {
-  foo: Foo
-  name: String
-  some: SomeInterface
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Bar implements SomeInterface {
+        foo: Foo
+        name: String
+        some: SomeInterface
+      }
 
-type Biz implements NewInterface, SomeInterface {
-  buzz: String
-  fizz: String
-  name: String
-  newFieldA: Int
-  newFieldB: Float
-  some: SomeInterface
-}
+      type Biz implements NewInterface, SomeInterface {
+        buzz: String
+        fizz: String
+        name: String
+        newFieldA: Int
+        newFieldB: Float
+        some: SomeInterface
+      }
 
-type Foo implements SomeInterface {
-  name: String
-  some: SomeInterface
-  tree: [Foo]!
-}
+      type Foo implements SomeInterface {
+        name: String
+        some: SomeInterface
+        tree: [Foo]!
+      }
 
-interface NewInterface {
-  buzz: String
-}
+      interface NewInterface {
+        buzz: String
+      }
 
-type Query {
-  foo: Foo
-  someEnum: SomeEnum
-  someInterface(id: ID!): SomeInterface
-  someUnion: SomeUnion
-}
+      type Query {
+        foo: Foo
+        someEnum: SomeEnum
+        someInterface(id: ID!): SomeInterface
+        someUnion: SomeUnion
+      }
 
-enum SomeEnum {
-  ONE
-  TWO
-}
+      enum SomeEnum {
+        ONE
+        TWO
+      }
 
-interface SomeInterface {
-  name: String
-  some: SomeInterface
-}
+      interface SomeInterface {
+        name: String
+        some: SomeInterface
+      }
 
-union SomeUnion = Foo | Biz
-`);
+      union SomeUnion = Foo | Biz
+    `);
   });
 
   it('may extend mutations and subscriptions', () => {
@@ -721,22 +722,22 @@ union SomeUnion = Foo | Biz
     const extendedSchema = extendSchema(mutationSchema, ast);
     expect(extendedSchema).to.not.equal(mutationSchema);
     expect(printSchema(mutationSchema)).to.equal(originalPrint);
-    expect(printSchema(extendedSchema)).to.equal(
-`type Mutation {
-  mutationField: String
-  newMutationField: Int
-}
+    expect(printSchema(extendedSchema)).to.equal(dedent`
+      type Mutation {
+        mutationField: String
+        newMutationField: Int
+      }
 
-type Query {
-  newQueryField: Int
-  queryField: String
-}
+      type Query {
+        newQueryField: Int
+        queryField: String
+      }
 
-type Subscription {
-  newSubscriptionField: Int
-  subscriptionField: String
-}
-`);
+      type Subscription {
+        newSubscriptionField: Int
+        subscriptionField: String
+      }
+    `);
   });
 
   it('may extend directives with new simple directive', () => {

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -12,6 +12,7 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import dedent from '../../jsutils/dedent';
 import { printSchema, printIntrospectionSchema } from '../schemaPrinter';
 import {
   GraphQLSchema,
@@ -30,7 +31,7 @@ import {
 
 
 function printForTest(schema) {
-  return '\n' + printSchema(schema);
+  return printSchema(schema);
 }
 
 function printSingleFieldSchema(fieldConfig) {
@@ -54,96 +55,90 @@ describe('Type System Printer', () => {
     const output = printSingleFieldSchema({
       type: GraphQLString
     });
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField: String
-}
-`
-    );
+      type Root {
+        singleField: String
+      }
+    `);
   });
 
   it('Prints [String] Field', () => {
     const output = printSingleFieldSchema({
       type: listOf(GraphQLString)
     });
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField: [String]
-}
-`
-    );
+      type Root {
+        singleField: [String]
+      }
+    `);
   });
 
   it('Prints String! Field', () => {
     const output = printSingleFieldSchema({
       type: nonNull(GraphQLString)
     });
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField: String!
-}
-`
-    );
+      type Root {
+        singleField: String!
+      }
+    `);
   });
 
   it('Prints [String]! Field', () => {
     const output = printSingleFieldSchema({
       type: nonNull(listOf(GraphQLString))
     });
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField: [String]!
-}
-`
-    );
+      type Root {
+        singleField: [String]!
+      }
+    `);
   });
 
   it('Prints [String!] Field', () => {
     const output = printSingleFieldSchema({
       type: listOf(nonNull(GraphQLString))
     });
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField: [String!]
-}
-`
-    );
+      type Root {
+        singleField: [String!]
+      }
+    `);
   });
 
   it('Prints [String!]! Field', () => {
     const output = printSingleFieldSchema({
       type: nonNull(listOf(nonNull(GraphQLString)))
     });
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField: [String!]!
-}
-`
-    );
+      type Root {
+        singleField: [String!]!
+      }
+    `);
   });
 
   it('Print Object Field', () => {
@@ -159,20 +154,19 @@ type Root {
 
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Foo {
-  str: String
-}
+      type Foo {
+        str: String
+      }
 
-type Root {
-  foo: Foo
-}
-`
-    );
+      type Root {
+        foo: Foo
+      }
+    `);
   });
 
   it('Prints String Field With Int Arg', () => {
@@ -182,16 +176,15 @@ type Root {
         args: { argOne: { type: GraphQLInt } },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int): String
+      }
+    `);
   });
 
   it('Prints String Field With Int Arg With Default', () => {
@@ -201,16 +194,15 @@ type Root {
         args: { argOne: { type: GraphQLInt, defaultValue: 2 } },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int = 2): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int = 2): String
+      }
+    `);
   });
 
   it('Prints String Field With Int Arg With Default Null', () => {
@@ -220,16 +212,15 @@ type Root {
         args: { argOne: { type: GraphQLInt, defaultValue: null } },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int = null): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int = null): String
+      }
+    `);
   });
 
   it('Prints String Field With Int! Arg', () => {
@@ -239,16 +230,15 @@ type Root {
         args: { argOne: { type: nonNull(GraphQLInt) } },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int!): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int!): String
+      }
+    `);
   });
 
   it('Prints String Field With Multiple Args', () => {
@@ -261,16 +251,15 @@ type Root {
         },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int, argTwo: String): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int, argTwo: String): String
+      }
+    `);
   });
 
   it('Prints String Field With Multiple Args, First is Default', () => {
@@ -284,16 +273,15 @@ type Root {
         },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int = 1, argTwo: String, argThree: Boolean): String
+      }
+    `);
   });
 
   it('Prints String Field With Multiple Args, Second is Default', () => {
@@ -307,16 +295,15 @@ type Root {
         },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int, argTwo: String = "foo", argThree: Boolean): String
+      }
+    `);
   });
 
   it('Prints String Field With Multiple Args, Last is Default', () => {
@@ -330,16 +317,15 @@ type Root {
         },
       }
     );
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Root {
-  singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
-}
-`
-    );
+      type Root {
+        singleField(argOne: Int, argTwo: String, argThree: Boolean = false): String
+      }
+    `);
   });
 
   it('Print Interface', () => {
@@ -365,24 +351,23 @@ type Root {
       types: [ BarType ]
     });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Bar implements Foo {
-  str: String
-}
+      type Bar implements Foo {
+        str: String
+      }
 
-interface Foo {
-  str: String
-}
+      interface Foo {
+        str: String
+      }
 
-type Root {
-  bar: Bar
-}
-`
-    );
+      type Root {
+        bar: Bar
+      }
+    `);
   });
 
   it('Print Multiple Interface', () => {
@@ -417,29 +402,28 @@ type Root {
       types: [ BarType ]
     });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-interface Baaz {
-  int: Int
-}
+      interface Baaz {
+        int: Int
+      }
 
-type Bar implements Foo, Baaz {
-  int: Int
-  str: String
-}
+      type Bar implements Foo, Baaz {
+        int: Int
+        str: String
+      }
 
-interface Foo {
-  str: String
-}
+      interface Foo {
+        str: String
+      }
 
-type Root {
-  bar: Bar
-}
-`
-    );
+      type Root {
+        bar: Bar
+      }
+    `);
   });
 
   it('Print Unions', () => {
@@ -479,29 +463,28 @@ type Root {
 
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-type Bar {
-  str: String
-}
+      type Bar {
+        str: String
+      }
 
-type Foo {
-  bool: Boolean
-}
+      type Foo {
+        bool: Boolean
+      }
 
-union MultipleUnion = Foo | Bar
+      union MultipleUnion = Foo | Bar
 
-type Root {
-  multiple: MultipleUnion
-  single: SingleUnion
-}
+      type Root {
+        multiple: MultipleUnion
+        single: SingleUnion
+      }
 
-union SingleUnion = Foo
-`
-    );
+      union SingleUnion = Foo
+    `);
   });
 
   it('Print Input Type', () => {
@@ -524,19 +507,19 @@ union SingleUnion = Foo
 
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-input InputType {
-  int: Int
-}
+      input InputType {
+        int: Int
+      }
 
-type Root {
-  str(argOne: InputType): String
-}
-`);
+      type Root {
+        str(argOne: InputType): String
+      }
+    `);
   });
 
   it('Custom Scalar', () => {
@@ -556,18 +539,17 @@ type Root {
 
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-scalar Odd
+      scalar Odd
 
-type Root {
-  odd: Odd
-}
-`
-     );
+      type Root {
+        odd: Odd
+      }
+    `);
   });
 
   it('Enum', () => {
@@ -589,21 +571,21 @@ type Root {
 
     const Schema = new GraphQLSchema({ query: Root });
     const output = printForTest(Schema);
-    expect(output).to.equal(`
-schema {
-  query: Root
-}
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
 
-enum RGB {
-  RED
-  GREEN
-  BLUE
-}
+      enum RGB {
+        RED
+        GREEN
+        BLUE
+      }
 
-type Root {
-  rgb: RGB
-}
-`);
+      type Root {
+        rgb: RGB
+      }
+    `);
   });
 
   it('Print Introspection Schema', () => {
@@ -614,205 +596,205 @@ type Root {
       },
     });
     const Schema = new GraphQLSchema({ query: Root });
-    const output = '\n' + printIntrospectionSchema(Schema);
-    const introspectionSchema = `
-schema {
-  query: Root
-}
+    const output = printIntrospectionSchema(Schema);
+    const introspectionSchema = dedent`
+      schema {
+        query: Root
+      }
 
-# Directs the executor to include this field or fragment only when the \`if\` argument is true.
-directive @include(
-  # Included when true.
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      # Directs the executor to include this field or fragment only when the \`if\` argument is true.
+      directive @include(
+        # Included when true.
+        if: Boolean!
+      ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-# Directs the executor to skip this field or fragment when the \`if\` argument is true.
-directive @skip(
-  # Skipped when true.
-  if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      # Directs the executor to skip this field or fragment when the \`if\` argument is true.
+      directive @skip(
+        # Skipped when true.
+        if: Boolean!
+      ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-# Marks an element of a GraphQL schema as no longer supported.
-directive @deprecated(
-  # Explains why this element was deprecated, usually also including a suggestion
-  # for how to access supported similar data. Formatted in
-  # [Markdown](https://daringfireball.net/projects/markdown/).
-  reason: String = "No longer supported"
-) on FIELD_DEFINITION | ENUM_VALUE
+      # Marks an element of a GraphQL schema as no longer supported.
+      directive @deprecated(
+        # Explains why this element was deprecated, usually also including a suggestion
+        # for how to access supported similar data. Formatted in
+        # [Markdown](https://daringfireball.net/projects/markdown/).
+        reason: String = "No longer supported"
+      ) on FIELD_DEFINITION | ENUM_VALUE
 
-# A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
-#
-# In some cases, you need to provide options to alter GraphQL's execution behavior
-# in ways field arguments will not suffice, such as conditionally including or
-# skipping a field. Directives provide this by describing additional information
-# to the executor.
-type __Directive {
-  args: [__InputValue!]!
-  description: String
-  locations: [__DirectiveLocation!]!
-  name: String!
-  onField: Boolean! @deprecated(reason: "Use \`locations\`.")
-  onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
-  onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
-}
+      # A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
+      #
+      # In some cases, you need to provide options to alter GraphQL's execution behavior
+      # in ways field arguments will not suffice, such as conditionally including or
+      # skipping a field. Directives provide this by describing additional information
+      # to the executor.
+      type __Directive {
+        args: [__InputValue!]!
+        description: String
+        locations: [__DirectiveLocation!]!
+        name: String!
+        onField: Boolean! @deprecated(reason: "Use \`locations\`.")
+        onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+        onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
+      }
 
-# A Directive can be adjacent to many parts of the GraphQL language, a
-# __DirectiveLocation describes one such possible adjacencies.
-enum __DirectiveLocation {
-  # Location adjacent to a query operation.
-  QUERY
+      # A Directive can be adjacent to many parts of the GraphQL language, a
+      # __DirectiveLocation describes one such possible adjacencies.
+      enum __DirectiveLocation {
+        # Location adjacent to a query operation.
+        QUERY
 
-  # Location adjacent to a mutation operation.
-  MUTATION
+        # Location adjacent to a mutation operation.
+        MUTATION
 
-  # Location adjacent to a subscription operation.
-  SUBSCRIPTION
+        # Location adjacent to a subscription operation.
+        SUBSCRIPTION
 
-  # Location adjacent to a field.
-  FIELD
+        # Location adjacent to a field.
+        FIELD
 
-  # Location adjacent to a fragment definition.
-  FRAGMENT_DEFINITION
+        # Location adjacent to a fragment definition.
+        FRAGMENT_DEFINITION
 
-  # Location adjacent to a fragment spread.
-  FRAGMENT_SPREAD
+        # Location adjacent to a fragment spread.
+        FRAGMENT_SPREAD
 
-  # Location adjacent to an inline fragment.
-  INLINE_FRAGMENT
+        # Location adjacent to an inline fragment.
+        INLINE_FRAGMENT
 
-  # Location adjacent to a schema definition.
-  SCHEMA
+        # Location adjacent to a schema definition.
+        SCHEMA
 
-  # Location adjacent to a scalar definition.
-  SCALAR
+        # Location adjacent to a scalar definition.
+        SCALAR
 
-  # Location adjacent to an object type definition.
-  OBJECT
+        # Location adjacent to an object type definition.
+        OBJECT
 
-  # Location adjacent to a field definition.
-  FIELD_DEFINITION
+        # Location adjacent to a field definition.
+        FIELD_DEFINITION
 
-  # Location adjacent to an argument definition.
-  ARGUMENT_DEFINITION
+        # Location adjacent to an argument definition.
+        ARGUMENT_DEFINITION
 
-  # Location adjacent to an interface definition.
-  INTERFACE
+        # Location adjacent to an interface definition.
+        INTERFACE
 
-  # Location adjacent to a union definition.
-  UNION
+        # Location adjacent to a union definition.
+        UNION
 
-  # Location adjacent to an enum definition.
-  ENUM
+        # Location adjacent to an enum definition.
+        ENUM
 
-  # Location adjacent to an enum value definition.
-  ENUM_VALUE
+        # Location adjacent to an enum value definition.
+        ENUM_VALUE
 
-  # Location adjacent to an input object type definition.
-  INPUT_OBJECT
+        # Location adjacent to an input object type definition.
+        INPUT_OBJECT
 
-  # Location adjacent to an input object field definition.
-  INPUT_FIELD_DEFINITION
-}
+        # Location adjacent to an input object field definition.
+        INPUT_FIELD_DEFINITION
+      }
 
-# One possible value for a given Enum. Enum values are unique values, not a
-# placeholder for a string or numeric value. However an Enum value is returned in
-# a JSON response as a string.
-type __EnumValue {
-  deprecationReason: String
-  description: String
-  isDeprecated: Boolean!
-  name: String!
-}
+      # One possible value for a given Enum. Enum values are unique values, not a
+      # placeholder for a string or numeric value. However an Enum value is returned in
+      # a JSON response as a string.
+      type __EnumValue {
+        deprecationReason: String
+        description: String
+        isDeprecated: Boolean!
+        name: String!
+      }
 
-# Object and Interface types are described by a list of Fields, each of which has
-# a name, potentially a list of arguments, and a return type.
-type __Field {
-  args: [__InputValue!]!
-  deprecationReason: String
-  description: String
-  isDeprecated: Boolean!
-  name: String!
-  type: __Type!
-}
+      # Object and Interface types are described by a list of Fields, each of which has
+      # a name, potentially a list of arguments, and a return type.
+      type __Field {
+        args: [__InputValue!]!
+        deprecationReason: String
+        description: String
+        isDeprecated: Boolean!
+        name: String!
+        type: __Type!
+      }
 
-# Arguments provided to Fields or Directives and the input fields of an
-# InputObject are represented as Input Values which describe their type and
-# optionally a default value.
-type __InputValue {
-  # A GraphQL-formatted string representing the default value for this input value.
-  defaultValue: String
-  description: String
-  name: String!
-  type: __Type!
-}
+      # Arguments provided to Fields or Directives and the input fields of an
+      # InputObject are represented as Input Values which describe their type and
+      # optionally a default value.
+      type __InputValue {
+        # A GraphQL-formatted string representing the default value for this input value.
+        defaultValue: String
+        description: String
+        name: String!
+        type: __Type!
+      }
 
-# A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
-# available types and directives on the server, as well as the entry points for
-# query, mutation, and subscription operations.
-type __Schema {
-  # A list of all directives supported by this server.
-  directives: [__Directive!]!
+      # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
+      # available types and directives on the server, as well as the entry points for
+      # query, mutation, and subscription operations.
+      type __Schema {
+        # A list of all directives supported by this server.
+        directives: [__Directive!]!
 
-  # If this server supports mutation, the type that mutation operations will be rooted at.
-  mutationType: __Type
+        # If this server supports mutation, the type that mutation operations will be rooted at.
+        mutationType: __Type
 
-  # The type that query operations will be rooted at.
-  queryType: __Type!
+        # The type that query operations will be rooted at.
+        queryType: __Type!
 
-  # If this server support subscription, the type that subscription operations will be rooted at.
-  subscriptionType: __Type
+        # If this server support subscription, the type that subscription operations will be rooted at.
+        subscriptionType: __Type
 
-  # A list of all types supported by this server.
-  types: [__Type!]!
-}
+        # A list of all types supported by this server.
+        types: [__Type!]!
+      }
 
-# The fundamental unit of any GraphQL Schema is the type. There are many kinds of
-# types in GraphQL as represented by the \`__TypeKind\` enum.
-#
-# Depending on the kind of a type, certain fields describe information about that
-# type. Scalar types provide no information beyond a name and description, while
-# Enum types provide their values. Object and Interface types provide the fields
-# they describe. Abstract types, Union and Interface, provide the Object types
-# possible at runtime. List and NonNull types compose other types.
-type __Type {
-  description: String
-  enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-  fields(includeDeprecated: Boolean = false): [__Field!]
-  inputFields: [__InputValue!]
-  interfaces: [__Type!]
-  kind: __TypeKind!
-  name: String
-  ofType: __Type
-  possibleTypes: [__Type!]
-}
+      # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
+      # types in GraphQL as represented by the \`__TypeKind\` enum.
+      #
+      # Depending on the kind of a type, certain fields describe information about that
+      # type. Scalar types provide no information beyond a name and description, while
+      # Enum types provide their values. Object and Interface types provide the fields
+      # they describe. Abstract types, Union and Interface, provide the Object types
+      # possible at runtime. List and NonNull types compose other types.
+      type __Type {
+        description: String
+        enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+        fields(includeDeprecated: Boolean = false): [__Field!]
+        inputFields: [__InputValue!]
+        interfaces: [__Type!]
+        kind: __TypeKind!
+        name: String
+        ofType: __Type
+        possibleTypes: [__Type!]
+      }
 
-# An enum describing what kind of type a given \`__Type\` is.
-enum __TypeKind {
-  # Indicates this type is a scalar.
-  SCALAR
+      # An enum describing what kind of type a given \`__Type\` is.
+      enum __TypeKind {
+        # Indicates this type is a scalar.
+        SCALAR
 
-  # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.
-  OBJECT
+        # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.
+        OBJECT
 
-  # Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
-  INTERFACE
+        # Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
+        INTERFACE
 
-  # Indicates this type is a union. \`possibleTypes\` is a valid field.
-  UNION
+        # Indicates this type is a union. \`possibleTypes\` is a valid field.
+        UNION
 
-  # Indicates this type is an enum. \`enumValues\` is a valid field.
-  ENUM
+        # Indicates this type is an enum. \`enumValues\` is a valid field.
+        ENUM
 
-  # Indicates this type is an input object. \`inputFields\` is a valid field.
-  INPUT_OBJECT
+        # Indicates this type is an input object. \`inputFields\` is a valid field.
+        INPUT_OBJECT
 
-  # Indicates this type is a list. \`ofType\` is a valid field.
-  LIST
+        # Indicates this type is a list. \`ofType\` is a valid field.
+        LIST
 
-  # Indicates this type is a non-null. \`ofType\` is a valid field.
-  NON_NULL
-}
-`;
+        # Indicates this type is a non-null. \`ofType\` is a valid field.
+        NON_NULL
+      }
+    `;
     expect(output).to.equal(introspectionSchema);
   });
 });

--- a/src/utilities/__tests__/separateOperations-test.js
+++ b/src/utilities/__tests__/separateOperations-test.js
@@ -9,6 +9,7 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import dedent from '../../jsutils/dedent';
 import { separateOperations } from '../separateOperations';
 import { parse, print } from '../../language';
 
@@ -58,66 +59,63 @@ describe('separateOperations', () => {
 
     expect(Object.keys(separatedASTs)).to.deep.equal([ '', 'One', 'Two' ]);
 
-    expect(print(separatedASTs[''])).to.equal(
-`{
-  ...Y
-  ...X
-}
+    expect(print(separatedASTs[''])).to.equal(dedent`
+      {
+        ...Y
+        ...X
+      }
 
-fragment X on T {
-  fieldX
-}
+      fragment X on T {
+        fieldX
+      }
 
-fragment Y on T {
-  fieldY
-}
-`
-    );
+      fragment Y on T {
+        fieldY
+      }
+    `);
 
-    expect(print(separatedASTs.One)).to.equal(
-`query One {
-  foo
-  bar
-  ...A
-  ...X
-}
+    expect(print(separatedASTs.One)).to.equal(dedent`
+      query One {
+        foo
+        bar
+        ...A
+        ...X
+      }
 
-fragment A on T {
-  field
-  ...B
-}
+      fragment A on T {
+        field
+        ...B
+      }
 
-fragment X on T {
-  fieldX
-}
+      fragment X on T {
+        fieldX
+      }
 
-fragment B on T {
-  something
-}
-`
-    );
+      fragment B on T {
+        something
+      }
+    `);
 
-    expect(print(separatedASTs.Two)).to.equal(
-`fragment A on T {
-  field
-  ...B
-}
+    expect(print(separatedASTs.Two)).to.equal(dedent`
+      fragment A on T {
+        field
+        ...B
+      }
 
-query Two {
-  ...A
-  ...Y
-  baz
-}
+      query Two {
+        ...A
+        ...Y
+        baz
+      }
 
-fragment Y on T {
-  fieldY
-}
+      fragment Y on T {
+        fieldY
+      }
 
-fragment B on T {
-  something
-}
-`
-    );
+      fragment B on T {
+        something
+      }
+    `);
 
   });
 
@@ -145,35 +143,33 @@ fragment B on T {
 
     expect(Object.keys(separatedASTs)).to.deep.equal([ 'One', 'Two' ]);
 
-    expect(print(separatedASTs.One)).to.equal(
-`query One {
-  ...A
-}
+    expect(print(separatedASTs.One)).to.equal(dedent`
+      query One {
+        ...A
+      }
 
-fragment A on T {
-  ...B
-}
+      fragment A on T {
+        ...B
+      }
 
-fragment B on T {
-  ...A
-}
-`
-    );
+      fragment B on T {
+        ...A
+      }
+    `);
 
-    expect(print(separatedASTs.Two)).to.equal(
-`fragment A on T {
-  ...B
-}
+    expect(print(separatedASTs.Two)).to.equal(dedent`
+      fragment A on T {
+        ...B
+      }
 
-fragment B on T {
-  ...A
-}
+      fragment B on T {
+        ...A
+      }
 
-query Two {
-  ...B
-}
-`
-    );
+      query Two {
+        ...B
+      }
+    `);
 
   });
 


### PR DESCRIPTION
Multiple places in tests use ES6 multiline strings. Becuase of that indentation is broken:
<img src="https://user-images.githubusercontent.com/3975738/27222824-7dec5cda-5296-11e7-8c99-785fad7e49ff.png" width="300">
It's really hard to read this code. When I first time had to read this file it melted my brain. I think this can discourage people from writing tests.

To fix that I added a simple deindentation ES6 string tag `dedent` which I used across the tests. Resulting code looks much better:
<img src="https://user-images.githubusercontent.com/3975738/27223326-90cf4a40-5298-11e7-94eb-c460dbe01b6d.png" width="300">

The one place where I left strings ident intact is parse tests where the number of character matters and changing indentation there can make it harder to reason about.

