### PR TITLE
Expanded findBreakingChanges test with missing case.

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -1213,6 +1213,36 @@ describe('findBreakingChanges', () => {
       }
     });
 
+    const interface1 = new GraphQLInterfaceType({
+      name: 'Interface1',
+      fields: {
+        field1: { type: GraphQLString },
+      },
+      resolveType: () => null,
+    });
+
+    const typeThatLosesInterfaceOld = new GraphQLObjectType({
+      name: 'TypeThatGainsInterface1',
+      interfaces: [
+        interface1
+      ],
+      fields: {
+        field1: {
+          type: GraphQLString,
+        },
+      },
+    });
+
+    const typeThaLosesInterfaceNew = new GraphQLObjectType({
+      name: 'TypeThatGainsInterface1',
+      interfaces: [],
+      fields: {
+        field1: {
+          type: GraphQLString,
+        },
+      },
+    });
+
     const oldSchema = new GraphQLSchema({
       query: queryType,
       types: [
@@ -1221,7 +1251,8 @@ describe('findBreakingChanges', () => {
         typeThatHasBreakingFieldChangesOld,
         unionTypeThatLosesATypeOld,
         enumTypeThatLosesAValueOld,
-        argThatChanges
+        argThatChanges,
+        typeThatLosesInterfaceOld
       ]
     });
 
@@ -1233,6 +1264,8 @@ describe('findBreakingChanges', () => {
         unionTypeThatLosesATypeNew,
         enumTypeThatLosesAValueNew,
         argChanged,
+        typeThaLosesInterfaceNew,
+        interface1
       ]
     });
 
@@ -1278,6 +1311,11 @@ describe('findBreakingChanges', () => {
         description: 'ArgThatChanges.field1 arg id has changed ' +
           'type from Int to String',
       },
+      {
+        type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
+        description: 'TypeThatGainsInterface1 no longer implements ' +
+        'interface Interface1.',
+      }
     ];
     expect(findBreakingChanges(oldSchema, newSchema)).to.eql(
       expectedBreakingChanges


### PR DESCRIPTION
I noticed the findBreakingChanges did not perform a check for the breaking change `INTERFACE_REMOVED_FROM_OBJECT` so I added it:)