### PR TITLE
Throw TypeError when coercing an array into a GraphQLString

### DIFF
--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -629,6 +629,20 @@ describe('Execute: Handles inputs', () => {
       );
     });
 
+    it('serializing an array via GraphQLString throws TypeError', async () => {
+      let caughtError;
+      try {
+        GraphQLString.serialize([ 1, 2, 3 ]);
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError instanceof TypeError).to.equal(true);
+      expect(caughtError && caughtError.message).to.equal(
+        'String cannot represent an array value: [1,2,3]'
+      );
+    });
+
     it('reports error for non-provided variables for non-nullable inputs', async () => {
       // Note: this test would typically fail validation before encountering
       // this execution error, however for queries which previously validated

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -190,7 +190,7 @@ export function getDirectiveValues(
 /**
  * Given a type and any value, return a runtime value coerced to match the type.
  */
-function coerceValue(type: GraphQLInputType, value: mixed): mixed {
+export function coerceValue(type: GraphQLInputType, value: mixed): mixed {
   // Ensure flow knows that we treat function params as const.
   const _value = value;
 

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -88,6 +88,15 @@ export const GraphQLFloat = new GraphQLScalarType({
   }
 });
 
+function coerceString(value: mixed): ?string {
+  if (Array.isArray(value)) {
+    throw new TypeError(
+      `String cannot represent an array value: [${String(value)}]`
+    );
+  }
+  return String(value);
+}
+
 export const GraphQLString = new GraphQLScalarType({
   name: 'String',
   description:
@@ -95,7 +104,7 @@ export const GraphQLString = new GraphQLScalarType({
     'character sequences. The String type is most often used by GraphQL to ' +
     'represent free-form human-readable text.',
   serialize: String,
-  parseValue: String,
+  parseValue: coerceString,
   parseLiteral(ast) {
     return ast.kind === Kind.STRING ? ast.value : null;
   }

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -103,7 +103,7 @@ export const GraphQLString = new GraphQLScalarType({
     'The `String` scalar type represents textual data, represented as UTF-8 ' +
     'character sequences. The String type is most often used by GraphQL to ' +
     'represent free-form human-readable text.',
-  serialize: String,
+  serialize: coerceString,
   parseValue: coerceString,
   parseLiteral(ast) {
     return ast.kind === Kind.STRING ? ast.value : null;


### PR DESCRIPTION
Previously, we were using the default JS logic to coerce arrays to strings. This PR detects and disallows conversion of arrays into strings. 

https://github.com/graphql/graphql-js/issues/771