### PR TITLE
fix flow errors by annotating null prototypes

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,4 +12,4 @@
 experimental.const_params=true
 
 [version]
-^0.54.0
+^0.56.0

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "4.4.1",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-flowtype": "2.35.0",
-    "flow-bin": "^0.54.0",
+    "flow-bin": "0.56.0",
     "isparta": "4.0.0",
     "mocha": "3.5.0",
     "sane": "2.0.0"

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -51,8 +51,8 @@ import type {
 export function getVariableValues(
   schema: GraphQLSchema,
   varDefNodes: Array<VariableDefinitionNode>,
-  inputs: { [key: string]: mixed }
-): { [key: string]: mixed } {
+  inputs: { [key: string]: mixed, __proto__: null }
+): { [key: string]: mixed, __proto__: null } {
   const coercedValues = Object.create(null);
   for (let i = 0; i < varDefNodes.length; i++) {
     const varDefNode = varDefNodes[i];
@@ -105,8 +105,8 @@ export function getVariableValues(
 export function getArgumentValues(
   def: GraphQLField<*, *> | GraphQLDirective,
   node: FieldNode | DirectiveNode,
-  variableValues?: ?{ [key: string]: mixed }
-): { [key: string]: mixed } {
+  variableValues?: ?{ [key: string]: mixed, __proto__: null }
+): { [key: string]: mixed, __proto__: null } {
   const argDefs = def.args;
   const argNodes = node.arguments;
   if (!argDefs || !argNodes) {
@@ -174,8 +174,8 @@ export function getArgumentValues(
 export function getDirectiveValues(
   directiveDef: GraphQLDirective,
   node: { directives?: ?Array<DirectiveNode> },
-  variableValues?: ?{ [key: string]: mixed }
-): void | { [key: string]: mixed } {
+  variableValues?: ?{ [key: string]: mixed, __proto__: null }
+): void | { [key: string]: mixed, __proto__: null } {
   const directiveNode = node.directives && find(
     node.directives,
     directive => directive.name.value === directiveDef.name

--- a/src/jsutils/ObjMap.js
+++ b/src/jsutils/ObjMap.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type ObjMap<T> = { [key: string]: T, __proto__: null };

--- a/src/jsutils/keyMap.js
+++ b/src/jsutils/keyMap.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ObjMap} from './ObjMap';
+
 /**
  * Creates a keyed JS object from an array, given a function to produce the keys
  * for each value in the array.
@@ -33,7 +35,7 @@
 export default function keyMap<T>(
   list: Array<T>,
   keyFn: (item: T) => string
-): {[key: string]: T} {
+): ObjMap<T> {
   return list.reduce(
     (map, item) => ((map[keyFn(item)] = item), map),
     Object.create(null)

--- a/src/jsutils/keyValMap.js
+++ b/src/jsutils/keyValMap.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ObjMap} from './ObjMap';
+
 /**
  * Creates a keyed JS object from an array, given a function to produce the keys
  * and a function to produce the values from each item in the array.
@@ -28,7 +30,7 @@ export default function keyValMap<T, V>(
   list: Array<T>,
   keyFn: (item: T) => string,
   valFn: (item: T) => V
-): {[key: string]: V} {
+): ObjMap<V> {
   return list.reduce(
     (map, item) => ((map[keyFn(item)] = valFn(item)), map),
     Object.create(null)

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -9,6 +9,7 @@
 
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
+import type {ObjMap} from '../jsutils/ObjMap';
 import * as Kind from '../language/kinds';
 import { assertValidName } from '../utilities/assertValidName';
 import type {
@@ -624,7 +625,7 @@ export type GraphQLIsTypeOfFn<TSource, TContext> = (
 
 export type GraphQLFieldResolver<TSource, TContext> = (
   source: TSource,
-  args: { [argName: string]: any },
+  args: ObjMap<any>,
   context: TContext,
   info: GraphQLResolveInfo
 ) => mixed;
@@ -636,10 +637,10 @@ export type GraphQLResolveInfo = {
   parentType: GraphQLCompositeType;
   path: ResponsePath;
   schema: GraphQLSchema;
-  fragments: { [fragmentName: string]: FragmentDefinitionNode };
+  fragments: ObjMap<FragmentDefinitionNode>;
   rootValue: mixed;
   operation: OperationDefinitionNode;
-  variableValues: { [variableName: string]: mixed };
+  variableValues: ObjMap<mixed>;
 };
 
 export type ResponsePath = { prev: ResponsePath, key: string | number } | void;
@@ -654,9 +655,7 @@ export type GraphQLFieldConfig<TSource, TContext> = {
   astNode?: ?FieldDefinitionNode;
 };
 
-export type GraphQLFieldConfigArgumentMap = {
-  [argName: string]: GraphQLArgumentConfig;
-};
+export type GraphQLFieldConfigArgumentMap = ObjMap<GraphQLArgumentConfig>;
 
 export type GraphQLArgumentConfig = {
   type: GraphQLInputType;
@@ -665,9 +664,8 @@ export type GraphQLArgumentConfig = {
   astNode?: ?InputValueDefinitionNode;
 };
 
-export type GraphQLFieldConfigMap<TSource, TContext> = {
-  [fieldName: string]: GraphQLFieldConfig<TSource, TContext>;
-};
+export type GraphQLFieldConfigMap<TSource, TContext> =
+  ObjMap<GraphQLFieldConfig<TSource, TContext>>;
 
 export type GraphQLField<TSource, TContext> = {
   name: string;
@@ -689,9 +687,8 @@ export type GraphQLArgument = {
   astNode?: ?InputValueDefinitionNode;
 };
 
-export type GraphQLFieldMap<TSource, TContext> = {
-  [fieldName: string]: GraphQLField<TSource, TContext>;
-};
+export type GraphQLFieldMap<TSource, TContext> =
+  ObjMap<GraphQLField<TSource, TContext>>;
 
 
 
@@ -918,7 +915,7 @@ export class GraphQLEnumType/* <T> */ {
   _enumConfig: GraphQLEnumTypeConfig/* <T> */;
   _values: Array<GraphQLEnumValue/* <T> */>;
   _valueLookup: Map<any/* T */, GraphQLEnumValue>;
-  _nameLookup: { [valueName: string]: GraphQLEnumValue };
+  _nameLookup: ObjMap<GraphQLEnumValue>;
 
   constructor(config: GraphQLEnumTypeConfig/* <T> */): void {
     this.name = config.name;
@@ -981,7 +978,7 @@ export class GraphQLEnumType/* <T> */ {
     return this._valueLookup;
   }
 
-  _getNameLookup(): { [valueName: string]: GraphQLEnumValue } {
+  _getNameLookup(): ObjMap<GraphQLEnumValue> {
     if (!this._nameLookup) {
       const lookup = Object.create(null);
       this.getValues().forEach(value => {
@@ -1055,9 +1052,8 @@ export type GraphQLEnumTypeConfig/* <T> */ = {
   isIntrospection?: boolean;
 };
 
-export type GraphQLEnumValueConfigMap/* <T> */ = {
-  [valueName: string]: GraphQLEnumValueConfig/* <T> */;
-};
+export type GraphQLEnumValueConfigMap/* <T> */ =
+  ObjMap<GraphQLEnumValueConfig/* <T> */>;
 
 export type GraphQLEnumValueConfig/* <T> */ = {
   value?: any/* T */;
@@ -1179,9 +1175,8 @@ export type GraphQLInputFieldConfig = {
   astNode?: ?InputValueDefinitionNode;
 };
 
-export type GraphQLInputFieldConfigMap = {
-  [fieldName: string]: GraphQLInputFieldConfig;
-};
+export type GraphQLInputFieldConfigMap =
+  ObjMap<GraphQLInputFieldConfig>;
 
 export type GraphQLInputField = {
   name: string;
@@ -1191,9 +1186,8 @@ export type GraphQLInputField = {
   astNode?: ?InputValueDefinitionNode;
 };
 
-export type GraphQLInputFieldMap = {
-  [fieldName: string]: GraphQLInputField;
-};
+export type GraphQLInputFieldMap =
+  ObjMap<GraphQLInputField>;
 
 
 

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -25,6 +25,7 @@ import { GraphQLDirective, specifiedDirectives } from './directives';
 import { __Schema } from './introspection';
 import find from '../jsutils/find';
 import invariant from '../jsutils/invariant';
+import type {ObjMap} from '../jsutils/ObjMap';
 import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators';
 
 
@@ -61,10 +62,8 @@ export class GraphQLSchema {
   _subscriptionType: ?GraphQLObjectType;
   _directives: Array<GraphQLDirective>;
   _typeMap: TypeMap;
-  _implementations: { [interfaceName: string]: Array<GraphQLObjectType> };
-  _possibleTypeMap: ?{
-    [abstractName: string]: { [possibleName: string]: boolean }
-  };
+  _implementations: ObjMap<Array<GraphQLObjectType>>;
+  _possibleTypeMap: ?ObjMap<{[possibleName: string]: boolean}>;
 
   constructor(config: GraphQLSchemaConfig): void {
     invariant(
@@ -221,7 +220,7 @@ export class GraphQLSchema {
   }
 }
 
-type TypeMap = { [typeName: string]: GraphQLNamedType };
+type TypeMap = ObjMap<GraphQLNamedType>;
 
 type GraphQLSchemaConfig = {
   query: GraphQLObjectType;

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -9,6 +9,7 @@
 
 import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
+import type {ObjMap} from '../jsutils/ObjMap';
 import { valueFromAST } from './valueFromAST';
 import { TokenKind } from '../language/lexer';
 import { parse } from '../language/parser';
@@ -133,7 +134,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
   let schemaDef: ?SchemaDefinitionNode;
 
   const typeDefs: Array<TypeDefinitionNode> = [];
-  const nodeMap: {[name: string]: TypeDefinitionNode} = Object.create(null);
+  const nodeMap: ObjMap<TypeDefinitionNode> = Object.create(null);
   const directiveDefs: Array<DirectiveDefinitionNode> = [];
   for (let i = 0; i < ast.definitions.length; i++) {
     const d = ast.definitions[i];

--- a/src/utilities/separateOperations.js
+++ b/src/utilities/separateOperations.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type {ObjMap} from '../jsutils/ObjMap';
 import { visit } from '../language/visitor';
 import type {
   DocumentNode,
@@ -21,8 +22,7 @@ import type {
  */
 export function separateOperations(
   documentAST: DocumentNode
-): { [operationName: string]: DocumentNode } {
-
+): ObjMap<DocumentNode> {
   const operations = [];
   const fragments = Object.create(null);
   const positions = new Map();
@@ -76,7 +76,10 @@ export function separateOperations(
   return separatedDocumentASTs;
 }
 
-type DepGraph = {[from: string]: {[to: string]: boolean}};
+type DepGraph = {
+  [from: string]: {[to: string]: boolean, __proto__: null},
+  __proto__: null,
+};
 
 // Provides the empty string for anonymous operations.
 function opName(operation: OperationDefinitionNode): string {
@@ -86,7 +89,7 @@ function opName(operation: OperationDefinitionNode): string {
 // From a dependency graph, collects a list of transitive dependencies by
 // recursing through a dependency graph.
 function collectTransitiveDependencies(
-  collected: {[key: string]: boolean},
+  collected: {[key: string]: boolean, __proto__: null},
   depGraph: DepGraph,
   fromName: string
 ): void {

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -11,6 +11,7 @@ import keyMap from '../jsutils/keyMap';
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
 import isInvalid from '../jsutils/isInvalid';
+import type {ObjMap} from '../jsutils/ObjMap';
 import * as Kind from '../language/kinds';
 import {
   GraphQLScalarType,
@@ -51,7 +52,7 @@ import type {
 export function valueFromAST(
   valueNode: ?ValueNode,
   type: GraphQLInputType,
-  variables?: ?{ [key: string]: mixed }
+  variables?: ?ObjMap<mixed>
 ): mixed | void {
   if (!valueNode) {
     // When there is no node, then there is also no value.

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -10,6 +10,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import find from '../../jsutils/find';
+import type {ObjMap} from '../../jsutils/ObjMap';
 import type {
   SelectionSetNode,
   FieldNode,
@@ -99,7 +100,7 @@ type ConflictReasonMessage = string | Array<ConflictReason>;
 // Tuple defining a field node in a context.
 type NodeAndDef = [ GraphQLCompositeType, FieldNode, ?GraphQLField<*, *> ];
 // Map of array of those.
-type NodeAndDefCollection = { [key: string]: Array<NodeAndDef> };
+type NodeAndDefCollection = ObjMap<Array<NodeAndDef>>;
 
 /**
  * Algorithm:
@@ -773,7 +774,7 @@ function subfieldConflicts(
  * not matter. We do this by maintaining a sort of double adjacency sets.
  */
 class PairSet {
-  _data: {[a: string]: {[b: string]: boolean}};
+  _data: ObjMap<ObjMap<boolean>>;
 
   constructor(): void {
     this._data = Object.create(null);

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -8,6 +8,7 @@
  */
 
 import invariant from '../jsutils/invariant';
+import type {ObjMap} from '../jsutils/ObjMap';
 import { GraphQLError } from '../error';
 import { visit, visitInParallel, visitWithTypeInfo } from '../language/visitor';
 import * as Kind from '../language/kinds';
@@ -101,7 +102,7 @@ export class ValidationContext {
   _ast: DocumentNode;
   _typeInfo: TypeInfo;
   _errors: Array<GraphQLError>;
-  _fragments: {[name: string]: FragmentDefinitionNode};
+  _fragments: ObjMap<FragmentDefinitionNode>;
   _fragmentSpreads: Map<SelectionSetNode, Array<FragmentSpreadNode>>;
   _recursivelyReferencedFragments: Map<
     OperationDefinitionNode,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,9 +1224,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.54.0:
-  version "0.54.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.0.tgz#f2fb0478e9e99702b623c9ed84079a39903bba77"
+flow-bin@0.56.0:
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.56.0.tgz#ce43092203a344ba9bf63c0cabe95d95145f6cad"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
From `flow@0.55.0`, flow started doing a more strict `null` prototype check. Fix them by annotating them with:
```
__proto__: null
```