### PR TITLE
use Symbol.hasInstance for looser instanceof checks

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -11,7 +11,9 @@
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
 import * as Kind from '../language/kinds';
+
 import { assertValidName } from '../utilities/assertValidName';
+import attachHasInstanceSymbol from '../utilities/attachHasInstanceSymbol';
 import type {
   ScalarTypeDefinitionNode,
   ObjectTypeDefinitionNode,
@@ -368,6 +370,8 @@ export class GraphQLScalarType {
   inspect: () => string;
 }
 
+attachHasInstanceSymbol(GraphQLScalarType);
+
 // Also provide toJSON and inspect aliases for toString.
 GraphQLScalarType.prototype.toJSON =
   GraphQLScalarType.prototype.inspect =
@@ -467,6 +471,8 @@ export class GraphQLObjectType {
   toJSON: () => string;
   inspect: () => string;
 }
+
+attachHasInstanceSymbol(GraphQLObjectType);
 
 // Also provide toJSON and inspect aliases for toString.
 GraphQLObjectType.prototype.toJSON =
@@ -749,6 +755,8 @@ export class GraphQLInterfaceType {
   inspect: () => string;
 }
 
+attachHasInstanceSymbol(GraphQLInterfaceType);
+
 // Also provide toJSON and inspect aliases for toString.
 GraphQLInterfaceType.prototype.toJSON =
   GraphQLInterfaceType.prototype.inspect =
@@ -830,6 +838,8 @@ export class GraphQLUnionType {
   toJSON: () => string;
   inspect: () => string;
 }
+
+attachHasInstanceSymbol(GraphQLUnionType);
 
 // Also provide toJSON and inspect aliases for toString.
 GraphQLUnionType.prototype.toJSON =
@@ -999,6 +1009,8 @@ export class GraphQLEnumType/* <T> */ {
   inspect: () => string;
 }
 
+attachHasInstanceSymbol(GraphQLEnumType);
+
 // Also provide toJSON and inspect aliases for toString.
 GraphQLEnumType.prototype.toJSON =
   GraphQLEnumType.prototype.inspect =
@@ -1159,6 +1171,8 @@ export class GraphQLInputObjectType {
   inspect: () => string;
 }
 
+attachHasInstanceSymbol(GraphQLInputObjectType);
+
 // Also provide toJSON and inspect aliases for toString.
 GraphQLInputObjectType.prototype.toJSON =
   GraphQLInputObjectType.prototype.inspect =
@@ -1233,6 +1247,8 @@ export class GraphQLList<T: GraphQLType> {
   inspect: () => string;
 }
 
+attachHasInstanceSymbol(GraphQLList);
+
 // Also provide toJSON and inspect aliases for toString.
 GraphQLList.prototype.toJSON =
   GraphQLList.prototype.inspect =
@@ -1278,6 +1294,8 @@ export class GraphQLNonNull<T: GraphQLNullableType> {
   toJSON: () => string;
   inspect: () => string;
 }
+
+attachHasInstanceSymbol(GraphQLNonNull);
 
 // Also provide toJSON and inspect aliases for toString.
 GraphQLNonNull.prototype.toJSON =

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -26,6 +26,7 @@ import { GraphQLDirective, specifiedDirectives } from './directives';
 import { __Schema } from './introspection';
 import find from '../jsutils/find';
 import invariant from '../jsutils/invariant';
+import attachHasInstanceSymbol from '../utilities/attachHasInstanceSymbol';
 import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators';
 
 
@@ -221,6 +222,8 @@ export class GraphQLSchema {
     return find(this.getDirectives(), directive => directive.name === name);
   }
 }
+
+attachHasInstanceSymbol(GraphQLSchema);
 
 type TypeMap = { [typeName: string]: GraphQLNamedType };
 

--- a/src/utilities/__tests__/attachHasInstanceSymbol.js
+++ b/src/utilities/__tests__/attachHasInstanceSymbol.js
@@ -1,0 +1,18 @@
+import { describe, it} from 'mocha';
+import chai from 'chai';
+import attachHasInstanceSymbol from '../attachHasInstanceSymbol';
+import { GraphQLInputObjectType as RealInputType } from '../../type';
+
+
+describe('attachHasInstanceSymbol()', () => {
+  it('passes instanceof checks for types for other package instances', () => {
+    class GraphQLInputObjectType {
+      constructor() {}
+    }
+
+    attachHasInstanceSymbol(GraphQLInputObjectType);
+
+    chai.expect(new GraphQLInputObjectType() instanceof RealInputType)
+      .to.equal(true);
+  });
+});

--- a/src/utilities/attachHasInstanceSymbol.js
+++ b/src/utilities/attachHasInstanceSymbol.js
@@ -1,0 +1,25 @@
+/* @flow */
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+// eslint-disable-next-line flowtype/no-weak-types
+export default function attachHasInstanceSymbol(ctor: Function): void {
+  if (typeof Symbol === 'undefined' || !Symbol.for || !Symbol.hasInstance) {
+    return;
+  }
+  const tag = `@@typeof/${ctor.name}`;
+
+  Object.defineProperty(ctor, Symbol.hasInstance, {
+    value: function $hasInstance(instance) {
+      return instance && instance[Symbol.for(tag)] === true;
+    },
+  });
+
+  ctor.prototype[Symbol.for(tag)] = true;
+}


### PR DESCRIPTION
fixes #491 

I'm not entirely sure how to field test this but `Symbol.for` should be resilent over package boundaries since its all the same runtime.