### PR TITLE
make buildObjectDef more robust

### DIFF
--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -741,6 +741,38 @@ describe('Type System: build schema from introspection', () => {
       );
     });
 
+    it('throws when null interfaces given', () => {
+      const nullInterfaceIntrospection = {
+        __schema: {
+          queryType: { name: 'QueryType' },
+          types: [
+            {
+              kind: 'OBJECT',
+              name: 'QueryType',
+              fields: [
+                {
+                  name: 'aString',
+                  args: [],
+                  type: { kind: 'SCALAR', name: 'String', ofType: null },
+                  isDeprecated: false,
+                }
+              ],
+              interfaces: null,
+            }
+          ]
+        }
+      };
+
+      expect(
+        () => buildClientSchema(nullInterfaceIntrospection)
+      ).to.throw(
+        'Introspection result missing interfaces: {"kind":"OBJECT",' +
+        '"name":"QueryType","fields":[{"name":"aString","args":[],' +
+        '"type":{"kind":"SCALAR","name":"String","ofType":null},' +
+        '"isDeprecated":false}],"interfaces":null}'
+      );
+    });
+
   });
 
   describe('very deep decorators are not supported', () => {

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -741,7 +741,7 @@ describe('Type System: build schema from introspection', () => {
       );
     });
 
-    it('throws when null interfaces given', () => {
+    it('throws when missing interfaces', () => {
       const nullInterfaceIntrospection = {
         __schema: {
           queryType: { name: 'QueryType' },
@@ -757,7 +757,6 @@ describe('Type System: build schema from introspection', () => {
                   isDeprecated: false,
                 }
               ],
-              interfaces: null,
             }
           ]
         }
@@ -769,7 +768,7 @@ describe('Type System: build schema from introspection', () => {
         'Introspection result missing interfaces: {"kind":"OBJECT",' +
         '"name":"QueryType","fields":[{"name":"aString","args":[],' +
         '"type":{"kind":"SCALAR","name":"String","ofType":null},' +
-        '"isDeprecated":false}],"interfaces":null}'
+        '"isDeprecated":false}]}'
       );
     });
 


### PR DESCRIPTION
The introspection schema says `__Type.interfaces` is nullable. This protects the function from throwing an exception when it is in fact `null`.