### PR TITLE
Add linter error preventing use of `async` outside the test suite

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -219,6 +219,8 @@
     "vars-on-top": 0,
     "wrap-iife": 2,
     "wrap-regex": 0,
-    "yoda": [2, "never", {"exceptRange": true}]
+    "yoda": [2, "never", {"exceptRange": true}],
+
+    "no-async": 2
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "npm run lint && npm run check && npm run testonly",
     "testonly": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",
     "t": "babel-node ./node_modules/.bin/_mocha --require ./resources/mocha-bootload",
-    "lint": "eslint src || (printf '\\033[33mTry: \\033[7m npm run lint -- --fix \\033[0m\\n' && exit 1)",
+    "lint": "eslint --rulesdir ./resources/lint src || (printf '\\033[33mTry: \\033[7m npm run lint -- --fix \\033[0m\\n' && exit 1)",
     "check": "flow check",
     "check-cover": "for file in {src/*.js,src/**/*.js}; do echo $file; flow coverage $file; done",
     "build": "babel src --optional runtime --ignore __tests__ --out-dir dist/ && cp package.json dist/ && npm run build-dot-flow",

--- a/resources/lint/no-async.js
+++ b/resources/lint/no-async.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+module.exports = function(context) {
+  if (context.getFilename().match(/\b__tests__\b/)) {
+    return {};
+  } else {
+    return {
+      FunctionDeclaration: function(node) {
+        if (node.async) {
+          context.report(
+            node,
+            'async functions are not allowed outside of the test suite'
+          );
+        }
+      },
+    };
+  }
+};

--- a/resources/lint/no-async.js
+++ b/resources/lint/no-async.js
@@ -16,7 +16,10 @@ module.exports = function(context) {
         if (node.async) {
           context.report(
             node,
-            'async functions are not allowed outside of the test suite'
+            'async functions are not allowed outside of the test suite ' +
+            'because older versions of NodeJS do not support them ' +
+            'without additional runtime dependencies. Instead, use explicit ' +
+            'Promises.'
           );
         }
       },


### PR DESCRIPTION
We want to keep the runtime dependency footprint small, so that means avoiding use of `async` at runtime (which creates a dependency on the Regenerator runtime).

There is no built-in eslint rule for this, so we make a custom one.

Test plan:

Add an `async` function to a file, run `yarn run lint` and see:

    graphql-js/src/subscription/subscribe.js
    288:1  error  async functions are not allowed outside of the test suite  no-async

    ✖ 1 problem (1 error, 0 warnings)

Note that no errors are issued for the `async` functions in the test suite.

Closes: https://github.com/graphql/graphql-js/issues/1008