### PR TITLE
Wrapper method on type classes

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -11,7 +11,6 @@ import {
   GraphQLEnumType,
   GraphQLInterfaceType,
   GraphQLObjectType,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLSchema,
   GraphQLString,
@@ -118,12 +117,12 @@ const characterInterface = new GraphQLInterfaceType({
       description: 'The name of the character.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: characterInterface.wrapList(),
       description: 'The friends of the character, or an empty list if they ' +
                    'have none.',
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: episodeEnum.wrapList(),
       description: 'Which movies they appear in.',
     },
     secretBackstory: {
@@ -166,13 +165,13 @@ const humanType = new GraphQLObjectType({
       description: 'The name of the human.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: characterInterface.wrapList(),
       description:
         'The friends of the human, or an empty list if they have none.',
       resolve: human => getFriends(human),
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: episodeEnum.wrapList(),
       description: 'Which movies they appear in.',
     },
     homePlanet: {
@@ -216,13 +215,13 @@ const droidType = new GraphQLObjectType({
       description: 'The name of the droid.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: characterInterface.wrapList(),
       description:
         'The friends of the droid, or an empty list if they have none.',
       resolve: droid => getFriends(droid),
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: episodeEnum.wrapList(),
       description: 'Which movies they appear in.',
     },
     secretBackstory: {

--- a/src/execution/__tests__/abstract-promise-test.js
+++ b/src/execution/__tests__/abstract-promise-test.js
@@ -13,7 +13,6 @@ import {
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
-  GraphQLList,
   GraphQLString,
   GraphQLBoolean,
 } from '../../';
@@ -73,7 +72,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [ new Dog('Odie', true), new Cat('Garfield', false) ];
             }
@@ -140,7 +139,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [ new Dog('Odie', true), new Cat('Garfield', false) ];
             }
@@ -212,7 +211,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [ new Dog('Odie', true), new Cat('Garfield', false) ];
             }
@@ -290,7 +289,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return Promise.resolve([
                 new Dog('Odie', true),
@@ -380,7 +379,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -465,7 +464,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -536,7 +535,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [
                 new Dog('Odie', true),

--- a/src/execution/__tests__/abstract-test.js
+++ b/src/execution/__tests__/abstract-test.js
@@ -13,7 +13,6 @@ import {
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
-  GraphQLList,
   GraphQLString,
   GraphQLBoolean,
 } from '../../';
@@ -73,7 +72,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [ new Dog('Odie', true), new Cat('Garfield', false) ];
             }
@@ -136,7 +135,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [ new Dog('Odie', true), new Cat('Garfield', false) ];
             }
@@ -214,7 +213,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -304,7 +303,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -389,7 +388,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: PetType.wrapList(),
             resolve() {
               return [
                 new Dog('Odie', true),

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -13,7 +13,6 @@ import { parse } from '../../language';
 import {
   GraphQLSchema,
   GraphQLObjectType,
-  GraphQLList,
   GraphQLBoolean,
   GraphQLInt,
   GraphQLString,
@@ -180,8 +179,8 @@ describe('Execute: Handles basic execution tasks', () => {
       fields: {
         a: { type: GraphQLString },
         b: { type: GraphQLString },
-        c: { type: new GraphQLList(GraphQLString) },
-        deeper: { type: new GraphQLList(DataType) },
+        c: { type: GraphQLString.wrapList() },
+        deeper: { type: DataType.wrapList() },
       }
     });
 
@@ -425,7 +424,7 @@ describe('Execute: Handles basic execution tasks', () => {
           syncError: { type: GraphQLString },
           syncRawError: { type: GraphQLString },
           syncReturnError: { type: GraphQLString },
-          syncReturnErrorList: { type: new GraphQLList(GraphQLString) },
+          syncReturnErrorList: { type: GraphQLString.wrapList() },
           async: { type: GraphQLString },
           asyncReject: { type: GraphQLString },
           asyncRawReject: { type: GraphQLString },
@@ -938,7 +937,7 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Query',
         fields: {
           specials: {
-            type: new GraphQLList(SpecialType),
+            type: SpecialType.wrapList(),
             resolve: rootValue => rootValue.specials
           }
         }

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -18,7 +18,6 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLInt,
-  GraphQLList,
   GraphQLNonNull
 } from '../../type';
 
@@ -69,7 +68,7 @@ function check(testType, testData, expected) {
 describe('Execute: Accepts any iterable as list value', () => {
 
   it('Accepts a Set as a List value', check(
-    new GraphQLList(GraphQLString),
+    GraphQLString.wrapList(),
     new Set([ 'apple', 'banana', 'apple', 'coconut' ]),
     { data: { nest: { test: [ 'apple', 'banana', 'coconut' ] } } }
   ));
@@ -81,7 +80,7 @@ describe('Execute: Accepts any iterable as list value', () => {
   }
 
   it('Accepts an Generator function as a List value', check(
-    new GraphQLList(GraphQLString),
+    GraphQLString.wrapList(),
     yieldItems(),
     { data: { nest: { test: [ 'one', '2', 'true' ] } } }
   ));
@@ -91,13 +90,13 @@ describe('Execute: Accepts any iterable as list value', () => {
   }
 
   it('Accepts function arguments as a List value', check(
-    new GraphQLList(GraphQLString),
+    GraphQLString.wrapList(),
     getArgs('one', 'two'),
     { data: { nest: { test: [ 'one', 'two' ] } } }
   ));
 
   it('Does not accept (Iterable) String-literal as a List value', check(
-    new GraphQLList(GraphQLString),
+    GraphQLString.wrapList(),
     'Singluar',
     { data: { nest: { test: null } },
       errors: [ {
@@ -112,7 +111,7 @@ describe('Execute: Accepts any iterable as list value', () => {
 describe('Execute: Handles list nullability', () => {
 
   describe('[T]', () => {
-    const type = new GraphQLList(GraphQLInt);
+    const type = GraphQLInt.wrapList();
 
     describe('Array<T>', () => {
 
@@ -190,7 +189,7 @@ describe('Execute: Handles list nullability', () => {
   });
 
   describe('[T]!', () => {
-    const type = new GraphQLNonNull(new GraphQLList(GraphQLInt));
+    const type = new GraphQLNonNull(GraphQLInt.wrapList());
 
     describe('Array<T>', () => {
 
@@ -277,7 +276,7 @@ describe('Execute: Handles list nullability', () => {
   });
 
   describe('[T!]', () => {
-    const type = new GraphQLList(new GraphQLNonNull(GraphQLInt));
+    const type = (new GraphQLNonNull(GraphQLInt)).wrapList();
 
     describe('Array<T>', () => {
 
@@ -370,7 +369,7 @@ describe('Execute: Handles list nullability', () => {
 
   describe('[T!]!', () => {
     const type =
-      new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt)));
+      new GraphQLNonNull((new GraphQLNonNull(GraphQLInt)).wrapList());
 
     describe('Array<T>', () => {
 

--- a/src/execution/__tests__/schema-test.js
+++ b/src/execution/__tests__/schema-test.js
@@ -13,7 +13,6 @@ import { parse } from '../../language';
 import {
   GraphQLSchema,
   GraphQLObjectType,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLInt,
   GraphQLString,
@@ -56,7 +55,7 @@ describe('Execute: Handles execution with a complex schema', () => {
         author: { type: BlogAuthor },
         title: { type: GraphQLString },
         body: { type: GraphQLString },
-        keywords: { type: new GraphQLList(GraphQLString) }
+        keywords: { type: GraphQLString.wrapList() }
       }
     });
 
@@ -69,7 +68,7 @@ describe('Execute: Handles execution with a complex schema', () => {
           resolve: (_, { id }) => article(id)
         },
         feed: {
-          type: new GraphQLList(BlogArticle),
+          type: BlogArticle.wrapList(),
           resolve: () => [
             article(1),
             article(2),

--- a/src/execution/__tests__/union-interface-test.js
+++ b/src/execution/__tests__/union-interface-test.js
@@ -15,7 +15,6 @@ import {
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
-  GraphQLList,
   GraphQLString,
   GraphQLBoolean
 } from '../../type';
@@ -88,8 +87,8 @@ const PersonType = new GraphQLObjectType({
   interfaces: [ NamedType ],
   fields: {
     name: { type: GraphQLString },
-    pets: { type: new GraphQLList(PetType) },
-    friends: { type: new GraphQLList(NamedType) },
+    pets: { type: PetType.wrapList() },
+    friends: { type: NamedType.wrapList() },
   },
   isTypeOf: value => value instanceof Person
 });
@@ -369,7 +368,7 @@ describe('Execute: Union and intersection types', () => {
       interfaces: [ NamedType2 ],
       fields: {
         name: { type: GraphQLString },
-        friends: { type: new GraphQLList(NamedType2) },
+        friends: { type: NamedType2.wrapList() },
       },
     });
 

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -17,7 +17,6 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLString,
   GraphQLNonNull,
   GraphQLScalarType
@@ -49,7 +48,7 @@ const TestInputObject = new GraphQLInputObjectType({
   name: 'TestInputObject',
   fields: {
     a: { type: GraphQLString },
-    b: { type: new GraphQLList(GraphQLString) },
+    b: { type: GraphQLString.wrapList() },
     c: { type: new GraphQLNonNull(GraphQLString) },
     d: { type: TestComplexScalar },
   }
@@ -97,23 +96,23 @@ const TestType = new GraphQLObjectType({
     },
     list: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLList(GraphQLString) } },
+      args: { input: { type: GraphQLString.wrapList() } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },
     nnList: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) } },
+      args: { input: { type: new GraphQLNonNull(GraphQLString.wrapList()) } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },
     listNN: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) } },
+      args: { input: { type: (new GraphQLNonNull(GraphQLString)).wrapList() } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },
     nnListNN: {
       type: GraphQLString,
       args: { input: { type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString)))
+        new GraphQLNonNull((new GraphQLNonNull(GraphQLString)).wrapList())
       } },
       resolve: (_, { input }) => input && JSON.stringify(input)
     },

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -14,7 +14,6 @@ import { parse } from '../../language';
 import {
   GraphQLSchema,
   GraphQLObjectType,
-  GraphQLList,
   GraphQLBoolean,
   GraphQLInt,
   GraphQLString,
@@ -41,7 +40,7 @@ const InboxType = new GraphQLObjectType({
       type: GraphQLInt,
       resolve: inbox => inbox.emails.filter(email => email.unread).length,
     },
-    emails: { type: new GraphQLList(EmailType) },
+    emails: { type: EmailType.wrapList() },
   }
 });
 

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -65,7 +65,7 @@ const BlogQuery = new GraphQLObjectType({
       type: BlogArticle
     },
     feed: {
-      type: new GraphQLList(BlogArticle)
+      type: BlogArticle.wrapList()
     }
   }
 });
@@ -340,16 +340,16 @@ describe('Type System: Example', () => {
       String(new GraphQLNonNull(GraphQLInt))
     ).to.equal('Int!');
     expect(
-      String(new GraphQLList(GraphQLInt))
+      String(GraphQLInt.wrapList())
     ).to.equal('[Int]');
     expect(
-      String(new GraphQLNonNull(new GraphQLList(GraphQLInt)))
+      String(new GraphQLNonNull(GraphQLInt.wrapList()))
     ).to.equal('[Int]!');
     expect(
-      String(new GraphQLList(new GraphQLNonNull(GraphQLInt)))
+      String((new GraphQLNonNull(GraphQLInt)).wrapList())
     ).to.equal('[Int!]');
     expect(
-      String(new GraphQLList(new GraphQLList(GraphQLInt)))
+      String(GraphQLInt.wrapList().wrapList())
     ).to.equal('[[Int]]');
   });
 
@@ -364,7 +364,7 @@ describe('Type System: Example', () => {
     ];
     expected.forEach(([ type, answer ]) => {
       expect(isInputType(type)).to.equal(answer);
-      expect(isInputType(new GraphQLList(type))).to.equal(answer);
+      expect(isInputType(type.wrapList())).to.equal(answer);
       expect(isInputType(new GraphQLNonNull(type))).to.equal(answer);
     });
   });
@@ -380,7 +380,7 @@ describe('Type System: Example', () => {
     ];
     expected.forEach(([ type, answer ]) => {
       expect(isOutputType(type)).to.equal(answer);
-      expect(isOutputType(new GraphQLList(type))).to.equal(answer);
+      expect(isOutputType(type.wrapList())).to.equal(answer);
       expect(isOutputType(new GraphQLNonNull(type))).to.equal(answer);
     });
   });
@@ -397,7 +397,7 @@ describe('Type System: Example', () => {
     const badUnionTypes = [
       GraphQLInt,
       new GraphQLNonNull(GraphQLInt),
-      new GraphQLList(GraphQLInt),
+      GraphQLInt.wrapList(),
       InterfaceType,
       UnionType,
       EnumType,

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -15,7 +15,6 @@ import {
   graphql,
   GraphQLSchema,
   GraphQLObjectType,
-  GraphQLList,
   GraphQLInputObjectType,
   GraphQLString,
   GraphQLEnumType,
@@ -823,7 +822,7 @@ describe('Introspection', () => {
       name: 'TestInputObject',
       fields: {
         a: { type: GraphQLString, defaultValue: 'foo' },
-        b: { type: new GraphQLList(GraphQLString) },
+        b: { type: GraphQLString.wrapList() },
         c: { type: GraphQLString, defaultValue: null }
       }
     });

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -70,9 +70,9 @@ const SomeInputObjectType = new GraphQLInputObjectType({
 
 function withModifiers(types) {
   return types
-    .concat(types.map(type => new GraphQLList(type)))
+    .concat(types.map(type => type.wrapList()))
     .concat(types.map(type => new GraphQLNonNull(type)))
-    .concat(types.map(type => new GraphQLNonNull(new GraphQLList(type))));
+    .concat(types.map(type => new GraphQLNonNull(type.wrapList())));
 }
 
 const outputTypes = withModifiers([
@@ -1604,7 +1604,7 @@ describe('Type System: List must accept GraphQL types', () => {
 
   types.forEach(type => {
     it(`accepts an type as item type of list: ${type}`, () => {
-      expect(() => new GraphQLList(type)).not.to.throw();
+      expect(() => type.wrapList()).not.to.throw();
     });
   });
 
@@ -1629,8 +1629,8 @@ describe('Type System: NonNull must accept GraphQL types', () => {
     SomeInterfaceType,
     SomeEnumType,
     SomeInputObjectType,
-    new GraphQLList(GraphQLString),
-    new GraphQLList(new GraphQLNonNull(GraphQLString)),
+    GraphQLString.wrapList(),
+    (new GraphQLNonNull(GraphQLString)).wrapList(),
   ];
 
   const notNullableTypes = [
@@ -2005,7 +2005,7 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) }
+          field: { type: new GraphQLNonNull(GraphQLString.wrapList()) }
         }
       });
 
@@ -2013,7 +2013,7 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherObject',
         interfaces: [ AnotherInterface ],
         fields: {
-          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) }
+          field: { type: new GraphQLNonNull(GraphQLString.wrapList()) }
         }
       });
 
@@ -2027,7 +2027,7 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: new GraphQLList(GraphQLString) }
+          field: { type: GraphQLString.wrapList() }
         }
       });
 
@@ -2060,7 +2060,7 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherObject',
         interfaces: [ AnotherInterface ],
         fields: {
-          field: { type: new GraphQLList(GraphQLString) }
+          field: { type: GraphQLString.wrapList() }
         }
       });
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -366,6 +366,10 @@ export class GraphQLScalarType {
     return this.name;
   }
 
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
+  }
+
   toJSON: () => string;
   inspect: () => string;
 }
@@ -464,6 +468,10 @@ export class GraphQLObjectType {
 
   toString(): string {
     return this.name;
+  }
+
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
   }
 
   toJSON: () => string;
@@ -743,6 +751,10 @@ export class GraphQLInterfaceType {
     return this.name;
   }
 
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
+  }
+
   toJSON: () => string;
   inspect: () => string;
 }
@@ -822,6 +834,10 @@ export class GraphQLUnionType {
 
   toString(): string {
     return this.name;
+  }
+
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
   }
 
   toJSON: () => string;
@@ -992,6 +1008,10 @@ export class GraphQLEnumType/* <T> */ {
     return this.name;
   }
 
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
+  }
+
   toJSON: () => string;
   inspect: () => string;
 }
@@ -1151,6 +1171,10 @@ export class GraphQLInputObjectType {
     return this.name;
   }
 
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
+  }
+
   toJSON: () => string;
   inspect: () => string;
 }
@@ -1223,6 +1247,10 @@ export class GraphQLList<T: GraphQLType> {
     return '[' + String(this.ofType) + ']';
   }
 
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
+  }
+
   toJSON: () => string;
   inspect: () => string;
 }
@@ -1267,6 +1295,10 @@ export class GraphQLNonNull<T: GraphQLNullableType> {
 
   toString(): string {
     return this.ofType.toString() + '!';
+  }
+
+  wrapList(): GraphQLList<*> {
+    return new GraphQLList(this);
   }
 
   toJSON: () => string;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -309,6 +309,7 @@ export class GraphQLScalarType {
   astNode: ?ScalarTypeDefinitionNode;
 
   _scalarConfig: GraphQLScalarTypeConfig<*, *>;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(config: GraphQLScalarTypeConfig<*, *>): void {
     assertValidName(config.name);
@@ -367,7 +368,7 @@ export class GraphQLScalarType {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -437,6 +438,7 @@ export class GraphQLObjectType {
   _typeConfig: GraphQLObjectTypeConfig<*, *>;
   _fields: GraphQLFieldMap<*, *>;
   _interfaces: Array<GraphQLInterfaceType>;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(config: GraphQLObjectTypeConfig<*, *>): void {
     assertValidName(config.name, config.isIntrospection);
@@ -471,7 +473,7 @@ export class GraphQLObjectType {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -726,6 +728,7 @@ export class GraphQLInterfaceType {
 
   _typeConfig: GraphQLInterfaceTypeConfig<*, *>;
   _fields: GraphQLFieldMap<*, *>;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(config: GraphQLInterfaceTypeConfig<*, *>): void {
     assertValidName(config.name);
@@ -752,7 +755,7 @@ export class GraphQLInterfaceType {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -810,6 +813,7 @@ export class GraphQLUnionType {
 
   _typeConfig: GraphQLUnionTypeConfig<*, *>;
   _types: Array<GraphQLObjectType>;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(config: GraphQLUnionTypeConfig<*, *>): void {
     assertValidName(config.name);
@@ -837,7 +841,7 @@ export class GraphQLUnionType {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -931,6 +935,7 @@ export class GraphQLEnumType/* <T> */ {
   _values: Array<GraphQLEnumValue/* <T> */>;
   _valueLookup: Map<any/* T */, GraphQLEnumValue>;
   _nameLookup: ObjMap<GraphQLEnumValue>;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(config: GraphQLEnumTypeConfig/* <T> */): void {
     this.name = config.name;
@@ -1009,7 +1014,7 @@ export class GraphQLEnumType/* <T> */ {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -1119,6 +1124,7 @@ export class GraphQLInputObjectType {
 
   _typeConfig: GraphQLInputObjectTypeConfig;
   _fields: GraphQLInputFieldMap;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(config: GraphQLInputObjectTypeConfig): void {
     assertValidName(config.name);
@@ -1172,7 +1178,7 @@ export class GraphQLInputObjectType {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -1226,14 +1232,15 @@ export type GraphQLInputFieldMap =
  *     const PersonType = new GraphQLObjectType({
  *       name: 'Person',
  *       fields: () => ({
- *         parents: { type: new GraphQLList(Person) },
- *         children: { type: new GraphQLList(Person) },
+ *         parents: { type: Person.wrapList() },
+ *         children: { type: Person.wrapList() },
  *       })
  *     })
  *
  */
 export class GraphQLList<T: GraphQLType> {
   ofType: T;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(type: T): void {
     invariant(
@@ -1248,7 +1255,7 @@ export class GraphQLList<T: GraphQLType> {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;
@@ -1283,6 +1290,7 @@ GraphQLList.prototype.toJSON =
  */
 export class GraphQLNonNull<T: GraphQLNullableType> {
   ofType: T;
+  _wrappedList: ?GraphQLList<*>;
 
   constructor(type: T): void {
     invariant(
@@ -1298,7 +1306,7 @@ export class GraphQLNonNull<T: GraphQLNullableType> {
   }
 
   wrapList(): GraphQLList<*> {
-    return new GraphQLList(this);
+    return this._wrappedList || (this._wrappedList = new GraphQLList(this));
   }
 
   toJSON: () => string;

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -36,7 +36,7 @@ export const __Schema = new GraphQLObjectType({
   fields: () => ({
     types: {
       description: 'A list of all types supported by this server.',
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__Type))),
+      type: new GraphQLNonNull((new GraphQLNonNull(__Type)).wrapList()),
       resolve(schema) {
         const typeMap = schema.getTypeMap();
         return Object.keys(typeMap).map(key => typeMap[key]);
@@ -62,7 +62,7 @@ export const __Schema = new GraphQLObjectType({
     directives: {
       description: 'A list of all directives supported by this server.',
       type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__Directive))),
+        new GraphQLNonNull((new GraphQLNonNull(__Directive)).wrapList()),
       resolve: schema => schema.getDirectives(),
     }
   })
@@ -82,13 +82,13 @@ export const __Directive = new GraphQLObjectType({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     locations: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(
+      type: new GraphQLNonNull((new GraphQLNonNull(
         __DirectiveLocation
-      )))
+      )).wrapList())
     },
     args: {
       type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__InputValue))),
+        new GraphQLNonNull((new GraphQLNonNull(__InputValue)).wrapList()),
       resolve: directive => directive.args || []
     },
     // NOTE: the following three fields are deprecated and are no longer part
@@ -238,7 +238,7 @@ export const __Type = new GraphQLObjectType({
     name: { type: GraphQLString },
     description: { type: GraphQLString },
     fields: {
-      type: new GraphQLList(new GraphQLNonNull(__Field)),
+      type: (new GraphQLNonNull(__Field)).wrapList(),
       args: {
         includeDeprecated: { type: GraphQLBoolean, defaultValue: false }
       },
@@ -257,7 +257,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     interfaces: {
-      type: new GraphQLList(new GraphQLNonNull(__Type)),
+      type: (new GraphQLNonNull(__Type)).wrapList(),
       resolve(type) {
         if (type instanceof GraphQLObjectType) {
           return type.getInterfaces();
@@ -265,7 +265,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     possibleTypes: {
-      type: new GraphQLList(new GraphQLNonNull(__Type)),
+      type: (new GraphQLNonNull(__Type)).wrapList(),
       resolve(type, args, context, { schema }) {
         if (isAbstractType(type)) {
           return schema.getPossibleTypes(type);
@@ -273,7 +273,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     enumValues: {
-      type: new GraphQLList(new GraphQLNonNull(__EnumValue)),
+      type: (new GraphQLNonNull(__EnumValue)).wrapList(),
       args: {
         includeDeprecated: { type: GraphQLBoolean, defaultValue: false }
       },
@@ -288,7 +288,7 @@ export const __Type = new GraphQLObjectType({
       }
     },
     inputFields: {
-      type: new GraphQLList(new GraphQLNonNull(__InputValue)),
+      type: (new GraphQLNonNull(__InputValue)).wrapList(),
       resolve(type) {
         if (type instanceof GraphQLInputObjectType) {
           const fieldMap = type.getFields();
@@ -311,7 +311,7 @@ export const __Field = new GraphQLObjectType({
     description: { type: GraphQLString },
     args: {
       type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__InputValue))),
+        new GraphQLNonNull((new GraphQLNonNull(__InputValue)).wrapList()),
       resolve: field => field.args || []
     },
     type: { type: new GraphQLNonNull(__Type) },

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -11,7 +11,6 @@ import { astFromValue } from '../astFromValue';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
@@ -197,7 +196,7 @@ describe('astFromValue', () => {
 
   it('converts array values to List ASTs', () => {
     expect(
-      astFromValue([ 'FOO', 'BAR' ], new GraphQLList(GraphQLString))
+      astFromValue([ 'FOO', 'BAR' ], GraphQLString.wrapList())
     ).to.deep.equal(
       { kind: 'ListValue',
         values: [
@@ -206,7 +205,7 @@ describe('astFromValue', () => {
     );
 
     expect(
-      astFromValue([ 'HELLO', 'GOODBYE' ], new GraphQLList(myEnum))
+      astFromValue([ 'HELLO', 'GOODBYE' ], myEnum.wrapList())
     ).to.deep.equal(
       { kind: 'ListValue',
         values: [
@@ -218,7 +217,7 @@ describe('astFromValue', () => {
   it('converts list singletons', () => {
     expect(astFromValue(
       'FOO',
-      new GraphQLList(GraphQLString)
+      GraphQLString.wrapList()
     )).to.deep.equal(
       { kind: 'StringValue', value: 'FOO' }
     );

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -18,7 +18,6 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLInt,
   GraphQLFloat,
@@ -286,16 +285,16 @@ describe('Type System: build schema from introspection', () => {
         name: 'ComplexFields',
         fields: {
           string: { type: GraphQLString },
-          listOfString: { type: new GraphQLList(GraphQLString) },
+          listOfString: { type: GraphQLString.wrapList() },
           nonNullString: {
             type: new GraphQLNonNull(GraphQLString)
           },
           nonNullListOfString: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLString))
+            type: new GraphQLNonNull(GraphQLString.wrapList())
           },
           nonNullListOfNonNullString: {
             type: new GraphQLNonNull(
-              new GraphQLList(new GraphQLNonNull(GraphQLString))
+              (new GraphQLNonNull(GraphQLString)).wrapList()
             )
           },
         }
@@ -326,7 +325,7 @@ describe('Type System: build schema from introspection', () => {
             args: {
               listArg: {
                 description: 'This is an list of int arg',
-                type: new GraphQLList(GraphQLInt)
+                type: GraphQLInt.wrapList()
               },
               requiredArg: {
                 description: 'This is a required arg',
@@ -499,7 +498,7 @@ describe('Type System: build schema from introspection', () => {
             type: GraphQLString,
             args: {
               listArg: {
-                type: new GraphQLList(GraphQLInt),
+                type: GraphQLInt.wrapList(),
                 defaultValue: [ 1, 2, 3 ]
               }
             }
@@ -752,10 +751,15 @@ describe('Type System: build schema from introspection', () => {
           name: 'Query',
           fields: {
             foo: {
-              type: new GraphQLList(new GraphQLList(new GraphQLList(
-                new GraphQLList(new GraphQLList(new GraphQLList(
-                new GraphQLList(new GraphQLList(GraphQLString))
-              ))))))
+              type: GraphQLString
+                .wrapList()
+                .wrapList()
+                .wrapList()
+                .wrapList()
+                .wrapList()
+                .wrapList()
+                .wrapList()
+                .wrapList()
             }
           }
         })
@@ -773,10 +777,10 @@ describe('Type System: build schema from introspection', () => {
           name: 'Query',
           fields: {
             foo: {
-              type: new GraphQLList(new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(new GraphQLNonNull(GraphQLString))
-              ))))))
+              type: (new GraphQLNonNull((
+                new GraphQLNonNull((new GraphQLNonNull(
+                (new GraphQLNonNull(GraphQLString)).wrapList()
+              )).wrapList())).wrapList())).wrapList()
             }
           }
         })
@@ -795,11 +799,11 @@ describe('Type System: build schema from introspection', () => {
           fields: {
             foo: {
               // e.g., fully non-null 3D matrix
-              type: new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(
+              type: new GraphQLNonNull((
+                new GraphQLNonNull((
+                new GraphQLNonNull((
                 new GraphQLNonNull(GraphQLString)
-              ))))))
+              ).wrapList())).wrapList())).wrapList())
             }
           }
         })

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -22,7 +22,6 @@ import {
   GraphQLString,
   GraphQLEnumType,
   GraphQLNonNull,
-  GraphQLList,
   GraphQLScalarType,
 } from '../../type';
 
@@ -42,7 +41,7 @@ const FooType = new GraphQLObjectType({
   fields: () => ({
     name: { type: GraphQLString },
     some: { type: SomeInterfaceType },
-    tree: { type: new GraphQLNonNull(new GraphQLList(FooType)) },
+    tree: { type: new GraphQLNonNull(FooType.wrapList()) },
   })
 });
 

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -12,7 +12,6 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLInterfaceType,
-  GraphQLList,
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLString,
@@ -150,20 +149,20 @@ describe('findBreakingChanges', () => {
         field3: { type: GraphQLString },
         field4: { type: TypeA },
         field6: { type: GraphQLString },
-        field7: { type: new GraphQLList(GraphQLString) },
+        field7: { type: GraphQLString.wrapList() },
         field8: { type: GraphQLInt },
         field9: { type: new GraphQLNonNull(GraphQLInt) },
-        field10: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
+        field10: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
         field11: { type: GraphQLInt },
-        field12: { type: new GraphQLList(GraphQLInt) },
-        field13: { type: new GraphQLList(new GraphQLNonNull(GraphQLInt)) },
-        field14: { type: new GraphQLList(GraphQLInt) },
-        field15: { type: new GraphQLList(new GraphQLList(GraphQLInt)) },
+        field12: { type: GraphQLInt.wrapList() },
+        field13: { type: (new GraphQLNonNull(GraphQLInt)).wrapList() },
+        field14: { type: GraphQLInt.wrapList() },
+        field15: { type: GraphQLInt.wrapList().wrapList() },
         field16: { type: new GraphQLNonNull(GraphQLInt) },
-        field17: { type: new GraphQLList(GraphQLInt) },
+        field17: { type: GraphQLInt.wrapList() },
         field18: {
-          type: new GraphQLList(new GraphQLNonNull(
-            new GraphQLList(new GraphQLNonNull(GraphQLInt)))),
+          type: (new GraphQLNonNull(
+            (new GraphQLNonNull(GraphQLInt)).wrapList())).wrapList(),
         },
       }
     });
@@ -174,21 +173,20 @@ describe('findBreakingChanges', () => {
         field3: { type: GraphQLBoolean },
         field4: { type: TypeB },
         field5: { type: GraphQLString },
-        field6: { type: new GraphQLList(GraphQLString) },
+        field6: { type: GraphQLString.wrapList() },
         field7: { type: GraphQLString },
         field8: { type: new GraphQLNonNull(GraphQLInt) },
         field9: { type: GraphQLInt },
-        field10: { type: new GraphQLList(GraphQLInt) },
-        field11: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
-        field12: { type: new GraphQLList(new GraphQLNonNull(GraphQLInt)) },
-        field13: { type: new GraphQLList(GraphQLInt) },
-        field14: { type: new GraphQLList(new GraphQLList(GraphQLInt)) },
-        field15: { type: new GraphQLList(GraphQLInt) },
-        field16: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
-        field17: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
+        field10: { type: GraphQLInt.wrapList() },
+        field11: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
+        field12: { type: (new GraphQLNonNull(GraphQLInt)).wrapList() },
+        field13: { type: GraphQLInt.wrapList() },
+        field14: { type: GraphQLInt.wrapList().wrapList() },
+        field15: { type: GraphQLInt.wrapList() },
+        field16: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
+        field17: { type: new GraphQLNonNull(GraphQLInt.wrapList()) },
         field18: {
-          type: new GraphQLList(
-            new GraphQLList(new GraphQLNonNull(GraphQLInt))),
+          type: (new GraphQLNonNull(GraphQLInt)).wrapList().wrapList(),
         },
       }
     });
@@ -278,7 +276,7 @@ describe('findBreakingChanges', () => {
             type: GraphQLBoolean,
           },
           field3: {
-            type: new GraphQLList(GraphQLString),
+            type: GraphQLString.wrapList(),
           },
           field4: {
             type: new GraphQLNonNull(GraphQLString),
@@ -287,36 +285,36 @@ describe('findBreakingChanges', () => {
             type: GraphQLString,
           },
           field6: {
-            type: new GraphQLList(GraphQLInt),
+            type: GraphQLInt.wrapList(),
           },
           field7: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+            type: new GraphQLNonNull(GraphQLInt.wrapList()),
           },
           field8: {
             type: GraphQLInt,
           },
           field9: {
-            type: new GraphQLList(GraphQLInt),
+            type: GraphQLInt.wrapList(),
           },
           field10: {
-            type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+            type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
           },
           field11: {
-            type: new GraphQLList(GraphQLInt),
+            type: GraphQLInt.wrapList(),
           },
           field12: {
-            type: new GraphQLList(new GraphQLList(GraphQLInt)),
+            type: GraphQLInt.wrapList().wrapList(),
           },
           field13: {
             type: new GraphQLNonNull(GraphQLInt),
           },
           field14: {
-            type: new GraphQLList(new GraphQLNonNull(
-              new GraphQLList(GraphQLInt))),
+            type: (new GraphQLNonNull(
+              GraphQLInt.wrapList())).wrapList(),
           },
           field15: {
-            type: new GraphQLList(new GraphQLNonNull(
-              new GraphQLList(GraphQLInt))),
+            type: (new GraphQLNonNull(
+              GraphQLInt.wrapList())).wrapList(),
           },
         },
       });
@@ -336,35 +334,35 @@ describe('findBreakingChanges', () => {
             type: new GraphQLNonNull(GraphQLString),
           },
           field6: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+            type: new GraphQLNonNull(GraphQLInt.wrapList()),
           },
           field7: {
-            type: new GraphQLList(GraphQLInt),
+            type: GraphQLInt.wrapList(),
           },
           field8: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+            type: new GraphQLNonNull(GraphQLInt.wrapList()),
           },
           field9: {
-            type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+            type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
           },
           field10: {
-            type: new GraphQLList(GraphQLInt),
+            type: GraphQLInt.wrapList(),
           },
           field11: {
-            type: new GraphQLList(new GraphQLList(GraphQLInt)),
+            type: GraphQLInt.wrapList().wrapList(),
           },
           field12: {
-            type: new GraphQLList(GraphQLInt),
+            type: GraphQLInt.wrapList(),
           },
           field13: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+            type: new GraphQLNonNull(GraphQLInt.wrapList()),
           },
           field14: {
-            type: new GraphQLList(new GraphQLList(GraphQLInt)),
+            type: GraphQLInt.wrapList().wrapList(),
           },
           field15: {
-            type: new GraphQLList(new GraphQLNonNull(
-              new GraphQLList(new GraphQLNonNull(GraphQLInt)))),
+            type: (new GraphQLNonNull(
+              (new GraphQLNonNull(GraphQLInt)).wrapList())).wrapList(),
           },
         },
       });
@@ -699,7 +697,7 @@ describe('findBreakingChanges', () => {
               type: GraphQLString,
             },
             arg3: {
-              type: new GraphQLList(GraphQLString),
+              type: GraphQLString.wrapList(),
             },
             arg4: {
               type: GraphQLString,
@@ -711,33 +709,33 @@ describe('findBreakingChanges', () => {
               type: new GraphQLNonNull(GraphQLString),
             },
             arg7: {
-              type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              type: new GraphQLNonNull(GraphQLInt.wrapList()),
             },
             arg8: {
               type: GraphQLInt,
             },
             arg9: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLInt.wrapList(),
             },
             arg10: {
-              type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+              type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
             },
             arg11: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLInt.wrapList(),
             },
             arg12: {
-              type: new GraphQLList(new GraphQLList(GraphQLInt)),
+              type: GraphQLInt.wrapList().wrapList(),
             },
             arg13: {
               type: new GraphQLNonNull(GraphQLInt),
             },
             arg14: {
-              type: new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(GraphQLInt))),
+              type: (new GraphQLNonNull(
+                GraphQLInt.wrapList())).wrapList(),
             },
             arg15: {
-              type: new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(GraphQLInt))),
+              type: (new GraphQLNonNull(
+                GraphQLInt.wrapList())).wrapList(),
             },
           },
         },
@@ -754,7 +752,7 @@ describe('findBreakingChanges', () => {
               type: GraphQLInt,
             },
             arg2: {
-              type: new GraphQLList(GraphQLString),
+              type: GraphQLString.wrapList(),
             },
             arg3: {
               type: GraphQLString,
@@ -769,32 +767,32 @@ describe('findBreakingChanges', () => {
               type: new GraphQLNonNull(GraphQLInt),
             },
             arg7: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLInt.wrapList(),
             },
             arg8: {
-              type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              type: new GraphQLNonNull(GraphQLInt.wrapList()),
             },
             arg9: {
-              type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+              type: (new GraphQLNonNull(GraphQLInt)).wrapList(),
             },
             arg10: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLInt.wrapList(),
             },
             arg11: {
-              type: new GraphQLList(new GraphQLList(GraphQLInt)),
+              type: GraphQLInt.wrapList().wrapList(),
             },
             arg12: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLInt.wrapList(),
             },
             arg13: {
-              type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              type: new GraphQLNonNull(GraphQLInt.wrapList()),
             },
             arg14: {
-              type: new GraphQLList(new GraphQLList(GraphQLInt)),
+              type: GraphQLInt.wrapList().wrapList(),
             },
             arg15: {
-              type: new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(new GraphQLNonNull(GraphQLInt)))),
+              type: (new GraphQLNonNull(
+                (new GraphQLNonNull(GraphQLInt)).wrapList())).wrapList(),
             },
           },
         },

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -23,7 +23,6 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLBoolean,
-  GraphQLList,
   GraphQLNonNull,
 } from '../../';
 
@@ -41,7 +40,7 @@ function printSingleFieldSchema(fieldConfig) {
 }
 
 function listOf(type) {
-  return new GraphQLList(type);
+  return type.wrapList();
 }
 
 function nonNull(type) {

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -12,7 +12,6 @@ import {
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLInterfaceType,
@@ -35,13 +34,13 @@ describe('typeComparators', () => {
 
     it('lists of same type are equal', () => {
       expect(
-        isEqualType(new GraphQLList(GraphQLInt), new GraphQLList(GraphQLInt))
+        isEqualType(GraphQLInt.wrapList(), GraphQLInt.wrapList())
       ).to.equal(true);
     });
 
     it('lists is not equal to item', () => {
       expect(
-        isEqualType(new GraphQLList(GraphQLInt), GraphQLInt)
+        isEqualType(GraphQLInt.wrapList(), GraphQLInt)
       ).to.equal(false);
     });
 
@@ -104,14 +103,14 @@ describe('typeComparators', () => {
     it('item is not subtype of list', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLList(GraphQLInt))
+        isTypeSubTypeOf(schema, GraphQLInt, GraphQLInt.wrapList())
       ).to.equal(false);
     });
 
     it('list is not subtype of item', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLList(GraphQLInt), GraphQLInt)
+        isTypeSubTypeOf(schema, GraphQLInt.wrapList(), GraphQLInt)
       ).to.equal(false);
     });
 

--- a/src/utilities/__tests__/valueFromAST-test.js
+++ b/src/utilities/__tests__/valueFromAST-test.js
@@ -11,7 +11,6 @@ import { valueFromAST } from '../valueFromAST';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
@@ -86,9 +85,9 @@ describe('valueFromAST', () => {
   // Boolean!
   const nonNullBool = new GraphQLNonNull(GraphQLBoolean);
   // [Boolean]
-  const listOfBool = new GraphQLList(GraphQLBoolean);
+  const listOfBool = GraphQLBoolean.wrapList();
   // [Boolean!]
-  const listOfNonNullBool = new GraphQLList(nonNullBool);
+  const listOfNonNullBool = nonNullBool.wrapList();
   // [Boolean]!
   const nonNullListOfBool = new GraphQLNonNull(listOfBool);
   // [Boolean!]!

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -54,7 +54,6 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLNonNull,
   assertInputType,
   assertOutputType,
@@ -95,7 +94,7 @@ function buildWrappedType(
   inputTypeNode: TypeNode
 ): GraphQLType {
   if (inputTypeNode.kind === Kind.LIST_TYPE) {
-    return new GraphQLList(buildWrappedType(innerType, inputTypeNode.type));
+    return buildWrappedType(innerType, inputTypeNode.type).wrapList();
   }
   if (inputTypeNode.kind === Kind.NON_NULL_TYPE) {
     const wrappedType = buildWrappedType(innerType, inputTypeNode.type);

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -23,7 +23,6 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLNonNull,
 } from '../type/definition';
 
@@ -121,7 +120,7 @@ export function buildClientSchema(
       if (!itemRef) {
         throw new Error('Decorated type deeper than introspection query.');
       }
-      return new GraphQLList(getType(itemRef));
+      return getType(itemRef).wrapList();
     }
     if (typeRef.kind === TypeKind.NON_NULL) {
       const nullableRef = ((typeRef: any): IntrospectionNonNullTypeRef).ofType;

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -441,7 +441,7 @@ export function extendSchema(
 
   function extendFieldType<T: GraphQLType>(typeDef: T): T {
     if (typeDef instanceof GraphQLList) {
-      return (new GraphQLList(extendFieldType(typeDef.ofType)): any);
+      return (extendFieldType(typeDef.ofType).wrapList(): any);
     }
     if (typeDef instanceof GraphQLNonNull) {
       return (new GraphQLNonNull(extendFieldType(typeDef.ofType)): any);
@@ -585,7 +585,7 @@ export function extendSchema(
 
   function buildInputFieldType(typeNode: TypeNode): GraphQLInputType {
     if (typeNode.kind === Kind.LIST_TYPE) {
-      return new GraphQLList(buildInputFieldType(typeNode.type));
+      return buildInputFieldType(typeNode.type).wrapList();
     }
     if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const nullableType = buildInputFieldType(typeNode.type);
@@ -597,7 +597,7 @@ export function extendSchema(
 
   function buildOutputFieldType(typeNode: TypeNode): GraphQLOutputType {
     if (typeNode.kind === Kind.LIST_TYPE) {
-      return new GraphQLList(buildOutputFieldType(typeNode.type));
+      return buildOutputFieldType(typeNode.type).wrapList();
     }
     if (typeNode.kind === Kind.NON_NULL_TYPE) {
       const nullableType = buildOutputFieldType(typeNode.type);

--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -45,7 +45,7 @@ function typeFromASTImpl(schema, typeNode) {
   let innerType;
   if (typeNode.kind === Kind.LIST_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);
-    return innerType && new GraphQLList(innerType);
+    return innerType && innerType.wrapList();
   }
   if (typeNode.kind === Kind.NON_NULL_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -21,7 +21,6 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLInterfaceType,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLInt,
   GraphQLString,
@@ -485,7 +484,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         scalar: { type: GraphQLString },
         deepBox: { type: StringBox },
         unrelatedField: { type: GraphQLString },
-        listStringBox: { type: new GraphQLList(StringBox) },
+        listStringBox: { type: StringBox.wrapList() },
         stringBox: { type: StringBox },
         intBox: { type: IntBox },
       })
@@ -498,7 +497,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         scalar: { type: GraphQLInt },
         deepBox: { type: IntBox },
         unrelatedField: { type: GraphQLString },
-        listStringBox: { type: new GraphQLList(StringBox) },
+        listStringBox: { type: StringBox.wrapList() },
         stringBox: { type: StringBox },
         intBox: { type: IntBox },
       })
@@ -544,7 +543,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'Connection',
       fields: {
         edges: {
-          type: new GraphQLList(new GraphQLObjectType({
+          type: (new GraphQLObjectType({
             name: 'Edge',
             fields: {
               node: {
@@ -557,7 +556,7 @@ describe('Validate: Overlapping fields can be merged', () => {
                 })
               }
             }
-          }))
+          })).wrapList()
         }
       }
     });

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -16,7 +16,6 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
   GraphQLNonNull,
   GraphQLInt,
   GraphQLFloat,
@@ -144,8 +143,8 @@ const Human = new GraphQLObjectType({
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
     },
-    pets: { type: new GraphQLList(Pet) },
-    relatives: { type: new GraphQLList(Human) },
+    pets: { type: Pet.wrapList() },
+    relatives: { type: Human.wrapList() },
     iq: { type: GraphQLInt },
   })
 });
@@ -199,7 +198,7 @@ const ComplexInput = new GraphQLInputObjectType({
     intField: { type: GraphQLInt },
     stringField: { type: GraphQLString },
     booleanField: { type: GraphQLBoolean },
-    stringListField: { type: new GraphQLList(GraphQLString) },
+    stringListField: { type: GraphQLString.wrapList() },
   }
 });
 
@@ -239,7 +238,7 @@ const ComplicatedArgs = new GraphQLObjectType({
     },
     stringListArgField: {
       type: GraphQLString,
-      args: { stringListArg: { type: new GraphQLList(GraphQLString) } },
+      args: { stringListArg: { type: GraphQLString.wrapList() } },
     },
     complexArgField: {
       type: GraphQLString,


### PR DESCRIPTION
Rather than constantly do:

```
listType = new GraphQLList(otherType);
```

it would be nicer to do:

```
listType = otherType.wrapList();
```

It would be even nicer if the other type could memoise the "list" version, which would be safe because all these objects are immutable. This PR implements that.

Not included in the PR yet, since it is not working: I am trying to do the same for a `wrapNonNull` method but it is giving a strange type failure. It is particularly strange to me because the same syntax and type declarations work fine on the `wrapList` method. This is an excerpt of the error:

```
       Property `type` is incompatible:
        111:       type: GraphQLString.wrapNonNull(),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ GraphQLNonNull. This type is incompatible with
        673:   type: GraphQLOutputType;
                     ^^^^^^^^^^^^^^^^^ union: GraphQLScalarType | GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType | GraphQLEnumType | type application of class `GraphQLList` | type application of class `GraphQLNonNull`. See: src/type/definition.js:673
```

It seems to be losing the "type application" on `GraphQLNonNull`. It did this even when I adjusted the return type of `wrapNonNull` from `GraphQLNonNull<*>` to `GraphQLNonNull<GraphQLScalarType>`. Any insight into why would be greatly appreciated!