### PR TITLE
Fix rearranged schema printing

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -69,13 +69,14 @@ describe('Schema Builder', () => {
       }
 
       type HelloScalars {
-        bool: Boolean
+        str: String
+        int: Int
         float: Float
         id: ID
-        int: Int
-        str: String
+        bool: Boolean
       }
-    `;
+      `;
+
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
@@ -197,11 +198,11 @@ describe('Schema Builder', () => {
       }
 
       type HelloScalars {
-        listOfNonNullStrs: [String!]
-        listOfStrs: [String]
-        nonNullListOfNonNullStrs: [String!]!
-        nonNullListOfStrs: [String]!
         nonNullStr: String!
+        listOfStrs: [String]
+        listOfNonNullStrs: [String!]
+        nonNullListOfStrs: [String]!
+        nonNullListOfNonNullStrs: [String!]!
       }
     `;
     const output = cycleOutput(body);
@@ -216,8 +217,8 @@ describe('Schema Builder', () => {
       }
 
       type Recurse {
-        recurse: Recurse
         str: String
+        recurse: Recurse
       }
     `;
     const output = cycleOutput(body);
@@ -251,10 +252,10 @@ describe('Schema Builder', () => {
       }
 
       type Hello {
-        booleanToStr(bool: Boolean): String
+        str(int: Int): String
         floatToStr(float: Float): String
         idToStr(id: ID): String
-        str(int: Int): String
+        booleanToStr(bool: Boolean): String
         strToStr(bool: String): String
       }
     `;
@@ -451,9 +452,9 @@ describe('Schema Builder', () => {
       }
 
       type HelloScalars {
-        bool: Boolean
-        int: Int
         str: String
+        int: Int
+        bool: Boolean
       }
 
       type Mutation {
@@ -472,9 +473,9 @@ describe('Schema Builder', () => {
       }
 
       type HelloScalars {
-        bool: Boolean
-        int: Int
         str: String
+        int: Int
+        bool: Boolean
       }
 
       type Subscription {
@@ -528,9 +529,9 @@ describe('Schema Builder', () => {
       }
 
       type Query {
-        enum: MyEnum
         field1: String @deprecated
         field2: Int @deprecated(reason: "Because I said so")
+        enum: MyEnum
       }
     `;
     const output = cycleOutput(body);

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -159,9 +159,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz {
@@ -170,16 +170,16 @@ describe('extendSchema', () => {
 
       type Foo implements SomeInterface {
         name: String
-        newField: String
         some: SomeInterface
         tree: [Foo]!
+        newField: String
       }
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -252,9 +252,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz {
@@ -269,9 +269,9 @@ describe('extendSchema', () => {
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -310,9 +310,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz {
@@ -321,9 +321,9 @@ describe('extendSchema', () => {
 
       type Foo implements SomeInterface {
         name: String
-        newField(arg1: String, arg2: NewInputObj!): String
         some: SomeInterface
         tree: [Foo]!
+        newField(arg1: String, arg2: NewInputObj!): String
       }
 
       input NewInputObj {
@@ -334,9 +334,9 @@ describe('extendSchema', () => {
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -365,9 +365,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz {
@@ -376,16 +376,16 @@ describe('extendSchema', () => {
 
       type Foo implements SomeInterface {
         name: String
-        newField(arg1: SomeEnum!): SomeEnum
         some: SomeInterface
         tree: [Foo]!
+        newField(arg1: SomeEnum!): SomeEnum
       }
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -415,9 +415,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz implements SomeInterface {
@@ -434,9 +434,9 @@ describe('extendSchema', () => {
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -491,9 +491,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz {
@@ -502,14 +502,14 @@ describe('extendSchema', () => {
 
       type Foo implements SomeInterface {
         name: String
-        newEnum: NewEnum
-        newInterface: NewInterface
-        newObject: NewObject
-        newScalar: NewScalar
-        newTree: [Foo]!
-        newUnion: NewUnion
         some: SomeInterface
         tree: [Foo]!
+        newObject: NewObject
+        newInterface: NewInterface
+        newUnion: NewUnion
+        newScalar: NewScalar
+        newEnum: NewEnum
+        newTree: [Foo]!
       }
 
       enum NewEnum {
@@ -535,9 +535,9 @@ describe('extendSchema', () => {
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -570,9 +570,9 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz {
@@ -580,10 +580,10 @@ describe('extendSchema', () => {
       }
 
       type Foo implements SomeInterface, NewInterface {
-        baz: String
         name: String
         some: SomeInterface
         tree: [Foo]!
+        baz: String
       }
 
       interface NewInterface {
@@ -592,9 +592,9 @@ describe('extendSchema', () => {
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -638,18 +638,18 @@ describe('extendSchema', () => {
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
       type Bar implements SomeInterface {
-        foo: Foo
         name: String
         some: SomeInterface
+        foo: Foo
       }
 
       type Biz implements NewInterface, SomeInterface {
-        buzz: String
         fizz: String
+        buzz: String
         name: String
+        some: SomeInterface
         newFieldA: Int
         newFieldB: Float
-        some: SomeInterface
       }
 
       type Foo implements SomeInterface {
@@ -664,9 +664,9 @@ describe('extendSchema', () => {
 
       type Query {
         foo: Foo
+        someUnion: SomeUnion
         someEnum: SomeEnum
         someInterface(id: ID!): SomeInterface
-        someUnion: SomeUnion
       }
 
       enum SomeEnum {
@@ -729,13 +729,13 @@ describe('extendSchema', () => {
       }
 
       type Query {
-        newQueryField: Int
         queryField: String
+        newQueryField: Int
       }
 
       type Subscription {
-        newSubscriptionField: Int
         subscriptionField: String
+        newSubscriptionField: Int
       }
     `);
   });

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -412,8 +412,8 @@ describe('Type System Printer', () => {
       }
 
       type Bar implements Foo, Baaz {
-        int: Int
         str: String
+        int: Int
       }
 
       interface Foo {
@@ -479,8 +479,8 @@ describe('Type System Printer', () => {
       union MultipleUnion = Foo | Bar
 
       type Root {
-        multiple: MultipleUnion
         single: SingleUnion
+        multiple: MultipleUnion
       }
 
       union SingleUnion = Foo
@@ -629,13 +629,13 @@ describe('Type System Printer', () => {
       # skipping a field. Directives provide this by describing additional information
       # to the executor.
       type __Directive {
-        args: [__InputValue!]!
+        name: String!
         description: String
         locations: [__DirectiveLocation!]!
-        name: String!
-        onField: Boolean! @deprecated(reason: "Use \`locations\`.")
-        onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+        args: [__InputValue!]!
         onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
+        onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+        onField: Boolean! @deprecated(reason: "Use \`locations\`.")
       }
 
       # A Directive can be adjacent to many parts of the GraphQL language, a
@@ -700,52 +700,53 @@ describe('Type System Printer', () => {
       # placeholder for a string or numeric value. However an Enum value is returned in
       # a JSON response as a string.
       type __EnumValue {
-        deprecationReason: String
+        name: String!
         description: String
         isDeprecated: Boolean!
-        name: String!
+        deprecationReason: String
       }
 
       # Object and Interface types are described by a list of Fields, each of which has
       # a name, potentially a list of arguments, and a return type.
       type __Field {
-        args: [__InputValue!]!
-        deprecationReason: String
-        description: String
-        isDeprecated: Boolean!
         name: String!
+        description: String
+        args: [__InputValue!]!
         type: __Type!
+        isDeprecated: Boolean!
+        deprecationReason: String
       }
 
       # Arguments provided to Fields or Directives and the input fields of an
       # InputObject are represented as Input Values which describe their type and
       # optionally a default value.
       type __InputValue {
+        name: String!
+        description: String
+        type: __Type!
+
         # A GraphQL-formatted string representing the default value for this input value.
         defaultValue: String
-        description: String
-        name: String!
-        type: __Type!
       }
 
       # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
       # available types and directives on the server, as well as the entry points for
       # query, mutation, and subscription operations.
       type __Schema {
-        # A list of all directives supported by this server.
-        directives: [__Directive!]!
-
-        # If this server supports mutation, the type that mutation operations will be rooted at.
-        mutationType: __Type
+        # A list of all types supported by this server.
+        types: [__Type!]!
 
         # The type that query operations will be rooted at.
         queryType: __Type!
 
+        # If this server supports mutation, the type that mutation operations will be rooted at.
+        mutationType: __Type
+
         # If this server support subscription, the type that subscription operations will be rooted at.
         subscriptionType: __Type
 
-        # A list of all types supported by this server.
-        types: [__Type!]!
+        # A list of all directives supported by this server.
+        directives: [__Directive!]!
       }
 
       # The fundamental unit of any GraphQL Schema is the type. There are many kinds of
@@ -757,15 +758,15 @@ describe('Type System Printer', () => {
       # they describe. Abstract types, Union and Interface, provide the Object types
       # possible at runtime. List and NonNull types compose other types.
       type __Type {
-        description: String
-        enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
-        fields(includeDeprecated: Boolean = false): [__Field!]
-        inputFields: [__InputValue!]
-        interfaces: [__Type!]
         kind: __TypeKind!
         name: String
-        ofType: __Type
+        description: String
+        fields(includeDeprecated: Boolean = false): [__Field!]
+        interfaces: [__Type!]
         possibleTypes: [__Type!]
+        enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+        inputFields: [__InputValue!]
+        ofType: __Type
       }
 
       # An enum describing what kind of type a given \`__Type\` is.

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -195,9 +195,7 @@ function printEnumValues(values): string {
 
 function printInputObject(type: GraphQLInputObjectType): string {
   const fieldMap = type.getFields();
-  const fields = Object.keys(fieldMap)
-    .sort((name1, name2) => name1.localeCompare(name2))
-    .map(fieldName => fieldMap[fieldName]);
+  const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
   return printDescription(type) +
     `input ${type.name} {\n` +
       fields.map((f, i) =>
@@ -208,9 +206,7 @@ function printInputObject(type: GraphQLInputObjectType): string {
 
 function printFields(type) {
   const fieldMap = type.getFields();
-  const fields = Object.keys(fieldMap)
-    .sort((name1, name2) => name1.localeCompare(name2))
-    .map(fieldName => fieldMap[fieldName]);
+  const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
   return fields.map((f, i) =>
     printDescription(f, '  ', !i) + '  ' +
     f.name + printArgs(f.args, '  ') + ': ' +


### PR DESCRIPTION
Fixes issues with field definition order in printed schema not matching source which breaks `s = parse(print(s))`.

Test case: Revert "cycleOutput" test cases from back to correct form, see that they fail. Revert change and see that tests pass.