### PR TITLE
Return normal objects for args and vars.

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -89,7 +89,7 @@ export type ExecutionContext = {
   rootValue: mixed;
   contextValue: mixed;
   operation: OperationDefinitionNode;
-  variableValues: ObjMap<mixed>,
+  variableValues: {[variable: string]: mixed},
   fieldResolver: GraphQLFieldResolver<any, any>;
   errors: Array<GraphQLError>;
 };
@@ -102,7 +102,7 @@ export type ExecutionContext = {
  */
 export type ExecutionResult = {
   errors?: Array<GraphQLError>;
-  data?: ?{[key: string]: mixed};
+  data?: ObjMap<mixed>;
 };
 
 export type ExecutionArgs = {|
@@ -110,7 +110,7 @@ export type ExecutionArgs = {|
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ?{[variable: string]: mixed},
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>
 |};
@@ -135,7 +135,7 @@ declare function execute(
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ?{[variable: string]: mixed},
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>
 ): Promise<ExecutionResult>;
@@ -249,7 +249,7 @@ export function addPath(prev: ResponsePath, key: string | number) {
 export function assertValidExecutionArguments(
   schema: GraphQLSchema,
   document: DocumentNode,
-  rawVariableValues: ?{[key: string]: mixed}
+  rawVariableValues: ?ObjMap<mixed>
 ): void {
   invariant(schema, 'Must provide schema');
   invariant(document, 'Must provide document');
@@ -615,8 +615,8 @@ function doesFragmentConditionMatch(
 }
 
 /**
- * This function transforms a JS object `{[key: string]: Promise<T>}` into
- * a `Promise<{[key: string]: T}>`
+ * This function transforms a JS object `ObjMap<Promise<T>>` into
+ * a `Promise<ObjMap<T>>`
  *
  * This is akin to bluebird's `Promise.props`, but implemented only using
  * `Promise.all` so it will work with any implementation of ES6 promises.

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -10,6 +10,7 @@
 import { parse } from './language/parser';
 import { validate } from './validation/validate';
 import { execute } from './execution/execute';
+import type { ObjMap } from './jsutils/ObjMap';
 import type { Source } from './language/source';
 import type { GraphQLFieldResolver } from './type/definition';
 import type { GraphQLSchema } from './type/schema';
@@ -50,7 +51,7 @@ declare function graphql({|
   source: string | Source,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>
 |}, ..._: []): Promise<ExecutionResult>;
@@ -60,7 +61,7 @@ declare function graphql(
   source: Source | string,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>
 ): Promise<ExecutionResult>;

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -26,6 +26,7 @@ import { GraphQLSchema } from '../type/schema';
 import invariant from '../jsutils/invariant';
 import mapAsyncIterator from './mapAsyncIterator';
 
+import type { ObjMap } from '../jsutils/ObjMap';
 import type { ExecutionResult } from '../execution/execute';
 import type { DocumentNode } from '../language/ast';
 import type { GraphQLFieldResolver } from '../type/definition';
@@ -55,7 +56,7 @@ declare function subscribe({|
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   subscribeFieldResolver?: ?GraphQLFieldResolver<any, any>
@@ -66,7 +67,7 @@ declare function subscribe(
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   subscribeFieldResolver?: ?GraphQLFieldResolver<any, any>
@@ -191,7 +192,7 @@ export function createSourceEventStream(
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[key: string]: mixed},
+  variableValues?: ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>
 ): Promise<AsyncIterable<mixed>> {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -625,7 +625,7 @@ export type GraphQLIsTypeOfFn<TSource, TContext> = (
 
 export type GraphQLFieldResolver<TSource, TContext> = (
   source: TSource,
-  args: ObjMap<any>,
+  args: {[argument: string]: any},
   context: TContext,
   info: GraphQLResolveInfo
 ) => mixed;
@@ -640,7 +640,7 @@ export type GraphQLResolveInfo = {
   fragments: ObjMap<FragmentDefinitionNode>;
   rootValue: mixed;
   operation: OperationDefinitionNode;
-  variableValues: ObjMap<mixed>;
+  variableValues: {[variable: string]: mixed};
 };
 
 export type ResponsePath = { prev: ResponsePath, key: string | number } | void;
@@ -798,7 +798,6 @@ export class GraphQLUnionType {
 
   _typeConfig: GraphQLUnionTypeConfig<*, *>;
   _types: Array<GraphQLObjectType>;
-  _possibleTypeNames: {[typeName: string]: boolean};
 
   constructor(config: GraphQLUnionTypeConfig<*, *>): void {
     assertValidName(config.name);

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -63,7 +63,7 @@ export class GraphQLSchema {
   _directives: Array<GraphQLDirective>;
   _typeMap: TypeMap;
   _implementations: ObjMap<Array<GraphQLObjectType>>;
-  _possibleTypeMap: ?ObjMap<{[possibleName: string]: boolean}>;
+  _possibleTypeMap: ?ObjMap<ObjMap<boolean>>;
 
   constructor(config: GraphQLSchemaConfig): void {
     invariant(

--- a/src/utilities/separateOperations.js
+++ b/src/utilities/separateOperations.js
@@ -7,8 +7,8 @@
  * @flow
  */
 
-import type {ObjMap} from '../jsutils/ObjMap';
 import { visit } from '../language/visitor';
+import type {ObjMap} from '../jsutils/ObjMap';
 import type {
   DocumentNode,
   OperationDefinitionNode,
@@ -76,10 +76,7 @@ export function separateOperations(
   return separatedDocumentASTs;
 }
 
-type DepGraph = {
-  [from: string]: {[to: string]: boolean, __proto__: null},
-  __proto__: null,
-};
+type DepGraph = ObjMap<ObjMap<boolean>>;
 
 // Provides the empty string for anonymous operations.
 function opName(operation: OperationDefinitionNode): string {
@@ -89,7 +86,7 @@ function opName(operation: OperationDefinitionNode): string {
 // From a dependency graph, collects a list of transitive dependencies by
 // recursing through a dependency graph.
 function collectTransitiveDependencies(
-  collected: {[key: string]: boolean, __proto__: null},
+  collected: ObjMap<boolean>,
   depGraph: DepGraph,
   fromName: string
 ): void {


### PR DESCRIPTION
This is a follow up to #1048 which addresses an issue where flow typed resolver functions would need to be aware of the fact that arguments were prototype-less. That's something we maintain for internal usage, but is more burdensome for external use. Instead, this is just more cautious when using these values internally, using hasOwnProperty, but now returns prototypefull objects to user code.

Also follows up with a few additional conversions to ObjMap, such that the only remaining uses of `{[string]: mixed}` are for variables and arguments.