### PR TITLE
Correct types for 'path' & 'parentType' of GraphQLResolveInfo

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -238,7 +238,7 @@ export function responsePathAsArray(
  * Given a ResponsePath and a key, return a new ResponsePath containing the
  * new key.
  */
-export function addPath(prev: ?ResponsePath, key: string | number) {
+export function addPath(prev: ResponsePath | void, key: string | number) {
   return { prev, key };
 }
 
@@ -419,7 +419,7 @@ function executeFieldsSerially(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   sourceValue: mixed,
-  path: ?ResponsePath,
+  path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
 ): Promise<ObjMap<mixed>> {
   return Object.keys(fields).reduce(
@@ -458,7 +458,7 @@ function executeFields(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   sourceValue: mixed,
-  path: ?ResponsePath,
+  path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
 ): Promise<ObjMap<mixed>> | ObjMap<mixed> {
   let containsPromise = false;

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -238,7 +238,7 @@ export function responsePathAsArray(
  * Given a ResponsePath and a key, return a new ResponsePath containing the
  * new key.
  */
-export function addPath(prev: ResponsePath, key: string | number) {
+export function addPath(prev: ?ResponsePath, key: string | number) {
   return { prev, key };
 }
 
@@ -419,7 +419,7 @@ function executeFieldsSerially(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   sourceValue: mixed,
-  path: ResponsePath,
+  path: ?ResponsePath,
   fields: ObjMap<Array<FieldNode>>,
 ): Promise<ObjMap<mixed>> {
   return Object.keys(fields).reduce(
@@ -458,7 +458,7 @@ function executeFields(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   sourceValue: mixed,
-  path: ResponsePath,
+  path: ?ResponsePath,
   fields: ObjMap<Array<FieldNode>>,
 ): Promise<ObjMap<mixed>> | ObjMap<mixed> {
   let containsPromise = false;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -643,7 +643,7 @@ export type GraphQLResolveInfo = {
   variableValues: {[variable: string]: mixed};
 };
 
-export type ResponsePath = { prev: ?ResponsePath, key: string | number };
+export type ResponsePath = { prev: ResponsePath | void, key: string | number };
 
 export type GraphQLFieldConfig<TSource, TContext> = {
   type: GraphQLOutputType;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -634,7 +634,7 @@ export type GraphQLResolveInfo = {
   fieldName: string;
   fieldNodes: Array<FieldNode>;
   returnType: GraphQLOutputType;
-  parentType: GraphQLCompositeType;
+  parentType: GraphQLObjectType;
   path: ResponsePath;
   schema: GraphQLSchema;
   fragments: ObjMap<FragmentDefinitionNode>;
@@ -643,7 +643,7 @@ export type GraphQLResolveInfo = {
   variableValues: {[variable: string]: mixed};
 };
 
-export type ResponsePath = { prev: ResponsePath, key: string | number } | void;
+export type ResponsePath = { prev: ?ResponsePath, key: string | number };
 
 export type GraphQLFieldConfig<TSource, TContext> = {
   type: GraphQLOutputType;


### PR DESCRIPTION
In this PR I corrected types for `path` and `parentType` fields of `GraphQLResolveInfo`.
Without this info, I forced to add additional checks to my resolvers:
```ts
if (info.parentType instanceof GraphQLObjectType) {
  // ...
}
if (info.path) {
 // ...
}
```
Both checks always true and this is obvious from  code of [buildResolveInfo](https://github.com/APIs-guru/graphql-js/blob/2d43dd65a1b784ac790e66d0cc64a4c7b0a5a901/src/execution/execute.js#L701-L702) function.
But I forced to add above checks in all my resolvers 😞 

@wincent This PR affects only typings and doesn't change any runtime behaviour. Can you please review it?