### PR TITLE
Allow to extend GraphQL errors with additional properties

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -26,7 +26,8 @@ declare class GraphQLError extends Error {
     source?: ?Source,
     positions?: ?Array<number>,
     path?: ?Array<string | number>,
-    originalError?: ?Error
+    originalError?: ?Error,
+    extensions?: ?{ [key: string]: mixed },
   ): void;
 
   /**
@@ -76,6 +77,11 @@ declare class GraphQLError extends Error {
    * The original error thrown from a field resolver during execution.
    */
   originalError: ?Error;
+
+  /**
+   * The original error thrown from a field resolver during execution.
+   */
+  extensions: ?{ [key: string]: mixed };
 }
 
 export function GraphQLError( // eslint-disable-line no-redeclare
@@ -84,7 +90,8 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   source?: ?Source,
   positions?: ?Array<number>,
   path?: ?Array<string | number>,
-  originalError?: ?Error
+  originalError?: ?Error,
+  extensions?: ?{ [key: string]: mixed }
 ) {
   // Compute locations in the source for the given nodes/positions.
   let _source = source;
@@ -146,7 +153,10 @@ export function GraphQLError( // eslint-disable-line no-redeclare
     },
     originalError: {
       value: originalError
-    }
+    },
+    extensions: {
+      value: extensions
+    },
   });
 
   // Include (non-enumerable) stack trace.

--- a/src/error/__tests__/GraphQLError-test.js
+++ b/src/error/__tests__/GraphQLError-test.js
@@ -139,4 +139,23 @@ describe('GraphQLError', () => {
     });
   });
 
+  it('default error formatter includes extension fields', () => {
+    const e = new GraphQLError(
+      'msg',
+      null,
+      null,
+      null,
+      null,
+      null,
+      { foo: 'bar' }
+    );
+
+    expect(formatError(e)).to.deep.equal({
+      message: 'msg',
+      locations: undefined,
+      path: undefined,
+      foo: 'bar'
+    });
+  });
+
 });

--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -19,6 +19,7 @@ import type { GraphQLError } from './GraphQLError';
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   invariant(error, 'Received null or undefined error.');
   return {
+    ...error.extensions,
     message: error.message,
     locations: error.locations,
     path: error.path

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -36,6 +36,7 @@ export function locatedError(
     originalError && (originalError: any).source,
     originalError && (originalError: any).positions,
     path,
-    originalError
+    originalError,
+    originalError && (originalError: any).extensions,
   );
 }


### PR DESCRIPTION
Implementing suggestion from #912 
In some cases, it's required to provide additional details inside errors.
At the same time, we don't want to force users to override `formatError` method.

This PR adds `extensions` property to `GraphQLError` and extend error object in the response with fields from it.