### PR TITLE
Check isDeprecated instead of deprecationReason in printDeprecated

### DIFF
--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -245,10 +245,9 @@ function printDirective(directive) {
 }
 
 function printDeprecated(fieldOrEnumVal) {
-   if (fieldOrEnumVal.isDeprecated === false) {
-        return '';
-   }
-
+  if (!fieldOrEnumVal.isDeprecated) {
+    return '';
+  }
   const reason = fieldOrEnumVal.deprecationReason;
   if (
     isNullish(reason) ||

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -245,11 +245,13 @@ function printDirective(directive) {
 }
 
 function printDeprecated(fieldOrEnumVal) {
+   if (fieldOrEnumVal.isDeprecated === false) {
+        return '';
+   }
+
   const reason = fieldOrEnumVal.deprecationReason;
-  if (isNullish(reason)) {
-    return '';
-  }
   if (
+    isNullish(reason) ||
     reason === '' ||
     reason === DEFAULT_DEPRECATION_REASON
   ) {


### PR DESCRIPTION
`isDeprecated` is to determine deprecation instead of `deprecatedReason`.

currently `"isDeprecated"` is totally ignored, for example, if the input is like `{"isDeprecated": false, "deprecationReason": "-"}` it will be treated as deprecated, it is wrong.