### PR TITLE
Improve errors when receiving bad introspection data

### DIFF
--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -736,9 +736,8 @@ describe('Type System: build schema from introspection', () => {
       expect(
         () => buildClientSchema(incompleteIntrospection)
       ).to.throw(
-        'Invalid or incomplete schema, unknown kind: undefined. Ensure ' +
-        'that a full introspection query is used in order to build a ' +
-        'client schema.'
+        'Invalid or incomplete introspection result. Ensure that a full ' +
+        'introspection query is used in order to build a client schema'
       );
     });
 


### PR DESCRIPTION
I've seen a few examples of passing bad introspection data to buildClientSchema() result in a hard to understand internal error. This instead prints a more understandable error which includes a print out of the bad value in question. Hopefully this aids debugging.

This also adds a comment to the description of this function recommending that the "errors" field of a server response be checked before continuing to avoid partial results.