### PR TITLE
Account for query's offset in file for errors

### DIFF
--- a/src/error/syntaxError.js
+++ b/src/error/syntaxError.js
@@ -23,8 +23,9 @@ export function syntaxError(
 ): GraphQLError {
   const location = getLocation(source, position);
   const line = location.line + source.locationOffset.line - 1;
+  const column = location.column + source.locationOffset.column - 1;
   const error = new GraphQLError(
-    `Syntax Error ${source.name} (${line}:${location.column}) ${description}` +
+    `Syntax Error ${source.name} (${line}:${column}) ${description}` +
       '\n\n' +
       highlightSourceAtLocation(source, location),
     undefined,
@@ -41,22 +42,28 @@ export function syntaxError(
 function highlightSourceAtLocation(source, location) {
   const line = location.line;
   const lineOffset = source.locationOffset.line - 1;
+  const columnOffset = source.locationOffset.column - 1;
   const contextLine = line + lineOffset;
   const prevLineNum = (contextLine - 1).toString();
   const lineNum = contextLine.toString();
   const nextLineNum = (contextLine + 1).toString();
   const padLen = nextLineNum.length;
   const lines = source.body.split(/\r\n|[\n\r]/g);
+  lines[0] = whitespace(columnOffset) + lines[0];
   return (
     (line >= 2 ?
       lpad(padLen, prevLineNum) + ': ' + lines[line - 2] + '\n' : '') +
     lpad(padLen, lineNum) + ': ' + lines[line - 1] + '\n' +
-    Array(2 + padLen + location.column).join(' ') + '^\n' +
+    whitespace(2 + padLen + location.column + columnOffset - 1) + '^\n' +
     (line < lines.length ?
       lpad(padLen, nextLineNum) + ': ' + lines[line] + '\n' : '')
   );
 }
 
+function whitespace(len) {
+  return Array(len + 1).join(' ');
+}
+
 function lpad(len, str) {
-  return Array(len - str.length + 1).join(' ') + str;
+  return whitespace(len - str.length) + str;
 }

--- a/src/error/syntaxError.js
+++ b/src/error/syntaxError.js
@@ -22,9 +22,11 @@ export function syntaxError(
   description: string
 ): GraphQLError {
   const location = getLocation(source, position);
+  const line = location.line + source.location.line - 1;
   const error = new GraphQLError(
-    `Syntax Error ${source.name} (${location.line}:${location.column}) ` +
-    description + '\n\n' + highlightSourceAtLocation(source, location),
+    `Syntax Error ${source.name} (${line}:${location.column}) ${description}` +
+      '\n\n' +
+      highlightSourceAtLocation(source, location),
     undefined,
     source,
     [ position ]
@@ -38,9 +40,11 @@ export function syntaxError(
  */
 function highlightSourceAtLocation(source, location) {
   const line = location.line;
-  const prevLineNum = (line - 1).toString();
-  const lineNum = line.toString();
-  const nextLineNum = (line + 1).toString();
+  const lineOffset = source.location.line - 1;
+  const contextLine = line + lineOffset;
+  const prevLineNum = (contextLine - 1).toString();
+  const lineNum = contextLine.toString();
+  const nextLineNum = (contextLine + 1).toString();
   const padLen = nextLineNum.length;
   const lines = source.body.split(/\r\n|[\n\r]/g);
   return (

--- a/src/error/syntaxError.js
+++ b/src/error/syntaxError.js
@@ -22,7 +22,7 @@ export function syntaxError(
   description: string
 ): GraphQLError {
   const location = getLocation(source, position);
-  const line = location.line + source.location.line - 1;
+  const line = location.line + source.locationOffset.line - 1;
   const error = new GraphQLError(
     `Syntax Error ${source.name} (${line}:${location.column}) ${description}` +
       '\n\n' +
@@ -40,7 +40,7 @@ export function syntaxError(
  */
 function highlightSourceAtLocation(source, location) {
   const line = location.line;
-  const lineOffset = source.location.line - 1;
+  const lineOffset = source.locationOffset.line - 1;
   const contextLine = line + lineOffset;
   const prevLineNum = (contextLine - 1).toString();
   const lineNum = contextLine.toString();

--- a/src/error/syntaxError.js
+++ b/src/error/syntaxError.js
@@ -26,8 +26,7 @@ export function syntaxError(
   const column = location.column + source.locationOffset.column - 1;
   const error = new GraphQLError(
     `Syntax Error ${source.name} (${line}:${column}) ${description}` +
-      '\n\n' +
-      highlightSourceAtLocation(source, location),
+      '\n\n' + highlightSourceAtLocation(source, location),
     undefined,
     source,
     [ position ]
@@ -54,7 +53,7 @@ function highlightSourceAtLocation(source, location) {
     (line >= 2 ?
       lpad(padLen, prevLineNum) + ': ' + lines[line - 2] + '\n' : '') +
     lpad(padLen, lineNum) + ': ' + lines[line - 1] + '\n' +
-    whitespace(2 + padLen + location.column + columnOffset - 1) + '^\n' +
+    whitespace(2 + padLen + location.column - 1 + columnOffset) + '^\n' +
     (line < lines.length ?
       lpad(padLen, nextLineNum) + ': ' + lines[line] + '\n' : '')
   );

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -125,18 +125,31 @@ describe('Lexer', () => {
       const str = '' +
       '\n' +
       '\n' +
-      '    ?\n' +
+      '     ?\n' +
       '\n';
-      const source = new Source(str, 'foo.js', { line: 11, column: 0 });
+      const source = new Source(str, 'foo.js', { line: 11, column: 1 });
       return createLexer(source).advance();
     }).to.throw(
-        'Syntax Error foo.js (13:5) ' +
+        'Syntax Error foo.js (13:6) ' +
         'Cannot parse the unexpected character "?".\n' +
         '\n' +
         '12: \n' +
-        '13:     ?\n' +
-        '        ^\n' +
+        '13:      ?\n' +
+        '         ^\n' +
         '14: \n'
+      );
+  });
+
+  it('updates column numbers in error for file context', () => {
+    expect(() => {
+      const source = new Source('?', 'foo.js', { line: 1, column: 5 });
+      return createLexer(source).advance();
+    }).to.throw(
+        'Syntax Error foo.js (1:5) ' +
+        'Cannot parse the unexpected character "?".\n' +
+        '\n' +
+        '1:     ?\n' +
+        '       ^\n'
       );
   });
 

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -101,12 +101,13 @@ describe('Lexer', () => {
   });
 
   it('errors respect whitespace', () => {
-    const str = '' +
-    '\n' +
-    '\n' +
-    '    ?\n' +
-    '\n';
-    expect(() => lexOne(str)
+
+    expect(() => lexOne(`
+
+    ?
+
+
+`)
     ).to.throw(
       'Syntax Error GraphQL request (3:5) ' +
       'Cannot parse the unexpected character "?".\n' +
@@ -116,6 +117,7 @@ describe('Lexer', () => {
       '       ^\n' +
       '4: \n'
     );
+
   });
 
   it('updates line numbers in error for file context', () => {
@@ -126,7 +128,7 @@ describe('Lexer', () => {
       '    ?\n' +
       '\n';
       const source = new Source(str, 'foo.js', { line: 11, column: 0 });
-      return createLexer(source).advance()
+      return createLexer(source).advance();
     }).to.throw(
         'Syntax Error foo.js (13:5) ' +
         'Cannot parse the unexpected character "?".\n' +

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -101,13 +101,12 @@ describe('Lexer', () => {
   });
 
   it('errors respect whitespace', () => {
-
-    expect(() => lexOne(`
-
-    ?
-
-
-`)
+    const str = '' +
+    '\n' +
+    '\n' +
+    '    ?\n' +
+    '\n';
+    expect(() => lexOne(str)
     ).to.throw(
       'Syntax Error GraphQL request (3:5) ' +
       'Cannot parse the unexpected character "?".\n' +
@@ -117,7 +116,26 @@ describe('Lexer', () => {
       '       ^\n' +
       '4: \n'
     );
+  });
 
+  it('updates line numbers in error for file context', () => {
+    expect(() => {
+      const str = '' +
+      '\n' +
+      '\n' +
+      '    ?\n' +
+      '\n';
+      const source = new Source(str, 'foo.js', { line: 11, column: 0 });
+      return createLexer(source).advance()
+    }).to.throw(
+        'Syntax Error foo.js (13:5) ' +
+        'Cannot parse the unexpected character "?".\n' +
+        '\n' +
+        '12: \n' +
+        '13:     ?\n' +
+        '        ^\n' +
+        '14: \n'
+      );
   });
 
   it('lexes strings', () => {

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -8,18 +8,26 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+type Location = {
+  line: number,
+  column: number,
+};
+
 /**
- * A representation of source input to GraphQL. The name is optional,
- * but is mostly useful for clients who store GraphQL documents in
- * source files; for example, if the GraphQL input is in a file Foo.graphql,
- * it might be useful for name to be "Foo.graphql".
+ * A representation of source input to GraphQL.
+ * `name` and `location` are optional. They are useful for clients who store
+ * GraphQL documents in source files; for example, if the GraphQL input starts
+ * at line 40 in a file named Foo.graphql, it might be useful for name to be
+ * "Foo.graphql" and location to be `{ line: 40, column: 0 }`.
  */
 export class Source {
   body: string;
   name: string;
+  location: Location;
 
-  constructor(body: string, name?: string): void {
+  constructor(body: string, name?: string, location?: Location): void {
     this.body = body;
     this.name = name || 'GraphQL request';
+    this.location = location || { line: 1, column: 0 };
   }
 }

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -15,19 +15,19 @@ type Location = {
 
 /**
  * A representation of source input to GraphQL.
- * `name` and `location` are optional. They are useful for clients who store
- * GraphQL documents in source files; for example, if the GraphQL input starts
- * at line 40 in a file named Foo.graphql, it might be useful for name to be
- * "Foo.graphql" and location to be `{ line: 40, column: 0 }`.
+ * `name` and `locationOffset` are optional. They are useful for clients who
+ * store GraphQL documents in source files; for example, if the GraphQL input
+ * starts at line 40 in a file named Foo.graphql, it might be useful for name to
+ * be "Foo.graphql" and location to be `{ line: 40, column: 0 }`.
  */
 export class Source {
   body: string;
   name: string;
-  location: Location;
+  locationOffset: Location;
 
-  constructor(body: string, name?: string, location?: Location): void {
+  constructor(body: string, name?: string, locationOffset?: Location): void {
     this.body = body;
     this.name = name || 'GraphQL request';
-    this.location = location || { line: 1, column: 0 };
+    this.locationOffset = locationOffset || { line: 1, column: 0 };
   }
 }

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -8,6 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+import invariant from '../jsutils/invariant';
+
 type Location = {
   line: number,
   column: number,
@@ -30,5 +32,13 @@ export class Source {
     this.body = body;
     this.name = name || 'GraphQL request';
     this.locationOffset = locationOffset || { line: 1, column: 1 };
+    invariant(
+      this.locationOffset.line > 0,
+      'line in locationOffset is 1-indexed and must be positive'
+    );
+    invariant(
+      this.locationOffset.column > 0,
+      'column in locationOffset is 1-indexed and must be positive'
+    );
   }
 }

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -21,7 +21,7 @@ type Location = {
  * store GraphQL documents in source files; for example, if the GraphQL input
  * starts at line 40 in a file named Foo.graphql, it might be useful for name to
  * be "Foo.graphql" and location to be `{ line: 40, column: 0 }`.
- * line and columns in locationOffset are 1-indexed
+ * line and column in locationOffset are 1-indexed
  */
 export class Source {
   body: string;

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -19,6 +19,7 @@ type Location = {
  * store GraphQL documents in source files; for example, if the GraphQL input
  * starts at line 40 in a file named Foo.graphql, it might be useful for name to
  * be "Foo.graphql" and location to be `{ line: 40, column: 0 }`.
+ * line and columns in locationOffset are 1-indexed
  */
 export class Source {
   body: string;
@@ -28,6 +29,6 @@ export class Source {
   constructor(body: string, name?: string, locationOffset?: Location): void {
     this.body = body;
     this.name = name || 'GraphQL request';
-    this.locationOffset = locationOffset || { line: 1, column: 0 };
+    this.locationOffset = locationOffset || { line: 1, column: 1 };
   }
 }


### PR DESCRIPTION
Adds support for providing the location in a file that the graphQL source was located. If the location is provided as part of the source, the line numbers in the formatted errors will be updated to account for the offset.

For example, in file Foo.js:

```
1  const x = 1
2 
3  graphql`
4  query {
5   ?
6  }
7  `
```

The lexer will throw an error with message:

```
Parse error: GraphQLError: Syntax Error Foo.js (5:2) Cannot parse the unexpected character "?".
4: query {
5:  ?
    ^
6: }
```

It's up to the caller to provide the correct offset in the source.

Not sure if `location` is the best name for the field in the `Source` object. Very open to suggestions!