### PR TITLE
Keep comments when printing a parsed query

### DIFF
--- a/src/language/__tests__/kitchen-sink.graphql
+++ b/src/language/__tests__/kitchen-sink.graphql
@@ -52,6 +52,7 @@ fragment frag on Friend {
 }
 
 {
+  # Here is a comment
   unnamed(truthy: true, falsey: false, nullish: null),
   query
 }

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -36,6 +36,18 @@ describe('Printer', () => {
   });
 
   it('correctly prints non-query operations without name', () => {
+    const queryWithComment = parse(dedent`query {
+      # Test
+      id
+    }`);
+    console.log(JSON.stringify(queryWithComment, null, 2));
+    expect(print(queryWithComment)).to.equal(dedent`
+      {
+        # Test
+        id
+      }
+    `);
+
     const queryAstShorthanded = parse('query { id, name }');
     expect(print(queryAstShorthanded)).to.equal(dedent`
       {

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -126,6 +126,7 @@ export type ASTNode =
   | SelectionSetNode
   | FieldNode
   | ArgumentNode
+  | CommentNode
   | FragmentSpreadNode
   | InlineFragmentNode
   | FragmentDefinitionNode
@@ -232,6 +233,11 @@ export type ArgumentNode = {
   value: ValueNode;
 };
 
+export type CommentNode = {
+  kind: 'Comment';
+  loc?: Location;
+  value: string;
+};
 
 // Fragments
 

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -21,6 +21,7 @@ export const VARIABLE = 'Variable';
 export const SELECTION_SET = 'SelectionSet';
 export const FIELD = 'Field';
 export const ARGUMENT = 'Argument';
+export const COMMENT = 'Comment';
 
 // Fragments
 

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -40,9 +40,7 @@ export function createLexer<TOptions>(
 function advanceLexer() {
   let token = this.lastToken = this.token;
   if (token.kind !== EOF) {
-    do {
-      token = token.next = readToken(this, token);
-    } while (token.kind === COMMENT);
+    token = token.next = readToken(this, token);
     this.token = token;
   }
   return token;

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -33,6 +33,7 @@ import type {
   SelectionNode,
   FieldNode,
   ArgumentNode,
+  CommentNode,
 
   FragmentSpreadNode,
   InlineFragmentNode,
@@ -80,6 +81,7 @@ import {
   SELECTION_SET,
   FIELD,
   ARGUMENT,
+  COMMENT,
 
   FRAGMENT_SPREAD,
   INLINE_FRAGMENT,
@@ -431,6 +433,19 @@ function parseArgument(lexer: Lexer<*>): ArgumentNode {
     kind: ARGUMENT,
     name: parseName(lexer),
     value: (expect(lexer, TokenKind.COLON), parseValueLiteral(lexer, false)),
+    loc: loc(lexer, start)
+  };
+}
+
+/**
+ * Coment : Value
+ */
+// FIXME This is never used anywhere
+function parseComment(lexer: Lexer<*>): CommentNode {
+  const start = lexer.token;
+  return {
+    kind: COMMENT,
+    value: expect(lexer, TokenKind.COMMENT),
     loc: loc(lexer, start)
   };
 }

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -52,6 +52,8 @@ const printDocASTReducer = {
 
   Argument: ({ name, value }) => name + ': ' + value,
 
+  Comment: ({ value }) => '# ' + value,
+
   // Fragments
 
   FragmentSpread: ({ name, directives }) =>

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -18,6 +18,7 @@ export const QueryDocumentKeys = {
   SelectionSet: [ 'selections' ],
   Field: [ 'alias', 'name', 'arguments', 'directives', 'selectionSet' ],
   Argument: [ 'name', 'value' ],
+  Comment: [],
 
   FragmentSpread: [ 'name', 'directives' ],
   InlineFragment: [ 'typeCondition', 'directives', 'selectionSet' ],


### PR DESCRIPTION
**WIP WIP WIP**

This follows attempt and discussion started at https://github.com/graphql/graphiql/pull/578.

Opening this early to validate: am I going into the wall here?

Because the printer takes a parsed AST as an input, what this is doing for now is trying to keep comments in said parsed AST.
But is it something actually reasonable? Should comments be kept in the AST? If not, I'm not sure how to achieve this without changing the printer so that it takes the result of `lexer` as an input instead of the result of `parse`.

I was recommended in the link above to take example from [prettier](https://github.com/prettier/prettier) which already supports printing comments (as well as other goodies such breaking arguments into multiple lines when a line gets too long), but being entirely new to both codebases, it's rather difficult for me to understand, at least for now.

I'm more than happy to spend more time on this as I do want to achieve this, but any help would be welcome here :)