### PR TITLE
Fix directive description lost in extendSchema

### DIFF
--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -836,6 +836,17 @@ describe('extendSchema', () => {
     expect(newDirective.locations).to.contain('QUERY');
   });
 
+  it('sets correct description when extends with a new directive', () => {
+    const ast = parse(`
+      # new directive
+      directive @new on QUERY
+    `);
+
+    const extendedSchema = extendSchema(testSchema, ast);
+    const newDirective = extendedSchema.getDirective('new');
+    expect(newDirective.description).to.equal('new directive');
+  });
+
   it('may extend directives with new complex directive', () => {
     const ast = parse(`
       directive @profile(enable: Boolean! tag: String) on QUERY | FIELD

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -836,7 +836,7 @@ describe('extendSchema', () => {
     expect(newDirective.locations).to.contain('QUERY');
   });
 
-  it('sets correct description when extends with a new directive', () => {
+  it('sets correct description when extending with a new directive', () => {
     const ast = parse(`
       # new directive
       directive @new on QUERY

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -539,6 +539,7 @@ export function extendSchema(
   ): GraphQLDirective {
     return new GraphQLDirective({
       name: directiveNode.name.value,
+      description: getDescription(directiveNode),
       locations: directiveNode.locations.map(
         node => ((node.value: any): DirectiveLocationEnum)
       ),


### PR DESCRIPTION
[`getDirective`](https://github.com/graphql/graphql-js/blob/master/src/utilities/extendSchema.js#L537) from `extendSchema` misses `description` field which is present in `buildASTSchema` ([here](https://github.com/graphql/graphql-js/blob/master/src/utilities/buildASTSchema.js#L274))

Added it + created test to cover this