### PR TITLE
Update flow to 0.54.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "4.4.1",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-flowtype": "2.35.0",
-    "flow-bin": "0.52.0",
+    "flow-bin": "0.54.0",
     "isparta": "4.0.0",
     "mocha": "3.5.0",
     "sane": "2.0.0"

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -18,6 +18,7 @@ import { $$asyncIterator } from 'iterall';
  *
  * Should return `AsyncIterator<mixed>`
  *   used `any` until Flowtype get proper symbol support ($$asyncIterator)
+ *   https://github.com/facebook/flow/issues/3258
  */
 export default function eventEmitterAsyncIterator(
   eventEmitter: EventEmitter,

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -15,11 +15,14 @@ import { $$asyncIterator } from 'iterall';
 /**
  * Create an AsyncIterator from an EventEmitter. Useful for mocking a
  * PubSub system for tests.
+ *
+ * Should return `AsyncIterator<mixed>`
+ *   used `any` until Flowtype get proper symbol support ($$asyncIterator)
  */
 export default function eventEmitterAsyncIterator(
   eventEmitter: EventEmitter,
   eventName: string
-): AsyncIterator<mixed> {
+): any {
   const pullQueue = [];
   const pushQueue = [];
   let listening = true;

--- a/src/subscription/asyncIteratorReject.js
+++ b/src/subscription/asyncIteratorReject.js
@@ -15,8 +15,11 @@ import { $$asyncIterator } from 'iterall';
  * Given an error, returns an AsyncIterable which will fail with that error.
  *
  * Similar to Promise.reject(error)
+ *
+ * Should return AsyncIterator<void>
+ *   used `any` until Flowtype get proper symbol support ($$asyncIterator)
  */
-export default function asyncIteratorReject(error: Error): AsyncIterator<void> {
+export default function asyncIteratorReject(error: Error): any {
   let isComplete = false;
   return {
     next() {

--- a/src/subscription/asyncIteratorReject.js
+++ b/src/subscription/asyncIteratorReject.js
@@ -18,6 +18,7 @@ import { $$asyncIterator } from 'iterall';
  *
  * Should return AsyncIterator<void>
  *   used `any` until Flowtype get proper symbol support ($$asyncIterator)
+ *   https://github.com/facebook/flow/issues/3258
  */
 export default function asyncIteratorReject(error: Error): any {
   let isComplete = false;

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -14,12 +14,15 @@ import { $$asyncIterator, getAsyncIterator } from 'iterall';
 /**
  * Given an AsyncIterable and a callback function, return an AsyncIterator
  * which produces values mapped via calling the callback function.
+ *
+ * Should return `AsyncGenerator<U, void, void>`
+ *   used `any` until Flowtype get proper symbol support ($$asyncIterator)
  */
 export default function mapAsyncIterator<T, U>(
   iterable: AsyncIterable<T>,
   callback: T => Promise<U> | U,
   rejectCallback?: any => Promise<U> | U
-): AsyncGenerator<U, void, void> {
+): any {
   const iterator = getAsyncIterator(iterable);
   let $return;
   let abruptClose;

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -17,6 +17,7 @@ import { $$asyncIterator, getAsyncIterator } from 'iterall';
  *
  * Should return `AsyncGenerator<U, void, void>`
  *   used `any` until Flowtype get proper symbol support ($$asyncIterator)
+ *   https://github.com/facebook/flow/issues/3258
  */
 export default function mapAsyncIterator<T, U>(
   iterable: AsyncIterable<T>,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -217,7 +217,7 @@ export type GraphQLNullableType =
   GraphQLUnionType |
   GraphQLEnumType |
   GraphQLInputObjectType |
-  GraphQLList<*>;
+  GraphQLList<any>;
 
 export function getNullableType<T: GraphQLType>(
   type: ?T

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,9 +1224,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.52.0:
-  version "0.52.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.52.0.tgz#b6d9abe8bcd1ee5c62df386451a4e2553cadc3a3"
+flow-bin@0.54.0:
+  version "0.54.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.0.tgz#f2fb0478e9e99702b623c9ed84079a39903bba77"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Flowtype 0.54.0 found new errors and this PR fix them.

### 1. `GraphQLList<any>` instead of `GraphQLList<*>`

`GraphQLNullableType` uses `GraphQLList<*>` as available value and it can be used in `Input` and `Output` types.  So Flow 0.54 for `*` starts to mix output and input types in a new implicit type union, that's why it produces a bunch of flowtype errors (shortly: input types can not be used in conjunction with output types and vice versa). So `any` does not create implicit type union and fixes 22 "crazy" errors.

----
### 2. AsyncIterator - relax until proper symbol support

I [consulted](https://twitter.com/calebmer/status/905055263916306433) with @calebmer how to resolve errors with `AsyncIterator` and his recommendation was to use `any` until Flow get proper symbol support.

```js
Error: src/subscription/__tests__/eventEmitterAsyncIterator.js:22
 22: ): AsyncIterator<mixed> {
        ^^^^^^^^^^^^^^^^^^^^ property `@@asyncIterator` of $AsyncIterator. Property not found in
              v
 56:   return {
 57:     next() {
 58:       return listening ? pullValue() : this.return();
...:

 71:   };
       ^ object literal

Error: src/subscription/asyncIteratorReject.js:19
 19: export default function asyncIteratorReject(error: Error): AsyncIterator<void> {
                                                                ^^^^^^^^^^^^^^^^^^^ property `@@asyncIterator` of $AsyncIterator. Property not found in
              v
 21:   return {
 22:     next() {
 23:       const result = isComplete ?
...:
 40:   };
       ^ object literal

Error: src/subscription/mapAsyncIterator.js:22
 22: ): AsyncGenerator<U, void, void> {
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ property `@@asyncIterator` of AsyncGenerator. Property not found in
              v
 48:   return {
 49:     next() {
 50:       return iterator.next().then(mapResult, mapReject);
...:
 66:   };
       ^ object literal
```

It's strange cause `asyncIteratorReject` has `[$$asyncIterator]()` method L37-39: 
https://github.com/graphql/graphql-js/blob/96a869af951e7b7216e7b79ccfcb170b779ad4e9/src/subscription/asyncIteratorReject.js#L19-L41