### PR TITLE
Fix flow error in mapAsyncIterator

### DIFF
--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -39,8 +39,9 @@ export default function mapAsyncIterator<T, U>(
 
   let mapReject;
   if (rejectCallback) {
-    mapReject = error =>
-      asyncMapValue(error, rejectCallback).then(iteratorResult, abruptClose);
+    mapReject = error => rejectCallback ?
+      asyncMapValue(error, rejectCallback).then(iteratorResult, abruptClose) :
+      error;
   }
 
   return {

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -39,11 +39,10 @@ export default function mapAsyncIterator<T, U>(
 
   let mapReject;
   if (rejectCallback) {
-    // The redundant rejectCallback null check provides compatibility with
-    // different flow config options.
-    mapReject = error => rejectCallback ?
-      asyncMapValue(error, rejectCallback).then(iteratorResult, abruptClose) :
-      error;
+    // Capture rejectCallback to ensure it cannot be null.
+    const reject = rejectCallback;
+    mapReject = error =>
+      asyncMapValue(error, reject).then(iteratorResult, abruptClose);
   }
 
   return {

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -39,6 +39,8 @@ export default function mapAsyncIterator<T, U>(
 
   let mapReject;
   if (rejectCallback) {
+    // The redundant rejectCallback null check provides compatibility with
+    // different flow config options.
     mapReject = error => rejectCallback ?
       asyncMapValue(error, rejectCallback).then(iteratorResult, abruptClose) :
       error;


### PR DESCRIPTION
https://github.com/graphql/graphql-js/issues/1011

This fix attempts to address the flow errors found in libraries that depend on GraphQL-js but do not have `experimental.const_params=true` in their .flowconfig. 

With this explicit null check, I removed the `experimental.const_params=true` option from .flowconfig and saw all tests still pass. 