### PR TITLE
Upgrade to Flow v0.57.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,4 +12,4 @@
 experimental.const_params=true
 
 [version]
-^0.56.0
+^0.57.0

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint": "4.4.1",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-flowtype": "2.35.0",
-    "flow-bin": "0.56.0",
+    "flow-bin": "0.57.1",
     "isparta": "4.0.0",
     "mocha": "3.5.0",
     "sane": "2.0.0"

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -17,6 +17,8 @@ import {
   GraphQLString,
 } from '../type';
 
+import type {GraphQLFieldConfigMap} from '../type/definition';
+
 import { getFriends, getHero, getHuman, getDroid } from './starWarsData.js';
 
 /**
@@ -108,7 +110,7 @@ const episodeEnum = new GraphQLEnumType({
 const characterInterface = new GraphQLInterfaceType({
   name: 'Character',
   description: 'A character in the Star Wars Trilogy',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     id: {
       type: new GraphQLNonNull(GraphQLString),
       description: 'The id of the character.',
@@ -156,7 +158,7 @@ const characterInterface = new GraphQLInterfaceType({
 const humanType = new GraphQLObjectType({
   name: 'Human',
   description: 'A humanoid creature in the Star Wars universe.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     id: {
       type: new GraphQLNonNull(GraphQLString),
       description: 'The id of the human.',
@@ -206,7 +208,7 @@ const humanType = new GraphQLObjectType({
 const droidType = new GraphQLObjectType({
   name: 'Droid',
   description: 'A mechanical creature in the Star Wars universe.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     id: {
       type: new GraphQLNonNull(GraphQLString),
       description: 'The id of the droid.',
@@ -256,7 +258,7 @@ const droidType = new GraphQLObjectType({
  */
 const queryType = new GraphQLObjectType({
   name: 'Query',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     hero: {
       type: characterInterface,
       args: {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -23,7 +23,7 @@ import {
 } from './definition';
 import { GraphQLString, GraphQLBoolean } from './scalars';
 import { DirectiveLocation } from './directives';
-import type { GraphQLField } from './definition';
+import type { GraphQLField, GraphQLFieldConfigMap } from './definition';
 
 
 export const __Schema = new GraphQLObjectType({
@@ -33,7 +33,7 @@ export const __Schema = new GraphQLObjectType({
     'A GraphQL Schema defines the capabilities of a GraphQL server. It ' +
     'exposes all available types and directives on the server, as well as ' +
     'the entry points for query, mutation, and subscription operations.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     types: {
       description: 'A list of all types supported by this server.',
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__Type))),
@@ -78,7 +78,7 @@ export const __Directive = new GraphQLObjectType({
     'execution behavior in ways field arguments will not suffice, such as ' +
     'conditionally including or skipping a field. Directives provide this by ' +
     'describing additional information to the executor.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     locations: {
@@ -211,7 +211,7 @@ export const __Type = new GraphQLObjectType({
     'Object and Interface types provide the fields they describe. Abstract ' +
     'types, Union and Interface, provide the Object types possible ' +
     'at runtime. List and NonNull types compose other types.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     kind: {
       type: new GraphQLNonNull(__TypeKind),
       resolve(type) {
@@ -306,7 +306,7 @@ export const __Field = new GraphQLObjectType({
   description:
     'Object and Interface types are described by a list of Fields, each of ' +
     'which has a name, potentially a list of arguments, and a return type.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     args: {
@@ -329,7 +329,7 @@ export const __InputValue = new GraphQLObjectType({
     'Arguments provided to Fields or Directives and the input fields of an ' +
     'InputObject are represented as Input Values which describe their type ' +
     'and optionally a default value.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     type: { type: new GraphQLNonNull(__Type) },
@@ -352,7 +352,7 @@ export const __EnumValue = new GraphQLObjectType({
     'One possible value for a given Enum. Enum values are unique values, not ' +
     'a placeholder for a string or numeric value. However an Enum value is ' +
     'returned in a JSON response as a string.',
-  fields: () => ({
+  fields: (): GraphQLFieldConfigMap<*, *> => ({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -18,6 +18,7 @@ import { getDirectiveValues } from '../execution/values';
 
 import * as Kind from '../language/kinds';
 
+
 import type {
   Location,
   DocumentNode,
@@ -61,6 +62,7 @@ import {
 } from '../type/definition';
 
 import type {
+  GraphQLFieldConfigMap,
   GraphQLType,
   GraphQLNamedType,
   GraphQLInputType,
@@ -349,7 +351,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
     return new GraphQLObjectType({
       name: typeName,
       description: getDescription(def),
-      fields: () => makeFieldDefMap(def),
+      fields: (): GraphQLFieldConfigMap<*, *> => makeFieldDefMap(def),
       interfaces: () => makeImplementedInterfaces(def),
       astNode: def,
     });
@@ -396,7 +398,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
     return new GraphQLInterfaceType({
       name: def.name.value,
       description: getDescription(def),
-      fields: () => makeFieldDefMap(def),
+      fields: (): GraphQLFieldConfigMap<*, *> => makeFieldDefMap(def),
       astNode: def,
       resolveType: cannotExecuteSchema,
     });
@@ -448,7 +450,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
     return new GraphQLInputObjectType({
       name: def.name.value,
       description: getDescription(def),
-      fields: () => makeInputValues(def.fields),
+      fields: (): GraphQLFieldConfigMap<*, *> => makeInputValues(def.fields),
       astNode: def,
     });
   }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -51,6 +51,7 @@ import { DirectiveLocation, GraphQLDirective } from '../type/directives';
 import { TypeKind } from '../type/introspection';
 
 import type {
+  GraphQLFieldConfigMap,
   GraphQLType,
   GraphQLInputType,
   GraphQLOutputType,
@@ -242,7 +243,9 @@ export function buildClientSchema(
       name: objectIntrospection.name,
       description: objectIntrospection.description,
       interfaces: objectIntrospection.interfaces.map(getInterfaceType),
-      fields: () => buildFieldDefMap(objectIntrospection),
+      fields: (): GraphQLFieldConfigMap<*, *> => buildFieldDefMap(
+        objectIntrospection
+      ),
     });
   }
 
@@ -252,7 +255,9 @@ export function buildClientSchema(
     return new GraphQLInterfaceType({
       name: interfaceIntrospection.name,
       description: interfaceIntrospection.description,
-      fields: () => buildFieldDefMap(interfaceIntrospection),
+      fields: (): GraphQLFieldConfigMap<*, *> => buildFieldDefMap(
+        interfaceIntrospection
+      ),
       resolveType: cannotExecuteClientSchema,
     });
   }
@@ -291,7 +296,9 @@ export function buildClientSchema(
     return new GraphQLInputObjectType({
       name: inputObjectIntrospection.name,
       description: inputObjectIntrospection.description,
-      fields: () => buildInputValueDefMap(inputObjectIntrospection.inputFields),
+      fields: (): GraphQLFieldConfigMap<*, *> => buildInputValueDefMap(
+        inputObjectIntrospection.inputFields
+      ),
     });
   }
 

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -59,6 +59,7 @@ import * as Kind from '../language/kinds';
 import type {
   GraphQLType,
   GraphQLNamedType,
+  GraphQLFieldConfigMap,
   GraphQLInputType,
   GraphQLOutputType,
 } from '../type/definition';
@@ -342,7 +343,7 @@ export function extendSchema(
       name,
       description: type.description,
       interfaces: () => extendImplementedInterfaces(type),
-      fields: () => extendFieldMap(type),
+      fields: (): GraphQLFieldConfigMap<*, *> => extendFieldMap(type),
       astNode: type.astNode,
       extensionASTNodes,
       isTypeOf: type.isTypeOf,
@@ -355,7 +356,7 @@ export function extendSchema(
     return new GraphQLInterfaceType({
       name: type.name,
       description: type.description,
-      fields: () => extendFieldMap(type),
+      fields: (): GraphQLFieldConfigMap<*, *> => extendFieldMap(type),
       astNode: type.astNode,
       resolveType: type.resolveType,
     });
@@ -467,7 +468,7 @@ export function extendSchema(
       name: typeNode.name.value,
       description: getDescription(typeNode),
       interfaces: () => buildImplementedInterfaces(typeNode),
-      fields: () => buildFieldMap(typeNode),
+      fields: (): GraphQLFieldConfigMap<*, *> => buildFieldMap(typeNode),
       astNode: typeNode,
     });
   }
@@ -476,7 +477,7 @@ export function extendSchema(
     return new GraphQLInterfaceType({
       name: typeNode.name.value,
       description: getDescription(typeNode),
-      fields: () => buildFieldMap(typeNode),
+      fields: (): GraphQLFieldConfigMap<*, *> => buildFieldMap(typeNode),
       astNode: typeNode,
       resolveType: cannotExecuteExtendedSchema,
     });
@@ -528,7 +529,9 @@ export function extendSchema(
     return new GraphQLInputObjectType({
       name: typeNode.name.value,
       description: getDescription(typeNode),
-      fields: () => buildInputValues(typeNode.fields),
+      fields: (): GraphQLFieldConfigMap<*, *> => buildInputValues(
+        typeNode.fields
+      ),
       astNode: typeNode,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,9 +1224,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.56.0:
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.56.0.tgz#ce43092203a344ba9bf63c0cabe95d95145f6cad"
+flow-bin@0.57.1:
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.57.1.tgz#2fb37a8b6c9b0426bd3bf1a6158d4a659c2178a2"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
So unfortunately the `type Thunk<T> = (() => T) | T` type is a little ambiguous, and Flow v0.57.0 doesn't like it much. It has trouble telling which member of the union to choose. Adding return types to the thunks helps disambiguate.

@calebmer and I were discussing maybe adding a "anything but a function type" so we could write

```js
type Thunk<T: $NotAFunction> = (() => T) | T
```

but that's future work.