### PR TITLE
Updated flow to 0.54.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "4.4.1",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-flowtype": "2.35.0",
-    "flow-bin": "0.52.0",
+    "flow-bin": "^0.54.0",
     "isparta": "4.0.0",
     "mocha": "3.5.0",
     "sane": "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,9 +1224,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.52.0:
-  version "0.52.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.52.0.tgz#b6d9abe8bcd1ee5c62df386451a4e2553cadc3a3"
+flow-bin@^0.54.0:
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.0.tgz#f2fb0478e9e99702b623c9ed84079a39903bba77"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
I updated flow to 0.54.0 but there seem to be a lot errors after this upgrade. Anyone have an idea of the source of these flow errors?