### PR TITLE
added config option to scalar type to allow the serialize to return null

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -1013,7 +1013,7 @@ function completeLeafValue(
 ): mixed {
   invariant(returnType.serialize, 'Missing serialize method on type');
   const serializedResult = returnType.serialize(result);
-  if (isNullish(serializedResult)) {
+  if (isNullish(serializedResult) && !returnType.allowNullSerialize) {
     throw new Error(
       `Expected a value of type "${String(returnType)}" but ` +
       `received: ${String(result)}`

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -306,6 +306,7 @@ function resolveThunk<T>(thunk: Thunk<T>): T {
 export class GraphQLScalarType {
   name: string;
   description: ?string;
+  allowNullSerialize: ?boolean;
   astNode: ?ScalarTypeDefinitionNode;
 
   _scalarConfig: GraphQLScalarTypeConfig<*, *>;
@@ -315,6 +316,7 @@ export class GraphQLScalarType {
     this.name = config.name;
     this.description = config.description;
     this.astNode = config.astNode;
+    this.allowNullSerialize = Boolean(config.allowNullSerialize);
     invariant(
       typeof config.serialize === 'function',
       `${this.name} must provide "serialize" function. If this custom Scalar ` +
@@ -378,6 +380,7 @@ GraphQLScalarType.prototype.toJSON =
 export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
   name: string;
   description?: ?string;
+  allowNullSerialize?: ?boolean;
   astNode?: ?ScalarTypeDefinitionNode;
   serialize: (value: mixed) => ?TExternal;
   parseValue?: (value: mixed) => ?TInternal;


### PR DESCRIPTION
as per https://github.com/graphql/graphql-js/issues/1057.
