### PR TITLE
Remove extraneous transformation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,6 @@
     "syntax-async-functions",
     "syntax-async-generators",
     "transform-class-properties",
-    "transform-es3-property-literals",
     "transform-flow-strip-types",
     "transform-object-rest-spread",
     ["transform-es2015-classes", {"loose": true}],

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "babel-plugin-syntax-async-functions": "6.13.0",
     "babel-plugin-syntax-async-generators": "6.13.0",
     "babel-plugin-transform-class-properties": "6.24.1",
-    "babel-plugin-transform-es3-property-literals": "6.22.0",
     "babel-plugin-transform-flow-strip-types": "6.22.0",
     "babel-plugin-transform-object-rest-spread": "6.23.0",
     "babel-preset-env": "^1.5.2",


### PR DESCRIPTION
This PR removes the babel plugin [transform-es3-property-literals](https://babeljs.io/docs/plugins/transform-es3-property-literals/). It is extraneous compilation since the [quote-props](http://eslint.org/docs/rules/quote-props) ESLint rule defined [here](https://github.com/graphql/graphql-js/blob/master/.eslintrc#L202) already takes care of this.