### PR TITLE
Fix how TypeInfo handles inline fragments without type

### DIFF
--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -1066,7 +1066,9 @@ describe('Visitor', () => {
 
       const typeInfo = new TypeInfo(testSchema);
 
-      const ast = parse('{ human(id: 4) { name, pets { name }, unknown } }');
+      const ast = parse(
+        '{ human(id: 4) { name, pets { ... { name } }, unknown } }'
+      );
       visit(ast, visitWithTypeInfo(typeInfo, {
         enter(node) {
           const parentType = typeInfo.getParentType();
@@ -1118,10 +1120,14 @@ describe('Visitor', () => {
         [ 'enter', 'Name', 'pets', 'Human', '[Pet]', null ],
         [ 'leave', 'Name', 'pets', 'Human', '[Pet]', null ],
         [ 'enter', 'SelectionSet', null, 'Pet', '[Pet]', null ],
+        [ 'enter', 'InlineFragment', null, 'Pet', 'Pet', null ],
+        [ 'enter', 'SelectionSet', null, 'Pet', 'Pet', null ],
         [ 'enter', 'Field', null, 'Pet', 'String', null ],
         [ 'enter', 'Name', 'name', 'Pet', 'String', null ],
         [ 'leave', 'Name', 'name', 'Pet', 'String', null ],
         [ 'leave', 'Field', null, 'Pet', 'String', null ],
+        [ 'leave', 'SelectionSet', null, 'Pet', 'Pet', null ],
+        [ 'leave', 'InlineFragment', null, 'Pet', 'Pet', null ],
         [ 'leave', 'SelectionSet', null, 'Pet', '[Pet]', null ],
         [ 'leave', 'Field', null, 'Human', '[Pet]', null ],
         [ 'enter', 'Field', null, 'Human', null, null ],

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -150,7 +150,7 @@ export class TypeInfo {
         const typeConditionAST = node.typeCondition;
         const outputType = typeConditionAST ?
           typeFromAST(schema, typeConditionAST) :
-          this.getType();
+          getNamedType(this.getType());
         this._typeStack.push(
           isOutputType(outputType) ? outputType : undefined
         );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8336157/30555221-aa86e310-9caf-11e7-9f59-ddab2bcf173d.png)

[Try it](http://graphql.org/swapi-graphql/?query=%7B%0A%20%20allFilms%20%7B%0A%20%20%20%20films%20%7B%0A%20%20%20%20%20%20...%20%7B%0A%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=null)

This issue caused because `TypeInfo` incorrectly handles inline fragments without type condition.
#1027 masked this issue by introducing [additional type check](https://github.com/graphql/graphql-js/pull/1027/files#diff-7fee6c60aa31bc90e45e7a2fd844026dR48) but underlying bug in `TypeInfo` still exists.