### PR TITLE
Upgrade iterall dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gitpublish": ". ./resources/gitpublish.sh"
   },
   "dependencies": {
-    "iterall": "1.1.2"
+    "iterall": "1.1.3"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,9 +1677,9 @@ istanbul@^0.4.0:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-iterall@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.2.tgz#413332b3cdb46f8f5ede57d6cd8e3ca8a9df8816"
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 jodid25519@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Pulls in necessary fix for breakage in 1.1.2:

https://github.com/leebyron/iterall/commit/325e8ff9e7cd966156688d2012b16f3a588b886a