### PR TITLE
docs: Fix possible typo

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -1202,8 +1202,8 @@ export type GraphQLInputFieldMap =
  *     const PersonType = new GraphQLObjectType({
  *       name: 'Person',
  *       fields: () => ({
- *         parents: { type: new GraphQLList(Person) },
- *         children: { type: new GraphQLList(Person) },
+ *         parents: { type: new GraphQLList(PersonType) },
+ *         children: { type: new GraphQLList(PersonType) },
  *       })
  *     })
  *


### PR DESCRIPTION
The argument to the GraphQLList class should be of type `GraphQLType`, but
the docs of `GraphQLList` does not reflect this. In this case, `Person` is
`undefined`, when it *probably* should have been `PersonType`.

I wasn't quite sure if this was a typo or not, but I didn't think it would hurt to
send this PR anyway.