### PR TITLE
RFC: Descriptions as strings.

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -8,6 +8,10 @@ schema {
   mutation: MutationType
 }
 
+"""
+This is a description
+of the `Foo` type.
+"""
 type Foo implements Bar {
   one: Type
   two(argument: InputType!): Type

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -94,6 +94,55 @@ type Hello {
     expect(printJson(doc)).to.equal(printJson(expected));
   });
 
+  it('parses type with description string', () => {
+    const doc = parse(`
+"Description"
+type Hello {
+  world: String
+}`);
+    expect(doc).to.containSubset({
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'ObjectTypeDefinition',
+          name: nameNode('Hello', { start: 20, end: 25 }),
+          description: {
+            kind: 'StringValue',
+            value: 'Description',
+            loc: { start: 1, end: 14 },
+          }
+        }
+      ],
+      loc: { start: 0, end: 45 },
+    });
+  });
+
+  it('parses type with description multi-line string', () => {
+    const doc = parse(`
+"""
+Description
+"""
+# Even with comments between them
+type Hello {
+  world: String
+}`);
+    expect(doc).to.containSubset({
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'ObjectTypeDefinition',
+          name: nameNode('Hello', { start: 60, end: 65 }),
+          description: {
+            kind: 'StringValue',
+            value: 'Description',
+            loc: { start: 1, end: 20 },
+          }
+        }
+      ],
+      loc: { start: 0, end: 85 },
+    });
+  });
+
   it('Simple extension', () => {
     const body = `
 extend type Hello {
@@ -126,6 +175,15 @@ extend type Hello {
       loc: { start: 0, end: 39 }
     };
     expect(printJson(doc)).to.equal(printJson(expected));
+  });
+
+  it('Extension do not include descriptions', () => {
+    expect(() => parse(`
+      "Description"
+      extend type Hello {
+        world: String
+      }
+    `)).to.throw('Syntax Error GraphQL request (2:7)');
   });
 
   it('Simple non-null type', () => {

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -54,6 +54,10 @@ describe('Printer', () => {
   mutation: MutationType
 }
 
+"""
+This is a description
+of the \`Foo\` type.
+"""
 type Foo implements Bar {
   one: Type
   two(argument: InputType!): Type

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -396,6 +396,7 @@ export type TypeDefinitionNode =
 export type ScalarTypeDefinitionNode = {
   kind: 'ScalarTypeDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   directives?: ?Array<DirectiveNode>;
 };
@@ -403,6 +404,7 @@ export type ScalarTypeDefinitionNode = {
 export type ObjectTypeDefinitionNode = {
   kind: 'ObjectTypeDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   interfaces?: ?Array<NamedTypeNode>;
   directives?: ?Array<DirectiveNode>;
@@ -412,6 +414,7 @@ export type ObjectTypeDefinitionNode = {
 export type FieldDefinitionNode = {
   kind: 'FieldDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   arguments: Array<InputValueDefinitionNode>;
   type: TypeNode;
@@ -421,6 +424,7 @@ export type FieldDefinitionNode = {
 export type InputValueDefinitionNode = {
   kind: 'InputValueDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   type: TypeNode;
   defaultValue?: ?ValueNode;
@@ -430,6 +434,7 @@ export type InputValueDefinitionNode = {
 export type InterfaceTypeDefinitionNode = {
   kind: 'InterfaceTypeDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   directives?: ?Array<DirectiveNode>;
   fields: Array<FieldDefinitionNode>;
@@ -438,6 +443,7 @@ export type InterfaceTypeDefinitionNode = {
 export type UnionTypeDefinitionNode = {
   kind: 'UnionTypeDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   directives?: ?Array<DirectiveNode>;
   types: Array<NamedTypeNode>;
@@ -446,6 +452,7 @@ export type UnionTypeDefinitionNode = {
 export type EnumTypeDefinitionNode = {
   kind: 'EnumTypeDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   directives?: ?Array<DirectiveNode>;
   values: Array<EnumValueDefinitionNode>;
@@ -454,6 +461,7 @@ export type EnumTypeDefinitionNode = {
 export type EnumValueDefinitionNode = {
   kind: 'EnumValueDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   directives?: ?Array<DirectiveNode>;
 };
@@ -461,6 +469,7 @@ export type EnumValueDefinitionNode = {
 export type InputObjectTypeDefinitionNode = {
   kind: 'InputObjectTypeDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   directives?: ?Array<DirectiveNode>;
   fields: Array<InputValueDefinitionNode>;
@@ -475,6 +484,7 @@ export type TypeExtensionDefinitionNode = {
 export type DirectiveDefinitionNode = {
   kind: 'DirectiveDefinition';
   loc?: Location;
+  description?: ?StringValueNode;
   name: NameNode;
   arguments?: ?Array<InputValueDefinitionNode>;
   locations: Array<NameNode>;

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -32,18 +32,24 @@ export function createLexer<TOptions>(
     token: startOfFileToken,
     line: 1,
     lineStart: 0,
-    advance: advanceLexer
+    advance: advanceLexer,
+    lookahead
   };
   return lexer;
 }
 
 function advanceLexer() {
-  let token = this.lastToken = this.token;
+  this.lastToken = this.token;
+  const token = this.token = this.lookahead();
+  return token;
+}
+
+function lookahead() {
+  let token = this.token;
   if (token.kind !== EOF) {
     do {
-      token = token.next = readToken(this, token);
+      token = token.next || (token.next = readToken(this, token));
     } while (token.kind === COMMENT);
-    this.token = token;
   }
   return token;
 }
@@ -79,6 +85,12 @@ export type Lexer<TOptions> = {
    * Advances the token stream to the next non-ignored token.
    */
   advance(): Token;
+
+  /**
+   * Looks ahead and returns the next non-ignored token, but does not change
+   * the Lexer's state.
+   */
+  lookahead(): Token;
 };
 
 // Each kind of token.

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -72,9 +72,9 @@ const printDocASTReducer = {
 
   IntValue: ({ value }) => value,
   FloatValue: ({ value }) => value,
-  StringValue: ({ value, block: isBlockString }) =>
+  StringValue: ({ value, block: isBlockString }, key) =>
     isBlockString ?
-      printBlockString(value) :
+      printBlockString(value, key === 'description') :
       JSON.stringify(value),
   BooleanValue: ({ value }) => JSON.stringify(value),
   NullValue: () => 'null',
@@ -106,71 +106,109 @@ const printDocASTReducer = {
   OperationTypeDefinition: ({ operation, type }) =>
     operation + ': ' + type,
 
-  ScalarTypeDefinition: ({ name, directives }) =>
-    join([ 'scalar', name, join(directives, ' ') ], ' '),
-
-  ObjectTypeDefinition: ({ name, interfaces, directives, fields }) =>
+  ScalarTypeDefinition: ({ description, name, directives }) =>
     join([
-      'type',
-      name,
-      wrap('implements ', join(interfaces, ', ')),
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
+      description,
+      join([ 'scalar', name, join(directives, ' ') ], ' ')
+    ], '\n'),
 
-  FieldDefinition: ({ name, arguments: args, type, directives }) =>
-    name +
-    wrap('(', join(args, ', '), ')') +
-    ': ' + type +
-    wrap(' ', join(directives, ' ')),
-
-  InputValueDefinition: ({ name, type, defaultValue, directives }) =>
+  ObjectTypeDefinition: ({
+    description,
+    name,
+    interfaces,
+    directives,
+    fields
+  }) =>
     join([
-      name + ': ' + type,
-      wrap('= ', defaultValue),
-      join(directives, ' ')
-    ], ' '),
+      description,
+      join([
+        'type',
+        name,
+        wrap('implements ', join(interfaces, ', ')),
+        join(directives, ' '),
+        block(fields)
+      ], ' ')
+    ], '\n'),
 
-  InterfaceTypeDefinition: ({ name, directives, fields }) =>
+  FieldDefinition:
+    ({ description, name, arguments: args, type, directives }) =>
+      join([
+        description,
+        name +
+        wrap('(', join(args, ', '), ')') +
+        ': ' + type +
+        wrap(' ', join(directives, ' ')),
+      ], '\n'),
+
+  InputValueDefinition:
+    ({ description, name, type, defaultValue, directives }) =>
+      join([
+        description,
+        join([
+          name + ': ' + type,
+          wrap('= ', defaultValue),
+          join(directives, ' ')
+        ], ' '),
+      ], '\n'),
+
+  InterfaceTypeDefinition: ({ description, name, directives, fields }) =>
     join([
-      'interface',
-      name,
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
+      description,
+      join([
+        'interface',
+        name,
+        join(directives, ' '),
+        block(fields)
+      ], ' '),
+    ], '\n'),
 
-  UnionTypeDefinition: ({ name, directives, types }) =>
+  UnionTypeDefinition: ({ description, name, directives, types }) =>
     join([
-      'union',
-      name,
-      join(directives, ' '),
-      '= ' + join(types, ' | ')
-    ], ' '),
+      description,
+      join([
+        'union',
+        name,
+        join(directives, ' '),
+        '= ' + join(types, ' | ')
+      ], ' '),
+    ], '\n'),
 
-  EnumTypeDefinition: ({ name, directives, values }) =>
+  EnumTypeDefinition: ({ description, name, directives, values }) =>
     join([
-      'enum',
-      name,
-      join(directives, ' '),
-      block(values)
-    ], ' '),
+      description,
+      join([
+        'enum',
+        name,
+        join(directives, ' '),
+        block(values)
+      ], ' '),
+    ], '\n'),
 
-  EnumValueDefinition: ({ name, directives }) =>
-    join([ name, join(directives, ' ') ], ' '),
-
-  InputObjectTypeDefinition: ({ name, directives, fields }) =>
+  EnumValueDefinition: ({ description, name, directives }) =>
     join([
-      'input',
-      name,
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
+      description,
+      join([ name, join(directives, ' ') ], ' '),
+    ], '\n'),
+
+  InputObjectTypeDefinition: ({ description, name, directives, fields }) =>
+    join([
+      description,
+      join([
+        'input',
+        name,
+        join(directives, ' '),
+        block(fields)
+      ], ' '),
+    ], '\n'),
 
   TypeExtensionDefinition: ({ definition }) => `extend ${definition}`,
 
-  DirectiveDefinition: ({ name, arguments: args, locations }) =>
-    'directive @' + name + wrap('(', join(args, ', '), ')') +
-    ' on ' + join(locations, ' | '),
+  DirectiveDefinition: ({ description, name, arguments: args, locations }) =>
+    join([
+      description,
+      'directive @' + name + wrap('(', join(args, ', '), ')') +
+      ' on ' + join(locations, ' | '),
+    ], '\n'),
 };
 
 /**
@@ -210,8 +248,10 @@ function indent(maybeString) {
  * trailing blank line. However, if a block string starts with whitespace and is
  * a single-line, adding a leading blank line would strip that whitespace.
  */
-function printBlockString(value) {
+function printBlockString(value, isDescription) {
   return (value[0] === ' ' || value[0] === '\t') && value.indexOf('\n') === -1 ?
     `"""${value.replace(/"""/g, '\\"""')}"""` :
-    indent('"""\n' + value.replace(/"""/g, '\\"""')) + '\n"""';
+    isDescription ?
+      '"""\n' + value.replace(/"""/g, '\\"""') + '\n"""' :
+      indent('"""\n' + value.replace(/"""/g, '\\"""')) + '\n"""';
 }

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -40,19 +40,21 @@ export const QueryDocumentKeys = {
   SchemaDefinition: [ 'directives', 'operationTypes' ],
   OperationTypeDefinition: [ 'type' ],
 
-  ScalarTypeDefinition: [ 'name', 'directives' ],
-  ObjectTypeDefinition: [ 'name', 'interfaces', 'directives', 'fields' ],
-  FieldDefinition: [ 'name', 'arguments', 'type', 'directives' ],
-  InputValueDefinition: [ 'name', 'type', 'defaultValue', 'directives' ],
-  InterfaceTypeDefinition: [ 'name', 'directives', 'fields' ],
-  UnionTypeDefinition: [ 'name', 'directives', 'types' ],
-  EnumTypeDefinition: [ 'name', 'directives', 'values' ],
-  EnumValueDefinition: [ 'name', 'directives' ],
-  InputObjectTypeDefinition: [ 'name', 'directives', 'fields' ],
+  ScalarTypeDefinition: [ 'description', 'name', 'directives' ],
+  ObjectTypeDefinition:
+    [ 'description', 'name', 'interfaces', 'directives', 'fields' ],
+  FieldDefinition: [ 'description', 'name', 'arguments', 'type', 'directives' ],
+  InputValueDefinition:
+    [ 'description', 'name', 'type', 'defaultValue', 'directives' ],
+  InterfaceTypeDefinition: [ 'description', 'name', 'directives', 'fields' ],
+  UnionTypeDefinition: [ 'description', 'name', 'directives', 'types' ],
+  EnumTypeDefinition: [ 'description', 'name', 'directives', 'values' ],
+  EnumValueDefinition: [ 'description', 'name', 'directives' ],
+  InputObjectTypeDefinition: [ 'description', 'name', 'directives', 'fields' ],
 
   TypeExtensionDefinition: [ 'definition' ],
 
-  DirectiveDefinition: [ 'name', 'arguments', 'locations' ],
+  DirectiveDefinition: [ 'description', 'name', 'arguments', 'locations' ],
 };
 
 export const BREAK = {};

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -25,10 +25,10 @@ import {
  * into an in-memory GraphQLSchema, and then finally
  * printing that GraphQL into the DSL
  */
-function cycleOutput(body) {
+function cycleOutput(body, options) {
   const ast = parse(body);
-  const schema = buildASTSchema(ast);
-  return printSchema(schema);
+  const schema = buildASTSchema(ast, options);
+  return printSchema(schema, options);
 }
 
 describe('Schema Builder', () => {
@@ -101,6 +101,37 @@ describe('Schema Builder', () => {
         query: Hello
       }
 
+      """This is a directive"""
+      directive @foo(
+        """It has an argument"""
+        arg: Int
+      ) on FIELD
+
+      """With an enum"""
+      enum Color {
+        RED
+
+        """Not a creative color"""
+        GREEN
+        BLUE
+      }
+
+      """What a great type"""
+      type Hello {
+        """And a field to boot"""
+        str: String
+      }
+    `;
+    const output = cycleOutput(body);
+    expect(output).to.equal(body);
+  });
+
+  it('Supports option for comment descriptions', () => {
+    const body = dedent`
+      schema {
+        query: Hello
+      }
+
       # This is a directive
       directive @foo(
         # It has an argument
@@ -122,7 +153,7 @@ describe('Schema Builder', () => {
         str: String
       }
     `;
-    const output = cycleOutput(body);
+    const output = cycleOutput(body, { commentDescriptions: true });
     expect(output).to.equal(body);
   });
 

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -135,7 +135,7 @@ describe('extendSchema', () => {
   it('can describe the extended fields', async () => {
     const ast = parse(`
       extend type Query {
-        # New field description.
+        "New field description."
         newField: String
       }
     `);
@@ -144,6 +144,39 @@ describe('extendSchema', () => {
     expect(
       extendedSchema.getType('Query').getFields().newField.description
     ).to.equal('New field description.');
+  });
+
+  it('can describe the extended fields with legacy comments', async () => {
+    const ast = parse(`
+      extend type Query {
+        # New field description.
+        newField: String
+      }
+    `);
+    const extendedSchema = extendSchema(testSchema, ast, {
+      commentDescriptions: true
+    });
+
+    expect(
+      extendedSchema.getType('Query').getFields().newField.description
+    ).to.equal('New field description.');
+  });
+
+  it('describes extended fields with strings when present', async () => {
+    const ast = parse(`
+      extend type Query {
+        # New field description.
+        "Actually use this description."
+        newField: String
+      }
+    `);
+    const extendedSchema = extendSchema(testSchema, ast, {
+      commentDescriptions: true
+    });
+
+    expect(
+      extendedSchema.getType('Query').getFields().newField.description
+    ).to.equal('Actually use this description.');
   });
 
   it('extends objects by adding new fields', () => {
@@ -836,11 +869,26 @@ describe('extendSchema', () => {
 
   it('sets correct description when extending with a new directive', () => {
     const ast = parse(`
-      # new directive
+      """
+      new directive
+      """
       directive @new on QUERY
     `);
 
     const extendedSchema = extendSchema(testSchema, ast);
+    const newDirective = extendedSchema.getDirective('new');
+    expect(newDirective.description).to.equal('new directive');
+  });
+
+  it('sets correct description using legacy comments', () => {
+    const ast = parse(`
+      # new directive
+      directive @new on QUERY
+    `);
+
+    const extendedSchema = extendSchema(testSchema, ast, {
+      commentDescriptions: true
+    });
     const newDirective = extendedSchema.getDirective('new');
     expect(newDirective.description).to.equal('new directive');
   });

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -600,6 +600,251 @@ describe('Type System Printer', () => {
         query: Root
       }
 
+      """
+      Directs the executor to include this field or fragment only when the \`if\` argument is true.
+      """
+      directive @include(
+        """Included when true."""
+        if: Boolean!
+      ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      """
+      Directs the executor to skip this field or fragment when the \`if\` argument is true.
+      """
+      directive @skip(
+        """Skipped when true."""
+        if: Boolean!
+      ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      """Marks an element of a GraphQL schema as no longer supported."""
+      directive @deprecated(
+        """
+        Explains why this element was deprecated, usually also including a suggestion
+        for how to access supported similar data. Formatted in
+        [Markdown](https://daringfireball.net/projects/markdown/).
+        """
+        reason: String = "No longer supported"
+      ) on FIELD_DEFINITION | ENUM_VALUE
+
+      """
+      A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.
+
+      In some cases, you need to provide options to alter GraphQL's execution behavior
+      in ways field arguments will not suffice, such as conditionally including or
+      skipping a field. Directives provide this by describing additional information
+      to the executor.
+      """
+      type __Directive {
+        name: String!
+        description: String
+        locations: [__DirectiveLocation!]!
+        args: [__InputValue!]!
+        onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
+        onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
+        onField: Boolean! @deprecated(reason: "Use \`locations\`.")
+      }
+
+      """
+      A Directive can be adjacent to many parts of the GraphQL language, a
+      __DirectiveLocation describes one such possible adjacencies.
+      """
+      enum __DirectiveLocation {
+        """Location adjacent to a query operation."""
+        QUERY
+
+        """Location adjacent to a mutation operation."""
+        MUTATION
+
+        """Location adjacent to a subscription operation."""
+        SUBSCRIPTION
+
+        """Location adjacent to a field."""
+        FIELD
+
+        """Location adjacent to a fragment definition."""
+        FRAGMENT_DEFINITION
+
+        """Location adjacent to a fragment spread."""
+        FRAGMENT_SPREAD
+
+        """Location adjacent to an inline fragment."""
+        INLINE_FRAGMENT
+
+        """Location adjacent to a schema definition."""
+        SCHEMA
+
+        """Location adjacent to a scalar definition."""
+        SCALAR
+
+        """Location adjacent to an object type definition."""
+        OBJECT
+
+        """Location adjacent to a field definition."""
+        FIELD_DEFINITION
+
+        """Location adjacent to an argument definition."""
+        ARGUMENT_DEFINITION
+
+        """Location adjacent to an interface definition."""
+        INTERFACE
+
+        """Location adjacent to a union definition."""
+        UNION
+
+        """Location adjacent to an enum definition."""
+        ENUM
+
+        """Location adjacent to an enum value definition."""
+        ENUM_VALUE
+
+        """Location adjacent to an input object type definition."""
+        INPUT_OBJECT
+
+        """Location adjacent to an input object field definition."""
+        INPUT_FIELD_DEFINITION
+      }
+
+      """
+      One possible value for a given Enum. Enum values are unique values, not a
+      placeholder for a string or numeric value. However an Enum value is returned in
+      a JSON response as a string.
+      """
+      type __EnumValue {
+        name: String!
+        description: String
+        isDeprecated: Boolean!
+        deprecationReason: String
+      }
+
+      """
+      Object and Interface types are described by a list of Fields, each of which has
+      a name, potentially a list of arguments, and a return type.
+      """
+      type __Field {
+        name: String!
+        description: String
+        args: [__InputValue!]!
+        type: __Type!
+        isDeprecated: Boolean!
+        deprecationReason: String
+      }
+
+      """
+      Arguments provided to Fields or Directives and the input fields of an
+      InputObject are represented as Input Values which describe their type and
+      optionally a default value.
+      """
+      type __InputValue {
+        name: String!
+        description: String
+        type: __Type!
+
+        """
+        A GraphQL-formatted string representing the default value for this input value.
+        """
+        defaultValue: String
+      }
+
+      """
+      A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all
+      available types and directives on the server, as well as the entry points for
+      query, mutation, and subscription operations.
+      """
+      type __Schema {
+        """A list of all types supported by this server."""
+        types: [__Type!]!
+
+        """The type that query operations will be rooted at."""
+        queryType: __Type!
+
+        """
+        If this server supports mutation, the type that mutation operations will be rooted at.
+        """
+        mutationType: __Type
+
+        """
+        If this server support subscription, the type that subscription operations will be rooted at.
+        """
+        subscriptionType: __Type
+
+        """A list of all directives supported by this server."""
+        directives: [__Directive!]!
+      }
+
+      """
+      The fundamental unit of any GraphQL Schema is the type. There are many kinds of
+      types in GraphQL as represented by the \`__TypeKind\` enum.
+
+      Depending on the kind of a type, certain fields describe information about that
+      type. Scalar types provide no information beyond a name and description, while
+      Enum types provide their values. Object and Interface types provide the fields
+      they describe. Abstract types, Union and Interface, provide the Object types
+      possible at runtime. List and NonNull types compose other types.
+      """
+      type __Type {
+        kind: __TypeKind!
+        name: String
+        description: String
+        fields(includeDeprecated: Boolean = false): [__Field!]
+        interfaces: [__Type!]
+        possibleTypes: [__Type!]
+        enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+        inputFields: [__InputValue!]
+        ofType: __Type
+      }
+
+      """An enum describing what kind of type a given \`__Type\` is."""
+      enum __TypeKind {
+        """Indicates this type is a scalar."""
+        SCALAR
+
+        """
+        Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.
+        """
+        OBJECT
+
+        """
+        Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
+        """
+        INTERFACE
+
+        """Indicates this type is a union. \`possibleTypes\` is a valid field."""
+        UNION
+
+        """Indicates this type is an enum. \`enumValues\` is a valid field."""
+        ENUM
+
+        """
+        Indicates this type is an input object. \`inputFields\` is a valid field.
+        """
+        INPUT_OBJECT
+
+        """Indicates this type is a list. \`ofType\` is a valid field."""
+        LIST
+
+        """Indicates this type is a non-null. \`ofType\` is a valid field."""
+        NON_NULL
+      }
+    `;
+    expect(output).to.equal(introspectionSchema);
+  });
+
+  it('Print Introspection Schema with comment descriptions', () => {
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        onlyField: { type: GraphQLString }
+      },
+    });
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printIntrospectionSchema(Schema, {
+      commentDescriptions: true
+    });
+    const introspectionSchema = dedent`
+      schema {
+        query: Root
+      }
+
       # Directs the executor to include this field or fragment only when the \`if\` argument is true.
       directive @include(
         # Included when true.


### PR DESCRIPTION
**Breaking Change - those using comment descriptions will need to provide `{commentDescriptions: true}` to the relevant functions**

As discussed in https://github.com/facebook/graphql/pull/90

This proposes replacing leading comment blocks as descriptions in the schema definition language with leading strings.

While I think there is some reduced ergonomics of using a string literal instead of a comment to write descriptions (unless perhaps you are accustomed to Python or Clojure), there are some compelling advantages:

* Descriptions are first-class in the AST of the schema definition language.
* Comments can remain "ignored" characters.
* No ambiguity between commented out regions and descriptions.

Specific to this reference implementation, since this is a breaking change and comment descriptions in the experimental SDL have fairly wide usage, I've left the comment description implementation intact and allow it to be enabled via an option. This should help with allowing upgrading with minimal impact on existing codebases and aid in automated transforms.

Note: This PR is dependent on #926 and should not be merged out of order.