### PR TITLE
Fix incorrect column number in errors

### DIFF
--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -127,7 +127,7 @@ describe('Lexer', () => {
       '\n' +
       '     ?\n' +
       '\n';
-      const source = new Source(str, 'foo.js', { line: 11, column: 1 });
+      const source = new Source(str, 'foo.js', { line: 11, column: 12 });
       return createLexer(source).advance();
     }).to.throw(
         'Syntax Error foo.js (13:6) ' +

--- a/src/language/location.js
+++ b/src/language/location.js
@@ -13,7 +13,7 @@ import type { Source } from './source';
 /**
  * Represents a location in a Source.
  */
-type SourceLocation = {
+export type SourceLocation = {
   line: number;
   column: number;
 };


### PR DESCRIPTION
I forgot to check that we were on the first line before applying the column offset to the caret. It causes the indicator and reported column number for the error to be off if a locationOffset.column is larger than 1.



