### PR TITLE
Check if `process` is defined (for usage in the browser)

### DIFF
--- a/src/utilities/assertValidName.js
+++ b/src/utilities/assertValidName.js
@@ -11,8 +11,12 @@ const NAME_RX = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
 const ERROR_PREFIX_RX = /^Error: /;
 
 // Silences warnings if an environment flag is enabled
-const noNameWarning =
-  Boolean(process && process.env && process.env.GRAPHQL_NO_NAME_WARNING);
+const noNameWarning = Boolean(
+  typeof process !== 'undefined' &&
+    process &&
+    process.env &&
+    process.env.GRAPHQL_NO_NAME_WARNING
+);
 
 // Ensures console warnings are only issued once.
 let hasWarnedAboutDunder = false;


### PR DESCRIPTION
When running this library in the browser, Node.js's `process` global is not necessarily defined. Usage in the browser is great for [certain use cases](https://medium.com/taller-team/graphql-today-using-apollo-for-applications-that-still-depend-on-rest-apis-839895ce20d0). This adds a simple check that `process` is defined before using it in `assertValidName.js`