### PR TITLE
Export "ExecutionArgs" type

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -105,6 +105,16 @@ export type ExecutionResult = {
   data?: ?{[key: string]: mixed};
 };
 
+export type ExecutionArgs = {|
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  rootValue?: mixed,
+  contextValue?: mixed,
+  variableValues?: ?{[key: string]: mixed},
+  operationName?: ?string,
+  fieldResolver?: ?GraphQLFieldResolver<any, any>
+|};
+
 /**
  * Implements the "Evaluating requests" section of the GraphQL specification.
  *
@@ -115,15 +125,10 @@ export type ExecutionResult = {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-declare function execute({|
-  schema: GraphQLSchema,
-  document: DocumentNode,
-  rootValue?: mixed,
-  contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
-  operationName?: ?string,
-  fieldResolver?: ?GraphQLFieldResolver<any, any>
-|}, ..._: []): Promise<ExecutionResult>;
+declare function execute(
+  ExecutionArgs,
+  ..._: []
+): Promise<ExecutionResult>;
 /* eslint-disable no-redeclare */
 declare function execute(
   schema: GraphQLSchema,

--- a/src/index.js
+++ b/src/index.js
@@ -241,6 +241,7 @@ export {
 } from './execution';
 
 export type {
+  ExecutionArgs,
   ExecutionResult,
 } from './execution';
 


### PR DESCRIPTION
I need this type to apply some transformation on args before passing it to `execute`.
This PR just expose type without changing any run-time behavior.
@wincent Can you please review it?