### PR TITLE
Prettier!

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,8 @@
 
   "plugins": [
     "babel",
-    "flowtype"
+    "flowtype",
+    "prettier"
   ],
 
   "env": {
@@ -39,6 +40,8 @@
   },
 
   "rules": {
+    "prettier/prettier": 2,
+
     "flowtype/space-after-type-colon": [2, "always"],
     "flowtype/space-before-type-colon": [2, "never"],
     "flowtype/space-before-generic-bracket": [2, "never"],
@@ -48,7 +51,6 @@
     "flowtype/use-flow-type": 2,
     "flowtype/semi": 2,
 
-    "array-bracket-spacing": [2, "always"],
     "arrow-parens": [2, "as-needed"],
     "arrow-spacing": 2,
     "block-scoped-var": 0,
@@ -70,7 +72,6 @@
     "eqeqeq": ["error", "smart"],
     "func-names": 0,
     "func-style": 0,
-    "generator-star-spacing": [2, {"before": false, "after": true}],
     "guard-for-in": 2,
     "handle-callback-err": [2, "error"],
     "id-length": 0,
@@ -194,20 +195,17 @@
     "object-shorthand": [2, "always"],
     "one-var": [2, "never"],
     "operator-assignment": [2, "always"],
-    "operator-linebreak": [2, "after"],
     "padded-blocks": 0,
     "prefer-const": 2,
     "prefer-reflect": 0,
     "prefer-spread": 0,
     "quote-props": [2, "as-needed", {"numbers": true}],
-    "quotes": [2, "single"],
     "radix": 2,
     "require-yield": 0,
     "semi": [2, "always"],
     "semi-spacing": [2, {"before": false, "after": true}],
     "sort-vars": 0,
     "space-before-blocks": [2, "always"],
-    "space-before-function-paren": [2, {"anonymous": "always", "named": "never"}],
     "space-in-parens": 0,
     "space-infix-ops": [2, {"int32Hint": false}],
     "space-unary-ops": [2, {"words": true, "nonwords": false}],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "parser": "flow",
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "testonly": "babel-node ./node_modules/.bin/_mocha $npm_package_options_mocha",
     "t": "babel-node ./node_modules/.bin/_mocha --require ./resources/mocha-bootload",
     "lint": "eslint --rulesdir ./resources/lint src || (printf '\\033[33mTry: \\033[7m npm run lint -- --fix \\033[0m\\n' && exit 1)",
+    "prettier": "prettier --write 'src/**/*.js'",
     "check": "flow check",
     "check-cover": "for file in {src/*.js,src/**/*.js}; do echo $file; flow coverage $file; done",
     "build": "babel src --optional runtime --ignore __tests__ --out-dir dist/ && cp package.json dist/ && npm run build-dot-flow",
@@ -56,9 +57,11 @@
     "eslint": "4.4.1",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-flowtype": "2.35.0",
+    "eslint-plugin-prettier": "^2.3.1",
     "flow-bin": "0.56.0",
     "isparta": "4.0.0",
     "mocha": "3.5.0",
+    "prettier": "^1.7.4",
     "sane": "2.0.0"
   }
 }

--- a/src/__tests__/starWarsData.js
+++ b/src/__tests__/starWarsData.js
@@ -19,8 +19,8 @@ const luke = {
   type: 'Human',
   id: '1000',
   name: 'Luke Skywalker',
-  friends: [ '1002', '1003', '2000', '2001' ],
-  appearsIn: [ 4, 5, 6 ],
+  friends: ['1002', '1003', '2000', '2001'],
+  appearsIn: [4, 5, 6],
   homePlanet: 'Tatooine',
 };
 
@@ -28,8 +28,8 @@ const vader = {
   type: 'Human',
   id: '1001',
   name: 'Darth Vader',
-  friends: [ '1004' ],
-  appearsIn: [ 4, 5, 6 ],
+  friends: ['1004'],
+  appearsIn: [4, 5, 6],
   homePlanet: 'Tatooine',
 };
 
@@ -37,16 +37,16 @@ const han = {
   type: 'Human',
   id: '1002',
   name: 'Han Solo',
-  friends: [ '1000', '1003', '2001' ],
-  appearsIn: [ 4, 5, 6 ],
+  friends: ['1000', '1003', '2001'],
+  appearsIn: [4, 5, 6],
 };
 
 const leia = {
   type: 'Human',
   id: '1003',
   name: 'Leia Organa',
-  friends: [ '1000', '1002', '2000', '2001' ],
-  appearsIn: [ 4, 5, 6 ],
+  friends: ['1000', '1002', '2000', '2001'],
+  appearsIn: [4, 5, 6],
   homePlanet: 'Alderaan',
 };
 
@@ -54,8 +54,8 @@ const tarkin = {
   type: 'Human',
   id: '1004',
   name: 'Wilhuff Tarkin',
-  friends: [ '1001' ],
-  appearsIn: [ 4 ],
+  friends: ['1001'],
+  appearsIn: [4],
 };
 
 const humanData = {
@@ -70,8 +70,8 @@ const threepio = {
   type: 'Droid',
   id: '2000',
   name: 'C-3PO',
-  friends: [ '1000', '1002', '1003', '2001' ],
-  appearsIn: [ 4, 5, 6 ],
+  friends: ['1000', '1002', '1003', '2001'],
+  appearsIn: [4, 5, 6],
   primaryFunction: 'Protocol',
 };
 
@@ -79,8 +79,8 @@ const artoo = {
   type: 'Droid',
   id: '2001',
   name: 'R2-D2',
-  friends: [ '1000', '1002', '1003' ],
-  appearsIn: [ 4, 5, 6 ],
+  friends: ['1000', '1002', '1003'],
+  appearsIn: [4, 5, 6],
   primaryFunction: 'Astromech',
 };
 
@@ -115,7 +115,7 @@ export type Droid = {
   name: string,
   friends: Array<string>,
   appearsIn: Array<number>,
-  primaryFunction: string
+  primaryFunction: string,
 };
 
 /**

--- a/src/__tests__/starWarsIntrospection-test.js
+++ b/src/__tests__/starWarsIntrospection-test.js
@@ -31,52 +31,52 @@ describe('Star Wars Introspection Tests', () => {
         __schema: {
           types: [
             {
-              name: 'Query'
+              name: 'Query',
             },
             {
-              name: 'Episode'
+              name: 'Episode',
             },
             {
-              name: 'Character'
+              name: 'Character',
             },
             {
-              name: 'String'
+              name: 'String',
             },
             {
-              name: 'Human'
+              name: 'Human',
             },
             {
-              name: 'Droid'
+              name: 'Droid',
             },
             {
-              name: '__Schema'
+              name: '__Schema',
             },
             {
-              name: '__Type'
+              name: '__Type',
             },
             {
-              name: '__TypeKind'
+              name: '__TypeKind',
             },
             {
-              name: 'Boolean'
+              name: 'Boolean',
             },
             {
-              name: '__Field'
+              name: '__Field',
             },
             {
-              name: '__InputValue'
+              name: '__InputValue',
             },
             {
-              name: '__EnumValue'
+              name: '__EnumValue',
             },
             {
-              name: '__Directive'
+              name: '__Directive',
             },
             {
-              name: '__DirectiveLocation'
-            }
-          ]
-        }
+              name: '__DirectiveLocation',
+            },
+          ],
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -95,9 +95,9 @@ describe('Star Wars Introspection Tests', () => {
       const expected = {
         __schema: {
           queryType: {
-            name: 'Query'
+            name: 'Query',
           },
-        }
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -113,8 +113,8 @@ describe('Star Wars Introspection Tests', () => {
       `;
       const expected = {
         __type: {
-          name: 'Droid'
-        }
+          name: 'Droid',
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -132,8 +132,8 @@ describe('Star Wars Introspection Tests', () => {
       const expected = {
         __type: {
           name: 'Droid',
-          kind: 'OBJECT'
-        }
+          kind: 'OBJECT',
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -151,8 +151,8 @@ describe('Star Wars Introspection Tests', () => {
       const expected = {
         __type: {
           name: 'Character',
-          kind: 'INTERFACE'
-        }
+          kind: 'INTERFACE',
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -181,46 +181,46 @@ describe('Star Wars Introspection Tests', () => {
               name: 'id',
               type: {
                 name: null,
-                kind: 'NON_NULL'
-              }
+                kind: 'NON_NULL',
+              },
             },
             {
               name: 'name',
               type: {
                 name: 'String',
-                kind: 'SCALAR'
-              }
+                kind: 'SCALAR',
+              },
             },
             {
               name: 'friends',
               type: {
                 name: null,
-                kind: 'LIST'
-              }
+                kind: 'LIST',
+              },
             },
             {
               name: 'appearsIn',
               type: {
                 name: null,
-                kind: 'LIST'
-              }
+                kind: 'LIST',
+              },
             },
             {
               name: 'secretBackstory',
               type: {
                 name: 'String',
-                kind: 'SCALAR'
-              }
+                kind: 'SCALAR',
+              },
             },
             {
               name: 'primaryFunction',
               type: {
                 name: 'String',
-                kind: 'SCALAR'
-              }
-            }
-          ]
-        }
+                kind: 'SCALAR',
+              },
+            },
+          ],
+        },
       };
 
       const result = await graphql(StarWarsSchema, query);
@@ -257,17 +257,17 @@ describe('Star Wars Introspection Tests', () => {
                 kind: 'NON_NULL',
                 ofType: {
                   name: 'String',
-                  kind: 'SCALAR'
-                }
-              }
+                  kind: 'SCALAR',
+                },
+              },
             },
             {
               name: 'name',
               type: {
                 name: 'String',
                 kind: 'SCALAR',
-                ofType: null
-              }
+                ofType: null,
+              },
             },
             {
               name: 'friends',
@@ -276,9 +276,9 @@ describe('Star Wars Introspection Tests', () => {
                 kind: 'LIST',
                 ofType: {
                   name: 'Character',
-                  kind: 'INTERFACE'
-                }
-              }
+                  kind: 'INTERFACE',
+                },
+              },
             },
             {
               name: 'appearsIn',
@@ -287,28 +287,28 @@ describe('Star Wars Introspection Tests', () => {
                 kind: 'LIST',
                 ofType: {
                   name: 'Episode',
-                  kind: 'ENUM'
-                }
-              }
+                  kind: 'ENUM',
+                },
+              },
             },
             {
               name: 'secretBackstory',
               type: {
                 name: 'String',
                 kind: 'SCALAR',
-                ofType: null
-              }
+                ofType: null,
+              },
             },
             {
               name: 'primaryFunction',
               type: {
                 name: 'String',
                 kind: 'SCALAR',
-                ofType: null
-              }
-            }
-          ]
-        }
+                ofType: null,
+              },
+            },
+          ],
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -348,17 +348,18 @@ describe('Star Wars Introspection Tests', () => {
                 args: [
                   {
                     defaultValue: null,
-                    description: 'If omitted, returns the hero of the whole ' +
-                                 'saga. If provided, returns the hero of ' +
-                                 'that particular episode.',
+                    description:
+                      'If omitted, returns the hero of the whole ' +
+                      'saga. If provided, returns the hero of ' +
+                      'that particular episode.',
                     name: 'episode',
                     type: {
                       kind: 'ENUM',
                       name: 'Episode',
-                      ofType: null
-                    }
-                  }
-                ]
+                      ofType: null,
+                    },
+                  },
+                ],
               },
               {
                 name: 'human',
@@ -371,12 +372,12 @@ describe('Star Wars Introspection Tests', () => {
                       name: null,
                       ofType: {
                         kind: 'SCALAR',
-                        name: 'String'
-                      }
+                        name: 'String',
+                      },
                     },
-                    defaultValue: null
-                  }
-                ]
+                    defaultValue: null,
+                  },
+                ],
               },
               {
                 name: 'droid',
@@ -389,18 +390,17 @@ describe('Star Wars Introspection Tests', () => {
                       name: null,
                       ofType: {
                         kind: 'SCALAR',
-                        name: 'String'
-                      }
+                        name: 'String',
+                      },
                     },
-                    defaultValue: null
-                  }
-                ]
-              }
-            ]
-          }
-        }
+                    defaultValue: null,
+                  },
+                ],
+              },
+            ],
+          },
+        },
       };
-
 
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });
@@ -418,8 +418,8 @@ describe('Star Wars Introspection Tests', () => {
       const expected = {
         __type: {
           name: 'Droid',
-          description: 'A mechanical creature in the Star Wars universe.'
-        }
+          description: 'A mechanical creature in the Star Wars universe.',
+        },
       };
       const result = await graphql(StarWarsSchema, query);
       expect(result).to.deep.equal({ data: expected });

--- a/src/__tests__/starWarsQuery-test.js
+++ b/src/__tests__/starWarsQuery-test.js
@@ -29,9 +29,9 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           hero: {
-            name: 'R2-D2'
-          }
-        }
+            name: 'R2-D2',
+          },
+        },
       });
     });
 
@@ -50,9 +50,9 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           hero: {
-            name: 'R2-D2'
-          }
-        }
+            name: 'R2-D2',
+          },
+        },
       });
     });
 
@@ -84,9 +84,9 @@ describe('Star Wars Query Tests', () => {
               {
                 name: 'Leia Organa',
               },
-            ]
-          }
-        }
+            ],
+          },
+        },
       });
     });
   });
@@ -115,7 +115,7 @@ describe('Star Wars Query Tests', () => {
             friends: [
               {
                 name: 'Luke Skywalker',
-                appearsIn: [ 'NEWHOPE', 'EMPIRE', 'JEDI' ],
+                appearsIn: ['NEWHOPE', 'EMPIRE', 'JEDI'],
                 friends: [
                   {
                     name: 'Han Solo',
@@ -129,11 +129,11 @@ describe('Star Wars Query Tests', () => {
                   {
                     name: 'R2-D2',
                   },
-                ]
+                ],
               },
               {
                 name: 'Han Solo',
-                appearsIn: [ 'NEWHOPE', 'EMPIRE', 'JEDI' ],
+                appearsIn: ['NEWHOPE', 'EMPIRE', 'JEDI'],
                 friends: [
                   {
                     name: 'Luke Skywalker',
@@ -144,11 +144,11 @@ describe('Star Wars Query Tests', () => {
                   {
                     name: 'R2-D2',
                   },
-                ]
+                ],
               },
               {
                 name: 'Leia Organa',
-                appearsIn: [ 'NEWHOPE', 'EMPIRE', 'JEDI' ],
+                appearsIn: ['NEWHOPE', 'EMPIRE', 'JEDI'],
                 friends: [
                   {
                     name: 'Luke Skywalker',
@@ -162,11 +162,11 @@ describe('Star Wars Query Tests', () => {
                   {
                     name: 'R2-D2',
                   },
-                ]
+                ],
               },
-            ]
-          }
-        }
+            ],
+          },
+        },
       });
     });
   });
@@ -184,9 +184,9 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           human: {
-            name: 'Luke Skywalker'
-          }
-        }
+            name: 'Luke Skywalker',
+          },
+        },
       });
     });
 
@@ -203,9 +203,9 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           human: {
-            name: 'Luke Skywalker'
-          }
-        }
+            name: 'Luke Skywalker',
+          },
+        },
       });
     });
 
@@ -222,9 +222,9 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           human: {
-            name: 'Han Solo'
-          }
-        }
+            name: 'Han Solo',
+          },
+        },
       });
     });
 
@@ -240,8 +240,8 @@ describe('Star Wars Query Tests', () => {
       const result = await graphql(StarWarsSchema, query, null, null, params);
       expect(result).to.deep.equal({
         data: {
-          human: null
-        }
+          human: null,
+        },
       });
     });
   });
@@ -259,9 +259,9 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           luke: {
-            name: 'Luke Skywalker'
-          }
-        }
+            name: 'Luke Skywalker',
+          },
+        },
       });
     });
 
@@ -280,12 +280,12 @@ describe('Star Wars Query Tests', () => {
       expect(result).to.deep.equal({
         data: {
           luke: {
-            name: 'Luke Skywalker'
+            name: 'Luke Skywalker',
           },
           leia: {
-            name: 'Leia Organa'
-          }
-        }
+            name: 'Leia Organa',
+          },
+        },
       });
     });
   });
@@ -309,13 +309,13 @@ describe('Star Wars Query Tests', () => {
         data: {
           luke: {
             name: 'Luke Skywalker',
-            homePlanet: 'Tatooine'
+            homePlanet: 'Tatooine',
           },
           leia: {
             name: 'Leia Organa',
-            homePlanet: 'Alderaan'
-          }
-        }
+            homePlanet: 'Alderaan',
+          },
+        },
       });
     });
 
@@ -340,13 +340,13 @@ describe('Star Wars Query Tests', () => {
         data: {
           luke: {
             name: 'Luke Skywalker',
-            homePlanet: 'Tatooine'
+            homePlanet: 'Tatooine',
           },
           leia: {
             name: 'Leia Organa',
-            homePlanet: 'Alderaan'
-          }
-        }
+            homePlanet: 'Alderaan',
+          },
+        },
       });
     });
   });
@@ -366,9 +366,9 @@ describe('Star Wars Query Tests', () => {
         data: {
           hero: {
             __typename: 'Droid',
-            name: 'R2-D2'
-          }
-        }
+            name: 'R2-D2',
+          },
+        },
       });
     });
 
@@ -386,9 +386,9 @@ describe('Star Wars Query Tests', () => {
         data: {
           hero: {
             __typename: 'Human',
-            name: 'Luke Skywalker'
-          }
-        }
+            name: 'Luke Skywalker',
+          },
+        },
       });
     });
   });
@@ -408,16 +408,16 @@ describe('Star Wars Query Tests', () => {
         data: {
           hero: {
             name: 'R2-D2',
-            secretBackstory: null
-          }
+            secretBackstory: null,
+          },
         },
         errors: [
           {
             message: 'secretBackstory is secret.',
-            locations: [ { line: 5, column: 13 } ],
-            path: [ 'hero', 'secretBackstory' ]
-          }
-        ]
+            locations: [{ line: 5, column: 13 }],
+            path: ['hero', 'secretBackstory'],
+          },
+        ],
       });
     });
 
@@ -451,26 +451,26 @@ describe('Star Wars Query Tests', () => {
                 name: 'Leia Organa',
                 secretBackstory: null,
               },
-            ]
-          }
+            ],
+          },
         },
         errors: [
           {
             message: 'secretBackstory is secret.',
-            locations: [ { line: 7, column: 15 } ],
-            path: [ 'hero', 'friends', 0, 'secretBackstory' ]
+            locations: [{ line: 7, column: 15 }],
+            path: ['hero', 'friends', 0, 'secretBackstory'],
           },
           {
             message: 'secretBackstory is secret.',
-            locations: [ { line: 7, column: 15 } ],
-            path: [ 'hero', 'friends', 1, 'secretBackstory' ]
+            locations: [{ line: 7, column: 15 }],
+            path: ['hero', 'friends', 1, 'secretBackstory'],
           },
           {
             message: 'secretBackstory is secret.',
-            locations: [ { line: 7, column: 15 } ],
-            path: [ 'hero', 'friends', 2, 'secretBackstory' ]
-          }
-        ]
+            locations: [{ line: 7, column: 15 }],
+            path: ['hero', 'friends', 2, 'secretBackstory'],
+          },
+        ],
       });
     });
 
@@ -489,15 +489,15 @@ describe('Star Wars Query Tests', () => {
           mainHero: {
             name: 'R2-D2',
             story: null,
-          }
+          },
         },
         errors: [
           {
             message: 'secretBackstory is secret.',
-            locations: [ { line: 5, column: 13 } ],
-            path: [ 'mainHero', 'story' ]
-          }
-        ]
+            locations: [{ line: 5, column: 13 }],
+            path: ['mainHero', 'story'],
+          },
+        ],
       });
     });
   });

--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -90,7 +90,7 @@ const episodeEnum = new GraphQLEnumType({
       value: 6,
       description: 'Released in 1983.',
     },
-  }
+  },
 });
 
 /**
@@ -119,8 +119,9 @@ const characterInterface = new GraphQLInterfaceType({
     },
     friends: {
       type: new GraphQLList(characterInterface),
-      description: 'The friends of the character, or an empty list if they ' +
-                   'have none.',
+      description:
+        'The friends of the character, or an empty list if they ' +
+        'have none.',
     },
     appearsIn: {
       type: new GraphQLList(episodeEnum),
@@ -138,7 +139,7 @@ const characterInterface = new GraphQLInterfaceType({
     if (character.type === 'Droid') {
       return droidType;
     }
-  }
+  },
 });
 
 /**
@@ -187,7 +188,7 @@ const humanType = new GraphQLObjectType({
       },
     },
   }),
-  interfaces: [ characterInterface ]
+  interfaces: [characterInterface],
 });
 
 /**
@@ -237,7 +238,7 @@ const droidType = new GraphQLObjectType({
       description: 'The primary function of the droid.',
     },
   }),
-  interfaces: [ characterInterface ]
+  interfaces: [characterInterface],
 });
 
 /**
@@ -261,10 +262,11 @@ const queryType = new GraphQLObjectType({
       type: characterInterface,
       args: {
         episode: {
-          description: 'If omitted, returns the hero of the whole saga. If ' +
-                       'provided, returns the hero of that particular episode.',
-          type: episodeEnum
-        }
+          description:
+            'If omitted, returns the hero of the whole saga. If ' +
+            'provided, returns the hero of that particular episode.',
+          type: episodeEnum,
+        },
       },
       resolve: (root, { episode }) => getHero(episode),
     },
@@ -273,8 +275,8 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the human',
-          type: new GraphQLNonNull(GraphQLString)
-        }
+          type: new GraphQLNonNull(GraphQLString),
+        },
       },
       resolve: (root, { id }) => getHuman(id),
     },
@@ -283,12 +285,12 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the droid',
-          type: new GraphQLNonNull(GraphQLString)
-        }
+          type: new GraphQLNonNull(GraphQLString),
+        },
       },
       resolve: (root, { id }) => getDroid(id),
     },
-  })
+  }),
 });
 
 /**
@@ -297,5 +299,5 @@ const queryType = new GraphQLObjectType({
  */
 export const StarWarsSchema = new GraphQLSchema({
   query: queryType,
-  types: [ humanType, droidType ]
+  types: [humanType, droidType],
 });

--- a/src/__tests__/starWarsValidation-test.js
+++ b/src/__tests__/starWarsValidation-test.js
@@ -14,7 +14,6 @@ import { Source } from '../language/source';
 import { parse } from '../language/parser';
 import { validate } from '../validation/validate';
 
-
 /**
  * Helper function to test a query and the expected response.
  */

--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -18,14 +18,13 @@ import type { Source } from '../language/source';
  * GraphQL document and/or execution result that correspond to the Error.
  */
 declare class GraphQLError extends Error {
-
   constructor(
     message: string,
     nodes?: ?Array<*>,
     source?: ?Source,
     positions?: ?Array<number>,
     path?: ?Array<string | number>,
-    originalError?: ?Error
+    originalError?: ?Error,
   ): void;
 
   /**
@@ -83,7 +82,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   source?: ?Source,
   positions?: ?Array<number>,
   path?: ?Array<string | number>,
-  originalError?: ?Error
+  originalError?: ?Error,
 ) {
   // Compute locations in the source for the given nodes/positions.
   let _source = source;
@@ -94,7 +93,8 @@ export function GraphQLError( // eslint-disable-line no-redeclare
 
   let _positions = positions;
   if (!_positions && nodes) {
-    _positions = nodes.filter(node => Boolean(node.loc))
+    _positions = nodes
+      .filter(node => Boolean(node.loc))
       .map(node => node.loc.start);
   }
   if (_positions && _positions.length === 0) {
@@ -114,7 +114,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       // resulting output. This ensures that the simplest possible GraphQL
       // service adheres to the spec.
       enumerable: true,
-      writable: true
+      writable: true,
     },
     locations: {
       // Coercing falsey values to undefined ensures they will not be included
@@ -123,7 +123,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       // By being enumerable, JSON.stringify will include `locations` in the
       // resulting output. This ensures that the simplest possible GraphQL
       // service adheres to the spec.
-      enumerable: true
+      enumerable: true,
     },
     path: {
       // Coercing falsey values to undefined ensures they will not be included
@@ -132,10 +132,10 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       // By being enumerable, JSON.stringify will include `path` in the
       // resulting output. This ensures that the simplest possible GraphQL
       // service adheres to the spec.
-      enumerable: true
+      enumerable: true,
     },
     nodes: {
-      value: nodes || undefined
+      value: nodes || undefined,
     },
     source: {
       value: _source || undefined,
@@ -144,8 +144,8 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       value: _positions || undefined,
     },
     originalError: {
-      value: originalError
-    }
+      value: originalError,
+    },
   });
 
   // Include (non-enumerable) stack trace.
@@ -153,7 +153,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
     Object.defineProperty(this, 'stack', {
       value: originalError.stack,
       writable: true,
-      configurable: true
+      configurable: true,
     });
   } else if (Error.captureStackTrace) {
     Error.captureStackTrace(this, GraphQLError);
@@ -161,12 +161,12 @@ export function GraphQLError( // eslint-disable-line no-redeclare
     Object.defineProperty(this, 'stack', {
       value: Error().stack,
       writable: true,
-      configurable: true
+      configurable: true,
     });
   }
 }
 
 (GraphQLError: any).prototype = Object.create(Error.prototype, {
   constructor: { value: GraphQLError },
-  name: { value: 'GraphQLError' }
+  name: { value: 'GraphQLError' },
 });

--- a/src/error/__tests__/GraphQLError-test.js
+++ b/src/error/__tests__/GraphQLError-test.js
@@ -10,9 +10,7 @@ import { describe, it } from 'mocha';
 
 import { parse, Source, GraphQLError, formatError } from '../../';
 
-
 describe('GraphQLError', () => {
-
   it('is a class and is a subclass of Error', () => {
     expect(new GraphQLError()).to.be.instanceof(Error);
     expect(new GraphQLError()).to.be.instanceof(GraphQLError);
@@ -33,7 +31,7 @@ describe('GraphQLError', () => {
       undefined,
       undefined,
       undefined,
-      original
+      original,
     );
     expect(e.name).to.equal('GraphQLError');
     expect(e.stack).to.equal(original.stack);
@@ -43,14 +41,7 @@ describe('GraphQLError', () => {
 
   it('creates new stack if original error has no stack', () => {
     const original = { message: 'original' };
-    const e = new GraphQLError(
-      'msg',
-      null,
-      null,
-      null,
-      null,
-      original
-    );
+    const e = new GraphQLError('msg', null, null, null, null, original);
     expect(e.name).to.equal('GraphQLError');
     expect(e.stack).to.be.a('string');
     expect(e.message).to.equal('msg');
@@ -63,11 +54,11 @@ describe('GraphQLError', () => {
     }`);
     const ast = parse(source);
     const fieldNode = ast.definitions[0].selectionSet.selections[0];
-    const e = new GraphQLError('msg', [ fieldNode ]);
-    expect(e.nodes).to.deep.equal([ fieldNode ]);
+    const e = new GraphQLError('msg', [fieldNode]);
+    expect(e.nodes).to.deep.equal([fieldNode]);
     expect(e.source).to.equal(source);
-    expect(e.positions).to.deep.equal([ 8 ]);
-    expect(e.locations).to.deep.equal([ { line: 2, column: 7 } ]);
+    expect(e.positions).to.deep.equal([8]);
+    expect(e.locations).to.deep.equal([{ line: 2, column: 7 }]);
   });
 
   it('converts node with loc.start === 0 to positions and locations', () => {
@@ -76,22 +67,22 @@ describe('GraphQLError', () => {
     }`);
     const ast = parse(source);
     const operationNode = ast.definitions[0];
-    const e = new GraphQLError('msg', [ operationNode ]);
-    expect(e.nodes).to.deep.equal([ operationNode ]);
+    const e = new GraphQLError('msg', [operationNode]);
+    expect(e.nodes).to.deep.equal([operationNode]);
     expect(e.source).to.equal(source);
-    expect(e.positions).to.deep.equal([ 0 ]);
-    expect(e.locations).to.deep.equal([ { line: 1, column: 1 } ]);
+    expect(e.positions).to.deep.equal([0]);
+    expect(e.locations).to.deep.equal([{ line: 1, column: 1 }]);
   });
 
   it('converts source and positions to locations', () => {
     const source = new Source(`{
       field
     }`);
-    const e = new GraphQLError('msg', null, source, [ 10 ]);
+    const e = new GraphQLError('msg', null, source, [10]);
     expect(e.nodes).to.equal(undefined);
     expect(e.source).to.equal(source);
-    expect(e.positions).to.deep.equal([ 10 ]);
-    expect(e.locations).to.deep.equal([ { line: 2, column: 9 } ]);
+    expect(e.positions).to.deep.equal([10]);
+    expect(e.locations).to.deep.equal([{ line: 2, column: 9 }]);
   });
 
   it('serializes to include message', () => {
@@ -101,40 +92,37 @@ describe('GraphQLError', () => {
 
   it('serializes to include message and locations', () => {
     const node = parse('{ field }').definitions[0].selectionSet.selections[0];
-    const e = new GraphQLError('msg', [ node ]);
+    const e = new GraphQLError('msg', [node]);
     expect(JSON.stringify(e)).to.equal(
-      '{"message":"msg","locations":[{"line":1,"column":3}]}'
+      '{"message":"msg","locations":[{"line":1,"column":3}]}',
     );
   });
 
   it('serializes to include path', () => {
-    const e = new GraphQLError(
-      'msg',
-      null,
-      null,
-      null,
-      [ 'path', 3, 'to', 'field' ]
-    );
-    expect(e.path).to.deep.equal([ 'path', 3, 'to', 'field' ]);
+    const e = new GraphQLError('msg', null, null, null, [
+      'path',
+      3,
+      'to',
+      'field',
+    ]);
+    expect(e.path).to.deep.equal(['path', 3, 'to', 'field']);
     expect(JSON.stringify(e)).to.equal(
-      '{"message":"msg","path":["path",3,"to","field"]}'
+      '{"message":"msg","path":["path",3,"to","field"]}',
     );
   });
 
   it('default error formatter includes path', () => {
-    const e = new GraphQLError(
-      'msg',
-      null,
-      null,
-      null,
-      [ 'path', 3, 'to', 'field' ]
-    );
+    const e = new GraphQLError('msg', null, null, null, [
+      'path',
+      3,
+      'to',
+      'field',
+    ]);
 
     expect(formatError(e)).to.deep.equal({
       message: 'msg',
       locations: undefined,
-      path: [ 'path', 3, 'to', 'field' ]
+      path: ['path', 3, 'to', 'field'],
     });
   });
-
 });

--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -10,7 +10,6 @@
 import invariant from '../jsutils/invariant';
 import type { GraphQLError } from './GraphQLError';
 
-
 /**
  * Given a GraphQLError, format it according to the rules described by the
  * Response Format, Errors section of the GraphQL Specification.
@@ -20,17 +19,17 @@ export function formatError(error: GraphQLError): GraphQLFormattedError {
   return {
     message: error.message,
     locations: error.locations,
-    path: error.path
+    path: error.path,
   };
 }
 
 export type GraphQLFormattedError = {
   message: string,
   locations: ?Array<GraphQLErrorLocation>,
-  path: ?Array<string | number>
+  path: ?Array<string | number>,
 };
 
 export type GraphQLErrorLocation = {
   line: number,
-  column: number
+  column: number,
 };

--- a/src/error/index.js
+++ b/src/error/index.js
@@ -14,5 +14,5 @@ export { formatError } from './formatError';
 
 export type {
   GraphQLFormattedError,
-  GraphQLErrorLocation
+  GraphQLErrorLocation,
 } from './formatError';

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -9,7 +9,6 @@
 
 import { GraphQLError } from './GraphQLError';
 
-
 /**
  * Given an arbitrary Error, presumably thrown while attempting to execute a
  * GraphQL operation, produce a new GraphQLError aware of the location in the
@@ -18,7 +17,7 @@ import { GraphQLError } from './GraphQLError';
 export function locatedError(
   originalError: ?Error,
   nodes: Array<*>,
-  path: Array<string | number>
+  path: Array<string | number>,
 ): GraphQLError {
   // Note: this uses a brand-check to support GraphQL errors originating from
   // other contexts.
@@ -26,15 +25,15 @@ export function locatedError(
     return (originalError: any);
   }
 
-  const message = originalError ?
-    originalError.message || String(originalError) :
-    'An unknown error occurred.';
+  const message = originalError
+    ? originalError.message || String(originalError)
+    : 'An unknown error occurred.';
   return new GraphQLError(
     message,
-    originalError && (originalError: any).nodes || nodes,
+    (originalError && (originalError: any).nodes) || nodes,
     originalError && (originalError: any).source,
     originalError && (originalError: any).positions,
     path,
-    originalError
+    originalError,
   );
 }

--- a/src/error/syntaxError.js
+++ b/src/error/syntaxError.js
@@ -11,7 +11,7 @@ import { getLocation } from '../language/location';
 import type { Source } from '../language/source';
 import { GraphQLError } from './GraphQLError';
 
-import type {SourceLocation} from '../language/location';
+import type { SourceLocation } from '../language/location';
 
 /**
  * Produces a GraphQLError representing a syntax error, containing useful
@@ -20,7 +20,7 @@ import type {SourceLocation} from '../language/location';
 export function syntaxError(
   source: Source,
   position: number,
-  description: string
+  description: string,
 ): GraphQLError {
   const location = getLocation(source, position);
   const line = location.line + source.locationOffset.line - 1;
@@ -28,10 +28,11 @@ export function syntaxError(
   const column = location.column + columnOffset;
   const error = new GraphQLError(
     `Syntax Error ${source.name} (${line}:${column}) ${description}` +
-      '\n\n' + highlightSourceAtLocation(source, location),
+      '\n\n' +
+      highlightSourceAtLocation(source, location),
     undefined,
     source,
-    [ position ]
+    [position],
   );
   return error;
 }
@@ -52,19 +53,22 @@ function highlightSourceAtLocation(source, location) {
   const lines = source.body.split(/\r\n|[\n\r]/g);
   lines[0] = whitespace(source.locationOffset.column - 1) + lines[0];
   return (
-    (line >= 2 ?
-      lpad(padLen, prevLineNum) + ': ' + lines[line - 2] + '\n' : '') +
-    lpad(padLen, lineNum) + ': ' + lines[line - 1] + '\n' +
-    whitespace(2 + padLen + location.column - 1 + columnOffset) + '^\n' +
-    (line < lines.length ?
-      lpad(padLen, nextLineNum) + ': ' + lines[line] + '\n' : '')
+    (line >= 2
+      ? lpad(padLen, prevLineNum) + ': ' + lines[line - 2] + '\n'
+      : '') +
+    lpad(padLen, lineNum) +
+    ': ' +
+    lines[line - 1] +
+    '\n' +
+    whitespace(2 + padLen + location.column - 1 + columnOffset) +
+    '^\n' +
+    (line < lines.length
+      ? lpad(padLen, nextLineNum) + ': ' + lines[line] + '\n'
+      : '')
   );
 }
 
-function getColumnOffset(
-  source: Source,
-  location: SourceLocation
-): number {
+function getColumnOffset(source: Source, location: SourceLocation): number {
   return location.line === 1 ? source.locationOffset.column - 1 : 0;
 }
 

--- a/src/execution/__tests__/abstract-promise-test.js
+++ b/src/execution/__tests__/abstract-promise-test.js
@@ -39,33 +39,32 @@ class Human {
 }
 
 describe('Execute: Handles execution of abstract types with promises', () => {
-
   it('isTypeOf used to resolve runtime type for Interface', async () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       isTypeOf: obj => Promise.resolve(obj instanceof Dog),
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       isTypeOf: obj => Promise.resolve(obj instanceof Cat),
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -75,12 +74,12 @@ describe('Execute: Handles execution of abstract types with promises', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
-            }
-          }
-        }
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -100,10 +99,16 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     expect(result).to.deep.equal({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false } ] }
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+        ],
+      },
     });
   });
 
@@ -111,28 +116,28 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       isTypeOf: () => Promise.reject(new Error('We are testing this error')),
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       isTypeOf: obj => Promise.resolve(obj instanceof Cat),
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -142,12 +147,12 @@ describe('Execute: Handles execution of abstract types with promises', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
-            }
-          }
-        }
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -166,20 +171,20 @@ describe('Execute: Handles execution of abstract types with promises', () => {
 
     expect(result).to.deep.equal({
       data: {
-        pets: [ null, null ]
+        pets: [null, null],
       },
       errors: [
         {
           message: 'We are testing this error',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 0 ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 0],
         },
         {
           message: 'We are testing this error',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 1 ]
-        }
-      ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 1],
+        },
+      ],
     });
   });
 
@@ -190,7 +195,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
@@ -199,12 +204,12 @@ describe('Execute: Handles execution of abstract types with promises', () => {
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const PetType = new GraphQLUnionType({
       name: 'Pet',
-      types: [ DogType, CatType ]
+      types: [DogType, CatType],
     });
 
     const schema = new GraphQLSchema({
@@ -214,11 +219,11 @@ describe('Execute: Handles execution of abstract types with promises', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
-            }
-          }
-        }
-      })
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
+      }),
     });
 
     const query = `{
@@ -239,10 +244,16 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     expect(result).to.deep.equal({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false } ] }
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+        ],
+      },
     });
   });
 
@@ -250,39 +261,42 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       resolveType(obj) {
-        return Promise.resolve(obj instanceof Dog ? DogType :
-          obj instanceof Cat ? CatType :
-          obj instanceof Human ? HumanType :
-          null);
+        return Promise.resolve(
+          obj instanceof Dog
+            ? DogType
+            : obj instanceof Cat
+              ? CatType
+              : obj instanceof Human ? HumanType : null,
+        );
       },
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const HumanType = new GraphQLObjectType({
       name: 'Human',
       fields: {
         name: { type: GraphQLString },
-      }
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -295,13 +309,13 @@ describe('Execute: Handles execution of abstract types with promises', () => {
               return Promise.resolve([
                 new Dog('Odie', true),
                 new Cat('Garfield', false),
-                new Human('Jon')
+                new Human('Jon'),
               ]);
-            }
-          }
-        }
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -321,21 +335,25 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     expect(result).to.jsonEqual({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false },
-          null
-        ]
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+          null,
+        ],
       },
       errors: [
         {
           message:
             'Runtime Object type "Human" is not a possible type for "Pet".',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 2 ]
-        }
-      ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 2],
+        },
+      ],
     });
   });
 
@@ -344,7 +362,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
       name: 'Human',
       fields: {
         name: { type: GraphQLString },
-      }
+      },
     });
 
     const DogType = new GraphQLObjectType({
@@ -352,7 +370,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
@@ -360,20 +378,22 @@ describe('Execute: Handles execution of abstract types with promises', () => {
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const PetType = new GraphQLUnionType({
       name: 'Pet',
       resolveType(obj) {
-        return Promise.resolve(obj instanceof Dog ? DogType :
-          obj instanceof Cat ? CatType :
-          obj instanceof Human ? HumanType :
-          null);
+        return Promise.resolve(
+          obj instanceof Dog
+            ? DogType
+            : obj instanceof Cat
+              ? CatType
+              : obj instanceof Human ? HumanType : null,
+        );
       },
-      types: [ DogType, CatType ]
+      types: [DogType, CatType],
     });
-
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -385,12 +405,12 @@ describe('Execute: Handles execution of abstract types with promises', () => {
               return [
                 new Dog('Odie', true),
                 new Cat('Garfield', false),
-                new Human('Jon')
+                new Human('Jon'),
               ];
-            }
-          }
-        }
-      })
+            },
+          },
+        },
+      }),
     });
 
     const query = `{
@@ -411,21 +431,25 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     expect(result).to.jsonEqual({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false },
-          null
-        ]
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+          null,
+        ],
       },
       errors: [
         {
           message:
             'Runtime Object type "Human" is not a possible type for "Pet".',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 2 ]
-        }
-      ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 2],
+        },
+      ],
     });
   });
 
@@ -433,31 +457,31 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       resolveType(obj) {
-        return Promise.resolve(obj instanceof Dog ? 'Dog' :
-          obj instanceof Cat ? 'Cat' :
-          null);
+        return Promise.resolve(
+          obj instanceof Dog ? 'Dog' : obj instanceof Cat ? 'Cat' : null,
+        );
       },
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -467,15 +491,12 @@ describe('Execute: Handles execution of abstract types with promises', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [
-                new Dog('Odie', true),
-                new Cat('Garfield', false)
-              ];
-            }
-          }
-        }
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -495,12 +516,16 @@ describe('Execute: Handles execution of abstract types with promises', () => {
     expect(result).to.jsonEqual({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false },
-        ]
-      }
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+        ],
+      },
     });
   });
 
@@ -509,26 +534,26 @@ describe('Execute: Handles execution of abstract types with promises', () => {
       name: 'Pet',
       resolveType: () => Promise.reject('We are testing this error'),
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -538,15 +563,12 @@ describe('Execute: Handles execution of abstract types with promises', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [
-                new Dog('Odie', true),
-                new Cat('Garfield', false)
-              ];
-            }
-          }
-        }
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -565,21 +587,20 @@ describe('Execute: Handles execution of abstract types with promises', () => {
 
     expect(result).to.jsonEqual({
       data: {
-        pets: [ null, null ]
+        pets: [null, null],
       },
       errors: [
         {
           message: 'We are testing this error',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 0 ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 0],
         },
         {
           message: 'We are testing this error',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 1 ]
-        }
-      ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 1],
+        },
+      ],
     });
   });
-
 });

--- a/src/execution/__tests__/abstract-test.js
+++ b/src/execution/__tests__/abstract-test.js
@@ -39,33 +39,32 @@ class Human {
 }
 
 describe('Execute: Handles execution of abstract types', () => {
-
   it('isTypeOf used to resolve runtime type for Interface', async () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       isTypeOf: obj => obj instanceof Dog,
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       isTypeOf: obj => obj instanceof Cat,
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -75,12 +74,12 @@ describe('Execute: Handles execution of abstract types', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
-            }
-          }
-        }
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -100,10 +99,16 @@ describe('Execute: Handles execution of abstract types', () => {
     expect(result).to.deep.equal({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false } ] }
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+        ],
+      },
     });
   });
 
@@ -114,7 +119,7 @@ describe('Execute: Handles execution of abstract types', () => {
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
@@ -123,12 +128,12 @@ describe('Execute: Handles execution of abstract types', () => {
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const PetType = new GraphQLUnionType({
       name: 'Pet',
-      types: [ DogType, CatType ]
+      types: [DogType, CatType],
     });
 
     const schema = new GraphQLSchema({
@@ -138,11 +143,11 @@ describe('Execute: Handles execution of abstract types', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [ new Dog('Odie', true), new Cat('Garfield', false) ];
-            }
-          }
-        }
-      })
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
+      }),
     });
 
     const query = `{
@@ -163,10 +168,16 @@ describe('Execute: Handles execution of abstract types', () => {
     expect(result).to.deep.equal({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false } ] }
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+        ],
+      },
     });
   });
 
@@ -174,39 +185,40 @@ describe('Execute: Handles execution of abstract types', () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       resolveType(obj) {
-        return obj instanceof Dog ? DogType :
-          obj instanceof Cat ? CatType :
-          obj instanceof Human ? HumanType :
-          null;
+        return obj instanceof Dog
+          ? DogType
+          : obj instanceof Cat
+            ? CatType
+            : obj instanceof Human ? HumanType : null;
       },
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const HumanType = new GraphQLObjectType({
       name: 'Human',
       fields: {
         name: { type: GraphQLString },
-      }
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -219,13 +231,13 @@ describe('Execute: Handles execution of abstract types', () => {
               return [
                 new Dog('Odie', true),
                 new Cat('Garfield', false),
-                new Human('Jon')
+                new Human('Jon'),
               ];
-            }
-          }
-        }
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -245,21 +257,25 @@ describe('Execute: Handles execution of abstract types', () => {
     expect(result).to.jsonEqual({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false },
-          null
-        ]
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+          null,
+        ],
       },
       errors: [
         {
           message:
             'Runtime Object type "Human" is not a possible type for "Pet".',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 2 ]
-        }
-      ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 2],
+        },
+      ],
     });
   });
 
@@ -268,7 +284,7 @@ describe('Execute: Handles execution of abstract types', () => {
       name: 'Human',
       fields: {
         name: { type: GraphQLString },
-      }
+      },
     });
 
     const DogType = new GraphQLObjectType({
@@ -276,7 +292,7 @@ describe('Execute: Handles execution of abstract types', () => {
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
@@ -284,20 +300,20 @@ describe('Execute: Handles execution of abstract types', () => {
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const PetType = new GraphQLUnionType({
       name: 'Pet',
       resolveType(obj) {
-        return obj instanceof Dog ? DogType :
-          obj instanceof Cat ? CatType :
-          obj instanceof Human ? HumanType :
-          null;
+        return obj instanceof Dog
+          ? DogType
+          : obj instanceof Cat
+            ? CatType
+            : obj instanceof Human ? HumanType : null;
       },
-      types: [ DogType, CatType ]
+      types: [DogType, CatType],
     });
-
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -309,12 +325,12 @@ describe('Execute: Handles execution of abstract types', () => {
               return [
                 new Dog('Odie', true),
                 new Cat('Garfield', false),
-                new Human('Jon')
+                new Human('Jon'),
               ];
-            }
-          }
-        }
-      })
+            },
+          },
+        },
+      }),
     });
 
     const query = `{
@@ -335,21 +351,25 @@ describe('Execute: Handles execution of abstract types', () => {
     expect(result).to.jsonEqual({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false },
-          null
-        ]
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+          null,
+        ],
       },
       errors: [
         {
           message:
             'Runtime Object type "Human" is not a possible type for "Pet".',
-          locations: [ { line: 2, column: 7 } ],
-          path: [ 'pets', 2 ]
-        }
-      ]
+          locations: [{ line: 2, column: 7 }],
+          path: ['pets', 2],
+        },
+      ],
     });
   });
 
@@ -357,31 +377,29 @@ describe('Execute: Handles execution of abstract types', () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
       resolveType(obj) {
-        return obj instanceof Dog ? 'Dog' :
-          obj instanceof Cat ? 'Cat' :
-          null;
+        return obj instanceof Dog ? 'Dog' : obj instanceof Cat ? 'Cat' : null;
       },
       fields: {
-        name: { type: GraphQLString }
-      }
+        name: { type: GraphQLString },
+      },
     });
 
     const DogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         woofs: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const CatType = new GraphQLObjectType({
       name: 'Cat',
-      interfaces: [ PetType ],
+      interfaces: [PetType],
       fields: {
         name: { type: GraphQLString },
         meows: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -391,15 +409,12 @@ describe('Execute: Handles execution of abstract types', () => {
           pets: {
             type: new GraphQLList(PetType),
             resolve() {
-              return [
-                new Dog('Odie', true),
-                new Cat('Garfield', false)
-              ];
-            }
-          }
-        }
+              return [new Dog('Odie', true), new Cat('Garfield', false)];
+            },
+          },
+        },
       }),
-      types: [ CatType, DogType ]
+      types: [CatType, DogType],
     });
 
     const query = `{
@@ -419,13 +434,16 @@ describe('Execute: Handles execution of abstract types', () => {
     expect(result).to.jsonEqual({
       data: {
         pets: [
-          { name: 'Odie',
-            woofs: true },
-          { name: 'Garfield',
-            meows: false },
-        ]
-      }
+          {
+            name: 'Odie',
+            woofs: true,
+          },
+          {
+            name: 'Garfield',
+            meows: false,
+          },
+        ],
+      },
     });
   });
-
 });

--- a/src/execution/__tests__/directives-test.js
+++ b/src/execution/__tests__/directives-test.js
@@ -9,12 +9,7 @@ import { expect } from 'chai';
 import { execute } from '../execute';
 import { describe, it } from 'mocha';
 import { parse } from '../../language';
-import {
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLString,
-} from '../../type';
-
+import { GraphQLSchema, GraphQLObjectType, GraphQLString } from '../../type';
 
 const schema = new GraphQLSchema({
   query: new GraphQLObjectType({
@@ -22,13 +17,17 @@ const schema = new GraphQLSchema({
     fields: {
       a: { type: GraphQLString },
       b: { type: GraphQLString },
-    }
+    },
   }),
 });
 
 const data = {
-  a() { return 'a'; },
-  b() { return 'b'; }
+  a() {
+    return 'a';
+  },
+  b() {
+    return 'b';
+  },
 };
 
 async function executeTestQuery(doc) {
@@ -38,10 +37,8 @@ async function executeTestQuery(doc) {
 describe('Execute: handles directives', () => {
   describe('works without directives', () => {
     it('basic query works', async () => {
-      expect(
-        await executeTestQuery('{ a, b }')
-      ).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+      expect(await executeTestQuery('{ a, b }')).to.deep.equal({
+        data: { a: 'a', b: 'b' },
       });
     });
   });
@@ -49,33 +46,33 @@ describe('Execute: handles directives', () => {
   describe('works on scalars', () => {
     it('if true includes scalar', async () => {
       return expect(
-        await executeTestQuery('{ a, b @include(if: true) }')
+        await executeTestQuery('{ a, b @include(if: true) }'),
       ).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
 
     it('if false omits on scalar', async () => {
       return expect(
-        await executeTestQuery('{ a, b @include(if: false) }')
+        await executeTestQuery('{ a, b @include(if: false) }'),
       ).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
 
     it('unless false includes scalar', async () => {
       return expect(
-        await executeTestQuery('{ a, b @skip(if: false) }')
+        await executeTestQuery('{ a, b @skip(if: false) }'),
       ).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
 
     it('unless true omits scalar', async () => {
       return expect(
-        await executeTestQuery('{ a, b @skip(if: true) }')
+        await executeTestQuery('{ a, b @skip(if: true) }'),
       ).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
   });
@@ -92,7 +89,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
 
@@ -107,7 +104,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
 
@@ -122,7 +119,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
 
@@ -137,7 +134,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
   });
@@ -153,7 +150,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
 
@@ -167,7 +164,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
     it('unless false includes inline fragment', async () => {
@@ -180,7 +177,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
     it('unless true includes inline fragment', async () => {
@@ -193,7 +190,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
   });
@@ -209,7 +206,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
 
@@ -223,7 +220,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
     it('unless false includes anonymous inline fragment', async () => {
@@ -236,7 +233,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
     it('unless true includes anonymous inline fragment', async () => {
@@ -249,7 +246,7 @@ describe('Execute: handles directives', () => {
         }
       `;
       return expect(await executeTestQuery(q)).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
   });
@@ -257,25 +254,25 @@ describe('Execute: handles directives', () => {
   describe('works with skip and include directives', () => {
     it('include and no skip', async () => {
       return expect(
-        await executeTestQuery('{ a, b @include(if: true) @skip(if: false) }')
+        await executeTestQuery('{ a, b @include(if: true) @skip(if: false) }'),
       ).to.deep.equal({
-        data: { a: 'a', b: 'b' }
+        data: { a: 'a', b: 'b' },
       });
     });
 
     it('include and skip', async () => {
       return expect(
-        await executeTestQuery('{ a, b @include(if: true) @skip(if: true) }')
+        await executeTestQuery('{ a, b @include(if: true) @skip(if: true) }'),
       ).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
 
     it('no include or skip', async () => {
       return expect(
-        await executeTestQuery('{ a, b @include(if: false) @skip(if: false) }')
+        await executeTestQuery('{ a, b @include(if: false) @skip(if: false) }'),
       ).to.deep.equal({
-        data: { a: 'a' }
+        data: { a: 'a' },
       });
     });
   });

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -27,21 +27,19 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
-    expect(() => execute(schema, null)).to.throw(
-      'Must provide document'
-    );
+    expect(() => execute(schema, null)).to.throw('Must provide document');
   });
 
   it('throws if no schema is provided', () => {
-    expect(() => execute({
-      document: parse('{ field }')
-    })).to.throw(
-      'Must provide schema'
-    );
+    expect(() =>
+      execute({
+        document: parse('{ field }'),
+      }),
+    ).to.throw('Must provide schema');
   });
 
   it('accepts an object with named properties as arguments', async () => {
@@ -57,44 +55,65 @@ describe('Execute: Handles basic execution tasks', () => {
             type: GraphQLString,
             resolve(rootValue) {
               return rootValue;
-            }
-          }
-        }
-      })
+            },
+          },
+        },
+      }),
     });
 
     const result = await execute({
       schema,
       document: parse(doc),
-      rootValue: data
+      rootValue: data,
     });
 
     expect(result).to.jsonEqual({
-      data: { a: 'rootValue' }
+      data: { a: 'rootValue' },
     });
   });
 
-
   it('executes arbitrary code', async () => {
     const data = {
-      a() { return 'Apple'; },
-      b() { return 'Banana'; },
-      c() { return 'Cookie'; },
-      d() { return 'Donut'; },
-      e() { return 'Egg'; },
+      a() {
+        return 'Apple';
+      },
+      b() {
+        return 'Banana';
+      },
+      c() {
+        return 'Cookie';
+      },
+      d() {
+        return 'Donut';
+      },
+      e() {
+        return 'Egg';
+      },
       f: 'Fish',
       pic(size) {
         return 'Pic of size: ' + (size || 50);
       },
-      deep() { return deepData; },
-      promise() { return promiseData(); }
+      deep() {
+        return deepData;
+      },
+      promise() {
+        return promiseData();
+      },
     };
 
     const deepData = {
-      a() { return 'Already Been Done'; },
-      b() { return 'Boring'; },
-      c() { return [ 'Contrived', undefined, 'Confusing' ]; },
-      deeper() { return [ data, null, data ]; }
+      a() {
+        return 'Already Been Done';
+      },
+      b() {
+        return 'Boring';
+      },
+      c() {
+        return ['Contrived', undefined, 'Confusing'];
+      },
+      deeper() {
+        return [data, null, data];
+      },
     };
 
     function promiseData() {
@@ -149,11 +168,14 @@ describe('Execute: Handles basic execution tasks', () => {
         deep: {
           a: 'Already Been Done',
           b: 'Boring',
-          c: [ 'Contrived', null, 'Confusing' ],
+          c: ['Contrived', null, 'Confusing'],
           deeper: [
             { a: 'Apple', b: 'Banana' },
             null,
-            { a: 'Apple', b: 'Banana' } ] } }
+            { a: 'Apple', b: 'Banana' },
+          ],
+        },
+      },
     };
 
     const DataType = new GraphQLObjectType({
@@ -168,11 +190,11 @@ describe('Execute: Handles basic execution tasks', () => {
         pic: {
           args: { size: { type: GraphQLInt } },
           type: GraphQLString,
-          resolve: (obj, { size }) => obj.pic(size)
+          resolve: (obj, { size }) => obj.pic(size),
         },
         deep: { type: DeepDataType },
         promise: { type: DataType },
-      })
+      }),
     });
 
     const DeepDataType = new GraphQLObjectType({
@@ -182,15 +204,15 @@ describe('Execute: Handles basic execution tasks', () => {
         b: { type: GraphQLString },
         c: { type: new GraphQLList(GraphQLString) },
         deeper: { type: new GraphQLList(DataType) },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
-      query: DataType
+      query: DataType,
     });
 
     expect(
-      await execute(schema, ast, data, null, { size: 100 }, 'Example')
+      await execute(schema, ast, data, null, { size: 100 }, 'Example'),
     ).to.deep.equal(expected);
   });
 
@@ -216,13 +238,11 @@ describe('Execute: Handles basic execution tasks', () => {
         b: { type: GraphQLString, resolve: () => 'Banana' },
         c: { type: GraphQLString, resolve: () => 'Cherry' },
         deep: { type: Type, resolve: () => ({}) },
-      })
+      }),
     });
     const schema = new GraphQLSchema({ query: Type });
 
-    expect(
-      await execute(schema, ast)
-    ).to.deep.equal({
+    expect(await execute(schema, ast)).to.deep.equal({
       data: {
         a: 'Apple',
         b: 'Banana',
@@ -232,7 +252,10 @@ describe('Execute: Handles basic execution tasks', () => {
           c: 'Cherry',
           deeper: {
             b: 'Banana',
-            c: 'Cherry' } } }
+            c: 'Cherry',
+          },
+        },
+      },
     });
   });
 
@@ -249,10 +272,10 @@ describe('Execute: Handles basic execution tasks', () => {
             type: GraphQLString,
             resolve(val, args, ctx, _info) {
               info = _info;
-            }
-          }
-        }
-      })
+            },
+          },
+        },
+      }),
     });
 
     const rootValue = { root: 'val' };
@@ -274,7 +297,7 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(info.fieldName).to.equal('test');
     expect(info.fieldNodes).to.have.lengthOf(1);
     expect(info.fieldNodes[0]).to.equal(
-      ast.definitions[0].selectionSet.selections[0]
+      ast.definitions[0].selectionSet.selections[0],
     );
     expect(info.returnType).to.equal(GraphQLString);
     expect(info.parentType).to.equal(schema.getQueryType());
@@ -302,10 +325,10 @@ describe('Execute: Handles basic execution tasks', () => {
             type: GraphQLString,
             resolve(rootValue) {
               resolvedRootValue = rootValue;
-            }
-          }
-        }
-      })
+            },
+          },
+        },
+      }),
     });
 
     await execute(schema, parse(doc), data);
@@ -329,15 +352,15 @@ describe('Execute: Handles basic execution tasks', () => {
           b: {
             args: {
               numArg: { type: GraphQLInt },
-              stringArg: { type: GraphQLString }
+              stringArg: { type: GraphQLString },
             },
             type: GraphQLString,
             resolve(_, args) {
               resolvedArgs = args;
-            }
-          }
-        }
-      })
+            },
+          },
+        },
+      }),
     });
 
     await execute(schema, parse(doc));
@@ -382,7 +405,7 @@ describe('Execute: Handles basic execution tasks', () => {
           'sync0',
           new Error('Error getting syncReturnErrorList1'),
           'sync2',
-          new Error('Error getting syncReturnErrorList3')
+          new Error('Error getting syncReturnErrorList3'),
         ];
       },
       async() {
@@ -390,7 +413,7 @@ describe('Execute: Handles basic execution tasks', () => {
       },
       asyncReject() {
         return new Promise((_, reject) =>
-          reject(new Error('Error getting asyncReject'))
+          reject(new Error('Error getting asyncReject')),
         );
       },
       asyncRawReject() {
@@ -433,8 +456,8 @@ describe('Execute: Handles basic execution tasks', () => {
           asyncError: { type: GraphQLString },
           asyncRawError: { type: GraphQLString },
           asyncReturnError: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data);
@@ -444,7 +467,7 @@ describe('Execute: Handles basic execution tasks', () => {
       syncError: null,
       syncRawError: null,
       syncReturnError: null,
-      syncReturnErrorList: [ 'sync0', null, 'sync2', null ],
+      syncReturnErrorList: ['sync0', null, 'sync2', null],
       async: 'async',
       asyncReject: null,
       asyncRawReject: null,
@@ -455,42 +478,63 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     expect(result.errors && result.errors.map(formatError)).to.deep.equal([
-      { message: 'Error getting syncError',
-        locations: [ { line: 3, column: 7 } ],
-        path: [ 'syncError' ] },
-      { message: 'Error getting syncRawError',
-        locations: [ { line: 4, column: 7 } ],
-        path: [ 'syncRawError' ] },
-      { message: 'Error getting syncReturnError',
-        locations: [ { line: 5, column: 7 } ],
-        path: [ 'syncReturnError' ] },
-      { message: 'Error getting syncReturnErrorList1',
-        locations: [ { line: 6, column: 7 } ],
-        path: [ 'syncReturnErrorList', 1 ] },
-      { message: 'Error getting syncReturnErrorList3',
-        locations: [ { line: 6, column: 7 } ],
-        path: [ 'syncReturnErrorList', 3 ] },
-      { message: 'Error getting asyncReject',
-        locations: [ { line: 8, column: 7 } ],
-        path: [ 'asyncReject' ] },
-      { message: 'Error getting asyncRawReject',
-        locations: [ { line: 9, column: 7 } ],
-        path: [ 'asyncRawReject' ] },
-      { message: 'An unknown error occurred.',
-        locations: [ { line: 10, column: 7 } ],
-        path: [ 'asyncEmptyReject' ] },
-      { message: 'Error getting asyncError',
-        locations: [ { line: 11, column: 7 } ],
-        path: [ 'asyncError' ] },
-      { message: 'Error getting asyncRawError',
-        locations: [ { line: 12, column: 7 } ],
-        path: [ 'asyncRawError' ] },
-      { message: 'Error getting asyncReturnError',
-        locations: [ { line: 13, column: 7 } ],
-        path: [ 'asyncReturnError' ] },
+      {
+        message: 'Error getting syncError',
+        locations: [{ line: 3, column: 7 }],
+        path: ['syncError'],
+      },
+      {
+        message: 'Error getting syncRawError',
+        locations: [{ line: 4, column: 7 }],
+        path: ['syncRawError'],
+      },
+      {
+        message: 'Error getting syncReturnError',
+        locations: [{ line: 5, column: 7 }],
+        path: ['syncReturnError'],
+      },
+      {
+        message: 'Error getting syncReturnErrorList1',
+        locations: [{ line: 6, column: 7 }],
+        path: ['syncReturnErrorList', 1],
+      },
+      {
+        message: 'Error getting syncReturnErrorList3',
+        locations: [{ line: 6, column: 7 }],
+        path: ['syncReturnErrorList', 3],
+      },
+      {
+        message: 'Error getting asyncReject',
+        locations: [{ line: 8, column: 7 }],
+        path: ['asyncReject'],
+      },
+      {
+        message: 'Error getting asyncRawReject',
+        locations: [{ line: 9, column: 7 }],
+        path: ['asyncRawReject'],
+      },
+      {
+        message: 'An unknown error occurred.',
+        locations: [{ line: 10, column: 7 }],
+        path: ['asyncEmptyReject'],
+      },
+      {
+        message: 'Error getting asyncError',
+        locations: [{ line: 11, column: 7 }],
+        path: ['asyncError'],
+      },
+      {
+        message: 'Error getting asyncRawError',
+        locations: [{ line: 12, column: 7 }],
+        path: ['asyncRawError'],
+      },
+      {
+        message: 'Error getting asyncReturnError',
+        locations: [{ line: 13, column: 7 }],
+        path: ['asyncReturnError'],
+      },
     ]);
   });
-
 
   it('Full response path is included for non-nullable fields', async () => {
     const A = new GraphQLObjectType({
@@ -517,8 +561,8 @@ describe('Execute: Handles basic execution tasks', () => {
       fields: () => ({
         nullableA: {
           type: A,
-          resolve: () => ({})
-        }
+          resolve: () => ({}),
+        },
       }),
     });
     const schema = new GraphQLSchema({
@@ -543,16 +587,16 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(result).to.deep.equal({
       data: {
         nullableA: {
-          aliasedA: null
-        }
+          aliasedA: null,
+        },
       },
       errors: [
         {
           message: 'Catch me if you can',
-          locations: [ { line: 7, column: 17 } ],
-          path: [ 'nullableA', 'aliasedA', 'nonNullA', 'anotherA', 'throws' ]
-        }
-      ]
+          locations: [{ line: 7, column: 17 }],
+          path: ['nullableA', 'aliasedA', 'nonNullA', 'anotherA', 'throws'],
+        },
+      ],
     });
   });
 
@@ -565,8 +609,8 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data);
@@ -583,8 +627,8 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data);
@@ -601,8 +645,8 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data, null, null, 'OtherExample');
@@ -619,8 +663,8 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data);
@@ -630,8 +674,8 @@ describe('Execute: Handles basic execution tasks', () => {
           message: 'Must provide an operation.',
           locations: undefined,
           path: undefined,
-        }
-      ]
+        },
+      ],
     });
   });
 
@@ -644,20 +688,21 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data);
     expect(result).to.deep.equal({
       errors: [
         {
-          message: 'Must provide operation name if query contains ' +
+          message:
+            'Must provide operation name if query contains ' +
             'multiple operations.',
           locations: undefined,
           path: undefined,
-        }
-      ]
+        },
+      ],
     });
   });
 
@@ -669,14 +714,14 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute({
       schema,
       document: ast,
-      operationName: 'UnknownExample'
+      operationName: 'UnknownExample',
     });
     expect(result).to.deep.equal({
       errors: [
@@ -684,8 +729,8 @@ describe('Execute: Handles basic execution tasks', () => {
           message: 'Unknown operation named "UnknownExample".',
           locations: undefined,
           path: undefined,
-        }
-      ]
+        },
+      ],
     });
   });
 
@@ -698,20 +743,20 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Q',
         fields: {
           a: { type: GraphQLString },
-        }
+        },
       }),
       mutation: new GraphQLObjectType({
         name: 'M',
         fields: {
           c: { type: GraphQLString },
-        }
+        },
       }),
       subscription: new GraphQLObjectType({
         name: 'S',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const queryResult = await execute(schema, ast, data, null, {}, 'Q');
@@ -728,14 +773,14 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Q',
         fields: {
           a: { type: GraphQLString },
-        }
+        },
       }),
       mutation: new GraphQLObjectType({
         name: 'M',
         fields: {
           c: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const mutationResult = await execute(schema, ast, data, null, {}, 'M');
@@ -752,14 +797,14 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Q',
         fields: {
           a: { type: GraphQLString },
-        }
+        },
       }),
       subscription: new GraphQLObjectType({
         name: 'S',
         fields: {
           a: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const subscriptionResult = await execute(schema, ast, data, null, {}, 'S');
@@ -804,8 +849,8 @@ describe('Execute: Handles basic execution tasks', () => {
           c: { type: GraphQLString },
           d: { type: GraphQLString },
           e: { type: GraphQLString },
-        }
-      })
+        },
+      }),
     });
 
     const result = await execute(schema, ast, data);
@@ -817,10 +862,10 @@ describe('Execute: Handles basic execution tasks', () => {
         c: 'c',
         d: 'd',
         e: 'e',
-      }
+      },
     });
 
-    expect(Object.keys(result.data)).to.deep.equal([ 'a', 'b', 'c', 'd', 'e' ]);
+    expect(Object.keys(result.data)).to.deep.equal(['a', 'b', 'c', 'd', 'e']);
   });
 
   it('Avoids recursion', async () => {
@@ -843,7 +888,7 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Type',
         fields: {
           a: { type: GraphQLString },
-        }
+        },
       }),
     });
 
@@ -862,21 +907,20 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Q',
         fields: {
           a: { type: GraphQLString },
-        }
+        },
       }),
       mutation: new GraphQLObjectType({
         name: 'M',
         fields: {
           c: { type: GraphQLString },
-        }
+        },
       }),
     });
 
     const mutationResult = await execute(schema, ast);
 
     expect(mutationResult).to.deep.equal({
-      data: {
-      }
+      data: {},
     });
   });
 
@@ -895,9 +939,9 @@ describe('Execute: Handles basic execution tasks', () => {
               d: { type: GraphQLInt },
               e: { type: GraphQLInt },
             },
-          }
-        }
-      })
+          },
+        },
+      }),
     });
 
     const query = parse('{ field(a: true, c: false, e: 0) }');
@@ -905,8 +949,8 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expect(result).to.deep.equal({
       data: {
-        field: '{"a":true,"c":false,"e":0}'
-      }
+        field: '{"a":true,"c":false,"e":0}',
+      },
     });
   });
 
@@ -929,8 +973,8 @@ describe('Execute: Handles basic execution tasks', () => {
         return obj instanceof Special;
       },
       fields: {
-        value: { type: GraphQLString }
-      }
+        value: { type: GraphQLString },
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -939,29 +983,28 @@ describe('Execute: Handles basic execution tasks', () => {
         fields: {
           specials: {
             type: new GraphQLList(SpecialType),
-            resolve: rootValue => rootValue.specials
-          }
-        }
-      })
+            resolve: rootValue => rootValue.specials,
+          },
+        },
+      }),
     });
 
     const query = parse('{ specials { value } }');
     const value = {
-      specials: [ new Special('foo'), new NotSpecial('bar') ]
+      specials: [new Special('foo'), new NotSpecial('bar')],
     };
     const result = await execute(schema, query, value);
 
     expect(result.data).to.deep.equal({
-      specials: [
-        { value: 'foo' },
-        null
-      ]
+      specials: [{ value: 'foo' }, null],
     });
     expect(result.errors).to.have.lengthOf(1);
     expect(result.errors).to.containSubset([
-      { message:
+      {
+        message:
           'Expected value of type "SpecialType" but got: [object Object].',
-        locations: [ { line: 1, column: 3 } ] }
+        locations: [{ line: 1, column: 3 }],
+      },
     ]);
   });
 
@@ -976,21 +1019,22 @@ describe('Execute: Handles basic execution tasks', () => {
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          foo: { type: GraphQLString }
-        }
-      })
+          foo: { type: GraphQLString },
+        },
+      }),
     });
 
     const result = await execute(schema, query);
     expect(result).to.deep.equal({
       errors: [
         {
-          message: 'GraphQL cannot execute a request containing a ' +
+          message:
+            'GraphQL cannot execute a request containing a ' +
             'ObjectTypeDefinition.',
-          locations: [ { line: 4, column: 7 } ],
+          locations: [{ line: 4, column: 7 }],
           path: undefined,
-        }
-      ]
+        },
+      ],
     });
   });
 
@@ -1001,9 +1045,9 @@ describe('Execute: Handles basic execution tasks', () => {
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          foo: { type: GraphQLString }
-        }
-      })
+          foo: { type: GraphQLString },
+        },
+      }),
     });
 
     // For the purposes of test, just return the name of the field!
@@ -1018,10 +1062,9 @@ describe('Execute: Handles basic execution tasks', () => {
       null,
       null,
       null,
-      customResolver
+      customResolver,
     );
 
     expect(result).to.jsonEqual({ data: { foo: 'foo' } });
   });
-
 });

--- a/src/execution/__tests__/mutations-test.js
+++ b/src/execution/__tests__/mutations-test.js
@@ -12,11 +12,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { execute } from '../execute';
 import { parse } from '../../language';
-import {
-  GraphQLSchema,
-  GraphQLObjectType,
-  GraphQLInt,
-} from '../../type';
+import { GraphQLSchema, GraphQLObjectType, GraphQLInt } from '../../type';
 
 class NumberHolder {
   theNumber: number;
@@ -79,36 +75,35 @@ const schema = new GraphQLSchema({
         args: { newNumber: { type: GraphQLInt } },
         resolve(obj, { newNumber }) {
           return obj.immediatelyChangeTheNumber(newNumber);
-        }
+        },
       },
       promiseToChangeTheNumber: {
         type: numberHolderType,
         args: { newNumber: { type: GraphQLInt } },
         resolve(obj, { newNumber }) {
           return obj.promiseToChangeTheNumber(newNumber);
-        }
+        },
       },
       failToChangeTheNumber: {
         type: numberHolderType,
         args: { newNumber: { type: GraphQLInt } },
         resolve(obj, { newNumber }) {
           return obj.failToChangeTheNumber(newNumber);
-        }
+        },
       },
       promiseAndFailToChangeTheNumber: {
         type: numberHolderType,
         args: { newNumber: { type: GraphQLInt } },
         resolve(obj, { newNumber }) {
           return obj.promiseAndFailToChangeTheNumber(newNumber);
-        }
-      }
+        },
+      },
     },
     name: 'Mutation',
-  })
+  }),
 });
 
 describe('Execute: Handles mutation execution ordering', () => {
-
   it('evaluates mutations serially', async () => {
     const doc = `mutation M {
       first: immediatelyChangeTheNumber(newNumber: 1) {
@@ -133,21 +128,21 @@ describe('Execute: Handles mutation execution ordering', () => {
     return expect(mutationResult).to.deep.equal({
       data: {
         first: {
-          theNumber: 1
+          theNumber: 1,
         },
         second: {
-          theNumber: 2
+          theNumber: 2,
         },
         third: {
-          theNumber: 3
+          theNumber: 3,
         },
         fourth: {
-          theNumber: 4
+          theNumber: 4,
         },
         fifth: {
-          theNumber: 5
-        }
-      }
+          theNumber: 5,
+        },
+      },
     });
   });
 
@@ -177,27 +172,31 @@ describe('Execute: Handles mutation execution ordering', () => {
 
     expect(result.data).to.deep.equal({
       first: {
-        theNumber: 1
+        theNumber: 1,
       },
       second: {
-        theNumber: 2
+        theNumber: 2,
       },
       third: null,
       fourth: {
-        theNumber: 4
+        theNumber: 4,
       },
       fifth: {
-        theNumber: 5
+        theNumber: 5,
       },
       sixth: null,
     });
 
     expect(result.errors).to.have.length(2);
     expect(result.errors).to.containSubset([
-      { message: 'Cannot change the number',
-        locations: [ { line: 8, column: 7 } ] },
-      { message: 'Cannot change the number',
-        locations: [ { line: 17, column: 7 } ] }
+      {
+        message: 'Cannot change the number',
+        locations: [{ line: 8, column: 7 }],
+      },
+      {
+        message: 'Cannot change the number',
+        locations: [{ line: 17, column: 7 }],
+      },
     ]);
   });
 });

--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -16,7 +16,7 @@ import {
   GraphQLSchema,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLNonNull
+  GraphQLNonNull,
 } from '../../type';
 
 const syncError = new Error('sync');
@@ -25,21 +25,21 @@ const promiseError = new Error('promise');
 const nonNullPromiseError = new Error('nonNullPromise');
 
 const throwingData = {
-  sync() { throw syncError; },
-  nonNullSync() { throw nonNullSyncError; },
+  sync() {
+    throw syncError;
+  },
+  nonNullSync() {
+    throw nonNullSyncError;
+  },
   promise() {
-    return new Promise(
-      () => {
-        throw promiseError;
-      }
-    );
+    return new Promise(() => {
+      throw promiseError;
+    });
   },
   nonNullPromise() {
-    return new Promise(
-      () => {
-        throw nonNullPromiseError;
-      }
-    );
+    return new Promise(() => {
+      throw nonNullPromiseError;
+    });
   },
   nest() {
     return throwingData;
@@ -48,37 +48,33 @@ const throwingData = {
     return throwingData;
   },
   promiseNest() {
-    return new Promise(
-      resolve => {
-        resolve(throwingData);
-      }
-    );
+    return new Promise(resolve => {
+      resolve(throwingData);
+    });
   },
   nonNullPromiseNest() {
-    return new Promise(
-      resolve => {
-        resolve(throwingData);
-      }
-    );
+    return new Promise(resolve => {
+      resolve(throwingData);
+    });
   },
 };
 
 const nullingData = {
-  sync() { return null; },
-  nonNullSync() { return null; },
+  sync() {
+    return null;
+  },
+  nonNullSync() {
+    return null;
+  },
   promise() {
-    return new Promise(
-      resolve => {
-        resolve(null);
-      }
-    );
+    return new Promise(resolve => {
+      resolve(null);
+    });
   },
   nonNullPromise() {
-    return new Promise(
-      resolve => {
-        resolve(null);
-      }
-    );
+    return new Promise(resolve => {
+      resolve(null);
+    });
   },
   nest() {
     return nullingData;
@@ -87,18 +83,14 @@ const nullingData = {
     return nullingData;
   },
   promiseNest() {
-    return new Promise(
-      resolve => {
-        resolve(nullingData);
-      }
-    );
+    return new Promise(resolve => {
+      resolve(nullingData);
+    });
   },
   nonNullPromiseNest() {
-    return new Promise(
-      resolve => {
-        resolve(nullingData);
-      }
-    );
+    return new Promise(resolve => {
+      resolve(nullingData);
+    });
   },
 };
 
@@ -113,14 +105,13 @@ const dataType = new GraphQLObjectType({
     nonNullNest: { type: new GraphQLNonNull(dataType) },
     promiseNest: { type: dataType },
     nonNullPromiseNest: { type: new GraphQLNonNull(dataType) },
-  })
+  }),
 });
 const schema = new GraphQLSchema({
-  query: dataType
+  query: dataType,
 });
 
 describe('Execute: handles non-nullable types', () => {
-
   it('nulls a nullable field that throws synchronously', async () => {
     const doc = `
       query Q {
@@ -135,14 +126,16 @@ describe('Execute: handles non-nullable types', () => {
         sync: null,
       },
       errors: [
-        { message: syncError.message,
-          locations: [ { line: 3, column: 9 } ] }
-      ]
+        {
+          message: syncError.message,
+          locations: [{ line: 3, column: 9 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a nullable field that throws in a promise', async () => {
@@ -159,14 +152,16 @@ describe('Execute: handles non-nullable types', () => {
         promise: null,
       },
       errors: [
-        { message: promiseError.message,
-          locations: [ { line: 3, column: 9 } ] }
-      ]
+        {
+          message: promiseError.message,
+          locations: [{ line: 3, column: 9 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a synchronously returned object that contains a non-nullable field that throws synchronously', async () => {
@@ -182,17 +177,19 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        nest: null
+        nest: null,
       },
       errors: [
-        { message: nonNullSyncError.message,
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message: nonNullSyncError.message,
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a synchronously returned object that contains a non-nullable field that throws in a promise', async () => {
@@ -208,17 +205,19 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        nest: null
+        nest: null,
       },
       errors: [
-        { message: nonNullPromiseError.message,
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message: nonNullPromiseError.message,
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls an object returned in a promise that contains a non-nullable field that throws synchronously', async () => {
@@ -234,17 +233,19 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        promiseNest: null
+        promiseNest: null,
       },
       errors: [
-        { message: nonNullSyncError.message,
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message: nonNullSyncError.message,
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls an object returned in a promise that contains a non-nullable field that throws in a promise', async () => {
@@ -260,17 +261,19 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        promiseNest: null
+        promiseNest: null,
       },
       errors: [
-        { message: nonNullPromiseError.message,
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message: nonNullPromiseError.message,
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a complex tree of nullable fields that throw', async () => {
@@ -317,7 +320,7 @@ describe('Execute: handles non-nullable types', () => {
           promiseNest: {
             sync: null,
             promise: null,
-          }
+          },
         },
         promiseNest: {
           sync: null,
@@ -329,40 +332,64 @@ describe('Execute: handles non-nullable types', () => {
           promiseNest: {
             sync: null,
             promise: null,
-          }
-        }
+          },
+        },
       },
       errors: [
-        { message: syncError.message,
-          locations: [ { line: 4, column: 11 } ] },
-        { message: syncError.message,
-          locations: [ { line: 7, column: 13 } ] },
-        { message: syncError.message,
-          locations: [ { line: 11, column: 13 } ] },
-        { message: syncError.message,
-          locations: [ { line: 16, column: 11 } ] },
-        { message: syncError.message,
-          locations: [ { line: 19, column: 13 } ] },
-        { message: syncError.message,
-          locations: [ { line: 23, column: 13 } ] },
-        { message: promiseError.message,
-          locations: [ { line: 5, column: 11 } ] },
-        { message: promiseError.message,
-          locations: [ { line: 8, column: 13 } ] },
-        { message: promiseError.message,
-          locations: [ { line: 12, column: 13 } ] },
-        { message: promiseError.message,
-          locations: [ { line: 17, column: 11 } ] },
-        { message: promiseError.message,
-          locations: [ { line: 20, column: 13 } ] },
-        { message: promiseError.message,
-          locations: [ { line: 24, column: 13 } ] },
-      ]
+        {
+          message: syncError.message,
+          locations: [{ line: 4, column: 11 }],
+        },
+        {
+          message: syncError.message,
+          locations: [{ line: 7, column: 13 }],
+        },
+        {
+          message: syncError.message,
+          locations: [{ line: 11, column: 13 }],
+        },
+        {
+          message: syncError.message,
+          locations: [{ line: 16, column: 11 }],
+        },
+        {
+          message: syncError.message,
+          locations: [{ line: 19, column: 13 }],
+        },
+        {
+          message: syncError.message,
+          locations: [{ line: 23, column: 13 }],
+        },
+        {
+          message: promiseError.message,
+          locations: [{ line: 5, column: 11 }],
+        },
+        {
+          message: promiseError.message,
+          locations: [{ line: 8, column: 13 }],
+        },
+        {
+          message: promiseError.message,
+          locations: [{ line: 12, column: 13 }],
+        },
+        {
+          message: promiseError.message,
+          locations: [{ line: 17, column: 11 }],
+        },
+        {
+          message: promiseError.message,
+          locations: [{ line: 20, column: 13 }],
+        },
+        {
+          message: promiseError.message,
+          locations: [{ line: 24, column: 13 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls the first nullable object after a field throws in a long chain of fields that are non-null', async () => {
@@ -422,25 +449,32 @@ describe('Execute: handles non-nullable types', () => {
         nest: null,
         promiseNest: null,
         anotherNest: null,
-        anotherPromiseNest: null
+        anotherPromiseNest: null,
       },
       errors: [
-        { message: nonNullSyncError.message,
-          locations: [ { line: 8, column: 19 } ] },
-        { message: nonNullSyncError.message,
-          locations: [ { line: 19, column: 19 } ] },
-        { message: nonNullPromiseError.message,
-          locations: [ { line: 30, column: 19 } ] },
-        { message: nonNullPromiseError.message,
-          locations: [ { line: 41, column: 19 } ] }
-      ]
+        {
+          message: nonNullSyncError.message,
+          locations: [{ line: 8, column: 19 }],
+        },
+        {
+          message: nonNullSyncError.message,
+          locations: [{ line: 19, column: 19 }],
+        },
+        {
+          message: nonNullPromiseError.message,
+          locations: [{ line: 30, column: 19 }],
+        },
+        {
+          message: nonNullPromiseError.message,
+          locations: [{ line: 41, column: 19 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, throwingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, throwingData)).to.containSubset(
+      expected,
+    );
   });
-
 
   it('nulls a nullable field that synchronously returns null', async () => {
     const doc = `
@@ -454,12 +488,12 @@ describe('Execute: handles non-nullable types', () => {
     const expected = {
       data: {
         sync: null,
-      }
+      },
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a nullable field that returns null in a promise', async () => {
@@ -474,12 +508,12 @@ describe('Execute: handles non-nullable types', () => {
     const expected = {
       data: {
         promise: null,
-      }
+      },
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a synchronously returned object that contains a non-nullable field that returns null synchronously', async () => {
@@ -495,17 +529,20 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        nest: null
+        nest: null,
       },
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullSync.',
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullSync.',
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a synchronously returned object that contains a non-nullable field that returns null in a promise', async () => {
@@ -521,17 +558,20 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        nest: null
+        nest: null,
       },
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullPromise.',
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullPromise.',
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls an object returned in a promise that contains a non-nullable field that returns null synchronously', async () => {
@@ -547,17 +587,20 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        promiseNest: null
+        promiseNest: null,
       },
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullSync.',
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullSync.',
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls an object returned in a promise that contains a non-nullable field that returns null ina a promise', async () => {
@@ -573,17 +616,20 @@ describe('Execute: handles non-nullable types', () => {
 
     const expected = {
       data: {
-        promiseNest: null
+        promiseNest: null,
       },
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullPromise.',
-          locations: [ { line: 4, column: 11 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullPromise.',
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls a complex tree of nullable fields that return null', async () => {
@@ -630,7 +676,7 @@ describe('Execute: handles non-nullable types', () => {
           promiseNest: {
             sync: null,
             promise: null,
-          }
+          },
         },
         promiseNest: {
           sync: null,
@@ -642,14 +688,14 @@ describe('Execute: handles non-nullable types', () => {
           promiseNest: {
             sync: null,
             promise: null,
-          }
-        }
-      }
+          },
+        },
+      },
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls the first nullable object after a field returns null in a long chain of fields that are non-null', async () => {
@@ -709,23 +755,35 @@ describe('Execute: handles non-nullable types', () => {
         nest: null,
         promiseNest: null,
         anotherNest: null,
-        anotherPromiseNest: null
+        anotherPromiseNest: null,
       },
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullSync.',
-          locations: [ { line: 8, column: 19 } ] },
-        { message: 'Cannot return null for non-nullable field DataType.nonNullSync.',
-          locations: [ { line: 19, column: 19 } ] },
-        { message: 'Cannot return null for non-nullable field DataType.nonNullPromise.',
-          locations: [ { line: 30, column: 19 } ] },
-        { message: 'Cannot return null for non-nullable field DataType.nonNullPromise.',
-          locations: [ { line: 41, column: 19 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullSync.',
+          locations: [{ line: 8, column: 19 }],
+        },
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullSync.',
+          locations: [{ line: 19, column: 19 }],
+        },
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullPromise.',
+          locations: [{ line: 30, column: 19 }],
+        },
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullPromise.',
+          locations: [{ line: 41, column: 19 }],
+        },
+      ],
     };
 
-    return expect(
-      await execute(schema, ast, nullingData)
-    ).to.containSubset(expected);
+    return expect(await execute(schema, ast, nullingData)).to.containSubset(
+      expected,
+    );
   });
 
   it('nulls the top level if sync non-nullable field throws', async () => {
@@ -736,13 +794,15 @@ describe('Execute: handles non-nullable types', () => {
     const expected = {
       data: null,
       errors: [
-        { message: nonNullSyncError.message,
-          locations: [ { line: 2, column: 17 } ] }
-      ]
+        {
+          message: nonNullSyncError.message,
+          locations: [{ line: 2, column: 17 }],
+        },
+      ],
     };
 
     return expect(
-      await execute(schema, parse(doc), throwingData)
+      await execute(schema, parse(doc), throwingData),
     ).to.containSubset(expected);
   });
 
@@ -754,13 +814,15 @@ describe('Execute: handles non-nullable types', () => {
     const expected = {
       data: null,
       errors: [
-        { message: nonNullPromiseError.message,
-          locations: [ { line: 2, column: 17 } ] }
-      ]
+        {
+          message: nonNullPromiseError.message,
+          locations: [{ line: 2, column: 17 }],
+        },
+      ],
     };
 
     return expect(
-      await execute(schema, parse(doc), throwingData)
+      await execute(schema, parse(doc), throwingData),
     ).to.containSubset(expected);
   });
 
@@ -772,13 +834,16 @@ describe('Execute: handles non-nullable types', () => {
     const expected = {
       data: null,
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullSync.',
-          locations: [ { line: 2, column: 17 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullSync.',
+          locations: [{ line: 2, column: 17 }],
+        },
+      ],
     };
 
     return expect(
-      await execute(schema, parse(doc), nullingData)
+      await execute(schema, parse(doc), nullingData),
     ).to.containSubset(expected);
   });
 
@@ -790,13 +855,16 @@ describe('Execute: handles non-nullable types', () => {
     const expected = {
       data: null,
       errors: [
-        { message: 'Cannot return null for non-nullable field DataType.nonNullPromise.',
-          locations: [ { line: 2, column: 17 } ] }
-      ]
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.nonNullPromise.',
+          locations: [{ line: 2, column: 17 }],
+        },
+      ],
     };
 
     return expect(
-      await execute(schema, parse(doc), nullingData)
+      await execute(schema, parse(doc), nullingData),
     ).to.containSubset(expected);
   });
 });

--- a/src/execution/__tests__/resolve-test.js
+++ b/src/execution/__tests__/resolve-test.js
@@ -17,15 +17,14 @@ import {
 } from '../../';
 
 describe('Execute: resolve function', () => {
-
   function testSchema(testField) {
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          test: testField
-        }
-      })
+          test: testField,
+        },
+      }),
     });
   }
 
@@ -33,15 +32,13 @@ describe('Execute: resolve function', () => {
     const schema = testSchema({ type: GraphQLString });
 
     const source = {
-      test: 'testValue'
+      test: 'testValue',
     };
 
-    expect(
-      await graphql(schema, '{ test }', source)
-    ).to.deep.equal({
+    expect(await graphql(schema, '{ test }', source)).to.deep.equal({
       data: {
-        test: 'testValue'
-      }
+        test: 'testValue',
+      },
     });
   });
 
@@ -52,15 +49,13 @@ describe('Execute: resolve function', () => {
       _secret: 'secretValue',
       test() {
         return this._secret;
-      }
+      },
     };
 
-    expect(
-      await graphql(schema, '{ test }', source)
-    ).to.deep.equal({
+    expect(await graphql(schema, '{ test }', source)).to.deep.equal({
       data: {
-        test: 'secretValue'
-      }
+        test: 'secretValue',
+      },
     });
   });
 
@@ -77,18 +72,18 @@ describe('Execute: resolve function', () => {
         this._num = num;
       }
 
-      test({addend1}, context) {
+      test({ addend1 }, context) {
         return this._num + addend1 + context.addend2;
       }
     }
     const source = new Adder(700);
 
     expect(
-      await graphql(schema, '{ test(addend1: 80) }', source, { addend2: 9 })
+      await graphql(schema, '{ test(addend1: 80) }', source, { addend2: 9 }),
     ).to.deep.equal({
       data: {
-        test: 789
-      }
+        test: 789,
+      },
     });
   });
 
@@ -100,41 +95,36 @@ describe('Execute: resolve function', () => {
         aInt: { type: GraphQLInt },
       },
       resolve(source, args) {
-        return JSON.stringify([ source, args ]);
-      }
+        return JSON.stringify([source, args]);
+      },
+    });
+
+    expect(await graphql(schema, '{ test }')).to.deep.equal({
+      data: {
+        test: '[null,{}]',
+      },
+    });
+
+    expect(await graphql(schema, '{ test }', 'Source!')).to.deep.equal({
+      data: {
+        test: '["Source!",{}]',
+      },
     });
 
     expect(
-      await graphql(schema, '{ test }')
+      await graphql(schema, '{ test(aStr: "String!") }', 'Source!'),
     ).to.deep.equal({
       data: {
-        test: '[null,{}]'
-      }
+        test: '["Source!",{"aStr":"String!"}]',
+      },
     });
 
     expect(
-      await graphql(schema, '{ test }', 'Source!')
+      await graphql(schema, '{ test(aInt: -123, aStr: "String!") }', 'Source!'),
     ).to.deep.equal({
       data: {
-        test: '["Source!",{}]'
-      }
-    });
-
-    expect(
-      await graphql(schema, '{ test(aStr: "String!") }', 'Source!')
-    ).to.deep.equal({
-      data: {
-        test: '["Source!",{"aStr":"String!"}]'
-      }
-    });
-
-    expect(
-      await graphql(schema, '{ test(aInt: -123, aStr: "String!") }', 'Source!')
-    ).to.deep.equal({
-      data: {
-        test: '["Source!",{"aStr":"String!","aInt":-123}]'
-      }
+        test: '["Source!",{"aStr":"String!","aInt":-123}]',
+      },
     });
   });
-
 });

--- a/src/execution/__tests__/schema-test.js
+++ b/src/execution/__tests__/schema-test.js
@@ -21,17 +21,15 @@ import {
   GraphQLID,
 } from '../../type';
 
-
 describe('Execute: Handles execution with a complex schema', () => {
   it('executes using a schema', async () => {
-
     const BlogImage = new GraphQLObjectType({
       name: 'Image',
       fields: {
         url: { type: GraphQLString },
         width: { type: GraphQLInt },
         height: { type: GraphQLInt },
-      }
+      },
     });
 
     const BlogAuthor = new GraphQLObjectType({
@@ -42,10 +40,10 @@ describe('Execute: Handles execution with a complex schema', () => {
         pic: {
           args: { width: { type: GraphQLInt }, height: { type: GraphQLInt } },
           type: BlogImage,
-          resolve: (obj, { width, height }) => obj.pic(width, height)
+          resolve: (obj, { width, height }) => obj.pic(width, height),
         },
-        recentArticle: { type: BlogArticle }
-      })
+        recentArticle: { type: BlogArticle },
+      }),
     });
 
     const BlogArticle = new GraphQLObjectType({
@@ -56,8 +54,8 @@ describe('Execute: Handles execution with a complex schema', () => {
         author: { type: BlogAuthor },
         title: { type: GraphQLString },
         body: { type: GraphQLString },
-        keywords: { type: new GraphQLList(GraphQLString) }
-      }
+        keywords: { type: new GraphQLList(GraphQLString) },
+      },
     });
 
     const BlogQuery = new GraphQLObjectType({
@@ -66,7 +64,7 @@ describe('Execute: Handles execution with a complex schema', () => {
         article: {
           type: BlogArticle,
           args: { id: { type: GraphQLID } },
-          resolve: (_, { id }) => article(id)
+          resolve: (_, { id }) => article(id),
         },
         feed: {
           type: new GraphQLList(BlogArticle),
@@ -80,14 +78,14 @@ describe('Execute: Handles execution with a complex schema', () => {
             article(7),
             article(8),
             article(9),
-            article(10)
-          ]
-        }
-      }
+            article(10),
+          ],
+        },
+      },
     });
 
     const BlogSchema = new GraphQLSchema({
-      query: BlogQuery
+      query: BlogQuery,
     });
 
     function article(id) {
@@ -98,7 +96,7 @@ describe('Execute: Handles execution with a complex schema', () => {
         title: 'My Article ' + id,
         body: 'This is a post',
         hidden: 'This data is not exposed in the schema',
-        keywords: [ 'foo', 'bar', 1, true, null ]
+        keywords: ['foo', 'bar', 1, true, null],
       };
     }
 
@@ -106,14 +104,14 @@ describe('Execute: Handles execution with a complex schema', () => {
       id: 123,
       name: 'John Smith',
       pic: (width, height) => getPic(123, width, height),
-      recentArticle: article(1)
+      recentArticle: article(1),
     };
 
     function getPic(uid, width, height) {
       return {
         url: `cdn://${uid}`,
         width: `${width}`,
-        height: `${height}`
+        height: `${height}`,
       };
     }
 
@@ -153,31 +151,49 @@ describe('Execute: Handles execution with a complex schema', () => {
 
     // Note: this is intentionally not validating to ensure appropriate
     // behavior occurs when executing an invalid query.
-    return expect(
-      await execute(BlogSchema, parse(request))
-    ).to.deep.equal({
+    return expect(await execute(BlogSchema, parse(request))).to.deep.equal({
       data: {
         feed: [
-          { id: '1',
-            title: 'My Article 1' },
-          { id: '2',
-            title: 'My Article 2' },
-          { id: '3',
-            title: 'My Article 3' },
-          { id: '4',
-            title: 'My Article 4' },
-          { id: '5',
-            title: 'My Article 5' },
-          { id: '6',
-            title: 'My Article 6' },
-          { id: '7',
-            title: 'My Article 7' },
-          { id: '8',
-            title: 'My Article 8' },
-          { id: '9',
-            title: 'My Article 9' },
-          { id: '10',
-            title: 'My Article 10' }
+          {
+            id: '1',
+            title: 'My Article 1',
+          },
+          {
+            id: '2',
+            title: 'My Article 2',
+          },
+          {
+            id: '3',
+            title: 'My Article 3',
+          },
+          {
+            id: '4',
+            title: 'My Article 4',
+          },
+          {
+            id: '5',
+            title: 'My Article 5',
+          },
+          {
+            id: '6',
+            title: 'My Article 6',
+          },
+          {
+            id: '7',
+            title: 'My Article 7',
+          },
+          {
+            id: '8',
+            title: 'My Article 8',
+          },
+          {
+            id: '9',
+            title: 'My Article 9',
+          },
+          {
+            id: '10',
+            title: 'My Article 10',
+          },
         ],
         article: {
           id: '1',
@@ -190,18 +206,18 @@ describe('Execute: Handles execution with a complex schema', () => {
             pic: {
               url: 'cdn://123',
               width: 640,
-              height: 480
+              height: 480,
             },
             recentArticle: {
               id: '1',
               isPublished: true,
               title: 'My Article 1',
               body: 'This is a post',
-              keywords: [ 'foo', 'bar', '1', 'true', null ]
-            }
-          }
-        }
-      }
+              keywords: ['foo', 'bar', '1', 'true', null],
+            },
+          },
+        },
+      },
     });
   });
 });

--- a/src/execution/__tests__/union-interface-test.js
+++ b/src/execution/__tests__/union-interface-test.js
@@ -17,9 +17,8 @@ import {
   GraphQLUnionType,
   GraphQLList,
   GraphQLString,
-  GraphQLBoolean
+  GraphQLBoolean,
 } from '../../type';
-
 
 class Dog {
   constructor(name, barks) {
@@ -46,33 +45,33 @@ class Person {
 const NamedType = new GraphQLInterfaceType({
   name: 'Named',
   fields: {
-    name: { type: GraphQLString }
-  }
+    name: { type: GraphQLString },
+  },
 });
 
 const DogType = new GraphQLObjectType({
   name: 'Dog',
-  interfaces: [ NamedType ],
+  interfaces: [NamedType],
   fields: {
     name: { type: GraphQLString },
-    barks: { type: GraphQLBoolean }
+    barks: { type: GraphQLBoolean },
   },
-  isTypeOf: value => value instanceof Dog
+  isTypeOf: value => value instanceof Dog,
 });
 
 const CatType = new GraphQLObjectType({
   name: 'Cat',
-  interfaces: [ NamedType ],
+  interfaces: [NamedType],
   fields: {
     name: { type: GraphQLString },
-    meows: { type: GraphQLBoolean }
+    meows: { type: GraphQLBoolean },
   },
-  isTypeOf: value => value instanceof Cat
+  isTypeOf: value => value instanceof Cat,
 });
 
 const PetType = new GraphQLUnionType({
   name: 'Pet',
-  types: [ DogType, CatType ],
+  types: [DogType, CatType],
   resolveType(value) {
     if (value instanceof Dog) {
       return DogType;
@@ -80,32 +79,31 @@ const PetType = new GraphQLUnionType({
     if (value instanceof Cat) {
       return CatType;
     }
-  }
+  },
 });
 
 const PersonType = new GraphQLObjectType({
   name: 'Person',
-  interfaces: [ NamedType ],
+  interfaces: [NamedType],
   fields: {
     name: { type: GraphQLString },
     pets: { type: new GraphQLList(PetType) },
     friends: { type: new GraphQLList(NamedType) },
   },
-  isTypeOf: value => value instanceof Person
+  isTypeOf: value => value instanceof Person,
 });
 
 const schema = new GraphQLSchema({
   query: PersonType,
-  types: [ PetType ]
+  types: [PetType],
 });
 
 const garfield = new Cat('Garfield', false);
 const odie = new Dog('Odie', true);
 const liz = new Person('Liz');
-const john = new Person('John', [ garfield, odie ], [ liz, odie ]);
+const john = new Person('John', [garfield, odie], [liz, odie]);
 
 describe('Execute: Union and intersection types', () => {
-
   it('can introspect on union and intersection types', async () => {
     const ast = parse(`
       {
@@ -130,43 +128,31 @@ describe('Execute: Union and intersection types', () => {
       }
     `);
 
-    return expect(
-      await execute(schema, ast)
-    ).to.deep.equal({
+    return expect(await execute(schema, ast)).to.deep.equal({
       data: {
         Named: {
           kind: 'INTERFACE',
           name: 'Named',
-          fields: [
-            { name: 'name' }
-          ],
+          fields: [{ name: 'name' }],
           interfaces: null,
-          possibleTypes: [
-            { name: 'Person' },
-            { name: 'Dog' },
-            { name: 'Cat' },
-          ],
+          possibleTypes: [{ name: 'Person' }, { name: 'Dog' }, { name: 'Cat' }],
           enumValues: null,
-          inputFields: null
+          inputFields: null,
         },
         Pet: {
           kind: 'UNION',
           name: 'Pet',
           fields: null,
           interfaces: null,
-          possibleTypes: [
-            { name: 'Dog' },
-            { name: 'Cat' }
-          ],
+          possibleTypes: [{ name: 'Dog' }, { name: 'Cat' }],
           enumValues: null,
-          inputFields: null
-        }
-      }
+          inputFields: null,
+        },
+      },
     });
   });
 
   it('executes using union types', async () => {
-
     // NOTE: This is an *invalid* query, but it should be an *executable* query.
     const ast = parse(`
       {
@@ -181,22 +167,19 @@ describe('Execute: Union and intersection types', () => {
       }
     `);
 
-    return expect(
-      await execute(schema, ast, john)
-    ).to.deep.equal({
+    return expect(await execute(schema, ast, john)).to.deep.equal({
       data: {
         __typename: 'Person',
         name: 'John',
         pets: [
           { __typename: 'Cat', name: 'Garfield', meows: false },
-          { __typename: 'Dog', name: 'Odie', barks: true }
-        ]
-      }
+          { __typename: 'Dog', name: 'Odie', barks: true },
+        ],
+      },
     });
   });
 
   it('executes union types with inline fragments', async () => {
-
     // This is the valid version of the query in the above test.
     const ast = parse(`
       {
@@ -216,22 +199,19 @@ describe('Execute: Union and intersection types', () => {
       }
     `);
 
-    return expect(
-      await execute(schema, ast, john)
-    ).to.deep.equal({
+    return expect(await execute(schema, ast, john)).to.deep.equal({
       data: {
         __typename: 'Person',
         name: 'John',
         pets: [
           { __typename: 'Cat', name: 'Garfield', meows: false },
-          { __typename: 'Dog', name: 'Odie', barks: true }
-        ]
-      }
+          { __typename: 'Dog', name: 'Odie', barks: true },
+        ],
+      },
     });
   });
 
   it('executes using interface types', async () => {
-
     // NOTE: This is an *invalid* query, but it should be an *executable* query.
     const ast = parse(`
       {
@@ -246,22 +226,19 @@ describe('Execute: Union and intersection types', () => {
       }
     `);
 
-    return expect(
-      await execute(schema, ast, john)
-    ).to.deep.equal({
+    return expect(await execute(schema, ast, john)).to.deep.equal({
       data: {
         __typename: 'Person',
         name: 'John',
         friends: [
           { __typename: 'Person', name: 'Liz' },
-          { __typename: 'Dog', name: 'Odie', barks: true }
-        ]
-      }
+          { __typename: 'Dog', name: 'Odie', barks: true },
+        ],
+      },
     });
   });
 
   it('executes union types with inline fragments', async () => {
-
     // This is the valid version of the query in the above test.
     const ast = parse(`
       {
@@ -280,22 +257,19 @@ describe('Execute: Union and intersection types', () => {
       }
     `);
 
-    return expect(
-      await execute(schema, ast, john)
-    ).to.deep.equal({
+    return expect(await execute(schema, ast, john)).to.deep.equal({
       data: {
         __typename: 'Person',
         name: 'John',
         friends: [
           { __typename: 'Person', name: 'Liz' },
-          { __typename: 'Dog', name: 'Odie', barks: true }
-        ]
-      }
+          { __typename: 'Dog', name: 'Odie', barks: true },
+        ],
+      },
     });
   });
 
   it('allows fragment conditions to be abstract types', async () => {
-
     const ast = parse(`
       {
         __typename
@@ -328,21 +302,19 @@ describe('Execute: Union and intersection types', () => {
       }
     `);
 
-    return expect(
-      await execute(schema, ast, john)
-    ).to.deep.equal({
+    return expect(await execute(schema, ast, john)).to.deep.equal({
       data: {
         __typename: 'Person',
         name: 'John',
         pets: [
           { __typename: 'Cat', name: 'Garfield', meows: false },
-          { __typename: 'Dog', name: 'Odie', barks: true }
+          { __typename: 'Dog', name: 'Odie', barks: true },
         ],
         friends: [
           { __typename: 'Person', name: 'Liz' },
-          { __typename: 'Dog', name: 'Odie', barks: true }
-        ]
-      }
+          { __typename: 'Dog', name: 'Odie', barks: true },
+        ],
+      },
     });
   });
 
@@ -354,19 +326,19 @@ describe('Execute: Union and intersection types', () => {
     const NamedType2 = new GraphQLInterfaceType({
       name: 'Named',
       fields: {
-        name: { type: GraphQLString }
+        name: { type: GraphQLString },
       },
       resolveType(obj, context, { schema: _schema, rootValue }) {
         encounteredContext = context;
         encounteredSchema = _schema;
         encounteredRootValue = rootValue;
         return PersonType2;
-      }
+      },
     });
 
     const PersonType2 = new GraphQLObjectType({
       name: 'Person',
-      interfaces: [ NamedType2 ],
+      interfaces: [NamedType2],
       fields: {
         name: { type: GraphQLString },
         friends: { type: new GraphQLList(NamedType2) },
@@ -374,19 +346,17 @@ describe('Execute: Union and intersection types', () => {
     });
 
     const schema2 = new GraphQLSchema({
-      query: PersonType2
+      query: PersonType2,
     });
 
-    const john2 = new Person('John', [], [ liz ]);
+    const john2 = new Person('John', [], [liz]);
 
     const context = { authToken: '123abc' };
 
     const ast = parse('{ name, friends { name } }');
 
-    expect(
-      await execute(schema2, ast, john2, context)
-    ).to.deep.equal({
-      data: { name: 'John', friends: [ { name: 'Liz' } ] }
+    expect(await execute(schema2, ast, john2, context)).to.deep.equal({
+      data: { name: 'John', friends: [{ name: 'Liz' }] },
     });
 
     expect(encounteredContext).to.equal(context);

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -20,7 +20,7 @@ import {
   GraphQLList,
   GraphQLString,
   GraphQLNonNull,
-  GraphQLScalarType
+  GraphQLScalarType,
 } from '../../type';
 
 const TestComplexScalar = new GraphQLScalarType({
@@ -52,7 +52,7 @@ const TestInputObject = new GraphQLInputObjectType({
     b: { type: new GraphQLList(GraphQLString) },
     c: { type: new GraphQLNonNull(GraphQLString) },
     d: { type: TestComplexScalar },
-  }
+  },
 });
 
 const TestNestedInputObject = new GraphQLInputObjectType({
@@ -69,65 +69,71 @@ const TestType = new GraphQLObjectType({
     fieldWithObjectInput: {
       type: GraphQLString,
       args: { input: { type: TestInputObject } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     fieldWithNullableStringInput: {
       type: GraphQLString,
       args: { input: { type: GraphQLString } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     fieldWithNonNullableStringInput: {
       type: GraphQLString,
       args: { input: { type: new GraphQLNonNull(GraphQLString) } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     fieldWithDefaultArgumentValue: {
       type: GraphQLString,
       args: { input: { type: GraphQLString, defaultValue: 'Hello World' } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     fieldWithNestedInputObject: {
       type: GraphQLString,
       args: {
         input: {
-          type: TestNestedInputObject, defaultValue: 'Hello World'
-        }
+          type: TestNestedInputObject,
+          defaultValue: 'Hello World',
+        },
       },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     list: {
       type: GraphQLString,
       args: { input: { type: new GraphQLList(GraphQLString) } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     nnList: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      args: {
+        input: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) },
+      },
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     listNN: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      args: {
+        input: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+      },
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
     nnListNN: {
       type: GraphQLString,
-      args: { input: { type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLString)))
-      } },
-      resolve: (_, { input }) => input && JSON.stringify(input)
+      args: {
+        input: {
+          type: new GraphQLNonNull(
+            new GraphQLList(new GraphQLNonNull(GraphQLString)),
+          ),
+        },
+      },
+      resolve: (_, { input }) => input && JSON.stringify(input),
     },
-  }
+  },
 });
 
 const schema = new GraphQLSchema({ query: TestType });
 
 describe('Execute: Handles inputs', () => {
-
   describe('Handles objects and nullability', () => {
-
     describe('using inline structs', () => {
-
       it('executes with complex input', async () => {
         const doc = `
         {
@@ -138,8 +144,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(await execute(schema, ast)).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}'
-          }
+            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}',
+          },
         });
       });
 
@@ -153,8 +159,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(await execute(schema, ast)).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}'
-          }
+            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}',
+          },
         });
       });
 
@@ -168,8 +174,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(await execute(schema, ast)).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"a":null,"b":null,"c":"C","d":null}'
-          }
+            fieldWithObjectInput: '{"a":null,"b":null,"c":"C","d":null}',
+          },
         });
       });
 
@@ -183,8 +189,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(await execute(schema, ast)).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"b":["A",null,"C"],"c":"C"}'
-          }
+            fieldWithObjectInput: '{"b":["A",null,"C"],"c":"C"}',
+          },
         });
       });
 
@@ -200,14 +206,16 @@ describe('Execute: Handles inputs', () => {
 
         expect(result).to.containSubset({
           data: {
-            fieldWithObjectInput: null
+            fieldWithObjectInput: null,
           },
-          errors: [ {
-            message:
-              'Argument "input" got invalid value ["foo", "bar", "baz"].\n' +
-              'Expected "TestInputObject", found not an object.',
-            path: [ 'fieldWithObjectInput' ]
-          } ]
+          errors: [
+            {
+              message:
+                'Argument "input" got invalid value ["foo", "bar", "baz"].\n' +
+                'Expected "TestInputObject", found not an object.',
+              path: ['fieldWithObjectInput'],
+            },
+          ],
         });
       });
 
@@ -222,14 +230,12 @@ describe('Execute: Handles inputs', () => {
         expect(await execute(schema, ast)).to.deep.equal({
           data: {
             fieldWithObjectInput: '{"c":"foo","d":"DeserializedValue"}',
-          }
+          },
         });
       });
-
     });
 
     describe('using variables', () => {
-
       const doc = `
         query q($input: TestInputObject) {
           fieldWithObjectInput(input: $input)
@@ -238,13 +244,13 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       it('executes with complex input', async () => {
-        const params = { input: { a: 'foo', b: [ 'bar' ], c: 'baz' } };
+        const params = { input: { a: 'foo', b: ['bar'], c: 'baz' } };
         const result = await execute(schema, ast, null, null, params);
 
         expect(result).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}'
-          }
+            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}',
+          },
         });
       });
 
@@ -259,8 +265,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(result).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}'
-          }
+            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}',
+          },
         });
       });
 
@@ -270,8 +276,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(result).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}'
-          }
+            fieldWithObjectInput: '{"a":"foo","b":["bar"],"c":"baz"}',
+          },
         });
       });
 
@@ -281,8 +287,8 @@ describe('Execute: Handles inputs', () => {
 
         expect(result).to.deep.equal({
           data: {
-            fieldWithObjectInput: '{"c":"foo","d":"DeserializedValue"}'
-          }
+            fieldWithObjectInput: '{"c":"foo","d":"DeserializedValue"}',
+          },
         });
       });
 
@@ -297,10 +303,10 @@ describe('Execute: Handles inputs', () => {
                 'Variable "$input" got invalid value ' +
                 '{"a":"foo","b":"bar","c":null}.' +
                 '\nIn field "c": Expected "String!", found null.',
-              locations: [ { line: 2, column: 17 } ],
+              locations: [{ line: 2, column: 17 }],
               path: undefined,
-            }
-          ]
+            },
+          ],
         });
       });
 
@@ -314,10 +320,10 @@ describe('Execute: Handles inputs', () => {
               message:
                 'Variable "$input" got invalid value "foo bar".' +
                 '\nExpected "TestInputObject", found not an object.',
-              locations: [ { line: 2, column: 17 } ],
+              locations: [{ line: 2, column: 17 }],
               path: undefined,
-            }
-          ]
+            },
+          ],
         });
       });
 
@@ -331,10 +337,10 @@ describe('Execute: Handles inputs', () => {
               message:
                 'Variable "$input" got invalid value {"a":"foo","b":"bar"}.' +
                 '\nIn field "c": Expected "String!", found null.',
-              locations: [ { line: 2, column: 17 } ],
+              locations: [{ line: 2, column: 17 }],
               path: undefined,
-            }
-          ]
+            },
+          ],
         });
       });
 
@@ -356,16 +362,16 @@ describe('Execute: Handles inputs', () => {
                 '\nIn field "na": In field "c": Expected "String!", ' +
                 'found null.' +
                 '\nIn field "nb": Expected "String!", found null.',
-              locations: [ { line: 2, column: 19 } ],
+              locations: [{ line: 2, column: 19 }],
               path: undefined,
-            }
-          ]
+            },
+          ],
         });
       });
 
       it('errors on addition of unknown input field', async () => {
         const params = {
-          input: { a: 'foo', b: 'bar', c: 'baz', extra: 'dog' }
+          input: { a: 'foo', b: 'bar', c: 'baz', extra: 'dog' },
         };
 
         const result = await execute(schema, ast, null, null, params);
@@ -376,13 +382,12 @@ describe('Execute: Handles inputs', () => {
                 'Variable "$input" got invalid value ' +
                 '{"a":"foo","b":"bar","c":"baz","extra":"dog"}.' +
                 '\nIn field "extra": Unknown field.',
-              locations: [ { line: 2, column: 17 } ],
+              locations: [{ line: 2, column: 17 }],
               path: undefined,
-            }
-          ]
+            },
+          ],
         });
       });
-
     });
   });
 
@@ -397,8 +402,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNullableStringInput: null
-        }
+          fieldWithNullableStringInput: null,
+        },
       });
     });
 
@@ -412,8 +417,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNullableStringInput: null
-        }
+          fieldWithNullableStringInput: null,
+        },
       });
     });
 
@@ -427,8 +432,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNullableStringInput: null
-        }
+          fieldWithNullableStringInput: null,
+        },
       });
     });
 
@@ -441,11 +446,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { value: null })
+        await execute(schema, ast, null, null, { value: null }),
       ).to.deep.equal({
         data: {
-          fieldWithNullableStringInput: null
-        }
+          fieldWithNullableStringInput: null,
+        },
       });
     });
 
@@ -458,11 +463,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { value: 'a' })
+        await execute(schema, ast, null, null, { value: 'a' }),
       ).to.deep.equal({
         data: {
-          fieldWithNullableStringInput: '"a"'
-        }
+          fieldWithNullableStringInput: '"a"',
+        },
       });
     });
 
@@ -476,8 +481,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNullableStringInput: '"a"'
-        }
+          fieldWithNullableStringInput: '"a"',
+        },
       });
     });
   });
@@ -492,8 +497,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, parse(doc))).to.deep.equal({
         data: {
-          fieldWithNonNullableStringInput: '"default"'
-        }
+          fieldWithNonNullableStringInput: '"default"',
+        },
       });
     });
 
@@ -510,10 +515,10 @@ describe('Execute: Handles inputs', () => {
           {
             message:
               'Variable "$value" of required type "String!" was not provided.',
-            locations: [ { line: 2, column: 31 } ],
+            locations: [{ line: 2, column: 31 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -532,10 +537,10 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$value" got invalid value null.\n' +
               'Expected "String!", found null.',
-            locations: [ { line: 2, column: 31 } ],
+            locations: [{ line: 2, column: 31 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -548,11 +553,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { value: 'a' })
+        await execute(schema, ast, null, null, { value: 'a' }),
       ).to.deep.equal({
         data: {
-          fieldWithNonNullableStringInput: '"a"'
-        }
+          fieldWithNonNullableStringInput: '"a"',
+        },
       });
     });
 
@@ -566,8 +571,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNonNullableStringInput: '"a"'
-        }
+          fieldWithNonNullableStringInput: '"a"',
+        },
       });
     });
 
@@ -581,13 +586,16 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNonNullableStringInput: null
+          fieldWithNonNullableStringInput: null,
         },
-        errors: [ {
-          message: 'Argument "input" of required type "String!" was not provided.',
-          locations: [ { line: 3, column: 9 } ],
-          path: [ 'fieldWithNonNullableStringInput' ]
-        } ]
+        errors: [
+          {
+            message:
+              'Argument "input" of required type "String!" was not provided.',
+            locations: [{ line: 3, column: 9 }],
+            path: ['fieldWithNonNullableStringInput'],
+          },
+        ],
       });
     });
 
@@ -598,46 +606,46 @@ describe('Execute: Handles inputs', () => {
         }
       `;
       const ast = parse(doc);
-      const variables = {value: [ 1, 2, 3 ]};
+      const variables = { value: [1, 2, 3] };
 
-      expect(
-        await execute(schema, ast, null, null, variables)
-      ).to.deep.equal({
-        errors: [ {
-          message:
-            'Variable "$value" got invalid value [1,2,3].\nExpected type ' +
-            '"String", found [1,2,3]: String cannot represent an array value: [1,2,3]',
-          locations: [ { line: 2, column: 31 } ],
-          path: undefined,
-        } ]
+      expect(await execute(schema, ast, null, null, variables)).to.deep.equal({
+        errors: [
+          {
+            message:
+              'Variable "$value" got invalid value [1,2,3].\nExpected type ' +
+              '"String", found [1,2,3]: String cannot represent an array value: [1,2,3]',
+            locations: [{ line: 2, column: 31 }],
+            path: undefined,
+          },
+        ],
       });
     });
 
     it('coercing an array to GraphQLString throws TypeError', async () => {
       let caughtError;
       try {
-        coerceValue(GraphQLString, [ 1, 2, 3 ]);
+        coerceValue(GraphQLString, [1, 2, 3]);
       } catch (error) {
         caughtError = error;
       }
 
       expect(caughtError instanceof TypeError).to.equal(true);
       expect(caughtError && caughtError.message).to.equal(
-        'String cannot represent an array value: [1,2,3]'
+        'String cannot represent an array value: [1,2,3]',
       );
     });
 
     it('serializing an array via GraphQLString throws TypeError', async () => {
       let caughtError;
       try {
-        GraphQLString.serialize([ 1, 2, 3 ]);
+        GraphQLString.serialize([1, 2, 3]);
       } catch (error) {
         caughtError = error;
       }
 
       expect(caughtError instanceof TypeError).to.equal(true);
       expect(caughtError && caughtError.message).to.equal(
-        'String cannot represent an array value: [1,2,3]'
+        'String cannot represent an array value: [1,2,3]',
       );
     });
 
@@ -656,15 +664,17 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithNonNullableStringInput: null
+          fieldWithNonNullableStringInput: null,
         },
-        errors: [ {
-          message:
-            'Argument "input" of required type "String!" was provided the ' +
-            'variable "$foo" which was not provided a runtime value.',
-          locations: [ { line: 3, column: 48 } ],
-          path: [ 'fieldWithNonNullableStringInput' ]
-        } ]
+        errors: [
+          {
+            message:
+              'Argument "input" of required type "String!" was provided the ' +
+              'variable "$foo" which was not provided a runtime value.',
+            locations: [{ line: 3, column: 48 }],
+            path: ['fieldWithNonNullableStringInput'],
+          },
+        ],
       });
     });
   });
@@ -679,11 +689,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: null })
+        await execute(schema, ast, null, null, { input: null }),
       ).to.deep.equal({
         data: {
-          list: null
-        }
+          list: null,
+        },
       });
     });
 
@@ -696,11 +706,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: ['A'] }),
       ).to.deep.equal({
         data: {
-          list: '["A"]'
-        }
+          list: '["A"]',
+        },
       });
     });
 
@@ -713,11 +723,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: [ 'A', null, 'B' ] })
+        await execute(schema, ast, null, null, { input: ['A', null, 'B'] }),
       ).to.deep.equal({
         data: {
-          list: '["A",null,"B"]'
-        }
+          list: '["A",null,"B"]',
+        },
       });
     });
 
@@ -736,10 +746,10 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$input" got invalid value null.\n' +
               'Expected "[String]!", found null.',
-            locations: [ { line: 2, column: 17 } ],
+            locations: [{ line: 2, column: 17 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -752,11 +762,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: ['A'] }),
       ).to.deep.equal({
         data: {
-          nnList: '["A"]'
-        }
+          nnList: '["A"]',
+        },
       });
     });
 
@@ -769,11 +779,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: [ 'A', null, 'B' ] })
+        await execute(schema, ast, null, null, { input: ['A', null, 'B'] }),
       ).to.deep.equal({
         data: {
-          nnList: '["A",null,"B"]'
-        }
+          nnList: '["A",null,"B"]',
+        },
       });
     });
 
@@ -786,11 +796,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: null })
+        await execute(schema, ast, null, null, { input: null }),
       ).to.deep.equal({
         data: {
-          listNN: null
-        }
+          listNN: null,
+        },
       });
     });
 
@@ -803,11 +813,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: ['A'] }),
       ).to.deep.equal({
         data: {
-          listNN: '["A"]'
-        }
+          listNN: '["A"]',
+        },
       });
     });
 
@@ -818,7 +828,7 @@ describe('Execute: Handles inputs', () => {
         }
       `;
       const ast = parse(doc);
-      const vars = { input: [ 'A', null, 'B' ] };
+      const vars = { input: ['A', null, 'B'] };
 
       const result = await execute(schema, ast, null, null, vars);
       expect(result).to.deep.equal({
@@ -827,10 +837,10 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$input" got invalid value ["A",null,"B"].' +
               '\nIn element #1: Expected "String!", found null.',
-            locations: [ { line: 2, column: 17 } ],
+            locations: [{ line: 2, column: 17 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -849,10 +859,10 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$input" got invalid value null.\n' +
               'Expected "[String!]!", found null.',
-            locations: [ { line: 2, column: 17 } ],
+            locations: [{ line: 2, column: 17 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -865,11 +875,11 @@ describe('Execute: Handles inputs', () => {
       const ast = parse(doc);
 
       expect(
-        await execute(schema, ast, null, null, { input: [ 'A' ] })
+        await execute(schema, ast, null, null, { input: ['A'] }),
       ).to.deep.equal({
         data: {
-          nnListNN: '["A"]'
-        }
+          nnListNN: '["A"]',
+        },
       });
     });
 
@@ -880,7 +890,7 @@ describe('Execute: Handles inputs', () => {
         }
       `;
       const ast = parse(doc);
-      const vars = { input: [ 'A', null, 'B' ] };
+      const vars = { input: ['A', null, 'B'] };
 
       const result = await execute(schema, ast, null, null, vars);
       expect(result).to.deep.equal({
@@ -889,10 +899,10 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$input" got invalid value ["A",null,"B"].' +
               '\nIn element #1: Expected "String!", found null.',
-            locations: [ { line: 2, column: 17 } ],
+            locations: [{ line: 2, column: 17 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -903,7 +913,7 @@ describe('Execute: Handles inputs', () => {
         }
       `;
       const ast = parse(doc);
-      const vars = { input: { list: [ 'A', 'B' ] } };
+      const vars = { input: { list: ['A', 'B'] } };
 
       const result = await execute(schema, ast, null, null, vars);
       expect(result).to.deep.equal({
@@ -912,10 +922,10 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$input" expected value of type "TestType!" which ' +
               'cannot be used as an input type.',
-            locations: [ { line: 2, column: 25 } ],
+            locations: [{ line: 2, column: 25 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
 
@@ -935,17 +945,15 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$input" expected value of type "UnknownType!" which ' +
               'cannot be used as an input type.',
-            locations: [ { line: 2, column: 25 } ],
+            locations: [{ line: 2, column: 25 }],
             path: undefined,
-          }
-        ]
+          },
+        ],
       });
     });
-
   });
 
   describe('Execute: Uses argument default values', () => {
-
     it('when no argument provided', async () => {
       const ast = parse(`{
         fieldWithDefaultArgumentValue
@@ -953,8 +961,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithDefaultArgumentValue: '"Hello World"'
-        }
+          fieldWithDefaultArgumentValue: '"Hello World"',
+        },
       });
     });
 
@@ -965,8 +973,8 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithDefaultArgumentValue: '"Hello World"'
-        }
+          fieldWithDefaultArgumentValue: '"Hello World"',
+        },
       });
     });
 
@@ -977,18 +985,18 @@ describe('Execute: Handles inputs', () => {
 
       expect(await execute(schema, ast)).to.deep.equal({
         data: {
-          fieldWithDefaultArgumentValue: null
+          fieldWithDefaultArgumentValue: null,
         },
-        errors: [ {
-          message:
-            'Argument "input" got invalid value WRONG_TYPE.\n' +
-            'Expected type "String", found WRONG_TYPE.',
-          locations: [ { line: 2, column: 46 } ],
-          path: [ 'fieldWithDefaultArgumentValue' ]
-        } ]
+        errors: [
+          {
+            message:
+              'Argument "input" got invalid value WRONG_TYPE.\n' +
+              'Expected type "String", found WRONG_TYPE.',
+            locations: [{ line: 2, column: 46 }],
+            path: ['fieldWithDefaultArgumentValue'],
+          },
+        ],
       });
     });
-
   });
-
 });

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -11,7 +11,7 @@ import { forEach, isCollection } from 'iterall';
 import { GraphQLError, locatedError } from '../error';
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
-import type {ObjMap} from '../jsutils/ObjMap';
+import type { ObjMap } from '../jsutils/ObjMap';
 
 import { typeFromAST } from '../utilities/typeFromAST';
 import * as Kind from '../language/kinds';
@@ -56,7 +56,6 @@ import type {
   FragmentDefinitionNode,
 } from '../language/ast';
 
-
 /**
  * Terminology
  *
@@ -84,14 +83,14 @@ import type {
  * and the fragments defined in the query document
  */
 export type ExecutionContext = {
-  schema: GraphQLSchema;
-  fragments: ObjMap<FragmentDefinitionNode>;
-  rootValue: mixed;
-  contextValue: mixed;
-  operation: OperationDefinitionNode;
-  variableValues: {[variable: string]: mixed},
-  fieldResolver: GraphQLFieldResolver<any, any>;
-  errors: Array<GraphQLError>;
+  schema: GraphQLSchema,
+  fragments: ObjMap<FragmentDefinitionNode>,
+  rootValue: mixed,
+  contextValue: mixed,
+  operation: OperationDefinitionNode,
+  variableValues: { [variable: string]: mixed },
+  fieldResolver: GraphQLFieldResolver<any, any>,
+  errors: Array<GraphQLError>,
 };
 
 /**
@@ -101,8 +100,8 @@ export type ExecutionContext = {
  *   - `data` is the result of a successful execution of the query.
  */
 export type ExecutionResult = {
-  errors?: Array<GraphQLError>;
-  data?: ObjMap<mixed>;
+  errors?: Array<GraphQLError>,
+  data?: ObjMap<mixed>,
 };
 
 export type ExecutionArgs = {|
@@ -110,9 +109,9 @@ export type ExecutionArgs = {|
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[variable: string]: mixed},
+  variableValues?: ?{ [variable: string]: mixed },
   operationName?: ?string,
-  fieldResolver?: ?GraphQLFieldResolver<any, any>
+  fieldResolver?: ?GraphQLFieldResolver<any, any>,
 |};
 
 /**
@@ -125,19 +124,16 @@ export type ExecutionArgs = {|
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-declare function execute(
-  ExecutionArgs,
-  ..._: []
-): Promise<ExecutionResult>;
+declare function execute(ExecutionArgs, ..._: []): Promise<ExecutionResult>;
 /* eslint-disable no-redeclare */
 declare function execute(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: mixed,
   contextValue?: mixed,
-  variableValues?: ?{[variable: string]: mixed},
+  variableValues?: ?{ [variable: string]: mixed },
   operationName?: ?string,
-  fieldResolver?: ?GraphQLFieldResolver<any, any>
+  fieldResolver?: ?GraphQLFieldResolver<any, any>,
 ): Promise<ExecutionResult>;
 export function execute(
   argsOrSchema,
@@ -146,28 +142,28 @@ export function execute(
   contextValue,
   variableValues,
   operationName,
-  fieldResolver
+  fieldResolver,
 ) {
   // Extract arguments from object args if provided.
-  return arguments.length === 1 ?
-    executeImpl(
-      argsOrSchema.schema,
-      argsOrSchema.document,
-      argsOrSchema.rootValue,
-      argsOrSchema.contextValue,
-      argsOrSchema.variableValues,
-      argsOrSchema.operationName,
-      argsOrSchema.fieldResolver
-    ) :
-    executeImpl(
-      argsOrSchema,
-      document,
-      rootValue,
-      contextValue,
-      variableValues,
-      operationName,
-      fieldResolver
-    );
+  return arguments.length === 1
+    ? executeImpl(
+        argsOrSchema.schema,
+        argsOrSchema.document,
+        argsOrSchema.rootValue,
+        argsOrSchema.contextValue,
+        argsOrSchema.variableValues,
+        argsOrSchema.operationName,
+        argsOrSchema.fieldResolver,
+      )
+    : executeImpl(
+        argsOrSchema,
+        document,
+        rootValue,
+        contextValue,
+        variableValues,
+        operationName,
+        fieldResolver,
+      );
 }
 
 function executeImpl(
@@ -177,14 +173,10 @@ function executeImpl(
   contextValue,
   variableValues,
   operationName,
-  fieldResolver
+  fieldResolver,
 ) {
   // If arguments are missing or incorrect, throw an error.
-  assertValidExecutionArguments(
-    schema,
-    document,
-    variableValues
-  );
+  assertValidExecutionArguments(schema, document, variableValues);
 
   // If a valid context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
@@ -197,10 +189,10 @@ function executeImpl(
       contextValue,
       variableValues,
       operationName,
-      fieldResolver
+      fieldResolver,
     );
   } catch (error) {
-    return Promise.resolve({ errors: [ error ] });
+    return Promise.resolve({ errors: [error] });
   }
 
   // Return a Promise that will eventually resolve to the data described by
@@ -211,10 +203,10 @@ function executeImpl(
   // be executed. An execution which encounters errors will still result in a
   // resolved Promise.
   return Promise.resolve(
-    executeOperation(context, context.operation, rootValue)
-  ).then(data => context.errors.length === 0 ?
-    { data } :
-    { errors: context.errors, data }
+    executeOperation(context, context.operation, rootValue),
+  ).then(
+    data =>
+      context.errors.length === 0 ? { data } : { errors: context.errors, data },
   );
 }
 
@@ -223,7 +215,7 @@ function executeImpl(
  * as the last argument to a field resolver), return an Array of the path keys.
  */
 export function responsePathAsArray(
-  path: ResponsePath
+  path: ResponsePath,
 ): Array<string | number> {
   const flattened = [];
   let curr = path;
@@ -249,22 +241,22 @@ export function addPath(prev: ResponsePath, key: string | number) {
 export function assertValidExecutionArguments(
   schema: GraphQLSchema,
   document: DocumentNode,
-  rawVariableValues: ?ObjMap<mixed>
+  rawVariableValues: ?ObjMap<mixed>,
 ): void {
   invariant(schema, 'Must provide schema');
   invariant(document, 'Must provide document');
   invariant(
     schema instanceof GraphQLSchema,
     'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
-    'not multiple versions of GraphQL installed in your node_modules directory.'
+      'not multiple versions of GraphQL installed in your node_modules directory.',
   );
 
   // Variables, if provided, must be an object.
   invariant(
     !rawVariableValues || typeof rawVariableValues === 'object',
     'Variables must be provided as an Object where each property is a ' +
-    'variable value. Perhaps look to see if an unparsed JSON string ' +
-    'was provided.'
+      'variable value. Perhaps look to see if an unparsed JSON string ' +
+      'was provided.',
   );
 }
 
@@ -281,7 +273,7 @@ export function buildExecutionContext(
   contextValue: mixed,
   rawVariableValues: ?ObjMap<mixed>,
   operationName: ?string,
-  fieldResolver: ?GraphQLFieldResolver<any, any>
+  fieldResolver: ?GraphQLFieldResolver<any, any>,
 ): ExecutionContext {
   const errors: Array<GraphQLError> = [];
   let operation: ?OperationDefinitionNode;
@@ -291,21 +283,24 @@ export function buildExecutionContext(
       case Kind.OPERATION_DEFINITION:
         if (!operationName && operation) {
           throw new GraphQLError(
-            'Must provide operation name if query contains multiple operations.'
+            'Must provide operation name if query contains multiple operations.',
           );
         }
-        if (!operationName ||
-            definition.name && definition.name.value === operationName) {
+        if (
+          !operationName ||
+          (definition.name && definition.name.value === operationName)
+        ) {
           operation = definition;
         }
         break;
       case Kind.FRAGMENT_DEFINITION:
         fragments[definition.name.value] = definition;
         break;
-      default: throw new GraphQLError(
-        `GraphQL cannot execute a request containing a ${definition.kind}.`,
-        [ definition ]
-      );
+      default:
+        throw new GraphQLError(
+          `GraphQL cannot execute a request containing a ${definition.kind}.`,
+          [definition],
+        );
     }
   });
   if (!operation) {
@@ -318,7 +313,7 @@ export function buildExecutionContext(
   const variableValues = getVariableValues(
     schema,
     operation.variableDefinitions || [],
-    rawVariableValues || {}
+    rawVariableValues || {},
   );
 
   return {
@@ -339,7 +334,7 @@ export function buildExecutionContext(
 function executeOperation(
   exeContext: ExecutionContext,
   operation: OperationDefinitionNode,
-  rootValue: mixed
+  rootValue: mixed,
 ): ?(Promise<?ObjMap<mixed>> | ObjMap<mixed>) {
   const type = getOperationRootType(exeContext.schema, operation);
   const fields = collectFields(
@@ -347,7 +342,7 @@ function executeOperation(
     type,
     operation.selectionSet,
     Object.create(null),
-    Object.create(null)
+    Object.create(null),
   );
 
   const path = undefined;
@@ -358,9 +353,10 @@ function executeOperation(
   //
   // Similar to completeValueCatchingError.
   try {
-    const result = operation.operation === 'mutation' ?
-      executeFieldsSerially(exeContext, type, rootValue, path, fields) :
-      executeFields(exeContext, type, rootValue, path, fields);
+    const result =
+      operation.operation === 'mutation'
+        ? executeFieldsSerially(exeContext, type, rootValue, path, fields)
+        : executeFields(exeContext, type, rootValue, path, fields);
     const promise = getPromise(result);
     if (promise) {
       return promise.then(undefined, error => {
@@ -380,7 +376,7 @@ function executeOperation(
  */
 export function getOperationRootType(
   schema: GraphQLSchema,
-  operation: OperationDefinitionNode
+  operation: OperationDefinitionNode,
 ): GraphQLObjectType {
   switch (operation.operation) {
     case 'query':
@@ -388,25 +384,23 @@ export function getOperationRootType(
     case 'mutation':
       const mutationType = schema.getMutationType();
       if (!mutationType) {
-        throw new GraphQLError(
-          'Schema is not configured for mutations',
-          [ operation ]
-        );
+        throw new GraphQLError('Schema is not configured for mutations', [
+          operation,
+        ]);
       }
       return mutationType;
     case 'subscription':
       const subscriptionType = schema.getSubscriptionType();
       if (!subscriptionType) {
-        throw new GraphQLError(
-          'Schema is not configured for subscriptions',
-          [ operation ]
-        );
+        throw new GraphQLError('Schema is not configured for subscriptions', [
+          operation,
+        ]);
       }
       return subscriptionType;
     default:
       throw new GraphQLError(
         'Can only execute queries, mutations and subscriptions',
-        [ operation ]
+        [operation],
       );
   }
 }
@@ -423,30 +417,31 @@ function executeFieldsSerially(
   fields: ObjMap<Array<FieldNode>>,
 ): Promise<ObjMap<mixed>> {
   return Object.keys(fields).reduce(
-    (prevPromise, responseName) => prevPromise.then(results => {
-      const fieldNodes = fields[responseName];
-      const fieldPath = addPath(path, responseName);
-      const result = resolveField(
-        exeContext,
-        parentType,
-        sourceValue,
-        fieldNodes,
-        fieldPath
-      );
-      if (result === undefined) {
-        return results;
-      }
-      const promise = getPromise(result);
-      if (promise) {
-        return promise.then(resolvedResult => {
-          results[responseName] = resolvedResult;
+    (prevPromise, responseName) =>
+      prevPromise.then(results => {
+        const fieldNodes = fields[responseName];
+        const fieldPath = addPath(path, responseName);
+        const result = resolveField(
+          exeContext,
+          parentType,
+          sourceValue,
+          fieldNodes,
+          fieldPath,
+        );
+        if (result === undefined) {
           return results;
-        });
-      }
-      results[responseName] = result;
-      return results;
-    }),
-    Promise.resolve({})
+        }
+        const promise = getPromise(result);
+        if (promise) {
+          return promise.then(resolvedResult => {
+            results[responseName] = resolvedResult;
+            return results;
+          });
+        }
+        results[responseName] = result;
+        return results;
+      }),
+    Promise.resolve({}),
   );
 }
 
@@ -463,28 +458,25 @@ function executeFields(
 ): Promise<ObjMap<mixed>> | ObjMap<mixed> {
   let containsPromise = false;
 
-  const finalResults = Object.keys(fields).reduce(
-    (results, responseName) => {
-      const fieldNodes = fields[responseName];
-      const fieldPath = addPath(path, responseName);
-      const result = resolveField(
-        exeContext,
-        parentType,
-        sourceValue,
-        fieldNodes,
-        fieldPath
-      );
-      if (result === undefined) {
-        return results;
-      }
-      results[responseName] = result;
-      if (getPromise(result)) {
-        containsPromise = true;
-      }
+  const finalResults = Object.keys(fields).reduce((results, responseName) => {
+    const fieldNodes = fields[responseName];
+    const fieldPath = addPath(path, responseName);
+    const result = resolveField(
+      exeContext,
+      parentType,
+      sourceValue,
+      fieldNodes,
+      fieldPath,
+    );
+    if (result === undefined) {
       return results;
-    },
-    Object.create(null)
-  );
+    }
+    results[responseName] = result;
+    if (getPromise(result)) {
+      containsPromise = true;
+    }
+    return results;
+  }, Object.create(null));
 
   // If there are no promises, we can just return the object
   if (!containsPromise) {
@@ -527,8 +519,10 @@ export function collectFields(
         fields[name].push(selection);
         break;
       case Kind.INLINE_FRAGMENT:
-        if (!shouldIncludeNode(exeContext, selection) ||
-            !doesFragmentConditionMatch(exeContext, selection, runtimeType)) {
+        if (
+          !shouldIncludeNode(exeContext, selection) ||
+          !doesFragmentConditionMatch(exeContext, selection, runtimeType)
+        ) {
           continue;
         }
         collectFields(
@@ -536,19 +530,23 @@ export function collectFields(
           runtimeType,
           selection.selectionSet,
           fields,
-          visitedFragmentNames
+          visitedFragmentNames,
         );
         break;
       case Kind.FRAGMENT_SPREAD:
         const fragName = selection.name.value;
-        if (visitedFragmentNames[fragName] ||
-            !shouldIncludeNode(exeContext, selection)) {
+        if (
+          visitedFragmentNames[fragName] ||
+          !shouldIncludeNode(exeContext, selection)
+        ) {
           continue;
         }
         visitedFragmentNames[fragName] = true;
         const fragment = exeContext.fragments[fragName];
-        if (!fragment ||
-            !doesFragmentConditionMatch(exeContext, fragment, runtimeType)) {
+        if (
+          !fragment ||
+          !doesFragmentConditionMatch(exeContext, fragment, runtimeType)
+        ) {
           continue;
         }
         collectFields(
@@ -556,7 +554,7 @@ export function collectFields(
           runtimeType,
           fragment.selectionSet,
           fields,
-          visitedFragmentNames
+          visitedFragmentNames,
         );
         break;
     }
@@ -575,7 +573,7 @@ function shouldIncludeNode(
   const skip = getDirectiveValues(
     GraphQLSkipDirective,
     node,
-    exeContext.variableValues
+    exeContext.variableValues,
   );
   if (skip && skip.if === true) {
     return false;
@@ -584,7 +582,7 @@ function shouldIncludeNode(
   const include = getDirectiveValues(
     GraphQLIncludeDirective,
     node,
-    exeContext.variableValues
+    exeContext.variableValues,
   );
   if (include && include.if === false) {
     return false;
@@ -598,7 +596,7 @@ function shouldIncludeNode(
 function doesFragmentConditionMatch(
   exeContext: ExecutionContext,
   fragment: FragmentDefinitionNode | InlineFragmentNode,
-  type: GraphQLObjectType
+  type: GraphQLObjectType,
 ): boolean {
   const typeConditionNode = fragment.typeCondition;
   if (!typeConditionNode) {
@@ -624,11 +622,11 @@ function doesFragmentConditionMatch(
 function promiseForObject<T>(object: ObjMap<Promise<T>>): Promise<ObjMap<T>> {
   const keys = Object.keys(object);
   const valuesAndPromises = keys.map(name => object[name]);
-  return Promise.all(valuesAndPromises).then(
-    values => values.reduce((resolvedObject, value, i) => {
+  return Promise.all(valuesAndPromises).then(values =>
+    values.reduce((resolvedObject, value, i) => {
       resolvedObject[keys[i]] = value;
       return resolvedObject;
-    }, Object.create(null))
+    }, Object.create(null)),
   );
 }
 
@@ -650,7 +648,7 @@ function resolveField(
   parentType: GraphQLObjectType,
   source: mixed,
   fieldNodes: Array<FieldNode>,
-  path: ResponsePath
+  path: ResponsePath,
 ): mixed {
   const fieldNode = fieldNodes[0];
   const fieldName = fieldNode.name.value;
@@ -667,7 +665,7 @@ function resolveField(
     fieldDef,
     fieldNodes,
     parentType,
-    path
+    path,
   );
 
   // Get the resolve function, regardless of if its result is normal
@@ -678,7 +676,7 @@ function resolveField(
     fieldNodes,
     resolveFn,
     source,
-    info
+    info,
   );
 
   return completeValueCatchingError(
@@ -687,7 +685,7 @@ function resolveField(
     fieldNodes,
     info,
     path,
-    result
+    result,
   );
 }
 
@@ -696,7 +694,7 @@ export function buildResolveInfo(
   fieldDef: GraphQLField<*, *>,
   fieldNodes: Array<FieldNode>,
   parentType: GraphQLObjectType,
-  path: ResponsePath
+  path: ResponsePath,
 ): GraphQLResolveInfo {
   // The resolve function's optional fourth argument is a collection of
   // information about the current execution state.
@@ -722,7 +720,7 @@ export function resolveFieldValueOrError<TSource>(
   fieldNodes: Array<FieldNode>,
   resolveFn: GraphQLFieldResolver<TSource, *>,
   source: TSource,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ): Error | mixed {
   try {
     // Build a JS object of arguments from the field.arguments AST, using the
@@ -731,7 +729,7 @@ export function resolveFieldValueOrError<TSource>(
     const args = getArgumentValues(
       fieldDef,
       fieldNodes[0],
-      exeContext.variableValues
+      exeContext.variableValues,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -755,7 +753,7 @@ function completeValueCatchingError(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
   // If the field type is non-nullable, then it is resolved without any
   // protection from errors, however it still properly locates the error.
@@ -766,7 +764,7 @@ function completeValueCatchingError(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
   }
 
@@ -779,7 +777,7 @@ function completeValueCatchingError(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
     const promise = getPromise(completed);
     if (promise) {
@@ -809,7 +807,7 @@ function completeValueWithLocatedError(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
   try {
     const completed = completeValue(
@@ -818,15 +816,14 @@ function completeValueWithLocatedError(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
     const promise = getPromise(completed);
     if (promise) {
-      return promise.then(
-        undefined,
-        error => Promise.reject(
-          locatedError(error, fieldNodes, responsePathAsArray(path))
-        )
+      return promise.then(undefined, error =>
+        Promise.reject(
+          locatedError(error, fieldNodes, responsePathAsArray(path)),
+        ),
       );
     }
     return completed;
@@ -862,20 +859,13 @@ function completeValue(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
   // If result is a Promise, apply-lift over completeValue.
   const promise = getPromise(result);
   if (promise) {
-    return promise.then(
-      resolved => completeValue(
-        exeContext,
-        returnType,
-        fieldNodes,
-        info,
-        path,
-        resolved
-      )
+    return promise.then(resolved =>
+      completeValue(exeContext, returnType, fieldNodes, info, path, resolved),
     );
   }
 
@@ -893,12 +883,12 @@ function completeValue(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
     if (completed === null) {
       throw new Error(
-        `Cannot return null for non-nullable field ${
-          info.parentType.name}.${info.fieldName}.`
+        `Cannot return null for non-nullable field ${info.parentType
+          .name}.${info.fieldName}.`,
       );
     }
     return completed;
@@ -917,7 +907,7 @@ function completeValue(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
   }
 
@@ -936,7 +926,7 @@ function completeValue(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
   }
 
@@ -948,13 +938,13 @@ function completeValue(
       fieldNodes,
       info,
       path,
-      result
+      result,
     );
   }
 
   // Not reachable. All possible output types have been considered.
   throw new Error(
-    `Cannot complete value of unexpected type "${String(returnType)}".`
+    `Cannot complete value of unexpected type "${String(returnType)}".`,
   );
 }
 
@@ -968,12 +958,12 @@ function completeListValue(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
   invariant(
     isCollection(result),
-    `Expected Iterable, but did not find one for field ${
-      info.parentType.name}.${info.fieldName}.`
+    `Expected Iterable, but did not find one for field ${info.parentType
+      .name}.${info.fieldName}.`,
   );
 
   // This is specified as a simple map, however we're optimizing the path
@@ -991,7 +981,7 @@ function completeListValue(
       fieldNodes,
       info,
       fieldPath,
-      item
+      item,
     );
 
     if (!containsPromise && getPromise(completedItem)) {
@@ -1007,16 +997,13 @@ function completeListValue(
  * Complete a Scalar or Enum by serializing to a valid value, returning
  * null if serialization is not possible.
  */
-function completeLeafValue(
-  returnType: GraphQLLeafType,
-  result: mixed
-): mixed {
+function completeLeafValue(returnType: GraphQLLeafType, result: mixed): mixed {
   invariant(returnType.serialize, 'Missing serialize method on type');
   const serializedResult = returnType.serialize(result);
   if (isNullish(serializedResult)) {
     throw new Error(
       `Expected a value of type "${String(returnType)}" but ` +
-      `received: ${String(result)}`
+        `received: ${String(result)}`,
     );
   }
   return serializedResult;
@@ -1032,11 +1019,11 @@ function completeAbstractValue(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
-  const runtimeType = returnType.resolveType ?
-    returnType.resolveType(result, exeContext.contextValue, info) :
-    defaultResolveTypeFn(result, exeContext.contextValue, info, returnType);
+  const runtimeType = returnType.resolveType
+    ? returnType.resolveType(result, exeContext.contextValue, info)
+    : defaultResolveTypeFn(result, exeContext.contextValue, info, returnType);
 
   const promise = getPromise(runtimeType);
   if (promise) {
@@ -1049,13 +1036,13 @@ function completeAbstractValue(
           returnType,
           fieldNodes,
           info,
-          result
+          result,
         ),
         fieldNodes,
         info,
         path,
-        result
-      )
+        result,
+      ),
     );
   }
 
@@ -1067,12 +1054,12 @@ function completeAbstractValue(
       returnType,
       fieldNodes,
       info,
-      result
+      result,
     ),
     fieldNodes,
     info,
     path,
-    result
+    result,
   );
 }
 
@@ -1082,26 +1069,27 @@ function ensureValidRuntimeType(
   returnType: GraphQLAbstractType,
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
-  result: mixed
+  result: mixed,
 ): GraphQLObjectType {
-  const runtimeType = typeof runtimeTypeOrName === 'string' ?
-    exeContext.schema.getType(runtimeTypeOrName) :
-    runtimeTypeOrName;
+  const runtimeType =
+    typeof runtimeTypeOrName === 'string'
+      ? exeContext.schema.getType(runtimeTypeOrName)
+      : runtimeTypeOrName;
 
   if (!(runtimeType instanceof GraphQLObjectType)) {
     throw new GraphQLError(
       `Abstract type ${returnType.name} must resolve to an Object type at ` +
-      `runtime for field ${info.parentType.name}.${info.fieldName} with ` +
-      `value "${String(result)}", received "${String(runtimeType)}".`,
-      fieldNodes
+        `runtime for field ${info.parentType.name}.${info.fieldName} with ` +
+        `value "${String(result)}", received "${String(runtimeType)}".`,
+      fieldNodes,
     );
   }
 
   if (!exeContext.schema.isPossibleType(returnType, runtimeType)) {
     throw new GraphQLError(
       `Runtime Object type "${runtimeType.name}" is not a possible type ` +
-      `for "${returnType.name}".`,
-      fieldNodes
+        `for "${returnType.name}".`,
+      fieldNodes,
     );
   }
 
@@ -1117,7 +1105,7 @@ function completeObjectValue(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
   // If there is an isTypeOf predicate function, call it with the
   // current result. If isTypeOf returns false, then raise an error rather
@@ -1137,7 +1125,7 @@ function completeObjectValue(
           fieldNodes,
           info,
           path,
-          result
+          result,
         );
       });
     }
@@ -1153,18 +1141,18 @@ function completeObjectValue(
     fieldNodes,
     info,
     path,
-    result
+    result,
   );
 }
 
 function invalidReturnTypeError(
   returnType: GraphQLObjectType,
   result: mixed,
-  fieldNodes: Array<FieldNode>
+  fieldNodes: Array<FieldNode>,
 ): GraphQLError {
   return new GraphQLError(
     `Expected value of type "${returnType.name}" but got: ${String(result)}.`,
-    fieldNodes
+    fieldNodes,
   );
 }
 
@@ -1174,7 +1162,7 @@ function collectAndExecuteSubfields(
   fieldNodes: Array<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
-  result: mixed
+  result: mixed,
 ): mixed {
   // Collect sub-fields to execute to complete this value.
   let subFieldNodes = Object.create(null);
@@ -1187,7 +1175,7 @@ function collectAndExecuteSubfields(
         returnType,
         selectionSet,
         subFieldNodes,
-        visitedFragmentNames
+        visitedFragmentNames,
       );
     }
   }
@@ -1204,7 +1192,7 @@ function defaultResolveTypeFn(
   value: mixed,
   context: mixed,
   info: GraphQLResolveInfo,
-  abstractType: GraphQLAbstractType
+  abstractType: GraphQLAbstractType,
 ): ?GraphQLObjectType | Promise<?GraphQLObjectType> {
   const possibleTypes = info.schema.getPossibleTypes(abstractType);
   const promisedIsTypeOfResults = [];
@@ -1241,8 +1229,12 @@ function defaultResolveTypeFn(
  * and returns it as the result, or if it's a function, returns the result
  * of calling that function while passing along args and context.
  */
-export const defaultFieldResolver: GraphQLFieldResolver<any, *> =
-function (source, args, context, info) {
+export const defaultFieldResolver: GraphQLFieldResolver<any, *> = function(
+  source,
+  args,
+  context,
+  info,
+) {
   // ensure source is a value for which property access is acceptable.
   if (typeof source === 'object' || typeof source === 'function') {
     const property = source[info.fieldName];
@@ -1258,9 +1250,11 @@ function (source, args, context, info) {
  * otherwise returns void.
  */
 function getPromise<T>(value: Promise<T> | mixed): Promise<T> | void {
-  if (typeof value === 'object' &&
-      value !== null &&
-      typeof value.then === 'function') {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof value.then === 'function'
+  ) {
     return (value: any);
   }
 }
@@ -1277,13 +1271,17 @@ function getPromise<T>(value: Promise<T> | mixed): Promise<T> | void {
 export function getFieldDef(
   schema: GraphQLSchema,
   parentType: GraphQLObjectType,
-  fieldName: string
+  fieldName: string,
 ): ?GraphQLField<*, *> {
-  if (fieldName === SchemaMetaFieldDef.name &&
-      schema.getQueryType() === parentType) {
+  if (
+    fieldName === SchemaMetaFieldDef.name &&
+    schema.getQueryType() === parentType
+  ) {
     return SchemaMetaFieldDef;
-  } else if (fieldName === TypeMetaFieldDef.name &&
-             schema.getQueryType() === parentType) {
+  } else if (
+    fieldName === TypeMetaFieldDef.name &&
+    schema.getQueryType() === parentType
+  ) {
     return TypeMetaFieldDef;
   } else if (fieldName === TypeNameMetaFieldDef.name) {
     return TypeNameMetaFieldDef;

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -30,10 +30,7 @@ import {
   GraphQLNonNull,
 } from '../type/definition';
 import type { ObjMap } from '../jsutils/ObjMap';
-import type {
-  GraphQLInputType,
-  GraphQLField
-} from '../type/definition';
+import type { GraphQLInputType, GraphQLField } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';
 import type { GraphQLSchema } from '../type/schema';
 import type {
@@ -42,7 +39,6 @@ import type {
   VariableNode,
   VariableDefinitionNode,
 } from '../language/ast';
-
 
 /**
  * Prepares an object map of variableValues of the correct type based on the
@@ -56,7 +52,7 @@ import type {
 export function getVariableValues(
   schema: GraphQLSchema,
   varDefNodes: Array<VariableDefinitionNode>,
-  inputs: ObjMap<mixed>
+  inputs: ObjMap<mixed>,
 ): { [variable: string]: mixed } {
   const coercedValues = {};
   for (let i = 0; i < varDefNodes.length; i++) {
@@ -66,8 +62,8 @@ export function getVariableValues(
     if (!isInputType(varType)) {
       throw new GraphQLError(
         `Variable "$${varName}" expected value of type ` +
-        `"${print(varDefNode.type)}" which cannot be used as an input type.`,
-        [ varDefNode.type ]
+          `"${print(varDefNode.type)}" which cannot be used as an input type.`,
+        [varDefNode.type],
       );
     }
 
@@ -80,8 +76,8 @@ export function getVariableValues(
       if (varType instanceof GraphQLNonNull) {
         throw new GraphQLError(
           `Variable "$${varName}" of required type ` +
-          `"${String(varType)}" was not provided.`,
-          [ varDefNode ]
+            `"${String(varType)}" was not provided.`,
+          [varDefNode],
         );
       }
     } else {
@@ -90,8 +86,8 @@ export function getVariableValues(
         const message = errors ? '\n' + errors.join('\n') : '';
         throw new GraphQLError(
           `Variable "$${varName}" got invalid value ` +
-          `${JSON.stringify(value)}.${message}`,
-          [ varDefNode ]
+            `${JSON.stringify(value)}.${message}`,
+          [varDefNode],
         );
       }
 
@@ -114,7 +110,7 @@ export function getVariableValues(
 export function getArgumentValues(
   def: GraphQLField<*, *> | GraphQLDirective,
   node: FieldNode | DirectiveNode,
-  variableValues?: ?ObjMap<mixed>
+  variableValues?: ?ObjMap<mixed>,
 ): { [argument: string]: mixed } {
   const coercedValues = {};
   const argDefs = def.args;
@@ -135,8 +131,8 @@ export function getArgumentValues(
       } else if (argType instanceof GraphQLNonNull) {
         throw new GraphQLError(
           `Argument "${name}" of required type ` +
-          `"${String(argType)}" was not provided.`,
-          [ node ]
+            `"${String(argType)}" was not provided.`,
+          [node],
         );
       }
     } else if (argumentNode.value.kind === Kind.VARIABLE) {
@@ -155,9 +151,9 @@ export function getArgumentValues(
       } else if (argType instanceof GraphQLNonNull) {
         throw new GraphQLError(
           `Argument "${name}" of required type "${String(argType)}" was ` +
-          `provided the variable "$${variableName}" which was not provided ` +
-          'a runtime value.',
-          [ argumentNode.value ]
+            `provided the variable "$${variableName}" which was not provided ` +
+            'a runtime value.',
+          [argumentNode.value],
         );
       }
     } else {
@@ -168,7 +164,7 @@ export function getArgumentValues(
         const message = errors ? '\n' + errors.join('\n') : '';
         throw new GraphQLError(
           `Argument "${name}" got invalid value ${print(valueNode)}.${message}`,
-          [ argumentNode.value ]
+          [argumentNode.value],
         );
       }
       coercedValues[name] = coercedValue;
@@ -191,12 +187,14 @@ export function getArgumentValues(
 export function getDirectiveValues(
   directiveDef: GraphQLDirective,
   node: { directives?: ?Array<DirectiveNode> },
-  variableValues?: ?ObjMap<mixed>
+  variableValues?: ?ObjMap<mixed>,
 ): void | { [argument: string]: mixed } {
-  const directiveNode = node.directives && find(
-    node.directives,
-    directive => directive.name.value === directiveDef.name
-  );
+  const directiveNode =
+    node.directives &&
+    find(
+      node.directives,
+      directive => directive.name.value === directiveDef.name,
+    );
 
   if (directiveNode) {
     return getArgumentValues(directiveDef, directiveNode, variableValues);
@@ -248,7 +246,7 @@ export function coerceValue(type: GraphQLInputType, value: mixed): mixed {
     if (isInvalid(coercedValue)) {
       return; // Intentionally return no value.
     }
-    return [ coerceValue(itemType, _value) ];
+    return [coerceValue(itemType, _value)];
   }
 
   if (type instanceof GraphQLInputObjectType) {
@@ -280,7 +278,7 @@ export function coerceValue(type: GraphQLInputType, value: mixed): mixed {
 
   invariant(
     type instanceof GraphQLScalarType || type instanceof GraphQLEnumType,
-    'Must be input type'
+    'Must be input type',
   );
 
   const parsed = type.parseValue(_value);

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -46,15 +46,18 @@ import type { ExecutionResult } from './execution/execute';
  *    If not provided, the default field resolver is used (which looks for a
  *    value or method on the source value with the field's name).
  */
-declare function graphql({|
-  schema: GraphQLSchema,
-  source: string | Source,
-  rootValue?: mixed,
-  contextValue?: mixed,
-  variableValues?: ?ObjMap<mixed>,
-  operationName?: ?string,
-  fieldResolver?: ?GraphQLFieldResolver<any, any>
-|}, ..._: []): Promise<ExecutionResult>;
+declare function graphql(
+  {|
+    schema: GraphQLSchema,
+    source: string | Source,
+    rootValue?: mixed,
+    contextValue?: mixed,
+    variableValues?: ?ObjMap<mixed>,
+    operationName?: ?string,
+    fieldResolver?: ?GraphQLFieldResolver<any, any>,
+  |},
+  ..._: []
+): Promise<ExecutionResult>;
 /* eslint-disable no-redeclare */
 declare function graphql(
   schema: GraphQLSchema,
@@ -63,7 +66,7 @@ declare function graphql(
   contextValue?: mixed,
   variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
-  fieldResolver?: ?GraphQLFieldResolver<any, any>
+  fieldResolver?: ?GraphQLFieldResolver<any, any>,
 ): Promise<ExecutionResult>;
 export function graphql(
   argsOrSchema,
@@ -72,28 +75,28 @@ export function graphql(
   contextValue,
   variableValues,
   operationName,
-  fieldResolver
+  fieldResolver,
 ) {
   // Extract arguments from object args if provided.
-  return arguments.length === 1 ?
-    graphqlImpl(
-      argsOrSchema.schema,
-      argsOrSchema.source,
-      argsOrSchema.rootValue,
-      argsOrSchema.contextValue,
-      argsOrSchema.variableValues,
-      argsOrSchema.operationName,
-      argsOrSchema.fieldResolver
-    ) :
-    graphqlImpl(
-      argsOrSchema,
-      source,
-      rootValue,
-      contextValue,
-      variableValues,
-      operationName,
-      fieldResolver
-    );
+  return arguments.length === 1
+    ? graphqlImpl(
+        argsOrSchema.schema,
+        argsOrSchema.source,
+        argsOrSchema.rootValue,
+        argsOrSchema.contextValue,
+        argsOrSchema.variableValues,
+        argsOrSchema.operationName,
+        argsOrSchema.fieldResolver,
+      )
+    : graphqlImpl(
+        argsOrSchema,
+        source,
+        rootValue,
+        contextValue,
+        variableValues,
+        operationName,
+        fieldResolver,
+      );
 }
 
 function graphqlImpl(
@@ -103,7 +106,7 @@ function graphqlImpl(
   contextValue,
   variableValues,
   operationName,
-  fieldResolver
+  fieldResolver,
 ) {
   return new Promise(resolve => {
     // Parse
@@ -111,7 +114,7 @@ function graphqlImpl(
     try {
       document = parse(source);
     } catch (syntaxError) {
-      return resolve({ errors: [ syntaxError ]});
+      return resolve({ errors: [syntaxError] });
     }
 
     // Validate
@@ -129,8 +132,8 @@ function graphqlImpl(
         contextValue,
         variableValues,
         operationName,
-        fieldResolver
-      )
+        fieldResolver,
+      ),
     );
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,15 +32,11 @@
  */
 
 // The primary entry point into fulfilling a GraphQL request.
-export {
-  graphql
-} from './graphql';
-
+export { graphql } from './graphql';
 
 // Create and operate on GraphQL type definitions and schema.
 export {
   GraphQLSchema,
-
   // Definitions
   GraphQLScalarType,
   GraphQLObjectType,
@@ -51,34 +47,27 @@ export {
   GraphQLList,
   GraphQLNonNull,
   GraphQLDirective,
-
   // "Enum" of Type Kinds
   TypeKind,
-
   // "Enum" of Directive Locations
   DirectiveLocation,
-
   // Scalars
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
-
   // Built-in Directives defined by the Spec
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
-
   // Constant Deprecation Reason
   DEFAULT_DEPRECATION_REASON,
-
   // Meta-field definitions.
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
-
   // GraphQL Types for introspection.
   __Schema,
   __Directive,
@@ -88,7 +77,6 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-
   // Predicates
   isType,
   isInputType,
@@ -97,7 +85,6 @@ export {
   isCompositeType,
   isAbstractType,
   isNamedType,
-
   // Assertions
   assertType,
   assertInputType,
@@ -106,7 +93,6 @@ export {
   assertCompositeType,
   assertAbstractType,
   assertNamedType,
-
   // Un-modifiers
   getNullableType,
   getNamedType,
@@ -114,7 +100,6 @@ export {
 
 export type {
   DirectiveLocationEnum,
-
   GraphQLType,
   GraphQLInputType,
   GraphQLOutputType,
@@ -123,7 +108,6 @@ export type {
   GraphQLAbstractType,
   GraphQLNullableType,
   GraphQLNamedType,
-
   Thunk,
   GraphQLArgument,
   GraphQLArgumentConfig,
@@ -152,20 +136,16 @@ export type {
   GraphQLUnionTypeConfig,
 } from './type';
 
-
 // Parse and operate on GraphQL language source files.
 export {
   Source,
   getLocation,
-
   // Parse
   parse,
   parseValue,
   parseType,
-
   // Print
   print,
-
   // Visit
   visit,
   visitInParallel,
@@ -179,7 +159,6 @@ export {
 export type {
   Lexer,
   ParseOptions,
-
   // AST nodes
   Location,
   Token,
@@ -230,7 +209,6 @@ export type {
   DirectiveDefinitionNode,
 } from './language';
 
-
 // Execute GraphQL queries.
 export {
   execute,
@@ -239,10 +217,7 @@ export {
   getDirectiveValues,
 } from './execution';
 
-export type {
-  ExecutionArgs,
-  ExecutionResult,
-} from './execution';
+export type { ExecutionArgs, ExecutionResult } from './execution';
 
 export { subscribe, createSourceEventStream } from './subscription';
 
@@ -250,10 +225,8 @@ export { subscribe, createSourceEventStream } from './subscription';
 export {
   validate,
   ValidationContext,
-
   // All validation rules in the GraphQL Specification.
   specifiedRules,
-
   // Individual validation rules.
   ArgumentsOfCorrectTypeRule,
   DefaultValuesOfCorrectTypeRule,
@@ -283,89 +256,61 @@ export {
   VariablesInAllowedPositionRule,
 } from './validation';
 
-
 // Create and format GraphQL errors.
-export {
-  GraphQLError,
-  formatError,
-} from './error';
+export { GraphQLError, formatError } from './error';
 
-export type {
-  GraphQLFormattedError,
-  GraphQLErrorLocation,
-} from './error';
-
+export type { GraphQLFormattedError, GraphQLErrorLocation } from './error';
 
 // Utilities for operating on GraphQL type schema and parsed sources.
 export {
   // The GraphQL query recommended for a full schema introspection.
   introspectionQuery,
-
   // Gets the target Operation from a Document
   getOperationAST,
-
   // Build a GraphQLSchema from an introspection result.
   buildClientSchema,
-
   // Build a GraphQLSchema from a parsed GraphQL Schema language AST.
   buildASTSchema,
-
   // Build a GraphQLSchema from a GraphQL schema language document.
   buildSchema,
-
   // Extends an existing GraphQLSchema from a parsed GraphQL Schema
   // language AST.
   extendSchema,
-
   // Print a GraphQLSchema to GraphQL Schema language.
   printSchema,
-
   // Prints the built-in introspection schema in the Schema Language
   // format.
   printIntrospectionSchema,
-
   // Print a GraphQLType to GraphQL Schema language.
   printType,
-
   // Create a GraphQLType from a GraphQL language AST.
   typeFromAST,
-
   // Create a JavaScript value from a GraphQL language AST.
   valueFromAST,
-
   // Create a GraphQL language AST from a JavaScript value.
   astFromValue,
-
   // A helper to use within recursive-descent visitors which need to be aware of
   // the GraphQL type system.
   TypeInfo,
-
   // Determine if JavaScript values adhere to a GraphQL type.
   isValidJSValue,
-
   // Determine if AST values adhere to a GraphQL type.
   isValidLiteralValue,
-
   // Concatenates multiple AST together.
   concatAST,
-
   // Separates an AST into an AST per Operation.
   separateOperations,
-
   // Comparators for types
   isEqualType,
   isTypeSubTypeOf,
   doTypesOverlap,
-
   // Asserts a string is a valid GraphQL name.
   assertValidName,
-
   // Compares two GraphQLSchemas and detects breaking changes.
   findBreakingChanges,
   findDangerousChanges,
   BreakingChangeType,
   DangerousChangeType,
-
   // Report all deprecated usage within a GraphQL document.
   findDeprecatedUsages,
 } from './utilities';
@@ -373,7 +318,6 @@ export {
 export type {
   BreakingChange,
   DangerousChange,
-
   IntrospectionDirective,
   IntrospectionEnumType,
   IntrospectionEnumValue,

--- a/src/jsutils/__tests__/quotedOrList-test.js
+++ b/src/jsutils/__tests__/quotedOrList-test.js
@@ -10,29 +10,25 @@ import { describe, it } from 'mocha';
 import quotedOrList from '../quotedOrList';
 
 describe('quotedOrList', () => {
-
   it('Does not accept an empty list', () => {
     expect(() => quotedOrList([])).to.throw(TypeError);
   });
 
   it('Returns single quoted item', () => {
-    expect(quotedOrList([ 'A' ])).to.equal('"A"');
+    expect(quotedOrList(['A'])).to.equal('"A"');
   });
 
   it('Returns two item list', () => {
-    expect(quotedOrList([ 'A', 'B' ])).to.equal('"A" or "B"');
+    expect(quotedOrList(['A', 'B'])).to.equal('"A" or "B"');
   });
 
   it('Returns comma separated many item list', () => {
-    expect(quotedOrList([ 'A', 'B', 'C' ])).to.equal('"A", "B", or "C"');
+    expect(quotedOrList(['A', 'B', 'C'])).to.equal('"A", "B", or "C"');
   });
 
   it('Limits to five items', () => {
-    expect(
-      quotedOrList([ 'A', 'B', 'C', 'D', 'E', 'F' ])
-    ).to.equal(
-      '"A", "B", "C", "D", or "E"'
+    expect(quotedOrList(['A', 'B', 'C', 'D', 'E', 'F'])).to.equal(
+      '"A", "B", "C", "D", or "E"',
     );
   });
-
 });

--- a/src/jsutils/__tests__/suggestionList-test.js
+++ b/src/jsutils/__tests__/suggestionList-test.js
@@ -10,9 +10,8 @@ import { describe, it } from 'mocha';
 import suggestionList from '../suggestionList';
 
 describe('suggestionList', () => {
-
   it('Returns results when input is empty', () => {
-    expect(suggestionList('', [ 'a' ])).to.deep.equal([ 'a' ]);
+    expect(suggestionList('', ['a'])).to.deep.equal(['a']);
   });
 
   it('Returns empty array when there are no options', () => {
@@ -20,7 +19,9 @@ describe('suggestionList', () => {
   });
 
   it('Returns options sorted based on similarity', () => {
-    expect(suggestionList('abc', [ 'a', 'ab', 'abc' ]))
-      .to.deep.equal([ 'abc', 'ab' ]);
+    expect(suggestionList('abc', ['a', 'ab', 'abc'])).to.deep.equal([
+      'abc',
+      'ab',
+    ]);
   });
 });

--- a/src/jsutils/dedent.js
+++ b/src/jsutils/dedent.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
- /**
+/**
   * fixes identation by removing leading spaces from each line
   */
 function fixIdent(str: string): string {
@@ -31,10 +31,10 @@ function fixIdent(str: string): string {
  * str === "{\n  test\n}\n";
  */
 export default function dedent(
-  strings: string | { raw: [string]},
+  strings: string | { raw: [string] },
   ...values: Array<string>
 ) {
-  const raw = typeof strings === 'string' ? [ strings ] : strings.raw;
+  const raw = typeof strings === 'string' ? [strings] : strings.raw;
   let res = '';
   // interpolation
   for (let i = 0; i < raw.length; i++) {

--- a/src/jsutils/find.js
+++ b/src/jsutils/find.js
@@ -9,7 +9,7 @@
 
 export default function find<T>(
   list: Array<T>,
-  predicate: (item: T) => boolean
+  predicate: (item: T) => boolean,
 ): ?T {
   for (let i = 0; i < list.length; i++) {
     if (predicate(list[i])) {

--- a/src/jsutils/keyMap.js
+++ b/src/jsutils/keyMap.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ObjMap} from './ObjMap';
+import type { ObjMap } from './ObjMap';
 
 /**
  * Creates a keyed JS object from an array, given a function to produce the keys
@@ -34,10 +34,10 @@ import type {ObjMap} from './ObjMap';
  */
 export default function keyMap<T>(
   list: Array<T>,
-  keyFn: (item: T) => string
+  keyFn: (item: T) => string,
 ): ObjMap<T> {
   return list.reduce(
     (map, item) => ((map[keyFn(item)] = item), map),
-    Object.create(null)
+    Object.create(null),
   );
 }

--- a/src/jsutils/keyValMap.js
+++ b/src/jsutils/keyValMap.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {ObjMap} from './ObjMap';
+import type { ObjMap } from './ObjMap';
 
 /**
  * Creates a keyed JS object from an array, given a function to produce the keys
@@ -29,10 +29,10 @@ import type {ObjMap} from './ObjMap';
 export default function keyValMap<T, V>(
   list: Array<T>,
   keyFn: (item: T) => string,
-  valFn: (item: T) => V
+  valFn: (item: T) => V,
 ): ObjMap<V> {
   return list.reduce(
     (map, item) => ((map[keyFn(item)] = valFn(item)), map),
-    Object.create(null)
+    Object.create(null),
   );
 }

--- a/src/jsutils/quotedOrList.js
+++ b/src/jsutils/quotedOrList.js
@@ -16,10 +16,11 @@ export default function quotedOrList(items: Array<string>): string {
   const selected = items.slice(0, MAX_LENGTH);
   return selected
     .map(item => `"${item}"`)
-    .reduce((list, quoted, index) =>
-      list +
-      (selected.length > 2 ? ', ' : ' ') +
-      (index === selected.length - 1 ? 'or ' : '') +
-      quoted
+    .reduce(
+      (list, quoted, index) =>
+        list +
+        (selected.length > 2 ? ', ' : ' ') +
+        (index === selected.length - 1 ? 'or ' : '') +
+        quoted,
     );
 }

--- a/src/jsutils/suggestionList.js
+++ b/src/jsutils/suggestionList.js
@@ -13,7 +13,7 @@
  */
 export default function suggestionList(
   input: string,
-  options: Array<string>
+  options: Array<string>,
 ): Array<string> {
   const optionsByDistance = Object.create(null);
   const oLength = options.length;
@@ -26,7 +26,7 @@ export default function suggestionList(
     }
   }
   return Object.keys(optionsByDistance).sort(
-    (a , b) => optionsByDistance[a] - optionsByDistance[b]
+    (a, b) => optionsByDistance[a] - optionsByDistance[b],
   );
 }
 
@@ -52,7 +52,7 @@ function lexicalDistance(a, b) {
   const bLength = b.length;
 
   for (i = 0; i <= aLength; i++) {
-    d[i] = [ i ];
+    d[i] = [i];
   }
 
   for (j = 1; j <= bLength; j++) {
@@ -66,12 +66,10 @@ function lexicalDistance(a, b) {
       d[i][j] = Math.min(
         d[i - 1][j] + 1,
         d[i][j - 1] + 1,
-        d[i - 1][j - 1] + cost
+        d[i - 1][j - 1] + cost,
       );
 
-      if (i > 1 && j > 1 &&
-          a[i - 1] === b[j - 2] &&
-          a[i - 2] === b[j - 1]) {
+      if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
         d[i][j] = Math.min(d[i][j], d[i - 2][j - 2] + cost);
       }
     }

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -18,24 +18,19 @@ function lexOne(str) {
 /* eslint-disable max-len */
 
 describe('Lexer', () => {
-
   it('disallows uncommon control characters', () => {
-
-    expect(() => lexOne('\u0007')
-    ).to.throw(
+    expect(() => lexOne('\u0007')).to.throw(
       'Syntax Error GraphQL request (1:1) ' +
-      'Cannot contain the invalid character "\\u0007"'
+        'Cannot contain the invalid character "\\u0007"',
     );
-
   });
 
   it('accepts BOM header', () => {
-    expect(lexOne('\uFEFF foo')
-    ).to.containSubset({
+    expect(lexOne('\uFEFF foo')).to.containSubset({
       kind: TokenKind.NAME,
       start: 2,
       end: 5,
-      value: 'foo'
+      value: 'foo',
     });
   });
 
@@ -46,96 +41,91 @@ describe('Lexer', () => {
       end: 11,
       line: 4,
       column: 3,
-      value: 'foo'
+      value: 'foo',
     });
   });
 
   it('can be JSON.stringified or util.inspected', () => {
     const token = lexOne('foo');
     expect(JSON.stringify(token)).to.equal(
-      '{"kind":"Name","value":"foo","line":1,"column":1}'
+      '{"kind":"Name","value":"foo","line":1,"column":1}',
     );
     // NB: util.inspect used to suck
-    if (parseFloat(process.version.slice(1)) > 0.10) {
+    if (parseFloat(process.version.slice(1)) > 0.1) {
       expect(require('util').inspect(token)).to.equal(
-        '{ kind: \'Name\', value: \'foo\', line: 1, column: 1 }'
+        "{ kind: 'Name', value: 'foo', line: 1, column: 1 }",
       );
     }
   });
 
   it('skips whitespace and comments', () => {
-
-    expect(lexOne(`
+    expect(
+      lexOne(`
 
     foo
 
 
-`)
+`),
     ).to.containSubset({
       kind: TokenKind.NAME,
       start: 6,
       end: 9,
-      value: 'foo'
+      value: 'foo',
     });
 
-    expect(lexOne(`
+    expect(
+      lexOne(`
     #comment
     foo#comment
-`)
+`),
     ).to.containSubset({
       kind: TokenKind.NAME,
       start: 18,
       end: 21,
-      value: 'foo'
+      value: 'foo',
     });
 
     expect(lexOne(',,,foo,,,')).to.containSubset({
       kind: TokenKind.NAME,
       start: 3,
       end: 6,
-      value: 'foo'
+      value: 'foo',
     });
-
   });
 
   it('errors respect whitespace', () => {
-
-    expect(() => lexOne(`
+    expect(() =>
+      lexOne(`
 
     ?
 
 
-`)
+`),
     ).to.throw(
       'Syntax Error GraphQL request (3:5) ' +
-      'Cannot parse the unexpected character "?".\n' +
-      '\n' +
-      '2: \n' +
-      '3:     ?\n' +
-      '       ^\n' +
-      '4: \n'
+        'Cannot parse the unexpected character "?".\n' +
+        '\n' +
+        '2: \n' +
+        '3:     ?\n' +
+        '       ^\n' +
+        '4: \n',
     );
-
   });
 
   it('updates line numbers in error for file context', () => {
     expect(() => {
-      const str = '' +
-      '\n' +
-      '\n' +
-      '     ?\n' +
-      '\n';
+      const str = '' + '\n' + '\n' + '     ?\n' + '\n';
       const source = new Source(str, 'foo.js', { line: 11, column: 12 });
       return createLexer(source).advance();
     }).to.throw(
-        'Syntax Error foo.js (13:6) ' +
+      'Syntax Error foo.js (13:6) ' +
         'Cannot parse the unexpected character "?".\n' +
         '\n' +
         '12: \n' +
         '13:      ?\n' +
         '         ^\n' +
-        '14: \n'
-      );
+        '14: \n',
+    );
   });
 
   it('updates column numbers in error for file context', () => {
@@ -143,503 +133,381 @@ describe('Lexer', () => {
       const source = new Source('?', 'foo.js', { line: 1, column: 5 });
       return createLexer(source).advance();
     }).to.throw(
-        'Syntax Error foo.js (1:5) ' +
+      'Syntax Error foo.js (1:5) ' +
         'Cannot parse the unexpected character "?".\n' +
         '\n' +
         '1:     ?\n' +
-        '       ^\n'
-      );
+        '       ^\n',
+    );
   });
 
   it('lexes strings', () => {
-
-    expect(
-      lexOne('"simple"')
-    ).to.containSubset({
+    expect(lexOne('"simple"')).to.containSubset({
       kind: TokenKind.STRING,
       start: 0,
       end: 8,
-      value: 'simple'
+      value: 'simple',
     });
 
-    expect(
-      lexOne('" white space "')
-    ).to.containSubset({
+    expect(lexOne('" white space "')).to.containSubset({
       kind: TokenKind.STRING,
       start: 0,
       end: 15,
-      value: ' white space '
+      value: ' white space ',
     });
 
-    expect(
-      lexOne('"quote \\""')
-    ).to.containSubset({
+    expect(lexOne('"quote \\""')).to.containSubset({
       kind: TokenKind.STRING,
       start: 0,
       end: 10,
-      value: 'quote "'
+      value: 'quote "',
     });
 
-    expect(
-      lexOne('"escaped \\n\\r\\b\\t\\f"')
-    ).to.containSubset({
+    expect(lexOne('"escaped \\n\\r\\b\\t\\f"')).to.containSubset({
       kind: TokenKind.STRING,
       start: 0,
       end: 20,
-      value: 'escaped \n\r\b\t\f'
+      value: 'escaped \n\r\b\t\f',
     });
 
-    expect(
-      lexOne('"slashes \\\\ \\/"')
-    ).to.containSubset({
+    expect(lexOne('"slashes \\\\ \\/"')).to.containSubset({
       kind: TokenKind.STRING,
       start: 0,
       end: 15,
-      value: 'slashes \\ /'
+      value: 'slashes \\ /',
     });
 
-    expect(
-      lexOne('"unicode \\u1234\\u5678\\u90AB\\uCDEF"')
-    ).to.containSubset({
+    expect(lexOne('"unicode \\u1234\\u5678\\u90AB\\uCDEF"')).to.containSubset({
       kind: TokenKind.STRING,
       start: 0,
       end: 34,
-      value: 'unicode \u1234\u5678\u90AB\uCDEF'
+      value: 'unicode \u1234\u5678\u90AB\uCDEF',
     });
-
   });
 
   it('lex reports useful string errors', () => {
-
-    expect(
-      () => lexOne('"')
-    ).to.throw('Syntax Error GraphQL request (1:2) Unterminated string.');
-
-    expect(
-      () => lexOne('"no end quote')
-    ).to.throw('Syntax Error GraphQL request (1:14) Unterminated string.');
-
-    expect(
-      () => lexOne('\'single quotes\'')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:1) Unexpected single quote character (\'), ' +
-      'did you mean to use a double quote (")?'
+    expect(() => lexOne('"')).to.throw(
+      'Syntax Error GraphQL request (1:2) Unterminated string.',
     );
 
-    expect(
-      () => lexOne('"contains unescaped \u0007 control char"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:21) Invalid character within String: "\\u0007".'
+    expect(() => lexOne('"no end quote')).to.throw(
+      'Syntax Error GraphQL request (1:14) Unterminated string.',
     );
 
-    expect(
-      () => lexOne('"null-byte is not \u0000 end of file"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:19) Invalid character within String: "\\u0000".'
+    expect(() => lexOne("'single quotes'")).to.throw(
+      "Syntax Error GraphQL request (1:1) Unexpected single quote character ('), " +
+        'did you mean to use a double quote (")?',
     );
 
-    expect(
-      () => lexOne('"multi\nline"')
-    ).to.throw('Syntax Error GraphQL request (1:7) Unterminated string');
-
-    expect(
-      () => lexOne('"multi\rline"')
-    ).to.throw('Syntax Error GraphQL request (1:7) Unterminated string');
-
-    expect(
-      () => lexOne('"bad \\z esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\z.'
+    expect(() => lexOne('"contains unescaped \u0007 control char"')).to.throw(
+      'Syntax Error GraphQL request (1:21) Invalid character within String: "\\u0007".',
     );
 
-    expect(
-      () => lexOne('"bad \\x esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\x.'
+    expect(() => lexOne('"null-byte is not \u0000 end of file"')).to.throw(
+      'Syntax Error GraphQL request (1:19) Invalid character within String: "\\u0000".',
     );
 
-    expect(
-      () => lexOne('"bad \\u1 esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\u1 es.'
+    expect(() => lexOne('"multi\nline"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Unterminated string',
     );
 
-    expect(
-      () => lexOne('"bad \\u0XX1 esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\u0XX1.'
+    expect(() => lexOne('"multi\rline"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Unterminated string',
     );
 
-    expect(
-      () => lexOne('"bad \\uXXXX esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uXXXX.'
+    expect(() => lexOne('"bad \\z esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\z.',
     );
 
-    expect(
-      () => lexOne('"bad \\uFXXX esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uFXXX.'
+    expect(() => lexOne('"bad \\x esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\x.',
     );
 
-    expect(
-      () => lexOne('"bad \\uXXXF esc"')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uXXXF.'
+    expect(() => lexOne('"bad \\u1 esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\u1 es.',
+    );
+
+    expect(() => lexOne('"bad \\u0XX1 esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\u0XX1.',
+    );
+
+    expect(() => lexOne('"bad \\uXXXX esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uXXXX.',
+    );
+
+    expect(() => lexOne('"bad \\uFXXX esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uFXXX.',
+    );
+
+    expect(() => lexOne('"bad \\uXXXF esc"')).to.throw(
+      'Syntax Error GraphQL request (1:7) Invalid character escape sequence: \\uXXXF.',
     );
   });
 
   it('lexes numbers', () => {
-
-    expect(
-      lexOne('4')
-    ).to.containSubset({
+    expect(lexOne('4')).to.containSubset({
       kind: TokenKind.INT,
       start: 0,
       end: 1,
-      value: '4'
+      value: '4',
     });
 
-    expect(
-      lexOne('4.123')
-    ).to.containSubset({
+    expect(lexOne('4.123')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 5,
-      value: '4.123'
+      value: '4.123',
     });
 
-    expect(
-      lexOne('-4')
-    ).to.containSubset({
+    expect(lexOne('-4')).to.containSubset({
       kind: TokenKind.INT,
       start: 0,
       end: 2,
-      value: '-4'
+      value: '-4',
     });
 
-    expect(
-      lexOne('9')
-    ).to.containSubset({
+    expect(lexOne('9')).to.containSubset({
       kind: TokenKind.INT,
       start: 0,
       end: 1,
-      value: '9'
+      value: '9',
     });
 
-    expect(
-      lexOne('0')
-    ).to.containSubset({
+    expect(lexOne('0')).to.containSubset({
       kind: TokenKind.INT,
       start: 0,
       end: 1,
-      value: '0'
+      value: '0',
     });
 
-    expect(
-      lexOne('-4.123')
-    ).to.containSubset({
+    expect(lexOne('-4.123')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 6,
-      value: '-4.123'
+      value: '-4.123',
     });
 
-    expect(
-      lexOne('0.123')
-    ).to.containSubset({
+    expect(lexOne('0.123')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 5,
-      value: '0.123'
+      value: '0.123',
     });
 
-    expect(
-      lexOne('123e4')
-    ).to.containSubset({
+    expect(lexOne('123e4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 5,
-      value: '123e4'
+      value: '123e4',
     });
 
-    expect(
-      lexOne('123E4')
-    ).to.containSubset({
+    expect(lexOne('123E4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 5,
-      value: '123E4'
+      value: '123E4',
     });
 
-    expect(
-      lexOne('123e-4')
-    ).to.containSubset({
+    expect(lexOne('123e-4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 6,
-      value: '123e-4'
+      value: '123e-4',
     });
 
-    expect(
-      lexOne('123e+4')
-    ).to.containSubset({
+    expect(lexOne('123e+4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 6,
-      value: '123e+4'
+      value: '123e+4',
     });
 
-    expect(
-      lexOne('-1.123e4')
-    ).to.containSubset({
+    expect(lexOne('-1.123e4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 8,
-      value: '-1.123e4'
+      value: '-1.123e4',
     });
 
-    expect(
-      lexOne('-1.123E4')
-    ).to.containSubset({
+    expect(lexOne('-1.123E4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 8,
-      value: '-1.123E4'
+      value: '-1.123E4',
     });
 
-    expect(
-      lexOne('-1.123e-4')
-    ).to.containSubset({
+    expect(lexOne('-1.123e-4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 9,
-      value: '-1.123e-4'
+      value: '-1.123e-4',
     });
 
-    expect(
-      lexOne('-1.123e+4')
-    ).to.containSubset({
+    expect(lexOne('-1.123e+4')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 9,
-      value: '-1.123e+4'
+      value: '-1.123e+4',
     });
 
-    expect(
-      lexOne('-1.123e4567')
-    ).to.containSubset({
+    expect(lexOne('-1.123e4567')).to.containSubset({
       kind: TokenKind.FLOAT,
       start: 0,
       end: 11,
-      value: '-1.123e4567'
+      value: '-1.123e4567',
     });
-
   });
 
   it('lex reports useful number errors', () => {
-
-    expect(
-      () => lexOne('00')
-    ).to.throw(
+    expect(() => lexOne('00')).to.throw(
       'Syntax Error GraphQL request (1:2) Invalid number, ' +
-      'unexpected digit after 0: "0".'
+        'unexpected digit after 0: "0".',
     );
 
-    expect(
-      () => lexOne('+1')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character "+".'
+    expect(() => lexOne('+1')).to.throw(
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character "+".',
     );
 
-    expect(
-      () => lexOne('1.')
-    ).to.throw(
+    expect(() => lexOne('1.')).to.throw(
       'Syntax Error GraphQL request (1:3) Invalid number, ' +
-      'expected digit but got: <EOF>.'
+        'expected digit but got: <EOF>.',
     );
 
-    expect(
-      () => lexOne('.123')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character ".".'
+    expect(() => lexOne('.123')).to.throw(
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character ".".',
     );
 
-    expect(
-      () => lexOne('1.A')
-    ).to.throw(
+    expect(() => lexOne('1.A')).to.throw(
       'Syntax Error GraphQL request (1:3) Invalid number, ' +
-      'expected digit but got: "A".'
+        'expected digit but got: "A".',
     );
 
-    expect(
-      () => lexOne('-A')
-    ).to.throw(
+    expect(() => lexOne('-A')).to.throw(
       'Syntax Error GraphQL request (1:2) Invalid number, ' +
-      'expected digit but got: "A".'
+        'expected digit but got: "A".',
     );
 
-    expect(
-      () => lexOne('1.0e')
-    ).to.throw(
+    expect(() => lexOne('1.0e')).to.throw(
       'Syntax Error GraphQL request (1:5) Invalid number, ' +
-      'expected digit but got: <EOF>.');
+        'expected digit but got: <EOF>.',
+    );
 
-    expect(
-      () => lexOne('1.0eA')
-    ).to.throw(
+    expect(() => lexOne('1.0eA')).to.throw(
       'Syntax Error GraphQL request (1:5) Invalid number, ' +
-      'expected digit but got: "A".'
+        'expected digit but got: "A".',
     );
   });
 
   it('lexes punctuation', () => {
-
-    expect(
-      lexOne('!')
-    ).to.containSubset({
+    expect(lexOne('!')).to.containSubset({
       kind: TokenKind.BANG,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('$')
-    ).to.containSubset({
+    expect(lexOne('$')).to.containSubset({
       kind: TokenKind.DOLLAR,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('(')
-    ).to.containSubset({
+    expect(lexOne('(')).to.containSubset({
       kind: TokenKind.PAREN_L,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne(')')
-    ).to.containSubset({
+    expect(lexOne(')')).to.containSubset({
       kind: TokenKind.PAREN_R,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('...')
-    ).to.containSubset({
+    expect(lexOne('...')).to.containSubset({
       kind: TokenKind.SPREAD,
       start: 0,
       end: 3,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne(':')
-    ).to.containSubset({
+    expect(lexOne(':')).to.containSubset({
       kind: TokenKind.COLON,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('=')
-    ).to.containSubset({
+    expect(lexOne('=')).to.containSubset({
       kind: TokenKind.EQUALS,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('@')
-    ).to.containSubset({
+    expect(lexOne('@')).to.containSubset({
       kind: TokenKind.AT,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('[')
-    ).to.containSubset({
+    expect(lexOne('[')).to.containSubset({
       kind: TokenKind.BRACKET_L,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne(']')
-    ).to.containSubset({
+    expect(lexOne(']')).to.containSubset({
       kind: TokenKind.BRACKET_R,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('{')
-    ).to.containSubset({
+    expect(lexOne('{')).to.containSubset({
       kind: TokenKind.BRACE_L,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('|')
-    ).to.containSubset({
+    expect(lexOne('|')).to.containSubset({
       kind: TokenKind.PIPE,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
 
-    expect(
-      lexOne('}')
-    ).to.containSubset({
+    expect(lexOne('}')).to.containSubset({
       kind: TokenKind.BRACE_R,
       start: 0,
       end: 1,
-      value: undefined
+      value: undefined,
     });
-
   });
 
   it('lex reports useful unknown character error', () => {
-
-    expect(
-      () => lexOne('..')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character ".".'
+    expect(() => lexOne('..')).to.throw(
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character ".".',
     );
 
-    expect(
-      () => lexOne('?')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character "?".'
+    expect(() => lexOne('?')).to.throw(
+      'Syntax Error GraphQL request (1:1) Cannot parse the unexpected character "?".',
     );
 
-    expect(
-      () => lexOne('\u203B')
-    ).to.throw(
+    expect(() => lexOne('\u203B')).to.throw(
       'Syntax Error GraphQL request (1:1) ' +
-      'Cannot parse the unexpected character "\\u203B".'
+        'Cannot parse the unexpected character "\\u203B".',
     );
 
-    expect(
-      () => lexOne('\u200b')
-    ).to.throw(
+    expect(() => lexOne('\u200b')).to.throw(
       'Syntax Error GraphQL request (1:1) ' +
-      'Cannot parse the unexpected character "\\u200B".'
+        'Cannot parse the unexpected character "\\u200B".',
     );
   });
 
@@ -651,20 +519,20 @@ describe('Lexer', () => {
       kind: TokenKind.NAME,
       start: 0,
       end: 1,
-      value: 'a'
+      value: 'a',
     });
-    expect(
-      () => lexer.advance()
-    ).to.throw(
-      'Syntax Error GraphQL request (1:3) Invalid number, expected digit but got: "b".'
+    expect(() => lexer.advance()).to.throw(
+      'Syntax Error GraphQL request (1:3) Invalid number, expected digit but got: "b".',
     );
   });
 
   it('produces double linked list of tokens, including comments', () => {
-    const lexer = createLexer(new Source(`{
+    const lexer = createLexer(
+      new Source(`{
       #comment
       field
-    }`));
+    }`),
+    );
 
     const startToken = lexer.token;
     let endToken;
@@ -693,7 +561,7 @@ describe('Lexer', () => {
       'Comment',
       'Name',
       '}',
-      '<EOF>'
+      '<EOF>',
     ]);
   });
 });

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -15,19 +15,17 @@ import { join } from 'path';
 import dedent from '../../jsutils/dedent';
 
 describe('Parser', () => {
-
   it('asserts that a source to parse was provided', () => {
     expect(() => parse()).to.throw('Must provide Source. Received: undefined');
   });
 
   it('asserts that a source to parse was provided', () => {
-    expect(
-      () => parse({})
-    ).to.throw('Must provide Source. Received: [object Object]');
+    expect(() => parse({})).to.throw(
+      'Must provide Source. Received: [object Object]',
+    );
   });
 
   it('parse provides useful errors', () => {
-
     let caughtError;
     try {
       parse('{');
@@ -40,68 +38,62 @@ describe('Parser', () => {
 
       1: {
           ^
-      `
-    );
+      `);
 
-    expect(caughtError.positions).to.deep.equal([ 1 ]);
+    expect(caughtError.positions).to.deep.equal([1]);
 
-    expect(caughtError.locations).to.deep.equal([
-      { line: 1, column: 2 }
-    ]);
+    expect(caughtError.locations).to.deep.equal([{ line: 1, column: 2 }]);
 
-    expect(
-      () => parse(dedent`
+    expect(() =>
+      parse(dedent`
         { ...MissingOn }
         fragment MissingOn Type
-      `)
+      `),
     ).to.throw(
-      'Syntax Error GraphQL request (2:20) Expected "on", found Name "Type"'
+      'Syntax Error GraphQL request (2:20) Expected "on", found Name "Type"',
     );
 
-    expect(
-      () => parse('{ field: {} }')
-    ).to.throw('Syntax Error GraphQL request (1:10) Expected Name, found {');
-
-    expect(
-      () => parse('notanoperation Foo { field }')
-    ).to.throw(
-      'Syntax Error GraphQL request (1:1) Unexpected Name "notanoperation"'
+    expect(() => parse('{ field: {} }')).to.throw(
+      'Syntax Error GraphQL request (1:10) Expected Name, found {',
     );
 
-    expect(
-      () => parse('...')
-    ).to.throw('Syntax Error GraphQL request (1:1) Unexpected ...');
+    expect(() => parse('notanoperation Foo { field }')).to.throw(
+      'Syntax Error GraphQL request (1:1) Unexpected Name "notanoperation"',
+    );
 
+    expect(() => parse('...')).to.throw(
+      'Syntax Error GraphQL request (1:1) Unexpected ...',
+    );
   });
 
   it('parse provides useful error when using source', () => {
-    expect(
-      () => parse(new Source('query', 'MyQuery.graphql'))
-    ).to.throw('Syntax Error MyQuery.graphql (1:6) Expected {, found <EOF>');
+    expect(() => parse(new Source('query', 'MyQuery.graphql'))).to.throw(
+      'Syntax Error MyQuery.graphql (1:6) Expected {, found <EOF>',
+    );
   });
 
   it('parses variable inline values', () => {
-    expect(
-      () => parse('{ field(complex: { a: { b: [ $var ] } }) }')
+    expect(() =>
+      parse('{ field(complex: { a: { b: [ $var ] } }) }'),
     ).to.not.throw();
   });
 
   it('parses constant default values', () => {
-    expect(
-      () => parse('query Foo($x: Complex = { a: { b: [ $var ] } }) { field }')
+    expect(() =>
+      parse('query Foo($x: Complex = { a: { b: [ $var ] } }) { field }'),
     ).to.throw('Syntax Error GraphQL request (1:37) Unexpected $');
   });
 
   it('does not accept fragments named "on"', () => {
-    expect(
-      () => parse('fragment on on on { on }')
-    ).to.throw('Syntax Error GraphQL request (1:10) Unexpected Name "on"');
+    expect(() => parse('fragment on on on { on }')).to.throw(
+      'Syntax Error GraphQL request (1:10) Unexpected Name "on"',
+    );
   });
 
   it('does not accept fragments spread of "on"', () => {
-    expect(
-      () => parse('{ ...on }')
-    ).to.throw('Syntax Error GraphQL request (1:9) Expected Name, found }');
+    expect(() => parse('{ ...on }')).to.throw(
+      'Syntax Error GraphQL request (1:9) Expected Name, found }',
+    );
   });
 
   it('parses multi-byte characters', async () => {
@@ -110,27 +102,32 @@ describe('Parser', () => {
       parse(`
         # This comment has a \u0A0A multi-byte character.
         { field(arg: "Has a \u0A0A multi-byte character.") }
-      `)
+      `),
     ).to.containSubset({
-      definitions: [ {
-        selectionSet: {
-          selections: [ {
-            arguments: [ {
-              value: {
-                kind: Kind.STRING,
-                value: 'Has a \u0A0A multi-byte character.'
-              }
-            } ]
-          } ]
-        }
-      } ]
+      definitions: [
+        {
+          selectionSet: {
+            selections: [
+              {
+                arguments: [
+                  {
+                    value: {
+                      kind: Kind.STRING,
+                      value: 'Has a \u0A0A multi-byte character.',
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      ],
     });
   });
 
-  const kitchenSink = readFileSync(
-    join(__dirname, '/kitchen-sink.graphql'),
-    { encoding: 'utf8' }
-  );
+  const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
+    encoding: 'utf8',
+  });
 
   it('parses kitchen sink', () => {
     expect(() => parse(kitchenSink)).to.not.throw();
@@ -144,7 +141,7 @@ describe('Parser', () => {
       'mutation',
       'subscription',
       'true',
-      'false'
+      'false',
     ];
     nonKeywords.forEach(keyword => {
       let fragmentName = keyword;
@@ -161,46 +158,52 @@ describe('Parser', () => {
           fragment ${fragmentName} on Type {
             ${keyword}(${keyword}: $${keyword})
               @${keyword}(${keyword}: ${keyword})
-          }`
-        );
+          }`);
       }).to.not.throw();
     });
   });
 
   it('parses anonymous mutation operations', () => {
-    expect(() => parse(`
+    expect(() =>
+      parse(`
       mutation {
         mutationField
       }
-    `)).to.not.throw();
+    `),
+    ).to.not.throw();
   });
 
   it('parses anonymous subscription operations', () => {
-    expect(() => parse(`
+    expect(() =>
+      parse(`
       subscription {
         subscriptionField
       }
-    `)).to.not.throw();
+    `),
+    ).to.not.throw();
   });
 
   it('parses named mutation operations', () => {
-    expect(() => parse(`
+    expect(() =>
+      parse(`
       mutation Foo {
         mutationField
       }
-    `)).to.not.throw();
+    `),
+    ).to.not.throw();
   });
 
   it('parses named subscription operations', () => {
-    expect(() => parse(`
+    expect(() =>
+      parse(`
       subscription Foo {
         subscriptionField
       }
-    `)).to.not.throw();
+    `),
+    ).to.not.throw();
   });
 
   it('creates ast', () => {
-
     const source = new Source(`{
   node(id: 4) {
     id,
@@ -210,64 +213,85 @@ describe('Parser', () => {
 `);
     const result = parse(source);
 
-    expect(result).to.containSubset(
-      { kind: Kind.DOCUMENT,
-        loc: { start: 0, end: 41 },
-        definitions:
-        [ { kind: Kind.OPERATION_DEFINITION,
+    expect(result).to.containSubset({
+      kind: Kind.DOCUMENT,
+      loc: { start: 0, end: 41 },
+      definitions: [
+        {
+          kind: Kind.OPERATION_DEFINITION,
           loc: { start: 0, end: 40 },
           operation: 'query',
           name: null,
           variableDefinitions: null,
           directives: [],
-          selectionSet:
-          { kind: Kind.SELECTION_SET,
+          selectionSet: {
+            kind: Kind.SELECTION_SET,
             loc: { start: 0, end: 40 },
-            selections:
-            [ { kind: Kind.FIELD,
-              loc: { start: 4, end: 38 },
-              alias: null,
-              name:
-              { kind: Kind.NAME,
-                loc: { start: 4, end: 8 },
-                value: 'node' },
-              arguments:
-              [ { kind: Kind.ARGUMENT,
-                name:
-                { kind: Kind.NAME,
-                  loc: { start: 9, end: 11 },
-                  value: 'id' },
-                value:
-                { kind: Kind.INT,
-                  loc: { start: 13, end: 14 },
-                  value: '4' },
-                loc: { start: 9, end: 14 } } ],
-              directives: [],
-              selectionSet:
-              { kind: Kind.SELECTION_SET,
-                loc: { start: 16, end: 38 },
-                selections:
-                [ { kind: Kind.FIELD,
-                  loc: { start: 22, end: 24 },
-                  alias: null,
-                  name:
-                  { kind: Kind.NAME,
-                    loc: { start: 22, end: 24 },
-                    value: 'id' },
-                  arguments: [],
-                  directives: [],
-                  selectionSet: null },
-                { kind: Kind.FIELD,
-                  loc: { start: 30, end: 34 },
-                  alias: null,
-                  name:
-                  { kind: Kind.NAME,
-                    loc: { start: 30, end: 34 },
-                    value: 'name' },
-                  arguments: [],
-                  directives: [],
-                  selectionSet: null } ] } } ] } } ] }
-    );
+            selections: [
+              {
+                kind: Kind.FIELD,
+                loc: { start: 4, end: 38 },
+                alias: null,
+                name: {
+                  kind: Kind.NAME,
+                  loc: { start: 4, end: 8 },
+                  value: 'node',
+                },
+                arguments: [
+                  {
+                    kind: Kind.ARGUMENT,
+                    name: {
+                      kind: Kind.NAME,
+                      loc: { start: 9, end: 11 },
+                      value: 'id',
+                    },
+                    value: {
+                      kind: Kind.INT,
+                      loc: { start: 13, end: 14 },
+                      value: '4',
+                    },
+                    loc: { start: 9, end: 14 },
+                  },
+                ],
+                directives: [],
+                selectionSet: {
+                  kind: Kind.SELECTION_SET,
+                  loc: { start: 16, end: 38 },
+                  selections: [
+                    {
+                      kind: Kind.FIELD,
+                      loc: { start: 22, end: 24 },
+                      alias: null,
+                      name: {
+                        kind: Kind.NAME,
+                        loc: { start: 22, end: 24 },
+                        value: 'id',
+                      },
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null,
+                    },
+                    {
+                      kind: Kind.FIELD,
+                      loc: { start: 30, end: 34 },
+                      alias: null,
+                      name: {
+                        kind: Kind.NAME,
+                        loc: { start: 30, end: 34 },
+                        value: 'name',
+                      },
+                      arguments: [],
+                      directives: [],
+                      selectionSet: null,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
   });
 
   it('allows parsing without source location information', () => {
@@ -279,13 +303,11 @@ describe('Parser', () => {
   it('contains location information that only stringifys start/end', () => {
     const source = new Source('{ id }');
     const result = parse(source);
-    expect(JSON.stringify(result.loc)).to.equal(
-      '{"start":0,"end":6}'
-    );
+    expect(JSON.stringify(result.loc)).to.equal('{"start":0,"end":6}');
     // NB: util.inspect used to suck
-    if (parseFloat(process.version.slice(1)) > 0.10) {
+    if (parseFloat(process.version.slice(1)) > 0.1) {
       expect(require('util').inspect(result.loc)).to.equal(
-        '{ start: 0, end: 6 }'
+        '{ start: 0, end: 6 }',
       );
     }
   });
@@ -304,11 +326,10 @@ describe('Parser', () => {
   });
 
   describe('parseValue', () => {
-
     it('parses null value', () => {
       expect(parseValue('null')).to.containSubset({
         kind: Kind.NULL,
-        loc: { start: 0, end: 4 }
+        loc: { start: 0, end: 4 },
       });
     });
 
@@ -317,19 +338,22 @@ describe('Parser', () => {
         kind: Kind.LIST,
         loc: { start: 0, end: 11 },
         values: [
-          { kind: Kind.INT,
-            loc: { start: 1, end: 4},
-            value: '123' },
-          { kind: Kind.STRING,
-            loc: { start: 5, end: 10},
-            value: 'abc' } ]
+          {
+            kind: Kind.INT,
+            loc: { start: 1, end: 4 },
+            value: '123',
+          },
+          {
+            kind: Kind.STRING,
+            loc: { start: 5, end: 10 },
+            value: 'abc',
+          },
+        ],
       });
     });
-
   });
 
   describe('parseType', () => {
-
     it('parses well known types', () => {
       expect(parseType('String')).to.containSubset({
         kind: Kind.NAMED_TYPE,
@@ -337,7 +361,8 @@ describe('Parser', () => {
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
-          value: 'String' }
+          value: 'String',
+        },
       });
     });
 
@@ -348,7 +373,8 @@ describe('Parser', () => {
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
-          value: 'MyType' }
+          value: 'MyType',
+        },
       });
     });
 
@@ -362,7 +388,9 @@ describe('Parser', () => {
           name: {
             kind: Kind.NAME,
             loc: { start: 1, end: 7 },
-            value: 'MyType' } }
+            value: 'MyType',
+          },
+        },
       });
     });
 
@@ -376,7 +404,9 @@ describe('Parser', () => {
           name: {
             kind: Kind.NAME,
             loc: { start: 0, end: 6 },
-            value: 'MyType' } }
+            value: 'MyType',
+          },
+        },
       });
     });
 
@@ -393,9 +423,11 @@ describe('Parser', () => {
             name: {
               kind: Kind.NAME,
               loc: { start: 1, end: 7 },
-              value: 'MyType' } } }
+              value: 'MyType',
+            },
+          },
+        },
       });
     });
-
   });
 });

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -29,7 +29,7 @@ describe('Printer', () => {
   it('produces helpful error messages', () => {
     const badAst1 = { random: 'Data' };
     expect(() => print(badAst1)).to.throw(
-      'Invalid AST Node: {"random":"Data"}'
+      'Invalid AST Node: {"random":"Data"}',
     );
   });
 
@@ -51,7 +51,7 @@ describe('Printer', () => {
     `);
 
     const queryAstWithArtifacts = parse(
-      'query ($foo: TestType) @testDirective { id, name }'
+      'query ($foo: TestType) @testDirective { id, name }',
     );
     expect(print(queryAstWithArtifacts)).to.equal(dedent`
       query ($foo: TestType) @testDirective {
@@ -61,7 +61,7 @@ describe('Printer', () => {
     `);
 
     const mutationAstWithArtifacts = parse(
-      'mutation ($foo: TestType) @testDirective { id, name }'
+      'mutation ($foo: TestType) @testDirective { id, name }',
     );
     expect(print(mutationAstWithArtifacts)).to.equal(dedent`
       mutation ($foo: TestType) @testDirective {
@@ -71,14 +71,11 @@ describe('Printer', () => {
     `);
   });
 
-
-  const kitchenSink = readFileSync(
-    join(__dirname, '/kitchen-sink.graphql'),
-    { encoding: 'utf8' }
-  );
+  const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
+    encoding: 'utf8',
+  });
 
   it('prints kitchen sink', () => {
-
     const ast = parse(kitchenSink);
 
     const printed = print(ast);
@@ -135,6 +132,5 @@ describe('Printer', () => {
         query
       }
     `);
-
   });
 });

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -83,11 +83,11 @@ type Hello {
             fieldNode(
               nameNode('world', { start: 16, end: 21 }),
               typeNode('String', { start: 23, end: 29 }),
-              { start: 16, end: 29 }
-            )
+              { start: 16, end: 29 },
+            ),
           ],
           loc: { start: 1, end: 31 },
-        }
+        },
       ],
       loc: { start: 0, end: 31 },
     };
@@ -115,15 +115,15 @@ extend type Hello {
               fieldNode(
                 nameNode('world', { start: 23, end: 28 }),
                 typeNode('String', { start: 30, end: 36 }),
-                { start: 23, end: 36 }
-              )
+                { start: 23, end: 36 },
+              ),
             ],
             loc: { start: 8, end: 38 },
           },
           loc: { start: 1, end: 38 },
-        }
+        },
       ],
-      loc: { start: 0, end: 39 }
+      loc: { start: 0, end: 39 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
@@ -150,17 +150,16 @@ type Hello {
                 type: typeNode('String', { start: 23, end: 29 }),
                 loc: { start: 23, end: 30 },
               },
-              { start: 16, end: 30 }
-            )
+              { start: 16, end: 30 },
+            ),
           ],
           loc: { start: 1, end: 32 },
-        }
+        },
       ],
       loc: { start: 0, end: 32 },
     };
     expect(printJson(doc)).to.equal(printJson(expected));
   });
-
 
   it('Simple type inheriting interface', () => {
     const body = 'type Hello implements World { }';
@@ -171,11 +170,11 @@ type Hello {
         {
           kind: 'ObjectTypeDefinition',
           name: nameNode('Hello', { start: 5, end: 10 }),
-          interfaces: [ typeNode('World', { start: 22, end: 27 }) ],
+          interfaces: [typeNode('World', { start: 22, end: 27 })],
           directives: [],
           fields: [],
           loc: { start: 0, end: 31 },
-        }
+        },
       ],
       loc: { start: 0, end: 31 },
     };
@@ -193,12 +192,12 @@ type Hello {
           name: nameNode('Hello', { start: 5, end: 10 }),
           interfaces: [
             typeNode('Wo', { start: 22, end: 24 }),
-            typeNode('rld', { start: 26, end: 29 })
+            typeNode('rld', { start: 26, end: 29 }),
           ],
           directives: [],
           fields: [],
           loc: { start: 0, end: 33 },
-        }
+        },
       ],
       loc: { start: 0, end: 33 },
     };
@@ -215,9 +214,9 @@ type Hello {
           kind: 'EnumTypeDefinition',
           name: nameNode('Hello', { start: 5, end: 10 }),
           directives: [],
-          values: [ enumValueNode('WORLD', { start: 13, end: 18 }) ],
+          values: [enumValueNode('WORLD', { start: 13, end: 18 })],
           loc: { start: 0, end: 20 },
-        }
+        },
       ],
       loc: { start: 0, end: 20 },
     };
@@ -239,7 +238,7 @@ type Hello {
             enumValueNode('RLD', { start: 17, end: 20 }),
           ],
           loc: { start: 0, end: 22 },
-        }
+        },
       ],
       loc: { start: 0, end: 22 },
     };
@@ -263,11 +262,11 @@ interface Hello {
             fieldNode(
               nameNode('world', { start: 21, end: 26 }),
               typeNode('String', { start: 28, end: 34 }),
-              { start: 21, end: 34 }
-            )
+              { start: 21, end: 34 },
+            ),
           ],
           loc: { start: 1, end: 36 },
-        }
+        },
       ],
       loc: { start: 0, end: 36 },
     };
@@ -297,14 +296,14 @@ type Hello {
                   nameNode('flag', { start: 22, end: 26 }),
                   typeNode('Boolean', { start: 28, end: 35 }),
                   null,
-                  { start: 22, end: 35 }
-                )
+                  { start: 22, end: 35 },
+                ),
               ],
-              { start: 16, end: 44 }
-            )
+              { start: 16, end: 44 },
+            ),
           ],
           loc: { start: 1, end: 46 },
-        }
+        },
       ],
       loc: { start: 0, end: 46 },
     };
@@ -338,14 +337,14 @@ type Hello {
                     value: true,
                     loc: { start: 38, end: 42 },
                   },
-                  { start: 22, end: 42 }
-                )
+                  { start: 22, end: 42 },
+                ),
               ],
-              { start: 16, end: 51 }
-            )
+              { start: 16, end: 51 },
+            ),
           ],
           loc: { start: 1, end: 53 },
-        }
+        },
       ],
       loc: { start: 0, end: 53 },
     };
@@ -376,17 +375,17 @@ type Hello {
                   {
                     kind: 'ListType',
                     type: typeNode('String', { start: 31, end: 37 }),
-                    loc: { start: 30, end: 38 }
+                    loc: { start: 30, end: 38 },
                   },
                   null,
-                  { start: 22, end: 38 }
-                )
+                  { start: 22, end: 38 },
+                ),
               ],
-              { start: 16, end: 47 }
-            )
+              { start: 16, end: 47 },
+            ),
           ],
           loc: { start: 1, end: 49 },
-        }
+        },
       ],
       loc: { start: 0, end: 49 },
     };
@@ -416,20 +415,20 @@ type Hello {
                   nameNode('argOne', { start: 22, end: 28 }),
                   typeNode('Boolean', { start: 30, end: 37 }),
                   null,
-                  { start: 22, end: 37 }
+                  { start: 22, end: 37 },
                 ),
                 inputValueNode(
                   nameNode('argTwo', { start: 39, end: 45 }),
                   typeNode('Int', { start: 47, end: 50 }),
                   null,
-                  { start: 39, end: 50 }
+                  { start: 39, end: 50 },
                 ),
               ],
-              { start: 16, end: 59 }
-            )
+              { start: 16, end: 59 },
+            ),
           ],
           loc: { start: 1, end: 61 },
-        }
+        },
       ],
       loc: { start: 0, end: 61 },
     };
@@ -446,9 +445,9 @@ type Hello {
           kind: 'UnionTypeDefinition',
           name: nameNode('Hello', { start: 6, end: 11 }),
           directives: [],
-          types: [ typeNode('World', { start: 14, end: 19 }) ],
+          types: [typeNode('World', { start: 14, end: 19 })],
           loc: { start: 0, end: 19 },
-        }
+        },
       ],
       loc: { start: 0, end: 19 },
     };
@@ -470,7 +469,7 @@ type Hello {
             typeNode('Rld', { start: 19, end: 22 }),
           ],
           loc: { start: 0, end: 22 },
-        }
+        },
       ],
       loc: { start: 0, end: 22 },
     };
@@ -492,7 +491,7 @@ type Hello {
             typeNode('Rld', { start: 21, end: 24 }),
           ],
           loc: { start: 0, end: 24 },
-        }
+        },
       ],
       loc: { start: 0, end: 24 },
     };
@@ -530,7 +529,7 @@ type Hello {
           name: nameNode('Hello', { start: 7, end: 12 }),
           directives: [],
           loc: { start: 0, end: 12 },
-        }
+        },
       ],
       loc: { start: 0, end: 12 },
     };
@@ -555,11 +554,11 @@ input Hello {
               nameNode('world', { start: 17, end: 22 }),
               typeNode('String', { start: 24, end: 30 }),
               null,
-              { start: 17, end: 30 }
-            )
+              { start: 17, end: 30 },
+            ),
           ],
           loc: { start: 1, end: 32 },
-        }
+        },
       ],
       loc: { start: 0, end: 32 },
     };
@@ -573,5 +572,4 @@ input Hello {
 }`;
     expect(() => parse(body)).to.throw('Error');
   });
-
 });

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -13,11 +13,10 @@ import { parse } from '../parser';
 import { print } from '../printer';
 
 describe('Printer', () => {
-
   it('prints minimal ast', () => {
     const ast = {
       kind: 'ScalarTypeDefinition',
-      name: { kind: 'Name', value: 'foo' }
+      name: { kind: 'Name', value: 'foo' },
     };
     expect(print(ast)).to.equal('scalar foo');
   });
@@ -25,13 +24,13 @@ describe('Printer', () => {
   it('produces helpful error messages', () => {
     const badAst1 = { random: 'Data' };
     expect(() => print(badAst1)).to.throw(
-      'Invalid AST Node: {"random":"Data"}'
+      'Invalid AST Node: {"random":"Data"}',
     );
   });
 
   const kitchenSink = readFileSync(
     join(__dirname, '/schema-kitchen-sink.graphql'),
-    { encoding: 'utf8' }
+    { encoding: 'utf8' },
   );
 
   it('does not alter ast', () => {
@@ -42,14 +41,13 @@ describe('Printer', () => {
   });
 
   it('prints kitchen sink', () => {
-
     const ast = parse(kitchenSink);
 
     const printed = print(ast);
 
     /* eslint-disable max-len */
     expect(printed).to.equal(
-`schema {
+      `schema {
   query: QueryType
   mutation: MutationType
 }
@@ -119,7 +117,7 @@ directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include2(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
-`);
-
+`,
+    );
   });
 });

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -16,11 +16,8 @@ import { TypeInfo } from '../../utilities/TypeInfo';
 import { testSchema } from '../../validation/__tests__/harness';
 import { getNamedType, isCompositeType } from '../../type';
 
-
 describe('Visitor', () => {
-
   it('allows editing a node both on enter and on leave', () => {
-
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
 
     let selectionSet;
@@ -33,7 +30,7 @@ describe('Visitor', () => {
             ...node,
             selectionSet: {
               kind: 'SelectionSet',
-              selections: []
+              selections: [],
             },
             didEnter: true,
           };
@@ -44,8 +41,8 @@ describe('Visitor', () => {
             selectionSet,
             didLeave: true,
           };
-        }
-      }
+        },
+      },
     });
 
     expect(editedAst).to.deep.equal({
@@ -54,14 +51,13 @@ describe('Visitor', () => {
         {
           ...ast.definitions[0],
           didEnter: true,
-          didLeave: true
-        }
-      ]
+          didLeave: true,
+        },
+      ],
     });
   });
 
   it('allows editing the root node on enter and on leave', () => {
-
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
 
     const { definitions } = ast;
@@ -81,64 +77,63 @@ describe('Visitor', () => {
             definitions,
             didLeave: true,
           };
-        }
-      }
+        },
+      },
     });
 
     expect(editedAst).to.deep.equal({
       ...ast,
       didEnter: true,
-      didLeave: true
+      didLeave: true,
     });
   });
 
   it('allows for editing on enter', () => {
-
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
     const editedAst = visit(ast, {
       enter(node) {
         if (node.kind === 'Field' && node.name.value === 'b') {
           return null;
         }
-      }
+      },
     });
 
     expect(ast).to.deep.equal(
-      parse('{ a, b, c { a, b, c } }', { noLocation: true })
+      parse('{ a, b, c { a, b, c } }', { noLocation: true }),
     );
 
     expect(editedAst).to.deep.equal(
-      parse('{ a,    c { a,    c } }', { noLocation: true })
+      parse('{ a,    c { a,    c } }', { noLocation: true }),
     );
   });
 
   it('allows for editing on leave', () => {
-
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
     const editedAst = visit(ast, {
       leave(node) {
         if (node.kind === 'Field' && node.name.value === 'b') {
           return null;
         }
-      }
+      },
     });
 
     expect(ast).to.deep.equal(
-      parse('{ a, b, c { a, b, c } }', { noLocation: true })
+      parse('{ a, b, c { a, b, c } }', { noLocation: true }),
     );
 
     expect(editedAst).to.deep.equal(
-      parse('{ a,    c { a,    c } }', { noLocation: true })
+      parse('{ a,    c { a,    c } }', { noLocation: true }),
     );
   });
 
   it('visits edited node', () => {
-
-    const addedField =
-      { kind: 'Field',
-        name:
-        { kind: 'Name',
-          value: '__typename' } };
+    const addedField = {
+      kind: 'Field',
+      name: {
+        kind: 'Name',
+        value: '__typename',
+      },
+    };
 
     let didVisitAddedField;
 
@@ -148,524 +143,521 @@ describe('Visitor', () => {
         if (node.kind === 'Field' && node.name.value === 'a') {
           return {
             kind: 'Field',
-            selectionSet: [ addedField ].concat(node.selectionSet)
+            selectionSet: [addedField].concat(node.selectionSet),
           };
         }
         if (node === addedField) {
           didVisitAddedField = true;
         }
-      }
+      },
     });
 
     expect(didVisitAddedField).to.equal(true);
   });
 
   it('allows skipping a sub-tree', () => {
-
     const visited = [];
 
     const ast = parse('{ a, b { x }, c }');
     visit(ast, {
       enter(node) {
-        visited.push([ 'enter', node.kind, node.value ]);
+        visited.push(['enter', node.kind, node.value]);
         if (node.kind === 'Field' && node.name.value === 'b') {
           return false;
         }
       },
 
       leave(node) {
-        visited.push([ 'leave', node.kind, node.value ]);
-      }
+        visited.push(['leave', node.kind, node.value]);
+      },
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined ],
-      [ 'enter', 'OperationDefinition', undefined ],
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'a' ],
-      [ 'leave', 'Name', 'a' ],
-      [ 'leave', 'Field', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'c' ],
-      [ 'leave', 'Name', 'c' ],
-      [ 'leave', 'Field', undefined ],
-      [ 'leave', 'SelectionSet', undefined ],
-      [ 'leave', 'OperationDefinition', undefined ],
-      [ 'leave', 'Document', undefined ],
+      ['enter', 'Document', undefined],
+      ['enter', 'OperationDefinition', undefined],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'a'],
+      ['leave', 'Name', 'a'],
+      ['leave', 'Field', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'c'],
+      ['leave', 'Name', 'c'],
+      ['leave', 'Field', undefined],
+      ['leave', 'SelectionSet', undefined],
+      ['leave', 'OperationDefinition', undefined],
+      ['leave', 'Document', undefined],
     ]);
   });
 
   it('allows early exit while visiting', () => {
-
     const visited = [];
 
     const ast = parse('{ a, b { x }, c }');
     visit(ast, {
       enter(node) {
-        visited.push([ 'enter', node.kind, node.value ]);
+        visited.push(['enter', node.kind, node.value]);
         if (node.kind === 'Name' && node.value === 'x') {
           return BREAK;
         }
       },
 
       leave(node) {
-        visited.push([ 'leave', node.kind, node.value ]);
-      }
+        visited.push(['leave', node.kind, node.value]);
+      },
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined ],
-      [ 'enter', 'OperationDefinition', undefined ],
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'a' ],
-      [ 'leave', 'Name', 'a' ],
-      [ 'leave', 'Field', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'b' ],
-      [ 'leave', 'Name', 'b' ],
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'x' ]
+      ['enter', 'Document', undefined],
+      ['enter', 'OperationDefinition', undefined],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'a'],
+      ['leave', 'Name', 'a'],
+      ['leave', 'Field', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'b'],
+      ['leave', 'Name', 'b'],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'x'],
     ]);
   });
 
   it('allows early exit while leaving', () => {
-
     const visited = [];
 
     const ast = parse('{ a, b { x }, c }');
     visit(ast, {
       enter(node) {
-        visited.push([ 'enter', node.kind, node.value ]);
+        visited.push(['enter', node.kind, node.value]);
       },
 
       leave(node) {
-        visited.push([ 'leave', node.kind, node.value ]);
+        visited.push(['leave', node.kind, node.value]);
         if (node.kind === 'Name' && node.value === 'x') {
           return BREAK;
         }
-      }
+      },
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined ],
-      [ 'enter', 'OperationDefinition', undefined ],
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'a' ],
-      [ 'leave', 'Name', 'a' ],
-      [ 'leave', 'Field', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'b' ],
-      [ 'leave', 'Name', 'b' ],
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Field', undefined ],
-      [ 'enter', 'Name', 'x' ],
-      [ 'leave', 'Name', 'x' ]
+      ['enter', 'Document', undefined],
+      ['enter', 'OperationDefinition', undefined],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'a'],
+      ['leave', 'Name', 'a'],
+      ['leave', 'Field', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'b'],
+      ['leave', 'Name', 'b'],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'x'],
+      ['leave', 'Name', 'x'],
     ]);
   });
 
   it('allows a named functions visitor API', () => {
-
     const visited = [];
 
     const ast = parse('{ a, b { x }, c }');
     visit(ast, {
       Name(node) {
-        visited.push([ 'enter', node.kind, node.value ]);
+        visited.push(['enter', node.kind, node.value]);
       },
       SelectionSet: {
         enter(node) {
-          visited.push([ 'enter', node.kind, node.value ]);
+          visited.push(['enter', node.kind, node.value]);
         },
         leave(node) {
-          visited.push([ 'leave', node.kind, node.value ]);
-        }
-      }
+          visited.push(['leave', node.kind, node.value]);
+        },
+      },
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Name', 'a' ],
-      [ 'enter', 'Name', 'b' ],
-      [ 'enter', 'SelectionSet', undefined ],
-      [ 'enter', 'Name', 'x' ],
-      [ 'leave', 'SelectionSet', undefined ],
-      [ 'enter', 'Name', 'c' ],
-      [ 'leave', 'SelectionSet', undefined ],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Name', 'a'],
+      ['enter', 'Name', 'b'],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Name', 'x'],
+      ['leave', 'SelectionSet', undefined],
+      ['enter', 'Name', 'c'],
+      ['leave', 'SelectionSet', undefined],
     ]);
   });
 
-
-  const kitchenSink = readFileSync(
-    join(__dirname, '/kitchen-sink.graphql'),
-    { encoding: 'utf8' }
-  );
+  const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
+    encoding: 'utf8',
+  });
 
   it('visits kitchen sink', () => {
-
     const ast = parse(kitchenSink);
 
     const visited = [];
 
     visit(ast, {
       enter(node, key, parent) {
-        visited.push([ 'enter', node.kind, key, parent && parent.kind ]);
+        visited.push(['enter', node.kind, key, parent && parent.kind]);
       },
 
       leave(node, key, parent) {
-        visited.push([ 'leave', node.kind, key, parent && parent.kind ]);
-      }
+        visited.push(['leave', node.kind, key, parent && parent.kind]);
+      },
     });
 
     expect(visited).to.deep.equal([
-      [ 'enter', 'Document', undefined, undefined ],
-      [ 'enter', 'OperationDefinition', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'OperationDefinition' ],
-      [ 'leave', 'Name', 'name', 'OperationDefinition' ],
-      [ 'enter', 'VariableDefinition', 0, undefined ],
-      [ 'enter', 'Variable', 'variable', 'VariableDefinition' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'variable', 'VariableDefinition' ],
-      [ 'enter', 'NamedType', 'type', 'VariableDefinition' ],
-      [ 'enter', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'NamedType', 'type', 'VariableDefinition' ],
-      [ 'leave', 'VariableDefinition', 0, undefined ],
-      [ 'enter', 'VariableDefinition', 1, undefined ],
-      [ 'enter', 'Variable', 'variable', 'VariableDefinition' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'variable', 'VariableDefinition' ],
-      [ 'enter', 'NamedType', 'type', 'VariableDefinition' ],
-      [ 'enter', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'NamedType', 'type', 'VariableDefinition' ],
-      [ 'enter', 'EnumValue', 'defaultValue', 'VariableDefinition' ],
-      [ 'leave', 'EnumValue', 'defaultValue', 'VariableDefinition' ],
-      [ 'leave', 'VariableDefinition', 1, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'alias', 'Field' ],
-      [ 'leave', 'Name', 'alias', 'Field' ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'ListValue', 'value', 'Argument' ],
-      [ 'enter', 'IntValue', 0, undefined ],
-      [ 'leave', 'IntValue', 0, undefined ],
-      [ 'enter', 'IntValue', 1, undefined ],
-      [ 'leave', 'IntValue', 1, undefined ],
-      [ 'leave', 'ListValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'enter', 'InlineFragment', 1, undefined ],
-      [ 'enter', 'NamedType', 'typeCondition', 'InlineFragment' ],
-      [ 'enter', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'NamedType', 'typeCondition', 'InlineFragment' ],
-      [ 'enter', 'Directive', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Directive' ],
-      [ 'leave', 'Name', 'name', 'Directive' ],
-      [ 'leave', 'Directive', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'InlineFragment' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'enter', 'Field', 1, undefined ],
-      [ 'enter', 'Name', 'alias', 'Field' ],
-      [ 'leave', 'Name', 'alias', 'Field' ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'IntValue', 'value', 'Argument' ],
-      [ 'leave', 'IntValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'enter', 'Argument', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'Variable', 'value', 'Argument' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 1, undefined ],
-      [ 'enter', 'Directive', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Directive' ],
-      [ 'leave', 'Name', 'name', 'Directive' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'Variable', 'value', 'Argument' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'leave', 'Directive', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'enter', 'FragmentSpread', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'FragmentSpread' ],
-      [ 'leave', 'Name', 'name', 'FragmentSpread' ],
-      [ 'leave', 'FragmentSpread', 1, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 1, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'InlineFragment' ],
-      [ 'leave', 'InlineFragment', 1, undefined ],
-      [ 'enter', 'InlineFragment', 2, undefined ],
-      [ 'enter', 'Directive', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Directive' ],
-      [ 'leave', 'Name', 'name', 'Directive' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'Variable', 'value', 'Argument' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'leave', 'Directive', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'InlineFragment' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'InlineFragment' ],
-      [ 'leave', 'InlineFragment', 2, undefined ],
-      [ 'enter', 'InlineFragment', 3, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'InlineFragment' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'InlineFragment' ],
-      [ 'leave', 'InlineFragment', 3, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'leave', 'OperationDefinition', 0, undefined ],
-      [ 'enter', 'OperationDefinition', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'OperationDefinition' ],
-      [ 'leave', 'Name', 'name', 'OperationDefinition' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'IntValue', 'value', 'Argument' ],
-      [ 'leave', 'IntValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'enter', 'Directive', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Directive' ],
-      [ 'leave', 'Name', 'name', 'Directive' ],
-      [ 'leave', 'Directive', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'leave', 'OperationDefinition', 1, undefined ],
-      [ 'enter', 'OperationDefinition', 2, undefined ],
-      [ 'enter', 'Name', 'name', 'OperationDefinition' ],
-      [ 'leave', 'Name', 'name', 'OperationDefinition' ],
-      [ 'enter', 'VariableDefinition', 0, undefined ],
-      [ 'enter', 'Variable', 'variable', 'VariableDefinition' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'variable', 'VariableDefinition' ],
-      [ 'enter', 'NamedType', 'type', 'VariableDefinition' ],
-      [ 'enter', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'NamedType', 'type', 'VariableDefinition' ],
-      [ 'leave', 'VariableDefinition', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'Variable', 'value', 'Argument' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'enter', 'Field', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 1, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'Field' ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'leave', 'OperationDefinition', 2, undefined ],
-      [ 'enter', 'FragmentDefinition', 3, undefined ],
-      [ 'enter', 'Name', 'name', 'FragmentDefinition' ],
-      [ 'leave', 'Name', 'name', 'FragmentDefinition' ],
-      [ 'enter', 'NamedType', 'typeCondition', 'FragmentDefinition' ],
-      [ 'enter', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'Name', 'name', 'NamedType' ],
-      [ 'leave', 'NamedType', 'typeCondition', 'FragmentDefinition' ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'FragmentDefinition' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'Variable', 'value', 'Argument' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'enter', 'Argument', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'Variable', 'value', 'Argument' ],
-      [ 'enter', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Name', 'name', 'Variable' ],
-      [ 'leave', 'Variable', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 1, undefined ],
-      [ 'enter', 'Argument', 2, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'ObjectValue', 'value', 'Argument' ],
-      [ 'enter', 'ObjectField', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'ObjectField' ],
-      [ 'leave', 'Name', 'name', 'ObjectField' ],
-      [ 'enter', 'StringValue', 'value', 'ObjectField' ],
-      [ 'leave', 'StringValue', 'value', 'ObjectField' ],
-      [ 'leave', 'ObjectField', 0, undefined ],
-      [ 'leave', 'ObjectValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 2, undefined ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'FragmentDefinition' ],
-      [ 'leave', 'FragmentDefinition', 3, undefined ],
-      [ 'enter', 'OperationDefinition', 4, undefined ],
-      [ 'enter', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'enter', 'Field', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'enter', 'Argument', 0, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'BooleanValue', 'value', 'Argument' ],
-      [ 'leave', 'BooleanValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 0, undefined ],
-      [ 'enter', 'Argument', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'BooleanValue', 'value', 'Argument' ],
-      [ 'leave', 'BooleanValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 1, undefined ],
-      [ 'enter', 'Argument', 2, undefined ],
-      [ 'enter', 'Name', 'name', 'Argument' ],
-      [ 'leave', 'Name', 'name', 'Argument' ],
-      [ 'enter', 'NullValue', 'value', 'Argument' ],
-      [ 'leave', 'NullValue', 'value', 'Argument' ],
-      [ 'leave', 'Argument', 2, undefined ],
-      [ 'leave', 'Field', 0, undefined ],
-      [ 'enter', 'Field', 1, undefined ],
-      [ 'enter', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Name', 'name', 'Field' ],
-      [ 'leave', 'Field', 1, undefined ],
-      [ 'leave', 'SelectionSet', 'selectionSet', 'OperationDefinition' ],
-      [ 'leave', 'OperationDefinition', 4, undefined ],
-      [ 'leave', 'Document', undefined, undefined ] ]);
+      ['enter', 'Document', undefined, undefined],
+      ['enter', 'OperationDefinition', 0, undefined],
+      ['enter', 'Name', 'name', 'OperationDefinition'],
+      ['leave', 'Name', 'name', 'OperationDefinition'],
+      ['enter', 'VariableDefinition', 0, undefined],
+      ['enter', 'Variable', 'variable', 'VariableDefinition'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'variable', 'VariableDefinition'],
+      ['enter', 'NamedType', 'type', 'VariableDefinition'],
+      ['enter', 'Name', 'name', 'NamedType'],
+      ['leave', 'Name', 'name', 'NamedType'],
+      ['leave', 'NamedType', 'type', 'VariableDefinition'],
+      ['leave', 'VariableDefinition', 0, undefined],
+      ['enter', 'VariableDefinition', 1, undefined],
+      ['enter', 'Variable', 'variable', 'VariableDefinition'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'variable', 'VariableDefinition'],
+      ['enter', 'NamedType', 'type', 'VariableDefinition'],
+      ['enter', 'Name', 'name', 'NamedType'],
+      ['leave', 'Name', 'name', 'NamedType'],
+      ['leave', 'NamedType', 'type', 'VariableDefinition'],
+      ['enter', 'EnumValue', 'defaultValue', 'VariableDefinition'],
+      ['leave', 'EnumValue', 'defaultValue', 'VariableDefinition'],
+      ['leave', 'VariableDefinition', 1, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'alias', 'Field'],
+      ['leave', 'Name', 'alias', 'Field'],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'ListValue', 'value', 'Argument'],
+      ['enter', 'IntValue', 0, undefined],
+      ['leave', 'IntValue', 0, undefined],
+      ['enter', 'IntValue', 1, undefined],
+      ['leave', 'IntValue', 1, undefined],
+      ['leave', 'ListValue', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['enter', 'InlineFragment', 1, undefined],
+      ['enter', 'NamedType', 'typeCondition', 'InlineFragment'],
+      ['enter', 'Name', 'name', 'NamedType'],
+      ['leave', 'Name', 'name', 'NamedType'],
+      ['leave', 'NamedType', 'typeCondition', 'InlineFragment'],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'InlineFragment'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['enter', 'Field', 1, undefined],
+      ['enter', 'Name', 'alias', 'Field'],
+      ['leave', 'Name', 'alias', 'Field'],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'IntValue', 'value', 'Argument'],
+      ['leave', 'IntValue', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['enter', 'Argument', 1, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'Variable', 'value', 'Argument'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'value', 'Argument'],
+      ['leave', 'Argument', 1, undefined],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'Variable', 'value', 'Argument'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['leave', 'Directive', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['enter', 'FragmentSpread', 1, undefined],
+      ['enter', 'Name', 'name', 'FragmentSpread'],
+      ['leave', 'Name', 'name', 'FragmentSpread'],
+      ['leave', 'FragmentSpread', 1, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 1, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'InlineFragment'],
+      ['leave', 'InlineFragment', 1, undefined],
+      ['enter', 'InlineFragment', 2, undefined],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'Variable', 'value', 'Argument'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['leave', 'Directive', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'InlineFragment'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'InlineFragment'],
+      ['leave', 'InlineFragment', 2, undefined],
+      ['enter', 'InlineFragment', 3, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'InlineFragment'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'InlineFragment'],
+      ['leave', 'InlineFragment', 3, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['leave', 'OperationDefinition', 0, undefined],
+      ['enter', 'OperationDefinition', 1, undefined],
+      ['enter', 'Name', 'name', 'OperationDefinition'],
+      ['leave', 'Name', 'name', 'OperationDefinition'],
+      ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'IntValue', 'value', 'Argument'],
+      ['leave', 'IntValue', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['leave', 'OperationDefinition', 1, undefined],
+      ['enter', 'OperationDefinition', 2, undefined],
+      ['enter', 'Name', 'name', 'OperationDefinition'],
+      ['leave', 'Name', 'name', 'OperationDefinition'],
+      ['enter', 'VariableDefinition', 0, undefined],
+      ['enter', 'Variable', 'variable', 'VariableDefinition'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'variable', 'VariableDefinition'],
+      ['enter', 'NamedType', 'type', 'VariableDefinition'],
+      ['enter', 'Name', 'name', 'NamedType'],
+      ['leave', 'Name', 'name', 'NamedType'],
+      ['leave', 'NamedType', 'type', 'VariableDefinition'],
+      ['leave', 'VariableDefinition', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'Variable', 'value', 'Argument'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['enter', 'Field', 1, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'SelectionSet', 'selectionSet', 'Field'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 1, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['leave', 'OperationDefinition', 2, undefined],
+      ['enter', 'FragmentDefinition', 3, undefined],
+      ['enter', 'Name', 'name', 'FragmentDefinition'],
+      ['leave', 'Name', 'name', 'FragmentDefinition'],
+      ['enter', 'NamedType', 'typeCondition', 'FragmentDefinition'],
+      ['enter', 'Name', 'name', 'NamedType'],
+      ['leave', 'Name', 'name', 'NamedType'],
+      ['leave', 'NamedType', 'typeCondition', 'FragmentDefinition'],
+      ['enter', 'SelectionSet', 'selectionSet', 'FragmentDefinition'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'Variable', 'value', 'Argument'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['enter', 'Argument', 1, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'Variable', 'value', 'Argument'],
+      ['enter', 'Name', 'name', 'Variable'],
+      ['leave', 'Name', 'name', 'Variable'],
+      ['leave', 'Variable', 'value', 'Argument'],
+      ['leave', 'Argument', 1, undefined],
+      ['enter', 'Argument', 2, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'ObjectValue', 'value', 'Argument'],
+      ['enter', 'ObjectField', 0, undefined],
+      ['enter', 'Name', 'name', 'ObjectField'],
+      ['leave', 'Name', 'name', 'ObjectField'],
+      ['enter', 'StringValue', 'value', 'ObjectField'],
+      ['leave', 'StringValue', 'value', 'ObjectField'],
+      ['leave', 'ObjectField', 0, undefined],
+      ['leave', 'ObjectValue', 'value', 'Argument'],
+      ['leave', 'Argument', 2, undefined],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'FragmentDefinition'],
+      ['leave', 'FragmentDefinition', 3, undefined],
+      ['enter', 'OperationDefinition', 4, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Argument', 0, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'BooleanValue', 'value', 'Argument'],
+      ['leave', 'BooleanValue', 'value', 'Argument'],
+      ['leave', 'Argument', 0, undefined],
+      ['enter', 'Argument', 1, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'BooleanValue', 'value', 'Argument'],
+      ['leave', 'BooleanValue', 'value', 'Argument'],
+      ['leave', 'Argument', 1, undefined],
+      ['enter', 'Argument', 2, undefined],
+      ['enter', 'Name', 'name', 'Argument'],
+      ['leave', 'Name', 'name', 'Argument'],
+      ['enter', 'NullValue', 'value', 'Argument'],
+      ['leave', 'NullValue', 'value', 'Argument'],
+      ['leave', 'Argument', 2, undefined],
+      ['leave', 'Field', 0, undefined],
+      ['enter', 'Field', 1, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 1, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['leave', 'OperationDefinition', 4, undefined],
+      ['leave', 'Document', undefined, undefined],
+    ]);
   });
 
   describe('visitInParallel', () => {
-
     // Note: nearly identical to the above test of the same test but
     // using visitInParallel.
     it('allows skipping a sub-tree', () => {
-
       const visited = [];
 
       const ast = parse('{ a, b { x }, c }');
-      visit(ast, visitInParallel([ {
-        enter(node) {
-          visited.push([ 'enter', node.kind, node.value ]);
-          if (node.kind === 'Field' && node.name.value === 'b') {
-            return false;
-          }
-        },
+      visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              visited.push(['enter', node.kind, node.value]);
+              if (node.kind === 'Field' && node.name.value === 'b') {
+                return false;
+              }
+            },
 
-        leave(node) {
-          visited.push([ 'leave', node.kind, node.value ]);
-        }
-      } ]));
+            leave(node) {
+              visited.push(['leave', node.kind, node.value]);
+            },
+          },
+        ]),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', undefined ],
-        [ 'enter', 'OperationDefinition', undefined ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'c' ],
-        [ 'leave', 'Name', 'c' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'leave', 'SelectionSet', undefined ],
-        [ 'leave', 'OperationDefinition', undefined ],
-        [ 'leave', 'Document', undefined ],
+        ['enter', 'Document', undefined],
+        ['enter', 'OperationDefinition', undefined],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'c'],
+        ['leave', 'Name', 'c'],
+        ['leave', 'Field', undefined],
+        ['leave', 'SelectionSet', undefined],
+        ['leave', 'OperationDefinition', undefined],
+        ['leave', 'Document', undefined],
       ]);
     });
 
@@ -673,263 +665,278 @@ describe('Visitor', () => {
       const visited = [];
 
       const ast = parse('{ a { x }, b { y} }');
-      visit(ast, visitInParallel([
-        {
-          enter(node) {
-            visited.push([ 'no-a', 'enter', node.kind, node.value ]);
-            if (node.kind === 'Field' && node.name.value === 'a') {
-              return false;
-            }
+      visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              visited.push(['no-a', 'enter', node.kind, node.value]);
+              if (node.kind === 'Field' && node.name.value === 'a') {
+                return false;
+              }
+            },
+            leave(node) {
+              visited.push(['no-a', 'leave', node.kind, node.value]);
+            },
           },
-          leave(node) {
-            visited.push([ 'no-a', 'leave', node.kind, node.value ]);
-          }
-        },
-        {
-          enter(node) {
-            visited.push([ 'no-b', 'enter', node.kind, node.value ]);
-            if (node.kind === 'Field' && node.name.value === 'b') {
-              return false;
-            }
+          {
+            enter(node) {
+              visited.push(['no-b', 'enter', node.kind, node.value]);
+              if (node.kind === 'Field' && node.name.value === 'b') {
+                return false;
+              }
+            },
+            leave(node) {
+              visited.push(['no-b', 'leave', node.kind, node.value]);
+            },
           },
-          leave(node) {
-            visited.push([ 'no-b', 'leave', node.kind, node.value ]);
-          }
-        }
-      ]));
+        ]),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'no-a', 'enter', 'Document', undefined ],
-        [ 'no-b', 'enter', 'Document', undefined ],
-        [ 'no-a', 'enter', 'OperationDefinition', undefined ],
-        [ 'no-b', 'enter', 'OperationDefinition', undefined ],
-        [ 'no-a', 'enter', 'SelectionSet', undefined ],
-        [ 'no-b', 'enter', 'SelectionSet', undefined ],
-        [ 'no-a', 'enter', 'Field', undefined ],
-        [ 'no-b', 'enter', 'Field', undefined ],
-        [ 'no-b', 'enter', 'Name', 'a' ],
-        [ 'no-b', 'leave', 'Name', 'a' ],
-        [ 'no-b', 'enter', 'SelectionSet', undefined ],
-        [ 'no-b', 'enter', 'Field', undefined ],
-        [ 'no-b', 'enter', 'Name', 'x' ],
-        [ 'no-b', 'leave', 'Name', 'x' ],
-        [ 'no-b', 'leave', 'Field', undefined ],
-        [ 'no-b', 'leave', 'SelectionSet', undefined ],
-        [ 'no-b', 'leave', 'Field', undefined ],
-        [ 'no-a', 'enter', 'Field', undefined ],
-        [ 'no-b', 'enter', 'Field', undefined ],
-        [ 'no-a', 'enter', 'Name', 'b' ],
-        [ 'no-a', 'leave', 'Name', 'b' ],
-        [ 'no-a', 'enter', 'SelectionSet', undefined ],
-        [ 'no-a', 'enter', 'Field', undefined ],
-        [ 'no-a', 'enter', 'Name', 'y' ],
-        [ 'no-a', 'leave', 'Name', 'y' ],
-        [ 'no-a', 'leave', 'Field', undefined ],
-        [ 'no-a', 'leave', 'SelectionSet', undefined ],
-        [ 'no-a', 'leave', 'Field', undefined ],
-        [ 'no-a', 'leave', 'SelectionSet', undefined ],
-        [ 'no-b', 'leave', 'SelectionSet', undefined ],
-        [ 'no-a', 'leave', 'OperationDefinition', undefined ],
-        [ 'no-b', 'leave', 'OperationDefinition', undefined ],
-        [ 'no-a', 'leave', 'Document', undefined ],
-        [ 'no-b', 'leave', 'Document', undefined ],
+        ['no-a', 'enter', 'Document', undefined],
+        ['no-b', 'enter', 'Document', undefined],
+        ['no-a', 'enter', 'OperationDefinition', undefined],
+        ['no-b', 'enter', 'OperationDefinition', undefined],
+        ['no-a', 'enter', 'SelectionSet', undefined],
+        ['no-b', 'enter', 'SelectionSet', undefined],
+        ['no-a', 'enter', 'Field', undefined],
+        ['no-b', 'enter', 'Field', undefined],
+        ['no-b', 'enter', 'Name', 'a'],
+        ['no-b', 'leave', 'Name', 'a'],
+        ['no-b', 'enter', 'SelectionSet', undefined],
+        ['no-b', 'enter', 'Field', undefined],
+        ['no-b', 'enter', 'Name', 'x'],
+        ['no-b', 'leave', 'Name', 'x'],
+        ['no-b', 'leave', 'Field', undefined],
+        ['no-b', 'leave', 'SelectionSet', undefined],
+        ['no-b', 'leave', 'Field', undefined],
+        ['no-a', 'enter', 'Field', undefined],
+        ['no-b', 'enter', 'Field', undefined],
+        ['no-a', 'enter', 'Name', 'b'],
+        ['no-a', 'leave', 'Name', 'b'],
+        ['no-a', 'enter', 'SelectionSet', undefined],
+        ['no-a', 'enter', 'Field', undefined],
+        ['no-a', 'enter', 'Name', 'y'],
+        ['no-a', 'leave', 'Name', 'y'],
+        ['no-a', 'leave', 'Field', undefined],
+        ['no-a', 'leave', 'SelectionSet', undefined],
+        ['no-a', 'leave', 'Field', undefined],
+        ['no-a', 'leave', 'SelectionSet', undefined],
+        ['no-b', 'leave', 'SelectionSet', undefined],
+        ['no-a', 'leave', 'OperationDefinition', undefined],
+        ['no-b', 'leave', 'OperationDefinition', undefined],
+        ['no-a', 'leave', 'Document', undefined],
+        ['no-b', 'leave', 'Document', undefined],
       ]);
     });
 
     // Note: nearly identical to the above test of the same test but
     // using visitInParallel.
     it('allows early exit while visiting', () => {
-
       const visited = [];
 
       const ast = parse('{ a, b { x }, c }');
-      visit(ast, visitInParallel([ {
-        enter(node) {
-          visited.push([ 'enter', node.kind, node.value ]);
-          if (node.kind === 'Name' && node.value === 'x') {
-            return BREAK;
-          }
-        },
-        leave(node) {
-          visited.push([ 'leave', node.kind, node.value ]);
-        }
-      } ]));
+      visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              visited.push(['enter', node.kind, node.value]);
+              if (node.kind === 'Name' && node.value === 'x') {
+                return BREAK;
+              }
+            },
+            leave(node) {
+              visited.push(['leave', node.kind, node.value]);
+            },
+          },
+        ]),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', undefined ],
-        [ 'enter', 'OperationDefinition', undefined ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'b' ],
-        [ 'leave', 'Name', 'b' ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'x' ]
+        ['enter', 'Document', undefined],
+        ['enter', 'OperationDefinition', undefined],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'b'],
+        ['leave', 'Name', 'b'],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'x'],
       ]);
     });
 
     it('allows early exit from different points', () => {
-
       const visited = [];
 
       const ast = parse('{ a { y }, b { x } }');
-      visit(ast, visitInParallel([
-        {
-          enter(node) {
-            visited.push([ 'break-a', 'enter', node.kind, node.value ]);
-            if (node.kind === 'Name' && node.value === 'a') {
-              return BREAK;
-            }
+      visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              visited.push(['break-a', 'enter', node.kind, node.value]);
+              if (node.kind === 'Name' && node.value === 'a') {
+                return BREAK;
+              }
+            },
+            leave(node) {
+              visited.push(['break-a', 'leave', node.kind, node.value]);
+            },
           },
-          leave(node) {
-            visited.push([ 'break-a', 'leave', node.kind, node.value ]);
-          }
-        },
-        {
-          enter(node) {
-            visited.push([ 'break-b', 'enter', node.kind, node.value ]);
-            if (node.kind === 'Name' && node.value === 'b') {
-              return BREAK;
-            }
+          {
+            enter(node) {
+              visited.push(['break-b', 'enter', node.kind, node.value]);
+              if (node.kind === 'Name' && node.value === 'b') {
+                return BREAK;
+              }
+            },
+            leave(node) {
+              visited.push(['break-b', 'leave', node.kind, node.value]);
+            },
           },
-          leave(node) {
-            visited.push([ 'break-b', 'leave', node.kind, node.value ]);
-          }
-        },
-      ]));
+        ]),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'break-a', 'enter', 'Document', undefined ],
-        [ 'break-b', 'enter', 'Document', undefined ],
-        [ 'break-a', 'enter', 'OperationDefinition', undefined ],
-        [ 'break-b', 'enter', 'OperationDefinition', undefined ],
-        [ 'break-a', 'enter', 'SelectionSet', undefined ],
-        [ 'break-b', 'enter', 'SelectionSet', undefined ],
-        [ 'break-a', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-a', 'enter', 'Name', 'a' ],
-        [ 'break-b', 'enter', 'Name', 'a' ],
-        [ 'break-b', 'leave', 'Name', 'a' ],
-        [ 'break-b', 'enter', 'SelectionSet', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Name', 'y' ],
-        [ 'break-b', 'leave', 'Name', 'y' ],
-        [ 'break-b', 'leave', 'Field', undefined ],
-        [ 'break-b', 'leave', 'SelectionSet', undefined ],
-        [ 'break-b', 'leave', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Name', 'b' ]
+        ['break-a', 'enter', 'Document', undefined],
+        ['break-b', 'enter', 'Document', undefined],
+        ['break-a', 'enter', 'OperationDefinition', undefined],
+        ['break-b', 'enter', 'OperationDefinition', undefined],
+        ['break-a', 'enter', 'SelectionSet', undefined],
+        ['break-b', 'enter', 'SelectionSet', undefined],
+        ['break-a', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-a', 'enter', 'Name', 'a'],
+        ['break-b', 'enter', 'Name', 'a'],
+        ['break-b', 'leave', 'Name', 'a'],
+        ['break-b', 'enter', 'SelectionSet', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Name', 'y'],
+        ['break-b', 'leave', 'Name', 'y'],
+        ['break-b', 'leave', 'Field', undefined],
+        ['break-b', 'leave', 'SelectionSet', undefined],
+        ['break-b', 'leave', 'Field', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Name', 'b'],
       ]);
     });
 
     // Note: nearly identical to the above test of the same test but
     // using visitInParallel.
     it('allows early exit while leaving', () => {
-
       const visited = [];
 
       const ast = parse('{ a, b { x }, c }');
-      visit(ast, visitInParallel([ {
-        enter(node) {
-          visited.push([ 'enter', node.kind, node.value ]);
-        },
-        leave(node) {
-          visited.push([ 'leave', node.kind, node.value ]);
-          if (node.kind === 'Name' && node.value === 'x') {
-            return BREAK;
-          }
-        }
-      } ]));
+      visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              visited.push(['enter', node.kind, node.value]);
+            },
+            leave(node) {
+              visited.push(['leave', node.kind, node.value]);
+              if (node.kind === 'Name' && node.value === 'x') {
+                return BREAK;
+              }
+            },
+          },
+        ]),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', undefined ],
-        [ 'enter', 'OperationDefinition', undefined ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'b' ],
-        [ 'leave', 'Name', 'b' ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'x' ],
-        [ 'leave', 'Name', 'x' ]
+        ['enter', 'Document', undefined],
+        ['enter', 'OperationDefinition', undefined],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'b'],
+        ['leave', 'Name', 'b'],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'x'],
+        ['leave', 'Name', 'x'],
       ]);
     });
 
     it('allows early exit from leaving different points', () => {
-
       const visited = [];
 
       const ast = parse('{ a { y }, b { x } }');
-      visit(ast, visitInParallel([
-        {
-          enter(node) {
-            visited.push([ 'break-a', 'enter', node.kind, node.value ]);
+      visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              visited.push(['break-a', 'enter', node.kind, node.value]);
+            },
+            leave(node) {
+              visited.push(['break-a', 'leave', node.kind, node.value]);
+              if (node.kind === 'Field' && node.name.value === 'a') {
+                return BREAK;
+              }
+            },
           },
-          leave(node) {
-            visited.push([ 'break-a', 'leave', node.kind, node.value ]);
-            if (node.kind === 'Field' && node.name.value === 'a') {
-              return BREAK;
-            }
-          }
-        },
-        {
-          enter(node) {
-            visited.push([ 'break-b', 'enter', node.kind, node.value ]);
+          {
+            enter(node) {
+              visited.push(['break-b', 'enter', node.kind, node.value]);
+            },
+            leave(node) {
+              visited.push(['break-b', 'leave', node.kind, node.value]);
+              if (node.kind === 'Field' && node.name.value === 'b') {
+                return BREAK;
+              }
+            },
           },
-          leave(node) {
-            visited.push([ 'break-b', 'leave', node.kind, node.value ]);
-            if (node.kind === 'Field' && node.name.value === 'b') {
-              return BREAK;
-            }
-          }
-        },
-      ]));
+        ]),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'break-a', 'enter', 'Document', undefined ],
-        [ 'break-b', 'enter', 'Document', undefined ],
-        [ 'break-a', 'enter', 'OperationDefinition', undefined ],
-        [ 'break-b', 'enter', 'OperationDefinition', undefined ],
-        [ 'break-a', 'enter', 'SelectionSet', undefined ],
-        [ 'break-b', 'enter', 'SelectionSet', undefined ],
-        [ 'break-a', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-a', 'enter', 'Name', 'a' ],
-        [ 'break-b', 'enter', 'Name', 'a' ],
-        [ 'break-a', 'leave', 'Name', 'a' ],
-        [ 'break-b', 'leave', 'Name', 'a' ],
-        [ 'break-a', 'enter', 'SelectionSet', undefined ],
-        [ 'break-b', 'enter', 'SelectionSet', undefined ],
-        [ 'break-a', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-a', 'enter', 'Name', 'y' ],
-        [ 'break-b', 'enter', 'Name', 'y' ],
-        [ 'break-a', 'leave', 'Name', 'y' ],
-        [ 'break-b', 'leave', 'Name', 'y' ],
-        [ 'break-a', 'leave', 'Field', undefined ],
-        [ 'break-b', 'leave', 'Field', undefined ],
-        [ 'break-a', 'leave', 'SelectionSet', undefined ],
-        [ 'break-b', 'leave', 'SelectionSet', undefined ],
-        [ 'break-a', 'leave', 'Field', undefined ],
-        [ 'break-b', 'leave', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Name', 'b' ],
-        [ 'break-b', 'leave', 'Name', 'b' ],
-        [ 'break-b', 'enter', 'SelectionSet', undefined ],
-        [ 'break-b', 'enter', 'Field', undefined ],
-        [ 'break-b', 'enter', 'Name', 'x' ],
-        [ 'break-b', 'leave', 'Name', 'x' ],
-        [ 'break-b', 'leave', 'Field', undefined ],
-        [ 'break-b', 'leave', 'SelectionSet', undefined ],
-        [ 'break-b', 'leave', 'Field', undefined ]
+        ['break-a', 'enter', 'Document', undefined],
+        ['break-b', 'enter', 'Document', undefined],
+        ['break-a', 'enter', 'OperationDefinition', undefined],
+        ['break-b', 'enter', 'OperationDefinition', undefined],
+        ['break-a', 'enter', 'SelectionSet', undefined],
+        ['break-b', 'enter', 'SelectionSet', undefined],
+        ['break-a', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-a', 'enter', 'Name', 'a'],
+        ['break-b', 'enter', 'Name', 'a'],
+        ['break-a', 'leave', 'Name', 'a'],
+        ['break-b', 'leave', 'Name', 'a'],
+        ['break-a', 'enter', 'SelectionSet', undefined],
+        ['break-b', 'enter', 'SelectionSet', undefined],
+        ['break-a', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-a', 'enter', 'Name', 'y'],
+        ['break-b', 'enter', 'Name', 'y'],
+        ['break-a', 'leave', 'Name', 'y'],
+        ['break-b', 'leave', 'Name', 'y'],
+        ['break-a', 'leave', 'Field', undefined],
+        ['break-b', 'leave', 'Field', undefined],
+        ['break-a', 'leave', 'SelectionSet', undefined],
+        ['break-b', 'leave', 'SelectionSet', undefined],
+        ['break-a', 'leave', 'Field', undefined],
+        ['break-b', 'leave', 'Field', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Name', 'b'],
+        ['break-b', 'leave', 'Name', 'b'],
+        ['break-b', 'enter', 'SelectionSet', undefined],
+        ['break-b', 'enter', 'Field', undefined],
+        ['break-b', 'enter', 'Name', 'x'],
+        ['break-b', 'leave', 'Name', 'x'],
+        ['break-b', 'leave', 'Field', undefined],
+        ['break-b', 'leave', 'SelectionSet', undefined],
+        ['break-b', 'leave', 'Field', undefined],
       ]);
     });
 
@@ -937,57 +944,60 @@ describe('Visitor', () => {
       const visited = [];
 
       const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
-      const editedAst = visit(ast, visitInParallel([
-        {
-          enter(node) {
-            if (node.kind === 'Field' && node.name.value === 'b') {
-              return null;
-            }
-          }
-        },
-        {
-          enter(node) {
-            visited.push([ 'enter', node.kind, node.value ]);
+      const editedAst = visit(
+        ast,
+        visitInParallel([
+          {
+            enter(node) {
+              if (node.kind === 'Field' && node.name.value === 'b') {
+                return null;
+              }
+            },
           },
-          leave(node) {
-            visited.push([ 'leave', node.kind, node.value ]);
-          }
-        },
-      ]));
+          {
+            enter(node) {
+              visited.push(['enter', node.kind, node.value]);
+            },
+            leave(node) {
+              visited.push(['leave', node.kind, node.value]);
+            },
+          },
+        ]),
+      );
 
       expect(ast).to.deep.equal(
-        parse('{ a, b, c { a, b, c } }', { noLocation: true })
+        parse('{ a, b, c { a, b, c } }', { noLocation: true }),
       );
 
       expect(editedAst).to.deep.equal(
-        parse('{ a,    c { a,    c } }', { noLocation: true })
+        parse('{ a,    c { a,    c } }', { noLocation: true }),
       );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', undefined ],
-        [ 'enter', 'OperationDefinition', undefined ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'c' ],
-        [ 'leave', 'Name', 'c' ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'c' ],
-        [ 'leave', 'Name', 'c' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'leave', 'SelectionSet', undefined ],
-        [ 'leave', 'Field', undefined ],
-        [ 'leave', 'SelectionSet', undefined ],
-        [ 'leave', 'OperationDefinition', undefined ],
-        [ 'leave', 'Document', undefined ]
+        ['enter', 'Document', undefined],
+        ['enter', 'OperationDefinition', undefined],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'c'],
+        ['leave', 'Name', 'c'],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'c'],
+        ['leave', 'Name', 'c'],
+        ['leave', 'Field', undefined],
+        ['leave', 'SelectionSet', undefined],
+        ['leave', 'Field', undefined],
+        ['leave', 'SelectionSet', undefined],
+        ['leave', 'OperationDefinition', undefined],
+        ['leave', 'Document', undefined],
       ]);
     });
 
@@ -995,142 +1005,146 @@ describe('Visitor', () => {
       const visited = [];
 
       const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
-      const editedAst = visit(ast, visitInParallel([
-        {
-          leave(node) {
-            if (node.kind === 'Field' && node.name.value === 'b') {
-              return null;
-            }
-          }
-        },
-        {
-          enter(node) {
-            visited.push([ 'enter', node.kind, node.value ]);
+      const editedAst = visit(
+        ast,
+        visitInParallel([
+          {
+            leave(node) {
+              if (node.kind === 'Field' && node.name.value === 'b') {
+                return null;
+              }
+            },
           },
-          leave(node) {
-            visited.push([ 'leave', node.kind, node.value ]);
-          }
-        },
-      ]));
+          {
+            enter(node) {
+              visited.push(['enter', node.kind, node.value]);
+            },
+            leave(node) {
+              visited.push(['leave', node.kind, node.value]);
+            },
+          },
+        ]),
+      );
 
       expect(ast).to.deep.equal(
-        parse('{ a, b, c { a, b, c } }', { noLocation: true })
+        parse('{ a, b, c { a, b, c } }', { noLocation: true }),
       );
 
       expect(editedAst).to.deep.equal(
-        parse('{ a,    c { a,    c } }', { noLocation: true })
+        parse('{ a,    c { a,    c } }', { noLocation: true }),
       );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', undefined ],
-        [ 'enter', 'OperationDefinition', undefined ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'b' ],
-        [ 'leave', 'Name', 'b' ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'c' ],
-        [ 'leave', 'Name', 'c' ],
-        [ 'enter', 'SelectionSet', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'a' ],
-        [ 'leave', 'Name', 'a' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'b' ],
-        [ 'leave', 'Name', 'b' ],
-        [ 'enter', 'Field', undefined ],
-        [ 'enter', 'Name', 'c' ],
-        [ 'leave', 'Name', 'c' ],
-        [ 'leave', 'Field', undefined ],
-        [ 'leave', 'SelectionSet', undefined ],
-        [ 'leave', 'Field', undefined ],
-        [ 'leave', 'SelectionSet', undefined ],
-        [ 'leave', 'OperationDefinition', undefined ],
-        [ 'leave', 'Document', undefined ]
+        ['enter', 'Document', undefined],
+        ['enter', 'OperationDefinition', undefined],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'b'],
+        ['leave', 'Name', 'b'],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'c'],
+        ['leave', 'Name', 'c'],
+        ['enter', 'SelectionSet', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'a'],
+        ['leave', 'Name', 'a'],
+        ['leave', 'Field', undefined],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'b'],
+        ['leave', 'Name', 'b'],
+        ['enter', 'Field', undefined],
+        ['enter', 'Name', 'c'],
+        ['leave', 'Name', 'c'],
+        ['leave', 'Field', undefined],
+        ['leave', 'SelectionSet', undefined],
+        ['leave', 'Field', undefined],
+        ['leave', 'SelectionSet', undefined],
+        ['leave', 'OperationDefinition', undefined],
+        ['leave', 'Document', undefined],
       ]);
     });
-
   });
 
   describe('visitWithTypeInfo', () => {
-
     it('maintains type info during visit', () => {
       const visited = [];
 
       const typeInfo = new TypeInfo(testSchema);
 
       const ast = parse('{ human(id: 4) { name, pets { name }, unknown } }');
-      visit(ast, visitWithTypeInfo(typeInfo, {
-        enter(node) {
-          const parentType = typeInfo.getParentType();
-          const type = typeInfo.getType();
-          const inputType = typeInfo.getInputType();
-          visited.push([
-            'enter',
-            node.kind,
-            node.kind === 'Name' ? node.value : null,
-            parentType ? String(parentType) : null,
-            type ? String(type) : null,
-            inputType ? String(inputType) : null
-          ]);
-        },
-        leave(node) {
-          const parentType = typeInfo.getParentType();
-          const type = typeInfo.getType();
-          const inputType = typeInfo.getInputType();
-          visited.push([
-            'leave',
-            node.kind,
-            node.kind === 'Name' ? node.value : null,
-            parentType ? String(parentType) : null,
-            type ? String(type) : null,
-            inputType ? String(inputType) : null
-          ]);
-        }
-      }));
+      visit(
+        ast,
+        visitWithTypeInfo(typeInfo, {
+          enter(node) {
+            const parentType = typeInfo.getParentType();
+            const type = typeInfo.getType();
+            const inputType = typeInfo.getInputType();
+            visited.push([
+              'enter',
+              node.kind,
+              node.kind === 'Name' ? node.value : null,
+              parentType ? String(parentType) : null,
+              type ? String(type) : null,
+              inputType ? String(inputType) : null,
+            ]);
+          },
+          leave(node) {
+            const parentType = typeInfo.getParentType();
+            const type = typeInfo.getType();
+            const inputType = typeInfo.getInputType();
+            visited.push([
+              'leave',
+              node.kind,
+              node.kind === 'Name' ? node.value : null,
+              parentType ? String(parentType) : null,
+              type ? String(type) : null,
+              inputType ? String(inputType) : null,
+            ]);
+          },
+        }),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', null, null, null, null ],
-        [ 'enter', 'OperationDefinition', null, null, 'QueryRoot', null ],
-        [ 'enter', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null ],
-        [ 'enter', 'Field', null, 'QueryRoot', 'Human', null ],
-        [ 'enter', 'Name', 'human', 'QueryRoot', 'Human', null ],
-        [ 'leave', 'Name', 'human', 'QueryRoot', 'Human', null ],
-        [ 'enter', 'Argument', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'enter', 'Name', 'id', 'QueryRoot', 'Human', 'ID' ],
-        [ 'leave', 'Name', 'id', 'QueryRoot', 'Human', 'ID' ],
-        [ 'enter', 'IntValue', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'leave', 'IntValue', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'leave', 'Argument', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'enter', 'SelectionSet', null, 'Human', 'Human', null ],
-        [ 'enter', 'Field', null, 'Human', 'String', null ],
-        [ 'enter', 'Name', 'name', 'Human', 'String', null ],
-        [ 'leave', 'Name', 'name', 'Human', 'String', null ],
-        [ 'leave', 'Field', null, 'Human', 'String', null ],
-        [ 'enter', 'Field', null, 'Human', '[Pet]', null ],
-        [ 'enter', 'Name', 'pets', 'Human', '[Pet]', null ],
-        [ 'leave', 'Name', 'pets', 'Human', '[Pet]', null ],
-        [ 'enter', 'SelectionSet', null, 'Pet', '[Pet]', null ],
-        [ 'enter', 'Field', null, 'Pet', 'String', null ],
-        [ 'enter', 'Name', 'name', 'Pet', 'String', null ],
-        [ 'leave', 'Name', 'name', 'Pet', 'String', null ],
-        [ 'leave', 'Field', null, 'Pet', 'String', null ],
-        [ 'leave', 'SelectionSet', null, 'Pet', '[Pet]', null ],
-        [ 'leave', 'Field', null, 'Human', '[Pet]', null ],
-        [ 'enter', 'Field', null, 'Human', null, null ],
-        [ 'enter', 'Name', 'unknown', 'Human', null, null ],
-        [ 'leave', 'Name', 'unknown', 'Human', null, null ],
-        [ 'leave', 'Field', null, 'Human', null, null ],
-        [ 'leave', 'SelectionSet', null, 'Human', 'Human', null ],
-        [ 'leave', 'Field', null, 'QueryRoot', 'Human', null ],
-        [ 'leave', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null ],
-        [ 'leave', 'OperationDefinition', null, null, 'QueryRoot', null ],
-        [ 'leave', 'Document', null, null, null, null ]
+        ['enter', 'Document', null, null, null, null],
+        ['enter', 'OperationDefinition', null, null, 'QueryRoot', null],
+        ['enter', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null],
+        ['enter', 'Field', null, 'QueryRoot', 'Human', null],
+        ['enter', 'Name', 'human', 'QueryRoot', 'Human', null],
+        ['leave', 'Name', 'human', 'QueryRoot', 'Human', null],
+        ['enter', 'Argument', null, 'QueryRoot', 'Human', 'ID'],
+        ['enter', 'Name', 'id', 'QueryRoot', 'Human', 'ID'],
+        ['leave', 'Name', 'id', 'QueryRoot', 'Human', 'ID'],
+        ['enter', 'IntValue', null, 'QueryRoot', 'Human', 'ID'],
+        ['leave', 'IntValue', null, 'QueryRoot', 'Human', 'ID'],
+        ['leave', 'Argument', null, 'QueryRoot', 'Human', 'ID'],
+        ['enter', 'SelectionSet', null, 'Human', 'Human', null],
+        ['enter', 'Field', null, 'Human', 'String', null],
+        ['enter', 'Name', 'name', 'Human', 'String', null],
+        ['leave', 'Name', 'name', 'Human', 'String', null],
+        ['leave', 'Field', null, 'Human', 'String', null],
+        ['enter', 'Field', null, 'Human', '[Pet]', null],
+        ['enter', 'Name', 'pets', 'Human', '[Pet]', null],
+        ['leave', 'Name', 'pets', 'Human', '[Pet]', null],
+        ['enter', 'SelectionSet', null, 'Pet', '[Pet]', null],
+        ['enter', 'Field', null, 'Pet', 'String', null],
+        ['enter', 'Name', 'name', 'Pet', 'String', null],
+        ['leave', 'Name', 'name', 'Pet', 'String', null],
+        ['leave', 'Field', null, 'Pet', 'String', null],
+        ['leave', 'SelectionSet', null, 'Pet', '[Pet]', null],
+        ['leave', 'Field', null, 'Human', '[Pet]', null],
+        ['enter', 'Field', null, 'Human', null, null],
+        ['enter', 'Name', 'unknown', 'Human', null, null],
+        ['leave', 'Name', 'unknown', 'Human', null, null],
+        ['leave', 'Field', null, 'Human', null, null],
+        ['leave', 'SelectionSet', null, 'Human', 'Human', null],
+        ['leave', 'Field', null, 'QueryRoot', 'Human', null],
+        ['leave', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null],
+        ['leave', 'OperationDefinition', null, null, 'QueryRoot', null],
+        ['leave', 'Document', null, null, null, null],
       ]);
     });
 
@@ -1138,116 +1152,119 @@ describe('Visitor', () => {
       const visited = [];
       const typeInfo = new TypeInfo(testSchema);
 
-      const ast = parse(
-        '{ human(id: 4) { name, pets }, alien }'
+      const ast = parse('{ human(id: 4) { name, pets }, alien }');
+      const editedAst = visit(
+        ast,
+        visitWithTypeInfo(typeInfo, {
+          enter(node) {
+            const parentType = typeInfo.getParentType();
+            const type = typeInfo.getType();
+            const inputType = typeInfo.getInputType();
+            visited.push([
+              'enter',
+              node.kind,
+              node.kind === 'Name' ? node.value : null,
+              parentType ? String(parentType) : null,
+              type ? String(type) : null,
+              inputType ? String(inputType) : null,
+            ]);
+
+            // Make a query valid by adding missing selection sets.
+            if (
+              node.kind === 'Field' &&
+              !node.selectionSet &&
+              isCompositeType(getNamedType(type))
+            ) {
+              return {
+                kind: 'Field',
+                alias: node.alias,
+                name: node.name,
+                arguments: node.arguments,
+                directives: node.directives,
+                selectionSet: {
+                  kind: 'SelectionSet',
+                  selections: [
+                    {
+                      kind: 'Field',
+                      name: { kind: 'Name', value: '__typename' },
+                    },
+                  ],
+                },
+              };
+            }
+          },
+          leave(node) {
+            const parentType = typeInfo.getParentType();
+            const type = typeInfo.getType();
+            const inputType = typeInfo.getInputType();
+            visited.push([
+              'leave',
+              node.kind,
+              node.kind === 'Name' ? node.value : null,
+              parentType ? String(parentType) : null,
+              type ? String(type) : null,
+              inputType ? String(inputType) : null,
+            ]);
+          },
+        }),
       );
-      const editedAst = visit(ast, visitWithTypeInfo(typeInfo, {
-        enter(node) {
-          const parentType = typeInfo.getParentType();
-          const type = typeInfo.getType();
-          const inputType = typeInfo.getInputType();
-          visited.push([
-            'enter',
-            node.kind,
-            node.kind === 'Name' ? node.value : null,
-            parentType ? String(parentType) : null,
-            type ? String(type) : null,
-            inputType ? String(inputType) : null
-          ]);
 
-          // Make a query valid by adding missing selection sets.
-          if (
-            node.kind === 'Field' &&
-            !node.selectionSet &&
-            isCompositeType(getNamedType(type))
-          ) {
-            return {
-              kind: 'Field',
-              alias: node.alias,
-              name: node.name,
-              arguments: node.arguments,
-              directives: node.directives,
-              selectionSet: {
-                kind: 'SelectionSet',
-                selections: [
-                  {
-                    kind: 'Field',
-                    name: { kind: 'Name', value: '__typename' }
-                  }
-                ]
-              }
-            };
-          }
-        },
-        leave(node) {
-          const parentType = typeInfo.getParentType();
-          const type = typeInfo.getType();
-          const inputType = typeInfo.getInputType();
-          visited.push([
-            'leave',
-            node.kind,
-            node.kind === 'Name' ? node.value : null,
-            parentType ? String(parentType) : null,
-            type ? String(type) : null,
-            inputType ? String(inputType) : null
-          ]);
-        }
-      }));
+      expect(print(ast)).to.deep.equal(
+        print(parse('{ human(id: 4) { name, pets }, alien }')),
+      );
 
-      expect(print(ast)).to.deep.equal(print(parse(
-        '{ human(id: 4) { name, pets }, alien }'
-      )));
-
-      expect(print(editedAst)).to.deep.equal(print(parse(
-        '{ human(id: 4) { name, pets { __typename } }, alien { __typename } }'
-      )));
+      expect(print(editedAst)).to.deep.equal(
+        print(
+          parse(
+            '{ human(id: 4) { name, pets { __typename } }, alien { __typename } }',
+          ),
+        ),
+      );
 
       expect(visited).to.deep.equal([
-        [ 'enter', 'Document', null, null, null, null ],
-        [ 'enter', 'OperationDefinition', null, null, 'QueryRoot', null ],
-        [ 'enter', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null ],
-        [ 'enter', 'Field', null, 'QueryRoot', 'Human', null ],
-        [ 'enter', 'Name', 'human', 'QueryRoot', 'Human', null ],
-        [ 'leave', 'Name', 'human', 'QueryRoot', 'Human', null ],
-        [ 'enter', 'Argument', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'enter', 'Name', 'id', 'QueryRoot', 'Human', 'ID' ],
-        [ 'leave', 'Name', 'id', 'QueryRoot', 'Human', 'ID' ],
-        [ 'enter', 'IntValue', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'leave', 'IntValue', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'leave', 'Argument', null, 'QueryRoot', 'Human', 'ID' ],
-        [ 'enter', 'SelectionSet', null, 'Human', 'Human', null ],
-        [ 'enter', 'Field', null, 'Human', 'String', null ],
-        [ 'enter', 'Name', 'name', 'Human', 'String', null ],
-        [ 'leave', 'Name', 'name', 'Human', 'String', null ],
-        [ 'leave', 'Field', null, 'Human', 'String', null ],
-        [ 'enter', 'Field', null, 'Human', '[Pet]', null ],
-        [ 'enter', 'Name', 'pets', 'Human', '[Pet]', null ],
-        [ 'leave', 'Name', 'pets', 'Human', '[Pet]', null ],
-        [ 'enter', 'SelectionSet', null, 'Pet', '[Pet]', null ],
-        [ 'enter', 'Field', null, 'Pet', 'String!', null ],
-        [ 'enter', 'Name', '__typename', 'Pet', 'String!', null ],
-        [ 'leave', 'Name', '__typename', 'Pet', 'String!', null ],
-        [ 'leave', 'Field', null, 'Pet', 'String!', null ],
-        [ 'leave', 'SelectionSet', null, 'Pet', '[Pet]', null ],
-        [ 'leave', 'Field', null, 'Human', '[Pet]', null ],
-        [ 'leave', 'SelectionSet', null, 'Human', 'Human', null ],
-        [ 'leave', 'Field', null, 'QueryRoot', 'Human', null ],
-        [ 'enter', 'Field', null, 'QueryRoot', 'Alien', null ],
-        [ 'enter', 'Name', 'alien', 'QueryRoot', 'Alien', null ],
-        [ 'leave', 'Name', 'alien', 'QueryRoot', 'Alien', null ],
-        [ 'enter', 'SelectionSet', null, 'Alien', 'Alien', null ],
-        [ 'enter', 'Field', null, 'Alien', 'String!', null ],
-        [ 'enter', 'Name', '__typename', 'Alien', 'String!', null ],
-        [ 'leave', 'Name', '__typename', 'Alien', 'String!', null ],
-        [ 'leave', 'Field', null, 'Alien', 'String!', null ],
-        [ 'leave', 'SelectionSet', null, 'Alien', 'Alien', null ],
-        [ 'leave', 'Field', null, 'QueryRoot', 'Alien', null ],
-        [ 'leave', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null ],
-        [ 'leave', 'OperationDefinition', null, null, 'QueryRoot', null ],
-        [ 'leave', 'Document', null, null, null, null ]
+        ['enter', 'Document', null, null, null, null],
+        ['enter', 'OperationDefinition', null, null, 'QueryRoot', null],
+        ['enter', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null],
+        ['enter', 'Field', null, 'QueryRoot', 'Human', null],
+        ['enter', 'Name', 'human', 'QueryRoot', 'Human', null],
+        ['leave', 'Name', 'human', 'QueryRoot', 'Human', null],
+        ['enter', 'Argument', null, 'QueryRoot', 'Human', 'ID'],
+        ['enter', 'Name', 'id', 'QueryRoot', 'Human', 'ID'],
+        ['leave', 'Name', 'id', 'QueryRoot', 'Human', 'ID'],
+        ['enter', 'IntValue', null, 'QueryRoot', 'Human', 'ID'],
+        ['leave', 'IntValue', null, 'QueryRoot', 'Human', 'ID'],
+        ['leave', 'Argument', null, 'QueryRoot', 'Human', 'ID'],
+        ['enter', 'SelectionSet', null, 'Human', 'Human', null],
+        ['enter', 'Field', null, 'Human', 'String', null],
+        ['enter', 'Name', 'name', 'Human', 'String', null],
+        ['leave', 'Name', 'name', 'Human', 'String', null],
+        ['leave', 'Field', null, 'Human', 'String', null],
+        ['enter', 'Field', null, 'Human', '[Pet]', null],
+        ['enter', 'Name', 'pets', 'Human', '[Pet]', null],
+        ['leave', 'Name', 'pets', 'Human', '[Pet]', null],
+        ['enter', 'SelectionSet', null, 'Pet', '[Pet]', null],
+        ['enter', 'Field', null, 'Pet', 'String!', null],
+        ['enter', 'Name', '__typename', 'Pet', 'String!', null],
+        ['leave', 'Name', '__typename', 'Pet', 'String!', null],
+        ['leave', 'Field', null, 'Pet', 'String!', null],
+        ['leave', 'SelectionSet', null, 'Pet', '[Pet]', null],
+        ['leave', 'Field', null, 'Human', '[Pet]', null],
+        ['leave', 'SelectionSet', null, 'Human', 'Human', null],
+        ['leave', 'Field', null, 'QueryRoot', 'Human', null],
+        ['enter', 'Field', null, 'QueryRoot', 'Alien', null],
+        ['enter', 'Name', 'alien', 'QueryRoot', 'Alien', null],
+        ['leave', 'Name', 'alien', 'QueryRoot', 'Alien', null],
+        ['enter', 'SelectionSet', null, 'Alien', 'Alien', null],
+        ['enter', 'Field', null, 'Alien', 'String!', null],
+        ['enter', 'Name', '__typename', 'Alien', 'String!', null],
+        ['leave', 'Name', '__typename', 'Alien', 'String!', null],
+        ['leave', 'Field', null, 'Alien', 'String!', null],
+        ['leave', 'SelectionSet', null, 'Alien', 'Alien', null],
+        ['leave', 'Field', null, 'QueryRoot', 'Alien', null],
+        ['leave', 'SelectionSet', null, 'QueryRoot', 'QueryRoot', null],
+        ['leave', 'OperationDefinition', null, null, 'QueryRoot', null],
+        ['leave', 'Document', null, null, null, null],
       ]);
     });
-
   });
-
 });

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -9,37 +9,35 @@
 
 import type { Source } from './source';
 
-
 /**
  * Contains a range of UTF-8 character offsets and token references that
  * identify the region of the source from which the AST derived.
  */
 export type Location = {
-
   /**
    * The character offset at which this Node begins.
    */
-  start: number;
+  start: number,
 
   /**
    * The character offset at which this Node ends.
    */
-  end: number;
+  end: number,
 
   /**
    * The Token at which this Node begins.
    */
-  startToken: Token;
+  startToken: Token,
 
   /**
    * The Token at which this Node ends.
    */
-  endToken: Token;
+  endToken: Token,
 
   /**
    * The Source document the AST represents.
    */
-  source: Source;
+  source: Source,
 };
 
 /**
@@ -47,70 +45,70 @@ export type Location = {
  * This type is not inlined in `Token` to fix syntax highlighting on GitHub
  * *only*.
  */
-type TokenKind = '<SOF>'
-               | '<EOF>'
-               | '!'
-               | '$'
-               | '('
-               | ')'
-               | '...'
-               | ':'
-               | '='
-               | '@'
-               | '['
-               | ']'
-               | '{'
-               | '|'
-               | '}'
-               | 'Name'
-               | 'Int'
-               | 'Float'
-               | 'String'
-               | 'Comment';
+type TokenKind =
+  | '<SOF>'
+  | '<EOF>'
+  | '!'
+  | '$'
+  | '('
+  | ')'
+  | '...'
+  | ':'
+  | '='
+  | '@'
+  | '['
+  | ']'
+  | '{'
+  | '|'
+  | '}'
+  | 'Name'
+  | 'Int'
+  | 'Float'
+  | 'String'
+  | 'Comment';
 
 /**
  * Represents a range of characters represented by a lexical token
  * within a Source.
  */
 export type Token = {
-
   /**
    * The kind of Token.
    */
-  kind: TokenKind;
+  kind: TokenKind,
 
   /**
    * The character offset at which this Node begins.
    */
-  start: number;
+  start: number,
 
   /**
    * The character offset at which this Node ends.
    */
-  end: number;
+  end: number,
 
   /**
    * The 1-indexed line number on which this Token appears.
    */
-  line: number;
+  line: number,
 
   /**
    * The 1-indexed column number at which this Token begins.
    */
-  column: number;
+  column: number,
 
   /**
    * For non-punctuation tokens, represents the interpreted value of the token.
    */
-  value: string | void;
+  value: string | void,
 
   /**
    * Tokens exist as nodes in a double-linked-list amongst all tokens
    * including ignored tokens. <SOF> is always the first node and <EOF>
    * the last.
    */
-  prev: Token | null;
-  next: Token | null;
+  prev: Token | null,
+  next: Token | null,
 };
 
 /**
@@ -158,17 +156,17 @@ export type ASTNode =
 // Name
 
 export type NameNode = {
-  kind: 'Name';
-  loc?: Location;
-  value: string;
+  kind: 'Name',
+  loc?: Location,
+  value: string,
 };
 
 // Document
 
 export type DocumentNode = {
-  kind: 'Document';
-  loc?: Location;
-  definitions: Array<DefinitionNode>;
+  kind: 'Document',
+  loc?: Location,
+  definitions: Array<DefinitionNode>,
 };
 
 export type DefinitionNode =
@@ -177,87 +175,82 @@ export type DefinitionNode =
   | TypeSystemDefinitionNode; // experimental non-spec addition.
 
 export type OperationDefinitionNode = {
-  kind: 'OperationDefinition';
-  loc?: Location;
-  operation: OperationTypeNode;
-  name?: ?NameNode;
-  variableDefinitions?: ?Array<VariableDefinitionNode>;
-  directives?: ?Array<DirectiveNode>;
-  selectionSet: SelectionSetNode;
+  kind: 'OperationDefinition',
+  loc?: Location,
+  operation: OperationTypeNode,
+  name?: ?NameNode,
+  variableDefinitions?: ?Array<VariableDefinitionNode>,
+  directives?: ?Array<DirectiveNode>,
+  selectionSet: SelectionSetNode,
 };
 
 // Note: subscription is an experimental non-spec addition.
 export type OperationTypeNode = 'query' | 'mutation' | 'subscription';
 
 export type VariableDefinitionNode = {
-  kind: 'VariableDefinition';
-  loc?: Location;
-  variable: VariableNode;
-  type: TypeNode;
-  defaultValue?: ?ValueNode;
+  kind: 'VariableDefinition',
+  loc?: Location,
+  variable: VariableNode,
+  type: TypeNode,
+  defaultValue?: ?ValueNode,
 };
 
 export type VariableNode = {
-  kind: 'Variable';
-  loc?: Location;
-  name: NameNode;
+  kind: 'Variable',
+  loc?: Location,
+  name: NameNode,
 };
 
 export type SelectionSetNode = {
-  kind: 'SelectionSet';
-  loc?: Location;
-  selections: Array<SelectionNode>;
+  kind: 'SelectionSet',
+  loc?: Location,
+  selections: Array<SelectionNode>,
 };
 
-export type SelectionNode =
-  | FieldNode
-  | FragmentSpreadNode
-  | InlineFragmentNode;
+export type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
 
 export type FieldNode = {
-  kind: 'Field';
-  loc?: Location;
-  alias?: ?NameNode;
-  name: NameNode;
-  arguments?: ?Array<ArgumentNode>;
-  directives?: ?Array<DirectiveNode>;
-  selectionSet?: ?SelectionSetNode;
+  kind: 'Field',
+  loc?: Location,
+  alias?: ?NameNode,
+  name: NameNode,
+  arguments?: ?Array<ArgumentNode>,
+  directives?: ?Array<DirectiveNode>,
+  selectionSet?: ?SelectionSetNode,
 };
 
 export type ArgumentNode = {
-  kind: 'Argument';
-  loc?: Location;
-  name: NameNode;
-  value: ValueNode;
+  kind: 'Argument',
+  loc?: Location,
+  name: NameNode,
+  value: ValueNode,
 };
-
 
 // Fragments
 
 export type FragmentSpreadNode = {
-  kind: 'FragmentSpread';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
+  kind: 'FragmentSpread',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
 };
 
 export type InlineFragmentNode = {
-  kind: 'InlineFragment';
-  loc?: Location;
-  typeCondition?: ?NamedTypeNode;
-  directives?: ?Array<DirectiveNode>;
-  selectionSet: SelectionSetNode;
+  kind: 'InlineFragment',
+  loc?: Location,
+  typeCondition?: ?NamedTypeNode,
+  directives?: ?Array<DirectiveNode>,
+  selectionSet: SelectionSetNode,
 };
 
 export type FragmentDefinitionNode = {
-  kind: 'FragmentDefinition';
-  loc?: Location;
-  name: NameNode;
-  typeCondition: NamedTypeNode;
-  directives?: ?Array<DirectiveNode>;
-  selectionSet: SelectionSetNode;
+  kind: 'FragmentDefinition',
+  loc?: Location,
+  name: NameNode,
+  typeCondition: NamedTypeNode,
+  directives?: ?Array<DirectiveNode>,
+  selectionSet: SelectionSetNode,
 };
-
 
 // Values
 
@@ -273,93 +266,88 @@ export type ValueNode =
   | ObjectValueNode;
 
 export type IntValueNode = {
-  kind: 'IntValue';
-  loc?: Location;
-  value: string;
+  kind: 'IntValue',
+  loc?: Location,
+  value: string,
 };
 
 export type FloatValueNode = {
-  kind: 'FloatValue';
-  loc?: Location;
-  value: string;
+  kind: 'FloatValue',
+  loc?: Location,
+  value: string,
 };
 
 export type StringValueNode = {
-  kind: 'StringValue';
-  loc?: Location;
-  value: string;
+  kind: 'StringValue',
+  loc?: Location,
+  value: string,
 };
 
 export type BooleanValueNode = {
-  kind: 'BooleanValue';
-  loc?: Location;
-  value: boolean;
+  kind: 'BooleanValue',
+  loc?: Location,
+  value: boolean,
 };
 
 export type NullValueNode = {
-  kind: 'NullValue';
-  loc?: Location;
+  kind: 'NullValue',
+  loc?: Location,
 };
 
 export type EnumValueNode = {
-  kind: 'EnumValue';
-  loc?: Location;
-  value: string;
+  kind: 'EnumValue',
+  loc?: Location,
+  value: string,
 };
 
 export type ListValueNode = {
-  kind: 'ListValue';
-  loc?: Location;
-  values: Array<ValueNode>;
+  kind: 'ListValue',
+  loc?: Location,
+  values: Array<ValueNode>,
 };
 
 export type ObjectValueNode = {
-  kind: 'ObjectValue';
-  loc?: Location;
-  fields: Array<ObjectFieldNode>;
+  kind: 'ObjectValue',
+  loc?: Location,
+  fields: Array<ObjectFieldNode>,
 };
 
 export type ObjectFieldNode = {
-  kind: 'ObjectField';
-  loc?: Location;
-  name: NameNode;
-  value: ValueNode;
+  kind: 'ObjectField',
+  loc?: Location,
+  name: NameNode,
+  value: ValueNode,
 };
-
 
 // Directives
 
 export type DirectiveNode = {
-  kind: 'Directive';
-  loc?: Location;
-  name: NameNode;
-  arguments?: ?Array<ArgumentNode>;
+  kind: 'Directive',
+  loc?: Location,
+  name: NameNode,
+  arguments?: ?Array<ArgumentNode>,
 };
-
 
 // Type Reference
 
-export type TypeNode =
-  | NamedTypeNode
-  | ListTypeNode
-  | NonNullTypeNode;
+export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
 
 export type NamedTypeNode = {
-  kind: 'NamedType';
-  loc?: Location;
-  name: NameNode;
+  kind: 'NamedType',
+  loc?: Location,
+  name: NameNode,
 };
 
 export type ListTypeNode = {
-  kind: 'ListType';
-  loc?: Location;
-  type: TypeNode;
+  kind: 'ListType',
+  loc?: Location,
+  type: TypeNode,
 };
 
 export type NonNullTypeNode = {
-  kind: 'NonNullType';
-  loc?: Location;
-  type: NamedTypeNode | ListTypeNode;
+  kind: 'NonNullType',
+  loc?: Location,
+  type: NamedTypeNode | ListTypeNode,
 };
 
 // Type System Definition
@@ -371,17 +359,17 @@ export type TypeSystemDefinitionNode =
   | DirectiveDefinitionNode;
 
 export type SchemaDefinitionNode = {
-  kind: 'SchemaDefinition';
-  loc?: Location;
-  directives: Array<DirectiveNode>;
-  operationTypes: Array<OperationTypeDefinitionNode>;
+  kind: 'SchemaDefinition',
+  loc?: Location,
+  directives: Array<DirectiveNode>,
+  operationTypes: Array<OperationTypeDefinitionNode>,
 };
 
 export type OperationTypeDefinitionNode = {
-  kind: 'OperationTypeDefinition';
-  loc?: Location;
-  operation: OperationTypeNode;
-  type: NamedTypeNode;
+  kind: 'OperationTypeDefinition',
+  loc?: Location,
+  operation: OperationTypeNode,
+  type: NamedTypeNode,
 };
 
 export type TypeDefinitionNode =
@@ -393,88 +381,88 @@ export type TypeDefinitionNode =
   | InputObjectTypeDefinitionNode;
 
 export type ScalarTypeDefinitionNode = {
-  kind: 'ScalarTypeDefinition';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
+  kind: 'ScalarTypeDefinition',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
 };
 
 export type ObjectTypeDefinitionNode = {
-  kind: 'ObjectTypeDefinition';
-  loc?: Location;
-  name: NameNode;
-  interfaces?: ?Array<NamedTypeNode>;
-  directives?: ?Array<DirectiveNode>;
-  fields: Array<FieldDefinitionNode>;
+  kind: 'ObjectTypeDefinition',
+  loc?: Location,
+  name: NameNode,
+  interfaces?: ?Array<NamedTypeNode>,
+  directives?: ?Array<DirectiveNode>,
+  fields: Array<FieldDefinitionNode>,
 };
 
 export type FieldDefinitionNode = {
-  kind: 'FieldDefinition';
-  loc?: Location;
-  name: NameNode;
-  arguments: Array<InputValueDefinitionNode>;
-  type: TypeNode;
-  directives?: ?Array<DirectiveNode>;
+  kind: 'FieldDefinition',
+  loc?: Location,
+  name: NameNode,
+  arguments: Array<InputValueDefinitionNode>,
+  type: TypeNode,
+  directives?: ?Array<DirectiveNode>,
 };
 
 export type InputValueDefinitionNode = {
-  kind: 'InputValueDefinition';
-  loc?: Location;
-  name: NameNode;
-  type: TypeNode;
-  defaultValue?: ?ValueNode;
-  directives?: ?Array<DirectiveNode>;
+  kind: 'InputValueDefinition',
+  loc?: Location,
+  name: NameNode,
+  type: TypeNode,
+  defaultValue?: ?ValueNode,
+  directives?: ?Array<DirectiveNode>,
 };
 
 export type InterfaceTypeDefinitionNode = {
-  kind: 'InterfaceTypeDefinition';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
-  fields: Array<FieldDefinitionNode>;
+  kind: 'InterfaceTypeDefinition',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
+  fields: Array<FieldDefinitionNode>,
 };
 
 export type UnionTypeDefinitionNode = {
-  kind: 'UnionTypeDefinition';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
-  types: Array<NamedTypeNode>;
+  kind: 'UnionTypeDefinition',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
+  types: Array<NamedTypeNode>,
 };
 
 export type EnumTypeDefinitionNode = {
-  kind: 'EnumTypeDefinition';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
-  values: Array<EnumValueDefinitionNode>;
+  kind: 'EnumTypeDefinition',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
+  values: Array<EnumValueDefinitionNode>,
 };
 
 export type EnumValueDefinitionNode = {
-  kind: 'EnumValueDefinition';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
+  kind: 'EnumValueDefinition',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
 };
 
 export type InputObjectTypeDefinitionNode = {
-  kind: 'InputObjectTypeDefinition';
-  loc?: Location;
-  name: NameNode;
-  directives?: ?Array<DirectiveNode>;
-  fields: Array<InputValueDefinitionNode>;
+  kind: 'InputObjectTypeDefinition',
+  loc?: Location,
+  name: NameNode,
+  directives?: ?Array<DirectiveNode>,
+  fields: Array<InputValueDefinitionNode>,
 };
 
 export type TypeExtensionDefinitionNode = {
-  kind: 'TypeExtensionDefinition';
-  loc?: Location;
-  definition: ObjectTypeDefinitionNode;
+  kind: 'TypeExtensionDefinition',
+  loc?: Location,
+  definition: ObjectTypeDefinitionNode,
 };
 
 export type DirectiveDefinitionNode = {
-  kind: 'DirectiveDefinition';
-  loc?: Location;
-  name: NameNode;
-  arguments?: ?Array<InputValueDefinitionNode>;
-  locations: Array<NameNode>;
+  kind: 'DirectiveDefinition',
+  loc?: Location,
+  name: NameNode,
+  arguments?: ?Array<InputValueDefinitionNode>,
+  locations: Array<NameNode>,
 };

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -29,7 +29,6 @@ export type {
   Location,
   Token,
   ASTNode,
-
   // Each kind of AST node
   NameNode,
   DocumentNode,

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -21,7 +21,7 @@ import { syntaxError } from '../error';
  */
 export function createLexer<TOptions>(
   source: Source,
-  options: TOptions
+  options: TOptions,
 ): Lexer<TOptions> {
   const startOfFileToken = new Tok(SOF, 0, 0, 0, 0, null);
   const lexer: Lexer<TOptions> = {
@@ -31,13 +31,13 @@ export function createLexer<TOptions>(
     token: startOfFileToken,
     line: 1,
     lineStart: 0,
-    advance: advanceLexer
+    advance: advanceLexer,
   };
   return lexer;
 }
 
 function advanceLexer() {
-  let token = this.lastToken = this.token;
+  let token = (this.lastToken = this.token);
   if (token.kind !== EOF) {
     do {
       token = token.next = readToken(this, token);
@@ -51,33 +51,33 @@ function advanceLexer() {
  * The return type of createLexer.
  */
 export type Lexer<TOptions> = {
-  source: Source;
-  options: TOptions;
+  source: Source,
+  options: TOptions,
 
   /**
    * The previously focused non-ignored token.
    */
-  lastToken: Token;
+  lastToken: Token,
 
   /**
    * The currently focused non-ignored token.
    */
-  token: Token;
+  token: Token,
 
   /**
    * The (1-indexed) line containing the current token.
    */
-  line: number;
+  line: number,
 
   /**
    * The character offset at which the current line begins.
    */
-  lineStart: number;
+  lineStart: number,
 
   /**
    * Advances the token stream to the next non-ignored token.
    */
-  advance(): Token;
+  advance(): Token,
 };
 
 // Each kind of token.
@@ -126,7 +126,7 @@ export const TokenKind = {
   INT,
   FLOAT,
   STRING,
-  COMMENT
+  COMMENT,
 };
 
 /**
@@ -150,7 +150,7 @@ function Tok(
   line: number,
   column: number,
   prev: Token | null,
-  value?: string
+  value?: string,
 ) {
   this.kind = kind;
   this.start = start;
@@ -168,18 +168,20 @@ Tok.prototype.toJSON = Tok.prototype.inspect = function toJSON() {
     kind: this.kind,
     value: this.value,
     line: this.line,
-    column: this.column
+    column: this.column,
   };
 };
 
 function printCharCode(code) {
   return (
     // NaN/undefined represents access beyond the end of the file.
-    isNaN(code) ? EOF :
-    // Trust JSON for ASCII.
-    code < 0x007F ? JSON.stringify(String.fromCharCode(code)) :
-    // Otherwise print the escaped form.
-    `"\\u${('00' + code.toString(16).toUpperCase()).slice(-4)}"`
+    isNaN(code)
+      ? EOF
+      : // Trust JSON for ASCII.
+        code < 0x007f
+        ? JSON.stringify(String.fromCharCode(code))
+        : // Otherwise print the escaped form.
+          `"\\u${('00' + code.toString(16).toUpperCase()).slice(-4)}"`
   );
 }
 
@@ -206,38 +208,48 @@ function readToken(lexer: Lexer<*>, prev: Token): Token {
   const code = charCodeAt.call(body, position);
 
   // SourceCharacter
-  if (code < 0x0020 && code !== 0x0009 && code !== 0x000A && code !== 0x000D) {
+  if (code < 0x0020 && code !== 0x0009 && code !== 0x000a && code !== 0x000d) {
     throw syntaxError(
       source,
       position,
-      `Cannot contain the invalid character ${printCharCode(code)}.`
+      `Cannot contain the invalid character ${printCharCode(code)}.`,
     );
   }
 
   switch (code) {
     // !
-    case 33: return new Tok(BANG, position, position + 1, line, col, prev);
+    case 33:
+      return new Tok(BANG, position, position + 1, line, col, prev);
     // #
-    case 35: return readComment(source, position, line, col, prev);
+    case 35:
+      return readComment(source, position, line, col, prev);
     // $
-    case 36: return new Tok(DOLLAR, position, position + 1, line, col, prev);
+    case 36:
+      return new Tok(DOLLAR, position, position + 1, line, col, prev);
     // (
-    case 40: return new Tok(PAREN_L, position, position + 1, line, col, prev);
+    case 40:
+      return new Tok(PAREN_L, position, position + 1, line, col, prev);
     // )
-    case 41: return new Tok(PAREN_R, position, position + 1, line, col, prev);
+    case 41:
+      return new Tok(PAREN_R, position, position + 1, line, col, prev);
     // .
     case 46:
-      if (charCodeAt.call(body, position + 1) === 46 &&
-          charCodeAt.call(body, position + 2) === 46) {
+      if (
+        charCodeAt.call(body, position + 1) === 46 &&
+        charCodeAt.call(body, position + 2) === 46
+      ) {
         return new Tok(SPREAD, position, position + 3, line, col, prev);
       }
       break;
     // :
-    case 58: return new Tok(COLON, position, position + 1, line, col, prev);
+    case 58:
+      return new Tok(COLON, position, position + 1, line, col, prev);
     // =
-    case 61: return new Tok(EQUALS, position, position + 1, line, col, prev);
+    case 61:
+      return new Tok(EQUALS, position, position + 1, line, col, prev);
     // @
-    case 64: return new Tok(AT, position, position + 1, line, col, prev);
+    case 64:
+      return new Tok(AT, position, position + 1, line, col, prev);
     // [
     case 91:
       return new Tok(BRACKET_L, position, position + 1, line, col, prev);
@@ -248,44 +260,97 @@ function readToken(lexer: Lexer<*>, prev: Token): Token {
     case 123:
       return new Tok(BRACE_L, position, position + 1, line, col, prev);
     // |
-    case 124: return new Tok(PIPE, position, position + 1, line, col, prev);
+    case 124:
+      return new Tok(PIPE, position, position + 1, line, col, prev);
     // }
     case 125:
       return new Tok(BRACE_R, position, position + 1, line, col, prev);
     // A-Z _ a-z
-    case 65: case 66: case 67: case 68: case 69: case 70: case 71: case 72:
-    case 73: case 74: case 75: case 76: case 77: case 78: case 79: case 80:
-    case 81: case 82: case 83: case 84: case 85: case 86: case 87: case 88:
-    case 89: case 90:
+    case 65:
+    case 66:
+    case 67:
+    case 68:
+    case 69:
+    case 70:
+    case 71:
+    case 72:
+    case 73:
+    case 74:
+    case 75:
+    case 76:
+    case 77:
+    case 78:
+    case 79:
+    case 80:
+    case 81:
+    case 82:
+    case 83:
+    case 84:
+    case 85:
+    case 86:
+    case 87:
+    case 88:
+    case 89:
+    case 90:
     case 95:
-    case 97: case 98: case 99: case 100: case 101: case 102: case 103: case 104:
-    case 105: case 106: case 107: case 108: case 109: case 110: case 111:
-    case 112: case 113: case 114: case 115: case 116: case 117: case 118:
-    case 119: case 120: case 121: case 122:
+    case 97:
+    case 98:
+    case 99:
+    case 100:
+    case 101:
+    case 102:
+    case 103:
+    case 104:
+    case 105:
+    case 106:
+    case 107:
+    case 108:
+    case 109:
+    case 110:
+    case 111:
+    case 112:
+    case 113:
+    case 114:
+    case 115:
+    case 116:
+    case 117:
+    case 118:
+    case 119:
+    case 120:
+    case 121:
+    case 122:
       return readName(source, position, line, col, prev);
     // - 0-9
     case 45:
-    case 48: case 49: case 50: case 51: case 52:
-    case 53: case 54: case 55: case 56: case 57:
+    case 48:
+    case 49:
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
       return readNumber(source, position, code, line, col, prev);
     // "
-    case 34: return readString(source, position, line, col, prev);
+    case 34:
+      return readString(source, position, line, col, prev);
   }
 
-  throw syntaxError(
-    source,
-    position,
-    unexpectedCharacterMessage(code)
-  );
+  throw syntaxError(source, position, unexpectedCharacterMessage(code));
 }
 
 /**
  * Report a message that an unexpected character was encountered.
  */
 function unexpectedCharacterMessage(code) {
-  if (code === 39) { // '
-    return 'Unexpected single quote character (\'), did you mean to use ' +
-      'a double quote (")?';
+  if (code === 39) {
+    // '
+    return (
+      "Unexpected single quote character ('), did you mean to use " +
+      'a double quote (")?'
+    );
   }
 
   return 'Cannot parse the unexpected character ' + printCharCode(code) + '.';
@@ -299,20 +364,22 @@ function unexpectedCharacterMessage(code) {
 function positionAfterWhitespace(
   body: string,
   startPosition: number,
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): number {
   const bodyLength = body.length;
   let position = startPosition;
   while (position < bodyLength) {
     const code = charCodeAt.call(body, position);
     // tab | space | comma | BOM
-    if (code === 9 || code === 32 || code === 44 || code === 0xFEFF) {
+    if (code === 9 || code === 32 || code === 44 || code === 0xfeff) {
       ++position;
-    } else if (code === 10) { // new line
+    } else if (code === 10) {
+      // new line
       ++position;
       ++lexer.line;
       lexer.lineStart = position;
-    } else if (code === 13) { // carriage return
+    } else if (code === 13) {
+      // carriage return
       if (charCodeAt.call(body, position + 1) === 10) {
         position += 2;
       } else {
@@ -342,7 +409,7 @@ function readComment(source, start, line, col, prev): Token {
   } while (
     code !== null &&
     // SourceCharacter but not LineTerminator
-    (code > 0x001F || code === 0x0009)
+    (code > 0x001f || code === 0x0009)
   );
 
   return new Tok(
@@ -352,7 +419,7 @@ function readComment(source, start, line, col, prev): Token {
     line,
     col,
     prev,
-    slice.call(body, start + 1, position)
+    slice.call(body, start + 1, position),
   );
 }
 
@@ -369,17 +436,19 @@ function readNumber(source, start, firstCode, line, col, prev): Token {
   let position = start;
   let isFloat = false;
 
-  if (code === 45) { // -
+  if (code === 45) {
+    // -
     code = charCodeAt.call(body, ++position);
   }
 
-  if (code === 48) { // 0
+  if (code === 48) {
+    // 0
     code = charCodeAt.call(body, ++position);
     if (code >= 48 && code <= 57) {
       throw syntaxError(
         source,
         position,
-        `Invalid number, unexpected digit after 0: ${printCharCode(code)}.`
+        `Invalid number, unexpected digit after 0: ${printCharCode(code)}.`,
       );
     }
   } else {
@@ -387,7 +456,8 @@ function readNumber(source, start, firstCode, line, col, prev): Token {
     code = charCodeAt.call(body, position);
   }
 
-  if (code === 46) { // .
+  if (code === 46) {
+    // .
     isFloat = true;
 
     code = charCodeAt.call(body, ++position);
@@ -395,11 +465,13 @@ function readNumber(source, start, firstCode, line, col, prev): Token {
     code = charCodeAt.call(body, position);
   }
 
-  if (code === 69 || code === 101) { // E e
+  if (code === 69 || code === 101) {
+    // E e
     isFloat = true;
 
     code = charCodeAt.call(body, ++position);
-    if (code === 43 || code === 45) { // + -
+    if (code === 43 || code === 45) {
+      // + -
       code = charCodeAt.call(body, ++position);
     }
     position = readDigits(source, position, code);
@@ -412,7 +484,7 @@ function readNumber(source, start, firstCode, line, col, prev): Token {
     line,
     col,
     prev,
-    slice.call(body, start, position)
+    slice.call(body, start, position),
   );
 }
 
@@ -423,7 +495,8 @@ function readDigits(source, start, firstCode) {
   const body = source.body;
   let position = start;
   let code = firstCode;
-  if (code >= 48 && code <= 57) { // 0 - 9
+  if (code >= 48 && code <= 57) {
+    // 0 - 9
     do {
       code = charCodeAt.call(body, ++position);
     } while (code >= 48 && code <= 57); // 0 - 9
@@ -432,7 +505,7 @@ function readDigits(source, start, firstCode) {
   throw syntaxError(
     source,
     position,
-    `Invalid number, expected digit but got: ${printCharCode(code)}.`
+    `Invalid number, expected digit but got: ${printCharCode(code)}.`,
   );
 }
 
@@ -452,7 +525,8 @@ function readString(source, start, line, col, prev): Token {
     position < body.length &&
     (code = charCodeAt.call(body, position)) !== null &&
     // not LineTerminator
-    code !== 0x000A && code !== 0x000D &&
+    code !== 0x000a &&
+    code !== 0x000d &&
     // not Quote (")
     code !== 34
   ) {
@@ -461,36 +535,53 @@ function readString(source, start, line, col, prev): Token {
       throw syntaxError(
         source,
         position,
-        `Invalid character within String: ${printCharCode(code)}.`
+        `Invalid character within String: ${printCharCode(code)}.`,
       );
     }
 
     ++position;
-    if (code === 92) { // \
+    if (code === 92) {
+      // \
       value += slice.call(body, chunkStart, position - 1);
       code = charCodeAt.call(body, position);
       switch (code) {
-        case 34: value += '"'; break;
-        case 47: value += '/'; break;
-        case 92: value += '\\'; break;
-        case 98: value += '\b'; break;
-        case 102: value += '\f'; break;
-        case 110: value += '\n'; break;
-        case 114: value += '\r'; break;
-        case 116: value += '\t'; break;
+        case 34:
+          value += '"';
+          break;
+        case 47:
+          value += '/';
+          break;
+        case 92:
+          value += '\\';
+          break;
+        case 98:
+          value += '\b';
+          break;
+        case 102:
+          value += '\f';
+          break;
+        case 110:
+          value += '\n';
+          break;
+        case 114:
+          value += '\r';
+          break;
+        case 116:
+          value += '\t';
+          break;
         case 117: // u
           const charCode = uniCharCode(
             charCodeAt.call(body, position + 1),
             charCodeAt.call(body, position + 2),
             charCodeAt.call(body, position + 3),
-            charCodeAt.call(body, position + 4)
+            charCodeAt.call(body, position + 4),
           );
           if (charCode < 0) {
             throw syntaxError(
               source,
               position,
               'Invalid character escape sequence: ' +
-              `\\u${body.slice(position + 1, position + 5)}.`
+                `\\u${body.slice(position + 1, position + 5)}.`,
             );
           }
           value += String.fromCharCode(charCode);
@@ -500,7 +591,9 @@ function readString(source, start, line, col, prev): Token {
           throw syntaxError(
             source,
             position,
-            `Invalid character escape sequence: \\${String.fromCharCode(code)}.`
+            `Invalid character escape sequence: \\${String.fromCharCode(
+              code,
+            )}.`,
           );
       }
       ++position;
@@ -508,7 +601,8 @@ function readString(source, start, line, col, prev): Token {
     }
   }
 
-  if (code !== 34) { // quote (")
+  if (code !== 34) {
+    // quote (")
     throw syntaxError(source, position, 'Unterminated string.');
   }
 
@@ -527,7 +621,9 @@ function readString(source, start, line, col, prev): Token {
  * which means the result of ORing the char2hex() will also be negative.
  */
 function uniCharCode(a, b, c, d) {
-  return char2hex(a) << 12 | char2hex(b) << 8 | char2hex(c) << 4 | char2hex(d);
+  return (
+    (char2hex(a) << 12) | (char2hex(b) << 8) | (char2hex(c) << 4) | char2hex(d)
+  );
 }
 
 /**
@@ -539,12 +635,13 @@ function uniCharCode(a, b, c, d) {
  * Returns -1 on error.
  */
 function char2hex(a) {
-  return (
-    a >= 48 && a <= 57 ? a - 48 : // 0-9
-    a >= 65 && a <= 70 ? a - 55 : // A-F
-    a >= 97 && a <= 102 ? a - 87 : // a-f
-    -1
-  );
+  return a >= 48 && a <= 57
+    ? a - 48 // 0-9
+    : a >= 65 && a <= 70
+      ? a - 55 // A-F
+      : a >= 97 && a <= 102
+        ? a - 87 // a-f
+        : -1;
 }
 
 /**
@@ -560,12 +657,10 @@ function readName(source, position, line, col, prev): Token {
   while (
     end !== bodyLength &&
     (code = charCodeAt.call(body, end)) !== null &&
-    (
-      code === 95 || // _
-      code >= 48 && code <= 57 || // 0-9
-      code >= 65 && code <= 90 || // A-Z
-      code >= 97 && code <= 122 // a-z
-    )
+    (code === 95 || // _
+    (code >= 48 && code <= 57) || // 0-9
+    (code >= 65 && code <= 90) || // A-Z
+      (code >= 97 && code <= 122)) // a-z
   ) {
     ++end;
   }
@@ -576,6 +671,6 @@ function readName(source, position, line, col, prev): Token {
     line,
     col,
     prev,
-    slice.call(body, position, end)
+    slice.call(body, position, end),
   );
 }

--- a/src/language/location.js
+++ b/src/language/location.js
@@ -13,8 +13,8 @@ import type { Source } from './source';
  * Represents a location in a Source.
  */
 export type SourceLocation = {
-  line: number;
-  column: number;
+  line: number,
+  column: number,
 };
 
 /**

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -10,19 +10,13 @@
 import { Source } from './source';
 import { syntaxError } from '../error';
 import type { GraphQLError } from '../error';
-import {
-  createLexer,
-  TokenKind,
-  getTokenDesc
-} from './lexer';
+import { createLexer, TokenKind, getTokenDesc } from './lexer';
 import type { Lexer } from './lexer';
 import type {
   Location,
   Token,
-
   NameNode,
   VariableNode,
-
   DocumentNode,
   DefinitionNode,
   OperationDefinitionNode,
@@ -32,28 +26,21 @@ import type {
   SelectionNode,
   FieldNode,
   ArgumentNode,
-
   FragmentSpreadNode,
   InlineFragmentNode,
   FragmentDefinitionNode,
-
   ValueNode,
   ListValueNode,
   ObjectValueNode,
   ObjectFieldNode,
-
   DirectiveNode,
-
   TypeNode,
   NamedTypeNode,
   ListTypeNode,
   NonNullTypeNode,
-
   TypeSystemDefinitionNode,
-
   SchemaDefinitionNode,
   OperationTypeDefinitionNode,
-
   ScalarTypeDefinitionNode,
   ObjectTypeDefinitionNode,
   FieldDefinitionNode,
@@ -63,27 +50,22 @@ import type {
   EnumTypeDefinitionNode,
   EnumValueDefinitionNode,
   InputObjectTypeDefinitionNode,
-
   TypeExtensionDefinitionNode,
-
   DirectiveDefinitionNode,
 } from './ast';
 
 import {
   NAME,
   VARIABLE,
-
   DOCUMENT,
   OPERATION_DEFINITION,
   VARIABLE_DEFINITION,
   SELECTION_SET,
   FIELD,
   ARGUMENT,
-
   FRAGMENT_SPREAD,
   INLINE_FRAGMENT,
   FRAGMENT_DEFINITION,
-
   INT,
   FLOAT,
   STRING,
@@ -93,16 +75,12 @@ import {
   LIST,
   OBJECT,
   OBJECT_FIELD,
-
   DIRECTIVE,
-
   NAMED_TYPE,
   LIST_TYPE,
   NON_NULL_TYPE,
-
   SCHEMA_DEFINITION,
   OPERATION_TYPE_DEFINITION,
-
   SCALAR_TYPE_DEFINITION,
   OBJECT_TYPE_DEFINITION,
   FIELD_DEFINITION,
@@ -112,12 +90,9 @@ import {
   ENUM_TYPE_DEFINITION,
   ENUM_VALUE_DEFINITION,
   INPUT_OBJECT_TYPE_DEFINITION,
-
   TYPE_EXTENSION_DEFINITION,
-
   DIRECTIVE_DEFINITION,
 } from './kinds';
-
 
 /**
  * Configuration options to control parser behavior
@@ -128,7 +103,7 @@ export type ParseOptions = {
    * in the source that they correspond to. This configuration flag
    * disables that behavior for performance or testing.
    */
-  noLocation?: boolean
+  noLocation?: boolean,
 };
 
 /**
@@ -137,7 +112,7 @@ export type ParseOptions = {
  */
 export function parse(
   source: string | Source,
-  options?: ParseOptions
+  options?: ParseOptions,
 ): DocumentNode {
   const sourceObj = typeof source === 'string' ? new Source(source) : source;
   if (!(sourceObj instanceof Source)) {
@@ -159,7 +134,7 @@ export function parse(
  */
 export function parseValue(
   source: string | Source,
-  options?: ParseOptions
+  options?: ParseOptions,
 ): ValueNode {
   const sourceObj = typeof source === 'string' ? new Source(source) : source;
   const lexer = createLexer(sourceObj, options || {});
@@ -181,7 +156,7 @@ export function parseValue(
  */
 export function parseType(
   source: string | Source,
-  options?: ParseOptions
+  options?: ParseOptions,
 ): TypeNode {
   const sourceObj = typeof source === 'string' ? new Source(source) : source;
   const lexer = createLexer(sourceObj, options || {});
@@ -199,7 +174,7 @@ function parseName(lexer: Lexer<*>): NameNode {
   return {
     kind: NAME,
     value: ((token.value: any): string),
-    loc: loc(lexer, token)
+    loc: loc(lexer, token),
   };
 }
 
@@ -219,7 +194,7 @@ function parseDocument(lexer: Lexer<*>): DocumentNode {
   return {
     kind: DOCUMENT,
     definitions,
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -242,7 +217,8 @@ function parseDefinition(lexer: Lexer<*>): DefinitionNode {
       case 'subscription':
         return parseOperationDefinition(lexer);
 
-      case 'fragment': return parseFragmentDefinition(lexer);
+      case 'fragment':
+        return parseFragmentDefinition(lexer);
 
       // Note: the Type System IDL is an experimental non-spec addition.
       case 'schema':
@@ -253,13 +229,13 @@ function parseDefinition(lexer: Lexer<*>): DefinitionNode {
       case 'enum':
       case 'input':
       case 'extend':
-      case 'directive': return parseTypeSystemDefinition(lexer);
+      case 'directive':
+        return parseTypeSystemDefinition(lexer);
     }
   }
 
   throw unexpected(lexer);
 }
-
 
 // Implements the parsing rules in the Operations section.
 
@@ -278,7 +254,7 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
       variableDefinitions: null,
       directives: [],
       selectionSet: parseSelectionSet(lexer),
-      loc: loc(lexer, start)
+      loc: loc(lexer, start),
     };
   }
   const operation = parseOperationType(lexer);
@@ -293,7 +269,7 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
     variableDefinitions: parseVariableDefinitions(lexer),
     directives: parseDirectives(lexer),
     selectionSet: parseSelectionSet(lexer),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -303,10 +279,13 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
 function parseOperationType(lexer: Lexer<*>): OperationTypeNode {
   const operationToken = expect(lexer, TokenKind.NAME);
   switch (operationToken.value) {
-    case 'query': return 'query';
-    case 'mutation': return 'mutation';
+    case 'query':
+      return 'query';
+    case 'mutation':
+      return 'mutation';
     // Note: subscription is an experimental non-spec addition.
-    case 'subscription': return 'subscription';
+    case 'subscription':
+      return 'subscription';
   }
 
   throw unexpected(lexer, operationToken);
@@ -316,16 +295,11 @@ function parseOperationType(lexer: Lexer<*>): OperationTypeNode {
  * VariableDefinitions : ( VariableDefinition+ )
  */
 function parseVariableDefinitions(
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): Array<VariableDefinitionNode> {
-  return peek(lexer, TokenKind.PAREN_L) ?
-    many(
-      lexer,
-      TokenKind.PAREN_L,
-      parseVariableDefinition,
-      TokenKind.PAREN_R
-    ) :
-    [];
+  return peek(lexer, TokenKind.PAREN_L)
+    ? many(lexer, TokenKind.PAREN_L, parseVariableDefinition, TokenKind.PAREN_R)
+    : [];
 }
 
 /**
@@ -337,9 +311,10 @@ function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
     kind: VARIABLE_DEFINITION,
     variable: parseVariable(lexer),
     type: (expect(lexer, TokenKind.COLON), parseTypeReference(lexer)),
-    defaultValue:
-      skip(lexer, TokenKind.EQUALS) ? parseValueLiteral(lexer, true) : null,
-    loc: loc(lexer, start)
+    defaultValue: skip(lexer, TokenKind.EQUALS)
+      ? parseValueLiteral(lexer, true)
+      : null,
+    loc: loc(lexer, start),
   };
 }
 
@@ -352,7 +327,7 @@ function parseVariable(lexer: Lexer<*>): VariableNode {
   return {
     kind: VARIABLE,
     name: parseName(lexer),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -363,9 +338,13 @@ function parseSelectionSet(lexer: Lexer<*>): SelectionSetNode {
   const start = lexer.token;
   return {
     kind: SELECTION_SET,
-    selections:
-      many(lexer, TokenKind.BRACE_L, parseSelection, TokenKind.BRACE_R),
-    loc: loc(lexer, start)
+    selections: many(
+      lexer,
+      TokenKind.BRACE_L,
+      parseSelection,
+      TokenKind.BRACE_R,
+    ),
+    loc: loc(lexer, start),
   };
 }
 
@@ -376,9 +355,9 @@ function parseSelectionSet(lexer: Lexer<*>): SelectionSetNode {
  *   - InlineFragment
  */
 function parseSelection(lexer: Lexer<*>): SelectionNode {
-  return peek(lexer, TokenKind.SPREAD) ?
-    parseFragment(lexer) :
-    parseField(lexer);
+  return peek(lexer, TokenKind.SPREAD)
+    ? parseFragment(lexer)
+    : parseField(lexer);
 }
 
 /**
@@ -406,9 +385,10 @@ function parseField(lexer: Lexer<*>): FieldNode {
     name,
     arguments: parseArguments(lexer),
     directives: parseDirectives(lexer),
-    selectionSet:
-      peek(lexer, TokenKind.BRACE_L) ? parseSelectionSet(lexer) : null,
-    loc: loc(lexer, start)
+    selectionSet: peek(lexer, TokenKind.BRACE_L)
+      ? parseSelectionSet(lexer)
+      : null,
+    loc: loc(lexer, start),
   };
 }
 
@@ -416,9 +396,9 @@ function parseField(lexer: Lexer<*>): FieldNode {
  * Arguments : ( Argument+ )
  */
 function parseArguments(lexer: Lexer<*>): Array<ArgumentNode> {
-  return peek(lexer, TokenKind.PAREN_L) ?
-    many(lexer, TokenKind.PAREN_L, parseArgument, TokenKind.PAREN_R) :
-    [];
+  return peek(lexer, TokenKind.PAREN_L)
+    ? many(lexer, TokenKind.PAREN_L, parseArgument, TokenKind.PAREN_R)
+    : [];
 }
 
 /**
@@ -430,10 +410,9 @@ function parseArgument(lexer: Lexer<*>): ArgumentNode {
     kind: ARGUMENT,
     name: parseName(lexer),
     value: (expect(lexer, TokenKind.COLON), parseValueLiteral(lexer, false)),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
-
 
 // Implements the parsing rules in the Fragments section.
 
@@ -445,7 +424,7 @@ function parseArgument(lexer: Lexer<*>): ArgumentNode {
  * InlineFragment : ... TypeCondition? Directives? SelectionSet
  */
 function parseFragment(
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): FragmentSpreadNode | InlineFragmentNode {
   const start = lexer.token;
   expect(lexer, TokenKind.SPREAD);
@@ -454,7 +433,7 @@ function parseFragment(
       kind: FRAGMENT_SPREAD,
       name: parseFragmentName(lexer),
       directives: parseDirectives(lexer),
-      loc: loc(lexer, start)
+      loc: loc(lexer, start),
     };
   }
   let typeCondition = null;
@@ -467,7 +446,7 @@ function parseFragment(
     typeCondition,
     directives: parseDirectives(lexer),
     selectionSet: parseSelectionSet(lexer),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -486,7 +465,7 @@ function parseFragmentDefinition(lexer: Lexer<*>): FragmentDefinitionNode {
     typeCondition: (expectKeyword(lexer, 'on'), parseNamedType(lexer)),
     directives: parseDirectives(lexer),
     selectionSet: parseSelectionSet(lexer),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -499,7 +478,6 @@ function parseFragmentName(lexer: Lexer<*>): NameNode {
   }
   return parseName(lexer);
 }
-
 
 // Implements the parsing rules in the Values section.
 
@@ -533,21 +511,21 @@ function parseValueLiteral(lexer: Lexer<*>, isConst: boolean): ValueNode {
       return {
         kind: (INT: 'IntValue'),
         value: ((token.value: any): string),
-        loc: loc(lexer, token)
+        loc: loc(lexer, token),
       };
     case TokenKind.FLOAT:
       lexer.advance();
       return {
         kind: (FLOAT: 'FloatValue'),
         value: ((token.value: any): string),
-        loc: loc(lexer, token)
+        loc: loc(lexer, token),
       };
     case TokenKind.STRING:
       lexer.advance();
       return {
         kind: (STRING: 'StringValue'),
         value: ((token.value: any): string),
-        loc: loc(lexer, token)
+        loc: loc(lexer, token),
       };
     case TokenKind.NAME:
       if (token.value === 'true' || token.value === 'false') {
@@ -555,20 +533,20 @@ function parseValueLiteral(lexer: Lexer<*>, isConst: boolean): ValueNode {
         return {
           kind: (BOOLEAN: 'BooleanValue'),
           value: token.value === 'true',
-          loc: loc(lexer, token)
+          loc: loc(lexer, token),
         };
       } else if (token.value === 'null') {
         lexer.advance();
         return {
           kind: (NULL: 'NullValue'),
-          loc: loc(lexer, token)
+          loc: loc(lexer, token),
         };
       }
       lexer.advance();
       return {
         kind: (ENUM: 'EnumValue'),
         value: ((token.value: any): string),
-        loc: loc(lexer, token)
+        loc: loc(lexer, token),
       };
     case TokenKind.DOLLAR:
       if (!isConst) {
@@ -598,7 +576,7 @@ function parseList(lexer: Lexer<*>, isConst: boolean): ListValueNode {
   return {
     kind: LIST,
     values: any(lexer, TokenKind.BRACKET_L, item, TokenKind.BRACKET_R),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -617,7 +595,7 @@ function parseObject(lexer: Lexer<*>, isConst: boolean): ObjectValueNode {
   return {
     kind: OBJECT,
     fields,
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -629,12 +607,10 @@ function parseObjectField(lexer: Lexer<*>, isConst: boolean): ObjectFieldNode {
   return {
     kind: OBJECT_FIELD,
     name: parseName(lexer),
-    value:
-      (expect(lexer, TokenKind.COLON), parseValueLiteral(lexer, isConst)),
-    loc: loc(lexer, start)
+    value: (expect(lexer, TokenKind.COLON), parseValueLiteral(lexer, isConst)),
+    loc: loc(lexer, start),
   };
 }
-
 
 // Implements the parsing rules in the Directives section.
 
@@ -659,10 +635,9 @@ function parseDirective(lexer: Lexer<*>): DirectiveNode {
     kind: DIRECTIVE,
     name: parseName(lexer),
     arguments: parseArguments(lexer),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
-
 
 // Implements the parsing rules in the Types section.
 
@@ -681,7 +656,7 @@ export function parseTypeReference(lexer: Lexer<*>): TypeNode {
     type = ({
       kind: LIST_TYPE,
       type,
-      loc: loc(lexer, start)
+      loc: loc(lexer, start),
     }: ListTypeNode);
   } else {
     type = parseNamedType(lexer);
@@ -690,7 +665,7 @@ export function parseTypeReference(lexer: Lexer<*>): TypeNode {
     return ({
       kind: NON_NULL_TYPE,
       type,
-      loc: loc(lexer, start)
+      loc: loc(lexer, start),
     }: NonNullTypeNode);
   }
   return type;
@@ -704,10 +679,9 @@ export function parseNamedType(lexer: Lexer<*>): NamedTypeNode {
   return {
     kind: NAMED_TYPE,
     name: parseName(lexer),
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
-
 
 // Implements the parsing rules in the Type Definition section.
 
@@ -729,15 +703,24 @@ export function parseNamedType(lexer: Lexer<*>): NamedTypeNode {
 function parseTypeSystemDefinition(lexer: Lexer<*>): TypeSystemDefinitionNode {
   if (peek(lexer, TokenKind.NAME)) {
     switch (lexer.token.value) {
-      case 'schema': return parseSchemaDefinition(lexer);
-      case 'scalar': return parseScalarTypeDefinition(lexer);
-      case 'type': return parseObjectTypeDefinition(lexer);
-      case 'interface': return parseInterfaceTypeDefinition(lexer);
-      case 'union': return parseUnionTypeDefinition(lexer);
-      case 'enum': return parseEnumTypeDefinition(lexer);
-      case 'input': return parseInputObjectTypeDefinition(lexer);
-      case 'extend': return parseTypeExtensionDefinition(lexer);
-      case 'directive': return parseDirectiveDefinition(lexer);
+      case 'schema':
+        return parseSchemaDefinition(lexer);
+      case 'scalar':
+        return parseScalarTypeDefinition(lexer);
+      case 'type':
+        return parseObjectTypeDefinition(lexer);
+      case 'interface':
+        return parseInterfaceTypeDefinition(lexer);
+      case 'union':
+        return parseUnionTypeDefinition(lexer);
+      case 'enum':
+        return parseEnumTypeDefinition(lexer);
+      case 'input':
+        return parseInputObjectTypeDefinition(lexer);
+      case 'extend':
+        return parseTypeExtensionDefinition(lexer);
+      case 'directive':
+        return parseDirectiveDefinition(lexer);
     }
   }
 
@@ -757,7 +740,7 @@ function parseSchemaDefinition(lexer: Lexer<*>): SchemaDefinitionNode {
     lexer,
     TokenKind.BRACE_L,
     parseOperationTypeDefinition,
-    TokenKind.BRACE_R
+    TokenKind.BRACE_R,
   );
   return {
     kind: SCHEMA_DEFINITION,
@@ -768,7 +751,7 @@ function parseSchemaDefinition(lexer: Lexer<*>): SchemaDefinitionNode {
 }
 
 function parseOperationTypeDefinition(
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): OperationTypeDefinitionNode {
   const start = lexer.token;
   const operation = parseOperationType(lexer);
@@ -812,7 +795,7 @@ function parseObjectTypeDefinition(lexer: Lexer<*>): ObjectTypeDefinitionNode {
     lexer,
     TokenKind.BRACE_L,
     parseFieldDefinition,
-    TokenKind.BRACE_R
+    TokenKind.BRACE_R,
   );
   return {
     kind: OBJECT_TYPE_DEFINITION,
@@ -895,7 +878,7 @@ function parseInputValueDef(lexer: Lexer<*>): InputValueDefinitionNode {
  * InterfaceTypeDefinition : interface Name Directives? { FieldDefinition+ }
  */
 function parseInterfaceTypeDefinition(
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): InterfaceTypeDefinitionNode {
   const start = lexer.token;
   expectKeyword(lexer, 'interface');
@@ -905,7 +888,7 @@ function parseInterfaceTypeDefinition(
     lexer,
     TokenKind.BRACE_L,
     parseFieldDefinition,
-    TokenKind.BRACE_R
+    TokenKind.BRACE_R,
   );
   return {
     kind: INTERFACE_TYPE_DEFINITION,
@@ -962,7 +945,7 @@ function parseEnumTypeDefinition(lexer: Lexer<*>): EnumTypeDefinitionNode {
     lexer,
     TokenKind.BRACE_L,
     parseEnumValueDefinition,
-    TokenKind.BRACE_R
+    TokenKind.BRACE_R,
   );
   return {
     kind: ENUM_TYPE_DEFINITION,
@@ -994,7 +977,7 @@ function parseEnumValueDefinition(lexer: Lexer<*>): EnumValueDefinitionNode {
  * InputObjectTypeDefinition : input Name Directives? { InputValueDefinition+ }
  */
 function parseInputObjectTypeDefinition(
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): InputObjectTypeDefinitionNode {
   const start = lexer.token;
   expectKeyword(lexer, 'input');
@@ -1004,7 +987,7 @@ function parseInputObjectTypeDefinition(
     lexer,
     TokenKind.BRACE_L,
     parseInputValueDef,
-    TokenKind.BRACE_R
+    TokenKind.BRACE_R,
   );
   return {
     kind: INPUT_OBJECT_TYPE_DEFINITION,
@@ -1019,7 +1002,7 @@ function parseInputObjectTypeDefinition(
  * TypeExtensionDefinition : extend ObjectTypeDefinition
  */
 function parseTypeExtensionDefinition(
-  lexer: Lexer<*>
+  lexer: Lexer<*>,
 ): TypeExtensionDefinitionNode {
   const start = lexer.token;
   expectKeyword(lexer, 'extend');
@@ -1048,7 +1031,7 @@ function parseDirectiveDefinition(lexer: Lexer<*>): DirectiveDefinitionNode {
     name,
     arguments: args,
     locations,
-    loc: loc(lexer, start)
+    loc: loc(lexer, start),
   };
 }
 
@@ -1124,7 +1107,7 @@ function expect(lexer: Lexer<*>, kind: string): Token {
   throw syntaxError(
     lexer.source,
     token.start,
-    `Expected ${kind}, found ${getTokenDesc(token)}`
+    `Expected ${kind}, found ${getTokenDesc(token)}`,
   );
 }
 
@@ -1142,7 +1125,7 @@ function expectKeyword(lexer: Lexer<*>, value: string): Token {
   throw syntaxError(
     lexer.source,
     token.start,
-    `Expected "${value}", found ${getTokenDesc(token)}`
+    `Expected "${value}", found ${getTokenDesc(token)}`,
   );
 }
 
@@ -1155,7 +1138,7 @@ function unexpected(lexer: Lexer<*>, atToken?: ?Token): GraphQLError {
   return syntaxError(
     lexer.source,
     token.start,
-    `Unexpected ${getTokenDesc(token)}`
+    `Unexpected ${getTokenDesc(token)}`,
   );
 }
 
@@ -1169,7 +1152,7 @@ function any<T>(
   lexer: Lexer<*>,
   openKind: string,
   parseFn: (lexer: Lexer<*>) => T,
-  closeKind: string
+  closeKind: string,
 ): Array<T> {
   expect(lexer, openKind);
   const nodes = [];
@@ -1189,10 +1172,10 @@ function many<T>(
   lexer: Lexer<*>,
   openKind: string,
   parseFn: (lexer: Lexer<*>) => T,
-  closeKind: string
+  closeKind: string,
 ): Array<T> {
   expect(lexer, openKind);
-  const nodes = [ parseFn(lexer) ];
+  const nodes = [parseFn(lexer)];
   while (!skip(lexer, closeKind)) {
     nodes.push(parseFn(lexer));
   }

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -31,9 +31,9 @@ const printDocASTReducer = {
     const selectionSet = node.selectionSet;
     // Anonymous queries with no directives or variable definitions can use
     // the query short form.
-    return !name && !directives && !varDefs && op === 'query' ?
-      selectionSet :
-      join([ op, join([ name, varDefs ]), directives, selectionSet ], ' ');
+    return !name && !directives && !varDefs && op === 'query'
+      ? selectionSet
+      : join([op, join([name, varDefs]), directives, selectionSet], ' ');
   },
 
   VariableDefinition: ({ variable, type, defaultValue }) =>
@@ -42,11 +42,14 @@ const printDocASTReducer = {
   SelectionSet: ({ selections }) => block(selections),
 
   Field: ({ alias, name, arguments: args, directives, selectionSet }) =>
-    join([
-      wrap('', alias, ': ') + name + wrap('(', join(args, ', '), ')'),
-      join(directives, ' '),
-      selectionSet
-    ], ' '),
+    join(
+      [
+        wrap('', alias, ': ') + name + wrap('(', join(args, ', '), ')'),
+        join(directives, ' '),
+        selectionSet,
+      ],
+      ' ',
+    ),
 
   Argument: ({ name, value }) => name + ': ' + value,
 
@@ -56,12 +59,10 @@ const printDocASTReducer = {
     '...' + name + wrap(' ', join(directives, ' ')),
 
   InlineFragment: ({ typeCondition, directives, selectionSet }) =>
-    join([
-      '...',
-      wrap('on ', typeCondition),
-      join(directives, ' '),
-      selectionSet
-    ], ' '),
+    join(
+      ['...', wrap('on ', typeCondition), join(directives, ' '), selectionSet],
+      ' ',
+    ),
 
   FragmentDefinition: ({ name, typeCondition, directives, selectionSet }) =>
     `fragment ${name} on ${typeCondition} ` +
@@ -94,80 +95,64 @@ const printDocASTReducer = {
   // Type System Definitions
 
   SchemaDefinition: ({ directives, operationTypes }) =>
-    join([
-      'schema',
-      join(directives, ' '),
-      block(operationTypes),
-    ], ' '),
+    join(['schema', join(directives, ' '), block(operationTypes)], ' '),
 
-  OperationTypeDefinition: ({ operation, type }) =>
-    operation + ': ' + type,
+  OperationTypeDefinition: ({ operation, type }) => operation + ': ' + type,
 
   ScalarTypeDefinition: ({ name, directives }) =>
-    join([ 'scalar', name, join(directives, ' ') ], ' '),
+    join(['scalar', name, join(directives, ' ')], ' '),
 
   ObjectTypeDefinition: ({ name, interfaces, directives, fields }) =>
-    join([
-      'type',
-      name,
-      wrap('implements ', join(interfaces, ', ')),
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
+    join(
+      [
+        'type',
+        name,
+        wrap('implements ', join(interfaces, ', ')),
+        join(directives, ' '),
+        block(fields),
+      ],
+      ' ',
+    ),
 
   FieldDefinition: ({ name, arguments: args, type, directives }) =>
     name +
     wrap('(', join(args, ', '), ')') +
-    ': ' + type +
+    ': ' +
+    type +
     wrap(' ', join(directives, ' ')),
 
   InputValueDefinition: ({ name, type, defaultValue, directives }) =>
-    join([
-      name + ': ' + type,
-      wrap('= ', defaultValue),
-      join(directives, ' ')
-    ], ' '),
+    join(
+      [name + ': ' + type, wrap('= ', defaultValue), join(directives, ' ')],
+      ' ',
+    ),
 
   InterfaceTypeDefinition: ({ name, directives, fields }) =>
-    join([
-      'interface',
-      name,
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
+    join(['interface', name, join(directives, ' '), block(fields)], ' '),
 
   UnionTypeDefinition: ({ name, directives, types }) =>
-    join([
-      'union',
-      name,
-      join(directives, ' '),
-      '= ' + join(types, ' | ')
-    ], ' '),
+    join(
+      ['union', name, join(directives, ' '), '= ' + join(types, ' | ')],
+      ' ',
+    ),
 
   EnumTypeDefinition: ({ name, directives, values }) =>
-    join([
-      'enum',
-      name,
-      join(directives, ' '),
-      block(values)
-    ], ' '),
+    join(['enum', name, join(directives, ' '), block(values)], ' '),
 
   EnumValueDefinition: ({ name, directives }) =>
-    join([ name, join(directives, ' ') ], ' '),
+    join([name, join(directives, ' ')], ' '),
 
   InputObjectTypeDefinition: ({ name, directives, fields }) =>
-    join([
-      'input',
-      name,
-      join(directives, ' '),
-      block(fields)
-    ], ' '),
+    join(['input', name, join(directives, ' '), block(fields)], ' '),
 
   TypeExtensionDefinition: ({ definition }) => `extend ${definition}`,
 
   DirectiveDefinition: ({ name, arguments: args, locations }) =>
-    'directive @' + name + wrap('(', join(args, ', '), ')') +
-    ' on ' + join(locations, ' | '),
+    'directive @' +
+    name +
+    wrap('(', join(args, ', '), ')') +
+    ' on ' +
+    join(locations, ' | '),
 };
 
 /**
@@ -183,9 +168,9 @@ function join(maybeArray, separator) {
  * indented "{ }" block.
  */
 function block(array) {
-  return array && array.length !== 0 ?
-    indent('{\n' + join(array, '\n')) + '\n}' :
-    '{}';
+  return array && array.length !== 0
+    ? indent('{\n' + join(array, '\n')) + '\n}'
+    : '{}';
 }
 
 /**
@@ -193,9 +178,7 @@ function block(array) {
  * print an empty string.
  */
 function wrap(start, maybeString, end) {
-  return maybeString ?
-    start + maybeString + (end || '') :
-    '';
+  return maybeString ? start + maybeString + (end || '') : '';
 }
 
 function indent(maybeString) {

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -33,11 +33,11 @@ export class Source {
     this.locationOffset = locationOffset || { line: 1, column: 1 };
     invariant(
       this.locationOffset.line > 0,
-      'line in locationOffset is 1-indexed and must be positive'
+      'line in locationOffset is 1-indexed and must be positive',
     );
     invariant(
       this.locationOffset.column > 0,
-      'column in locationOffset is 1-indexed and must be positive'
+      'column in locationOffset is 1-indexed and must be positive',
     );
   }
 }

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -8,18 +8,22 @@
 export const QueryDocumentKeys = {
   Name: [],
 
-  Document: [ 'definitions' ],
-  OperationDefinition:
-    [ 'name', 'variableDefinitions', 'directives', 'selectionSet' ],
-  VariableDefinition: [ 'variable', 'type', 'defaultValue' ],
-  Variable: [ 'name' ],
-  SelectionSet: [ 'selections' ],
-  Field: [ 'alias', 'name', 'arguments', 'directives', 'selectionSet' ],
-  Argument: [ 'name', 'value' ],
+  Document: ['definitions'],
+  OperationDefinition: [
+    'name',
+    'variableDefinitions',
+    'directives',
+    'selectionSet',
+  ],
+  VariableDefinition: ['variable', 'type', 'defaultValue'],
+  Variable: ['name'],
+  SelectionSet: ['selections'],
+  Field: ['alias', 'name', 'arguments', 'directives', 'selectionSet'],
+  Argument: ['name', 'value'],
 
-  FragmentSpread: [ 'name', 'directives' ],
-  InlineFragment: [ 'typeCondition', 'directives', 'selectionSet' ],
-  FragmentDefinition: [ 'name', 'typeCondition', 'directives', 'selectionSet' ],
+  FragmentSpread: ['name', 'directives'],
+  InlineFragment: ['typeCondition', 'directives', 'selectionSet'],
+  FragmentDefinition: ['name', 'typeCondition', 'directives', 'selectionSet'],
 
   IntValue: [],
   FloatValue: [],
@@ -27,32 +31,32 @@ export const QueryDocumentKeys = {
   BooleanValue: [],
   NullValue: [],
   EnumValue: [],
-  ListValue: [ 'values' ],
-  ObjectValue: [ 'fields' ],
-  ObjectField: [ 'name', 'value' ],
+  ListValue: ['values'],
+  ObjectValue: ['fields'],
+  ObjectField: ['name', 'value'],
 
-  Directive: [ 'name', 'arguments' ],
+  Directive: ['name', 'arguments'],
 
-  NamedType: [ 'name' ],
-  ListType: [ 'type' ],
-  NonNullType: [ 'type' ],
+  NamedType: ['name'],
+  ListType: ['type'],
+  NonNullType: ['type'],
 
-  SchemaDefinition: [ 'directives', 'operationTypes' ],
-  OperationTypeDefinition: [ 'type' ],
+  SchemaDefinition: ['directives', 'operationTypes'],
+  OperationTypeDefinition: ['type'],
 
-  ScalarTypeDefinition: [ 'name', 'directives' ],
-  ObjectTypeDefinition: [ 'name', 'interfaces', 'directives', 'fields' ],
-  FieldDefinition: [ 'name', 'arguments', 'type', 'directives' ],
-  InputValueDefinition: [ 'name', 'type', 'defaultValue', 'directives' ],
-  InterfaceTypeDefinition: [ 'name', 'directives', 'fields' ],
-  UnionTypeDefinition: [ 'name', 'directives', 'types' ],
-  EnumTypeDefinition: [ 'name', 'directives', 'values' ],
-  EnumValueDefinition: [ 'name', 'directives' ],
-  InputObjectTypeDefinition: [ 'name', 'directives', 'fields' ],
+  ScalarTypeDefinition: ['name', 'directives'],
+  ObjectTypeDefinition: ['name', 'interfaces', 'directives', 'fields'],
+  FieldDefinition: ['name', 'arguments', 'type', 'directives'],
+  InputValueDefinition: ['name', 'type', 'defaultValue', 'directives'],
+  InterfaceTypeDefinition: ['name', 'directives', 'fields'],
+  UnionTypeDefinition: ['name', 'directives', 'types'],
+  EnumTypeDefinition: ['name', 'directives', 'values'],
+  EnumValueDefinition: ['name', 'directives'],
+  InputObjectTypeDefinition: ['name', 'directives', 'fields'],
 
-  TypeExtensionDefinition: [ 'definition' ],
+  TypeExtensionDefinition: ['definition'],
 
-  DirectiveDefinition: [ 'name', 'arguments', 'locations' ],
+  DirectiveDefinition: ['name', 'arguments', 'locations'],
 };
 
 export const BREAK = {};
@@ -148,7 +152,7 @@ export function visit(root, visitor, keyMap) {
 
   let stack;
   let inArray = Array.isArray(root);
-  let keys = [ root ];
+  let keys = [root];
   let index = -1;
   let edits = [];
   let parent;
@@ -199,7 +203,7 @@ export function visit(root, visitor, keyMap) {
       inArray = stack.inArray;
       stack = stack.prev;
     } else {
-      key = parent ? inArray ? index : keys[index] : undefined;
+      key = parent ? (inArray ? index : keys[index]) : undefined;
       node = parent ? parent[key] : newRoot;
       if (node === null || node === undefined) {
         continue;
@@ -228,7 +232,7 @@ export function visit(root, visitor, keyMap) {
             continue;
           }
         } else if (result !== undefined) {
-          edits.push([ key, result ]);
+          edits.push([key, result]);
           if (!isLeaving) {
             if (isNode(result)) {
               node = result;
@@ -242,7 +246,7 @@ export function visit(root, visitor, keyMap) {
     }
 
     if (result === undefined && isEdited) {
-      edits.push([ key, node ]);
+      edits.push([key, node]);
     }
 
     if (!isLeaving) {
@@ -268,7 +272,6 @@ export function visit(root, visitor, keyMap) {
 function isNode(maybeNode) {
   return maybeNode && typeof maybeNode.kind === 'string';
 }
-
 
 /**
  * Creates a new visitor instance which delegates to many visitors to run in
@@ -313,10 +316,9 @@ export function visitInParallel(visitors) {
           skipping[i] = null;
         }
       }
-    }
+    },
   };
 }
-
 
 /**
  * Creates a new visitor instance which maintains a provided TypeInfo instance
@@ -346,10 +348,9 @@ export function visitWithTypeInfo(typeInfo, visitor) {
       }
       typeInfo.leave(node);
       return result;
-    }
+    },
   };
 }
-
 
 /**
  * Given a visitor instance, if it is leaving or not, and a node kind, return
@@ -362,8 +363,9 @@ export function getVisitFn(visitor, kind, isLeaving) {
       // { Kind() {} }
       return kindVisitor;
     }
-    const kindSpecificVisitor =
-      isLeaving ? kindVisitor.leave : kindVisitor.enter;
+    const kindSpecificVisitor = isLeaving
+      ? kindVisitor.leave
+      : kindVisitor.enter;
     if (typeof kindSpecificVisitor === 'function') {
       // { Kind: { enter() {}, leave() {} } }
       return kindSpecificVisitor;

--- a/src/subscription/__tests__/asyncIteratorReject-test.js
+++ b/src/subscription/__tests__/asyncIteratorReject-test.js
@@ -11,7 +11,6 @@ import { describe, it } from 'mocha';
 import asyncIteratorReject from '../asyncIteratorReject';
 
 describe('asyncIteratorReject', () => {
-
   it('creates a failing async iterator', async () => {
     const error = new Error('Oh no, Mr. Bill!');
     const iter = asyncIteratorReject(error);

--- a/src/subscription/__tests__/eventEmitterAsyncIterator-test.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator-test.js
@@ -12,7 +12,6 @@ import EventEmitter from 'events';
 import eventEmitterAsyncIterator from './eventEmitterAsyncIterator';
 
 describe('eventEmitterAsyncIterator', () => {
-
   it('subscribe async-iterator mock', async () => {
     // Create an AsyncIterator from an EventEmitter
     const emitter = new EventEmitter();
@@ -23,12 +22,14 @@ describe('eventEmitterAsyncIterator', () => {
     expect(emitter.emit('publish', 'Banana')).to.equal(true);
 
     // Read payloads
-    expect(await iterator.next()).to.deep.equal(
-      { done: false, value: 'Apple' }
-    );
-    expect(await iterator.next()).to.deep.equal(
-      { done: false, value: 'Banana' }
-    );
+    expect(await iterator.next()).to.deep.equal({
+      done: false,
+      value: 'Apple',
+    });
+    expect(await iterator.next()).to.deep.equal({
+      done: false,
+      value: 'Banana',
+    });
 
     // Read ahead
     const i3 = iterator.next().then(x => x);
@@ -39,8 +40,8 @@ describe('eventEmitterAsyncIterator', () => {
     expect(emitter.emit('publish', 'Durian')).to.equal(true);
 
     // Await out of order to get correct results
-    expect(await i4).to.deep.equal({ done: false, value: 'Durian'});
-    expect(await i3).to.deep.equal({ done: false, value: 'Coconut'});
+    expect(await i4).to.deep.equal({ done: false, value: 'Durian' });
+    expect(await i3).to.deep.equal({ done: false, value: 'Coconut' });
 
     // Read ahead
     const i5 = iterator.next().then(x => x);
@@ -55,8 +56,9 @@ describe('eventEmitterAsyncIterator', () => {
     expect(await i5).to.deep.equal({ done: true, value: undefined });
 
     // And next returns empty completion value
-    expect(await iterator.next()).to.deep.equal(
-      { done: true, value: undefined }
-    );
+    expect(await iterator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
   });
 });

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -16,7 +16,7 @@ import { $$asyncIterator } from 'iterall';
  */
 export default function eventEmitterAsyncIterator(
   eventEmitter: EventEmitter,
-  eventName: string
+  eventName: string,
 ): AsyncIterator<mixed> {
   const pullQueue = [];
   const pushQueue = [];

--- a/src/subscription/__tests__/mapAsyncIterator-test.js
+++ b/src/subscription/__tests__/mapAsyncIterator-test.js
@@ -12,7 +12,6 @@ import { describe, it } from 'mocha';
 import mapAsyncIterator from '../mapAsyncIterator';
 
 describe('mapAsyncIterator', () => {
-
   it('maps over async values', async () => {
     async function* source() {
       yield 1;
@@ -22,18 +21,13 @@ describe('mapAsyncIterator', () => {
 
     const doubles = mapAsyncIterator(source(), x => x + x);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 2, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 4, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 6, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 6, done: false });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('maps over async values with async function', async () => {
@@ -44,21 +38,18 @@ describe('mapAsyncIterator', () => {
     }
 
     // Flow test: this is *not* AsyncIterator<Promise<number>>
-    const doubles: AsyncIterator<number> =
-      mapAsyncIterator(source(), async x => await x + x);
+    const doubles: AsyncIterator<number> = mapAsyncIterator(
+      source(),
+      async x => (await x) + x,
+    );
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 2, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 4, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 6, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 6, done: false });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('allows returning early from async values', async () => {
@@ -70,25 +61,24 @@ describe('mapAsyncIterator', () => {
 
     const doubles = mapAsyncIterator(source(), x => x + x);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 2, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
 
     // Early return
-    expect(
-      await doubles.return()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.return()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
 
     // Subsequent nexts
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('passes through early return from async values', async () => {
@@ -105,25 +95,24 @@ describe('mapAsyncIterator', () => {
 
     const doubles = mapAsyncIterator(source(), x => x + x);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 2, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
 
     // Early return
-    expect(
-      await doubles.return()
-    ).to.deep.equal({ value: 'donedone', done: false });
+    expect(await doubles.return()).to.deep.equal({
+      value: 'donedone',
+      done: false,
+    });
 
     // Subsequent nexts may yield from finally block
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 'lastlast', done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({
+      value: 'lastlast',
+      done: false,
+    });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('allows throwing errors through async generators', async () => {
@@ -135,12 +124,8 @@ describe('mapAsyncIterator', () => {
 
     const doubles = mapAsyncIterator(source(), x => x + x);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 2, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
 
     // Throw error
     let caughtError;
@@ -151,12 +136,14 @@ describe('mapAsyncIterator', () => {
     }
     expect(caughtError).to.equal('ouch');
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('passes through caught errors through async generators', async () => {
@@ -172,24 +159,23 @@ describe('mapAsyncIterator', () => {
 
     const doubles = mapAsyncIterator(source(), x => x + x);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 2, done: false });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
 
     // Throw error
-    expect(
-      await doubles.throw('ouch')
-    ).to.deep.equal({ value: 'ouchouch', done: false });
+    expect(await doubles.throw('ouch')).to.deep.equal({
+      value: 'ouchouch',
+      done: false,
+    });
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('does not normally map over thrown errors', async () => {
@@ -200,9 +186,10 @@ describe('mapAsyncIterator', () => {
 
     const doubles = mapAsyncIterator(source(), x => x + x);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 'HelloHello', done: false });
+    expect(await doubles.next()).to.deep.equal({
+      value: 'HelloHello',
+      done: false,
+    });
 
     let caughtError;
     try {
@@ -219,24 +206,22 @@ describe('mapAsyncIterator', () => {
       throw new Error('Goodbye');
     }
 
-    const doubles = mapAsyncIterator(
-      source(),
-      x => x + x,
-      error => error
-    );
+    const doubles = mapAsyncIterator(source(), x => x + x, error => error);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: 'HelloHello', done: false });
+    expect(await doubles.next()).to.deep.equal({
+      value: 'HelloHello',
+      done: false,
+    });
 
     const result = await doubles.next();
     expect(result.value).to.be.instanceof(Error);
     expect(result.value && result.value.message).to.equal('Goodbye');
     expect(result.done).to.equal(false);
 
-    expect(
-      await doubles.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   });
 
   async function testClosesSourceWithMapper(mapper) {
@@ -255,9 +240,7 @@ describe('mapAsyncIterator', () => {
 
     const throwOver1 = mapAsyncIterator(source(), mapper);
 
-    expect(
-      await throwOver1.next()
-    ).to.deep.equal({ value: 1, done: false });
+    expect(await throwOver1.next()).to.deep.equal({ value: 1, done: false });
 
     let expectedError;
     try {
@@ -271,9 +254,10 @@ describe('mapAsyncIterator', () => {
       expect(expectedError.message).to.equal('Cannot count to 2');
     }
 
-    expect(
-      await throwOver1.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await throwOver1.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
 
     expect(didVisitFinally).to.equal(true);
   }
@@ -304,9 +288,7 @@ describe('mapAsyncIterator', () => {
 
     const throwOver1 = mapAsyncIterator(source(), x => x, mapper);
 
-    expect(
-      await throwOver1.next()
-    ).to.deep.equal({ value: 1, done: false });
+    expect(await throwOver1.next()).to.deep.equal({ value: 1, done: false });
 
     let expectedError;
     try {
@@ -320,9 +302,10 @@ describe('mapAsyncIterator', () => {
       expect(expectedError.message).to.equal('Cannot count to 2');
     }
 
-    expect(
-      await throwOver1.next()
-    ).to.deep.equal({ value: undefined, done: true });
+    expect(await throwOver1.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
   }
 
   it('closes source if mapper throws an error', async () => {
@@ -336,5 +319,4 @@ describe('mapAsyncIterator', () => {
       throw new Error('Cannot count to ' + error.message);
     });
   });
-
 });

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -27,7 +27,7 @@ const EmailType = new GraphQLObjectType({
     subject: { type: GraphQLString },
     message: { type: GraphQLString },
     unread: { type: GraphQLBoolean },
-  }
+  },
 });
 
 const InboxType = new GraphQLObjectType({
@@ -42,14 +42,14 @@ const InboxType = new GraphQLObjectType({
       resolve: inbox => inbox.emails.filter(email => email.unread).length,
     },
     emails: { type: new GraphQLList(EmailType) },
-  }
+  },
 });
 
 const QueryType = new GraphQLObjectType({
   name: 'Query',
   fields: {
     inbox: { type: InboxType },
-  }
+  },
 });
 
 const EmailEventType = new GraphQLObjectType({
@@ -57,7 +57,7 @@ const EmailEventType = new GraphQLObjectType({
   fields: {
     email: { type: EmailType },
     inbox: { type: InboxType },
-  }
+  },
 });
 
 const emailSchema = emailSchemaWithResolvers();
@@ -74,11 +74,11 @@ function emailSchemaWithResolvers(subscribeFn, resolveFn) {
           subscribe: subscribeFn,
           // TODO: remove
           args: {
-            priority: {type: GraphQLInt}
-          }
+            priority: { type: GraphQLInt },
+          },
         },
       },
-    })
+    }),
   });
 }
 
@@ -96,7 +96,7 @@ async function createSubscription(pubsub, schema = emailSchema, ast, vars) {
     },
     importantEmail() {
       return eventEmitterAsyncIterator(pubsub, 'importantEmail');
-    }
+    },
   };
 
   function sendImportantEmail(newEmail) {
@@ -106,7 +106,7 @@ async function createSubscription(pubsub, schema = emailSchema, ast, vars) {
       importantEmail: {
         email: newEmail,
         inbox: data.inbox,
-      }
+      },
     });
   }
 
@@ -128,13 +128,7 @@ async function createSubscription(pubsub, schema = emailSchema, ast, vars) {
   // `subscribe` returns Promise<AsyncIterator | ExecutionResult>
   return {
     sendImportantEmail,
-    subscription: await subscribe(
-      schema,
-      ast || defaultAst,
-      data,
-      null,
-      vars,
-    ),
+    subscription: await subscribe(schema, ast || defaultAst, data, null, vars),
   };
 }
 
@@ -149,7 +143,6 @@ async function expectPromiseToThrow(promise, message) {
 
 // Check all error cases when initializing the subscription.
 describe('Subscription Initialization Phase', () => {
-
   it('accepts an object with named properties as arguments', async () => {
     const document = parse(`
       subscription {
@@ -165,8 +158,8 @@ describe('Subscription Initialization Phase', () => {
       schema: emailSchema,
       document,
       rootValue: {
-        importantEmail: emptyAsyncIterator
-      }
+        importantEmail: emptyAsyncIterator,
+      },
     });
 
     ai.return();
@@ -179,18 +172,18 @@ describe('Subscription Initialization Phase', () => {
       fields: {
         importantEmail: { type: EmailEventType },
         nonImportantEmail: { type: EmailEventType },
-      }
+      },
     });
 
     const testSchema = new GraphQLSchema({
       query: QueryType,
-      subscription: SubscriptionTypeMultiple
+      subscription: SubscriptionTypeMultiple,
     });
 
-    const {
-      subscription,
-      sendImportantEmail,
-    } = await createSubscription(pubsub, testSchema);
+    const { subscription, sendImportantEmail } = await createSubscription(
+      pubsub,
+      testSchema,
+    );
 
     sendImportantEmail({
       from: 'yuzhi@graphql.org',
@@ -211,10 +204,11 @@ describe('Subscription Initialization Phase', () => {
         fields: {
           importantEmail: {
             type: GraphQLString,
-            subscribe: () => eventEmitterAsyncIterator(pubsub, 'importantEmail')
+            subscribe: () =>
+              eventEmitterAsyncIterator(pubsub, 'importantEmail'),
           },
-        }
-      })
+        },
+      }),
     });
 
     const ast = parse(`
@@ -223,13 +217,10 @@ describe('Subscription Initialization Phase', () => {
       }
     `);
 
-    const subscription = await subscribe(
-      schema,
-      ast
-    );
+    const subscription = await subscribe(schema, ast);
 
     pubsub.emit('importantEmail', {
-      importantEmail: {}
+      importantEmail: {},
     });
 
     await subscription.next();
@@ -247,10 +238,10 @@ describe('Subscription Initialization Phase', () => {
             subscribe: async () => {
               await new Promise(setImmediate);
               return eventEmitterAsyncIterator(pubsub, 'importantEmail');
-            }
+            },
           },
-        }
-      })
+        },
+      }),
     });
 
     const ast = parse(`
@@ -259,13 +250,10 @@ describe('Subscription Initialization Phase', () => {
       }
     `);
 
-    const subscription = await subscribe(
-      schema,
-      ast
-    );
+    const subscription = await subscribe(schema, ast);
 
     pubsub.emit('importantEmail', {
-      importantEmail: {}
+      importantEmail: {},
     });
 
     await subscription.next();
@@ -283,21 +271,21 @@ describe('Subscription Initialization Phase', () => {
           subscribe() {
             didResolveImportantEmail = true;
             return eventEmitterAsyncIterator(new EventEmitter(), 'event');
-          }
+          },
         },
         nonImportantEmail: {
           type: EmailEventType,
           subscribe() {
             didResolveNonImportantEmail = true;
             return eventEmitterAsyncIterator(new EventEmitter(), 'event');
-          }
+          },
         },
-      }
+      },
     });
 
     const testSchema = new GraphQLSchema({
       query: QueryType,
-      subscription: SubscriptionTypeMultiple
+      subscription: SubscriptionTypeMultiple,
     });
 
     const ast = parse(`
@@ -329,21 +317,18 @@ describe('Subscription Initialization Phase', () => {
       'Must provide schema',
     );
 
-    expectPromiseToThrow(
-      () => subscribe({ document }),
-      'Must provide schema',
-    );
+    expectPromiseToThrow(() => subscribe({ document }), 'Must provide schema');
   });
 
   it('throws an error if document is missing', async () => {
     expectPromiseToThrow(
       () => subscribe(emailSchema, null),
-      'Must provide document'
+      'Must provide document',
     );
 
     expectPromiseToThrow(
       () => subscribe({ schema: emailSchema }),
-      'Must provide document'
+      'Must provide document',
     );
   });
 
@@ -358,7 +343,7 @@ describe('Subscription Initialization Phase', () => {
 
     expectPromiseToThrow(
       () => createSubscription(pubsub, emailSchema, ast),
-      'This subscription is not defined by the schema.'
+      'This subscription is not defined by the schema.',
     );
   });
 
@@ -372,22 +357,22 @@ describe('Subscription Initialization Phase', () => {
             type: GraphQLString,
             subscribe: () => 'test',
           },
-        }
-      })
+        },
+      }),
     });
 
     const pubsub = new EventEmitter();
 
     expectPromiseToThrow(
       () => createSubscription(pubsub, invalidEmailSchema),
-      'Subscription must return Async Iterable. Received: test'
+      'Subscription must return Async Iterable. Received: test',
     );
   });
 
   it('returns an error if subscribe function returns error', async () => {
-    const erroringEmailSchema = emailSchemaWithResolvers(
-      () => { return new Error('test error'); }
-    );
+    const erroringEmailSchema = emailSchemaWithResolvers(() => {
+      return new Error('test error');
+    });
 
     const result = await subscribe(
       erroringEmailSchema,
@@ -395,24 +380,24 @@ describe('Subscription Initialization Phase', () => {
         subscription {
           importantEmail
         }
-      `)
+      `),
     );
 
     expect(result).to.deep.equal({
       errors: [
         {
           message: 'test error',
-          locations: [ { line: 3, column: 11 } ],
-          path: [ 'importantEmail' ]
-        }
-      ]
+          locations: [{ line: 3, column: 11 }],
+          path: ['importantEmail'],
+        },
+      ],
     });
   });
 
   it('returns an ExecutionResult for resolver errors', async () => {
-    const erroringEmailSchema = emailSchemaWithResolvers(
-      () => { throw new Error('test error'); }
-    );
+    const erroringEmailSchema = emailSchemaWithResolvers(() => {
+      throw new Error('test error');
+    });
 
     const result = await subscribe(
       erroringEmailSchema,
@@ -420,17 +405,17 @@ describe('Subscription Initialization Phase', () => {
         subscription {
           importantEmail
         }
-      `)
+      `),
     );
 
     expect(result).to.deep.equal({
       errors: [
         {
           message: 'test error',
-          locations: [ { line: 3, column: 11 } ],
-          path: [ 'importantEmail' ]
-        }
-      ]
+          locations: [{ line: 3, column: 11 }],
+          path: ['importantEmail'],
+        },
+      ],
     });
   });
 
@@ -467,29 +452,24 @@ describe('Subscription Initialization Phase', () => {
       },
       importantEmail() {
         return eventEmitterAsyncIterator(pubsub, 'importantEmail');
-      }
+      },
     };
 
-    const result = await subscribe(
-      emailSchema,
-      ast,
-      data,
-      null,
-      {
-        priority: 'meow',
-      }
-    );
+    const result = await subscribe(emailSchema, ast, data, null, {
+      priority: 'meow',
+    });
 
     expect(result).to.deep.equal({
       errors: [
         {
-          message: 'Variable "$priority" got invalid value "meow".\nExpected ' +
-          'type "Int", found "meow": Int cannot represent non 32-bit signed ' +
-          'integer value: meow',
-          locations: [ { line: 2, column: 21 } ],
-          path: undefined
-        }
-      ]
+          message:
+            'Variable "$priority" got invalid value "meow".\nExpected ' +
+            'type "Int", found "meow": Int cannot represent non 32-bit signed ' +
+            'integer value: meow',
+          locations: [{ line: 2, column: 21 }],
+          path: undefined,
+        },
+      ],
     });
   });
 });
@@ -497,65 +477,65 @@ describe('Subscription Initialization Phase', () => {
 // Once a subscription returns a valid AsyncIterator, it can still yield
 // errors.
 describe('Subscription Publish Phase', () => {
+  it('produces a payload for multiple subscribe in same subscription', async () => {
+    const pubsub = new EventEmitter();
+    const { sendImportantEmail, subscription } = await createSubscription(
+      pubsub,
+    );
+    const second = await createSubscription(pubsub);
 
-  it('produces a payload for multiple subscribe in same subscription',
-    async () => {
-      const pubsub = new EventEmitter();
-      const {
-        sendImportantEmail,
-        subscription,
-      } = await createSubscription(pubsub);
-      const second = await createSubscription(pubsub);
+    const payload1 = subscription.next();
+    const payload2 = second.subscription.next();
 
-      const payload1 = subscription.next();
-      const payload2 = second.subscription.next();
-
-      expect(sendImportantEmail({
+    expect(
+      sendImportantEmail({
         from: 'yuzhi@graphql.org',
         subject: 'Alright',
         message: 'Tests are good',
         unread: true,
-      })).to.equal(true);
+      }),
+    ).to.equal(true);
 
-      const expectedPayload = {
-        done: false,
-        value: {
-          data: {
-            importantEmail: {
-              email: {
-                from: 'yuzhi@graphql.org',
-                subject: 'Alright',
-              },
-              inbox: {
-                unread: 1,
-                total: 2,
-              },
+    const expectedPayload = {
+      done: false,
+      value: {
+        data: {
+          importantEmail: {
+            email: {
+              from: 'yuzhi@graphql.org',
+              subject: 'Alright',
+            },
+            inbox: {
+              unread: 1,
+              total: 2,
             },
           },
         },
-      };
+      },
+    };
 
-      expect(await payload1).to.deep.equal(expectedPayload);
-      expect(await payload2).to.deep.equal(expectedPayload);
-    });
+    expect(await payload1).to.deep.equal(expectedPayload);
+    expect(await payload2).to.deep.equal(expectedPayload);
+  });
 
   it('produces a payload per subscription event', async () => {
     const pubsub = new EventEmitter();
-    const {
-      sendImportantEmail,
-      subscription,
-    } = await createSubscription(pubsub);
+    const { sendImportantEmail, subscription } = await createSubscription(
+      pubsub,
+    );
 
     // Wait for the next subscription payload.
     const payload = subscription.next();
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Alright',
-      message: 'Tests are good',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright',
+        message: 'Tests are good',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     // The previously waited on payload now has a value.
     expect(await payload).to.deep.equal({
@@ -577,12 +557,14 @@ describe('Subscription Publish Phase', () => {
     });
 
     // Another new email arrives, before subscription.next() is called.
-    expect(sendImportantEmail({
-      from: 'hyo@graphql.org',
-      subject: 'Tools',
-      message: 'I <3 making things',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'hyo@graphql.org',
+        subject: 'Tools',
+        message: 'I <3 making things',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     // The next waited on payload will have a value.
     expect(await subscription.next()).to.deep.equal({
@@ -610,12 +592,14 @@ describe('Subscription Publish Phase', () => {
     });
 
     // Which may result in disconnecting upstream services as well.
-    expect(sendImportantEmail({
-      from: 'adam@graphql.org',
-      subject: 'Important',
-      message: 'Read me please',
-      unread: true,
-    })).to.equal(false); // No more listeners.
+    expect(
+      sendImportantEmail({
+        from: 'adam@graphql.org',
+        subject: 'Important',
+        message: 'Read me please',
+        unread: true,
+      }),
+    ).to.equal(false); // No more listeners.
 
     // Awaiting a subscription after closing it results in completed results.
     expect(await subscription.next()).to.deep.equal({
@@ -626,19 +610,20 @@ describe('Subscription Publish Phase', () => {
 
   it('produces a payload when there are multiple events', async () => {
     const pubsub = new EventEmitter();
-    const {
-      sendImportantEmail,
-      subscription,
-    } = await createSubscription(pubsub);
+    const { sendImportantEmail, subscription } = await createSubscription(
+      pubsub,
+    );
     let payload = subscription.next();
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Alright',
-      message: 'Tests are good',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright',
+        message: 'Tests are good',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     expect(await payload).to.deep.equal({
       done: false,
@@ -661,12 +646,14 @@ describe('Subscription Publish Phase', () => {
     payload = subscription.next();
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Alright 2',
-      message: 'Tests are good 2',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright 2',
+        message: 'Tests are good 2',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     expect(await payload).to.deep.equal({
       done: false,
@@ -689,19 +676,20 @@ describe('Subscription Publish Phase', () => {
 
   it('should not trigger when subscription is already done', async () => {
     const pubsub = new EventEmitter();
-    const {
-      sendImportantEmail,
-      subscription,
-    } = await createSubscription(pubsub);
+    const { sendImportantEmail, subscription } = await createSubscription(
+      pubsub,
+    );
     let payload = subscription.next();
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Alright',
-      message: 'Tests are good',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright',
+        message: 'Tests are good',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     expect(await payload).to.deep.equal({
       done: false,
@@ -725,12 +713,14 @@ describe('Subscription Publish Phase', () => {
     subscription.return();
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Alright 2',
-      message: 'Tests are good 2',
-      unread: true,
-    })).to.equal(false);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright 2',
+        message: 'Tests are good 2',
+        unread: true,
+      }),
+    ).to.equal(false);
 
     expect(await payload).to.deep.equal({
       done: true,
@@ -740,27 +730,30 @@ describe('Subscription Publish Phase', () => {
 
   it('event order is correct for multiple publishes', async () => {
     const pubsub = new EventEmitter();
-    const {
-      sendImportantEmail,
-      subscription,
-    } = await createSubscription(pubsub);
+    const { sendImportantEmail, subscription } = await createSubscription(
+      pubsub,
+    );
     let payload = subscription.next();
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Message',
-      message: 'Tests are good',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Message',
+        message: 'Tests are good',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     // A new email arrives!
-    expect(sendImportantEmail({
-      from: 'yuzhi@graphql.org',
-      subject: 'Message 2',
-      message: 'Tests are good 2',
-      unread: true,
-    })).to.equal(true);
+    expect(
+      sendImportantEmail({
+        from: 'yuzhi@graphql.org',
+        subject: 'Message 2',
+        message: 'Tests are good 2',
+        unread: true,
+      }),
+    ).to.equal(true);
 
     expect(await payload).to.deep.equal({
       done: false,
@@ -803,7 +796,7 @@ describe('Subscription Publish Phase', () => {
 
   it('should handle error during execuction of source event', async () => {
     const erroringEmailSchema = emailSchemaWithResolvers(
-      async function* () {
+      async function*() {
         yield { email: { subject: 'Hello' } };
         yield { email: { subject: 'Goodbye' } };
         yield { email: { subject: 'Bonjour' } };
@@ -813,7 +806,7 @@ describe('Subscription Publish Phase', () => {
           throw new Error('Never leave.');
         }
         return event;
-      }
+      },
     );
 
     const subscription = await subscribe(
@@ -826,7 +819,7 @@ describe('Subscription Publish Phase', () => {
             }
           }
         }
-      `)
+      `),
     );
 
     const payload1 = await subscription.next();
@@ -836,11 +829,11 @@ describe('Subscription Publish Phase', () => {
         data: {
           importantEmail: {
             email: {
-              subject: 'Hello'
-            }
-          }
-        }
-      }
+              subject: 'Hello',
+            },
+          },
+        },
+      },
     });
 
     // An error in execution is presented as such.
@@ -851,14 +844,14 @@ describe('Subscription Publish Phase', () => {
         errors: [
           {
             message: 'Never leave.',
-            locations: [ { line: 3, column: 11 } ],
-            path: [ 'importantEmail' ],
-          }
+            locations: [{ line: 3, column: 11 }],
+            path: ['importantEmail'],
+          },
         ],
         data: {
           importantEmail: null,
-        }
-      }
+        },
+      },
     });
 
     // However that does not close the response event stream. Subsequent
@@ -870,23 +863,19 @@ describe('Subscription Publish Phase', () => {
         data: {
           importantEmail: {
             email: {
-              subject: 'Bonjour'
-            }
-          }
-        }
-      }
+              subject: 'Bonjour',
+            },
+          },
+        },
+      },
     });
-
   });
 
   it('should pass through error thrown in source event stream', async () => {
-    const erroringEmailSchema = emailSchemaWithResolvers(
-      async function* () {
-        yield { email: { subject: 'Hello' } };
-        throw new Error('test error');
-      },
-      email => email
-    );
+    const erroringEmailSchema = emailSchemaWithResolvers(async function*() {
+      yield { email: { subject: 'Hello' } };
+      throw new Error('test error');
+    }, email => email);
 
     const subscription = await subscribe(
       erroringEmailSchema,
@@ -898,7 +887,7 @@ describe('Subscription Publish Phase', () => {
             }
           }
         }
-      `)
+      `),
     );
 
     const payload1 = await subscription.next();
@@ -908,11 +897,11 @@ describe('Subscription Publish Phase', () => {
         data: {
           importantEmail: {
             email: {
-              subject: 'Hello'
-            }
-          }
-        }
-      }
+              subject: 'Hello',
+            },
+          },
+        },
+      },
     });
 
     let expectedError;
@@ -928,7 +917,7 @@ describe('Subscription Publish Phase', () => {
     const payload2 = await subscription.next();
     expect(payload2).to.deep.equal({
       done: true,
-      value: undefined
+      value: undefined,
     });
   });
 });

--- a/src/subscription/asyncIteratorReject.js
+++ b/src/subscription/asyncIteratorReject.js
@@ -20,9 +20,9 @@ export default function asyncIteratorReject(error: Error): AsyncIterator<void> {
      https://github.com/facebook/flow/issues/3258 */
   return ({
     next() {
-      const result = isComplete ?
-        Promise.resolve({ value: undefined, done: true }) :
-        Promise.reject(error);
+      const result = isComplete
+        ? Promise.resolve({ value: undefined, done: true })
+        : Promise.reject(error);
       isComplete = true;
       return result;
     },

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -16,7 +16,7 @@ import { $$asyncIterator, getAsyncIterator } from 'iterall';
 export default function mapAsyncIterator<T, U>(
   iterable: AsyncIterable<T>,
   callback: T => Promise<U> | U,
-  rejectCallback?: any => Promise<U> | U
+  rejectCallback?: any => Promise<U> | U,
 ): AsyncGenerator<U, void, void> {
   const iterator = getAsyncIterator(iterable);
   let $return;
@@ -30,9 +30,9 @@ export default function mapAsyncIterator<T, U>(
   }
 
   function mapResult(result) {
-    return result.done ?
-      result :
-      asyncMapValue(result.value, callback).then(iteratorResult, abruptClose);
+    return result.done
+      ? result
+      : asyncMapValue(result.value, callback).then(iteratorResult, abruptClose);
   }
 
   let mapReject;
@@ -50,9 +50,9 @@ export default function mapAsyncIterator<T, U>(
       return iterator.next().then(mapResult, mapReject);
     },
     return() {
-      return $return ?
-        $return.call(iterator).then(mapResult, mapReject) :
-        Promise.resolve({ value: undefined, done: true });
+      return $return
+        ? $return.call(iterator).then(mapResult, mapReject)
+        : Promise.resolve({ value: undefined, done: true });
     },
     throw(error) {
       if (typeof iterator.throw === 'function') {
@@ -68,7 +68,7 @@ export default function mapAsyncIterator<T, U>(
 
 function asyncMapValue<T, U>(
   value: T,
-  callback: T => Promise<U> | U
+  callback: T => Promise<U> | U,
 ): Promise<U> {
   return new Promise(resolve => resolve(callback(value)));
 }

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -16,7 +16,7 @@ import {
   GraphQLNonNull,
   GraphQLInt,
   GraphQLString,
-  GraphQLBoolean
+  GraphQLBoolean,
 } from '../';
 
 import { describe, it } from 'mocha';
@@ -30,7 +30,7 @@ const BlogImage = new GraphQLObjectType({
     url: { type: GraphQLString },
     width: { type: GraphQLInt },
     height: { type: GraphQLInt },
-  }
+  },
 });
 
 const BlogAuthor = new GraphQLObjectType({
@@ -40,10 +40,10 @@ const BlogAuthor = new GraphQLObjectType({
     name: { type: GraphQLString },
     pic: {
       args: { width: { type: GraphQLInt }, height: { type: GraphQLInt } },
-      type: BlogImage
+      type: BlogImage,
     },
-    recentArticle: { type: BlogArticle }
-  })
+    recentArticle: { type: BlogArticle },
+  }),
 });
 
 const BlogArticle = new GraphQLObjectType({
@@ -53,8 +53,8 @@ const BlogArticle = new GraphQLObjectType({
     isPublished: { type: GraphQLBoolean },
     author: { type: BlogAuthor },
     title: { type: GraphQLString },
-    body: { type: GraphQLString }
-  }
+    body: { type: GraphQLString },
+  },
 });
 
 const BlogQuery = new GraphQLObjectType({
@@ -62,21 +62,21 @@ const BlogQuery = new GraphQLObjectType({
   fields: {
     article: {
       args: { id: { type: GraphQLString } },
-      type: BlogArticle
+      type: BlogArticle,
     },
     feed: {
-      type: new GraphQLList(BlogArticle)
-    }
-  }
+      type: new GraphQLList(BlogArticle),
+    },
+  },
 });
 
 const BlogMutation = new GraphQLObjectType({
   name: 'Mutation',
   fields: {
     writeArticle: {
-      type: BlogArticle
+      type: BlogArticle,
     },
-  }
+  },
 });
 
 const BlogSubscription = new GraphQLObjectType({
@@ -84,25 +84,24 @@ const BlogSubscription = new GraphQLObjectType({
   fields: {
     articleSubscribe: {
       args: { id: { type: GraphQLString } },
-      type: BlogArticle
-    }
-  }
+      type: BlogArticle,
+    },
+  },
 });
 
 const ObjectType = new GraphQLObjectType({
   name: 'Object',
-  isTypeOf: () => true
+  isTypeOf: () => true,
 });
 const InterfaceType = new GraphQLInterfaceType({ name: 'Interface' });
-const UnionType =
-  new GraphQLUnionType({ name: 'Union', types: [ ObjectType ] });
+const UnionType = new GraphQLUnionType({ name: 'Union', types: [ObjectType] });
 const EnumType = new GraphQLEnumType({ name: 'Enum', values: { foo: {} } });
 const InputObjectType = new GraphQLInputObjectType({ name: 'InputObject' });
 
 describe('Type System: Example', () => {
   it('defines a query only schema', () => {
     const BlogSchema = new GraphQLSchema({
-      query: BlogQuery
+      query: BlogQuery,
     });
 
     expect(BlogSchema.getQueryType()).to.equal(BlogQuery);
@@ -114,33 +113,35 @@ describe('Type System: Example', () => {
 
     const articleFieldType = articleField ? articleField.type : null;
 
-    const titleField = articleFieldType instanceof GraphQLObjectType &&
+    const titleField =
+      articleFieldType instanceof GraphQLObjectType &&
       articleFieldType.getFields()[('title': string)];
     expect(titleField && titleField.name).to.equal('title');
     expect(titleField && titleField.type).to.equal(GraphQLString);
     expect(titleField && titleField.type.name).to.equal('String');
 
-    const authorField = articleFieldType instanceof GraphQLObjectType &&
+    const authorField =
+      articleFieldType instanceof GraphQLObjectType &&
       articleFieldType.getFields()[('author': string)];
 
     const authorFieldType = authorField ? authorField.type : null;
-    const recentArticleField = authorFieldType instanceof GraphQLObjectType &&
+    const recentArticleField =
+      authorFieldType instanceof GraphQLObjectType &&
       authorFieldType.getFields()[('recentArticle': string)];
 
     expect(recentArticleField && recentArticleField.type).to.equal(BlogArticle);
 
     const feedField = BlogQuery.getFields()[('feed': string)];
-    expect(
-      feedField && (feedField.type: GraphQLList).ofType
-    ).to.equal(BlogArticle);
+    expect(feedField && (feedField.type: GraphQLList).ofType).to.equal(
+      BlogArticle,
+    );
     expect(feedField && feedField.name).to.equal('feed');
-
   });
 
   it('defines a mutation schema', () => {
     const BlogSchema = new GraphQLSchema({
       query: BlogQuery,
-      mutation: BlogMutation
+      mutation: BlogMutation,
     });
 
     expect(BlogSchema.getMutationType()).to.equal(BlogMutation);
@@ -149,13 +150,12 @@ describe('Type System: Example', () => {
     expect(writeMutation && writeMutation.type).to.equal(BlogArticle);
     expect(writeMutation && writeMutation.type.name).to.equal('Article');
     expect(writeMutation && writeMutation.name).to.equal('writeArticle');
-
   });
 
   it('defines a subscription schema', () => {
     const BlogSchema = new GraphQLSchema({
       query: BlogQuery,
-      subscription: BlogSubscription
+      subscription: BlogSubscription,
     });
 
     expect(BlogSchema.getSubscriptionType()).to.equal(BlogSubscription);
@@ -164,13 +164,12 @@ describe('Type System: Example', () => {
     expect(sub && sub.type).to.equal(BlogArticle);
     expect(sub && sub.type.name).to.equal('Article');
     expect(sub && sub.name).to.equal('articleSubscribe');
-
   });
 
   it('defines an enum type with deprecated value', () => {
     const EnumTypeWithDeprecatedValue = new GraphQLEnumType({
       name: 'EnumWithDeprecatedValue',
-      values: { foo: { deprecationReason: 'Just because' } }
+      values: { foo: { deprecationReason: 'Just because' } },
     });
 
     expect(EnumTypeWithDeprecatedValue.getValues()[0]).to.deep.equal({
@@ -189,7 +188,7 @@ describe('Type System: Example', () => {
       values: {
         NULL: { value: null },
         UNDEFINED: { value: undefined },
-      }
+      },
     });
 
     expect(EnumTypeWithNullishValue.getValues()).to.deep.equal([
@@ -218,9 +217,9 @@ describe('Type System: Example', () => {
       fields: {
         bar: {
           type: GraphQLString,
-          deprecationReason: 'A terrible reason'
-        }
-      }
+          deprecationReason: 'A terrible reason',
+        },
+      },
     });
 
     expect(TypeWithDeprecatedField.getFields().bar).to.deep.equal({
@@ -228,141 +227,135 @@ describe('Type System: Example', () => {
       deprecationReason: 'A terrible reason',
       isDeprecated: true,
       name: 'bar',
-      args: []
+      args: [],
     });
   });
 
   it('includes nested input objects in the map', () => {
     const NestedInputObject = new GraphQLInputObjectType({
       name: 'NestedInputObject',
-      fields: { value: { type: GraphQLString } }
+      fields: { value: { type: GraphQLString } },
     });
     const SomeInputObject = new GraphQLInputObjectType({
       name: 'SomeInputObject',
-      fields: { nested: { type: NestedInputObject } }
+      fields: { nested: { type: NestedInputObject } },
     });
     const SomeMutation = new GraphQLObjectType({
       name: 'SomeMutation',
       fields: {
         mutateSomething: {
           type: BlogArticle,
-          args: { input: { type: SomeInputObject } }
-        }
-      }
+          args: { input: { type: SomeInputObject } },
+        },
+      },
     });
     const SomeSubscription = new GraphQLObjectType({
       name: 'SomeSubscription',
       fields: {
         subscribeToSomething: {
           type: BlogArticle,
-          args: { input: { type: SomeInputObject } }
-        }
-      }
+          args: { input: { type: SomeInputObject } },
+        },
+      },
     });
     const schema = new GraphQLSchema({
       query: BlogQuery,
       mutation: SomeMutation,
-      subscription: SomeSubscription
+      subscription: SomeSubscription,
     });
     expect(schema.getTypeMap().NestedInputObject).to.equal(NestedInputObject);
   });
 
-  it('includes interfaces\' subtypes in the type map', () => {
+  it("includes interfaces' subtypes in the type map", () => {
     const SomeInterface = new GraphQLInterfaceType({
       name: 'SomeInterface',
       fields: {
-        f: { type: GraphQLInt }
-      }
+        f: { type: GraphQLInt },
+      },
     });
 
     const SomeSubtype = new GraphQLObjectType({
       name: 'SomeSubtype',
       fields: {
-        f: { type: GraphQLInt }
+        f: { type: GraphQLInt },
       },
-      interfaces: [ SomeInterface ],
-      isTypeOf: () => true
+      interfaces: [SomeInterface],
+      isTypeOf: () => true,
     });
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          iface: { type: SomeInterface }
-        }
+          iface: { type: SomeInterface },
+        },
       }),
-      types: [ SomeSubtype ]
+      types: [SomeSubtype],
     });
 
     expect(schema.getTypeMap().SomeSubtype).to.equal(SomeSubtype);
   });
 
-  it('includes interfaces\' thunk subtypes in the type map', () => {
+  it("includes interfaces' thunk subtypes in the type map", () => {
     const SomeInterface = new GraphQLInterfaceType({
       name: 'SomeInterface',
       fields: {
-        f: { type: GraphQLInt }
-      }
+        f: { type: GraphQLInt },
+      },
     });
 
     const SomeSubtype = new GraphQLObjectType({
       name: 'SomeSubtype',
       fields: {
-        f: { type: GraphQLInt }
+        f: { type: GraphQLInt },
       },
-      interfaces: () => [ SomeInterface ],
-      isTypeOf: () => true
+      interfaces: () => [SomeInterface],
+      isTypeOf: () => true,
     });
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          iface: { type: SomeInterface }
-        }
+          iface: { type: SomeInterface },
+        },
       }),
-      types: [ SomeSubtype ]
+      types: [SomeSubtype],
     });
 
     expect(schema.getTypeMap().SomeSubtype).to.equal(SomeSubtype);
   });
-
 
   it('stringifies simple types', () => {
-
     expect(String(GraphQLInt)).to.equal('Int');
     expect(String(BlogArticle)).to.equal('Article');
     expect(String(InterfaceType)).to.equal('Interface');
     expect(String(UnionType)).to.equal('Union');
     expect(String(EnumType)).to.equal('Enum');
     expect(String(InputObjectType)).to.equal('InputObject');
-    expect(
-      String(new GraphQLNonNull(GraphQLInt))
-    ).to.equal('Int!');
-    expect(
-      String(new GraphQLList(GraphQLInt))
-    ).to.equal('[Int]');
-    expect(
-      String(new GraphQLNonNull(new GraphQLList(GraphQLInt)))
-    ).to.equal('[Int]!');
-    expect(
-      String(new GraphQLList(new GraphQLNonNull(GraphQLInt)))
-    ).to.equal('[Int!]');
-    expect(
-      String(new GraphQLList(new GraphQLList(GraphQLInt)))
-    ).to.equal('[[Int]]');
+    expect(String(new GraphQLNonNull(GraphQLInt))).to.equal('Int!');
+    expect(String(new GraphQLList(GraphQLInt))).to.equal('[Int]');
+    expect(String(new GraphQLNonNull(new GraphQLList(GraphQLInt)))).to.equal(
+      '[Int]!',
+    );
+    expect(String(new GraphQLList(new GraphQLNonNull(GraphQLInt)))).to.equal(
+      '[Int!]',
+    );
+    expect(String(new GraphQLList(new GraphQLList(GraphQLInt)))).to.equal(
+      '[[Int]]',
+    );
   });
 
   it('identifies input types', () => {
     const expected = [
-      [ GraphQLInt, true ],
-      [ ObjectType, false ],
-      [ InterfaceType, false ],
-      [ UnionType, false ],
-      [ EnumType, true ],
-      [ InputObjectType, true ]
+      [GraphQLInt, true],
+      [ObjectType, false],
+      [InterfaceType, false],
+      [UnionType, false],
+      [EnumType, true],
+      [InputObjectType, true],
     ];
-    expected.forEach(([ type, answer ]) => {
+    expected.forEach(([type, answer]) => {
       expect(isInputType(type)).to.equal(answer);
       expect(isInputType(new GraphQLList(type))).to.equal(answer);
       expect(isInputType(new GraphQLNonNull(type))).to.equal(answer);
@@ -371,14 +364,14 @@ describe('Type System: Example', () => {
 
   it('identifies output types', () => {
     const expected = [
-      [ GraphQLInt, true ],
-      [ ObjectType, true ],
-      [ InterfaceType, true ],
-      [ UnionType, true ],
-      [ EnumType, true ],
-      [ InputObjectType, false ]
+      [GraphQLInt, true],
+      [ObjectType, true],
+      [InterfaceType, true],
+      [UnionType, true],
+      [EnumType, true],
+      [InputObjectType, false],
     ];
-    expected.forEach(([ type, answer ]) => {
+    expected.forEach(([type, answer]) => {
       expect(isOutputType(type)).to.equal(answer);
       expect(isOutputType(new GraphQLList(type))).to.equal(answer);
       expect(isOutputType(new GraphQLNonNull(type))).to.equal(answer);
@@ -386,10 +379,8 @@ describe('Type System: Example', () => {
   });
 
   it('prohibits nesting NonNull inside NonNull', () => {
-    expect(() =>
-      new GraphQLNonNull(new GraphQLNonNull(GraphQLInt))
-    ).to.throw(
-      'Can only create NonNull of a Nullable GraphQLType but got: Int!.'
+    expect(() => new GraphQLNonNull(new GraphQLNonNull(GraphQLInt))).to.throw(
+      'Can only create NonNull of a Nullable GraphQLType but got: Int!.',
     );
   });
 
@@ -401,21 +392,21 @@ describe('Type System: Example', () => {
       InterfaceType,
       UnionType,
       EnumType,
-      InputObjectType
+      InputObjectType,
     ];
     badUnionTypes.forEach(x => {
       expect(() =>
-        new GraphQLUnionType({ name: 'BadUnion', types: [ x ] }).getTypes()
+        new GraphQLUnionType({ name: 'BadUnion', types: [x] }).getTypes(),
       ).to.throw(
-        `BadUnion may only contain Object types, it cannot contain: ${x}.`
+        `BadUnion may only contain Object types, it cannot contain: ${x}.`,
       );
     });
   });
 
-  it('allows a thunk for Union\'s types', () => {
+  it("allows a thunk for Union's types", () => {
     const union = new GraphQLUnionType({
       name: 'ThunkUnion',
-      types: () => [ ObjectType ]
+      types: () => [ObjectType],
     });
 
     const types = union.getTypes();
@@ -432,10 +423,10 @@ describe('Type System: Example', () => {
         type: GraphQLString,
         args: {
           id: {
-            type: GraphQLString
-          }
-        }
-      }
+            type: GraphQLString,
+          },
+        },
+      },
     };
     const testObject1 = new GraphQLObjectType({
       name: 'Test1',
@@ -455,23 +446,23 @@ describe('Type System: Example', () => {
         type: GraphQLString,
         args: {
           id: {
-            type: GraphQLString
-          }
-        }
-      }
+            type: GraphQLString,
+          },
+        },
+      },
     });
 
     const testInputObject1 = new GraphQLInputObjectType({
       name: 'Test1',
-      fields
+      fields,
     });
     const testInputObject2 = new GraphQLInputObjectType({
       name: 'Test2',
-      fields
+      fields,
     });
 
     expect(testInputObject1.getFields()).to.deep.equal(
-      testInputObject2.getFields()
+      testInputObject2.getFields(),
     );
     expect(fields).to.deep.equal({
       field1: {
@@ -481,10 +472,10 @@ describe('Type System: Example', () => {
         type: GraphQLString,
         args: {
           id: {
-            type: GraphQLString
-          }
-        }
-      }
+            type: GraphQLString,
+          },
+        },
+      },
     });
   });
 });

--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -18,16 +18,14 @@ import {
   introspectionQuery,
 } from '../../';
 
-
 describe('Type System: Enum Values', () => {
-
   const ColorType = new GraphQLEnumType({
     name: 'Color',
     values: {
       RED: { value: 0 },
       GREEN: { value: 1 },
       BLUE: { value: 2 },
-    }
+    },
   });
 
   const Complex1 = { someRandomFunction: () => {} };
@@ -38,7 +36,7 @@ describe('Type System: Enum Values', () => {
     values: {
       ONE: { value: Complex1 },
       TWO: { value: Complex2 },
-    }
+    },
   });
 
   const QueryType = new GraphQLObjectType({
@@ -52,10 +50,10 @@ describe('Type System: Enum Values', () => {
           fromString: { type: GraphQLString },
         },
         resolve(value, { fromEnum, fromInt, fromString }) {
-          return fromInt !== undefined ? fromInt :
-            fromString !== undefined ? fromString :
-            fromEnum;
-        }
+          return fromInt !== undefined
+            ? fromInt
+            : fromString !== undefined ? fromString : fromEnum;
+        },
       },
       colorInt: {
         type: GraphQLInt,
@@ -65,7 +63,7 @@ describe('Type System: Enum Values', () => {
         },
         resolve(value, { fromEnum, fromInt }) {
           return fromInt !== undefined ? fromInt : fromEnum;
-        }
+        },
       },
       complexEnum: {
         type: ComplexEnum,
@@ -74,10 +72,10 @@ describe('Type System: Enum Values', () => {
             type: ComplexEnum,
             // Note: defaultValue is provided an *internal* representation for
             // Enums, rather than the string name.
-            defaultValue: Complex1
+            defaultValue: Complex1,
           },
           provideGoodValue: { type: GraphQLBoolean },
-          provideBadValue: { type: GraphQLBoolean }
+          provideBadValue: { type: GraphQLBoolean },
         },
         resolve(value, { fromEnum, provideGoodValue, provideBadValue }) {
           if (provideGoodValue) {
@@ -91,9 +89,9 @@ describe('Type System: Enum Values', () => {
             return { someRandomValue: 123 };
           }
           return fromEnum;
-        }
-      }
-    }
+        },
+      },
+    },
   });
 
   const MutationType = new GraphQLObjectType({
@@ -102,9 +100,11 @@ describe('Type System: Enum Values', () => {
       favoriteEnum: {
         type: ColorType,
         args: { color: { type: ColorType } },
-        resolve(value, { color }) { return color; }
-      }
-    }
+        resolve(value, { color }) {
+          return color;
+        },
+      },
+    },
   });
 
   const SubscriptionType = new GraphQLObjectType({
@@ -113,103 +113,103 @@ describe('Type System: Enum Values', () => {
       subscribeToEnum: {
         type: ColorType,
         args: { color: { type: ColorType } },
-        resolve(value, { color }) { return color; }
-      }
-    }
+        resolve(value, { color }) {
+          return color;
+        },
+      },
+    },
   });
 
   const schema = new GraphQLSchema({
     query: QueryType,
     mutation: MutationType,
-    subscription: SubscriptionType
+    subscription: SubscriptionType,
   });
 
   it('accepts enum literals as input', async () => {
     expect(
-      await graphql(schema, '{ colorInt(fromEnum: GREEN) }')
+      await graphql(schema, '{ colorInt(fromEnum: GREEN) }'),
     ).to.jsonEqual({
       data: {
-        colorInt: 1
-      }
+        colorInt: 1,
+      },
     });
   });
 
   it('enum may be output type', async () => {
-    expect(
-      await graphql(schema, '{ colorEnum(fromInt: 1) }')
-    ).to.jsonEqual({
+    expect(await graphql(schema, '{ colorEnum(fromInt: 1) }')).to.jsonEqual({
       data: {
-        colorEnum: 'GREEN'
-      }
+        colorEnum: 'GREEN',
+      },
     });
   });
 
   it('enum may be both input and output type', async () => {
     expect(
-      await graphql(schema, '{ colorEnum(fromEnum: GREEN) }')
+      await graphql(schema, '{ colorEnum(fromEnum: GREEN) }'),
     ).to.jsonEqual({
       data: {
-        colorEnum: 'GREEN'
-      }
+        colorEnum: 'GREEN',
+      },
     });
   });
 
   it('does not accept string literals', async () => {
     expect(
-      await graphql(schema, '{ colorEnum(fromEnum: "GREEN") }')
+      await graphql(schema, '{ colorEnum(fromEnum: "GREEN") }'),
     ).to.jsonEqual({
       errors: [
         {
           message:
             'Argument "fromEnum" has invalid value "GREEN".' +
             '\nExpected type "Color", found "GREEN".',
-          locations: [ { line: 1, column: 23 } ]
-        }
-      ]
+          locations: [{ line: 1, column: 23 }],
+        },
+      ],
     });
   });
 
   it('does not accept incorrect internal value', async () => {
     expect(
-      await graphql(schema, '{ colorEnum(fromString: "GREEN") }')
+      await graphql(schema, '{ colorEnum(fromString: "GREEN") }'),
     ).to.containSubset({
       data: {
-        colorEnum: null
+        colorEnum: null,
       },
       errors: [
-        { message: 'Expected a value of type "Color" but received: GREEN',
-          locations: [ { line: 1, column: 3 } ] }
-      ]
+        {
+          message: 'Expected a value of type "Color" but received: GREEN',
+          locations: [{ line: 1, column: 3 }],
+        },
+      ],
     });
   });
 
   it('does not accept internal value in place of enum literal', async () => {
-    expect(
-      await graphql(schema, '{ colorEnum(fromEnum: 1) }')
-    ).to.jsonEqual({
+    expect(await graphql(schema, '{ colorEnum(fromEnum: 1) }')).to.jsonEqual({
       errors: [
         {
           message:
             'Argument "fromEnum" has invalid value 1.' +
             '\nExpected type "Color", found 1.',
-          locations: [ { line: 1, column: 23 } ]
-        }
-      ]
+          locations: [{ line: 1, column: 23 }],
+        },
+      ],
     });
   });
 
   it('does not accept enum literal in place of int', async () => {
     expect(
-      await graphql(schema, '{ colorEnum(fromInt: GREEN) }')
+      await graphql(schema, '{ colorEnum(fromInt: GREEN) }'),
     ).to.jsonEqual({
       errors: [
         {
           message:
             'Argument "fromInt" has invalid value GREEN.' +
             '\nExpected type "Int", found GREEN.',
-          locations: [ { line: 1, column: 22 } ]
-        }
-      ]
+          locations: [{ line: 1, column: 22 }],
+        },
+      ],
     });
   });
 
@@ -220,12 +220,12 @@ describe('Type System: Enum Values', () => {
         'query test($color: Color!) { colorEnum(fromEnum: $color) }',
         null,
         null,
-        { color: 'BLUE' }
-      )
+        { color: 'BLUE' },
+      ),
     ).to.jsonEqual({
       data: {
-        colorEnum: 'BLUE'
-      }
+        colorEnum: 'BLUE',
+      },
     });
   });
 
@@ -236,12 +236,12 @@ describe('Type System: Enum Values', () => {
         'mutation x($color: Color!) { favoriteEnum(color: $color) }',
         null,
         null,
-        { color: 'GREEN' }
-      )
+        { color: 'GREEN' },
+      ),
     ).to.jsonEqual({
       data: {
-        favoriteEnum: 'GREEN'
-      }
+        favoriteEnum: 'GREEN',
+      },
     });
   });
 
@@ -252,12 +252,12 @@ describe('Type System: Enum Values', () => {
         'subscription x($color: Color!) { subscribeToEnum(color: $color) }',
         null,
         null,
-        { color: 'GREEN' }
-      )
+        { color: 'GREEN' },
+      ),
     ).to.jsonEqual({
       data: {
-        subscribeToEnum: 'GREEN'
-      }
+        subscribeToEnum: 'GREEN',
+      },
     });
   });
 
@@ -268,17 +268,17 @@ describe('Type System: Enum Values', () => {
         'query test($color: Color!) { colorEnum(fromEnum: $color) }',
         null,
         null,
-        { color: 2 }
-      )
+        { color: 2 },
+      ),
     ).to.jsonEqual({
       errors: [
         {
           message:
             'Variable "$color" got invalid value 2.' +
             '\nExpected type "Color", found 2.',
-          locations: [ { line: 1, column: 12 } ]
-        }
-      ]
+          locations: [{ line: 1, column: 12 }],
+        },
+      ],
     });
   });
 
@@ -289,17 +289,17 @@ describe('Type System: Enum Values', () => {
         'query test($color: String!) { colorEnum(fromEnum: $color) }',
         null,
         null,
-        { color: 'BLUE' }
-      )
+        { color: 'BLUE' },
+      ),
     ).to.jsonEqual({
       errors: [
         {
           message:
             'Variable "$color" of type "String!" used in position ' +
             'expecting type "Color".',
-          locations: [ { line: 1, column: 12 }, { line: 1, column: 51 } ]
-        }
-      ]
+          locations: [{ line: 1, column: 12 }, { line: 1, column: 51 }],
+        },
+      ],
     });
   });
 
@@ -310,45 +310,55 @@ describe('Type System: Enum Values', () => {
         'query test($color: Int!) { colorEnum(fromEnum: $color) }',
         null,
         null,
-        { color: 2 }
-      )
+        { color: 2 },
+      ),
     ).to.jsonEqual({
       errors: [
         {
           message:
             'Variable "$color" of type "Int!" used in position ' +
             'expecting type "Color".',
-          locations: [ { line: 1, column: 12 }, { line: 1, column: 48 } ]
-        }
-      ]
+          locations: [{ line: 1, column: 12 }, { line: 1, column: 48 }],
+        },
+      ],
     });
   });
 
   it('enum value may have an internal value of 0', async () => {
     expect(
-      await graphql(schema, `{
-        colorEnum(fromEnum: RED)
-        colorInt(fromEnum: RED)
-      }`)
+      await graphql(
+        schema,
+        `
+          {
+            colorEnum(fromEnum: RED)
+            colorInt(fromEnum: RED)
+          }
+        `,
+      ),
     ).to.jsonEqual({
       data: {
         colorEnum: 'RED',
-        colorInt: 0
-      }
+        colorInt: 0,
+      },
     });
   });
 
   it('enum inputs may be nullable', async () => {
     expect(
-      await graphql(schema, `{
-        colorEnum
-        colorInt
-      }`)
+      await graphql(
+        schema,
+        `
+          {
+            colorEnum
+            colorInt
+          }
+        `,
+      ),
     ).to.jsonEqual({
       data: {
         colorEnum: null,
-        colorInt: null
-      }
+        colorInt: null,
+      },
     });
   });
 
@@ -372,24 +382,31 @@ describe('Type System: Enum Values', () => {
 
   it('may be internally represented with complex values', async () => {
     expect(
-      await graphql(schema, `{
-        first: complexEnum
-        second: complexEnum(fromEnum: TWO)
-        good: complexEnum(provideGoodValue: true)
-        bad: complexEnum(provideBadValue: true)
-      }`)
+      await graphql(
+        schema,
+        `
+          {
+            first: complexEnum
+            second: complexEnum(fromEnum: TWO)
+            good: complexEnum(provideGoodValue: true)
+            bad: complexEnum(provideBadValue: true)
+          }
+        `,
+      ),
     ).to.containSubset({
       data: {
         first: 'ONE',
         second: 'TWO',
         good: 'TWO',
-        bad: null
+        bad: null,
       },
-      errors: [ {
-        message:
-          'Expected a value of type "Complex" but received: [object Object]',
-        locations: [ { line: 5, column: 9 } ]
-      } ]
+      errors: [
+        {
+          message:
+            'Expected a value of type "Complex" but received: [object Object]',
+          locations: [{ line: 5, column: 9 }],
+        },
+      ],
     });
   });
 
@@ -397,5 +414,4 @@ describe('Type System: Enum Values', () => {
     const result = await graphql(schema, introspectionQuery);
     expect(result).to.not.have.property('errors');
   });
-
 });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -8,9 +8,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import {
-  missingFieldArgMessage
-} from '../../validation/rules/ProvidedNonNullArguments';
+import { missingFieldArgMessage } from '../../validation/rules/ProvidedNonNullArguments';
 import {
   graphql,
   GraphQLSchema,
@@ -29,13 +27,13 @@ describe('Introspection', () => {
       query: new GraphQLObjectType({
         name: 'QueryRoot',
         fields: {
-          onlyField: { type: GraphQLString }
-        }
-      })
+          onlyField: { type: GraphQLString },
+        },
+      }),
     });
 
     return expect(
-      await graphql(EmptySchema, introspectionQuery)
+      await graphql(EmptySchema, introspectionQuery),
     ).to.containSubset({
       data: {
         __schema: {
@@ -71,13 +69,13 @@ describe('Introspection', () => {
                         name: null,
                         ofType: {
                           kind: 'OBJECT',
-                          name: '__Type'
-                        }
-                      }
-                    }
+                          name: '__Type',
+                        },
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'queryType',
@@ -88,11 +86,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'OBJECT',
                       name: '__Type',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'mutationType',
@@ -100,10 +98,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'OBJECT',
                     name: '__Type',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'subscriptionType',
@@ -111,10 +109,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'OBJECT',
                     name: '__Type',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'directives',
@@ -130,14 +128,14 @@ describe('Introspection', () => {
                         name: null,
                         ofType: {
                           kind: 'OBJECT',
-                          name: '__Directive'
-                        }
-                      }
-                    }
+                          name: '__Directive',
+                        },
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
-                }
+                  deprecationReason: null,
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -157,11 +155,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'ENUM',
                       name: '__TypeKind',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'name',
@@ -169,10 +167,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'description',
@@ -180,10 +178,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'fields',
@@ -193,10 +191,10 @@ describe('Introspection', () => {
                       type: {
                         kind: 'SCALAR',
                         name: 'Boolean',
-                        ofType: null
+                        ofType: null,
                       },
-                      defaultValue: 'false'
-                    }
+                      defaultValue: 'false',
+                    },
                   ],
                   type: {
                     kind: 'LIST',
@@ -207,12 +205,12 @@ describe('Introspection', () => {
                       ofType: {
                         kind: 'OBJECT',
                         name: '__Field',
-                        ofType: null
-                      }
-                    }
+                        ofType: null,
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'interfaces',
@@ -226,12 +224,12 @@ describe('Introspection', () => {
                       ofType: {
                         kind: 'OBJECT',
                         name: '__Type',
-                        ofType: null
-                      }
-                    }
+                        ofType: null,
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'possibleTypes',
@@ -245,12 +243,12 @@ describe('Introspection', () => {
                       ofType: {
                         kind: 'OBJECT',
                         name: '__Type',
-                        ofType: null
-                      }
-                    }
+                        ofType: null,
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'enumValues',
@@ -260,10 +258,10 @@ describe('Introspection', () => {
                       type: {
                         kind: 'SCALAR',
                         name: 'Boolean',
-                        ofType: null
+                        ofType: null,
                       },
-                      defaultValue: 'false'
-                    }
+                      defaultValue: 'false',
+                    },
                   ],
                   type: {
                     kind: 'LIST',
@@ -274,12 +272,12 @@ describe('Introspection', () => {
                       ofType: {
                         kind: 'OBJECT',
                         name: '__EnumValue',
-                        ofType: null
-                      }
-                    }
+                        ofType: null,
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'inputFields',
@@ -293,12 +291,12 @@ describe('Introspection', () => {
                       ofType: {
                         kind: 'OBJECT',
                         name: '__InputValue',
-                        ofType: null
-                      }
-                    }
+                        ofType: null,
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'ofType',
@@ -306,11 +304,11 @@ describe('Introspection', () => {
                   type: {
                     kind: 'OBJECT',
                     name: '__Type',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
-                }
+                  deprecationReason: null,
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -327,43 +325,43 @@ describe('Introspection', () => {
                 {
                   name: 'SCALAR',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'OBJECT',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'INTERFACE',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'UNION',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'ENUM',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'INPUT_OBJECT',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'LIST',
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'NON_NULL',
                   isDeprecated: false,
-                  deprecationReason: null
-                }
+                  deprecationReason: null,
+                },
               ],
               possibleTypes: null,
             },
@@ -398,11 +396,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'String',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'description',
@@ -410,10 +408,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'args',
@@ -429,13 +427,13 @@ describe('Introspection', () => {
                         name: null,
                         ofType: {
                           kind: 'OBJECT',
-                          name: '__InputValue'
-                        }
-                      }
-                    }
+                          name: '__InputValue',
+                        },
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'type',
@@ -446,11 +444,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'OBJECT',
                       name: '__Type',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'isDeprecated',
@@ -461,11 +459,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'Boolean',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'deprecationReason',
@@ -473,11 +471,11 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
-                }
+                  deprecationReason: null,
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -497,11 +495,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'String',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'description',
@@ -509,10 +507,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'type',
@@ -523,11 +521,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'OBJECT',
                       name: '__Type',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'defaultValue',
@@ -535,11 +533,11 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
-                }
+                  deprecationReason: null,
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -559,11 +557,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'String',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'description',
@@ -571,10 +569,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'isDeprecated',
@@ -585,11 +583,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'Boolean',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'deprecationReason',
@@ -597,11 +595,11 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
-                }
+                  deprecationReason: null,
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -621,11 +619,11 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'String',
-                      ofType: null
-                    }
+                      ofType: null,
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'description',
@@ -633,10 +631,10 @@ describe('Introspection', () => {
                   type: {
                     kind: 'SCALAR',
                     name: 'String',
-                    ofType: null
+                    ofType: null,
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'locations',
@@ -652,13 +650,13 @@ describe('Introspection', () => {
                         name: null,
                         ofType: {
                           kind: 'ENUM',
-                          name: '__DirectiveLocation'
-                        }
-                      }
-                    }
+                          name: '__DirectiveLocation',
+                        },
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'args',
@@ -674,13 +672,13 @@ describe('Introspection', () => {
                         name: null,
                         ofType: {
                           kind: 'OBJECT',
-                          name: '__InputValue'
-                        }
-                      }
-                    }
+                          name: '__InputValue',
+                        },
+                      },
+                    },
                   },
                   isDeprecated: false,
-                  deprecationReason: null
+                  deprecationReason: null,
                 },
                 {
                   name: 'onOperation',
@@ -695,7 +693,7 @@ describe('Introspection', () => {
                     },
                   },
                   isDeprecated: true,
-                  deprecationReason: 'Use `locations`.'
+                  deprecationReason: 'Use `locations`.',
                 },
                 {
                   name: 'onFragment',
@@ -710,7 +708,7 @@ describe('Introspection', () => {
                     },
                   },
                   isDeprecated: true,
-                  deprecationReason: 'Use `locations`.'
+                  deprecationReason: 'Use `locations`.',
                 },
                 {
                   name: 'onField',
@@ -725,8 +723,8 @@ describe('Introspection', () => {
                     },
                   },
                   isDeprecated: true,
-                  deprecationReason: 'Use `locations`.'
-                }
+                  deprecationReason: 'Use `locations`.',
+                },
               ],
               inputFields: null,
               interfaces: [],
@@ -742,40 +740,40 @@ describe('Introspection', () => {
               enumValues: [
                 {
                   name: 'QUERY',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
                 {
                   name: 'MUTATION',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
                 {
                   name: 'SUBSCRIPTION',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
                 {
                   name: 'FIELD',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
                 {
                   name: 'FRAGMENT_DEFINITION',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
                 {
                   name: 'FRAGMENT_SPREAD',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
                 {
                   name: 'INLINE_FRAGMENT',
-                  isDeprecated: false
+                  isDeprecated: false,
                 },
               ],
               possibleTypes: null,
-            }
+            },
           ],
           directives: [
             {
               name: 'include',
-              locations: [ 'FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT' ],
+              locations: ['FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'],
               args: [
                 {
                   defaultValue: null,
@@ -786,15 +784,15 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'Boolean',
-                      ofType: null
-                    }
-                  }
-                }
+                      ofType: null,
+                    },
+                  },
+                },
               ],
             },
             {
               name: 'skip',
-              locations: [ 'FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT' ],
+              locations: ['FIELD', 'FRAGMENT_SPREAD', 'INLINE_FRAGMENT'],
               args: [
                 {
                   defaultValue: null,
@@ -805,27 +803,26 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'Boolean',
-                      ofType: null
-                    }
-                  }
-                }
+                      ofType: null,
+                    },
+                  },
+                },
               ],
-            }
-          ]
-        }
-      }
+            },
+          ],
+        },
+      },
     });
   });
 
   it('introspects on input object', async () => {
-
     const TestInputObject = new GraphQLInputObjectType({
       name: 'TestInputObject',
       fields: {
         a: { type: GraphQLString, defaultValue: 'foo' },
         b: { type: new GraphQLList(GraphQLString) },
-        c: { type: GraphQLString, defaultValue: null }
-      }
+        c: { type: GraphQLString, defaultValue: null },
+      },
     });
 
     const TestType = new GraphQLObjectType({
@@ -834,9 +831,9 @@ describe('Introspection', () => {
         field: {
           type: GraphQLString,
           args: { complex: { type: TestInputObject } },
-          resolve: (_, { complex }) => JSON.stringify(complex)
-        }
-      }
+          resolve: (_, { complex }) => JSON.stringify(complex),
+        },
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -873,36 +870,50 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.containSubset({
-      data:
-      { __schema:
-      { types:
-      [ { kind: 'INPUT_OBJECT',
-        name: 'TestInputObject',
-        inputFields:
-        [ { name: 'a',
-          type:
-          { kind: 'SCALAR',
-            name: 'String',
-            ofType: null },
-          defaultValue: '"foo"' },
-        { name: 'b',
-          type:
-          { kind: 'LIST',
-            name: null,
-            ofType:
-            { kind: 'SCALAR',
-              name: 'String',
-              ofType: null } },
-          defaultValue: null },
-        { name: 'c',
-          type:
-          { kind: 'SCALAR',
-            name: 'String',
-            ofType: null },
-          defaultValue: 'null' } ] } ] } }
+    return expect(await graphql(schema, request)).to.containSubset({
+      data: {
+        __schema: {
+          types: [
+            {
+              kind: 'INPUT_OBJECT',
+              name: 'TestInputObject',
+              inputFields: [
+                {
+                  name: 'a',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                  defaultValue: '"foo"',
+                },
+                {
+                  name: 'b',
+                  type: {
+                    kind: 'LIST',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'String',
+                      ofType: null,
+                    },
+                  },
+                  defaultValue: null,
+                },
+                {
+                  name: 'c',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                  defaultValue: 'null',
+                },
+              ],
+            },
+          ],
+        },
+      },
     });
   });
 
@@ -912,8 +923,8 @@ describe('Introspection', () => {
       fields: {
         testField: {
           type: GraphQLString,
-        }
-      }
+        },
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -925,19 +936,16 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         __type: {
-          name: 'TestType'
-        }
-      }
+          name: 'TestType',
+        },
+      },
     });
   });
 
   it('identifies deprecated fields', async () => {
-
     const TestType = new GraphQLObjectType({
       name: 'TestType',
       fields: {
@@ -946,9 +954,9 @@ describe('Introspection', () => {
         },
         deprecated: {
           type: GraphQLString,
-          deprecationReason: 'Removed in 1.0'
-        }
-      }
+          deprecationReason: 'Removed in 1.0',
+        },
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -965,9 +973,7 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         __type: {
           name: 'TestType',
@@ -975,21 +981,20 @@ describe('Introspection', () => {
             {
               name: 'nonDeprecated',
               isDeprecated: false,
-              deprecationReason: null
+              deprecationReason: null,
             },
             {
               name: 'deprecated',
               isDeprecated: true,
-              deprecationReason: 'Removed in 1.0'
-            }
-          ]
-        }
-      }
+              deprecationReason: 'Removed in 1.0',
+            },
+          ],
+        },
+      },
     });
   });
 
   it('respects the includeDeprecated parameter for fields', async () => {
-
     const TestType = new GraphQLObjectType({
       name: 'TestType',
       fields: {
@@ -998,9 +1003,9 @@ describe('Introspection', () => {
         },
         deprecated: {
           type: GraphQLString,
-          deprecationReason: 'Removed in 1.0'
-        }
-      }
+          deprecationReason: 'Removed in 1.0',
+        },
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -1021,9 +1026,7 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         __type: {
           name: 'TestType',
@@ -1033,32 +1036,31 @@ describe('Introspection', () => {
             },
             {
               name: 'deprecated',
-            }
+            },
           ],
           falseFields: [
             {
               name: 'nonDeprecated',
-            }
+            },
           ],
           omittedFields: [
             {
               name: 'nonDeprecated',
-            }
+            },
           ],
-        }
-      }
+        },
+      },
     });
   });
 
   it('identifies deprecated enum values', async () => {
-
     const TestEnum = new GraphQLEnumType({
       name: 'TestEnum',
       values: {
         NONDEPRECATED: { value: 0 },
         DEPRECATED: { value: 1, deprecationReason: 'Removed in 1.0' },
-        ALSONONDEPRECATED: { value: 2 }
-      }
+        ALSONONDEPRECATED: { value: 2 },
+      },
     });
 
     const TestType = new GraphQLObjectType({
@@ -1067,7 +1069,7 @@ describe('Introspection', () => {
         testEnum: {
           type: TestEnum,
         },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -1084,9 +1086,7 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         __type: {
           name: 'TestEnum',
@@ -1094,33 +1094,32 @@ describe('Introspection', () => {
             {
               name: 'NONDEPRECATED',
               isDeprecated: false,
-              deprecationReason: null
+              deprecationReason: null,
             },
             {
               name: 'DEPRECATED',
               isDeprecated: true,
-              deprecationReason: 'Removed in 1.0'
+              deprecationReason: 'Removed in 1.0',
             },
             {
               name: 'ALSONONDEPRECATED',
               isDeprecated: false,
-              deprecationReason: null
-            }
-          ]
-        }
-      }
+              deprecationReason: null,
+            },
+          ],
+        },
+      },
     });
   });
 
   it('respects the includeDeprecated parameter for enum values', async () => {
-
     const TestEnum = new GraphQLEnumType({
       name: 'TestEnum',
       values: {
         NONDEPRECATED: { value: 0 },
         DEPRECATED: { value: 1, deprecationReason: 'Removed in 1.0' },
-        ALSONONDEPRECATED: { value: 2 }
-      }
+        ALSONONDEPRECATED: { value: 2 },
+      },
     });
 
     const TestType = new GraphQLObjectType({
@@ -1129,7 +1128,7 @@ describe('Introspection', () => {
         testEnum: {
           type: TestEnum,
         },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -1150,9 +1149,7 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         __type: {
           name: 'TestEnum',
@@ -1165,7 +1162,7 @@ describe('Introspection', () => {
             },
             {
               name: 'ALSONONDEPRECATED',
-            }
+            },
           ],
           falseValues: [
             {
@@ -1173,7 +1170,7 @@ describe('Introspection', () => {
             },
             {
               name: 'ALSONONDEPRECATED',
-            }
+            },
           ],
           omittedValues: [
             {
@@ -1181,10 +1178,10 @@ describe('Introspection', () => {
             },
             {
               name: 'ALSONONDEPRECATED',
-            }
+            },
           ],
-        }
-      }
+        },
+      },
     });
   });
 
@@ -1194,8 +1191,8 @@ describe('Introspection', () => {
       fields: {
         testField: {
           type: GraphQLString,
-        }
-      }
+        },
+      },
     });
 
     const schema = new GraphQLSchema({ query: TestType });
@@ -1207,13 +1204,13 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.containSubset({
+    return expect(await graphql(schema, request)).to.containSubset({
       errors: [
-        { message: missingFieldArgMessage('__type', 'name', 'String!'),
-          locations: [ { line: 3, column: 9 } ] }
-      ]
+        {
+          message: missingFieldArgMessage('__type', 'name', 'String!'),
+          locations: [{ line: 3, column: 9 }],
+        },
+      ],
     });
   });
 
@@ -1221,8 +1218,8 @@ describe('Introspection', () => {
     const QueryRoot = new GraphQLObjectType({
       name: 'QueryRoot',
       fields: {
-        onlyField: { type: GraphQLString }
-      }
+        onlyField: { type: GraphQLString },
+      },
     });
 
     const schema = new GraphQLSchema({ query: QueryRoot });
@@ -1239,43 +1236,44 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         schemaType: {
           name: '__Schema',
-          description: 'A GraphQL Schema defines the capabilities of a ' +
-                       'GraphQL server. It exposes all available types and ' +
-                       'directives on the server, as well as the entry ' +
-                       'points for query, mutation, ' +
-                       'and subscription operations.',
+          description:
+            'A GraphQL Schema defines the capabilities of a ' +
+            'GraphQL server. It exposes all available types and ' +
+            'directives on the server, as well as the entry ' +
+            'points for query, mutation, ' +
+            'and subscription operations.',
           fields: [
             {
               name: 'types',
-              description: 'A list of all types supported by this server.'
+              description: 'A list of all types supported by this server.',
             },
             {
               name: 'queryType',
-              description: 'The type that query operations will be rooted at.'
+              description: 'The type that query operations will be rooted at.',
             },
             {
               name: 'mutationType',
-              description: 'If this server supports mutation, the type that ' +
-                           'mutation operations will be rooted at.'
+              description:
+                'If this server supports mutation, the type that ' +
+                'mutation operations will be rooted at.',
             },
             {
               name: 'subscriptionType',
-              description: 'If this server support subscription, the type ' +
-                           'that subscription operations will be rooted at.',
+              description:
+                'If this server support subscription, the type ' +
+                'that subscription operations will be rooted at.',
             },
             {
               name: 'directives',
-              description: 'A list of all directives supported by this server.'
-            }
-          ]
-        }
-      }
+              description: 'A list of all directives supported by this server.',
+            },
+          ],
+        },
+      },
     });
   });
 
@@ -1283,8 +1281,8 @@ describe('Introspection', () => {
     const QueryRoot = new GraphQLObjectType({
       name: 'QueryRoot',
       fields: {
-        onlyField: { type: GraphQLString }
-      }
+        onlyField: { type: GraphQLString },
+      },
     });
 
     const schema = new GraphQLSchema({ query: QueryRoot });
@@ -1301,9 +1299,7 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(
-      await graphql(schema, request)
-    ).to.deep.equal({
+    return expect(await graphql(schema, request)).to.deep.equal({
       data: {
         typeKindType: {
           name: '__TypeKind',
@@ -1312,47 +1308,53 @@ describe('Introspection', () => {
           enumValues: [
             {
               description: 'Indicates this type is a scalar.',
-              name: 'SCALAR'
+              name: 'SCALAR',
             },
             {
-              description: 'Indicates this type is an object. ' +
-                           '`fields` and `interfaces` are valid fields.',
-              name: 'OBJECT'
+              description:
+                'Indicates this type is an object. ' +
+                '`fields` and `interfaces` are valid fields.',
+              name: 'OBJECT',
             },
             {
-              description: 'Indicates this type is an interface. ' +
-                           '`fields` and `possibleTypes` are valid fields.',
-              name: 'INTERFACE'
+              description:
+                'Indicates this type is an interface. ' +
+                '`fields` and `possibleTypes` are valid fields.',
+              name: 'INTERFACE',
             },
             {
-              description: 'Indicates this type is a union. ' +
-                           '`possibleTypes` is a valid field.',
-              name: 'UNION'
+              description:
+                'Indicates this type is a union. ' +
+                '`possibleTypes` is a valid field.',
+              name: 'UNION',
             },
             {
-              description: 'Indicates this type is an enum. ' +
-                           '`enumValues` is a valid field.',
-              name: 'ENUM'
+              description:
+                'Indicates this type is an enum. ' +
+                '`enumValues` is a valid field.',
+              name: 'ENUM',
             },
             {
-              description: 'Indicates this type is an input object. ' +
-                           '`inputFields` is a valid field.',
-              name: 'INPUT_OBJECT'
+              description:
+                'Indicates this type is an input object. ' +
+                '`inputFields` is a valid field.',
+              name: 'INPUT_OBJECT',
             },
             {
-              description: 'Indicates this type is a list. ' +
-                           '`ofType` is a valid field.',
-              name: 'LIST'
+              description:
+                'Indicates this type is a list. ' +
+                '`ofType` is a valid field.',
+              name: 'LIST',
             },
             {
-              description: 'Indicates this type is a non-null. ' +
-                           '`ofType` is a valid field.',
-              name: 'NON_NULL'
-            }
-          ]
-        }
-      }
+              description:
+                'Indicates this type is a non-null. ' +
+                '`ofType` is a valid field.',
+              name: 'NON_NULL',
+            },
+          ],
+        },
+      },
     });
   });
-
 });

--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -9,7 +9,7 @@ import {
   GraphQLSchema,
   GraphQLInterfaceType,
   GraphQLObjectType,
-  GraphQLString
+  GraphQLString,
 } from '../';
 
 import { describe, it } from 'mocha';
@@ -20,13 +20,13 @@ const InterfaceType = new GraphQLInterfaceType({
   fields: { fieldName: { type: GraphQLString } },
   resolveType() {
     return ImplementingType;
-  }
+  },
 });
 
 const ImplementingType = new GraphQLObjectType({
   name: 'Object',
-  interfaces: [ InterfaceType ],
-  fields: { fieldName: { type: GraphQLString, resolve: () => '' }}
+  interfaces: [InterfaceType],
+  fields: { fieldName: { type: GraphQLString, resolve: () => '' } },
 });
 
 const Schema = new GraphQLSchema({
@@ -37,10 +37,10 @@ const Schema = new GraphQLSchema({
         type: InterfaceType,
         resolve() {
           return {};
-        }
-      }
-    }
-  })
+        },
+      },
+    },
+  }),
 });
 
 describe('Type System: Schema', () => {
@@ -51,8 +51,8 @@ describe('Type System: Schema', () => {
       };
       expect(checkPossible).to.throw(
         'Could not find possible implementing types for Interface in schema. ' +
-        'Check that schema.types is defined and is an array of all possible ' +
-        'types in the schema.'
+          'Check that schema.types is defined and is an array of all possible ' +
+          'types in the schema.',
       );
     });
   });

--- a/src/type/__tests__/serialization-test.js
+++ b/src/type/__tests__/serialization-test.js
@@ -5,189 +5,99 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  GraphQLInt,
-  GraphQLFloat,
-  GraphQLString,
-  GraphQLBoolean
-} from '../';
+import { GraphQLInt, GraphQLFloat, GraphQLString, GraphQLBoolean } from '../';
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
-
 describe('Type System: Scalar coercion', () => {
   it('serializes output int', () => {
-    expect(
-      GraphQLInt.serialize(1)
-    ).to.equal(1);
-    expect(
-      GraphQLInt.serialize('123')
-    ).to.equal(123);
-    expect(
-      GraphQLInt.serialize(0)
-    ).to.equal(0);
-    expect(
-      GraphQLInt.serialize(-1)
-    ).to.equal(-1);
-    expect(
-      GraphQLInt.serialize(1e5)
-    ).to.equal(100000);
+    expect(GraphQLInt.serialize(1)).to.equal(1);
+    expect(GraphQLInt.serialize('123')).to.equal(123);
+    expect(GraphQLInt.serialize(0)).to.equal(0);
+    expect(GraphQLInt.serialize(-1)).to.equal(-1);
+    expect(GraphQLInt.serialize(1e5)).to.equal(100000);
     // The GraphQL specification does not allow serializing non-integer values
     // as Int to avoid accidental data loss.
-    expect(() =>
-      GraphQLInt.serialize(0.1)
-    ).to.throw(
-      'Int cannot represent non-integer value: 0.1'
+    expect(() => GraphQLInt.serialize(0.1)).to.throw(
+      'Int cannot represent non-integer value: 0.1',
     );
-    expect(() =>
-      GraphQLInt.serialize(1.1)
-    ).to.throw(
-      'Int cannot represent non-integer value: 1.1'
+    expect(() => GraphQLInt.serialize(1.1)).to.throw(
+      'Int cannot represent non-integer value: 1.1',
     );
-    expect(() =>
-      GraphQLInt.serialize(-1.1)
-    ).to.throw(
-      'Int cannot represent non-integer value: -1.1'
+    expect(() => GraphQLInt.serialize(-1.1)).to.throw(
+      'Int cannot represent non-integer value: -1.1',
     );
-    expect(() =>
-      GraphQLInt.serialize('-1.1')
-    ).to.throw(
-      'Int cannot represent non-integer value: -1.1'
+    expect(() => GraphQLInt.serialize('-1.1')).to.throw(
+      'Int cannot represent non-integer value: -1.1',
     );
     // Maybe a safe JavaScript int, but bigger than 2^32, so not
     // representable as a GraphQL Int
-    expect(() =>
-      GraphQLInt.serialize(9876504321)
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: 9876504321'
+    expect(() => GraphQLInt.serialize(9876504321)).to.throw(
+      'Int cannot represent non 32-bit signed integer value: 9876504321',
     );
-    expect(() =>
-      GraphQLInt.serialize(-9876504321)
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: -9876504321'
+    expect(() => GraphQLInt.serialize(-9876504321)).to.throw(
+      'Int cannot represent non 32-bit signed integer value: -9876504321',
     );
     // Too big to represent as an Int in JavaScript or GraphQL
-    expect(() =>
-      GraphQLInt.serialize(1e100)
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: 1e+100'
+    expect(() => GraphQLInt.serialize(1e100)).to.throw(
+      'Int cannot represent non 32-bit signed integer value: 1e+100',
     );
-    expect(() =>
-      GraphQLInt.serialize(-1e100)
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: -1e+100'
+    expect(() => GraphQLInt.serialize(-1e100)).to.throw(
+      'Int cannot represent non 32-bit signed integer value: -1e+100',
     );
-    expect(() =>
-      GraphQLInt.serialize('one')
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: one'
+    expect(() => GraphQLInt.serialize('one')).to.throw(
+      'Int cannot represent non 32-bit signed integer value: one',
     );
-    expect(
-      GraphQLInt.serialize(false)
-    ).to.equal(0);
-    expect(
-      GraphQLInt.serialize(true)
-    ).to.equal(1);
-    expect(() =>
-      GraphQLInt.serialize('')
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: (empty string)'
+    expect(GraphQLInt.serialize(false)).to.equal(0);
+    expect(GraphQLInt.serialize(true)).to.equal(1);
+    expect(() => GraphQLInt.serialize('')).to.throw(
+      'Int cannot represent non 32-bit signed integer value: (empty string)',
     );
-    expect(() =>
-      GraphQLInt.serialize(NaN)
-    ).to.throw(
-      'Int cannot represent non 32-bit signed integer value: NaN'
+    expect(() => GraphQLInt.serialize(NaN)).to.throw(
+      'Int cannot represent non 32-bit signed integer value: NaN',
     );
   });
 
   it('serializes output float', () => {
-    expect(
-      GraphQLFloat.serialize(1)
-    ).to.equal(1.0);
-    expect(
-      GraphQLFloat.serialize(0)
-    ).to.equal(0.0);
-    expect(
-      GraphQLFloat.serialize('123.5')
-    ).to.equal(123.5);
-    expect(
-      GraphQLFloat.serialize(-1)
-    ).to.equal(-1.0);
-    expect(
-      GraphQLFloat.serialize(0.1)
-    ).to.equal(0.1);
-    expect(
-      GraphQLFloat.serialize(1.1)
-    ).to.equal(1.1);
-    expect(
-      GraphQLFloat.serialize(-1.1)
-    ).to.equal(-1.1);
-    expect(
-      GraphQLFloat.serialize('-1.1')
-    ).to.equal(-1.1);
-    expect(
-      GraphQLFloat.serialize(false)
-    ).to.equal(0.0);
-    expect(
-      GraphQLFloat.serialize(true)
-    ).to.equal(1.0);
+    expect(GraphQLFloat.serialize(1)).to.equal(1.0);
+    expect(GraphQLFloat.serialize(0)).to.equal(0.0);
+    expect(GraphQLFloat.serialize('123.5')).to.equal(123.5);
+    expect(GraphQLFloat.serialize(-1)).to.equal(-1.0);
+    expect(GraphQLFloat.serialize(0.1)).to.equal(0.1);
+    expect(GraphQLFloat.serialize(1.1)).to.equal(1.1);
+    expect(GraphQLFloat.serialize(-1.1)).to.equal(-1.1);
+    expect(GraphQLFloat.serialize('-1.1')).to.equal(-1.1);
+    expect(GraphQLFloat.serialize(false)).to.equal(0.0);
+    expect(GraphQLFloat.serialize(true)).to.equal(1.0);
 
-    expect(() =>
-      GraphQLFloat.serialize(NaN)
-    ).to.throw(
-      'Float cannot represent non numeric value: NaN'
+    expect(() => GraphQLFloat.serialize(NaN)).to.throw(
+      'Float cannot represent non numeric value: NaN',
     );
 
-    expect(() =>
-      GraphQLFloat.serialize('one')
-    ).to.throw(
-      'Float cannot represent non numeric value: one'
+    expect(() => GraphQLFloat.serialize('one')).to.throw(
+      'Float cannot represent non numeric value: one',
     );
 
-    expect(() =>
-      GraphQLFloat.serialize('')
-    ).to.throw(
-      'Float cannot represent non numeric value: (empty string)'
+    expect(() => GraphQLFloat.serialize('')).to.throw(
+      'Float cannot represent non numeric value: (empty string)',
     );
   });
 
   it('serializes output strings', () => {
-    expect(
-      GraphQLString.serialize('string')
-    ).to.equal('string');
-    expect(
-      GraphQLString.serialize(1)
-    ).to.equal('1');
-    expect(
-      GraphQLString.serialize(-1.1)
-    ).to.equal('-1.1');
-    expect(
-      GraphQLString.serialize(true)
-    ).to.equal('true');
-    expect(
-      GraphQLString.serialize(false)
-    ).to.equal('false');
+    expect(GraphQLString.serialize('string')).to.equal('string');
+    expect(GraphQLString.serialize(1)).to.equal('1');
+    expect(GraphQLString.serialize(-1.1)).to.equal('-1.1');
+    expect(GraphQLString.serialize(true)).to.equal('true');
+    expect(GraphQLString.serialize(false)).to.equal('false');
   });
 
   it('serializes output boolean', () => {
-    expect(
-      GraphQLBoolean.serialize('string')
-    ).to.equal(true);
-    expect(
-      GraphQLBoolean.serialize('')
-    ).to.equal(false);
-    expect(
-      GraphQLBoolean.serialize(1)
-    ).to.equal(true);
-    expect(
-      GraphQLBoolean.serialize(0)
-    ).to.equal(false);
-    expect(
-      GraphQLBoolean.serialize(true)
-    ).to.equal(true);
-    expect(
-      GraphQLBoolean.serialize(false)
-    ).to.equal(false);
+    expect(GraphQLBoolean.serialize('string')).to.equal(true);
+    expect(GraphQLBoolean.serialize('')).to.equal(false);
+    expect(GraphQLBoolean.serialize(1)).to.equal(true);
+    expect(GraphQLBoolean.serialize(0)).to.equal(false);
+    expect(GraphQLBoolean.serialize(true)).to.equal(true);
+    expect(GraphQLBoolean.serialize(false)).to.equal(false);
   });
 });

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -23,49 +23,48 @@ import {
   GraphQLString,
 } from '../../';
 
-
 const SomeScalarType = new GraphQLScalarType({
   name: 'SomeScalar',
   serialize() {},
   parseValue() {},
-  parseLiteral() {}
+  parseLiteral() {},
 });
 
 const SomeObjectType = new GraphQLObjectType({
   name: 'SomeObject',
-  fields: { f: { type: GraphQLString } }
+  fields: { f: { type: GraphQLString } },
 });
 
 const ObjectWithIsTypeOf = new GraphQLObjectType({
   name: 'ObjectWithIsTypeOf',
   isTypeOf: () => true,
-  fields: { f: { type: GraphQLString} }
+  fields: { f: { type: GraphQLString } },
 });
 
 const SomeUnionType = new GraphQLUnionType({
   name: 'SomeUnion',
   resolveType: () => null,
-  types: [ SomeObjectType ]
+  types: [SomeObjectType],
 });
 
 const SomeInterfaceType = new GraphQLInterfaceType({
   name: 'SomeInterface',
   resolveType: () => null,
-  fields: { f: { type: GraphQLString } }
+  fields: { f: { type: GraphQLString } },
 });
 
 const SomeEnumType = new GraphQLEnumType({
   name: 'SomeEnum',
   values: {
-    ONLY: {}
-  }
+    ONLY: {},
+  },
 });
 
 const SomeInputObjectType = new GraphQLInputObjectType({
   name: 'SomeInputObject',
   fields: {
-    val: { type: GraphQLString, defaultValue: 'hello' }
-  }
+    val: { type: GraphQLString, defaultValue: 'hello' },
+  },
 });
 
 function withModifiers(types) {
@@ -84,9 +83,7 @@ const outputTypes = withModifiers([
   SomeInterfaceType,
 ]);
 
-const notOutputTypes = withModifiers([
-  SomeInputObjectType,
-]).concat(String);
+const notOutputTypes = withModifiers([SomeInputObjectType]).concat(String);
 
 const inputTypes = withModifiers([
   GraphQLString,
@@ -105,20 +102,19 @@ function schemaWithFieldType(type) {
   return new GraphQLSchema({
     query: new GraphQLObjectType({
       name: 'Query',
-      fields: { f: { type } }
+      fields: { f: { type } },
     }),
-    types: [ type ],
+    types: [type],
   });
 }
 
-
 describe('Type System: A Schema must have Object root types', () => {
-
   it('accepts a Schema whose query type is an object type', () => {
     expect(
-      () => new GraphQLSchema({
-        query: SomeObjectType
-      })
+      () =>
+        new GraphQLSchema({
+          query: SomeObjectType,
+        }),
     ).not.to.throw();
   });
 
@@ -126,12 +122,12 @@ describe('Type System: A Schema must have Object root types', () => {
     expect(() => {
       const MutationType = new GraphQLObjectType({
         name: 'Mutation',
-        fields: { edit: { type: GraphQLString } }
+        fields: { edit: { type: GraphQLString } },
       });
 
       return new GraphQLSchema({
         query: SomeObjectType,
-        mutation: MutationType
+        mutation: MutationType,
       });
     }).not.to.throw();
   });
@@ -140,69 +136,66 @@ describe('Type System: A Schema must have Object root types', () => {
     expect(() => {
       const SubscriptionType = new GraphQLObjectType({
         name: 'Subscription',
-        fields: { subscribe: { type: GraphQLString } }
+        fields: { subscribe: { type: GraphQLString } },
       });
 
       return new GraphQLSchema({
         query: SomeObjectType,
-        subscription: SubscriptionType
+        subscription: SubscriptionType,
       });
     }).not.to.throw();
   });
 
   it('rejects a Schema without a query type', () => {
-    expect(
-      () => new GraphQLSchema({ })
-    ).to.throw(
-      'Schema query must be Object Type but got: undefined.'
+    expect(() => new GraphQLSchema({})).to.throw(
+      'Schema query must be Object Type but got: undefined.',
     );
   });
 
   it('rejects a Schema whose query type is an input type', () => {
-    expect(
-      () => new GraphQLSchema({ query: SomeInputObjectType })
-    ).to.throw(
-      'Schema query must be Object Type but got: SomeInputObject.'
+    expect(() => new GraphQLSchema({ query: SomeInputObjectType })).to.throw(
+      'Schema query must be Object Type but got: SomeInputObject.',
     );
   });
 
   it('rejects a Schema whose mutation type is an input type', () => {
     expect(
-      () => new GraphQLSchema({
-        query: SomeObjectType,
-        mutation: SomeInputObjectType
-      })
+      () =>
+        new GraphQLSchema({
+          query: SomeObjectType,
+          mutation: SomeInputObjectType,
+        }),
     ).to.throw(
-      'Schema mutation must be Object Type if provided but got: SomeInputObject.'
+      'Schema mutation must be Object Type if provided but got: SomeInputObject.',
     );
   });
 
   it('rejects a Schema whose subscription type is an input type', () => {
     expect(
-      () => new GraphQLSchema({
-        query: SomeObjectType,
-        subscription: SomeInputObjectType
-      })
+      () =>
+        new GraphQLSchema({
+          query: SomeObjectType,
+          subscription: SomeInputObjectType,
+        }),
     ).to.throw(
-      'Schema subscription must be Object Type if provided but got: SomeInputObject.'
+      'Schema subscription must be Object Type if provided but got: SomeInputObject.',
     );
   });
 
   it('rejects a Schema whose directives are incorrectly typed', () => {
     expect(
-      () => new GraphQLSchema({
-        query: SomeObjectType,
-        directives: [ 'somedirective' ]
-      })
+      () =>
+        new GraphQLSchema({
+          query: SomeObjectType,
+          directives: ['somedirective'],
+        }),
     ).to.throw(
-      'Schema directives must be Array<GraphQLDirective> if provided but got: somedirective.'
+      'Schema directives must be Array<GraphQLDirective> if provided but got: somedirective.',
     );
   });
-
 });
 
 describe('Type System: A Schema must contain uniquely named types', () => {
-
   it('rejects a Schema which redefines a built-in type', () => {
     expect(() => {
       const FakeString = new GraphQLScalarType({
@@ -215,13 +208,13 @@ describe('Type System: A Schema must contain uniquely named types', () => {
         fields: {
           normal: { type: GraphQLString },
           fake: { type: FakeString },
-        }
+        },
       });
 
       return new GraphQLSchema({ query: QueryType });
     }).to.throw(
       'Schema must contain unique named types but contains multiple types ' +
-      'named "String".'
+        'named "String".',
     );
   });
 
@@ -241,14 +234,14 @@ describe('Type System: A Schema must contain uniquely named types', () => {
         name: 'Query',
         fields: {
           a: { type: A },
-          b: { type: B }
-        }
+          b: { type: B },
+        },
       });
 
       return new GraphQLSchema({ query: QueryType });
     }).to.throw(
       'Schema must contain unique named types but contains multiple types ' +
-      'named "SameName".'
+        'named "SameName".',
     );
   });
 
@@ -262,13 +255,13 @@ describe('Type System: A Schema must contain uniquely named types', () => {
 
       const FirstBadObject = new GraphQLObjectType({
         name: 'BadObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: { f: { type: GraphQLString } },
       });
 
       const SecondBadObject = new GraphQLObjectType({
         name: 'BadObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: { f: { type: GraphQLString } },
       });
 
@@ -276,79 +269,85 @@ describe('Type System: A Schema must contain uniquely named types', () => {
         name: 'Query',
         fields: {
           iface: { type: AnotherInterface },
-        }
+        },
       });
 
       return new GraphQLSchema({
         query: QueryType,
-        types: [ FirstBadObject, SecondBadObject ]
+        types: [FirstBadObject, SecondBadObject],
       });
     }).to.throw(
       'Schema must contain unique named types but contains multiple types ' +
-      'named "BadObject".'
+        'named "BadObject".',
     );
   });
-
 });
 
 describe('Type System: Objects must have fields', () => {
-
   it('accepts an Object type with fields object', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          f: { type: GraphQLString }
-        }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {
+            f: { type: GraphQLString },
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts an Object type with a field function', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields() {
-          return {
-            f: { type: GraphQLString }
-          };
-        }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields() {
+            return {
+              f: { type: GraphQLString },
+            };
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects an Object type with missing fields', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+        }),
+      ),
     ).to.throw(
       'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Object type field with undefined config', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          f: undefined
-        }
-      }))
-    ).to.throw(
-      'SomeObject.f field config must be an object'
-    );
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {
+            f: undefined,
+          },
+        }),
+      ),
+    ).to.throw('SomeObject.f field config must be an object');
   });
 
   it('rejects an Object type with incorrectly named fields', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: { 'bad-name-with-dashes': { type: GraphQLString } }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: { 'bad-name-with-dashes': { type: GraphQLString } },
+        }),
+      ),
     ).to.throw(
-      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.'
+      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
     );
   });
 
@@ -356,17 +355,19 @@ describe('Type System: Objects must have fields', () => {
     /* eslint-disable no-console */
     const realConsoleWarn = console.warn;
     const calls = [];
-    console.warn = function () {
+    console.warn = function() {
       calls.push(Array.prototype.slice.call(arguments));
     };
     try {
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: { __notPartOfIntrospection: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: { __notPartOfIntrospection: { type: GraphQLString } },
+        }),
+      );
 
       expect(calls[0][0]).contains(
-        'Name "__notPartOfIntrospection" must not begin with "__", which is reserved by GraphQL introspection.'
+        'Name "__notPartOfIntrospection" must not begin with "__", which is reserved by GraphQL introspection.',
       );
     } finally {
       console.warn = realConsoleWarn;
@@ -375,157 +376,157 @@ describe('Type System: Objects must have fields', () => {
   });
 
   it('rejects an Object type with incorrectly typed fields', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: [
-          { field: GraphQLString }
-        ]
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: [{ field: GraphQLString }],
+        }),
+      ),
     ).to.throw(
       'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Object type with empty fields', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {}
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {},
+        }),
+      ),
     ).to.throw(
       'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Object type with a field function that returns nothing', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields() {
-
-        }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields() {},
+        }),
+      ),
     ).to.throw(
       'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Object type with a field function that returns empty', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields() {
-          return {};
-        }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields() {
+            return {};
+          },
+        }),
+      ),
     ).to.throw(
       'SomeObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
-
 });
 
-
 describe('Type System: Fields args must be properly named', () => {
-
   it('accepts field args with valid names', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          goodField: {
-            type: GraphQLString,
-            args: {
-              goodArg: { type: GraphQLString }
-            }
-          }
-        }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {
+            goodField: {
+              type: GraphQLString,
+              args: {
+                goodArg: { type: GraphQLString },
+              },
+            },
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects field arg with invalid names', () => {
-    expect(
-      () => {
-        const QueryType = new GraphQLObjectType({
-          name: 'SomeObject',
-          fields: {
-            badField: {
-              type: GraphQLString,
-              args: {
-                'bad-name-with-dashes': { type: GraphQLString }
-              }
-            }
-          }
-        });
-        return new GraphQLSchema({ query: QueryType });
-      }).to.throw(
-      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.'
-    );
-  });
-
-});
-
-
-describe('Type System: Fields args must be objects', () => {
-
-  it('accepts an Object type with field args', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          goodField: {
-            type: GraphQLString,
-            args: {
-              goodArg: { type: GraphQLString }
-            }
-          }
-        }
-      }))
-    ).not.to.throw();
-  });
-
-  it('rejects an Object type with incorrectly typed field args', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
+    expect(() => {
+      const QueryType = new GraphQLObjectType({
         name: 'SomeObject',
         fields: {
           badField: {
             type: GraphQLString,
-            args: [
-              { badArg: GraphQLString }
-            ]
-          }
-        }
-      }))
-    ).to.throw(
-      'SomeObject.badField args must be an object with argument names as keys.'
+            args: {
+              'bad-name-with-dashes': { type: GraphQLString },
+            },
+          },
+        },
+      });
+      return new GraphQLSchema({ query: QueryType });
+    }).to.throw(
+      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
     );
   });
-
 });
 
+describe('Type System: Fields args must be objects', () => {
+  it('accepts an Object type with field args', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {
+            goodField: {
+              type: GraphQLString,
+              args: {
+                goodArg: { type: GraphQLString },
+              },
+            },
+          },
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('rejects an Object type with incorrectly typed field args', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          fields: {
+            badField: {
+              type: GraphQLString,
+              args: [{ badArg: GraphQLString }],
+            },
+          },
+        }),
+      ),
+    ).to.throw(
+      'SomeObject.badField args must be an object with argument names as keys.',
+    );
+  });
+});
 
 describe('Type System: Object interfaces must be array', () => {
-
   it('accepts an Object type with array interfaces', () => {
     expect(() => {
       const AnotherInterfaceType = new GraphQLInterfaceType({
         name: 'AnotherInterface',
         resolveType: () => null,
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces: [ AnotherInterfaceType ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: [AnotherInterfaceType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).not.to.throw();
   });
 
@@ -534,26 +535,30 @@ describe('Type System: Object interfaces must be array', () => {
       const AnotherInterfaceType = new GraphQLInterfaceType({
         name: 'AnotherInterface',
         resolveType: () => null,
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces: () => [ AnotherInterfaceType ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: () => [AnotherInterfaceType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).not.to.throw();
   });
 
   it('rejects an Object type with incorrectly typed interfaces', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces: {},
-        fields: { f: { type: GraphQLString } }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: {},
+          fields: { f: { type: GraphQLString } },
+        }),
+      ),
     ).to.throw(
-      'SomeObject interfaces must be an Array or a function which returns an Array.'
+      'SomeObject interfaces must be an Array or a function which returns an Array.',
     );
   });
 
@@ -571,112 +576,124 @@ describe('Type System: Object interfaces must be array', () => {
         fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces: () => [ NonUniqInterface, AnotherInterface, NonUniqInterface ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: () => [
+            NonUniqInterface,
+            AnotherInterface,
+            NonUniqInterface,
+          ],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).to.throw(
-      'SomeObject may declare it implements NonUniqInterface only once.'
+      'SomeObject may declare it implements NonUniqInterface only once.',
     );
   });
 
   it('rejects an Object type with interfaces as a function returning an incorrect type', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces() {
-          return {};
-        },
-        fields: { f: { type: GraphQLString } }
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces() {
+            return {};
+          },
+          fields: { f: { type: GraphQLString } },
+        }),
+      ),
     ).to.throw(
-      'SomeObject interfaces must be an Array or a function which returns an Array.'
+      'SomeObject interfaces must be an Array or a function which returns an Array.',
     );
   });
 });
 
-
 describe('Type System: Union types must be array', () => {
-
   it('accepts a Union type with array types', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: [ SomeObjectType ],
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: [SomeObjectType],
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts a Union type with function returning an array of types', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: () => [ SomeObjectType ],
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: () => [SomeObjectType],
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects a Union type without types', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+        }),
+      ),
     ).to.throw(
       'Must provide Array of types or a function which returns such an array ' +
-      'for Union SomeUnion.'
+        'for Union SomeUnion.',
     );
   });
 
   it('rejects a Union type with empty types', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: []
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: [],
+        }),
+      ),
     ).to.throw(
       'Must provide Array of types or a function which returns such an array ' +
-      'for Union SomeUnion.'
+        'for Union SomeUnion.',
     );
   });
 
   it('rejects a Union type with incorrectly typed types', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: {
-          SomeObjectType
-        },
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: {
+            SomeObjectType,
+          },
+        }),
+      ),
     ).to.throw(
       'Must provide Array of types or a function which returns such an array ' +
-      'for Union SomeUnion.'
+        'for Union SomeUnion.',
     );
   });
 
   it('rejects a Union type with duplicated member type', () => {
-    expect(
-      () => schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: [
-          SomeObjectType,
-          SomeObjectType,
-        ],
-      }))
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: [SomeObjectType, SomeObjectType],
+        }),
+      ),
     ).to.throw('SomeUnion can include SomeObject type only once.');
   });
-
 });
 
-
 describe('Type System: Input Objects must have fields', () => {
-
   function schemaWithInputObject(inputObjectType) {
     return new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -685,108 +702,115 @@ describe('Type System: Input Objects must have fields', () => {
           f: {
             type: GraphQLString,
             args: {
-              badArg: { type: inputObjectType }
-            }
-          }
-        }
-      })
+              badArg: { type: inputObjectType },
+            },
+          },
+        },
+      }),
     });
   }
 
   it('accepts an Input Object type with fields', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          f: { type: GraphQLString }
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {
+            f: { type: GraphQLString },
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts an Input Object type with a field function', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields() {
-          return {
-            f: { type: GraphQLString }
-          };
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields() {
+            return {
+              f: { type: GraphQLString },
+            };
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects an Input Object type with missing fields', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+        }),
+      ),
     ).to.throw(
       'SomeInputObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Input Object type with incorrectly typed fields', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: [
-          { field: GraphQLString }
-        ]
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: [{ field: GraphQLString }],
+        }),
+      ),
     ).to.throw(
       'SomeInputObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Input Object type with empty fields', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {}
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {},
+        }),
+      ),
     ).to.throw(
       'SomeInputObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Input Object type with a field function that returns nothing', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields() {
-
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields() {},
+        }),
+      ),
     ).to.throw(
       'SomeInputObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
 
   it('rejects an Input Object type with a field function that returns empty', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields() {
-          return {};
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields() {
+            return {};
+          },
+        }),
+      ),
     ).to.throw(
       'SomeInputObject fields must be an object with field names as keys or a ' +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
   });
-
 });
 
-
 describe('Type System: Input Object fields must not have resolvers', () => {
-
   function schemaWithInputObject(inputObjectType) {
     return new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -795,129 +819,144 @@ describe('Type System: Input Object fields must not have resolvers', () => {
           f: {
             type: GraphQLString,
             args: {
-              input: { type: inputObjectType }
-            }
-          }
-        }
-      })
+              input: { type: inputObjectType },
+            },
+          },
+        },
+      }),
     });
   }
 
   it('accepts an Input Object type with no resolver', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          f: {
-            type: GraphQLString,
-          }
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {
+            f: {
+              type: GraphQLString,
+            },
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts an Input Object type with null resolver', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          f: {
-            type: GraphQLString,
-            resolve: null,
-          }
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {
+            f: {
+              type: GraphQLString,
+              resolve: null,
+            },
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts an Input Object type with undefined resolver', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          f: {
-            type: GraphQLString,
-            resolve: undefined,
-          }
-        }
-      }))
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {
+            f: {
+              type: GraphQLString,
+              resolve: undefined,
+            },
+          },
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects an Input Object type with resolver function', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          f: {
-            type: GraphQLString,
-            resolve: () => { return 0; },
-          }
-        }
-      }))
-    ).to.throw('SomeInputObject.f field type has a resolve property,' +
-    ' but Input Types cannot define resolvers.');
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {
+            f: {
+              type: GraphQLString,
+              resolve: () => {
+                return 0;
+              },
+            },
+          },
+        }),
+      ),
+    ).to.throw(
+      'SomeInputObject.f field type has a resolve property,' +
+        ' but Input Types cannot define resolvers.',
+    );
   });
 
   it('rejects an Input Object type with resolver constant', () => {
-    expect(
-      () => schemaWithInputObject(new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          f: {
-            type: GraphQLString,
-            resolve: {},
-          }
-        }
-      }))
-    ).to.throw('SomeInputObject.f field type has a resolve property,' +
-    ' but Input Types cannot define resolvers.');
+    expect(() =>
+      schemaWithInputObject(
+        new GraphQLInputObjectType({
+          name: 'SomeInputObject',
+          fields: {
+            f: {
+              type: GraphQLString,
+              resolve: {},
+            },
+          },
+        }),
+      ),
+    ).to.throw(
+      'SomeInputObject.f field type has a resolve property,' +
+        ' but Input Types cannot define resolvers.',
+    );
   });
 });
 
-
 describe('Type System: Object types must be assertable', () => {
-
   it('accepts an Object type with an isTypeOf function', () => {
     expect(() => {
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'AnotherObject',
-        isTypeOf: () => true,
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'AnotherObject',
+          isTypeOf: () => true,
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).not.to.throw();
   });
 
   it('rejects an Object type with an incorrect type for isTypeOf', () => {
     expect(() => {
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'AnotherObject',
-        isTypeOf: {},
-        fields: { f: { type: GraphQLString } }
-      }));
-    }).to.throw(
-      'AnotherObject must provide "isTypeOf" as a function.'
-    );
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'AnotherObject',
+          isTypeOf: {},
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
+    }).to.throw('AnotherObject must provide "isTypeOf" as a function.');
   });
-
 });
 
-
 describe('Type System: Interface types must be resolvable', () => {
-
   it('accepts an Interface type defining resolveType', () => {
     expect(() => {
       const AnotherInterfaceType = new GraphQLInterfaceType({
         name: 'AnotherInterface',
         resolveType: () => null,
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces: [ AnotherInterfaceType ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: [AnotherInterfaceType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).not.to.throw();
   });
 
@@ -925,15 +964,17 @@ describe('Type System: Interface types must be resolvable', () => {
     expect(() => {
       const InterfaceTypeWithoutResolveType = new GraphQLInterfaceType({
         name: 'InterfaceTypeWithoutResolveType',
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        isTypeOf: () => true,
-        interfaces: [ InterfaceTypeWithoutResolveType ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          isTypeOf: () => true,
+          interfaces: [InterfaceTypeWithoutResolveType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).not.to.throw();
   });
 
@@ -942,284 +983,299 @@ describe('Type System: Interface types must be resolvable', () => {
       const AnotherInterfaceType = new GraphQLInterfaceType({
         name: 'AnotherInterface',
         resolveType: () => null,
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        isTypeOf: () => true,
-        interfaces: [ AnotherInterfaceType ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          isTypeOf: () => true,
+          interfaces: [AnotherInterfaceType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).not.to.throw();
   });
 
   it('rejects an Interface type with an incorrect type for resolveType', () => {
-    expect(() =>
-      new GraphQLInterfaceType({
-        name: 'AnotherInterface',
-        resolveType: {},
-        fields: { f: { type: GraphQLString } }
-      })
-    ).to.throw(
-      'AnotherInterface must provide "resolveType" as a function.'
-    );
+    expect(
+      () =>
+        new GraphQLInterfaceType({
+          name: 'AnotherInterface',
+          resolveType: {},
+          fields: { f: { type: GraphQLString } },
+        }),
+    ).to.throw('AnotherInterface must provide "resolveType" as a function.');
   });
 
   it('rejects an Interface type not defining resolveType with implementing type not defining isTypeOf', () => {
     expect(() => {
       const InterfaceTypeWithoutResolveType = new GraphQLInterfaceType({
         name: 'InterfaceTypeWithoutResolveType',
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
-      schemaWithFieldType(new GraphQLObjectType({
-        name: 'SomeObject',
-        interfaces: [ InterfaceTypeWithoutResolveType ],
-        fields: { f: { type: GraphQLString } }
-      }));
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: [InterfaceTypeWithoutResolveType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
     }).to.throw(
       'Interface Type InterfaceTypeWithoutResolveType does not provide a ' +
-      '"resolveType" function and implementing Type SomeObject does not ' +
-      'provide a "isTypeOf" function. ' +
-      'There is no way to resolve this implementing type during execution.'
+        '"resolveType" function and implementing Type SomeObject does not ' +
+        'provide a "isTypeOf" function. ' +
+        'There is no way to resolve this implementing type during execution.',
     );
   });
-
 });
 
-
 describe('Type System: Union types must be resolvable', () => {
-
   it('accepts a Union type defining resolveType', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: [ SomeObjectType ],
-      }))
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: [SomeObjectType],
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts a Union of Object types defining isTypeOf', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        types: [ ObjectWithIsTypeOf ],
-      }))
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: [ObjectWithIsTypeOf],
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('accepts a Union type defining resolveType of Object types defining isTypeOf', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: () => null,
-        types: [ ObjectWithIsTypeOf ],
-      }))
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: () => null,
+          types: [ObjectWithIsTypeOf],
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects an Interface type with an incorrect type for resolveType', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        resolveType: {},
-        types: [ ObjectWithIsTypeOf ],
-      }))
-    ).to.throw(
-      'SomeUnion must provide "resolveType" as a function.'
-    );
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: {},
+          types: [ObjectWithIsTypeOf],
+        }),
+      ),
+    ).to.throw('SomeUnion must provide "resolveType" as a function.');
   });
 
   it('rejects a Union type not defining resolveType of Object types not defining isTypeOf', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLUnionType({
-        name: 'SomeUnion',
-        types: [ SomeObjectType ],
-      }))
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: [SomeObjectType],
+        }),
+      ),
     ).to.throw(
       'Union type "SomeUnion" does not provide a "resolveType" function and ' +
-      'possible type "SomeObject" does not provide an "isTypeOf" function. ' +
-      'There is no way to resolve this possible type during execution.'
+        'possible type "SomeObject" does not provide an "isTypeOf" function. ' +
+        'There is no way to resolve this possible type during execution.',
     );
   });
-
 });
 
-
 describe('Type System: Scalar types must be serializable', () => {
-
   it('accepts a Scalar type defining serialize', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-        serialize: () => null,
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects a Scalar type not defining serialize', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+        }),
+      ),
     ).to.throw(
       'SomeScalar must provide "serialize" function. If this custom Scalar ' +
-      'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
-      'functions are also provided.'
+        'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
+        'functions are also provided.',
     );
   });
 
   it('rejects a Scalar type defining serialize with an incorrect type', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-        serialize: {}
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: {},
+        }),
+      ),
     ).to.throw(
       'SomeScalar must provide "serialize" function. If this custom Scalar ' +
-      'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
-      'functions are also provided.'
+        'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
+        'functions are also provided.',
     );
   });
 
   it('accepts a Scalar type defining parseValue and parseLiteral', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-        serialize: () => null,
-        parseValue: () => null,
-        parseLiteral: () => null,
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseValue: () => null,
+          parseLiteral: () => null,
+        }),
+      ),
     ).not.to.throw();
   });
 
   it('rejects a Scalar type defining parseValue but not parseLiteral', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-        serialize: () => null,
-        parseValue: () => null,
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseValue: () => null,
+        }),
+      ),
     ).to.throw(
-      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.'
+      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
     );
   });
 
   it('rejects a Scalar type defining parseLiteral but not parseValue', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-        serialize: () => null,
-        parseLiteral: () => null,
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseLiteral: () => null,
+        }),
+      ),
     ).to.throw(
-      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.'
+      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
     );
   });
 
   it('rejects a Scalar type defining parseValue and parseLiteral with an incorrect type', () => {
     expect(() =>
-      schemaWithFieldType(new GraphQLScalarType({
-        name: 'SomeScalar',
-        serialize: () => null,
-        parseValue: {},
-        parseLiteral: {},
-      }))
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseValue: {},
+          parseLiteral: {},
+        }),
+      ),
     ).to.throw(
-      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.'
+      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
     );
   });
-
 });
 
-
 describe('Type System: Enum types must be well defined', () => {
-
   it('accepts a well defined Enum type with empty value definition', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {
-          FOO: {},
-          BAR: {},
-        }
-      })
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {
+            FOO: {},
+            BAR: {},
+          },
+        }),
     ).not.to.throw();
   });
 
   it('accepts a well defined Enum type with internal value definition', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {
-          FOO: { value: 10 },
-          BAR: { value: 20 },
-        }
-      })
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {
+            FOO: { value: 10 },
+            BAR: { value: 20 },
+          },
+        }),
     ).not.to.throw();
   });
 
   it('rejects an Enum type without values', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-      })
-    ).to.throw(
-      'SomeEnum values must be an object with value names as keys.'
-    );
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+        }),
+    ).to.throw('SomeEnum values must be an object with value names as keys.');
   });
 
   it('rejects an Enum type with empty values', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {}
-      })
-    ).to.throw(
-      'SomeEnum values must be an object with value names as keys.'
-    );
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {},
+        }),
+    ).to.throw('SomeEnum values must be an object with value names as keys.');
   });
 
   it('rejects an Enum type with incorrectly typed values', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: [
-          { FOO: 10 }
-        ]
-      })
-    ).to.throw(
-      'SomeEnum values must be an object with value names as keys.'
-    );
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: [{ FOO: 10 }],
+        }),
+    ).to.throw('SomeEnum values must be an object with value names as keys.');
   });
 
   it('rejects an Enum type with missing value definition', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {
-          FOO: null
-        }
-      })
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {
+            FOO: null,
+          },
+        }),
     ).to.throw(
       'SomeEnum.FOO must refer to an object with a "value" key representing ' +
-      'an internal value but got: null.'
+        'an internal value but got: null.',
     );
   });
 
   it('rejects an Enum type with incorrectly typed value definition', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {
-          FOO: 10
-        }
-      })
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {
+            FOO: 10,
+          },
+        }),
     ).to.throw(
       'SomeEnum.FOO must refer to an object with a "value" key representing ' +
-      'an internal value but got: 10.'
+        'an internal value but got: 10.',
     );
   });
 
@@ -1228,58 +1284,60 @@ describe('Type System: Enum types must be well defined', () => {
       return new GraphQLEnumType({
         name: 'SomeEnum',
         values: {
-          [name]: {}
-        }
+          [name]: {},
+        },
       });
     }
 
-    expect(() => enumValue('#value')
-    ).to.throw('Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.');
+    expect(() => enumValue('#value')).to.throw(
+      'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.',
+    );
 
-    expect(() => enumValue('true')
-    ).to.throw('Name "true" can not be used as an Enum value.');
+    expect(() => enumValue('true')).to.throw(
+      'Name "true" can not be used as an Enum value.',
+    );
 
-    expect(() => enumValue('false')
-    ).to.throw('Name "false" can not be used as an Enum value.');
+    expect(() => enumValue('false')).to.throw(
+      'Name "false" can not be used as an Enum value.',
+    );
 
-    expect(() => enumValue('null')
-    ).to.throw('Name "null" can not be used as an Enum value.');
-  });
-
-  it('does not allow isDeprecated without deprecationReason on enum', () => {
-    expect(() =>
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {
-          value: { isDeprecated: true }
-        }
-      })
-    ).to.throw(
-      'SomeEnum.value should provide "deprecationReason" instead ' +
-      'of "isDeprecated".'
+    expect(() => enumValue('null')).to.throw(
+      'Name "null" can not be used as an Enum value.',
     );
   });
 
+  it('does not allow isDeprecated without deprecationReason on enum', () => {
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {
+            value: { isDeprecated: true },
+          },
+        }),
+    ).to.throw(
+      'SomeEnum.value should provide "deprecationReason" instead ' +
+        'of "isDeprecated".',
+    );
+  });
 });
 
-
 describe('Type System: Object fields must have output types', () => {
-
   function schemaWithObjectFieldOfType(fieldType) {
     const BadObjectType = new GraphQLObjectType({
       name: 'BadObject',
       fields: {
-        badField: { type: fieldType }
-      }
+        badField: { type: fieldType },
+      },
     });
 
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          f: { type: BadObjectType }
-        }
-      })
+          f: { type: BadObjectType },
+        },
+      }),
     });
   }
 
@@ -1291,41 +1349,38 @@ describe('Type System: Object fields must have output types', () => {
 
   it('rejects an empty Object field type', () => {
     expect(() => schemaWithObjectFieldOfType(undefined)).to.throw(
-      'BadObject.badField field type must be Output Type but got: undefined.'
+      'BadObject.badField field type must be Output Type but got: undefined.',
     );
   });
 
   notOutputTypes.forEach(type => {
     it(`rejects a non-output type as an Object field type: ${type}`, () => {
       expect(() => schemaWithObjectFieldOfType(type)).to.throw(
-        `BadObject.badField field type must be Output Type but got: ${type}.`
+        `BadObject.badField field type must be Output Type but got: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: Object fields must have valid resolve values', () => {
-
   function schemaWithObjectWithFieldResolver(resolveValue) {
     const BadResolverType = new GraphQLObjectType({
       name: 'BadResolver',
       fields: {
         badField: {
           type: GraphQLString,
-          resolve: resolveValue
-        }
-      }
+          resolve: resolveValue,
+        },
+      },
     });
 
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          f: { type: BadResolverType }
-        }
-      })
+          f: { type: BadResolverType },
+        },
+      }),
     });
   }
 
@@ -1336,36 +1391,34 @@ describe('Type System: Object fields must have valid resolve values', () => {
   it('rejects an empty Object field resolver', () => {
     expect(() => schemaWithObjectWithFieldResolver({})).to.throw(
       'BadResolver.badField field resolver must be a function if provided, ' +
-      'but got: [object Object].'
+        'but got: [object Object].',
     );
   });
 
   it('rejects a constant scalar value resolver', () => {
     expect(() => schemaWithObjectWithFieldResolver(0)).to.throw(
       'BadResolver.badField field resolver must be a function if provided, ' +
-      'but got: 0.'
+        'but got: 0.',
     );
   });
 });
 
-
 describe('Type System: Objects can only implement interfaces', () => {
-
   function schemaWithObjectImplementingType(implementedType) {
     const BadObjectType = new GraphQLObjectType({
       name: 'BadObject',
-      interfaces: [ implementedType ],
-      fields: { f: { type: GraphQLString } }
+      interfaces: [implementedType],
+      fields: { f: { type: GraphQLString } },
     });
 
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          f: { type: BadObjectType }
-        }
+          f: { type: BadObjectType },
+        },
       }),
-      types: [ BadObjectType ]
+      types: [BadObjectType],
     });
   }
 
@@ -1374,7 +1427,7 @@ describe('Type System: Objects can only implement interfaces', () => {
       const AnotherInterfaceType = new GraphQLInterfaceType({
         name: 'AnotherInterface',
         resolveType: () => null,
-        fields: { f: { type: GraphQLString } }
+        fields: { f: { type: GraphQLString } },
       });
 
       schemaWithObjectImplementingType(AnotherInterfaceType);
@@ -1392,37 +1445,32 @@ describe('Type System: Objects can only implement interfaces', () => {
   notInterfaceTypes.forEach(type => {
     it(`rejects an Object implementing a non-Interface type: ${type}`, () => {
       expect(() => schemaWithObjectImplementingType(type)).to.throw(
-        `BadObject may only implement Interface types, it cannot implement: ${type}.`
+        `BadObject may only implement Interface types, it cannot implement: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: Unions must represent Object types', () => {
-
   function schemaWithUnionOfType(type) {
     const BadUnionType = new GraphQLUnionType({
       name: 'BadUnion',
       resolveType: () => null,
-      types: [ type ],
+      types: [type],
     });
 
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          f: { type: BadUnionType }
-        }
-      })
+          f: { type: BadUnionType },
+        },
+      }),
     });
   }
 
   it('accepts a Union of an Object Type', () => {
-    expect(() =>
-      schemaWithUnionOfType(SomeObjectType)
-    ).not.to.throw();
+    expect(() => schemaWithUnionOfType(SomeObjectType)).not.to.throw();
   });
 
   const notObjectTypes = withModifiers([
@@ -1436,31 +1484,28 @@ describe('Type System: Unions must represent Object types', () => {
   notObjectTypes.forEach(type => {
     it(`rejects a Union of a non-Object type: ${type}`, () => {
       expect(() => schemaWithUnionOfType(type)).to.throw(
-        `BadUnion may only contain Object types, it cannot contain: ${type}.`
+        `BadUnion may only contain Object types, it cannot contain: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: Interface fields must have output types', () => {
-
   function schemaWithInterfaceFieldOfType(fieldType) {
     const BadInterfaceType = new GraphQLInterfaceType({
       name: 'BadInterface',
       fields: {
-        badField: { type: fieldType }
-      }
+        badField: { type: fieldType },
+      },
     });
 
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          f: { type: BadInterfaceType }
-        }
-      })
+          f: { type: BadInterfaceType },
+        },
+      }),
     });
   }
 
@@ -1472,23 +1517,20 @@ describe('Type System: Interface fields must have output types', () => {
 
   it('rejects an empty Interface field type', () => {
     expect(() => schemaWithInterfaceFieldOfType(undefined)).to.throw(
-      'BadInterface.badField field type must be Output Type but got: undefined.'
+      'BadInterface.badField field type must be Output Type but got: undefined.',
     );
   });
 
   notOutputTypes.forEach(type => {
     it(`rejects a non-output type as an Interface field type: ${type}`, () => {
       expect(() => schemaWithInterfaceFieldOfType(type)).to.throw(
-        `BadInterface.badField field type must be Output Type but got: ${type}.`
+        `BadInterface.badField field type must be Output Type but got: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: Field arguments must have input types', () => {
-
   function schemaWithArgOfType(argType) {
     const BadObjectType = new GraphQLObjectType({
       name: 'BadObject',
@@ -1496,19 +1538,19 @@ describe('Type System: Field arguments must have input types', () => {
         badField: {
           type: GraphQLString,
           args: {
-            badArg: { type: argType }
-          }
-        }
-      }
+            badArg: { type: argType },
+          },
+        },
+      },
     });
 
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          f: { type: BadObjectType }
-        }
-      })
+          f: { type: BadObjectType },
+        },
+      }),
     });
   }
 
@@ -1520,29 +1562,26 @@ describe('Type System: Field arguments must have input types', () => {
 
   it('rejects an empty field arg type', () => {
     expect(() => schemaWithArgOfType(undefined)).to.throw(
-      'BadObject.badField(badArg:) argument type must be Input Type but got: undefined.'
+      'BadObject.badField(badArg:) argument type must be Input Type but got: undefined.',
     );
   });
 
   notInputTypes.forEach(type => {
     it(`rejects a non-input type as a field arg type: ${type}`, () => {
       expect(() => schemaWithArgOfType(type)).to.throw(
-        `BadObject.badField(badArg:) argument type must be Input Type but got: ${type}.`
+        `BadObject.badField(badArg:) argument type must be Input Type but got: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: Input Object fields must have input types', () => {
-
   function schemaWithInputFieldOfType(inputFieldType) {
     const BadInputObjectType = new GraphQLInputObjectType({
       name: 'BadInputObject',
       fields: {
-        badField: { type: inputFieldType }
-      }
+        badField: { type: inputFieldType },
+      },
     });
 
     return new GraphQLSchema({
@@ -1552,11 +1591,11 @@ describe('Type System: Input Object fields must have input types', () => {
           f: {
             type: GraphQLString,
             args: {
-              badArg: { type: BadInputObjectType }
-            }
-          }
-        }
-      })
+              badArg: { type: BadInputObjectType },
+            },
+          },
+        },
+      }),
     });
   }
 
@@ -1568,23 +1607,20 @@ describe('Type System: Input Object fields must have input types', () => {
 
   it('rejects an empty input field type', () => {
     expect(() => schemaWithInputFieldOfType(undefined)).to.throw(
-      'BadInputObject.badField field type must be Input Type but got: undefined.'
+      'BadInputObject.badField field type must be Input Type but got: undefined.',
     );
   });
 
   notInputTypes.forEach(type => {
     it(`rejects a non-input type as an input field type: ${type}`, () => {
       expect(() => schemaWithInputFieldOfType(type)).to.throw(
-        `BadInputObject.badField field type must be Input Type but got: ${type}.`
+        `BadInputObject.badField field type must be Input Type but got: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: List must accept GraphQL types', () => {
-
   const types = withModifiers([
     GraphQLString,
     SomeScalarType,
@@ -1595,12 +1631,7 @@ describe('Type System: List must accept GraphQL types', () => {
     SomeInputObjectType,
   ]);
 
-  const notTypes = [
-    {},
-    String,
-    undefined,
-    null,
-  ];
+  const notTypes = [{}, String, undefined, null];
 
   types.forEach(type => {
     it(`accepts an type as item type of list: ${type}`, () => {
@@ -1611,16 +1642,13 @@ describe('Type System: List must accept GraphQL types', () => {
   notTypes.forEach(type => {
     it(`rejects a non-type as item type of list: ${type}`, () => {
       expect(() => new GraphQLList(type)).to.throw(
-        `Can only create List of a GraphQLType but got: ${type}.`
+        `Can only create List of a GraphQLType but got: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Type System: NonNull must accept GraphQL types', () => {
-
   const nullableTypes = [
     GraphQLString,
     SomeScalarType,
@@ -1650,16 +1678,13 @@ describe('Type System: NonNull must accept GraphQL types', () => {
   notNullableTypes.forEach(type => {
     it(`rejects a non-type as nullable type of non-null: ${type}`, () => {
       expect(() => new GraphQLNonNull(type)).to.throw(
-        `Can only create NonNull of a Nullable GraphQLType but got: ${type}.`
+        `Can only create NonNull of a Nullable GraphQLType but got: ${type}.`,
       );
     });
   });
-
 });
 
-
 describe('Objects must adhere to Interface they implement', () => {
-
   it('accepts an Object which implements an Interface', () => {
     expect(() => {
       const AnotherInterface = new GraphQLInterfaceType({
@@ -1669,23 +1694,23 @@ describe('Objects must adhere to Interface they implement', () => {
           field: {
             type: GraphQLString,
             args: {
-              input: { type: GraphQLString }
-            }
-          }
-        }
+              input: { type: GraphQLString },
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
           field: {
             type: GraphQLString,
             args: {
-              input: { type: GraphQLString }
-            }
-          }
-        }
+              input: { type: GraphQLString },
+            },
+          },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -1702,23 +1727,23 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
           field: {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
+            },
           },
-          anotherfield: { type: GraphQLString }
-        }
+          anotherfield: { type: GraphQLString },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -1735,23 +1760,23 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
           field: {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
               anotherInput: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -1768,29 +1793,29 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
           field: {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
               anotherInput: { type: new GraphQLNonNull(GraphQLString) },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherObject.field(anotherInput:) is of required type "String!" but ' +
-      'is not also provided by the interface AnotherInterface.field.'
+        'is not also provided by the interface AnotherInterface.field.',
     );
   });
 
@@ -1804,23 +1829,23 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          anotherfield: { type: GraphQLString }
-        }
+          anotherfield: { type: GraphQLString },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       '"AnotherInterface" expects field "field" but ' +
-      '"AnotherObject" does not provide it.'
+        '"AnotherObject" does not provide it.',
     );
   });
 
@@ -1830,22 +1855,22 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: SomeScalarType }
-        }
+          field: { type: SomeScalarType },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field expects type "String" but ' +
-      'AnotherObject.field provides type "SomeScalar".'
+        'AnotherObject.field provides type "SomeScalar".',
     );
   });
 
@@ -1854,37 +1879,37 @@ describe('Objects must adhere to Interface they implement', () => {
       const TypeA = new GraphQLObjectType({
         name: 'A',
         fields: {
-          foo: { type: GraphQLString }
-        }
+          foo: { type: GraphQLString },
+        },
       });
 
       const TypeB = new GraphQLObjectType({
         name: 'B',
         fields: {
-          foo: { type: GraphQLString }
-        }
+          foo: { type: GraphQLString },
+        },
       });
 
       const AnotherInterface = new GraphQLInterfaceType({
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: TypeA }
-        }
+          field: { type: TypeA },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: TypeB }
-        }
+          field: { type: TypeB },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field expects type "A" but ' +
-      'AnotherObject.field provides type "B".'
+        'AnotherObject.field provides type "B".',
     );
   });
 
@@ -1894,16 +1919,16 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: () => ({
-          field: { type: AnotherInterface }
-        })
+          field: { type: AnotherInterface },
+        }),
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: () => ({
-          field: { type: AnotherObject }
-        })
+          field: { type: AnotherObject },
+        }),
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -1916,16 +1941,16 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: SomeUnionType }
-        }
+          field: { type: SomeUnionType },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: SomeObjectType }
-        }
+          field: { type: SomeObjectType },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -1942,25 +1967,25 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
           field: {
             type: GraphQLString,
-          }
-        }
+          },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field expects argument "input" but ' +
-      'AnotherObject.field does not provide it.'
+        'AnotherObject.field does not provide it.',
     );
   });
 
@@ -1974,28 +1999,28 @@ describe('Objects must adhere to Interface they implement', () => {
             type: GraphQLString,
             args: {
               input: { type: GraphQLString },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
           field: {
             type: GraphQLString,
             args: {
               input: { type: SomeScalarType },
-            }
-          }
-        }
+            },
+          },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field(input:) expects type "String" but ' +
-      'AnotherObject.field(input:) provides type "SomeScalar".'
+        'AnotherObject.field(input:) provides type "SomeScalar".',
     );
   });
 
@@ -2005,16 +2030,16 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) }
-        }
+          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) }
-        }
+          field: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -2027,22 +2052,22 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: new GraphQLList(GraphQLString) }
-        }
+          field: { type: new GraphQLList(GraphQLString) },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field expects type "[String]" but ' +
-      'AnotherObject.field provides type "String".'
+        'AnotherObject.field provides type "String".',
     );
   });
 
@@ -2052,22 +2077,22 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: new GraphQLList(GraphQLString) }
-        }
+          field: { type: new GraphQLList(GraphQLString) },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field expects type "String" but ' +
-      'AnotherObject.field provides type "[String]".'
+        'AnotherObject.field provides type "[String]".',
     );
   });
 
@@ -2077,16 +2102,16 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: new GraphQLNonNull(GraphQLString) }
-        }
+          field: { type: new GraphQLNonNull(GraphQLString) },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
@@ -2099,22 +2124,22 @@ describe('Objects must adhere to Interface they implement', () => {
         name: 'AnotherInterface',
         resolveType: () => null,
         fields: {
-          field: { type: new GraphQLNonNull(GraphQLString) }
-        }
+          field: { type: new GraphQLNonNull(GraphQLString) },
+        },
       });
 
       const AnotherObject = new GraphQLObjectType({
         name: 'AnotherObject',
-        interfaces: [ AnotherInterface ],
+        interfaces: [AnotherInterface],
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
 
       return schemaWithFieldType(AnotherObject);
     }).to.throw(
       'AnotherInterface.field expects type "String!" but ' +
-      'AnotherObject.field provides type "String".'
+        'AnotherObject.field provides type "String".',
     );
   });
 
@@ -2125,16 +2150,15 @@ describe('Objects must adhere to Interface they implement', () => {
         fields: {
           field: {
             type: GraphQLString,
-            isDeprecated: true
-          }
-        }
+            isDeprecated: true,
+          },
+        },
       });
 
       return schemaWithFieldType(OldObject);
     }).to.throw(
       'OldObject.field should provide "deprecationReason" instead ' +
-      'of "isDeprecated".'
+        'of "isDeprecated".',
     );
   });
-
 });

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -9,7 +9,7 @@
 
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
-import type {ObjMap} from '../jsutils/ObjMap';
+import type { ObjMap } from '../jsutils/ObjMap';
 import * as Kind from '../language/kinds';
 import { assertValidName } from '../utilities/assertValidName';
 import type {
@@ -30,21 +30,20 @@ import type {
 } from '../language/ast';
 import type { GraphQLSchema } from './schema';
 
-
 // Predicates & Assertions
 
 /**
  * These are all of the possible kinds of types.
  */
 export type GraphQLType =
-  GraphQLScalarType |
-  GraphQLObjectType |
-  GraphQLInterfaceType |
-  GraphQLUnionType |
-  GraphQLEnumType |
-  GraphQLInputObjectType |
-  GraphQLList<any> |
-  GraphQLNonNull<any>;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<any>
+  | GraphQLNonNull<any>;
 
 export function isType(type: mixed): boolean {
   return (
@@ -60,10 +59,7 @@ export function isType(type: mixed): boolean {
 }
 
 export function assertType(type: mixed): GraphQLType {
-  invariant(
-    isType(type),
-    `Expected ${String(type)} to be a GraphQL type.`
-  );
+  invariant(isType(type), `Expected ${String(type)} to be a GraphQL type.`);
   return (type: any);
 }
 
@@ -71,16 +67,16 @@ export function assertType(type: mixed): GraphQLType {
  * These types may be used as input types for arguments and directives.
  */
 type GraphQLInputType_<T> =
-  GraphQLScalarType |
-  GraphQLEnumType |
-  GraphQLInputObjectType |
-  GraphQLList<T> |
-  GraphQLNonNull<
-    GraphQLScalarType |
-    GraphQLEnumType |
-    GraphQLInputObjectType |
-    GraphQLList<T>
-  >;
+  | GraphQLScalarType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<T>
+  | GraphQLNonNull<
+      | GraphQLScalarType
+      | GraphQLEnumType
+      | GraphQLInputObjectType
+      | GraphQLList<T>,
+    >;
 export type GraphQLInputType = GraphQLInputType_<*>;
 
 export function isInputType(type: ?GraphQLType): boolean %checks {
@@ -88,15 +84,15 @@ export function isInputType(type: ?GraphQLType): boolean %checks {
     type instanceof GraphQLScalarType ||
     type instanceof GraphQLEnumType ||
     type instanceof GraphQLInputObjectType ||
-    type instanceof GraphQLNonNull && isInputType(type.ofType) ||
-    type instanceof GraphQLList && isInputType(type.ofType)
+    (type instanceof GraphQLNonNull && isInputType(type.ofType)) ||
+    (type instanceof GraphQLList && isInputType(type.ofType))
   );
 }
 
 export function assertInputType(type: ?GraphQLType): GraphQLInputType {
   invariant(
     isInputType(type),
-    `Expected ${String(type)} to be a GraphQL input type.`
+    `Expected ${String(type)} to be a GraphQL input type.`,
   );
   return type;
 }
@@ -105,20 +101,20 @@ export function assertInputType(type: ?GraphQLType): GraphQLInputType {
  * These types may be used as output types as the result of fields.
  */
 export type GraphQLOutputType =
-  GraphQLScalarType |
-  GraphQLObjectType |
-  GraphQLInterfaceType |
-  GraphQLUnionType |
-  GraphQLEnumType |
-  GraphQLList<GraphQLOutputType> |
-  GraphQLNonNull<
-    GraphQLScalarType |
-    GraphQLObjectType |
-    GraphQLInterfaceType |
-    GraphQLUnionType |
-    GraphQLEnumType |
-    GraphQLList<GraphQLOutputType>
-  >;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLList<GraphQLOutputType>
+  | GraphQLNonNull<
+      | GraphQLScalarType
+      | GraphQLObjectType
+      | GraphQLInterfaceType
+      | GraphQLUnionType
+      | GraphQLEnumType
+      | GraphQLList<GraphQLOutputType>,
+    >;
 
 export function isOutputType(type: ?GraphQLType): boolean %checks {
   return (
@@ -127,8 +123,8 @@ export function isOutputType(type: ?GraphQLType): boolean %checks {
     type instanceof GraphQLInterfaceType ||
     type instanceof GraphQLUnionType ||
     type instanceof GraphQLEnumType ||
-    type instanceof GraphQLNonNull && isOutputType(type.ofType) ||
-    type instanceof GraphQLList && isOutputType(type.ofType)
+    (type instanceof GraphQLNonNull && isOutputType(type.ofType)) ||
+    (type instanceof GraphQLList && isOutputType(type.ofType))
   );
 }
 
@@ -143,15 +139,10 @@ export function assertOutputType(type: ?GraphQLType): GraphQLOutputType {
 /**
  * These types may describe types which may be leaf values.
  */
-export type GraphQLLeafType =
-  GraphQLScalarType |
-  GraphQLEnumType;
+export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
 
 export function isLeafType(type: ?GraphQLType): boolean %checks {
-  return (
-    type instanceof GraphQLScalarType ||
-    type instanceof GraphQLEnumType
-  );
+  return type instanceof GraphQLScalarType || type instanceof GraphQLEnumType;
 }
 
 export function assertLeafType(type: ?GraphQLType): GraphQLLeafType {
@@ -166,9 +157,9 @@ export function assertLeafType(type: ?GraphQLType): GraphQLLeafType {
  * These types may describe the parent context of a selection set.
  */
 export type GraphQLCompositeType =
-  GraphQLObjectType |
-  GraphQLInterfaceType |
-  GraphQLUnionType;
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType;
 
 export function isCompositeType(type: ?GraphQLType): boolean %checks {
   return (
@@ -189,14 +180,11 @@ export function assertCompositeType(type: ?GraphQLType): GraphQLCompositeType {
 /**
  * These types may describe the parent context of a selection set.
  */
-export type GraphQLAbstractType =
-  GraphQLInterfaceType |
-  GraphQLUnionType;
+export type GraphQLAbstractType = GraphQLInterfaceType | GraphQLUnionType;
 
 export function isAbstractType(type: ?GraphQLType): boolean %checks {
   return (
-    type instanceof GraphQLInterfaceType ||
-    type instanceof GraphQLUnionType
+    type instanceof GraphQLInterfaceType || type instanceof GraphQLUnionType
   );
 }
 
@@ -212,17 +200,17 @@ export function assertAbstractType(type: ?GraphQLType): GraphQLAbstractType {
  * These types can all accept null as a value.
  */
 type GraphQLNullableType_<T> =
-  GraphQLScalarType |
-  GraphQLObjectType |
-  GraphQLInterfaceType |
-  GraphQLUnionType |
-  GraphQLEnumType |
-  GraphQLInputObjectType |
-  GraphQLList<T>;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLInputObjectType
+  | GraphQLList<T>;
 export type GraphQLNullableType = GraphQLNullableType_<*>;
 
 export function getNullableType<T: GraphQLType>(
-  type: ?T
+  type: ?T,
 ): ?(T & GraphQLNullableType) {
   return type instanceof GraphQLNonNull ? type.ofType : type;
 }
@@ -231,12 +219,12 @@ export function getNullableType<T: GraphQLType>(
  * These named types do not include modifiers like List or NonNull.
  */
 export type GraphQLNamedType =
-  GraphQLScalarType |
-  GraphQLObjectType |
-  GraphQLInterfaceType |
-  GraphQLUnionType |
-  GraphQLEnumType |
-  GraphQLInputObjectType;
+  | GraphQLScalarType
+  | GraphQLObjectType
+  | GraphQLInterfaceType
+  | GraphQLUnionType
+  | GraphQLEnumType
+  | GraphQLInputObjectType;
 
 export function isNamedType(type: ?GraphQLType): boolean %checks {
   return (
@@ -261,7 +249,7 @@ export function assertNamedType(type: ?GraphQLType): GraphQLNamedType {
 declare function getNamedType(type: void | null): void;
 declare function getNamedType(type: GraphQLType): GraphQLNamedType;
 export function getNamedType(type) {
-/* eslint-enable no-redeclare */
+  /* eslint-enable no-redeclare */
   if (type) {
     let unmodifiedType = type;
     while (
@@ -274,7 +262,6 @@ export function getNamedType(type) {
   }
 }
 
-
 /**
  * Used while defining GraphQL types to allow for circular references in
  * otherwise immutable type definitions.
@@ -284,7 +271,6 @@ export type Thunk<T> = (() => T) | T;
 function resolveThunk<T>(thunk: Thunk<T>): T {
   return typeof thunk === 'function' ? thunk() : thunk;
 }
-
 
 /**
  * Scalar Type Definition
@@ -318,15 +304,15 @@ export class GraphQLScalarType {
     invariant(
       typeof config.serialize === 'function',
       `${this.name} must provide "serialize" function. If this custom Scalar ` +
-      'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
-      'functions are also provided.'
+        'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
+        'functions are also provided.',
     );
     if (config.parseValue || config.parseLiteral) {
       invariant(
         typeof config.parseValue === 'function' &&
-        typeof config.parseLiteral === 'function',
+          typeof config.parseLiteral === 'function',
         `${this.name} must provide both "parseValue" and "parseLiteral" ` +
-        'functions.'
+          'functions.',
       );
     }
     this._scalarConfig = config;
@@ -371,20 +357,17 @@ export class GraphQLScalarType {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLScalarType.prototype.toJSON =
-  GraphQLScalarType.prototype.inspect =
-    GraphQLScalarType.prototype.toString;
+GraphQLScalarType.prototype.toJSON = GraphQLScalarType.prototype.inspect =
+  GraphQLScalarType.prototype.toString;
 
 export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
-  name: string;
-  description?: ?string;
-  astNode?: ?ScalarTypeDefinitionNode;
-  serialize: (value: mixed) => ?TExternal;
-  parseValue?: (value: mixed) => ?TInternal;
-  parseLiteral?: (valueNode: ValueNode) => ?TInternal;
+  name: string,
+  description?: ?string,
+  astNode?: ?ScalarTypeDefinitionNode,
+  serialize: (value: mixed) => ?TExternal,
+  parseValue?: (value: mixed) => ?TInternal,
+  parseLiteral?: (valueNode: ValueNode) => ?TInternal,
 };
-
-
 
 /**
  * Object Type Definition
@@ -443,7 +426,7 @@ export class GraphQLObjectType {
     if (config.isTypeOf) {
       invariant(
         typeof config.isTypeOf === 'function',
-        `${this.name} must provide "isTypeOf" as a function.`
+        `${this.name} must provide "isTypeOf" as a function.`,
       );
     }
     this.isTypeOf = config.isTypeOf;
@@ -451,14 +434,16 @@ export class GraphQLObjectType {
   }
 
   getFields(): GraphQLFieldMap<*, *> {
-    return this._fields || (this._fields =
-      defineFieldMap(this, this._typeConfig.fields)
+    return (
+      this._fields ||
+      (this._fields = defineFieldMap(this, this._typeConfig.fields))
     );
   }
 
   getInterfaces(): Array<GraphQLInterfaceType> {
-    return this._interfaces || (this._interfaces =
-      defineInterfaces(this, this._typeConfig.interfaces)
+    return (
+      this._interfaces ||
+      (this._interfaces = defineInterfaces(this, this._typeConfig.interfaces))
     );
   }
 
@@ -471,13 +456,12 @@ export class GraphQLObjectType {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLObjectType.prototype.toJSON =
-  GraphQLObjectType.prototype.inspect =
-    GraphQLObjectType.prototype.toString;
+GraphQLObjectType.prototype.toJSON = GraphQLObjectType.prototype.inspect =
+  GraphQLObjectType.prototype.toString;
 
 function defineInterfaces(
   type: GraphQLObjectType,
-  interfacesThunk: Thunk<?Array<GraphQLInterfaceType>>
+  interfacesThunk: Thunk<?Array<GraphQLInterfaceType>>,
 ): Array<GraphQLInterfaceType> {
   const interfaces = resolveThunk(interfacesThunk);
   if (!interfaces) {
@@ -486,7 +470,7 @@ function defineInterfaces(
   invariant(
     Array.isArray(interfaces),
     `${type.name} interfaces must be an Array or a function which returns ` +
-    'an Array.'
+      'an Array.',
   );
 
   const implementedTypeNames = Object.create(null);
@@ -494,20 +478,20 @@ function defineInterfaces(
     invariant(
       iface instanceof GraphQLInterfaceType,
       `${type.name} may only implement Interface types, it cannot ` +
-      `implement: ${String(iface)}.`
+        `implement: ${String(iface)}.`,
     );
     invariant(
       !implementedTypeNames[iface.name],
-      `${type.name} may declare it implements ${iface.name} only once.`
+      `${type.name} may declare it implements ${iface.name} only once.`,
     );
     implementedTypeNames[iface.name] = true;
     if (typeof iface.resolveType !== 'function') {
       invariant(
         typeof type.isTypeOf === 'function',
         `Interface Type ${iface.name} does not provide a "resolveType" ` +
-        `function and implementing Type ${type.name} does not provide a ` +
-        '"isTypeOf" function. There is no way to resolve this implementing ' +
-        'type during execution.'
+          `function and implementing Type ${type.name} does not provide a ` +
+          '"isTypeOf" function. There is no way to resolve this implementing ' +
+          'type during execution.',
       );
     }
   });
@@ -516,20 +500,20 @@ function defineInterfaces(
 
 function defineFieldMap<TSource, TContext>(
   type: GraphQLNamedType,
-  fieldsThunk: Thunk<GraphQLFieldConfigMap<TSource, TContext>>
+  fieldsThunk: Thunk<GraphQLFieldConfigMap<TSource, TContext>>,
 ): GraphQLFieldMap<TSource, TContext> {
   const fieldMap = resolveThunk(fieldsThunk);
   invariant(
     isPlainObj(fieldMap),
     `${type.name} fields must be an object with field names as keys or a ` +
-    'function which returns such an object.'
+      'function which returns such an object.',
   );
 
   const fieldNames = Object.keys(fieldMap);
   invariant(
     fieldNames.length > 0,
     `${type.name} fields must be an object with field names as keys or a ` +
-    'function which returns such an object.'
+      'function which returns such an object.',
   );
 
   const resultFieldMap = Object.create(null);
@@ -538,27 +522,27 @@ function defineFieldMap<TSource, TContext>(
     const fieldConfig = fieldMap[fieldName];
     invariant(
       isPlainObj(fieldConfig),
-      `${type.name}.${fieldName} field config must be an object`
+      `${type.name}.${fieldName} field config must be an object`,
     );
     invariant(
       !fieldConfig.hasOwnProperty('isDeprecated'),
       `${type.name}.${fieldName} should provide "deprecationReason" instead ` +
-      'of "isDeprecated".'
+        'of "isDeprecated".',
     );
     const field = {
       ...fieldConfig,
       isDeprecated: Boolean(fieldConfig.deprecationReason),
-      name: fieldName
+      name: fieldName,
     };
     invariant(
       isOutputType(field.type),
       `${type.name}.${fieldName} field type must be Output Type but ` +
-      `got: ${String(field.type)}.`
+        `got: ${String(field.type)}.`,
     );
     invariant(
       isValidResolver(field.resolve),
       `${type.name}.${fieldName} field resolver must be a function if ` +
-      `provided, but got: ${String(field.resolve)}.`
+        `provided, but got: ${String(field.resolve)}.`,
     );
     const argsConfig = fieldConfig.args;
     if (!argsConfig) {
@@ -567,7 +551,7 @@ function defineFieldMap<TSource, TContext>(
       invariant(
         isPlainObj(argsConfig),
         `${type.name}.${fieldName} args must be an object with argument ` +
-        'names as keys.'
+          'names as keys.',
       );
       field.args = Object.keys(argsConfig).map(argName => {
         assertValidName(argName);
@@ -575,7 +559,7 @@ function defineFieldMap<TSource, TContext>(
         invariant(
           isInputType(arg.type),
           `${type.name}.${fieldName}(${argName}:) argument type must be ` +
-          `Input Type but got: ${String(arg.type)}.`
+            `Input Type but got: ${String(arg.type)}.`,
         );
         return {
           name: argName,
@@ -597,100 +581,100 @@ function isPlainObj(obj) {
 
 // If a resolver is defined, it must be a function.
 function isValidResolver(resolver: mixed): boolean {
-  return (resolver == null || typeof resolver === 'function');
+  return resolver == null || typeof resolver === 'function';
 }
 
 export type GraphQLObjectTypeConfig<TSource, TContext> = {
-  name: string;
-  interfaces?: Thunk<?Array<GraphQLInterfaceType>>;
-  fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
-  isTypeOf?: ?GraphQLIsTypeOfFn<TSource, TContext>;
-  description?: ?string;
-  isIntrospection?: boolean;
-  astNode?: ?ObjectTypeDefinitionNode;
-  extensionASTNodes?: ?Array<TypeExtensionDefinitionNode>;
+  name: string,
+  interfaces?: Thunk<?Array<GraphQLInterfaceType>>,
+  fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>,
+  isTypeOf?: ?GraphQLIsTypeOfFn<TSource, TContext>,
+  description?: ?string,
+  isIntrospection?: boolean,
+  astNode?: ?ObjectTypeDefinitionNode,
+  extensionASTNodes?: ?Array<TypeExtensionDefinitionNode>,
 };
 
 export type GraphQLTypeResolver<TSource, TContext> = (
   value: TSource,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => ?GraphQLObjectType | string | Promise<?GraphQLObjectType | string>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
   source: TSource,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => boolean | Promise<boolean>;
 
 export type GraphQLFieldResolver<TSource, TContext> = (
   source: TSource,
-  args: {[argument: string]: any},
+  args: { [argument: string]: any },
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => mixed;
 
 export type GraphQLResolveInfo = {
-  fieldName: string;
-  fieldNodes: Array<FieldNode>;
-  returnType: GraphQLOutputType;
-  parentType: GraphQLCompositeType;
-  path: ResponsePath;
-  schema: GraphQLSchema;
-  fragments: ObjMap<FragmentDefinitionNode>;
-  rootValue: mixed;
-  operation: OperationDefinitionNode;
-  variableValues: {[variable: string]: mixed};
+  fieldName: string,
+  fieldNodes: Array<FieldNode>,
+  returnType: GraphQLOutputType,
+  parentType: GraphQLCompositeType,
+  path: ResponsePath,
+  schema: GraphQLSchema,
+  fragments: ObjMap<FragmentDefinitionNode>,
+  rootValue: mixed,
+  operation: OperationDefinitionNode,
+  variableValues: { [variable: string]: mixed },
 };
 
 export type ResponsePath = { prev: ResponsePath, key: string | number } | void;
 
 export type GraphQLFieldConfig<TSource, TContext> = {
-  type: GraphQLOutputType;
-  args?: GraphQLFieldConfigArgumentMap;
-  resolve?: GraphQLFieldResolver<TSource, TContext>;
-  subscribe?: GraphQLFieldResolver<TSource, TContext>;
-  deprecationReason?: ?string;
-  description?: ?string;
-  astNode?: ?FieldDefinitionNode;
+  type: GraphQLOutputType,
+  args?: GraphQLFieldConfigArgumentMap,
+  resolve?: GraphQLFieldResolver<TSource, TContext>,
+  subscribe?: GraphQLFieldResolver<TSource, TContext>,
+  deprecationReason?: ?string,
+  description?: ?string,
+  astNode?: ?FieldDefinitionNode,
 };
 
 export type GraphQLFieldConfigArgumentMap = ObjMap<GraphQLArgumentConfig>;
 
 export type GraphQLArgumentConfig = {
-  type: GraphQLInputType;
-  defaultValue?: mixed;
-  description?: ?string;
-  astNode?: ?InputValueDefinitionNode;
+  type: GraphQLInputType,
+  defaultValue?: mixed,
+  description?: ?string,
+  astNode?: ?InputValueDefinitionNode,
 };
 
-export type GraphQLFieldConfigMap<TSource, TContext> =
-  ObjMap<GraphQLFieldConfig<TSource, TContext>>;
+export type GraphQLFieldConfigMap<TSource, TContext> = ObjMap<
+  GraphQLFieldConfig<TSource, TContext>,
+>;
 
 export type GraphQLField<TSource, TContext> = {
-  name: string;
-  description: ?string;
-  type: GraphQLOutputType;
-  args: Array<GraphQLArgument>;
-  resolve?: GraphQLFieldResolver<TSource, TContext>;
-  subscribe?: GraphQLFieldResolver<TSource, TContext>;
-  isDeprecated?: boolean;
-  deprecationReason?: ?string;
-  astNode?: ?FieldDefinitionNode;
+  name: string,
+  description: ?string,
+  type: GraphQLOutputType,
+  args: Array<GraphQLArgument>,
+  resolve?: GraphQLFieldResolver<TSource, TContext>,
+  subscribe?: GraphQLFieldResolver<TSource, TContext>,
+  isDeprecated?: boolean,
+  deprecationReason?: ?string,
+  astNode?: ?FieldDefinitionNode,
 };
 
 export type GraphQLArgument = {
-  name: string;
-  type: GraphQLInputType;
-  defaultValue?: mixed;
-  description?: ?string;
-  astNode?: ?InputValueDefinitionNode;
+  name: string,
+  type: GraphQLInputType,
+  defaultValue?: mixed,
+  description?: ?string,
+  astNode?: ?InputValueDefinitionNode,
 };
 
-export type GraphQLFieldMap<TSource, TContext> =
-  ObjMap<GraphQLField<TSource, TContext>>;
-
-
+export type GraphQLFieldMap<TSource, TContext> = ObjMap<
+  GraphQLField<TSource, TContext>,
+>;
 
 /**
  * Interface Type Definition
@@ -727,7 +711,7 @@ export class GraphQLInterfaceType {
     if (config.resolveType) {
       invariant(
         typeof config.resolveType === 'function',
-        `${this.name} must provide "resolveType" as a function.`
+        `${this.name} must provide "resolveType" as a function.`,
       );
     }
     this.resolveType = config.resolveType;
@@ -735,8 +719,10 @@ export class GraphQLInterfaceType {
   }
 
   getFields(): GraphQLFieldMap<*, *> {
-    return this._fields ||
-      (this._fields = defineFieldMap(this, this._typeConfig.fields));
+    return (
+      this._fields ||
+      (this._fields = defineFieldMap(this, this._typeConfig.fields))
+    );
   }
 
   toString(): string {
@@ -748,9 +734,8 @@ export class GraphQLInterfaceType {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLInterfaceType.prototype.toJSON =
-  GraphQLInterfaceType.prototype.inspect =
-    GraphQLInterfaceType.prototype.toString;
+GraphQLInterfaceType.prototype.toJSON = GraphQLInterfaceType.prototype.inspect =
+  GraphQLInterfaceType.prototype.toString;
 
 export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
   name: string,
@@ -764,8 +749,6 @@ export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
   description?: ?string,
   astNode?: ?InterfaceTypeDefinitionNode,
 };
-
-
 
 /**
  * Union Type Definition
@@ -807,7 +790,7 @@ export class GraphQLUnionType {
     if (config.resolveType) {
       invariant(
         typeof config.resolveType === 'function',
-        `${this.name} must provide "resolveType" as a function.`
+        `${this.name} must provide "resolveType" as a function.`,
       );
     }
     this.resolveType = config.resolveType;
@@ -815,8 +798,8 @@ export class GraphQLUnionType {
   }
 
   getTypes(): Array<GraphQLObjectType> {
-    return this._types || (this._types =
-      defineTypes(this, this._typeConfig.types)
+    return (
+      this._types || (this._types = defineTypes(this, this._typeConfig.types))
     );
   }
 
@@ -829,40 +812,39 @@ export class GraphQLUnionType {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLUnionType.prototype.toJSON =
-  GraphQLUnionType.prototype.inspect =
-    GraphQLUnionType.prototype.toString;
+GraphQLUnionType.prototype.toJSON = GraphQLUnionType.prototype.inspect =
+  GraphQLUnionType.prototype.toString;
 
 function defineTypes(
   unionType: GraphQLUnionType,
-  typesThunk: Thunk<Array<GraphQLObjectType>>
+  typesThunk: Thunk<Array<GraphQLObjectType>>,
 ): Array<GraphQLObjectType> {
   const types = resolveThunk(typesThunk);
 
   invariant(
     Array.isArray(types) && types.length > 0,
     'Must provide Array of types or a function which returns ' +
-    `such an array for Union ${unionType.name}.`
+      `such an array for Union ${unionType.name}.`,
   );
   const includedTypeNames = Object.create(null);
   types.forEach(objType => {
     invariant(
       objType instanceof GraphQLObjectType,
       `${unionType.name} may only contain Object types, it cannot contain: ` +
-      `${String(objType)}.`
+        `${String(objType)}.`,
     );
     invariant(
       !includedTypeNames[objType.name],
-      `${unionType.name} can include ${objType.name} type only once.`
+      `${unionType.name} can include ${objType.name} type only once.`,
     );
     includedTypeNames[objType.name] = true;
     if (typeof unionType.resolveType !== 'function') {
       invariant(
         typeof objType.isTypeOf === 'function',
         `Union type "${unionType.name}" does not provide a "resolveType" ` +
-        `function and possible type "${objType.name}" does not provide an ` +
-        '"isTypeOf" function. There is no way to resolve this possible type ' +
-        'during execution.'
+          `function and possible type "${objType.name}" does not provide an ` +
+          '"isTypeOf" function. There is no way to resolve this possible type ' +
+          'during execution.',
       );
     }
   });
@@ -878,12 +860,10 @@ export type GraphQLUnionTypeConfig<TSource, TContext> = {
    * the default implementation will call `isTypeOf` on each implementing
    * Object type.
    */
-  resolveType?: ?GraphQLTypeResolver<TSource, TContext>;
-  description?: ?string;
-  astNode?: ?UnionTypeDefinitionNode;
+  resolveType?: ?GraphQLTypeResolver<TSource, TContext>,
+  description?: ?string,
+  astNode?: ?UnionTypeDefinitionNode,
 };
-
-
 
 /**
  * Enum Type Definition
@@ -906,17 +886,17 @@ export type GraphQLUnionTypeConfig<TSource, TContext> = {
  * Note: If a value is not provided in a definition, the name of the enum value
  * will be used as its internal value.
  */
-export class GraphQLEnumType/* <T> */ {
+export class GraphQLEnumType /* <T> */ {
   name: string;
   description: ?string;
   astNode: ?EnumTypeDefinitionNode;
 
-  _enumConfig: GraphQLEnumTypeConfig/* <T> */;
-  _values: Array<GraphQLEnumValue/* <T> */>;
-  _valueLookup: Map<any/* T */, GraphQLEnumValue>;
+  _enumConfig: GraphQLEnumTypeConfig /* <T> */;
+  _values: Array<GraphQLEnumValue /* <T> */>;
+  _valueLookup: Map<any /* T */, GraphQLEnumValue>;
   _nameLookup: ObjMap<GraphQLEnumValue>;
 
-  constructor(config: GraphQLEnumTypeConfig/* <T> */): void {
+  constructor(config: GraphQLEnumTypeConfig /* <T> */): void {
     this.name = config.name;
     assertValidName(config.name, config.isIntrospection);
     this.description = config.description;
@@ -925,7 +905,7 @@ export class GraphQLEnumType/* <T> */ {
     this._enumConfig = config;
   }
 
-  getValues(): Array<GraphQLEnumValue/* <T> */> {
+  getValues(): Array<GraphQLEnumValue /* <T> */> {
     return this._values;
   }
 
@@ -933,17 +913,18 @@ export class GraphQLEnumType/* <T> */ {
     return this._getNameLookup()[name];
   }
 
-  serialize(value: any/* T */): ?string {
+  serialize(value: any /* T */): ?string {
     const enumValue = this._getValueLookup().get(value);
     return enumValue ? enumValue.name : null;
   }
 
   isValidValue(value: mixed): boolean {
-    return typeof value === 'string' &&
-      this._getNameLookup()[value] !== undefined;
+    return (
+      typeof value === 'string' && this._getNameLookup()[value] !== undefined
+    );
   }
 
-  parseValue(value: mixed): ?any/* T */ {
+  parseValue(value: mixed): ?any /* T */ {
     if (typeof value === 'string') {
       const enumValue = this._getNameLookup()[value];
       if (enumValue) {
@@ -953,11 +934,13 @@ export class GraphQLEnumType/* <T> */ {
   }
 
   isValidLiteral(valueNode: ValueNode): boolean {
-    return valueNode.kind === Kind.ENUM &&
-      this._getNameLookup()[valueNode.value] !== undefined;
+    return (
+      valueNode.kind === Kind.ENUM &&
+      this._getNameLookup()[valueNode.value] !== undefined
+    );
   }
 
-  parseLiteral(valueNode: ValueNode): ?any/* T */ {
+  parseLiteral(valueNode: ValueNode): ?any /* T */ {
     if (valueNode.kind === Kind.ENUM) {
       const enumValue = this._getNameLookup()[valueNode.value];
       if (enumValue) {
@@ -966,7 +949,7 @@ export class GraphQLEnumType/* <T> */ {
     }
   }
 
-  _getValueLookup(): Map<any/* T */, GraphQLEnumValue> {
+  _getValueLookup(): Map<any /* T */, GraphQLEnumValue> {
     if (!this._valueLookup) {
       const lookup = new Map();
       this.getValues().forEach(value => {
@@ -997,40 +980,39 @@ export class GraphQLEnumType/* <T> */ {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLEnumType.prototype.toJSON =
-  GraphQLEnumType.prototype.inspect =
-    GraphQLEnumType.prototype.toString;
+GraphQLEnumType.prototype.toJSON = GraphQLEnumType.prototype.inspect =
+  GraphQLEnumType.prototype.toString;
 
 function defineEnumValues(
   type: GraphQLEnumType,
-  valueMap: GraphQLEnumValueConfigMap/* <T> */
-): Array<GraphQLEnumValue/* <T> */> {
+  valueMap: GraphQLEnumValueConfigMap /* <T> */,
+): Array<GraphQLEnumValue /* <T> */> {
   invariant(
     isPlainObj(valueMap),
-    `${type.name} values must be an object with value names as keys.`
+    `${type.name} values must be an object with value names as keys.`,
   );
   const valueNames = Object.keys(valueMap);
   invariant(
     valueNames.length > 0,
-    `${type.name} values must be an object with value names as keys.`
+    `${type.name} values must be an object with value names as keys.`,
   );
   return valueNames.map(valueName => {
     assertValidName(valueName);
     invariant(
-      [ 'true', 'false', 'null' ].indexOf(valueName) === -1,
-      `Name "${valueName}" can not be used as an Enum value.`
+      ['true', 'false', 'null'].indexOf(valueName) === -1,
+      `Name "${valueName}" can not be used as an Enum value.`,
     );
 
     const value = valueMap[valueName];
     invariant(
       isPlainObj(value),
       `${type.name}.${valueName} must refer to an object with a "value" key ` +
-      `representing an internal value but got: ${String(value)}.`
+        `representing an internal value but got: ${String(value)}.`,
     );
     invariant(
       !value.hasOwnProperty('isDeprecated'),
       `${type.name}.${valueName} should provide "deprecationReason" instead ` +
-      'of "isDeprecated".'
+        'of "isDeprecated".',
     );
     return {
       name: valueName,
@@ -1043,34 +1025,33 @@ function defineEnumValues(
   });
 }
 
-export type GraphQLEnumTypeConfig/* <T> */ = {
-  name: string;
-  values: GraphQLEnumValueConfigMap/* <T> */;
-  description?: ?string;
-  astNode?: ?EnumTypeDefinitionNode;
-  isIntrospection?: boolean;
+export type GraphQLEnumTypeConfig /* <T> */ = {
+  name: string,
+  values: GraphQLEnumValueConfigMap /* <T> */,
+  description?: ?string,
+  astNode?: ?EnumTypeDefinitionNode,
+  isIntrospection?: boolean,
 };
 
-export type GraphQLEnumValueConfigMap/* <T> */ =
-  ObjMap<GraphQLEnumValueConfig/* <T> */>;
+export type GraphQLEnumValueConfigMap /* <T> */ = ObjMap<
+  GraphQLEnumValueConfig /* <T> */,
+>;
 
-export type GraphQLEnumValueConfig/* <T> */ = {
-  value?: any/* T */;
-  deprecationReason?: ?string;
-  description?: ?string;
-  astNode?: ?EnumValueDefinitionNode;
+export type GraphQLEnumValueConfig /* <T> */ = {
+  value?: any /* T */,
+  deprecationReason?: ?string,
+  description?: ?string,
+  astNode?: ?EnumValueDefinitionNode,
 };
 
-export type GraphQLEnumValue/* <T> */ = {
-  name: string;
-  description: ?string;
-  isDeprecated?: boolean;
-  deprecationReason: ?string;
-  astNode?: ?EnumValueDefinitionNode;
-  value: any/* T */;
+export type GraphQLEnumValue /* <T> */ = {
+  name: string,
+  description: ?string,
+  isDeprecated?: boolean,
+  deprecationReason: ?string,
+  astNode?: ?EnumValueDefinitionNode,
+  value: any /* T */,
 };
-
-
 
 /**
  * Input Object Type Definition
@@ -1117,30 +1098,30 @@ export class GraphQLInputObjectType {
     invariant(
       isPlainObj(fieldMap),
       `${this.name} fields must be an object with field names as keys or a ` +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
     const fieldNames = Object.keys(fieldMap);
     invariant(
       fieldNames.length > 0,
       `${this.name} fields must be an object with field names as keys or a ` +
-      'function which returns such an object.'
+        'function which returns such an object.',
     );
     const resultFieldMap = Object.create(null);
     fieldNames.forEach(fieldName => {
       assertValidName(fieldName);
       const field = {
         ...fieldMap[fieldName],
-        name: fieldName
+        name: fieldName,
       };
       invariant(
         isInputType(field.type),
         `${this.name}.${fieldName} field type must be Input Type but ` +
-        `got: ${String(field.type)}.`
+          `got: ${String(field.type)}.`,
       );
       invariant(
         field.resolve == null,
         `${this.name}.${fieldName} field type has a resolve property, but ` +
-        'Input Types cannot define resolvers.'
+          'Input Types cannot define resolvers.',
       );
       resultFieldMap[fieldName] = field;
     });
@@ -1156,39 +1137,34 @@ export class GraphQLInputObjectType {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLInputObjectType.prototype.toJSON =
-  GraphQLInputObjectType.prototype.inspect =
-    GraphQLInputObjectType.prototype.toString;
+GraphQLInputObjectType.prototype.toJSON = GraphQLInputObjectType.prototype.inspect =
+  GraphQLInputObjectType.prototype.toString;
 
 export type GraphQLInputObjectTypeConfig = {
-  name: string;
-  fields: Thunk<GraphQLInputFieldConfigMap>;
-  description?: ?string;
-  astNode?: ?InputObjectTypeDefinitionNode;
+  name: string,
+  fields: Thunk<GraphQLInputFieldConfigMap>,
+  description?: ?string,
+  astNode?: ?InputObjectTypeDefinitionNode,
 };
 
 export type GraphQLInputFieldConfig = {
-  type: GraphQLInputType;
-  defaultValue?: mixed;
-  description?: ?string;
-  astNode?: ?InputValueDefinitionNode;
+  type: GraphQLInputType,
+  defaultValue?: mixed,
+  description?: ?string,
+  astNode?: ?InputValueDefinitionNode,
 };
 
-export type GraphQLInputFieldConfigMap =
-  ObjMap<GraphQLInputFieldConfig>;
+export type GraphQLInputFieldConfigMap = ObjMap<GraphQLInputFieldConfig>;
 
 export type GraphQLInputField = {
-  name: string;
-  type: GraphQLInputType;
-  defaultValue?: mixed;
-  description?: ?string;
-  astNode?: ?InputValueDefinitionNode;
+  name: string,
+  type: GraphQLInputType,
+  defaultValue?: mixed,
+  description?: ?string,
+  astNode?: ?InputValueDefinitionNode,
 };
 
-export type GraphQLInputFieldMap =
-  ObjMap<GraphQLInputField>;
-
-
+export type GraphQLInputFieldMap = ObjMap<GraphQLInputField>;
 
 /**
  * List Modifier
@@ -1214,7 +1190,7 @@ export class GraphQLList<T: GraphQLType> {
   constructor(type: T): void {
     invariant(
       isType(type),
-      `Can only create List of a GraphQLType but got: ${String(type)}.`
+      `Can only create List of a GraphQLType but got: ${String(type)}.`,
     );
     this.ofType = type;
   }
@@ -1228,10 +1204,8 @@ export class GraphQLList<T: GraphQLType> {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLList.prototype.toJSON =
-  GraphQLList.prototype.inspect =
-    GraphQLList.prototype.toString;
-
+GraphQLList.prototype.toJSON = GraphQLList.prototype.inspect =
+  GraphQLList.prototype.toString;
 
 /**
  * Non-Null Modifier
@@ -1260,7 +1234,7 @@ export class GraphQLNonNull<T: GraphQLNullableType> {
     invariant(
       isType(type) && !(type instanceof GraphQLNonNull),
       'Can only create NonNull of a Nullable GraphQLType but got: ' +
-      `${String(type)}.`
+        `${String(type)}.`,
     );
     this.ofType = type;
   }
@@ -1274,6 +1248,5 @@ export class GraphQLNonNull<T: GraphQLNullableType> {
 }
 
 // Also provide toJSON and inspect aliases for toString.
-GraphQLNonNull.prototype.toJSON =
-  GraphQLNonNull.prototype.inspect =
-    GraphQLNonNull.prototype.toString;
+GraphQLNonNull.prototype.toJSON = GraphQLNonNull.prototype.inspect =
+  GraphQLNonNull.prototype.toString;

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -10,13 +10,12 @@
 import { isInputType, GraphQLNonNull } from './definition';
 import type {
   GraphQLFieldConfigArgumentMap,
-  GraphQLArgument
+  GraphQLArgument,
 } from './definition';
 import { GraphQLString, GraphQLBoolean } from './scalars';
 import invariant from '../jsutils/invariant';
 import { assertValidName } from '../utilities/assertValidName';
 import type { DirectiveDefinitionNode } from '../language/ast';
-
 
 export const DirectiveLocation = {
   // Operations
@@ -59,7 +58,7 @@ export class GraphQLDirective {
     assertValidName(config.name);
     invariant(
       Array.isArray(config.locations),
-      'Must provide locations for directive.'
+      'Must provide locations for directive.',
     );
     this.name = config.name;
     this.description = config.description;
@@ -72,7 +71,7 @@ export class GraphQLDirective {
     } else {
       invariant(
         !Array.isArray(args),
-        `@${config.name} args must be an object with argument names as keys.`
+        `@${config.name} args must be an object with argument names as keys.`,
       );
       this.args = Object.keys(args).map(argName => {
         assertValidName(argName);
@@ -80,7 +79,7 @@ export class GraphQLDirective {
         invariant(
           isInputType(arg.type),
           `@${config.name}(${argName}:) argument type must be ` +
-          `Input Type but got: ${String(arg.type)}.`
+            `Input Type but got: ${String(arg.type)}.`,
         );
         return {
           name: argName,
@@ -91,16 +90,15 @@ export class GraphQLDirective {
         };
       });
     }
-
   }
 }
 
 type GraphQLDirectiveConfig = {
-  name: string;
-  description?: ?string;
-  locations: Array<DirectiveLocationEnum>;
-  args?: ?GraphQLFieldConfigArgumentMap;
-  astNode?: ?DirectiveDefinitionNode;
+  name: string,
+  description?: ?string,
+  locations: Array<DirectiveLocationEnum>,
+  args?: ?GraphQLFieldConfigArgumentMap,
+  astNode?: ?DirectiveDefinitionNode,
 };
 
 /**
@@ -119,8 +117,8 @@ export const GraphQLIncludeDirective = new GraphQLDirective({
   args: {
     if: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      description: 'Included when true.'
-    }
+      description: 'Included when true.',
+    },
   },
 });
 
@@ -140,8 +138,8 @@ export const GraphQLSkipDirective = new GraphQLDirective({
   args: {
     if: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      description: 'Skipped when true.'
-    }
+      description: 'Skipped when true.',
+    },
   },
 });
 
@@ -155,12 +153,8 @@ export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
  */
 export const GraphQLDeprecatedDirective = new GraphQLDirective({
   name: 'deprecated',
-  description:
-    'Marks an element of a GraphQL schema as no longer supported.',
-  locations: [
-    DirectiveLocation.FIELD_DEFINITION,
-    DirectiveLocation.ENUM_VALUE,
-  ],
+  description: 'Marks an element of a GraphQL schema as no longer supported.',
+  locations: [DirectiveLocation.FIELD_DEFINITION, DirectiveLocation.ENUM_VALUE],
   args: {
     reason: {
       type: GraphQLString,
@@ -168,8 +162,8 @@ export const GraphQLDeprecatedDirective = new GraphQLDirective({
         'Explains why this element was deprecated, usually also including a ' +
         'suggestion for how to access supported similar data. Formatted ' +
         'in [Markdown](https://daringfireball.net/projects/markdown/).',
-      defaultValue: DEFAULT_DEPRECATION_REASON
-    }
+      defaultValue: DEFAULT_DEPRECATION_REASON,
+    },
   },
 });
 

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -19,7 +19,6 @@ export {
   isCompositeType,
   isAbstractType,
   isNamedType,
-
   // Assertions
   assertType,
   assertInputType,
@@ -28,11 +27,9 @@ export {
   assertCompositeType,
   assertAbstractType,
   assertNamedType,
-
   // Un-modifiers
   getNullableType,
   getNamedType,
-
   // Definitions
   GraphQLScalarType,
   GraphQLObjectType,
@@ -47,16 +44,13 @@ export {
 export {
   // "Enum" of Directive Locations
   DirectiveLocation,
-
   // Directives Definition
   GraphQLDirective,
-
   // Built-in Directives defined by the Spec
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
-
   // Constant Deprecation Reason
   DEFAULT_DEPRECATION_REASON,
 } from './directives';
@@ -73,7 +67,6 @@ export {
 export {
   // "Enum" of Type Kinds
   TypeKind,
-
   // GraphQL Types for introspection.
   __Schema,
   __Directive,
@@ -83,7 +76,6 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-
   // Meta-field definitions.
   SchemaMetaFieldDef,
   TypeMetaFieldDef,

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -25,7 +25,6 @@ import { GraphQLString, GraphQLBoolean } from './scalars';
 import { DirectiveLocation } from './directives';
 import type { GraphQLField } from './definition';
 
-
 export const __Schema = new GraphQLObjectType({
   name: '__Schema',
   isIntrospection: true,
@@ -40,32 +39,35 @@ export const __Schema = new GraphQLObjectType({
       resolve(schema) {
         const typeMap = schema.getTypeMap();
         return Object.keys(typeMap).map(key => typeMap[key]);
-      }
+      },
     },
     queryType: {
       description: 'The type that query operations will be rooted at.',
       type: new GraphQLNonNull(__Type),
-      resolve: schema => schema.getQueryType()
+      resolve: schema => schema.getQueryType(),
     },
     mutationType: {
-      description: 'If this server supports mutation, the type that ' +
-                   'mutation operations will be rooted at.',
+      description:
+        'If this server supports mutation, the type that ' +
+        'mutation operations will be rooted at.',
       type: __Type,
-      resolve: schema => schema.getMutationType()
+      resolve: schema => schema.getMutationType(),
     },
     subscriptionType: {
-      description: 'If this server support subscription, the type that ' +
-                   'subscription operations will be rooted at.',
+      description:
+        'If this server support subscription, the type that ' +
+        'subscription operations will be rooted at.',
       type: __Type,
-      resolve: schema => schema.getSubscriptionType()
+      resolve: schema => schema.getSubscriptionType(),
     },
     directives: {
       description: 'A list of all directives supported by this server.',
-      type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__Directive))),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(__Directive)),
+      ),
       resolve: schema => schema.getDirectives(),
-    }
-  })
+    },
+  }),
 });
 
 export const __Directive = new GraphQLObjectType({
@@ -74,7 +76,7 @@ export const __Directive = new GraphQLObjectType({
   description:
     'A Directive provides a way to describe alternate runtime execution and ' +
     'type validation behavior in a GraphQL document.' +
-    '\n\nIn some cases, you need to provide options to alter GraphQL\'s ' +
+    "\n\nIn some cases, you need to provide options to alter GraphQL's " +
     'execution behavior in ways field arguments will not suffice, such as ' +
     'conditionally including or skipping a field. Directives provide this by ' +
     'describing additional information to the executor.',
@@ -82,14 +84,15 @@ export const __Directive = new GraphQLObjectType({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     locations: {
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(
-        __DirectiveLocation
-      )))
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(__DirectiveLocation)),
+      ),
     },
     args: {
-      type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__InputValue))),
-      resolve: directive => directive.args || []
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(__InputValue)),
+      ),
+      resolve: directive => directive.args || [],
     },
     // NOTE: the following three fields are deprecated and are no longer part
     // of the GraphQL specification.
@@ -99,7 +102,7 @@ export const __Directive = new GraphQLObjectType({
       resolve: d =>
         d.locations.indexOf(DirectiveLocation.QUERY) !== -1 ||
         d.locations.indexOf(DirectiveLocation.MUTATION) !== -1 ||
-        d.locations.indexOf(DirectiveLocation.SUBSCRIPTION) !== -1
+        d.locations.indexOf(DirectiveLocation.SUBSCRIPTION) !== -1,
     },
     onFragment: {
       deprecationReason: 'Use `locations`.',
@@ -107,12 +110,12 @@ export const __Directive = new GraphQLObjectType({
       resolve: d =>
         d.locations.indexOf(DirectiveLocation.FRAGMENT_SPREAD) !== -1 ||
         d.locations.indexOf(DirectiveLocation.INLINE_FRAGMENT) !== -1 ||
-        d.locations.indexOf(DirectiveLocation.FRAGMENT_DEFINITION) !== -1
+        d.locations.indexOf(DirectiveLocation.FRAGMENT_DEFINITION) !== -1,
     },
     onField: {
       deprecationReason: 'Use `locations`.',
       type: new GraphQLNonNull(GraphQLBoolean),
-      resolve: d => d.locations.indexOf(DirectiveLocation.FIELD) !== -1
+      resolve: d => d.locations.indexOf(DirectiveLocation.FIELD) !== -1,
     },
   }),
 });
@@ -126,77 +129,77 @@ export const __DirectiveLocation = new GraphQLEnumType({
   values: {
     QUERY: {
       value: DirectiveLocation.QUERY,
-      description: 'Location adjacent to a query operation.'
+      description: 'Location adjacent to a query operation.',
     },
     MUTATION: {
       value: DirectiveLocation.MUTATION,
-      description: 'Location adjacent to a mutation operation.'
+      description: 'Location adjacent to a mutation operation.',
     },
     SUBSCRIPTION: {
       value: DirectiveLocation.SUBSCRIPTION,
-      description: 'Location adjacent to a subscription operation.'
+      description: 'Location adjacent to a subscription operation.',
     },
     FIELD: {
       value: DirectiveLocation.FIELD,
-      description: 'Location adjacent to a field.'
+      description: 'Location adjacent to a field.',
     },
     FRAGMENT_DEFINITION: {
       value: DirectiveLocation.FRAGMENT_DEFINITION,
-      description: 'Location adjacent to a fragment definition.'
+      description: 'Location adjacent to a fragment definition.',
     },
     FRAGMENT_SPREAD: {
       value: DirectiveLocation.FRAGMENT_SPREAD,
-      description: 'Location adjacent to a fragment spread.'
+      description: 'Location adjacent to a fragment spread.',
     },
     INLINE_FRAGMENT: {
       value: DirectiveLocation.INLINE_FRAGMENT,
-      description: 'Location adjacent to an inline fragment.'
+      description: 'Location adjacent to an inline fragment.',
     },
     SCHEMA: {
       value: DirectiveLocation.SCHEMA,
-      description: 'Location adjacent to a schema definition.'
+      description: 'Location adjacent to a schema definition.',
     },
     SCALAR: {
       value: DirectiveLocation.SCALAR,
-      description: 'Location adjacent to a scalar definition.'
+      description: 'Location adjacent to a scalar definition.',
     },
     OBJECT: {
       value: DirectiveLocation.OBJECT,
-      description: 'Location adjacent to an object type definition.'
+      description: 'Location adjacent to an object type definition.',
     },
     FIELD_DEFINITION: {
       value: DirectiveLocation.FIELD_DEFINITION,
-      description: 'Location adjacent to a field definition.'
+      description: 'Location adjacent to a field definition.',
     },
     ARGUMENT_DEFINITION: {
       value: DirectiveLocation.ARGUMENT_DEFINITION,
-      description: 'Location adjacent to an argument definition.'
+      description: 'Location adjacent to an argument definition.',
     },
     INTERFACE: {
       value: DirectiveLocation.INTERFACE,
-      description: 'Location adjacent to an interface definition.'
+      description: 'Location adjacent to an interface definition.',
     },
     UNION: {
       value: DirectiveLocation.UNION,
-      description: 'Location adjacent to a union definition.'
+      description: 'Location adjacent to a union definition.',
     },
     ENUM: {
       value: DirectiveLocation.ENUM,
-      description: 'Location adjacent to an enum definition.'
+      description: 'Location adjacent to an enum definition.',
     },
     ENUM_VALUE: {
       value: DirectiveLocation.ENUM_VALUE,
-      description: 'Location adjacent to an enum value definition.'
+      description: 'Location adjacent to an enum value definition.',
     },
     INPUT_OBJECT: {
       value: DirectiveLocation.INPUT_OBJECT,
-      description: 'Location adjacent to an input object type definition.'
+      description: 'Location adjacent to an input object type definition.',
     },
     INPUT_FIELD_DEFINITION: {
       value: DirectiveLocation.INPUT_FIELD_DEFINITION,
-      description: 'Location adjacent to an input object field definition.'
+      description: 'Location adjacent to an input object field definition.',
     },
-  }
+  },
 });
 
 export const __Type = new GraphQLObjectType({
@@ -233,28 +236,31 @@ export const __Type = new GraphQLObjectType({
           return TypeKind.NON_NULL;
         }
         throw new Error('Unknown kind of type: ' + type);
-      }
+      },
     },
     name: { type: GraphQLString },
     description: { type: GraphQLString },
     fields: {
       type: new GraphQLList(new GraphQLNonNull(__Field)),
       args: {
-        includeDeprecated: { type: GraphQLBoolean, defaultValue: false }
+        includeDeprecated: { type: GraphQLBoolean, defaultValue: false },
       },
       resolve(type, { includeDeprecated }) {
-        if (type instanceof GraphQLObjectType ||
-            type instanceof GraphQLInterfaceType) {
+        if (
+          type instanceof GraphQLObjectType ||
+          type instanceof GraphQLInterfaceType
+        ) {
           const fieldMap = type.getFields();
-          let fields =
-            Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
+          let fields = Object.keys(fieldMap).map(
+            fieldName => fieldMap[fieldName],
+          );
           if (!includeDeprecated) {
             fields = fields.filter(field => !field.deprecationReason);
           }
           return fields;
         }
         return null;
-      }
+      },
     },
     interfaces: {
       type: new GraphQLList(new GraphQLNonNull(__Type)),
@@ -262,7 +268,7 @@ export const __Type = new GraphQLObjectType({
         if (type instanceof GraphQLObjectType) {
           return type.getInterfaces();
         }
-      }
+      },
     },
     possibleTypes: {
       type: new GraphQLList(new GraphQLNonNull(__Type)),
@@ -270,12 +276,12 @@ export const __Type = new GraphQLObjectType({
         if (isAbstractType(type)) {
           return schema.getPossibleTypes(type);
         }
-      }
+      },
     },
     enumValues: {
       type: new GraphQLList(new GraphQLNonNull(__EnumValue)),
       args: {
-        includeDeprecated: { type: GraphQLBoolean, defaultValue: false }
+        includeDeprecated: { type: GraphQLBoolean, defaultValue: false },
       },
       resolve(type, { includeDeprecated }) {
         if (type instanceof GraphQLEnumType) {
@@ -285,7 +291,7 @@ export const __Type = new GraphQLObjectType({
           }
           return values;
         }
-      }
+      },
     },
     inputFields: {
       type: new GraphQLList(new GraphQLNonNull(__InputValue)),
@@ -294,10 +300,10 @@ export const __Type = new GraphQLObjectType({
           const fieldMap = type.getFields();
           return Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
         }
-      }
+      },
     },
-    ofType: { type: __Type }
-  })
+    ofType: { type: __Type },
+  }),
 });
 
 export const __Field = new GraphQLObjectType({
@@ -310,16 +316,17 @@ export const __Field = new GraphQLObjectType({
     name: { type: new GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     args: {
-      type:
-        new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__InputValue))),
-      resolve: field => field.args || []
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(__InputValue)),
+      ),
+      resolve: field => field.args || [],
     },
     type: { type: new GraphQLNonNull(__Type) },
     isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },
     deprecationReason: {
       type: GraphQLString,
-    }
-  })
+    },
+  }),
 });
 
 export const __InputValue = new GraphQLObjectType({
@@ -338,11 +345,12 @@ export const __InputValue = new GraphQLObjectType({
       description:
         'A GraphQL-formatted string representing the default value for this ' +
         'input value.',
-      resolve: inputVal => isInvalid(inputVal.defaultValue) ?
-        null :
-        print(astFromValue(inputVal.defaultValue, inputVal.type))
-    }
-  })
+      resolve: inputVal =>
+        isInvalid(inputVal.defaultValue)
+          ? null
+          : print(astFromValue(inputVal.defaultValue, inputVal.type)),
+    },
+  }),
 });
 
 export const __EnumValue = new GraphQLObjectType({
@@ -358,8 +366,8 @@ export const __EnumValue = new GraphQLObjectType({
     isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },
     deprecationReason: {
       type: GraphQLString,
-    }
-  })
+    },
+  }),
 });
 
 export const TypeKind = {
@@ -380,44 +388,48 @@ export const __TypeKind = new GraphQLEnumType({
   values: {
     SCALAR: {
       value: TypeKind.SCALAR,
-      description: 'Indicates this type is a scalar.'
+      description: 'Indicates this type is a scalar.',
     },
     OBJECT: {
       value: TypeKind.OBJECT,
-      description: 'Indicates this type is an object. ' +
-                   '`fields` and `interfaces` are valid fields.'
+      description:
+        'Indicates this type is an object. ' +
+        '`fields` and `interfaces` are valid fields.',
     },
     INTERFACE: {
       value: TypeKind.INTERFACE,
-      description: 'Indicates this type is an interface. ' +
-                   '`fields` and `possibleTypes` are valid fields.'
+      description:
+        'Indicates this type is an interface. ' +
+        '`fields` and `possibleTypes` are valid fields.',
     },
     UNION: {
       value: TypeKind.UNION,
-      description: 'Indicates this type is a union. ' +
-                   '`possibleTypes` is a valid field.'
+      description:
+        'Indicates this type is a union. ' +
+        '`possibleTypes` is a valid field.',
     },
     ENUM: {
       value: TypeKind.ENUM,
-      description: 'Indicates this type is an enum. ' +
-                   '`enumValues` is a valid field.'
+      description:
+        'Indicates this type is an enum. ' + '`enumValues` is a valid field.',
     },
     INPUT_OBJECT: {
       value: TypeKind.INPUT_OBJECT,
-      description: 'Indicates this type is an input object. ' +
-                   '`inputFields` is a valid field.'
+      description:
+        'Indicates this type is an input object. ' +
+        '`inputFields` is a valid field.',
     },
     LIST: {
       value: TypeKind.LIST,
-      description: 'Indicates this type is a list. ' +
-                   '`ofType` is a valid field.'
+      description:
+        'Indicates this type is a list. ' + '`ofType` is a valid field.',
     },
     NON_NULL: {
       value: TypeKind.NON_NULL,
-      description: 'Indicates this type is a non-null. ' +
-                   '`ofType` is a valid field.'
+      description:
+        'Indicates this type is a non-null. ' + '`ofType` is a valid field.',
     },
-  }
+  },
 });
 
 /**
@@ -430,18 +442,15 @@ export const SchemaMetaFieldDef: GraphQLField<*, *> = {
   type: new GraphQLNonNull(__Schema),
   description: 'Access the current type schema of this server.',
   args: [],
-  resolve: (source, args, context, { schema }) => schema
+  resolve: (source, args, context, { schema }) => schema,
 };
 
 export const TypeMetaFieldDef: GraphQLField<*, *> = {
   name: '__type',
   type: __Type,
   description: 'Request the type information of a single type.',
-  args: [
-    { name: 'name', type: new GraphQLNonNull(GraphQLString) }
-  ],
-  resolve: (source, { name }, context, { schema }) =>
-    schema.getType(name)
+  args: [{ name: 'name', type: new GraphQLNonNull(GraphQLString) }],
+  resolve: (source, { name }, context, { schema }) => schema.getType(name),
 };
 
 export const TypeNameMetaFieldDef: GraphQLField<*, *> = {
@@ -449,5 +458,5 @@ export const TypeNameMetaFieldDef: GraphQLField<*, *> = {
   type: new GraphQLNonNull(GraphQLString),
   description: 'The name of the current Object type at runtime.',
   args: [],
-  resolve: (source, args, context, { parentType }) => parentType.name
+  resolve: (source, args, context, { parentType }) => parentType.name,
 };

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -21,19 +21,19 @@ const MIN_INT = -2147483648;
 function coerceInt(value: mixed): ?number {
   if (value === '') {
     throw new TypeError(
-      'Int cannot represent non 32-bit signed integer value: (empty string)'
+      'Int cannot represent non 32-bit signed integer value: (empty string)',
     );
   }
   const num = Number(value);
   if (num !== num || num > MAX_INT || num < MIN_INT) {
     throw new TypeError(
-      'Int cannot represent non 32-bit signed integer value: ' + String(value)
+      'Int cannot represent non 32-bit signed integer value: ' + String(value),
     );
   }
   const int = Math.floor(num);
   if (int !== num) {
     throw new TypeError(
-      'Int cannot represent non-integer value: ' + String(value)
+      'Int cannot represent non-integer value: ' + String(value),
     );
   }
   return int;
@@ -54,13 +54,13 @@ export const GraphQLInt = new GraphQLScalarType({
       }
     }
     return null;
-  }
+  },
 });
 
 function coerceFloat(value: mixed): ?number {
   if (value === '') {
     throw new TypeError(
-      'Float cannot represent non numeric value: (empty string)'
+      'Float cannot represent non numeric value: (empty string)',
     );
   }
   const num = Number(value);
@@ -68,7 +68,7 @@ function coerceFloat(value: mixed): ?number {
     return num;
   }
   throw new TypeError(
-    'Float cannot represent non numeric value: ' + String(value)
+    'Float cannot represent non numeric value: ' + String(value),
   );
 }
 
@@ -81,16 +81,16 @@ export const GraphQLFloat = new GraphQLScalarType({
   serialize: coerceFloat,
   parseValue: coerceFloat,
   parseLiteral(ast) {
-    return ast.kind === Kind.FLOAT || ast.kind === Kind.INT ?
-      parseFloat(ast.value) :
-      null;
-  }
+    return ast.kind === Kind.FLOAT || ast.kind === Kind.INT
+      ? parseFloat(ast.value)
+      : null;
+  },
 });
 
 function coerceString(value: mixed): ?string {
   if (Array.isArray(value)) {
     throw new TypeError(
-      `String cannot represent an array value: [${String(value)}]`
+      `String cannot represent an array value: [${String(value)}]`,
     );
   }
   return String(value);
@@ -106,7 +106,7 @@ export const GraphQLString = new GraphQLScalarType({
   parseValue: coerceString,
   parseLiteral(ast) {
     return ast.kind === Kind.STRING ? ast.value : null;
-  }
+  },
 });
 
 export const GraphQLBoolean = new GraphQLScalarType({
@@ -116,7 +116,7 @@ export const GraphQLBoolean = new GraphQLScalarType({
   parseValue: Boolean,
   parseLiteral(ast) {
     return ast.kind === Kind.BOOLEAN ? ast.value : null;
-  }
+  },
 });
 
 export const GraphQLID = new GraphQLScalarType({
@@ -130,8 +130,6 @@ export const GraphQLID = new GraphQLScalarType({
   serialize: String,
   parseValue: String,
   parseLiteral(ast) {
-    return ast.kind === Kind.STRING || ast.kind === Kind.INT ?
-      ast.value :
-      null;
-  }
+    return ast.kind === Kind.STRING || ast.kind === Kind.INT ? ast.value : null;
+  },
 });

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -13,21 +13,20 @@ import {
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLList,
-  GraphQLNonNull
+  GraphQLNonNull,
 } from './definition';
 import type {
   GraphQLType,
   GraphQLNamedType,
-  GraphQLAbstractType
+  GraphQLAbstractType,
 } from './definition';
 import type { SchemaDefinitionNode } from '../language/ast';
 import { GraphQLDirective, specifiedDirectives } from './directives';
 import { __Schema } from './introspection';
 import find from '../jsutils/find';
 import invariant from '../jsutils/invariant';
-import type {ObjMap} from '../jsutils/ObjMap';
+import type { ObjMap } from '../jsutils/ObjMap';
 import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators';
-
 
 /**
  * Schema Definition
@@ -66,44 +65,46 @@ export class GraphQLSchema {
   _possibleTypeMap: ?ObjMap<ObjMap<boolean>>;
 
   constructor(config: GraphQLSchemaConfig): void {
-    invariant(
-      typeof config === 'object',
-      'Must provide configuration object.'
-    );
+    invariant(typeof config === 'object', 'Must provide configuration object.');
 
     invariant(
       config.query instanceof GraphQLObjectType,
-      `Schema query must be Object Type but got: ${
-        String(config.query)}.`
+      `Schema query must be Object Type but got: ${String(config.query)}.`,
     );
     this._queryType = config.query;
 
     invariant(
       !config.mutation || config.mutation instanceof GraphQLObjectType,
-      `Schema mutation must be Object Type if provided but got: ${
-        String(config.mutation)}.`
+      `Schema mutation must be Object Type if provided but got: ${String(
+        config.mutation,
+      )}.`,
     );
     this._mutationType = config.mutation;
 
     invariant(
       !config.subscription || config.subscription instanceof GraphQLObjectType,
-      `Schema subscription must be Object Type if provided but got: ${
-        String(config.subscription)}.`
+      `Schema subscription must be Object Type if provided but got: ${String(
+        config.subscription,
+      )}.`,
     );
     this._subscriptionType = config.subscription;
 
     invariant(
       !config.types || Array.isArray(config.types),
-      `Schema types must be Array if provided but got: ${String(config.types)}.`
+      `Schema types must be Array if provided but got: ${String(
+        config.types,
+      )}.`,
     );
 
     invariant(
       !config.directives ||
-      Array.isArray(config.directives) && config.directives.every(
-        directive => directive instanceof GraphQLDirective
-      ),
-      `Schema directives must be Array<GraphQLDirective> if provided but got: ${
-        String(config.directives)}.`
+        (Array.isArray(config.directives) &&
+          config.directives.every(
+            directive => directive instanceof GraphQLDirective,
+          )),
+      `Schema directives must be Array<GraphQLDirective> if provided but got: ${String(
+        config.directives,
+      )}.`,
     );
     // Provide specified directives (e.g. @include and @skip) by default.
     this._directives = config.directives || specifiedDirectives;
@@ -114,7 +115,7 @@ export class GraphQLSchema {
       this.getQueryType(),
       this.getMutationType(),
       this.getSubscriptionType(),
-      __Schema
+      __Schema,
     ];
 
     const types = config.types;
@@ -124,7 +125,7 @@ export class GraphQLSchema {
 
     this._typeMap = initialTypes.reduce(
       typeMapReducer,
-      (Object.create(null): TypeMap)
+      (Object.create(null): TypeMap),
     );
 
     // Keep track of all implementations by interface name.
@@ -137,7 +138,7 @@ export class GraphQLSchema {
           if (impls) {
             impls.push(type);
           } else {
-            this._implementations[iface.name] = [ type ];
+            this._implementations[iface.name] = [type];
           }
         });
       }
@@ -147,9 +148,9 @@ export class GraphQLSchema {
     Object.keys(this._typeMap).forEach(typeName => {
       const type = this._typeMap[typeName];
       if (type instanceof GraphQLObjectType) {
-        type.getInterfaces().forEach(
-          iface => assertObjectImplementsInterface(this, type, iface)
-        );
+        type
+          .getInterfaces()
+          .forEach(iface => assertObjectImplementsInterface(this, type, iface));
       }
     });
   }
@@ -175,7 +176,7 @@ export class GraphQLSchema {
   }
 
   getPossibleTypes(
-    abstractType: GraphQLAbstractType
+    abstractType: GraphQLAbstractType,
   ): Array<GraphQLObjectType> {
     if (abstractType instanceof GraphQLUnionType) {
       return abstractType.getTypes();
@@ -186,7 +187,7 @@ export class GraphQLSchema {
 
   isPossibleType(
     abstractType: GraphQLAbstractType,
-    possibleType: GraphQLObjectType
+    possibleType: GraphQLObjectType,
   ): boolean {
     let possibleTypeMap = this._possibleTypeMap;
     if (!possibleTypeMap) {
@@ -198,14 +199,13 @@ export class GraphQLSchema {
       invariant(
         Array.isArray(possibleTypes),
         `Could not find possible implementing types for ${abstractType.name} ` +
-        'in schema. Check that schema.types is defined and is an array of ' +
-        'all possible types in the schema.'
+          'in schema. Check that schema.types is defined and is an array of ' +
+          'all possible types in the schema.',
       );
-      possibleTypeMap[abstractType.name] =
-        possibleTypes.reduce(
-          (map, type) => ((map[type.name] = true), map),
-          Object.create(null)
-        );
+      possibleTypeMap[abstractType.name] = possibleTypes.reduce(
+        (map, type) => ((map[type.name] = true), map),
+        Object.create(null),
+      );
     }
 
     return Boolean(possibleTypeMap[abstractType.name][possibleType.name]);
@@ -223,12 +223,12 @@ export class GraphQLSchema {
 type TypeMap = ObjMap<GraphQLNamedType>;
 
 type GraphQLSchemaConfig = {
-  query: GraphQLObjectType;
-  mutation?: ?GraphQLObjectType;
-  subscription?: ?GraphQLObjectType;
-  types?: ?Array<GraphQLNamedType>;
-  directives?: ?Array<GraphQLDirective>;
-  astNode?: ?SchemaDefinitionNode;
+  query: GraphQLObjectType,
+  mutation?: ?GraphQLObjectType,
+  subscription?: ?GraphQLObjectType,
+  types?: ?Array<GraphQLNamedType>,
+  directives?: ?Array<GraphQLDirective>,
+  astNode?: ?SchemaDefinitionNode,
 };
 
 function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
@@ -242,7 +242,7 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
     invariant(
       map[type.name] === type,
       'Schema must contain unique named types but contains multiple ' +
-      `types named "${type.name}".`
+        `types named "${type.name}".`,
     );
     return map;
   }
@@ -258,8 +258,10 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
     reducedMap = type.getInterfaces().reduce(typeMapReducer, reducedMap);
   }
 
-  if (type instanceof GraphQLObjectType ||
-      type instanceof GraphQLInterfaceType) {
+  if (
+    type instanceof GraphQLObjectType ||
+    type instanceof GraphQLInterfaceType
+  ) {
     const fieldMap = type.getFields();
     Object.keys(fieldMap).forEach(fieldName => {
       const field = fieldMap[fieldName];
@@ -286,7 +288,7 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
 function assertObjectImplementsInterface(
   schema: GraphQLSchema,
   object: GraphQLObjectType,
-  iface: GraphQLInterfaceType
+  iface: GraphQLInterfaceType,
 ): void {
   const objectFieldMap = object.getFields();
   const ifaceFieldMap = iface.getFields();
@@ -300,7 +302,7 @@ function assertObjectImplementsInterface(
     invariant(
       objectField,
       `"${iface.name}" expects field "${fieldName}" but "${object.name}" ` +
-      'does not provide it.'
+        'does not provide it.',
     );
 
     // Assert interface field type is satisfied by object field type, by being
@@ -308,8 +310,10 @@ function assertObjectImplementsInterface(
     invariant(
       isTypeSubTypeOf(schema, objectField.type, ifaceField.type),
       `${iface.name}.${fieldName} expects type "${String(ifaceField.type)}" ` +
-      'but ' +
-      `${object.name}.${fieldName} provides type "${String(objectField.type)}".`
+        'but ' +
+        `${object.name}.${fieldName} provides type "${String(
+          objectField.type,
+        )}".`,
     );
 
     // Assert each interface field arg is implemented.
@@ -321,7 +325,7 @@ function assertObjectImplementsInterface(
       invariant(
         objectArg,
         `${iface.name}.${fieldName} expects argument "${argName}" but ` +
-        `${object.name}.${fieldName} does not provide it.`
+          `${object.name}.${fieldName} does not provide it.`,
       );
 
       // Assert interface field arg type matches object field arg type.
@@ -329,9 +333,9 @@ function assertObjectImplementsInterface(
       invariant(
         isEqualType(ifaceArg.type, objectArg.type),
         `${iface.name}.${fieldName}(${argName}:) expects type ` +
-        `"${String(ifaceArg.type)}" but ` +
-        `${object.name}.${fieldName}(${argName}:) provides type ` +
-        `"${String(objectArg.type)}".`
+          `"${String(ifaceArg.type)}" but ` +
+          `${object.name}.${fieldName}(${argName}:) provides type ` +
+          `"${String(objectArg.type)}".`,
       );
     });
 
@@ -343,8 +347,8 @@ function assertObjectImplementsInterface(
         invariant(
           !(objectArg.type instanceof GraphQLNonNull),
           `${object.name}.${fieldName}(${argName}:) is of required type ` +
-          `"${String(objectArg.type)}" but is not also provided by the ` +
-          `interface ${iface.name}.${fieldName}.`
+            `"${String(objectArg.type)}" but is not also provided by the ` +
+            `interface ${iface.name}.${fieldName}.`,
         );
       }
     });

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -33,13 +33,12 @@ import type { GraphQLDirective } from '../type/directives';
 import {
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
-  TypeNameMetaFieldDef
+  TypeNameMetaFieldDef,
 } from '../type/introspection';
 import type { GraphQLSchema } from '../type/schema';
 import type { ASTNode, FieldNode } from '../language/ast';
 import { typeFromAST } from './typeFromAST';
 import find from '../jsutils/find';
-
 
 /**
  * TypeInfo is a utility class which, given a GraphQL schema, can keep track
@@ -62,7 +61,7 @@ export class TypeInfo {
     // NOTE: this experimental optional second parameter is only needed in order
     // to support non-spec-compliant codebases. You should never need to use it.
     // It may disappear in the future.
-    getFieldDefFn?: typeof getFieldDef
+    getFieldDefFn?: typeof getFieldDef,
   ): void {
     this._schema = schema;
     this._typeStack = [];
@@ -112,13 +111,13 @@ export class TypeInfo {
   }
 
   // Flow does not yet handle this case.
-  enter(node: any/* ASTNode */) {
+  enter(node: any /* ASTNode */) {
     const schema = this._schema;
     switch (node.kind) {
       case Kind.SELECTION_SET:
         const namedType = getNamedType(this.getType());
         this._parentTypeStack.push(
-          isCompositeType(namedType) ? namedType : undefined
+          isCompositeType(namedType) ? namedType : undefined,
         );
         break;
       case Kind.FIELD:
@@ -147,17 +146,15 @@ export class TypeInfo {
       case Kind.INLINE_FRAGMENT:
       case Kind.FRAGMENT_DEFINITION:
         const typeConditionAST = node.typeCondition;
-        const outputType = typeConditionAST ?
-          typeFromAST(schema, typeConditionAST) :
-          this.getType();
-        this._typeStack.push(
-          isOutputType(outputType) ? outputType : undefined
-        );
+        const outputType = typeConditionAST
+          ? typeFromAST(schema, typeConditionAST)
+          : this.getType();
+        this._typeStack.push(isOutputType(outputType) ? outputType : undefined);
         break;
       case Kind.VARIABLE_DEFINITION:
         const inputType = typeFromAST(schema, node.type);
         this._inputTypeStack.push(
-          isInputType(inputType) ? inputType : undefined
+          isInputType(inputType) ? inputType : undefined,
         );
         break;
       case Kind.ARGUMENT:
@@ -167,7 +164,7 @@ export class TypeInfo {
         if (fieldOrDirective) {
           argDef = find(
             fieldOrDirective.args,
-            arg => arg.name === node.name.value
+            arg => arg.name === node.name.value,
           );
           if (argDef) {
             argType = argDef.type;
@@ -179,7 +176,7 @@ export class TypeInfo {
       case Kind.LIST:
         const listType = getNullableType(this.getInputType());
         this._inputTypeStack.push(
-          listType instanceof GraphQLList ? listType.ofType : undefined
+          listType instanceof GraphQLList ? listType.ofType : undefined,
         );
         break;
       case Kind.OBJECT_FIELD:
@@ -245,22 +242,25 @@ export class TypeInfo {
 function getFieldDef(
   schema: GraphQLSchema,
   parentType: GraphQLType,
-  fieldNode: FieldNode
+  fieldNode: FieldNode,
 ): ?GraphQLField<*, *> {
   const name = fieldNode.name.value;
-  if (name === SchemaMetaFieldDef.name &&
-      schema.getQueryType() === parentType) {
+  if (
+    name === SchemaMetaFieldDef.name &&
+    schema.getQueryType() === parentType
+  ) {
     return SchemaMetaFieldDef;
   }
-  if (name === TypeMetaFieldDef.name &&
-      schema.getQueryType() === parentType) {
+  if (name === TypeMetaFieldDef.name && schema.getQueryType() === parentType) {
     return TypeMetaFieldDef;
   }
   if (name === TypeNameMetaFieldDef.name && isCompositeType(parentType)) {
     return TypeNameMetaFieldDef;
   }
-  if (parentType instanceof GraphQLObjectType ||
-      parentType instanceof GraphQLInterfaceType) {
+  if (
+    parentType instanceof GraphQLObjectType ||
+    parentType instanceof GraphQLInterfaceType
+  ) {
     return parentType.getFields()[name];
   }
 }

--- a/src/utilities/__tests__/assertValidName-test.js
+++ b/src/utilities/__tests__/assertValidName-test.js
@@ -22,10 +22,7 @@ function dedent(string) {
   // Find smallest indent.
   const indent = lines.reduce((currentMinimum, line) => {
     const whitespace = line.match(/^ +/);
-    return Math.min(
-      whitespace ? whitespace[0].length : 0,
-      currentMinimum
-    );
+    return Math.min(whitespace ? whitespace[0].length : 0, currentMinimum);
   }, Infinity);
 
   // Remove indent from each line.
@@ -112,13 +109,15 @@ describe('formatWarning()', () => {
         at <anonymous>:1:6
     `);
     const error = createErrorObject('foo', chromeStack);
-    expect(formatWarning(error)).to.equal(dedent(`
+    expect(formatWarning(error)).to.equal(
+      dedent(`
       foo
         at z (<anonymous>:1:21)
         at y (<anonymous>:1:15)
         at x (<anonymous>:1:15)
         at <anonymous>:1:6
-    `));
+    `),
+    );
   });
 
   it('formats given a Node-style stack property', () => {
@@ -136,7 +135,8 @@ describe('formatWarning()', () => {
         at emitOne (events.js:101:20)
     `);
     const error = createErrorObject('foo', nodeStack);
-    expect(formatWarning(error)).to.equal(dedent(`
+    expect(formatWarning(error)).to.equal(
+      dedent(`
       foo
         at z (repl:1:29)
         at y (repl:1:23)
@@ -148,7 +148,8 @@ describe('formatWarning()', () => {
         at REPLServer.runBound [as eval] (domain.js:293:12)
         at REPLServer.onLine (repl.js:537:10)
         at emitOne (events.js:101:20)
-    `));
+    `),
+    );
   });
 
   it('formats given a Firefox-style stack property', () => {
@@ -159,13 +160,15 @@ describe('formatWarning()', () => {
       @debugger eval code:1:5
     `);
     const error = createErrorObject('foo', firefoxStack);
-    expect(formatWarning(error)).to.equal(dedent(`
+    expect(formatWarning(error)).to.equal(
+      dedent(`
       foo
       z@debugger eval code:1:20
       y@debugger eval code:1:14
       x@debugger eval code:1:14
       @debugger eval code:1:5
-    `));
+    `),
+    );
   });
 
   it('formats given a Safari-style stack property', () => {
@@ -180,7 +183,8 @@ describe('formatWarning()', () => {
       evaluate
     `);
     const error = createErrorObject('foo', safariStack);
-    expect(formatWarning(error)).to.equal(dedent(`
+    expect(formatWarning(error)).to.equal(
+      dedent(`
       foo
       z
       y
@@ -190,7 +194,8 @@ describe('formatWarning()', () => {
       _evaluateOn
       _evaluateAndWrap
       evaluate
-    `));
+    `),
+    );
   });
 
   it('formats in the absence of a stack property', () => {

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -20,148 +20,157 @@ import {
   GraphQLNonNull,
 } from '../../type';
 
-
 describe('astFromValue', () => {
-
   it('converts boolean values to ASTs', () => {
-    expect(astFromValue(true, GraphQLBoolean)).to.deep.equal(
-      { kind: 'BooleanValue', value: true }
-    );
+    expect(astFromValue(true, GraphQLBoolean)).to.deep.equal({
+      kind: 'BooleanValue',
+      value: true,
+    });
 
-    expect(astFromValue(false, GraphQLBoolean)).to.deep.equal(
-      { kind: 'BooleanValue', value: false }
-    );
+    expect(astFromValue(false, GraphQLBoolean)).to.deep.equal({
+      kind: 'BooleanValue',
+      value: false,
+    });
 
-    expect(astFromValue(undefined, GraphQLBoolean)).to.deep.equal(
-      null
-    );
+    expect(astFromValue(undefined, GraphQLBoolean)).to.deep.equal(null);
 
     expect(astFromValue(NaN, GraphQLInt)).to.deep.equal(null);
 
-    expect(astFromValue(null, GraphQLBoolean)).to.deep.equal(
-      { kind: 'NullValue' }
-    );
+    expect(astFromValue(null, GraphQLBoolean)).to.deep.equal({
+      kind: 'NullValue',
+    });
 
-    expect(astFromValue(0, GraphQLBoolean)).to.deep.equal(
-      { kind: 'BooleanValue', value: false }
-    );
+    expect(astFromValue(0, GraphQLBoolean)).to.deep.equal({
+      kind: 'BooleanValue',
+      value: false,
+    });
 
-    expect(astFromValue(1, GraphQLBoolean)).to.deep.equal(
-      { kind: 'BooleanValue', value: true }
-    );
+    expect(astFromValue(1, GraphQLBoolean)).to.deep.equal({
+      kind: 'BooleanValue',
+      value: true,
+    });
 
     const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
-    expect(astFromValue(0, NonNullBoolean)).to.deep.equal(
-      { kind: 'BooleanValue', value: false }
-    );
+    expect(astFromValue(0, NonNullBoolean)).to.deep.equal({
+      kind: 'BooleanValue',
+      value: false,
+    });
   });
 
   it('converts Int values to Int ASTs', () => {
-    expect(astFromValue(123.0, GraphQLInt)).to.deep.equal(
-      { kind: 'IntValue', value: '123' }
-    );
+    expect(astFromValue(123.0, GraphQLInt)).to.deep.equal({
+      kind: 'IntValue',
+      value: '123',
+    });
 
-    expect(astFromValue(1e4, GraphQLInt)).to.deep.equal(
-      { kind: 'IntValue', value: '10000' }
-    );
+    expect(astFromValue(1e4, GraphQLInt)).to.deep.equal({
+      kind: 'IntValue',
+      value: '10000',
+    });
 
     // GraphQL spec does not allow coercing non-integer values to Int to avoid
     // accidental data loss.
     expect(() => astFromValue(123.5, GraphQLInt)).to.throw(
-      'Int cannot represent non-integer value: 123.5'
+      'Int cannot represent non-integer value: 123.5',
     );
 
     // Note: outside the bounds of 32bit signed int.
     expect(() => astFromValue(1e40, GraphQLInt)).to.throw(
-      'Int cannot represent non 32-bit signed integer value: 1e+40'
+      'Int cannot represent non 32-bit signed integer value: 1e+40',
     );
   });
 
   it('converts Float values to Int/Float ASTs', () => {
-    expect(astFromValue(123.0, GraphQLFloat)).to.deep.equal(
-      { kind: 'IntValue', value: '123' }
-    );
+    expect(astFromValue(123.0, GraphQLFloat)).to.deep.equal({
+      kind: 'IntValue',
+      value: '123',
+    });
 
-    expect(astFromValue(123.5, GraphQLFloat)).to.deep.equal(
-      { kind: 'FloatValue', value: '123.5' }
-    );
+    expect(astFromValue(123.5, GraphQLFloat)).to.deep.equal({
+      kind: 'FloatValue',
+      value: '123.5',
+    });
 
-    expect(astFromValue(1e4, GraphQLFloat)).to.deep.equal(
-      { kind: 'IntValue', value: '10000' }
-    );
+    expect(astFromValue(1e4, GraphQLFloat)).to.deep.equal({
+      kind: 'IntValue',
+      value: '10000',
+    });
 
-    expect(astFromValue(1e40, GraphQLFloat)).to.deep.equal(
-      { kind: 'FloatValue', value: '1e+40' }
-    );
+    expect(astFromValue(1e40, GraphQLFloat)).to.deep.equal({
+      kind: 'FloatValue',
+      value: '1e+40',
+    });
   });
 
   it('converts String values to String ASTs', () => {
-    expect(astFromValue('hello', GraphQLString)).to.deep.equal(
-      { kind: 'StringValue', value: 'hello' }
-    );
+    expect(astFromValue('hello', GraphQLString)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'hello',
+    });
 
-    expect(astFromValue('VALUE', GraphQLString)).to.deep.equal(
-      { kind: 'StringValue', value: 'VALUE' }
-    );
+    expect(astFromValue('VALUE', GraphQLString)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'VALUE',
+    });
 
-    expect(astFromValue('VA\nLUE', GraphQLString)).to.deep.equal(
-      { kind: 'StringValue', value: 'VA\\nLUE' }
-    );
+    expect(astFromValue('VA\nLUE', GraphQLString)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'VA\\nLUE',
+    });
 
-    expect(astFromValue(123, GraphQLString)).to.deep.equal(
-      { kind: 'StringValue', value: '123' }
-    );
+    expect(astFromValue(123, GraphQLString)).to.deep.equal({
+      kind: 'StringValue',
+      value: '123',
+    });
 
-    expect(astFromValue(false, GraphQLString)).to.deep.equal(
-      { kind: 'StringValue', value: 'false' }
-    );
+    expect(astFromValue(false, GraphQLString)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'false',
+    });
 
-    expect(astFromValue(null, GraphQLString)).to.deep.equal(
-      { kind: 'NullValue' }
-    );
+    expect(astFromValue(null, GraphQLString)).to.deep.equal({
+      kind: 'NullValue',
+    });
 
-    expect(astFromValue(undefined, GraphQLString)).to.deep.equal(
-      null
-    );
+    expect(astFromValue(undefined, GraphQLString)).to.deep.equal(null);
   });
 
   it('converts ID values to Int/String ASTs', () => {
-    expect(astFromValue('hello', GraphQLID)).to.deep.equal(
-      { kind: 'StringValue', value: 'hello' }
-    );
+    expect(astFromValue('hello', GraphQLID)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'hello',
+    });
 
-    expect(astFromValue('VALUE', GraphQLID)).to.deep.equal(
-      { kind: 'StringValue', value: 'VALUE' }
-    );
+    expect(astFromValue('VALUE', GraphQLID)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'VALUE',
+    });
 
     // Note: EnumValues cannot contain non-identifier characters
-    expect(astFromValue('VA\nLUE', GraphQLID)).to.deep.equal(
-      { kind: 'StringValue', value: 'VA\\nLUE' }
-    );
+    expect(astFromValue('VA\nLUE', GraphQLID)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'VA\\nLUE',
+    });
 
     // Note: IntValues are used when possible.
-    expect(astFromValue(123, GraphQLID)).to.deep.equal(
-      { kind: 'IntValue', value: '123' }
-    );
+    expect(astFromValue(123, GraphQLID)).to.deep.equal({
+      kind: 'IntValue',
+      value: '123',
+    });
 
-    expect(astFromValue(false, GraphQLID)).to.deep.equal(
-      { kind: 'StringValue', value: 'false' }
-    );
+    expect(astFromValue(false, GraphQLID)).to.deep.equal({
+      kind: 'StringValue',
+      value: 'false',
+    });
 
-    expect(astFromValue(null, GraphQLID)).to.deep.equal(
-      { kind: 'NullValue' }
-    );
+    expect(astFromValue(null, GraphQLID)).to.deep.equal({ kind: 'NullValue' });
 
-    expect(astFromValue(undefined, GraphQLID)).to.deep.equal(
-      null
-    );
+    expect(astFromValue(undefined, GraphQLID)).to.deep.equal(null);
   });
 
   it('does not converts NonNull values to NullValue', () => {
     const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
-    expect(astFromValue(null, NonNullBoolean)).to.deep.equal(
-      null
-    );
+    expect(astFromValue(null, NonNullBoolean)).to.deep.equal(null);
   });
 
   const complexValue = { someArbitrary: 'complexValue' };
@@ -171,57 +180,55 @@ describe('astFromValue', () => {
     values: {
       HELLO: {},
       GOODBYE: {},
-      COMPLEX: { value: complexValue }
-    }
+      COMPLEX: { value: complexValue },
+    },
   });
 
   it('converts string values to Enum ASTs if possible', () => {
-    expect(astFromValue('HELLO', myEnum)).to.deep.equal(
-      { kind: 'EnumValue', value: 'HELLO' }
-    );
+    expect(astFromValue('HELLO', myEnum)).to.deep.equal({
+      kind: 'EnumValue',
+      value: 'HELLO',
+    });
 
-    expect(astFromValue(complexValue, myEnum)).to.deep.equal(
-      { kind: 'EnumValue', value: 'COMPLEX' }
-    );
+    expect(astFromValue(complexValue, myEnum)).to.deep.equal({
+      kind: 'EnumValue',
+      value: 'COMPLEX',
+    });
 
     // Note: case sensitive
-    expect(astFromValue('hello', myEnum)).to.deep.equal(
-      null
-    );
+    expect(astFromValue('hello', myEnum)).to.deep.equal(null);
 
     // Note: Not a valid enum value
-    expect(astFromValue('VALUE', myEnum)).to.deep.equal(
-      null
-    );
+    expect(astFromValue('VALUE', myEnum)).to.deep.equal(null);
   });
 
   it('converts array values to List ASTs', () => {
     expect(
-      astFromValue([ 'FOO', 'BAR' ], new GraphQLList(GraphQLString))
-    ).to.deep.equal(
-      { kind: 'ListValue',
-        values: [
-          { kind: 'StringValue', value: 'FOO' },
-          { kind: 'StringValue', value: 'BAR' } ] }
-    );
+      astFromValue(['FOO', 'BAR'], new GraphQLList(GraphQLString)),
+    ).to.deep.equal({
+      kind: 'ListValue',
+      values: [
+        { kind: 'StringValue', value: 'FOO' },
+        { kind: 'StringValue', value: 'BAR' },
+      ],
+    });
 
     expect(
-      astFromValue([ 'HELLO', 'GOODBYE' ], new GraphQLList(myEnum))
-    ).to.deep.equal(
-      { kind: 'ListValue',
-        values: [
-          { kind: 'EnumValue', value: 'HELLO' },
-          { kind: 'EnumValue', value: 'GOODBYE' } ] }
-    );
+      astFromValue(['HELLO', 'GOODBYE'], new GraphQLList(myEnum)),
+    ).to.deep.equal({
+      kind: 'ListValue',
+      values: [
+        { kind: 'EnumValue', value: 'HELLO' },
+        { kind: 'EnumValue', value: 'GOODBYE' },
+      ],
+    });
   });
 
   it('converts list singletons', () => {
-    expect(astFromValue(
-      'FOO',
-      new GraphQLList(GraphQLString)
-    )).to.deep.equal(
-      { kind: 'StringValue', value: 'FOO' }
-    );
+    expect(astFromValue('FOO', new GraphQLList(GraphQLString))).to.deep.equal({
+      kind: 'StringValue',
+      value: 'FOO',
+    });
   });
 
   it('converts input objects', () => {
@@ -229,23 +236,25 @@ describe('astFromValue', () => {
       name: 'MyInputObj',
       fields: {
         foo: { type: GraphQLFloat },
-        bar: { type: myEnum }
-      }
+        bar: { type: myEnum },
+      },
     });
 
-    expect(astFromValue(
-      { foo: 3, bar: 'HELLO' },
-      inputObj
-    )).to.deep.equal(
-      { kind: 'ObjectValue',
-        fields: [
-          { kind: 'ObjectField',
-            name: { kind: 'Name', value: 'foo' },
-            value: { kind: 'IntValue', value: '3' } },
-          { kind: 'ObjectField',
-            name: { kind: 'Name', value: 'bar' },
-            value: { kind: 'EnumValue', value: 'HELLO' } } ] }
-    );
+    expect(astFromValue({ foo: 3, bar: 'HELLO' }, inputObj)).to.deep.equal({
+      kind: 'ObjectValue',
+      fields: [
+        {
+          kind: 'ObjectField',
+          name: { kind: 'Name', value: 'foo' },
+          value: { kind: 'IntValue', value: '3' },
+        },
+        {
+          kind: 'ObjectField',
+          name: { kind: 'Name', value: 'bar' },
+          value: { kind: 'EnumValue', value: 'HELLO' },
+        },
+      ],
+    });
   });
 
   it('converts input objects with explicit nulls', () => {
@@ -254,19 +263,18 @@ describe('astFromValue', () => {
       fields: {
         foo: { type: GraphQLFloat },
         bar: { type: myEnum },
-      }
+      },
     });
 
-    expect(astFromValue(
-      { foo: null },
-      inputObj
-    )).to.deep.equal(
-      { kind: 'ObjectValue',
-        fields: [
-          { kind: 'ObjectField',
-            name: { kind: 'Name', value: 'foo' },
-            value: { kind: 'NullValue' } } ] }
-    );
+    expect(astFromValue({ foo: null }, inputObj)).to.deep.equal({
+      kind: 'ObjectValue',
+      fields: [
+        {
+          kind: 'ObjectField',
+          name: { kind: 'Name', value: 'foo' },
+          value: { kind: 'NullValue' },
+        },
+      ],
+    });
   });
-
 });

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -32,20 +32,17 @@ function cycleOutput(body) {
 }
 
 describe('Schema Builder', () => {
-
   it('can use built schema for limited execution', async () => {
-    const schema = buildASTSchema(parse(`
+    const schema = buildASTSchema(
+      parse(`
       schema { query: Query }
       type Query {
         str: String
       }
-    `));
-
-    const result = await graphql(
-      schema,
-      '{ str }',
-      { str: 123 }
+    `),
     );
+
+    const result = await graphql(schema, '{ str }', { str: 123 });
     expect(result.data).to.deep.equal({ str: '123' });
   });
 
@@ -55,9 +52,11 @@ describe('Schema Builder', () => {
         add(x: Int, y: Int): Int
       }
     `);
-    expect(await graphql(
-      schema, '{ add(x: 34, y: 55) }', { add: ({x, y}) => x + y }
-    )).to.deep.equal({ data: { add: 89 }});
+    expect(
+      await graphql(schema, '{ add(x: 34, y: 55) }', {
+        add: ({ x, y }) => x + y,
+      }),
+    ).to.deep.equal({ data: { add: 89 } });
   });
 
   it('Simple type', () => {
@@ -140,9 +139,9 @@ describe('Schema Builder', () => {
     expect(schema.getDirectives().length).to.equal(3);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
-    expect(
-      schema.getDirective('deprecated')
-    ).to.equal(GraphQLDeprecatedDirective);
+    expect(schema.getDirective('deprecated')).to.equal(
+      GraphQLDeprecatedDirective,
+    );
   });
 
   it('Overriding directives excludes specified', () => {
@@ -162,12 +161,12 @@ describe('Schema Builder', () => {
     const schema = buildASTSchema(parse(body));
     expect(schema.getDirectives().length).to.equal(3);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
-    expect(
-      schema.getDirective('include')
-    ).to.not.equal(GraphQLIncludeDirective);
-    expect(
-      schema.getDirective('deprecated')
-    ).to.not.equal(GraphQLDeprecatedDirective);
+    expect(schema.getDirective('include')).to.not.equal(
+      GraphQLIncludeDirective,
+    );
+    expect(schema.getDirective('deprecated')).to.not.equal(
+      GraphQLDeprecatedDirective,
+    );
   });
 
   it('Adding directives maintains @skip & @include', () => {
@@ -206,7 +205,6 @@ describe('Schema Builder', () => {
     const output = cycleOutput(body);
     expect(output).to.equal(body);
   });
-
 
   it('Recursive type', () => {
     const body = dedent`
@@ -597,43 +595,49 @@ describe('Schema Builder', () => {
     const testType = schema.getType('TestType');
     const testDirective = schema.getDirective('test');
 
-    const restoredIDL = printSchema(buildSchema(
-      print(schema.astNode) + '\n' +
-      print(query.astNode) + '\n' +
-      print(testInput.astNode) + '\n' +
-      print(testEnum.astNode) + '\n' +
-      print(testUnion.astNode) + '\n' +
-      print(testInterface.astNode) + '\n' +
-      print(testType.astNode) + '\n' +
-      print(testDirective.astNode)
-    ));
+    const restoredIDL = printSchema(
+      buildSchema(
+        print(schema.astNode) +
+          '\n' +
+          print(query.astNode) +
+          '\n' +
+          print(testInput.astNode) +
+          '\n' +
+          print(testEnum.astNode) +
+          '\n' +
+          print(testUnion.astNode) +
+          '\n' +
+          print(testInterface.astNode) +
+          '\n' +
+          print(testType.astNode) +
+          '\n' +
+          print(testDirective.astNode),
+      ),
+    );
     expect(restoredIDL).to.be.equal(printSchema(schema));
 
     const testField = query.getFields().testField;
     expect(print(testField.astNode)).to.equal(
-      'testField(testArg: TestInput): TestUnion'
+      'testField(testArg: TestInput): TestUnion',
     );
-    expect(print(testField.args[0].astNode)).to.equal(
-      'testArg: TestInput'
-    );
+    expect(print(testField.args[0].astNode)).to.equal('testArg: TestInput');
     expect(print(testInput.getFields().testInputField.astNode)).to.equal(
-      'testInputField: TestEnum'
+      'testInputField: TestEnum',
     );
     expect(print(testEnum.getValue('TEST_VALUE').astNode)).to.equal(
-      'TEST_VALUE'
+      'TEST_VALUE',
     );
     expect(print(testInterface.getFields().interfaceField.astNode)).to.equal(
-      'interfaceField: String'
+      'interfaceField: String',
     );
     expect(print(testType.getFields().interfaceField.astNode)).to.equal(
-      'interfaceField: String'
+      'interfaceField: String',
     );
     expect(print(testDirective.args[0].astNode)).to.equal('arg: Int');
   });
 });
 
 describe('Failures', () => {
-
   it('Requires a schema definition or Query type', () => {
     const body = dedent`
       type Hello {
@@ -642,7 +646,7 @@ describe('Failures', () => {
     `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc)).to.throw(
-      'Must provide schema definition with query type or a type named Query.'
+      'Must provide schema definition with query type or a type named Query.',
     );
   });
 
@@ -661,8 +665,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Must provide only one schema definition.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Must provide only one schema definition.',
+    );
   });
 
   it('Requires a query type', () => {
@@ -677,7 +682,7 @@ describe('Failures', () => {
     `;
     const doc = parse(body);
     expect(() => buildASTSchema(doc)).to.throw(
-      'Must provide schema definition with query type or a type named Query.'
+      'Must provide schema definition with query type or a type named Query.',
     );
   });
 
@@ -697,8 +702,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Must provide only one query type in schema.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Must provide only one query type in schema.',
+    );
   });
 
   it('Allows only a single mutation type', () => {
@@ -718,8 +724,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Must provide only one mutation type in schema.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Must provide only one mutation type in schema.',
+    );
   });
 
   it('Allows only a single subscription type', () => {
@@ -739,8 +746,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Must provide only one subscription type in schema.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Must provide only one subscription type in schema.',
+    );
   });
 
   it('Unknown type referenced', () => {
@@ -754,8 +762,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Type "Bar" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Type "Bar" not found in document.',
+    );
   });
 
   it('Unknown type in interface list', () => {
@@ -767,8 +776,9 @@ describe('Failures', () => {
       type Hello implements Bar { }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Type "Bar" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Type "Bar" not found in document.',
+    );
   });
 
   it('Unknown type in union list', () => {
@@ -781,8 +791,9 @@ describe('Failures', () => {
       type Hello { testUnion: TestUnion }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Type "Bar" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Type "Bar" not found in document.',
+    );
   });
 
   it('Unknown query type', () => {
@@ -796,8 +807,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Specified query type "Wat" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Specified query type "Wat" not found in document.',
+    );
   });
 
   it('Unknown mutation type', () => {
@@ -812,8 +824,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Specified mutation type "Wat" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Specified mutation type "Wat" not found in document.',
+    );
   });
 
   it('Unknown subscription type', () => {
@@ -833,8 +846,9 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Specified subscription type "Awesome" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Specified subscription type "Awesome" not found in document.',
+    );
   });
 
   it('Does not consider operation names', () => {
@@ -846,8 +860,9 @@ describe('Failures', () => {
       query Foo { field }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Specified query type "Foo" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Specified query type "Foo" not found in document.',
+    );
   });
 
   it('Does not consider fragment names', () => {
@@ -859,8 +874,9 @@ describe('Failures', () => {
       fragment Foo on Type { field }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Specified query type "Foo" not found in document.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Specified query type "Foo" not found in document.',
+    );
   });
 
   it('Forbids duplicate type definitions', () => {
@@ -878,7 +894,8 @@ describe('Failures', () => {
       }
     `;
     const doc = parse(body);
-    expect(() => buildASTSchema(doc))
-      .to.throw('Type "Repeated" was defined more than once.');
+    expect(() => buildASTSchema(doc)).to.throw(
+      'Type "Repeated" was defined more than once.',
+    );
   });
 });

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -28,7 +28,6 @@ import {
 } from '../../';
 import { GraphQLDirective } from '../../type/directives';
 
-
 // Test property:
 // Given a server's schema, a client may query that server with introspection,
 // and use the result to produce a client-side representation of the schema
@@ -43,7 +42,6 @@ async function testSchema(serverSchema) {
 }
 
 describe('Type System: build schema from introspection', () => {
-
   it('builds a simple schema', async () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -52,10 +50,10 @@ describe('Type System: build schema from introspection', () => {
         fields: {
           string: {
             type: GraphQLString,
-            description: 'This is a string field'
-          }
-        }
-      })
+            description: 'This is a string field',
+          },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -68,9 +66,9 @@ describe('Type System: build schema from introspection', () => {
       fields: {
         string: {
           type: GraphQLString,
-          description: 'This is a string field'
-        }
-      }
+          description: 'This is a string field',
+        },
+      },
     });
 
     const mutationType = new GraphQLObjectType({
@@ -81,10 +79,10 @@ describe('Type System: build schema from introspection', () => {
           type: GraphQLString,
           description: 'Set the string field',
           args: {
-            value: { type: GraphQLString }
-          }
-        }
-      }
+            value: { type: GraphQLString },
+          },
+        },
+      },
     });
 
     const subscriptionType = new GraphQLObjectType({
@@ -93,15 +91,15 @@ describe('Type System: build schema from introspection', () => {
       fields: {
         string: {
           type: GraphQLString,
-          description: 'This is a string field'
-        }
-      }
+          description: 'This is a string field',
+        },
+      },
     });
 
     const schema = new GraphQLSchema({
       query: queryType,
       mutation: mutationType,
-      subscription: subscriptionType
+      subscription: subscriptionType,
     });
 
     await testSchema(schema);
@@ -122,8 +120,8 @@ describe('Type System: build schema from introspection', () => {
           boolean: { type: GraphQLBoolean },
           id: { type: GraphQLID },
           custom: { type: customScalar },
-        }
-      })
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -146,11 +144,11 @@ describe('Type System: build schema from introspection', () => {
     const recurType = new GraphQLObjectType({
       name: 'Recur',
       fields: () => ({
-        recur: { type: recurType }
-      })
+        recur: { type: recurType },
+      }),
     });
     const schema = new GraphQLSchema({
-      query: recurType
+      query: recurType,
     });
 
     await testSchema(schema);
@@ -160,23 +158,23 @@ describe('Type System: build schema from introspection', () => {
     const dogType = new GraphQLObjectType({
       name: 'Dog',
       fields: () => ({
-        bestFriend: { type: humanType }
-      })
+        bestFriend: { type: humanType },
+      }),
     });
     const humanType = new GraphQLObjectType({
       name: 'Human',
       fields: () => ({
-        bestFriend: { type: dogType }
-      })
+        bestFriend: { type: dogType },
+      }),
     });
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Circular',
         fields: {
           dog: { type: dogType },
-          human: { type: humanType }
-        }
-      })
+          human: { type: humanType },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -189,32 +187,32 @@ describe('Type System: build schema from introspection', () => {
       fields: () => ({
         bestFriend: {
           type: friendlyType,
-          description: 'The best friend of this friendly thing'
-        }
-      })
+          description: 'The best friend of this friendly thing',
+        },
+      }),
     });
     const dogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ friendlyType ],
+      interfaces: [friendlyType],
       fields: () => ({
-        bestFriend: { type: friendlyType }
-      })
+        bestFriend: { type: friendlyType },
+      }),
     });
     const humanType = new GraphQLObjectType({
       name: 'Human',
-      interfaces: [ friendlyType ],
+      interfaces: [friendlyType],
       fields: () => ({
-        bestFriend: { type: friendlyType }
-      })
+        bestFriend: { type: friendlyType },
+      }),
     });
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'WithInterface',
         fields: {
-          friendly: { type: friendlyType }
-        }
+          friendly: { type: friendlyType },
+        },
       }),
-      types: [ dogType, humanType ]
+      types: [dogType, humanType],
     });
 
     await testSchema(schema);
@@ -227,24 +225,24 @@ describe('Type System: build schema from introspection', () => {
       fields: () => ({
         bestFriend: {
           type: friendlyType,
-          description: 'The best friend of this friendly thing'
-        }
-      })
+          description: 'The best friend of this friendly thing',
+        },
+      }),
     });
     const dogType = new GraphQLObjectType({
       name: 'Dog',
-      interfaces: [ friendlyType ],
+      interfaces: [friendlyType],
       fields: () => ({
-        bestFriend: { type: dogType }
-      })
+        bestFriend: { type: dogType },
+      }),
     });
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'WithInterface',
         fields: {
-          dog: { type: dogType }
-        }
-      })
+          dog: { type: dogType },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -254,27 +252,27 @@ describe('Type System: build schema from introspection', () => {
     const dogType = new GraphQLObjectType({
       name: 'Dog',
       fields: () => ({
-        bestFriend: { type: friendlyType }
-      })
+        bestFriend: { type: friendlyType },
+      }),
     });
     const humanType = new GraphQLObjectType({
       name: 'Human',
       fields: () => ({
-        bestFriend: { type: friendlyType }
-      })
+        bestFriend: { type: friendlyType },
+      }),
     });
     const friendlyType = new GraphQLUnionType({
       name: 'Friendly',
       resolveType: () => null,
-      types: [ dogType, humanType ]
+      types: [dogType, humanType],
     });
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'WithUnion',
         fields: {
-          friendly: { type: friendlyType }
-        }
-      })
+          friendly: { type: friendlyType },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -288,18 +286,18 @@ describe('Type System: build schema from introspection', () => {
           string: { type: GraphQLString },
           listOfString: { type: new GraphQLList(GraphQLString) },
           nonNullString: {
-            type: new GraphQLNonNull(GraphQLString)
+            type: new GraphQLNonNull(GraphQLString),
           },
           nonNullListOfString: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLString))
+            type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
           },
           nonNullListOfNonNullString: {
             type: new GraphQLNonNull(
-              new GraphQLList(new GraphQLNonNull(GraphQLString))
-            )
+              new GraphQLList(new GraphQLNonNull(GraphQLString)),
+            ),
           },
-        }
-      })
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -316,9 +314,9 @@ describe('Type System: build schema from introspection', () => {
             args: {
               intArg: {
                 description: 'This is an int arg',
-                type: GraphQLInt
-              }
-            }
+                type: GraphQLInt,
+              },
+            },
           },
           two: {
             description: 'A field with a two args',
@@ -326,16 +324,16 @@ describe('Type System: build schema from introspection', () => {
             args: {
               listArg: {
                 description: 'This is an list of int arg',
-                type: new GraphQLList(GraphQLInt)
+                type: new GraphQLList(GraphQLInt),
               },
               requiredArg: {
                 description: 'This is a required arg',
-                type: new GraphQLNonNull(GraphQLBoolean)
-              }
-            }
-          }
-        }
-      })
+                type: new GraphQLNonNull(GraphQLBoolean),
+              },
+            },
+          },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -348,25 +346,25 @@ describe('Type System: build schema from introspection', () => {
       values: {
         VEGETABLES: {
           description: 'Foods that are vegetables.',
-          value: 1
+          value: 1,
         },
         FRUITS: {
           description: 'Foods that are fruits.',
-          value: 2
+          value: 2,
         },
         OILS: {
           description: 'Foods that are oils.',
-          value: 3
+          value: 3,
         },
         DAIRY: {
           description: 'Foods that are dairy.',
-          value: 4
+          value: 4,
         },
         MEAT: {
           description: 'Foods that are meat.',
-          value: 5
-        }
-      }
+          value: 5,
+        },
+      },
     });
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -378,12 +376,12 @@ describe('Type System: build schema from introspection', () => {
             args: {
               kind: {
                 description: 'what kind of food?',
-                type: foodEnum
-              }
-            }
-          }
-        }
-      })
+                type: foodEnum,
+              },
+            },
+          },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -398,36 +396,46 @@ describe('Type System: build schema from introspection', () => {
     // Client types do not get server-only values, so `value` mirrors `name`,
     // rather than using the integers defined in the "server" schema.
     expect(clientFoodEnum.getValues()).to.deep.equal([
-      { name: 'VEGETABLES',
+      {
+        name: 'VEGETABLES',
         value: 'VEGETABLES',
         description: 'Foods that are vegetables.',
         isDeprecated: false,
         deprecationReason: null,
-        astNode: undefined, },
-      { name: 'FRUITS',
+        astNode: undefined,
+      },
+      {
+        name: 'FRUITS',
         value: 'FRUITS',
         description: 'Foods that are fruits.',
         isDeprecated: false,
         deprecationReason: null,
-        astNode: undefined, },
-      { name: 'OILS',
+        astNode: undefined,
+      },
+      {
+        name: 'OILS',
         value: 'OILS',
         description: 'Foods that are oils.',
         isDeprecated: false,
         deprecationReason: null,
-        astNode: undefined, },
-      { name: 'DAIRY',
+        astNode: undefined,
+      },
+      {
+        name: 'DAIRY',
         value: 'DAIRY',
         description: 'Foods that are dairy.',
         isDeprecated: false,
         deprecationReason: null,
-        astNode: undefined, },
-      { name: 'MEAT',
+        astNode: undefined,
+      },
+      {
+        name: 'MEAT',
         value: 'MEAT',
         description: 'Foods that are meat.',
         isDeprecated: false,
         deprecationReason: null,
-        astNode: undefined, },
+        astNode: undefined,
+      },
     ]);
   });
 
@@ -438,18 +446,18 @@ describe('Type System: build schema from introspection', () => {
       fields: {
         street: {
           description: 'What street is this address?',
-          type: new GraphQLNonNull(GraphQLString)
+          type: new GraphQLNonNull(GraphQLString),
         },
         city: {
           description: 'The city the address is within?',
-          type: new GraphQLNonNull(GraphQLString)
+          type: new GraphQLNonNull(GraphQLString),
         },
         country: {
           description: 'The country (blank will assume USA).',
           type: GraphQLString,
-          defaultValue: 'USA'
-        }
-      }
+          defaultValue: 'USA',
+        },
+      },
     });
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -461,17 +469,16 @@ describe('Type System: build schema from introspection', () => {
             args: {
               address: {
                 description: 'The address to lookup',
-                type: addressType
-              }
-            }
-          }
-        }
-      })
+                type: addressType,
+              },
+            },
+          },
+        },
+      }),
     });
 
     await testSchema(schema);
   });
-
 
   it('builds a schema with field arguments with default values', async () => {
     const geoType = new GraphQLInputObjectType({
@@ -479,7 +486,7 @@ describe('Type System: build schema from introspection', () => {
       fields: {
         lat: { type: GraphQLFloat },
         lon: { type: GraphQLFloat },
-      }
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -491,54 +498,53 @@ describe('Type System: build schema from introspection', () => {
             args: {
               intArg: {
                 type: GraphQLInt,
-                defaultValue: 10
-              }
-            }
+                defaultValue: 10,
+              },
+            },
           },
           defaultList: {
             type: GraphQLString,
             args: {
               listArg: {
                 type: new GraphQLList(GraphQLInt),
-                defaultValue: [ 1, 2, 3 ]
-              }
-            }
+                defaultValue: [1, 2, 3],
+              },
+            },
           },
           defaultObject: {
             type: GraphQLString,
             args: {
               objArg: {
                 type: geoType,
-                defaultValue: { lat: 37.485, lon: -122.148 }
-              }
-            }
+                defaultValue: { lat: 37.485, lon: -122.148 },
+              },
+            },
           },
           defaultNull: {
             type: GraphQLString,
             args: {
               intArg: {
                 type: GraphQLInt,
-                defaultValue: null
-              }
-            }
+                defaultValue: null,
+              },
+            },
           },
           noDefault: {
             type: GraphQLString,
             args: {
               intArg: {
-                type: GraphQLInt
-              }
-            }
-          }
-        }
-      })
+                type: GraphQLInt,
+              },
+            },
+          },
+        },
+      }),
     });
 
     await testSchema(schema);
   });
 
   it('builds a schema with custom directives', async () => {
-
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Simple',
@@ -546,48 +552,51 @@ describe('Type System: build schema from introspection', () => {
         fields: {
           string: {
             type: GraphQLString,
-            description: 'This is a string field'
-          }
-        }
+            description: 'This is a string field',
+          },
+        },
       }),
       directives: [
         new GraphQLDirective({
           name: 'customDirective',
           description: 'This is a custom directive',
-          locations: [ 'FIELD' ],
-        })
-      ]
+          locations: ['FIELD'],
+        }),
+      ],
     });
 
     await testSchema(schema);
   });
 
   it('builds a schema with legacy directives', async () => {
-
     const oldIntrospection = {
       __schema: {
         // Minimum required schema.
         queryType: {
-          name: 'Simple'
-        },
-        types: [ {
           name: 'Simple',
-          kind: 'OBJECT',
-          fields: [ {
-            name: 'simple',
-            args: [],
-            type: { name: 'Simple' }
-          } ],
-          interfaces: []
-        } ],
+        },
+        types: [
+          {
+            name: 'Simple',
+            kind: 'OBJECT',
+            fields: [
+              {
+                name: 'simple',
+                args: [],
+                type: { name: 'Simple' },
+              },
+            ],
+            interfaces: [],
+          },
+        ],
         // Test old directive introspection results.
         directives: [
           { name: 'Old1', args: [], onField: true },
           { name: 'Old2', args: [], onFragment: true },
           { name: 'Old3', args: [], onOperation: true },
           { name: 'Old4', args: [], onField: true, onFragment: true },
-        ]
-      }
+        ],
+      },
     };
 
     // New introspection produces correct new format.
@@ -597,7 +606,7 @@ describe('Type System: build schema from introspection', () => {
           {
             name: 'Old1',
             args: [],
-            locations: [ 'FIELD' ]
+            locations: ['FIELD'],
           },
           {
             name: 'Old2',
@@ -605,13 +614,13 @@ describe('Type System: build schema from introspection', () => {
             locations: [
               'FRAGMENT_DEFINITION',
               'FRAGMENT_SPREAD',
-              'INLINE_FRAGMENT'
-            ]
+              'INLINE_FRAGMENT',
+            ],
           },
           {
             name: 'Old3',
             args: [],
-            locations: [ 'QUERY', 'MUTATION', 'SUBSCRIPTION' ]
+            locations: ['QUERY', 'MUTATION', 'SUBSCRIPTION'],
           },
           {
             name: 'Old4',
@@ -620,11 +629,11 @@ describe('Type System: build schema from introspection', () => {
               'FIELD',
               'FRAGMENT_DEFINITION',
               'FRAGMENT_SPREAD',
-              'INLINE_FRAGMENT'
-            ]
+              'INLINE_FRAGMENT',
+            ],
           },
-        ]
-      }
+        ],
+      },
     };
 
     const clientSchema = buildClientSchema(oldIntrospection);
@@ -633,7 +642,6 @@ describe('Type System: build schema from introspection', () => {
   });
 
   it('builds a schema aware of deprecation', async () => {
-
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Simple',
@@ -641,7 +649,7 @@ describe('Type System: build schema from introspection', () => {
         fields: {
           shinyString: {
             type: GraphQLString,
-            description: 'This is a shiny string field'
+            description: 'This is a shiny string field',
           },
           deprecatedString: {
             type: GraphQLString,
@@ -657,13 +665,13 @@ describe('Type System: build schema from introspection', () => {
                 BLUE: { description: 'So calming' },
                 MAUVE: {
                   description: 'So sickening',
-                  deprecationReason: 'No longer in fashion'
+                  deprecationReason: 'No longer in fashion',
                 },
-              }
-            })
-          }
-        }
-      })
+              },
+            }),
+          },
+        },
+      }),
     });
 
     await testSchema(schema);
@@ -683,11 +691,11 @@ describe('Type System: build schema from introspection', () => {
             type: GraphQLString,
             args: {
               custom1: { type: customScalar },
-              custom2: { type: customScalar }
-            }
-          }
-        }
-      })
+              custom2: { type: customScalar },
+            },
+          },
+        },
+      }),
     });
 
     const introspection = await graphql(schema, introspectionQuery);
@@ -698,28 +706,25 @@ describe('Type System: build schema from introspection', () => {
       'query Limited($v: CustomScalar) { foo(custom1: 123, custom2: $v) }',
       { foo: 'bar', unused: 'value' },
       null,
-      { v: 'baz' }
+      { v: 'baz' },
     );
 
     expect(result.data).to.deep.equal({ foo: 'bar' });
   });
 
   describe('throws when given incomplete introspection', () => {
-
     it('throws when given empty types', () => {
       const incompleteIntrospection = {
         __schema: {
           queryType: { name: 'QueryType' },
-          types: []
-        }
+          types: [],
+        },
       };
 
-      expect(
-        () => buildClientSchema(incompleteIntrospection)
-      ).to.throw(
+      expect(() => buildClientSchema(incompleteIntrospection)).to.throw(
         'Invalid or incomplete schema, unknown type: QueryType. Ensure ' +
-        'that a full introspection query is used in order to build a ' +
-        'client schema.'
+          'that a full introspection query is used in order to build a ' +
+          'client schema.',
       );
     });
 
@@ -727,43 +732,46 @@ describe('Type System: build schema from introspection', () => {
       const incompleteIntrospection = {
         __schema: {
           queryType: { name: 'QueryType' },
-          types: [
-            { name: 'QueryType' }
-          ]
-        }
+          types: [{ name: 'QueryType' }],
+        },
       };
 
-      expect(
-        () => buildClientSchema(incompleteIntrospection)
-      ).to.throw(
+      expect(() => buildClientSchema(incompleteIntrospection)).to.throw(
         'Invalid or incomplete introspection result. Ensure that a full ' +
-        'introspection query is used in order to build a client schema'
+          'introspection query is used in order to build a client schema',
       );
     });
-
   });
 
   describe('very deep decorators are not supported', () => {
-
     it('fails on very deep (> 7 levels) lists', async () => {
       const schema = new GraphQLSchema({
         query: new GraphQLObjectType({
           name: 'Query',
           fields: {
             foo: {
-              type: new GraphQLList(new GraphQLList(new GraphQLList(
-                new GraphQLList(new GraphQLList(new GraphQLList(
-                new GraphQLList(new GraphQLList(GraphQLString))
-              ))))))
-            }
-          }
-        })
+              type: new GraphQLList(
+                new GraphQLList(
+                  new GraphQLList(
+                    new GraphQLList(
+                      new GraphQLList(
+                        new GraphQLList(
+                          new GraphQLList(new GraphQLList(GraphQLString)),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            },
+          },
+        }),
       });
 
       const introspection = await graphql(schema, introspectionQuery);
-      expect(
-        () => buildClientSchema(introspection.data)
-      ).to.throw('Decorated type deeper than introspection query.');
+      expect(() => buildClientSchema(introspection.data)).to.throw(
+        'Decorated type deeper than introspection query.',
+      );
     });
 
     it('fails on a very deep (> 7 levels) non-null', async () => {
@@ -772,19 +780,28 @@ describe('Type System: build schema from introspection', () => {
           name: 'Query',
           fields: {
             foo: {
-              type: new GraphQLList(new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(new GraphQLNonNull(GraphQLString))
-              ))))))
-            }
-          }
-        })
+              type: new GraphQLList(
+                new GraphQLNonNull(
+                  new GraphQLList(
+                    new GraphQLNonNull(
+                      new GraphQLList(
+                        new GraphQLNonNull(
+                          new GraphQLList(new GraphQLNonNull(GraphQLString)),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            },
+          },
+        }),
       });
 
       const introspection = await graphql(schema, introspectionQuery);
-      expect(
-        () => buildClientSchema(introspection.data)
-      ).to.throw('Decorated type deeper than introspection query.');
+      expect(() => buildClientSchema(introspection.data)).to.throw(
+        'Decorated type deeper than introspection query.',
+      );
     });
 
     it('succeeds on deep (<= 7 levels) types', async () => {
@@ -794,20 +811,24 @@ describe('Type System: build schema from introspection', () => {
           fields: {
             foo: {
               // e.g., fully non-null 3D matrix
-              type: new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(
-                new GraphQLNonNull(GraphQLString)
-              ))))))
-            }
-          }
-        })
+              type: new GraphQLNonNull(
+                new GraphQLList(
+                  new GraphQLNonNull(
+                    new GraphQLList(
+                      new GraphQLNonNull(
+                        new GraphQLList(new GraphQLNonNull(GraphQLString)),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            },
+          },
+        }),
       });
 
       const introspection = await graphql(schema, introspectionQuery);
       buildClientSchema(introspection.data);
     });
-
   });
-
 });

--- a/src/utilities/__tests__/concatAST-test.js
+++ b/src/utilities/__tests__/concatAST-test.js
@@ -11,9 +11,7 @@ import dedent from '../../jsutils/dedent';
 import { concatAST } from '../concatAST';
 import { Source, parse, print } from '../../language';
 
-
 describe('concatAST', () => {
-
   it('concats two ASTs together', () => {
     const sourceA = new Source(`
       { a, b, ...Frag }
@@ -27,7 +25,7 @@ describe('concatAST', () => {
 
     const astA = parse(sourceA);
     const astB = parse(sourceB);
-    const astC = concatAST([ astA, astB ]);
+    const astC = concatAST([astA, astB]);
 
     expect(print(astC)).to.equal(dedent`
       {
@@ -41,5 +39,4 @@ describe('concatAST', () => {
       }
     `);
   });
-
 });

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -33,40 +33,40 @@ const SomeInterfaceType = new GraphQLInterfaceType({
   fields: () => ({
     name: { type: GraphQLString },
     some: { type: SomeInterfaceType },
-  })
+  }),
 });
 
 const FooType = new GraphQLObjectType({
   name: 'Foo',
-  interfaces: [ SomeInterfaceType ],
+  interfaces: [SomeInterfaceType],
   fields: () => ({
     name: { type: GraphQLString },
     some: { type: SomeInterfaceType },
     tree: { type: new GraphQLNonNull(new GraphQLList(FooType)) },
-  })
+  }),
 });
 
 const BarType = new GraphQLObjectType({
   name: 'Bar',
-  interfaces: [ SomeInterfaceType ],
+  interfaces: [SomeInterfaceType],
   fields: () => ({
     name: { type: GraphQLString },
     some: { type: SomeInterfaceType },
     foo: { type: FooType },
-  })
+  }),
 });
 
 const BizType = new GraphQLObjectType({
   name: 'Biz',
   fields: () => ({
     fizz: { type: GraphQLString },
-  })
+  }),
 });
 
 const SomeUnionType = new GraphQLUnionType({
   name: 'SomeUnion',
   resolveType: () => FooType,
-  types: [ FooType, BizType ],
+  types: [FooType, BizType],
 });
 
 const SomeEnumType = new GraphQLEnumType({
@@ -74,7 +74,7 @@ const SomeEnumType = new GraphQLEnumType({
   values: {
     ONE: { value: 1 },
     TWO: { value: 2 },
-  }
+  },
 });
 
 const testSchema = new GraphQLSchema({
@@ -86,15 +86,14 @@ const testSchema = new GraphQLSchema({
       someEnum: { type: SomeEnumType },
       someInterface: {
         args: { id: { type: new GraphQLNonNull(GraphQLID) } },
-        type: SomeInterfaceType
+        type: SomeInterfaceType,
       },
-    })
+    }),
   }),
-  types: [ FooType, BarType ]
+  types: [FooType, BarType],
 });
 
 describe('extendSchema', () => {
-
   it('returns the original schema when there are no type definitions', () => {
     const ast = parse('{ field }');
     const extendedSchema = extendSchema(testSchema, ast);
@@ -124,11 +123,9 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(testSchema, ast);
     const clientQuery = parse('{ newField }');
 
-    const result = await execute(
-      extendedSchema,
-      clientQuery,
-      { newField: 123 }
-    );
+    const result = await execute(extendedSchema, clientQuery, {
+      newField: 123,
+    });
     expect(result.data).to.deep.equal({ newField: '123' });
   });
 
@@ -142,7 +139,7 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(testSchema, ast);
 
     expect(
-      extendedSchema.getType('Query').getFields().newField.description
+      extendedSchema.getType('Query').getFields().newField.description,
     ).to.equal('New field description.');
   });
 
@@ -232,8 +229,10 @@ describe('extendSchema', () => {
 
       directive @test(arg: Int) on FIELD
     `);
-    const extendedTwiceSchema = extendSchema(extendedSchema,
-      secondExtensionAst);
+    const extendedTwiceSchema = extendSchema(
+      extendedSchema,
+      secondExtensionAst,
+    );
 
     const query = extendedTwiceSchema.getType('Query');
     const testInput = extendedTwiceSchema.getType('TestInput');
@@ -247,40 +246,45 @@ describe('extendSchema', () => {
     expect(testType.extensionASTNodes).to.have.lengthOf(0);
 
     const restoredExtensionAST = parse(
-      print(query.extensionASTNodes[0]) + '\n' +
-      print(query.extensionASTNodes[1]) + '\n' +
-      print(testInput.astNode) + '\n' +
-      print(testEnum.astNode) + '\n' +
-      print(testUnion.astNode) + '\n' +
-      print(testInterface.astNode) + '\n' +
-      print(testType.astNode) + '\n' +
-      print(testDirective.astNode)
+      print(query.extensionASTNodes[0]) +
+        '\n' +
+        print(query.extensionASTNodes[1]) +
+        '\n' +
+        print(testInput.astNode) +
+        '\n' +
+        print(testEnum.astNode) +
+        '\n' +
+        print(testUnion.astNode) +
+        '\n' +
+        print(testInterface.astNode) +
+        '\n' +
+        print(testType.astNode) +
+        '\n' +
+        print(testDirective.astNode),
     );
     expect(
-      printSchema(extendSchema(schemaFromIDL, restoredExtensionAST))
+      printSchema(extendSchema(schemaFromIDL, restoredExtensionAST)),
     ).to.be.equal(printSchema(extendedTwiceSchema));
 
     const newField = query.getFields().newField;
     expect(print(newField.astNode)).to.equal(
-      'newField(testArg: TestInput): TestEnum'
+      'newField(testArg: TestInput): TestEnum',
     );
-    expect(print(newField.args[0].astNode)).to.equal(
-      'testArg: TestInput'
-    );
+    expect(print(newField.args[0].astNode)).to.equal('testArg: TestInput');
     expect(print(query.getFields().oneMoreNewField.astNode)).to.equal(
-      'oneMoreNewField: TestUnion'
+      'oneMoreNewField: TestUnion',
     );
     expect(print(testInput.getFields().testInputField.astNode)).to.equal(
-      'testInputField: TestEnum'
+      'testInputField: TestEnum',
     );
     expect(print(testEnum.getValue('TEST_VALUE').astNode)).to.equal(
-      'TEST_VALUE'
+      'TEST_VALUE',
     );
     expect(print(testInterface.getFields().interfaceField.astNode)).to.equal(
-      'interfaceField: String'
+      'interfaceField: String',
     );
     expect(print(testType.getFields().interfaceField.astNode)).to.equal(
-      'interfaceField: String'
+      'interfaceField: String',
     );
     expect(print(testDirective.args[0].astNode)).to.equal('arg: Int');
   });
@@ -298,8 +302,7 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(testSchema, ast);
     const deprecatedFieldDef = extendedSchema
       .getType('TypeWithDeprecatedField')
-      .getFields()
-      .newDeprecatedField;
+      .getFields().newDeprecatedField;
     expect(deprecatedFieldDef.isDeprecated).to.equal(true);
     expect(deprecatedFieldDef.deprecationReason).to.equal('not used anymore');
 
@@ -317,8 +320,8 @@ describe('extendSchema', () => {
       }
     `);
     const extendedSchema = extendSchema(testSchema, ast);
-    const deprecatedFieldDef =
-      extendedSchema.getType('Foo').getFields().deprecatedField;
+    const deprecatedFieldDef = extendedSchema.getType('Foo').getFields()
+      .deprecatedField;
     expect(deprecatedFieldDef.isDeprecated).to.equal(true);
     expect(deprecatedFieldDef.deprecationReason).to.equal('not used anymore');
   });
@@ -772,19 +775,19 @@ describe('extendSchema', () => {
         name: 'Query',
         fields: () => ({
           queryField: { type: GraphQLString },
-        })
+        }),
       }),
       mutation: new GraphQLObjectType({
         name: 'Mutation',
         fields: () => ({
           mutationField: { type: GraphQLString },
-        })
+        }),
       }),
       subscription: new GraphQLObjectType({
         name: 'Subscription',
         fields: () => ({
           subscriptionField: { type: GraphQLString },
-        })
+        }),
       }),
     });
 
@@ -873,11 +876,9 @@ describe('extendSchema', () => {
       directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD
     `);
 
-    expect(() =>
-      extendSchema(testSchema, ast)
-    ).to.throw(
+    expect(() => extendSchema(testSchema, ast)).to.throw(
       'Directive "include" already exists in the schema. It cannot be ' +
-      'redefined.'
+        'redefined.',
     );
   });
 
@@ -892,11 +893,9 @@ describe('extendSchema', () => {
       directive @meow(if: Boolean!) on FIELD | QUERY
     `);
 
-    expect(() =>
-      extendSchema(extendedSchema, replacementAst)
-    ).to.throw(
+    expect(() => extendSchema(extendedSchema, replacementAst)).to.throw(
       'Directive "meow" already exists in the schema. It cannot be ' +
-      'redefined.'
+        'redefined.',
     );
   });
 
@@ -906,11 +905,9 @@ describe('extendSchema', () => {
         baz: String
       }
     `);
-    expect(() =>
-      extendSchema(testSchema, ast)
-    ).to.throw(
+    expect(() => extendSchema(testSchema, ast)).to.throw(
       'Type "Bar" already exists in the schema. It cannot also be defined ' +
-      'in this type definition.'
+        'in this type definition.',
     );
   });
 
@@ -920,11 +917,9 @@ describe('extendSchema', () => {
         foo: Foo
       }
     `);
-    expect(() =>
-      extendSchema(testSchema, ast)
-    ).to.throw(
+    expect(() => extendSchema(testSchema, ast)).to.throw(
       'Field "Bar.foo" already exists in the schema. It cannot also be ' +
-      'defined in this type extension.'
+        'defined in this type extension.',
     );
   });
 
@@ -934,11 +929,9 @@ describe('extendSchema', () => {
         otherField: String
       }
     `);
-    expect(() =>
-      extendSchema(testSchema, ast)
-    ).to.throw(
+    expect(() => extendSchema(testSchema, ast)).to.throw(
       'Type "Foo" already implements "SomeInterface". It cannot also be ' +
-      'implemented in this type extension.'
+        'implemented in this type extension.',
     );
   });
 
@@ -948,11 +941,9 @@ describe('extendSchema', () => {
         quix: Quix
       }
     `);
-    expect(() =>
-      extendSchema(testSchema, ast)
-    ).to.throw(
+    expect(() => extendSchema(testSchema, ast)).to.throw(
       'Unknown type: "Quix". Ensure that this type exists either in the ' +
-      'original schema, or is added in a type definition.'
+        'original schema, or is added in a type definition.',
     );
   });
 
@@ -962,26 +953,21 @@ describe('extendSchema', () => {
         baz: String
       }
     `);
-    expect(() =>
-      extendSchema(testSchema, ast)
-    ).to.throw(
+    expect(() => extendSchema(testSchema, ast)).to.throw(
       'Cannot extend type "UnknownType" because it does not exist in the ' +
-      'existing schema.'
+        'existing schema.',
     );
   });
 
   describe('does not allow extending a non-object type', () => {
-
     it('not an interface', () => {
       const ast = parse(`
         extend type SomeInterface {
           baz: String
         }
       `);
-      expect(() =>
-        extendSchema(testSchema, ast)
-      ).to.throw(
-        'Cannot extend non-object type "SomeInterface".'
+      expect(() => extendSchema(testSchema, ast)).to.throw(
+        'Cannot extend non-object type "SomeInterface".',
       );
     });
 
@@ -991,12 +977,9 @@ describe('extendSchema', () => {
           baz: String
         }
       `);
-      expect(() =>
-        extendSchema(testSchema, ast)
-      ).to.throw(
-        'Cannot extend non-object type "String".'
+      expect(() => extendSchema(testSchema, ast)).to.throw(
+        'Cannot extend non-object type "String".',
       );
     });
-
   });
 });

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -41,7 +41,7 @@ describe('findBreakingChanges', () => {
     name: 'Query',
     fields: {
       field1: { type: GraphQLString },
-    }
+    },
   });
 
   it('should detect if a type was removed or not', () => {
@@ -49,33 +49,28 @@ describe('findBreakingChanges', () => {
       name: 'Type1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const type2 = new GraphQLObjectType({
       name: 'Type2',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        type1,
-        type2,
-      ]
+      types: [type1, type2],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        type2,
-      ]
+      types: [type2],
     });
     expect(findRemovedTypes(oldSchema, newSchema)).to.eql([
       {
         type: BreakingChangeType.TYPE_REMOVED,
         description: 'Type1 was removed.',
-      }
+      },
     ]);
     expect(findRemovedTypes(oldSchema, oldSchema)).to.eql([]);
   });
@@ -85,38 +80,34 @@ describe('findBreakingChanges', () => {
       name: 'ObjectType',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const interfaceType1 = new GraphQLInterfaceType({
       name: 'Type1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const unionType1 = new GraphQLUnionType({
       name: 'Type1',
-      types: [ objectType ],
+      types: [objectType],
       resolveType: () => null,
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        interfaceType1,
-      ]
+      types: [interfaceType1],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        unionType1,
-      ]
+      types: [unionType1],
     });
     expect(findTypesThatChangedKind(oldSchema, newSchema)).to.eql([
       {
         type: BreakingChangeType.TYPE_CHANGED_KIND,
         description: 'Type1 changed from an Interface type to a Union type.',
-      }
+      },
     ]);
   });
 
@@ -125,7 +116,7 @@ describe('findBreakingChanges', () => {
       name: 'TypeA',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     // logically equivalent to TypeA; findBreakingFieldChanges shouldn't
     // treat this as different than TypeA
@@ -133,13 +124,13 @@ describe('findBreakingChanges', () => {
       name: 'TypeA',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const TypeB = new GraphQLObjectType({
       name: 'TypeB',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const oldType1 = new GraphQLInterfaceType({
@@ -162,10 +153,11 @@ describe('findBreakingChanges', () => {
         field16: { type: new GraphQLNonNull(GraphQLInt) },
         field17: { type: new GraphQLList(GraphQLInt) },
         field18: {
-          type: new GraphQLList(new GraphQLNonNull(
-            new GraphQLList(new GraphQLNonNull(GraphQLInt)))),
+          type: new GraphQLList(
+            new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt))),
+          ),
         },
-      }
+      },
     });
     const newType1 = new GraphQLInterfaceType({
       name: 'Type1',
@@ -188,22 +180,19 @@ describe('findBreakingChanges', () => {
         field17: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
         field18: {
           type: new GraphQLList(
-            new GraphQLList(new GraphQLNonNull(GraphQLInt))),
+            new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          ),
         },
-      }
+      },
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType1,
-      ]
+      types: [oldType1],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType1,
-      ]
+      types: [newType1],
     });
 
     const expectedFieldChanges = [
@@ -261,187 +250,182 @@ describe('findBreakingChanges', () => {
       },
     ];
     expect(findFieldsThatChangedType(oldSchema, newSchema)).to.eql(
-      expectedFieldChanges
+      expectedFieldChanges,
     );
   });
 
-  it(
-    'should detect if fields on input types changed kind or were removed',
-    () => {
-      const oldInputType = new GraphQLInputObjectType({
-        name: 'InputType1',
-        fields: {
-          field1: {
-            type: GraphQLString,
-          },
-          field2: {
-            type: GraphQLBoolean,
-          },
-          field3: {
-            type: new GraphQLList(GraphQLString),
-          },
-          field4: {
-            type: new GraphQLNonNull(GraphQLString),
-          },
-          field5: {
-            type: GraphQLString,
-          },
-          field6: {
-            type: new GraphQLList(GraphQLInt),
-          },
-          field7: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-          },
-          field8: {
-            type: GraphQLInt,
-          },
-          field9: {
-            type: new GraphQLList(GraphQLInt),
-          },
-          field10: {
-            type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
-          },
-          field11: {
-            type: new GraphQLList(GraphQLInt),
-          },
-          field12: {
-            type: new GraphQLList(new GraphQLList(GraphQLInt)),
-          },
-          field13: {
-            type: new GraphQLNonNull(GraphQLInt),
-          },
-          field14: {
-            type: new GraphQLList(new GraphQLNonNull(
-              new GraphQLList(GraphQLInt))),
-          },
-          field15: {
-            type: new GraphQLList(new GraphQLNonNull(
-              new GraphQLList(GraphQLInt))),
-          },
+  it('should detect if fields on input types changed kind or were removed', () => {
+    const oldInputType = new GraphQLInputObjectType({
+      name: 'InputType1',
+      fields: {
+        field1: {
+          type: GraphQLString,
         },
-      });
-      const newInputType = new GraphQLInputObjectType({
-        name: 'InputType1',
-        fields: {
-          field1: {
-            type: GraphQLInt,
-          },
-          field3: {
-            type: GraphQLString,
-          },
-          field4: {
-            type: GraphQLString,
-          },
-          field5: {
-            type: new GraphQLNonNull(GraphQLString),
-          },
-          field6: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-          },
-          field7: {
-            type: new GraphQLList(GraphQLInt),
-          },
-          field8: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-          },
-          field9: {
-            type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
-          },
-          field10: {
-            type: new GraphQLList(GraphQLInt),
-          },
-          field11: {
-            type: new GraphQLList(new GraphQLList(GraphQLInt)),
-          },
-          field12: {
-            type: new GraphQLList(GraphQLInt),
-          },
-          field13: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-          },
-          field14: {
-            type: new GraphQLList(new GraphQLList(GraphQLInt)),
-          },
-          field15: {
-            type: new GraphQLList(new GraphQLNonNull(
-              new GraphQLList(new GraphQLNonNull(GraphQLInt)))),
-          },
+        field2: {
+          type: GraphQLBoolean,
         },
-      });
+        field3: {
+          type: new GraphQLList(GraphQLString),
+        },
+        field4: {
+          type: new GraphQLNonNull(GraphQLString),
+        },
+        field5: {
+          type: GraphQLString,
+        },
+        field6: {
+          type: new GraphQLList(GraphQLInt),
+        },
+        field7: {
+          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+        },
+        field8: {
+          type: GraphQLInt,
+        },
+        field9: {
+          type: new GraphQLList(GraphQLInt),
+        },
+        field10: {
+          type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+        },
+        field11: {
+          type: new GraphQLList(GraphQLInt),
+        },
+        field12: {
+          type: new GraphQLList(new GraphQLList(GraphQLInt)),
+        },
+        field13: {
+          type: new GraphQLNonNull(GraphQLInt),
+        },
+        field14: {
+          type: new GraphQLList(
+            new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+          ),
+        },
+        field15: {
+          type: new GraphQLList(
+            new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+          ),
+        },
+      },
+    });
+    const newInputType = new GraphQLInputObjectType({
+      name: 'InputType1',
+      fields: {
+        field1: {
+          type: GraphQLInt,
+        },
+        field3: {
+          type: GraphQLString,
+        },
+        field4: {
+          type: GraphQLString,
+        },
+        field5: {
+          type: new GraphQLNonNull(GraphQLString),
+        },
+        field6: {
+          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+        },
+        field7: {
+          type: new GraphQLList(GraphQLInt),
+        },
+        field8: {
+          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+        },
+        field9: {
+          type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+        },
+        field10: {
+          type: new GraphQLList(GraphQLInt),
+        },
+        field11: {
+          type: new GraphQLList(new GraphQLList(GraphQLInt)),
+        },
+        field12: {
+          type: new GraphQLList(GraphQLInt),
+        },
+        field13: {
+          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+        },
+        field14: {
+          type: new GraphQLList(new GraphQLList(GraphQLInt)),
+        },
+        field15: {
+          type: new GraphQLList(
+            new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt))),
+          ),
+        },
+      },
+    });
 
-      const oldSchema = new GraphQLSchema({
-        query: queryType,
-        types: [
-          oldInputType,
-        ]
-      });
-      const newSchema = new GraphQLSchema({
-        query: queryType,
-        types: [
-          newInputType,
-        ]
-      });
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [oldInputType],
+    });
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [newInputType],
+    });
 
-      const expectedFieldChanges = [
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field1 changed type from String to Int.',
-        },
-        {
-          type: BreakingChangeType.FIELD_REMOVED,
-          description: 'InputType1.field2 was removed.',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field3 changed type from [String] to ' +
-            'String.',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field5 changed type from String to ' +
-            'String!.',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field6 changed type from [Int] to ' +
-            '[Int]!.',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field8 changed type from Int to ' +
-            '[Int]!.',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field9 changed type from [Int] to ' +
-            '[Int!].',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field11 changed type from [Int] to ' +
-            '[[Int]].',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field12 changed type from [[Int]] to ' +
-            '[Int].',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field13 changed type from Int! to ' +
-            '[Int]!.',
-        },
-        {
-          type: BreakingChangeType.FIELD_CHANGED_KIND,
-          description: 'InputType1.field15 changed type from [[Int]!] to ' +
-            '[[Int!]!].',
-        },
-      ];
-      expect(findFieldsThatChangedType(oldSchema, newSchema)).to.eql(
-        expectedFieldChanges,
-      );
-    }
-  );
+    const expectedFieldChanges = [
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description: 'InputType1.field1 changed type from String to Int.',
+      },
+      {
+        type: BreakingChangeType.FIELD_REMOVED,
+        description: 'InputType1.field2 was removed.',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field3 changed type from [String] to ' + 'String.',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field5 changed type from String to ' + 'String!.',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field6 changed type from [Int] to ' + '[Int]!.',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description: 'InputType1.field8 changed type from Int to ' + '[Int]!.',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field9 changed type from [Int] to ' + '[Int!].',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field11 changed type from [Int] to ' + '[[Int]].',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field12 changed type from [[Int]] to ' + '[Int].',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field13 changed type from Int! to ' + '[Int]!.',
+      },
+      {
+        type: BreakingChangeType.FIELD_CHANGED_KIND,
+        description:
+          'InputType1.field15 changed type from [[Int]!] to ' + '[[Int!]!].',
+      },
+    ];
+    expect(findFieldsThatChangedType(oldSchema, newSchema)).to.eql(
+      expectedFieldChanges,
+    );
+  });
 
   it('should detect if a non-null field is added to an input type', () => {
     const oldInputType = new GraphQLInputObjectType({
@@ -463,27 +447,24 @@ describe('findBreakingChanges', () => {
         },
         optionalField: {
           type: GraphQLBoolean,
-        }
+        },
       },
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldInputType,
-      ]
+      types: [oldInputType],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newInputType,
-      ]
+      types: [newInputType],
     });
 
     const expectedFieldChanges = [
       {
         type: BreakingChangeType.NON_NULL_INPUT_FIELD_ADDED,
-        description: 'A non-null field requiredField on input type ' +
+        description:
+          'A non-null field requiredField on input type ' +
           'InputType1 was added.',
       },
     ];
@@ -497,7 +478,7 @@ describe('findBreakingChanges', () => {
       name: 'Type1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     // logially equivalent to type1; findTypesRemovedFromUnions should not
     // treat this as different than type1
@@ -505,43 +486,39 @@ describe('findBreakingChanges', () => {
       name: 'Type1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const type2 = new GraphQLObjectType({
       name: 'Type2',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const type3 = new GraphQLObjectType({
       name: 'Type3',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const oldUnionType = new GraphQLUnionType({
       name: 'UnionType1',
-      types: [ type1, type2 ],
+      types: [type1, type2],
       resolveType: () => null,
     });
     const newUnionType = new GraphQLUnionType({
       name: 'UnionType1',
-      types: [ type1a, type3 ],
+      types: [type1a, type3],
       resolveType: () => null,
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldUnionType,
-      ]
+      types: [oldUnionType],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newUnionType,
-      ]
+      types: [newUnionType],
     });
 
     expect(findTypesRemovedFromUnions(oldSchema, newSchema)).to.eql([
@@ -559,7 +536,7 @@ describe('findBreakingChanges', () => {
         VALUE0: { value: 0 },
         VALUE1: { value: 1 },
         VALUE2: { value: 2 },
-      }
+      },
     });
     const newEnumType = new GraphQLEnumType({
       name: 'EnumType1',
@@ -567,20 +544,16 @@ describe('findBreakingChanges', () => {
         VALUE0: { value: 0 },
         VALUE2: { value: 2 },
         VALUE3: { value: 3 },
-      }
+      },
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldEnumType,
-      ]
+      types: [oldEnumType],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newEnumType,
-      ]
+      types: [newEnumType],
     });
 
     expect(findValuesRemovedFromEnums(oldSchema, newSchema)).to.eql([
@@ -619,17 +592,17 @@ describe('findBreakingChanges', () => {
       name: 'Interface1',
       fields: {
         field1: {
-          type: GraphQLString ,
+          type: GraphQLString,
           args: {
             arg1: {
               type: GraphQLBoolean,
             },
             objectArg: {
               type: inputType,
-            }
-          }
+            },
+          },
         },
-      }
+      },
     });
 
     const newType = new GraphQLObjectType({
@@ -646,30 +619,22 @@ describe('findBreakingChanges', () => {
       name: 'Interface1',
       fields: {
         field1: {
-          type: GraphQLString
+          type: GraphQLString,
         },
-      }
+      },
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-        oldInterfaceType,
-      ]
+      types: [oldType, oldInterfaceType],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-        newInterfaceType,
-      ]
+      types: [newType, newInterfaceType],
     });
 
-    expect(
-      findArgChanges(oldSchema, newSchema).breakingChanges
-    ).to.eql([
+    expect(findArgChanges(oldSchema, newSchema).breakingChanges).to.eql([
       {
         type: BreakingChangeType.ARG_REMOVED,
         description: 'Type1.field1 arg name was removed',
@@ -681,7 +646,7 @@ describe('findBreakingChanges', () => {
       {
         type: BreakingChangeType.ARG_REMOVED,
         description: 'Interface1.field1 arg objectArg was removed',
-      }
+      },
     ]);
   });
 
@@ -732,12 +697,14 @@ describe('findBreakingChanges', () => {
               type: new GraphQLNonNull(GraphQLInt),
             },
             arg14: {
-              type: new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(GraphQLInt))),
+              type: new GraphQLList(
+                new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              ),
             },
             arg15: {
-              type: new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(GraphQLInt))),
+              type: new GraphQLList(
+                new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              ),
             },
           },
         },
@@ -793,8 +760,11 @@ describe('findBreakingChanges', () => {
               type: new GraphQLList(new GraphQLList(GraphQLInt)),
             },
             arg15: {
-              type: new GraphQLList(new GraphQLNonNull(
-                new GraphQLList(new GraphQLNonNull(GraphQLInt)))),
+              type: new GraphQLList(
+                new GraphQLNonNull(
+                  new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+                ),
+              ),
             },
           },
         },
@@ -803,79 +773,74 @@ describe('findBreakingChanges', () => {
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-      ]
+      types: [oldType],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-      ]
+      types: [newType],
     });
 
-    expect(
-      findArgChanges(oldSchema, newSchema).breakingChanges
-    ).to.eql([
+    expect(findArgChanges(oldSchema, newSchema).breakingChanges).to.eql([
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg1 has changed type ' +
-          'from String to Int',
+        description:
+          'Type1.field1 arg arg1 has changed type ' + 'from String to Int',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg2 has changed type from String ' +
-          'to [String]'
+        description:
+          'Type1.field1 arg arg2 has changed type from String ' + 'to [String]',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg3 has changed type from ' +
-          '[String] to String',
+        description:
+          'Type1.field1 arg arg3 has changed type from ' + '[String] to String',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg4 has changed type from String ' +
-          'to String!',
+        description:
+          'Type1.field1 arg arg4 has changed type from String ' + 'to String!',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg5 has changed type from String! ' +
-          'to Int',
+        description:
+          'Type1.field1 arg arg5 has changed type from String! ' + 'to Int',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg6 has changed type from String! ' +
-          'to Int!',
+        description:
+          'Type1.field1 arg arg6 has changed type from String! ' + 'to Int!',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg8 has changed type from Int to ' +
-          '[Int]!',
+        description:
+          'Type1.field1 arg arg8 has changed type from Int to ' + '[Int]!',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg9 has changed type from [Int] to ' +
-          '[Int!]',
+        description:
+          'Type1.field1 arg arg9 has changed type from [Int] to ' + '[Int!]',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg11 has changed type from [Int] to ' +
-          '[[Int]]',
+        description:
+          'Type1.field1 arg arg11 has changed type from [Int] to ' + '[[Int]]',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg12 has changed type from [[Int]] ' +
-          'to [Int]',
+        description:
+          'Type1.field1 arg arg12 has changed type from [[Int]] ' + 'to [Int]',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg13 has changed type from Int! to ' +
-          '[Int]!',
+        description:
+          'Type1.field1 arg arg13 has changed type from Int! to ' + '[Int]!',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'Type1.field1 arg arg15 has changed type from [[Int]!] ' +
+        description:
+          'Type1.field1 arg arg15 has changed type from [[Int]!] ' +
           'to [[Int!]!]',
       },
     ]);
@@ -910,7 +875,7 @@ describe('findBreakingChanges', () => {
             },
             newOptionalArg: {
               type: GraphQLInt,
-            }
+            },
           },
         },
       },
@@ -918,25 +883,19 @@ describe('findBreakingChanges', () => {
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-      ]
+      types: [oldType],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-      ]
+      types: [newType],
     });
 
-    expect(
-      findArgChanges(oldSchema, newSchema).breakingChanges
-    ).to.eql([
+    expect(findArgChanges(oldSchema, newSchema).breakingChanges).to.eql([
       {
         type: BreakingChangeType.NON_NULL_ARG_ADDED,
-        description: 'A non-null arg newRequiredArg on Type1.field1 was ' +
-          'added',
+        description:
+          'A non-null arg newRequiredArg on Type1.field1 was ' + 'added',
       },
     ]);
   });
@@ -970,7 +929,7 @@ describe('findBreakingChanges', () => {
             },
             arg2: {
               type: inputType1a,
-            }
+            },
           },
         },
       },
@@ -987,7 +946,7 @@ describe('findBreakingChanges', () => {
             },
             arg2: {
               type: inputType1b,
-            }
+            },
           },
         },
       },
@@ -995,21 +954,15 @@ describe('findBreakingChanges', () => {
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-      ]
+      types: [oldType],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-      ]
+      types: [newType],
     });
 
-    expect(
-      findArgChanges(oldSchema, newSchema).breakingChanges
-    ).to.eql([]);
+    expect(findArgChanges(oldSchema, newSchema).breakingChanges).to.eql([]);
   });
 
   it('should consider args that move away from NonNull as non-breaking', () => {
@@ -1043,21 +996,15 @@ describe('findBreakingChanges', () => {
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-      ]
+      types: [oldType],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-      ]
+      types: [newType],
     });
 
-    expect(
-      findArgChanges(oldSchema, newSchema).breakingChanges
-    ).to.eql([]);
+    expect(findArgChanges(oldSchema, newSchema).breakingChanges).to.eql([]);
   });
 
   it('should detect interfaces removed from types', () => {
@@ -1070,9 +1017,7 @@ describe('findBreakingChanges', () => {
     });
     const oldType = new GraphQLObjectType({
       name: 'Type1',
-      interfaces: [
-        interface1,
-      ],
+      interfaces: [interface1],
       fields: {
         field1: {
           type: GraphQLString,
@@ -1092,25 +1037,19 @@ describe('findBreakingChanges', () => {
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-      ]
+      types: [oldType],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-      ]
+      types: [newType],
     });
 
-    expect(
-      findInterfacesRemovedFromObjectTypes(oldSchema, newSchema)
-    ).to.eql([
+    expect(findInterfacesRemovedFromObjectTypes(oldSchema, newSchema)).to.eql([
       {
         description: 'Type1 no longer implements interface Interface1.',
-        type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT
-      }
+        type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
+      },
     ]);
   });
 
@@ -1119,7 +1058,7 @@ describe('findBreakingChanges', () => {
       name: 'TypeThatGetsRemoved',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const argThatChanges = new GraphQLObjectType({
@@ -1150,13 +1089,13 @@ describe('findBreakingChanges', () => {
       name: 'TypeThatChangesType',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const typeThatChangesTypeNew = new GraphQLInterfaceType({
       name: 'TypeThatChangesType',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const typeThatHasBreakingFieldChangesOld = new GraphQLInterfaceType({
@@ -1164,35 +1103,35 @@ describe('findBreakingChanges', () => {
       fields: {
         field1: { type: GraphQLString },
         field2: { type: GraphQLString },
-      }
+      },
     });
     const typeThatHasBreakingFieldChangesNew = new GraphQLInterfaceType({
       name: 'TypeThatHasBreakingFieldChanges',
       fields: {
         field2: { type: GraphQLBoolean },
-      }
+      },
     });
 
     const typeInUnion1 = new GraphQLObjectType({
       name: 'TypeInUnion1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const typeInUnion2 = new GraphQLObjectType({
       name: 'TypeInUnion2',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const unionTypeThatLosesATypeOld = new GraphQLUnionType({
       name: 'UnionTypeThatLosesAType',
-      types: [ typeInUnion1, typeInUnion2 ],
+      types: [typeInUnion1, typeInUnion2],
       resolveType: () => null,
     });
     const unionTypeThatLosesATypeNew = new GraphQLUnionType({
       name: 'UnionTypeThatLosesAType',
-      types: [ typeInUnion1 ],
+      types: [typeInUnion1],
       resolveType: () => null,
     });
 
@@ -1202,14 +1141,14 @@ describe('findBreakingChanges', () => {
         VALUE0: { value: 0 },
         VALUE1: { value: 1 },
         VALUE2: { value: 2 },
-      }
+      },
     });
     const enumTypeThatLosesAValueNew = new GraphQLEnumType({
       name: 'EnumTypeThatLosesAValue',
       values: {
         VALUE1: { value: 1 },
         VALUE2: { value: 2 },
-      }
+      },
     });
 
     const interface1 = new GraphQLInterfaceType({
@@ -1222,9 +1161,7 @@ describe('findBreakingChanges', () => {
 
     const typeThatLosesInterfaceOld = new GraphQLObjectType({
       name: 'TypeThatGainsInterface1',
-      interfaces: [
-        interface1
-      ],
+      interfaces: [interface1],
       fields: {
         field1: {
           type: GraphQLString,
@@ -1251,8 +1188,8 @@ describe('findBreakingChanges', () => {
         unionTypeThatLosesATypeOld,
         enumTypeThatLosesAValueOld,
         argThatChanges,
-        typeThatLosesInterfaceOld
-      ]
+        typeThatLosesInterfaceOld,
+      ],
     });
 
     const newSchema = new GraphQLSchema({
@@ -1264,8 +1201,8 @@ describe('findBreakingChanges', () => {
         enumTypeThatLosesAValueNew,
         argChanged,
         typeThaLosesInterfaceNew,
-        interface1
-      ]
+        interface1,
+      ],
     });
 
     const expectedBreakingChanges = [
@@ -1283,7 +1220,8 @@ describe('findBreakingChanges', () => {
       },
       {
         type: BreakingChangeType.TYPE_CHANGED_KIND,
-        description: 'TypeThatChangesType changed from an Object type to an ' +
+        description:
+          'TypeThatChangesType changed from an Object type to an ' +
           'Interface type.',
       },
       {
@@ -1292,32 +1230,36 @@ describe('findBreakingChanges', () => {
       },
       {
         type: BreakingChangeType.FIELD_CHANGED_KIND,
-        description: 'TypeThatHasBreakingFieldChanges.field2 changed type ' +
+        description:
+          'TypeThatHasBreakingFieldChanges.field2 changed type ' +
           'from String to Boolean.',
       },
       {
         type: BreakingChangeType.TYPE_REMOVED_FROM_UNION,
-        description: 'TypeInUnion2 was removed from union type ' +
+        description:
+          'TypeInUnion2 was removed from union type ' +
           'UnionTypeThatLosesAType.',
       },
       {
         type: BreakingChangeType.VALUE_REMOVED_FROM_ENUM,
-        description: 'VALUE0 was removed from enum type ' +
-          'EnumTypeThatLosesAValue.',
+        description:
+          'VALUE0 was removed from enum type ' + 'EnumTypeThatLosesAValue.',
       },
       {
         type: BreakingChangeType.ARG_CHANGED_KIND,
-        description: 'ArgThatChanges.field1 arg id has changed ' +
+        description:
+          'ArgThatChanges.field1 arg id has changed ' +
           'type from Int to String',
       },
       {
         type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
-        description: 'TypeThatGainsInterface1 no longer implements ' +
-        'interface Interface1.',
-      }
+        description:
+          'TypeThatGainsInterface1 no longer implements ' +
+          'interface Interface1.',
+      },
     ];
     expect(findBreakingChanges(oldSchema, newSchema)).to.eql(
-      expectedBreakingChanges
+      expectedBreakingChanges,
     );
   });
 });
@@ -1327,11 +1269,11 @@ describe('findDangerousChanges', () => {
     name: 'Query',
     fields: {
       field1: { type: GraphQLString },
-    }
+    },
   });
 
   describe('findArgChanges', () => {
-    it('should detect if an argument\'s defaultValue has changed', () => {
+    it("should detect if an argument's defaultValue has changed", () => {
       const oldType = new GraphQLObjectType({
         name: 'Type1',
         fields: {
@@ -1364,25 +1306,19 @@ describe('findDangerousChanges', () => {
 
       const oldSchema = new GraphQLSchema({
         query: queryType,
-        types: [
-          oldType,
-        ]
+        types: [oldType],
       });
 
       const newSchema = new GraphQLSchema({
         query: queryType,
-        types: [
-          newType,
-        ]
+        types: [newType],
       });
 
-      expect(
-        findArgChanges(oldSchema, newSchema).dangerousChanges
-      ).to.eql([
+      expect(findArgChanges(oldSchema, newSchema).dangerousChanges).to.eql([
         {
           type: DangerousChangeType.ARG_DEFAULT_VALUE_CHANGE,
           description: 'Type1.field1 arg name has changed defaultValue',
-        }
+        },
       ]);
     });
   });
@@ -1393,7 +1329,7 @@ describe('findDangerousChanges', () => {
       values: {
         VALUE0: { value: 0 },
         VALUE1: { value: 1 },
-      }
+      },
     });
     const newEnumType = new GraphQLEnumType({
       name: 'EnumType1',
@@ -1401,30 +1337,24 @@ describe('findDangerousChanges', () => {
         VALUE0: { value: 0 },
         VALUE1: { value: 1 },
         VALUE2: { value: 2 },
-      }
+      },
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldEnumType,
-      ]
+      types: [oldEnumType],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newEnumType,
-      ]
+      types: [newEnumType],
     });
 
-    expect(findValuesAddedToEnums(oldSchema, newSchema)).to.eql(
-      [
-        {
-          type: DangerousChangeType.VALUE_ADDED_TO_ENUM,
-          description: 'VALUE2 was added to enum type EnumType1.',
-        }
-      ]
-    );
+    expect(findValuesAddedToEnums(oldSchema, newSchema)).to.eql([
+      {
+        type: DangerousChangeType.VALUE_ADDED_TO_ENUM,
+        description: 'VALUE2 was added to enum type EnumType1.',
+      },
+    ]);
   });
 
   it('should detect if a type was added to a union type', () => {
@@ -1432,7 +1362,7 @@ describe('findDangerousChanges', () => {
       name: 'Type1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     // logially equivalent to type1; findTypesRemovedFromUnions should not
     // treat this as different than type1
@@ -1440,37 +1370,33 @@ describe('findDangerousChanges', () => {
       name: 'Type1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const type2 = new GraphQLObjectType({
       name: 'Type2',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
 
     const oldUnionType = new GraphQLUnionType({
       name: 'UnionType1',
-      types: [ type1 ],
+      types: [type1],
       resolveType: () => null,
     });
     const newUnionType = new GraphQLUnionType({
       name: 'UnionType1',
-      types: [ type1a, type2 ],
+      types: [type1a, type2],
       resolveType: () => null,
     });
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldUnionType,
-      ]
+      types: [oldUnionType],
     });
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newUnionType,
-      ]
+      types: [newUnionType],
     });
 
     expect(findTypesAddedToUnions(oldSchema, newSchema)).to.eql([
@@ -1487,7 +1413,7 @@ describe('findDangerousChanges', () => {
       values: {
         VALUE0: { value: 0 },
         VALUE1: { value: 1 },
-      }
+      },
     });
     const enumThatGainsAValueNew = new GraphQLEnumType({
       name: 'EnumType1',
@@ -1495,7 +1421,7 @@ describe('findDangerousChanges', () => {
         VALUE0: { value: 0 },
         VALUE1: { value: 1 },
         VALUE2: { value: 2 },
-      }
+      },
     });
 
     const oldType = new GraphQLObjectType({
@@ -1517,22 +1443,22 @@ describe('findDangerousChanges', () => {
       name: 'TypeInUnion1',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const typeInUnion2 = new GraphQLObjectType({
       name: 'TypeInUnion2',
       fields: {
         field1: { type: GraphQLString },
-      }
+      },
     });
     const unionTypeThatGainsATypeOld = new GraphQLUnionType({
       name: 'UnionTypeThatGainsAType',
-      types: [ typeInUnion1 ],
+      types: [typeInUnion1],
       resolveType: () => null,
     });
     const unionTypeThatGainsATypeNew = new GraphQLUnionType({
       name: 'UnionTypeThatGainsAType',
-      types: [ typeInUnion1, typeInUnion2 ],
+      types: [typeInUnion1, typeInUnion2],
       resolveType: () => null,
     });
 
@@ -1553,26 +1479,18 @@ describe('findDangerousChanges', () => {
 
     const oldSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        oldType,
-        enumThatGainsAValueOld,
-        unionTypeThatGainsATypeOld
-      ]
+      types: [oldType, enumThatGainsAValueOld, unionTypeThatGainsATypeOld],
     });
 
     const newSchema = new GraphQLSchema({
       query: queryType,
-      types: [
-        newType,
-        enumThatGainsAValueNew,
-        unionTypeThatGainsATypeNew
-      ]
+      types: [newType, enumThatGainsAValueNew, unionTypeThatGainsATypeNew],
     });
 
     const expectedDangerousChanges = [
       {
         description: 'Type1.field1 arg name has changed defaultValue',
-        type: 'ARG_DEFAULT_VALUE_CHANGE'
+        type: 'ARG_DEFAULT_VALUE_CHANGE',
       },
       {
         description: 'VALUE2 was added to enum type EnumType1.',
@@ -1580,13 +1498,13 @@ describe('findDangerousChanges', () => {
       },
       {
         type: DangerousChangeType.TYPE_ADDED_TO_UNION,
-        description: 'TypeInUnion2 was added to union type ' +
-          'UnionTypeThatGainsAType.',
-      }
+        description:
+          'TypeInUnion2 was added to union type ' + 'UnionTypeThatGainsAType.',
+      },
     ];
 
     expect(findDangerousChanges(oldSchema, newSchema)).to.eql(
-      expectedDangerousChanges
+      expectedDangerousChanges,
     );
   });
 });

--- a/src/utilities/__tests__/findDeprecatedUsages-test.js
+++ b/src/utilities/__tests__/findDeprecatedUsages-test.js
@@ -17,13 +17,12 @@ import {
 } from '../../type';
 
 describe('findDeprecatedUsages', () => {
-
   const enumType = new GraphQLEnumType({
     name: 'EnumType',
     values: {
       ONE: {},
-      TWO: { deprecationReason: 'Some enum reason.' }
-    }
+      TWO: { deprecationReason: 'Some enum reason.' },
+    },
   });
 
   const schema = new GraphQLSchema({
@@ -39,15 +38,15 @@ describe('findDeprecatedUsages', () => {
         deprecatedField: {
           type: GraphQLString,
           deprecationReason: 'Some field reason.',
-        }
-      }
-    })
+        },
+      },
+    }),
   });
 
   it('should report empty set for no deprecated usages', () => {
     const errors = findDeprecatedUsages(
       schema,
-      parse('{ normalField(enumArg: ONE) }')
+      parse('{ normalField(enumArg: ONE) }'),
     );
 
     expect(errors.length).to.equal(0);
@@ -56,27 +55,26 @@ describe('findDeprecatedUsages', () => {
   it('should report usage of deprecated fields', () => {
     const errors = findDeprecatedUsages(
       schema,
-      parse('{ normalField, deprecatedField }')
+      parse('{ normalField, deprecatedField }'),
     );
 
     const errorMessages = errors.map(err => err.message);
 
     expect(errorMessages).to.deep.equal([
-      'The field Query.deprecatedField is deprecated. Some field reason.'
+      'The field Query.deprecatedField is deprecated. Some field reason.',
     ]);
   });
 
   it('should report usage of deprecated enums', () => {
     const errors = findDeprecatedUsages(
       schema,
-      parse('{ normalField(enumArg: TWO) }')
+      parse('{ normalField(enumArg: TWO) }'),
     );
 
     const errorMessages = errors.map(err => err.message);
 
     expect(errorMessages).to.deep.equal([
-      'The enum value EnumType.TWO is deprecated. Some enum reason.'
+      'The enum value EnumType.TWO is deprecated. Some enum reason.',
     ]);
   });
-
 });

--- a/src/utilities/__tests__/getOperationAST-test.js
+++ b/src/utilities/__tests__/getOperationAST-test.js
@@ -11,7 +11,6 @@ import { parse } from '../../language';
 import { getOperationAST } from '../getOperationAST';
 
 describe('getOperationAST', () => {
-
   it('Gets an operation from a simple document', () => {
     const doc = parse('{ field }');
     expect(getOperationAST(doc)).to.equal(doc.definitions[0]);
@@ -65,5 +64,4 @@ describe('getOperationAST', () => {
     expect(getOperationAST(doc, 'TestM')).to.equal(doc.definitions[1]);
     expect(getOperationAST(doc, 'TestS')).to.equal(doc.definitions[2]);
   });
-
 });

--- a/src/utilities/__tests__/isValidJSValue-test.js
+++ b/src/utilities/__tests__/isValidJSValue-test.js
@@ -8,10 +8,7 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { isValidJSValue } from '../isValidJSValue';
-import {
-  GraphQLInt,
-  GraphQLFloat,
-} from '../../type';
+import { GraphQLInt, GraphQLFloat } from '../../type';
 
 function expectNoErrors(result) {
   expect(result).to.be.an.instanceof(Array);

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -27,7 +27,6 @@ import {
   GraphQLNonNull,
 } from '../../';
 
-
 function printForTest(schema) {
   return printSchema(schema);
 }
@@ -51,7 +50,7 @@ function nonNull(type) {
 describe('Type System Printer', () => {
   it('Prints String Field', () => {
     const output = printSingleFieldSchema({
-      type: GraphQLString
+      type: GraphQLString,
     });
     expect(output).to.equal(dedent`
       schema {
@@ -66,7 +65,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String] Field', () => {
     const output = printSingleFieldSchema({
-      type: listOf(GraphQLString)
+      type: listOf(GraphQLString),
     });
     expect(output).to.equal(dedent`
       schema {
@@ -81,7 +80,7 @@ describe('Type System Printer', () => {
 
   it('Prints String! Field', () => {
     const output = printSingleFieldSchema({
-      type: nonNull(GraphQLString)
+      type: nonNull(GraphQLString),
     });
     expect(output).to.equal(dedent`
       schema {
@@ -96,7 +95,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String]! Field', () => {
     const output = printSingleFieldSchema({
-      type: nonNull(listOf(GraphQLString))
+      type: nonNull(listOf(GraphQLString)),
     });
     expect(output).to.equal(dedent`
       schema {
@@ -111,7 +110,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String!] Field', () => {
     const output = printSingleFieldSchema({
-      type: listOf(nonNull(GraphQLString))
+      type: listOf(nonNull(GraphQLString)),
     });
     expect(output).to.equal(dedent`
       schema {
@@ -126,7 +125,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String!]! Field', () => {
     const output = printSingleFieldSchema({
-      type: nonNull(listOf(nonNull(GraphQLString)))
+      type: nonNull(listOf(nonNull(GraphQLString))),
     });
     expect(output).to.equal(dedent`
       schema {
@@ -142,7 +141,7 @@ describe('Type System Printer', () => {
   it('Print Object Field', () => {
     const FooType = new GraphQLObjectType({
       name: 'Foo',
-      fields: { str: { type: GraphQLString } }
+      fields: { str: { type: GraphQLString } },
     });
 
     const Root = new GraphQLObjectType({
@@ -168,12 +167,10 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Int Arg', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: { argOne: { type: GraphQLInt } },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: { argOne: { type: GraphQLInt } },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -186,12 +183,10 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Int Arg With Default', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: { argOne: { type: GraphQLInt, defaultValue: 2 } },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: { argOne: { type: GraphQLInt, defaultValue: 2 } },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -204,12 +199,10 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Int Arg With Default Null', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: { argOne: { type: GraphQLInt, defaultValue: null } },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: { argOne: { type: GraphQLInt, defaultValue: null } },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -222,12 +215,10 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Int! Arg', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: { argOne: { type: nonNull(GraphQLInt) } },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: { argOne: { type: nonNull(GraphQLInt) } },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -240,15 +231,13 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Multiple Args', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: {
-          argOne: { type: GraphQLInt },
-          argTwo: { type: GraphQLString },
-        },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: {
+        argOne: { type: GraphQLInt },
+        argTwo: { type: GraphQLString },
+      },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -261,16 +250,14 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Multiple Args, First is Default', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: {
-          argOne: { type: GraphQLInt, defaultValue: 1 },
-          argTwo: { type: GraphQLString },
-          argThree: { type: GraphQLBoolean },
-        },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: {
+        argOne: { type: GraphQLInt, defaultValue: 1 },
+        argTwo: { type: GraphQLString },
+        argThree: { type: GraphQLBoolean },
+      },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -283,16 +270,14 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Multiple Args, Second is Default', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: {
-          argOne: { type: GraphQLInt },
-          argTwo: { type: GraphQLString, defaultValue: 'foo' },
-          argThree: { type: GraphQLBoolean },
-        },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: {
+        argOne: { type: GraphQLInt },
+        argTwo: { type: GraphQLString, defaultValue: 'foo' },
+        argThree: { type: GraphQLBoolean },
+      },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -305,16 +290,14 @@ describe('Type System Printer', () => {
   });
 
   it('Prints String Field With Multiple Args, Last is Default', () => {
-    const output = printSingleFieldSchema(
-      {
-        type: GraphQLString,
-        args: {
-          argOne: { type: GraphQLInt },
-          argTwo: { type: GraphQLString },
-          argThree: { type: GraphQLBoolean, defaultValue: false },
-        },
-      }
-    );
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: {
+        argOne: { type: GraphQLInt },
+        argTwo: { type: GraphQLString },
+        argThree: { type: GraphQLBoolean, defaultValue: false },
+      },
+    });
     expect(output).to.equal(dedent`
       schema {
         query: Root
@@ -336,7 +319,7 @@ describe('Type System Printer', () => {
     const BarType = new GraphQLObjectType({
       name: 'Bar',
       fields: { str: { type: GraphQLString } },
-      interfaces: [ FooType ],
+      interfaces: [FooType],
     });
 
     const Root = new GraphQLObjectType({
@@ -346,7 +329,7 @@ describe('Type System Printer', () => {
 
     const Schema = new GraphQLSchema({
       query: Root,
-      types: [ BarType ]
+      types: [BarType],
     });
     const output = printForTest(Schema);
     expect(output).to.equal(dedent`
@@ -387,7 +370,7 @@ describe('Type System Printer', () => {
         str: { type: GraphQLString },
         int: { type: GraphQLInt },
       },
-      interfaces: [ FooType, BaazType ],
+      interfaces: [FooType, BaazType],
     });
 
     const Root = new GraphQLObjectType({
@@ -397,7 +380,7 @@ describe('Type System Printer', () => {
 
     const Schema = new GraphQLSchema({
       query: Root,
-      types: [ BarType ]
+      types: [BarType],
     });
     const output = printForTest(Schema);
     expect(output).to.equal(dedent`
@@ -442,13 +425,13 @@ describe('Type System Printer', () => {
     const SingleUnion = new GraphQLUnionType({
       name: 'SingleUnion',
       resolveType: () => null,
-      types: [ FooType ],
+      types: [FooType],
     });
 
     const MultipleUnion = new GraphQLUnionType({
       name: 'MultipleUnion',
       resolveType: () => null,
-      types: [ FooType, BarType ],
+      types: [FooType, BarType],
     });
 
     const Root = new GraphQLObjectType({
@@ -525,7 +508,7 @@ describe('Type System Printer', () => {
       name: 'Odd',
       serialize(value) {
         return value % 2 === 1 ? value : null;
-      }
+      },
     });
 
     const Root = new GraphQLObjectType({
@@ -556,8 +539,8 @@ describe('Type System Printer', () => {
       values: {
         RED: { value: 0 },
         GREEN: { value: 1 },
-        BLUE: { value: 2 }
-      }
+        BLUE: { value: 2 },
+      },
     });
 
     const Root = new GraphQLObjectType({
@@ -590,7 +573,7 @@ describe('Type System Printer', () => {
     const Root = new GraphQLObjectType({
       name: 'Root',
       fields: {
-        onlyField: { type: GraphQLString }
+        onlyField: { type: GraphQLString },
       },
     });
     const Schema = new GraphQLSchema({ query: Root });

--- a/src/utilities/__tests__/separateOperations-test.js
+++ b/src/utilities/__tests__/separateOperations-test.js
@@ -11,11 +11,8 @@ import dedent from '../../jsutils/dedent';
 import { separateOperations } from '../separateOperations';
 import { parse, print } from '../../language';
 
-
 describe('separateOperations', () => {
-
   it('separates one AST into multiple, maintaining document order', () => {
-
     const ast = parse(`
       {
         ...Y
@@ -55,7 +52,7 @@ describe('separateOperations', () => {
 
     const separatedASTs = separateOperations(ast);
 
-    expect(Object.keys(separatedASTs)).to.deep.equal([ '', 'One', 'Two' ]);
+    expect(Object.keys(separatedASTs)).to.deep.equal(['', 'One', 'Two']);
 
     expect(print(separatedASTs[''])).to.equal(dedent`
       {
@@ -114,11 +111,9 @@ describe('separateOperations', () => {
         something
       }
     `);
-
   });
 
   it('survives circular dependencies', () => {
-
     const ast = parse(`
       query One {
         ...A
@@ -139,7 +134,7 @@ describe('separateOperations', () => {
 
     const separatedASTs = separateOperations(ast);
 
-    expect(Object.keys(separatedASTs)).to.deep.equal([ 'One', 'Two' ]);
+    expect(Object.keys(separatedASTs)).to.deep.equal(['One', 'Two']);
 
     expect(print(separatedASTs.One)).to.equal(dedent`
       query One {
@@ -168,7 +163,5 @@ describe('separateOperations', () => {
         ...B
       }
     `);
-
   });
-
 });

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -20,11 +20,8 @@ import {
 } from '../../type';
 import { isEqualType, isTypeSubTypeOf } from '../typeComparators';
 
-
 describe('typeComparators', () => {
-
   describe('isEqualType', () => {
-
     it('same reference are equal', () => {
       expect(isEqualType(GraphQLString, GraphQLString)).to.equal(true);
     });
@@ -35,83 +32,79 @@ describe('typeComparators', () => {
 
     it('lists of same type are equal', () => {
       expect(
-        isEqualType(new GraphQLList(GraphQLInt), new GraphQLList(GraphQLInt))
+        isEqualType(new GraphQLList(GraphQLInt), new GraphQLList(GraphQLInt)),
       ).to.equal(true);
     });
 
     it('lists is not equal to item', () => {
-      expect(
-        isEqualType(new GraphQLList(GraphQLInt), GraphQLInt)
-      ).to.equal(false);
+      expect(isEqualType(new GraphQLList(GraphQLInt), GraphQLInt)).to.equal(
+        false,
+      );
     });
 
     it('non-null of same type are equal', () => {
       expect(
         isEqualType(
           new GraphQLNonNull(GraphQLInt),
-          new GraphQLNonNull(GraphQLInt)
-        )
+          new GraphQLNonNull(GraphQLInt),
+        ),
       ).to.equal(true);
     });
 
     it('non-null is not equal to nullable', () => {
-      expect(
-        isEqualType(new GraphQLNonNull(GraphQLInt), GraphQLInt)
-      ).to.equal(false);
+      expect(isEqualType(new GraphQLNonNull(GraphQLInt), GraphQLInt)).to.equal(
+        false,
+      );
     });
-
   });
 
   describe('isTypeSubTypeOf', () => {
-
     function testSchema(fields) {
       return new GraphQLSchema({
         query: new GraphQLObjectType({
           name: 'Query',
-          fields
-        })
+          fields,
+        }),
       });
     }
 
     it('same reference is subtype', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
-      expect(
-        isTypeSubTypeOf(schema, GraphQLString, GraphQLString)
-      ).to.equal(true);
+      expect(isTypeSubTypeOf(schema, GraphQLString, GraphQLString)).to.equal(
+        true,
+      );
     });
 
     it('int is not subtype of float', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
-      expect(
-        isTypeSubTypeOf(schema, GraphQLInt, GraphQLFloat)
-      ).to.equal(false);
+      expect(isTypeSubTypeOf(schema, GraphQLInt, GraphQLFloat)).to.equal(false);
     });
 
     it('non-null is subtype of nullable', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLNonNull(GraphQLInt), GraphQLInt)
+        isTypeSubTypeOf(schema, new GraphQLNonNull(GraphQLInt), GraphQLInt),
       ).to.equal(true);
     });
 
     it('nullable is not subtype of non-null', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLNonNull(GraphQLInt))
+        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLNonNull(GraphQLInt)),
       ).to.equal(false);
     });
 
     it('item is not subtype of list', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLList(GraphQLInt))
+        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLList(GraphQLInt)),
       ).to.equal(false);
     });
 
     it('list is not subtype of item', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLList(GraphQLInt), GraphQLInt)
+        isTypeSubTypeOf(schema, new GraphQLList(GraphQLInt), GraphQLInt),
       ).to.equal(false);
     });
 
@@ -120,37 +113,31 @@ describe('typeComparators', () => {
         name: 'Object',
         isTypeOf: () => true,
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
-      const union = new GraphQLUnionType({ name: 'Union', types: [ member ] });
+      const union = new GraphQLUnionType({ name: 'Union', types: [member] });
       const schema = testSchema({ field: { type: union } });
-      expect(
-        isTypeSubTypeOf(schema, member, union)
-      ).to.equal(true);
+      expect(isTypeSubTypeOf(schema, member, union)).to.equal(true);
     });
 
     it('implementation is subtype of interface', () => {
       const iface = new GraphQLInterfaceType({
         name: 'Interface',
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
       const impl = new GraphQLObjectType({
         name: 'Object',
         isTypeOf: () => true,
-        interfaces: [ iface ],
+        interfaces: [iface],
         fields: {
-          field: { type: GraphQLString }
-        }
+          field: { type: GraphQLString },
+        },
       });
       const schema = testSchema({ field: { type: impl } });
-      expect(
-        isTypeSubTypeOf(schema, impl, iface)
-      ).to.equal(true);
+      expect(isTypeSubTypeOf(schema, impl, iface)).to.equal(true);
     });
-
   });
-
 });

--- a/src/utilities/__tests__/valueFromAST-test.js
+++ b/src/utilities/__tests__/valueFromAST-test.js
@@ -21,19 +21,15 @@ import {
 } from '../../type';
 import { parseValue } from '../../language';
 
-
 describe('valueFromAST', () => {
-
   function testCase(type, valueText, expected) {
-    expect(
-      valueFromAST(parseValue(valueText), type)
-    ).to.deep.equal(expected);
+    expect(valueFromAST(parseValue(valueText), type)).to.deep.equal(expected);
   }
 
   function testCaseWithVars(variables, type, valueText, expected) {
-    expect(
-      valueFromAST(parseValue(valueText), type, variables)
-    ).to.deep.equal(expected);
+    expect(valueFromAST(parseValue(valueText), type, variables)).to.deep.equal(
+      expected,
+    );
   }
 
   it('rejects empty input', () => {
@@ -69,8 +65,8 @@ describe('valueFromAST', () => {
       GREEN: { value: 2 },
       BLUE: { value: 3 },
       NULL: { value: null },
-      UNDEFINED: { value: undefined }
-    }
+      UNDEFINED: { value: undefined },
+    },
   });
 
   it('converts enum values according to input coercion rules', () => {
@@ -100,38 +96,38 @@ describe('valueFromAST', () => {
   });
 
   it('coerces lists of values', () => {
-    testCase(listOfBool, 'true', [ true ]);
+    testCase(listOfBool, 'true', [true]);
     testCase(listOfBool, '123', undefined);
     testCase(listOfBool, 'null', null);
-    testCase(listOfBool, '[true, false]', [ true, false ]);
+    testCase(listOfBool, '[true, false]', [true, false]);
     testCase(listOfBool, '[true, 123]', undefined);
-    testCase(listOfBool, '[true, null]', [ true, null ]);
+    testCase(listOfBool, '[true, null]', [true, null]);
     testCase(listOfBool, '{ true: true }', undefined);
   });
 
   it('coerces non-null lists of values', () => {
-    testCase(nonNullListOfBool, 'true', [ true ]);
+    testCase(nonNullListOfBool, 'true', [true]);
     testCase(nonNullListOfBool, '123', undefined);
     testCase(nonNullListOfBool, 'null', undefined);
-    testCase(nonNullListOfBool, '[true, false]', [ true, false ]);
+    testCase(nonNullListOfBool, '[true, false]', [true, false]);
     testCase(nonNullListOfBool, '[true, 123]', undefined);
-    testCase(nonNullListOfBool, '[true, null]', [ true, null ]);
+    testCase(nonNullListOfBool, '[true, null]', [true, null]);
   });
 
   it('coerces lists of non-null values', () => {
-    testCase(listOfNonNullBool, 'true', [ true ]);
+    testCase(listOfNonNullBool, 'true', [true]);
     testCase(listOfNonNullBool, '123', undefined);
     testCase(listOfNonNullBool, 'null', null);
-    testCase(listOfNonNullBool, '[true, false]', [ true, false ]);
+    testCase(listOfNonNullBool, '[true, false]', [true, false]);
     testCase(listOfNonNullBool, '[true, 123]', undefined);
     testCase(listOfNonNullBool, '[true, null]', undefined);
   });
 
   it('coerces non-null lists of non-null values', () => {
-    testCase(nonNullListOfNonNullBool, 'true', [ true ]);
+    testCase(nonNullListOfNonNullBool, 'true', [true]);
     testCase(nonNullListOfNonNullBool, '123', undefined);
     testCase(nonNullListOfNonNullBool, 'null', undefined);
-    testCase(nonNullListOfNonNullBool, '[true, false]', [ true, false ]);
+    testCase(nonNullListOfNonNullBool, '[true, false]', [true, false]);
     testCase(nonNullListOfNonNullBool, '[true, 123]', undefined);
     testCase(nonNullListOfNonNullBool, '[true, null]', undefined);
   });
@@ -142,23 +138,22 @@ describe('valueFromAST', () => {
       int: { type: GraphQLInt, defaultValue: 42 },
       bool: { type: GraphQLBoolean },
       requiredBool: { type: nonNullBool },
-    }
+    },
   });
 
   it('coerces input objects according to input coercion rules', () => {
     testCase(testInputObj, 'null', null);
     testCase(testInputObj, '123', undefined);
     testCase(testInputObj, '[]', undefined);
-    testCase(
-      testInputObj,
-      '{ int: 123, requiredBool: false }',
-      { int: 123, requiredBool: false }
-    );
-    testCase(
-      testInputObj,
-      '{ bool: true, requiredBool: false }',
-      { int: 42, bool: true, requiredBool: false }
-    );
+    testCase(testInputObj, '{ int: 123, requiredBool: false }', {
+      int: 123,
+      requiredBool: false,
+    });
+    testCase(testInputObj, '{ bool: true, requiredBool: false }', {
+      int: 42,
+      bool: true,
+      requiredBool: false,
+    });
     testCase(testInputObj, '{ int: true, requiredBool: true }', undefined);
     testCase(testInputObj, '{ requiredBool: null }', undefined);
     testCase(testInputObj, '{ bool: true }', undefined);
@@ -171,13 +166,13 @@ describe('valueFromAST', () => {
   });
 
   it('asserts variables are provided as items in lists', () => {
-    testCaseWithVars({}, listOfBool, '[ $foo ]', [ null ]);
+    testCaseWithVars({}, listOfBool, '[ $foo ]', [null]);
     testCaseWithVars({}, listOfNonNullBool, '[ $foo ]', undefined);
-    testCaseWithVars({ foo: true }, listOfNonNullBool, '[ $foo ]', [ true ]);
+    testCaseWithVars({ foo: true }, listOfNonNullBool, '[ $foo ]', [true]);
     // Note: variables are expected to have already been coerced, so we
     // do not expect the singleton wrapping behavior for variables.
     testCaseWithVars({ foo: true }, listOfNonNullBool, '$foo', true);
-    testCaseWithVars({ foo: [ true ] }, listOfNonNullBool, '$foo', [ true ]);
+    testCaseWithVars({ foo: [true] }, listOfNonNullBool, '$foo', [true]);
   });
 
   it('omits input object fields for unprovided variables', () => {
@@ -185,20 +180,12 @@ describe('valueFromAST', () => {
       {},
       testInputObj,
       '{ int: $foo, bool: $foo, requiredBool: true }',
-      { int: 42, requiredBool: true }
+      { int: 42, requiredBool: true },
     );
-    testCaseWithVars(
-      {},
-      testInputObj,
-      '{ requiredBool: $foo }',
-      undefined
-    );
-    testCaseWithVars(
-      { foo: true },
-      testInputObj,
-      '{ requiredBool: $foo }',
-      { int: 42, requiredBool: true }
-    );
+    testCaseWithVars({}, testInputObj, '{ requiredBool: $foo }', undefined);
+    testCaseWithVars({ foo: true }, testInputObj, '{ requiredBool: $foo }', {
+      int: 42,
+      requiredBool: true,
+    });
   });
-
 });

--- a/src/utilities/assertValidName.js
+++ b/src/utilities/assertValidName.js
@@ -15,7 +15,7 @@ const noNameWarning = Boolean(
   typeof process !== 'undefined' &&
     process &&
     process.env &&
-    process.env.GRAPHQL_NO_NAME_WARNING
+    process.env.GRAPHQL_NO_NAME_WARNING,
 );
 
 // Ensures console warnings are only issued once.
@@ -24,14 +24,9 @@ let hasWarnedAboutDunder = false;
 /**
  * Upholds the spec rules about naming.
  */
-export function assertValidName(
-  name: string,
-  isIntrospection?: boolean
-): void {
+export function assertValidName(name: string, isIntrospection?: boolean): void {
   if (!name || typeof name !== 'string') {
-    throw new Error(
-      `Must be named. Unexpected name: ${name}.`
-    );
+    throw new Error(`Must be named. Unexpected name: ${name}.`);
   }
   if (
     !isIntrospection &&
@@ -44,8 +39,8 @@ export function assertValidName(
     if (console && console.warn) {
       const error = new Error(
         `Name "${name}" must not begin with "__", which is reserved by ` +
-        'GraphQL introspection. In a future release of graphql this will ' +
-        'become a hard error.'
+          'GraphQL introspection. In a future release of graphql this will ' +
+          'become a hard error.',
       );
       console.warn(formatWarning(error));
     }
@@ -53,7 +48,7 @@ export function assertValidName(
   }
   if (!NAME_RX.test(name)) {
     throw new Error(
-      `Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "${name}" does not.`
+      `Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "${name}" does not.`,
     );
   }
 }

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -34,7 +34,6 @@ import {
 } from '../type/definition';
 import { GraphQLID } from '../type/scalars';
 
-
 /**
  * Produces a GraphQL Value AST given a JavaScript value.
  *
@@ -52,10 +51,7 @@ import { GraphQLID } from '../type/scalars';
  * | null          | NullValue            |
  *
  */
-export function astFromValue(
-  value: mixed,
-  type: GraphQLInputType
-): ?ValueNode {
+export function astFromValue(value: mixed, type: GraphQLInputType): ?ValueNode {
   // Ensure flow knows that we treat function params as const.
   const _value = value;
 
@@ -109,7 +105,7 @@ export function astFromValue(
         fieldNodes.push({
           kind: Kind.OBJECT_FIELD,
           name: { kind: Kind.NAME, value: fieldName },
-          value: fieldValue
+          value: fieldValue,
         });
       }
     });
@@ -118,7 +114,7 @@ export function astFromValue(
 
   invariant(
     type instanceof GraphQLScalarType || type instanceof GraphQLEnumType,
-    'Must provide Input Type, cannot use: ' + String(type)
+    'Must provide Input Type, cannot use: ' + String(type),
   );
 
   // Since value is an internally represented value, it must be serialized
@@ -136,9 +132,9 @@ export function astFromValue(
   // JavaScript numbers can be Int or Float values.
   if (typeof serialized === 'number') {
     const stringNum = String(serialized);
-    return /^[0-9]+$/.test(stringNum) ?
-      ({ kind: Kind.INT, value: stringNum }: IntValueNode) :
-      ({ kind: Kind.FLOAT, value: stringNum }: FloatValueNode);
+    return /^[0-9]+$/.test(stringNum)
+      ? ({ kind: Kind.INT, value: stringNum }: IntValueNode)
+      : ({ kind: Kind.FLOAT, value: stringNum }: FloatValueNode);
   }
 
   if (typeof serialized === 'string') {
@@ -156,7 +152,7 @@ export function astFromValue(
     // then remove the quotes.
     return ({
       kind: Kind.STRING,
-      value: JSON.stringify(serialized).slice(1, -1)
+      value: JSON.stringify(serialized).slice(1, -1),
     }: StringValueNode);
   }
 

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -9,7 +9,7 @@
 
 import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
-import type {ObjMap} from '../jsutils/ObjMap';
+import type { ObjMap } from '../jsutils/ObjMap';
 import { valueFromAST } from './valueFromAST';
 import { TokenKind } from '../language/lexer';
 import { parse } from '../language/parser';
@@ -74,9 +74,7 @@ import {
   GraphQLDeprecatedDirective,
 } from '../type/directives';
 
-import type {
-  DirectiveLocationEnum
-} from '../type/directives';
+import type { DirectiveLocationEnum } from '../type/directives';
 
 import {
   __Schema,
@@ -89,10 +87,9 @@ import {
   __TypeKind,
 } from '../type/introspection';
 
-
 function buildWrappedType(
   innerType: GraphQLType,
-  inputTypeNode: TypeNode
+  inputTypeNode: TypeNode,
 ): GraphQLType {
   if (inputTypeNode.kind === Kind.LIST_TYPE) {
     return new GraphQLList(buildWrappedType(innerType, inputTypeNode.type));
@@ -176,7 +173,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
         }
         if (!nodeMap[typeName]) {
           throw new Error(
-            `Specified query type "${typeName}" not found in document.`
+            `Specified query type "${typeName}" not found in document.`,
           );
         }
         queryTypeName = typeName;
@@ -186,7 +183,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
         }
         if (!nodeMap[typeName]) {
           throw new Error(
-            `Specified mutation type "${typeName}" not found in document.`
+            `Specified mutation type "${typeName}" not found in document.`,
           );
         }
         mutationTypeName = typeName;
@@ -196,7 +193,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
         }
         if (!nodeMap[typeName]) {
           throw new Error(
-            `Specified subscription type "${typeName}" not found in document.`
+            `Specified subscription type "${typeName}" not found in document.`,
           );
         }
         subscriptionTypeName = typeName;
@@ -216,7 +213,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
 
   if (!queryTypeName) {
     throw new Error(
-      'Must provide schema definition with query type or a type named Query.'
+      'Must provide schema definition with query type or a type named Query.',
     );
   }
 
@@ -255,25 +252,25 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
 
   return new GraphQLSchema({
     query: getObjectType(nodeMap[queryTypeName]),
-    mutation: mutationTypeName ?
-      getObjectType(nodeMap[mutationTypeName]) :
-      null,
-    subscription: subscriptionTypeName ?
-      getObjectType(nodeMap[subscriptionTypeName]) :
-      null,
+    mutation: mutationTypeName
+      ? getObjectType(nodeMap[mutationTypeName])
+      : null,
+    subscription: subscriptionTypeName
+      ? getObjectType(nodeMap[subscriptionTypeName])
+      : null,
     types,
     directives,
     astNode: schemaDef,
   });
 
   function getDirective(
-    directiveNode: DirectiveDefinitionNode
+    directiveNode: DirectiveDefinitionNode,
   ): GraphQLDirective {
     return new GraphQLDirective({
       name: directiveNode.name.value,
       description: getDescription(directiveNode),
       locations: directiveNode.locations.map(
-        node => ((node.value: any): DirectiveLocationEnum)
+        node => ((node.value: any): DirectiveLocationEnum),
       ),
       args: directiveNode.arguments && makeInputValues(directiveNode.arguments),
       astNode: directiveNode,
@@ -284,7 +281,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
     const type = typeDefNamed(typeNode.name.value);
     invariant(
       type instanceof GraphQLObjectType,
-      'AST must provide object type.'
+      'AST must provide object type.',
     );
     return (type: any);
   }
@@ -356,7 +353,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
   }
 
   function makeFieldDefMap(
-    def: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode
+    def: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
   ) {
     return keyValMap(
       def.fields,
@@ -367,13 +364,14 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
         args: makeInputValues(field.arguments),
         deprecationReason: getDeprecationReason(field),
         astNode: field,
-      })
+      }),
     );
   }
 
   function makeImplementedInterfaces(def: ObjectTypeDefinitionNode) {
-    return def.interfaces &&
-      def.interfaces.map(iface => produceInterfaceType(iface));
+    return (
+      def.interfaces && def.interfaces.map(iface => produceInterfaceType(iface))
+    );
   }
 
   function makeInputValues(values: Array<InputValueDefinitionNode>) {
@@ -388,7 +386,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
           defaultValue: valueFromAST(value.defaultValue, type),
           astNode: value,
         };
-      }
+      },
     );
   }
 
@@ -413,7 +411,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
           description: getDescription(enumValue),
           deprecationReason: getDeprecationReason(enumValue),
           astNode: enumValue,
-        })
+        }),
       ),
       astNode: def,
     });
@@ -459,7 +457,7 @@ export function buildASTSchema(ast: DocumentNode): GraphQLSchema {
  * deprecation reason.
  */
 export function getDeprecationReason(
-  node: EnumValueDefinitionNode | FieldDefinitionNode
+  node: EnumValueDefinitionNode | FieldDefinitionNode,
 ): ?string {
   const deprecated = getDirectiveValues(GraphQLDeprecatedDirective, node);
   return deprecated && (deprecated.reason: any);
@@ -480,7 +478,8 @@ export function getDescription(node: { loc?: Location }): ?string {
   while (
     token &&
     token.kind === TokenKind.COMMENT &&
-    token.next && token.prev &&
+    token.next &&
+    token.prev &&
     token.line + 1 === token.next.line &&
     token.line !== token.prev.line
   ) {
@@ -519,6 +518,6 @@ function leadingSpaces(str) {
 
 function cannotExecuteSchema() {
   throw new Error(
-    'Generated Schema cannot use Interface or Union types for execution.'
+    'Generated Schema cannot use Interface or Union types for execution.',
   );
 }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -43,7 +43,7 @@ import {
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLID
+  GraphQLID,
 } from '../type/scalars';
 
 import { DirectiveLocation, GraphQLDirective } from '../type/directives';
@@ -71,7 +71,6 @@ import type {
   IntrospectionNonNullTypeRef,
 } from './introspectionQuery';
 
-
 /**
  * Build a GraphQLSchema for use by client tools.
  *
@@ -85,16 +84,15 @@ import type {
  * the "errors" field of a server response before calling this function.
  */
 export function buildClientSchema(
-  introspection: IntrospectionQuery
+  introspection: IntrospectionQuery,
 ): GraphQLSchema {
-
   // Get the schema from the introspection result.
   const schemaIntrospection = introspection.__schema;
 
   // Converts the list of types into a keyMap based on the type names.
   const typeIntrospectionMap = keyMap(
     schemaIntrospection.types,
-    type => type.name
+    type => type.name,
   );
 
   // A cache to use to store the actual GraphQLType definition objects by name.
@@ -134,7 +132,7 @@ export function buildClientSchema(
       const nullableType = getType(nullableRef);
       invariant(
         !(nullableType instanceof GraphQLNonNull),
-        'No nesting nonnull.'
+        'No nesting nonnull.',
       );
       return new GraphQLNonNull(nullableType);
     }
@@ -152,8 +150,8 @@ export function buildClientSchema(
     if (!typeIntrospection) {
       throw new Error(
         `Invalid or incomplete schema, unknown type: ${typeName}. Ensure ` +
-        'that a full introspection query is used in order to build a ' +
-        'client schema.'
+          'that a full introspection query is used in order to build a ' +
+          'client schema.',
       );
     }
     const typeDef = buildType(typeIntrospection);
@@ -165,7 +163,7 @@ export function buildClientSchema(
     const type = getType(typeRef);
     invariant(
       isInputType(type),
-      'Introspection must provide input type for arguments.'
+      'Introspection must provide input type for arguments.',
     );
     return type;
   }
@@ -174,7 +172,7 @@ export function buildClientSchema(
     const type = getType(typeRef);
     invariant(
       isOutputType(type),
-      'Introspection must provide output type for fields.'
+      'Introspection must provide output type for fields.',
     );
     return type;
   }
@@ -183,18 +181,18 @@ export function buildClientSchema(
     const type = getType(typeRef);
     invariant(
       type instanceof GraphQLObjectType,
-      'Introspection must provide object type for possibleTypes.'
+      'Introspection must provide object type for possibleTypes.',
     );
     return type;
   }
 
   function getInterfaceType(
-    typeRef: IntrospectionTypeRef
+    typeRef: IntrospectionTypeRef,
   ): GraphQLInterfaceType {
     const type = getType(typeRef);
     invariant(
       type instanceof GraphQLInterfaceType,
-      'Introspection must provide interface type for interfaces.'
+      'Introspection must provide interface type for interfaces.',
     );
     return type;
   }
@@ -221,12 +219,12 @@ export function buildClientSchema(
     throw new Error(
       'Invalid or incomplete introspection result. Ensure that a full ' +
         'introspection query is used in order to build a client schema:' +
-        JSON.stringify(type)
+        JSON.stringify(type),
     );
   }
 
   function buildScalarDef(
-    scalarIntrospection: IntrospectionScalarType
+    scalarIntrospection: IntrospectionScalarType,
   ): GraphQLScalarType {
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
@@ -242,12 +240,12 @@ export function buildClientSchema(
   }
 
   function buildObjectDef(
-    objectIntrospection: IntrospectionObjectType
+    objectIntrospection: IntrospectionObjectType,
   ): GraphQLObjectType {
     if (!objectIntrospection.interfaces) {
       throw new Error(
         'Introspection result missing interfaces: ' +
-          JSON.stringify(objectIntrospection)
+          JSON.stringify(objectIntrospection),
       );
     }
     return new GraphQLObjectType({
@@ -259,7 +257,7 @@ export function buildClientSchema(
   }
 
   function buildInterfaceDef(
-    interfaceIntrospection: IntrospectionInterfaceType
+    interfaceIntrospection: IntrospectionInterfaceType,
   ): GraphQLInterfaceType {
     return new GraphQLInterfaceType({
       name: interfaceIntrospection.name,
@@ -270,12 +268,12 @@ export function buildClientSchema(
   }
 
   function buildUnionDef(
-    unionIntrospection: IntrospectionUnionType
+    unionIntrospection: IntrospectionUnionType,
   ): GraphQLUnionType {
     if (!unionIntrospection.possibleTypes) {
       throw new Error(
         'Introspection result missing possibleTypes: ' +
-          JSON.stringify(unionIntrospection)
+          JSON.stringify(unionIntrospection),
       );
     }
     return new GraphQLUnionType({
@@ -287,12 +285,12 @@ export function buildClientSchema(
   }
 
   function buildEnumDef(
-    enumIntrospection: IntrospectionEnumType
+    enumIntrospection: IntrospectionEnumType,
   ): GraphQLEnumType {
     if (!enumIntrospection.enumValues) {
       throw new Error(
         'Introspection result missing enumValues: ' +
-          JSON.stringify(enumIntrospection)
+          JSON.stringify(enumIntrospection),
       );
     }
     return new GraphQLEnumType({
@@ -304,18 +302,18 @@ export function buildClientSchema(
         valueIntrospection => ({
           description: valueIntrospection.description,
           deprecationReason: valueIntrospection.deprecationReason,
-        })
-      )
+        }),
+      ),
     });
   }
 
   function buildInputObjectDef(
-    inputObjectIntrospection: IntrospectionInputObjectType
+    inputObjectIntrospection: IntrospectionInputObjectType,
   ): GraphQLInputObjectType {
     if (!inputObjectIntrospection.inputFields) {
       throw new Error(
         'Introspection result missing inputFields: ' +
-          JSON.stringify(inputObjectIntrospection)
+          JSON.stringify(inputObjectIntrospection),
       );
     }
     return new GraphQLInputObjectType({
@@ -329,7 +327,7 @@ export function buildClientSchema(
     if (!typeIntrospection.fields) {
       throw new Error(
         'Introspection result missing fields: ' +
-          JSON.stringify(typeIntrospection)
+          JSON.stringify(typeIntrospection),
       );
     }
     return keyValMap(
@@ -339,7 +337,7 @@ export function buildClientSchema(
         if (!fieldIntrospection.args) {
           throw new Error(
             'Introspection result missing field args: ' +
-              JSON.stringify(fieldIntrospection)
+              JSON.stringify(fieldIntrospection),
           );
         }
         return {
@@ -348,7 +346,7 @@ export function buildClientSchema(
           type: getOutputType(fieldIntrospection.type),
           args: buildInputValueDefMap(fieldIntrospection.args),
         };
-      }
+      },
     );
   }
 
@@ -356,15 +354,15 @@ export function buildClientSchema(
     return keyValMap(
       inputValueIntrospections,
       inputValue => inputValue.name,
-      buildInputValue
+      buildInputValue,
     );
   }
 
   function buildInputValue(inputValueIntrospection) {
     const type = getInputType(inputValueIntrospection.type);
-    const defaultValue = inputValueIntrospection.defaultValue ?
-      valueFromAST(parseValue(inputValueIntrospection.defaultValue), type) :
-      undefined;
+    const defaultValue = inputValueIntrospection.defaultValue
+      ? valueFromAST(parseValue(inputValueIntrospection.defaultValue), type)
+      : undefined;
     return {
       name: inputValueIntrospection.name,
       description: inputValueIntrospection.description,
@@ -376,27 +374,29 @@ export function buildClientSchema(
   function buildDirective(directiveIntrospection) {
     // Support deprecated `on****` fields for building `locations`, as this
     // is used by GraphiQL which may need to support outdated servers.
-    const locations = directiveIntrospection.locations ?
-      directiveIntrospection.locations.slice() :
-      [].concat(
-        !directiveIntrospection.onField ? [] : [
-          DirectiveLocation.FIELD,
-        ],
-        !directiveIntrospection.onOperation ? [] : [
-          DirectiveLocation.QUERY,
-          DirectiveLocation.MUTATION,
-          DirectiveLocation.SUBSCRIPTION,
-        ],
-        !directiveIntrospection.onFragment ? [] : [
-          DirectiveLocation.FRAGMENT_DEFINITION,
-          DirectiveLocation.FRAGMENT_SPREAD,
-          DirectiveLocation.INLINE_FRAGMENT,
-        ]
-      );
+    const locations = directiveIntrospection.locations
+      ? directiveIntrospection.locations.slice()
+      : [].concat(
+          !directiveIntrospection.onField ? [] : [DirectiveLocation.FIELD],
+          !directiveIntrospection.onOperation
+            ? []
+            : [
+                DirectiveLocation.QUERY,
+                DirectiveLocation.MUTATION,
+                DirectiveLocation.SUBSCRIPTION,
+              ],
+          !directiveIntrospection.onFragment
+            ? []
+            : [
+                DirectiveLocation.FRAGMENT_DEFINITION,
+                DirectiveLocation.FRAGMENT_SPREAD,
+                DirectiveLocation.INLINE_FRAGMENT,
+              ],
+        );
     if (!directiveIntrospection.args) {
       throw new Error(
         'Introspection result missing directive args: ' +
-          JSON.stringify(directiveIntrospection)
+          JSON.stringify(directiveIntrospection),
       );
     }
     return new GraphQLDirective({
@@ -409,26 +409,26 @@ export function buildClientSchema(
 
   // Iterate through all types, getting the type definition for each, ensuring
   // that any type not directly referenced by a field will get created.
-  const types = schemaIntrospection.types.map(
-    typeIntrospection => getNamedType(typeIntrospection.name)
+  const types = schemaIntrospection.types.map(typeIntrospection =>
+    getNamedType(typeIntrospection.name),
   );
 
   // Get the root Query, Mutation, and Subscription types.
   const queryType = getObjectType(schemaIntrospection.queryType);
 
-  const mutationType = schemaIntrospection.mutationType ?
-    getObjectType(schemaIntrospection.mutationType) :
-    null;
+  const mutationType = schemaIntrospection.mutationType
+    ? getObjectType(schemaIntrospection.mutationType)
+    : null;
 
-  const subscriptionType = schemaIntrospection.subscriptionType ?
-    getObjectType(schemaIntrospection.subscriptionType) :
-    null;
+  const subscriptionType = schemaIntrospection.subscriptionType
+    ? getObjectType(schemaIntrospection.subscriptionType)
+    : null;
 
   // Get the directives supported by Introspection, assuming empty-set if
   // directives were not queried for.
-  const directives = schemaIntrospection.directives ?
-    schemaIntrospection.directives.map(buildDirective) :
-    [];
+  const directives = schemaIntrospection.directives
+    ? schemaIntrospection.directives.map(buildDirective)
+    : [];
 
   // Then produce and return a Schema with these types.
   return new GraphQLSchema({
@@ -442,6 +442,6 @@ export function buildClientSchema(
 
 function cannotExecuteClientSchema() {
   throw new Error(
-    'Client Schema cannot use Interface or Union types for execution.'
+    'Client Schema cannot use Interface or Union types for execution.',
   );
 }

--- a/src/utilities/concatAST.js
+++ b/src/utilities/concatAST.js
@@ -9,7 +9,6 @@
 
 import type { DocumentNode } from '../language/ast';
 
-
 /**
  * Provided a collection of ASTs, presumably each from different files,
  * concatenate the ASTs together into batched AST, useful for validating many

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -10,10 +10,7 @@
 import invariant from '../jsutils/invariant';
 import keyMap from '../jsutils/keyMap';
 import keyValMap from '../jsutils/keyValMap';
-import {
-  getDescription,
-  getDeprecationReason,
-} from './buildASTSchema';
+import { getDescription, getDeprecationReason } from './buildASTSchema';
 import { valueFromAST } from './valueFromAST';
 import { GraphQLError } from '../error/GraphQLError';
 import { GraphQLSchema } from '../type/schema';
@@ -31,9 +28,7 @@ import {
   assertOutputType,
 } from '../type/definition';
 
-import {
-  GraphQLDirective,
-} from '../type/directives';
+import { GraphQLDirective } from '../type/directives';
 
 import {
   __Schema,
@@ -63,9 +58,7 @@ import type {
   GraphQLOutputType,
 } from '../type/definition';
 
-import type {
-  DirectiveLocationEnum
-} from '../type/directives';
+import type { DirectiveLocationEnum } from '../type/directives';
 
 import type {
   DocumentNode,
@@ -82,7 +75,6 @@ import type {
   DirectiveDefinitionNode,
 } from '../language/ast';
 
-
 /**
  * Produces a new schema given an existing schema and a document which may
  * contain GraphQL type extensions and definitions. The original schema will
@@ -97,16 +89,16 @@ import type {
  */
 export function extendSchema(
   schema: GraphQLSchema,
-  documentAST: DocumentNode
+  documentAST: DocumentNode,
 ): GraphQLSchema {
   invariant(
     schema instanceof GraphQLSchema,
-    'Must provide valid GraphQLSchema'
+    'Must provide valid GraphQLSchema',
   );
 
   invariant(
     documentAST && documentAST.kind === Kind.DOCUMENT,
-    'Must provide valid Document AST'
+    'Must provide valid Document AST',
   );
 
   // Collect the type definitions and extensions found in the document.
@@ -115,7 +107,7 @@ export function extendSchema(
 
   // New directives and types are separate because a directives and types can
   // have the same name. For example, a type named "skip".
-  const directiveDefinitions : Array<DirectiveDefinitionNode> = [];
+  const directiveDefinitions: Array<DirectiveDefinitionNode> = [];
 
   for (let i = 0; i < documentAST.definitions.length; i++) {
     const def = documentAST.definitions[i];
@@ -132,8 +124,8 @@ export function extendSchema(
         if (schema.getType(typeName)) {
           throw new GraphQLError(
             `Type "${typeName}" already exists in the schema. It cannot also ` +
-            'be defined in this type definition.',
-            [ def ]
+              'be defined in this type definition.',
+            [def],
           );
         }
         typeDefinitionMap[typeName] = def;
@@ -146,21 +138,21 @@ export function extendSchema(
         if (!existingType) {
           throw new GraphQLError(
             `Cannot extend type "${extendedTypeName}" because it does not ` +
-            'exist in the existing schema.',
-            [ def.definition ]
+              'exist in the existing schema.',
+            [def.definition],
           );
         }
         if (!(existingType instanceof GraphQLObjectType)) {
           throw new GraphQLError(
             `Cannot extend non-object type "${extendedTypeName}".`,
-            [ def.definition ]
+            [def.definition],
           );
         }
         let extensions = typeExtensionsMap[extendedTypeName];
         if (extensions) {
           extensions.push(def);
         } else {
-          extensions = [ def ];
+          extensions = [def];
         }
         typeExtensionsMap[extendedTypeName] = extensions;
         break;
@@ -170,8 +162,8 @@ export function extendSchema(
         if (existingDirective) {
           throw new GraphQLError(
             `Directive "${directiveName}" already exists in the schema. It ` +
-            'cannot be redefined.',
-            [ def ]
+              'cannot be redefined.',
+            [def],
           );
         }
         directiveDefinitions.push(def);
@@ -181,9 +173,11 @@ export function extendSchema(
 
   // If this document contains no new types, extensions, or directives then
   // return the same unmodified GraphQLSchema instance.
-  if (Object.keys(typeExtensionsMap).length === 0 &&
-      Object.keys(typeDefinitionMap).length === 0 &&
-      directiveDefinitions.length === 0) {
+  if (
+    Object.keys(typeExtensionsMap).length === 0 &&
+    Object.keys(typeDefinitionMap).length === 0 &&
+    directiveDefinitions.length === 0
+  ) {
     return schema;
   }
 
@@ -211,20 +205,20 @@ export function extendSchema(
   const queryType = getTypeFromDef(schema.getQueryType());
 
   const existingMutationType = schema.getMutationType();
-  const mutationType = existingMutationType ?
-    getTypeFromDef(existingMutationType) :
-    null;
+  const mutationType = existingMutationType
+    ? getTypeFromDef(existingMutationType)
+    : null;
 
   const existingSubscriptionType = schema.getSubscriptionType();
-  const subscriptionType = existingSubscriptionType ?
-    getTypeFromDef(existingSubscriptionType) :
-    null;
+  const subscriptionType = existingSubscriptionType
+    ? getTypeFromDef(existingSubscriptionType)
+    : null;
 
   // Iterate through all types, getting the type definition for each, ensuring
   // that any type not directly referenced by a field will get created.
   const typeMap = schema.getTypeMap();
   const types = Object.keys(typeMap).map(typeName =>
-    getTypeFromDef(typeMap[typeName])
+    getTypeFromDef(typeMap[typeName]),
   );
 
   // Do the same with new types, appending to the list of defined types.
@@ -250,7 +244,7 @@ export function extendSchema(
     invariant(existingDirectives, 'schema must have default directives');
 
     const newDirectives = directiveDefinitions.map(directiveNode =>
-      getDirective(directiveNode)
+      getDirective(directiveNode),
     );
     return existingDirectives.concat(newDirectives);
   }
@@ -266,8 +260,8 @@ export function extendSchema(
     if (!type) {
       throw new GraphQLError(
         `Unknown type: "${node.name.value}". Ensure that this type exists ` +
-        'either in the original schema, or is added in a type definition.',
-        [ node ]
+          'either in the original schema, or is added in a type definition.',
+        [node],
       );
     }
     return type;
@@ -350,7 +344,7 @@ export function extendSchema(
   }
 
   function extendInterfaceType(
-    type: GraphQLInterfaceType
+    type: GraphQLInterfaceType,
   ): GraphQLInterfaceType {
     return new GraphQLInterfaceType({
       name: type.name,
@@ -372,7 +366,7 @@ export function extendSchema(
   }
 
   function extendImplementedInterfaces(
-    type: GraphQLObjectType
+    type: GraphQLObjectType,
   ): Array<GraphQLInterfaceType> {
     const interfaces = type.getInterfaces().map(getTypeFromDef);
 
@@ -385,8 +379,8 @@ export function extendSchema(
           if (interfaces.some(def => def.name === interfaceName)) {
             throw new GraphQLError(
               `Type "${type.name}" already implements "${interfaceName}". ` +
-              'It cannot also be implemented in this type extension.',
-              [ namedType ]
+                'It cannot also be implemented in this type extension.',
+              [namedType],
             );
           }
           interfaces.push(getInterfaceTypeFromAST(namedType));
@@ -421,8 +415,8 @@ export function extendSchema(
           if (oldFieldMap[fieldName]) {
             throw new GraphQLError(
               `Field "${type.name}.${fieldName}" already exists in the ` +
-              'schema. It cannot also be defined in this type extension.',
-              [ field ]
+                'schema. It cannot also be defined in this type extension.',
+              [field],
             );
           }
           newFieldMap[fieldName] = {
@@ -451,11 +445,16 @@ export function extendSchema(
 
   function buildType(typeNode: TypeDefinitionNode): GraphQLNamedType {
     switch (typeNode.kind) {
-      case Kind.OBJECT_TYPE_DEFINITION: return buildObjectType(typeNode);
-      case Kind.INTERFACE_TYPE_DEFINITION: return buildInterfaceType(typeNode);
-      case Kind.UNION_TYPE_DEFINITION: return buildUnionType(typeNode);
-      case Kind.SCALAR_TYPE_DEFINITION: return buildScalarType(typeNode);
-      case Kind.ENUM_TYPE_DEFINITION: return buildEnumType(typeNode);
+      case Kind.OBJECT_TYPE_DEFINITION:
+        return buildObjectType(typeNode);
+      case Kind.INTERFACE_TYPE_DEFINITION:
+        return buildInterfaceType(typeNode);
+      case Kind.UNION_TYPE_DEFINITION:
+        return buildUnionType(typeNode);
+      case Kind.SCALAR_TYPE_DEFINITION:
+        return buildScalarType(typeNode);
+      case Kind.ENUM_TYPE_DEFINITION:
+        return buildEnumType(typeNode);
       case Kind.INPUT_OBJECT_TYPE_DEFINITION:
         return buildInputObjectType(typeNode);
     }
@@ -534,13 +533,13 @@ export function extendSchema(
   }
 
   function getDirective(
-    directiveNode: DirectiveDefinitionNode
+    directiveNode: DirectiveDefinitionNode,
   ): GraphQLDirective {
     return new GraphQLDirective({
       name: directiveNode.name.value,
       description: getDescription(directiveNode),
       locations: directiveNode.locations.map(
-        node => ((node.value: any): DirectiveLocationEnum)
+        node => ((node.value: any): DirectiveLocationEnum),
       ),
       args:
         directiveNode.arguments && buildInputValues(directiveNode.arguments),
@@ -549,8 +548,9 @@ export function extendSchema(
   }
 
   function buildImplementedInterfaces(typeNode: ObjectTypeDefinitionNode) {
-    return typeNode.interfaces &&
-      typeNode.interfaces.map(getInterfaceTypeFromAST);
+    return (
+      typeNode.interfaces && typeNode.interfaces.map(getInterfaceTypeFromAST)
+    );
   }
 
   function buildFieldMap(typeNode) {
@@ -563,7 +563,7 @@ export function extendSchema(
         args: buildInputValues(field.arguments),
         deprecationReason: getDeprecationReason(field),
         astNode: field,
-      })
+      }),
     );
   }
 
@@ -579,7 +579,7 @@ export function extendSchema(
           defaultValue: valueFromAST(value.defaultValue, type),
           astNode: value,
         };
-      }
+      },
     );
   }
 
@@ -610,6 +610,6 @@ export function extendSchema(
 
 function cannotExecuteExtendedSchema() {
   throw new Error(
-    'Extended Schema cannot use Interface or Union types for execution.'
+    'Extended Schema cannot use Interface or Union types for execution.',
   );
 }

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -48,13 +48,13 @@ export const DangerousChangeType = {
 };
 
 export type BreakingChange = {
-  type: $Keys<typeof BreakingChangeType>;
-  description: string;
+  type: $Keys<typeof BreakingChangeType>,
+  description: string,
 };
 
 export type DangerousChange = {
-  type: $Keys<typeof DangerousChangeType>;
-  description: string;
+  type: $Keys<typeof DangerousChangeType>,
+  description: string,
 };
 
 /**
@@ -63,7 +63,7 @@ export type DangerousChange = {
  */
 export function findBreakingChanges(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   return [
     ...findRemovedTypes(oldSchema, newSchema),
@@ -82,12 +82,12 @@ export function findBreakingChanges(
  */
 export function findDangerousChanges(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<DangerousChange> {
   return [
     ...findArgChanges(oldSchema, newSchema).dangerousChanges,
     ...findValuesAddedToEnums(oldSchema, newSchema),
-    ...findTypesAddedToUnions(oldSchema, newSchema)
+    ...findTypesAddedToUnions(oldSchema, newSchema),
   ];
 }
 
@@ -97,7 +97,7 @@ export function findDangerousChanges(
  */
 export function findRemovedTypes(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -119,8 +119,8 @@ export function findRemovedTypes(
  * changes in the newSchema related to changing the type of a type.
  */
 export function findTypesThatChangedKind(
- oldSchema: GraphQLSchema,
- newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -135,8 +135,9 @@ export function findTypesThatChangedKind(
     if (!(oldType instanceof newType.constructor)) {
       breakingChanges.push({
         type: BreakingChangeType.TYPE_CHANGED_KIND,
-        description: `${typeName} changed from ` +
-          `${typeKindName(oldType)} to ${typeKindName(newType)}.`
+        description:
+          `${typeName} changed from ` +
+          `${typeKindName(oldType)} to ${typeKindName(newType)}.`,
       });
     }
   });
@@ -150,11 +151,11 @@ export function findTypesThatChangedKind(
  * argument's default value).
  */
 export function findArgChanges(
- oldSchema: GraphQLSchema,
- newSchema: GraphQLSchema
+  oldSchema: GraphQLSchema,
+  newSchema: GraphQLSchema,
 ): {
   breakingChanges: Array<BreakingChange>,
-  dangerousChanges: Array<DangerousChange>
+  dangerousChanges: Array<DangerousChange>,
 } {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -166,8 +167,10 @@ export function findArgChanges(
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (
-      !(oldType instanceof GraphQLObjectType ||
-        oldType instanceof GraphQLInterfaceType) ||
+      !(
+        oldType instanceof GraphQLObjectType ||
+        oldType instanceof GraphQLInterfaceType
+      ) ||
       !(newType instanceof oldType.constructor)
     ) {
       return;
@@ -183,15 +186,14 @@ export function findArgChanges(
 
       oldTypeFields[fieldName].args.forEach(oldArgDef => {
         const newArgs = newTypeFields[fieldName].args;
-        const newArgDef = newArgs.find(
-          arg => arg.name === oldArgDef.name
-        );
+        const newArgDef = newArgs.find(arg => arg.name === oldArgDef.name);
 
         // Arg not present
         if (!newArgDef) {
           breakingChanges.push({
             type: BreakingChangeType.ARG_REMOVED,
-            description: `${oldType.name}.${fieldName} arg ` +
+            description:
+              `${oldType.name}.${fieldName} arg ` +
               `${oldArgDef.name} was removed`,
           });
         } else {
@@ -202,15 +204,19 @@ export function findArgChanges(
           if (!isSafe) {
             breakingChanges.push({
               type: BreakingChangeType.ARG_CHANGED_KIND,
-              description: `${oldType.name}.${fieldName} arg ` +
+              description:
+                `${oldType.name}.${fieldName} arg ` +
                 `${oldArgDef.name} has changed type from ` +
                 `${oldArgDef.type.toString()} to ${newArgDef.type.toString()}`,
             });
-          } else if (oldArgDef.defaultValue !== undefined &&
-          oldArgDef.defaultValue !== newArgDef.defaultValue) {
+          } else if (
+            oldArgDef.defaultValue !== undefined &&
+            oldArgDef.defaultValue !== newArgDef.defaultValue
+          ) {
             dangerousChanges.push({
               type: DangerousChangeType.ARG_DEFAULT_VALUE_CHANGE,
-              description: `${oldType.name}.${fieldName} arg ` +
+              description:
+                `${oldType.name}.${fieldName} arg ` +
                 `${oldArgDef.name} has changed defaultValue`,
             });
           }
@@ -219,13 +225,12 @@ export function findArgChanges(
       // Check if a non-null arg was added to the field
       newTypeFields[fieldName].args.forEach(newArgDef => {
         const oldArgs = oldTypeFields[fieldName].args;
-        const oldArgDef = oldArgs.find(
-          arg => arg.name === newArgDef.name
-        );
+        const oldArgDef = oldArgs.find(arg => arg.name === newArgDef.name);
         if (!oldArgDef && newArgDef.type instanceof GraphQLNonNull) {
           breakingChanges.push({
             type: BreakingChangeType.NON_NULL_ARG_ADDED,
-            description: `A non-null arg ${newArgDef.name} on ` +
+            description:
+              `A non-null arg ${newArgDef.name} on ` +
               `${newType.name}.${fieldName} was added`,
           });
         }
@@ -269,7 +274,7 @@ function typeKindName(type: GraphQLNamedType): string {
  */
 export function findFieldsThatChangedType(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   return [
     ...findFieldsThatChangedTypeOnObjectOrInterfaceTypes(oldSchema, newSchema),
@@ -289,8 +294,10 @@ function findFieldsThatChangedTypeOnObjectOrInterfaceTypes(
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (
-      !(oldType instanceof GraphQLObjectType ||
-        oldType instanceof GraphQLInterfaceType) ||
+      !(
+        oldType instanceof GraphQLObjectType ||
+        oldType instanceof GraphQLInterfaceType
+      ) ||
       !(newType instanceof oldType.constructor)
     ) {
       return;
@@ -308,18 +315,21 @@ function findFieldsThatChangedTypeOnObjectOrInterfaceTypes(
       } else {
         const oldFieldType = oldTypeFieldsDef[fieldName].type;
         const newFieldType = newTypeFieldsDef[fieldName].type;
-        const isSafe =
-          isChangeSafeForObjectOrInterfaceField(oldFieldType, newFieldType);
+        const isSafe = isChangeSafeForObjectOrInterfaceField(
+          oldFieldType,
+          newFieldType,
+        );
         if (!isSafe) {
-          const oldFieldTypeString = isNamedType(oldFieldType) ?
-            oldFieldType.name :
-            oldFieldType.toString();
-          const newFieldTypeString = isNamedType(newFieldType) ?
-            newFieldType.name :
-            newFieldType.toString();
+          const oldFieldTypeString = isNamedType(oldFieldType)
+            ? oldFieldType.name
+            : oldFieldType.toString();
+          const newFieldTypeString = isNamedType(newFieldType)
+            ? newFieldType.name
+            : newFieldType.toString();
           breakingFieldChanges.push({
             type: BreakingChangeType.FIELD_CHANGED_KIND,
-            description: `${typeName}.${fieldName} changed type from ` +
+            description:
+              `${typeName}.${fieldName} changed type from ` +
               `${oldFieldTypeString} to ${newFieldTypeString}.`,
           });
         }
@@ -331,7 +341,7 @@ function findFieldsThatChangedTypeOnObjectOrInterfaceTypes(
 
 export function findFieldsThatChangedTypeOnInputObjectTypes(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -360,18 +370,21 @@ export function findFieldsThatChangedTypeOnInputObjectTypes(
         const oldFieldType = oldTypeFieldsDef[fieldName].type;
         const newFieldType = newTypeFieldsDef[fieldName].type;
 
-        const isSafe =
-          isChangeSafeForInputObjectFieldOrFieldArg(oldFieldType, newFieldType);
+        const isSafe = isChangeSafeForInputObjectFieldOrFieldArg(
+          oldFieldType,
+          newFieldType,
+        );
         if (!isSafe) {
-          const oldFieldTypeString = isNamedType(oldFieldType) ?
-            oldFieldType.name :
-            oldFieldType.toString();
-          const newFieldTypeString = isNamedType(newFieldType) ?
-            newFieldType.name :
-            newFieldType.toString();
+          const oldFieldTypeString = isNamedType(oldFieldType)
+            ? oldFieldType.name
+            : oldFieldType.toString();
+          const newFieldTypeString = isNamedType(newFieldType)
+            ? newFieldType.name
+            : newFieldType.toString();
           breakingFieldChanges.push({
             type: BreakingChangeType.FIELD_CHANGED_KIND,
-            description: `${typeName}.${fieldName} changed type from ` +
+            description:
+              `${typeName}.${fieldName} changed type from ` +
               `${oldFieldTypeString} to ${newFieldTypeString}.`,
           });
         }
@@ -385,7 +398,8 @@ export function findFieldsThatChangedTypeOnInputObjectTypes(
       ) {
         breakingFieldChanges.push({
           type: BreakingChangeType.NON_NULL_INPUT_FIELD_ADDED,
-          description: `A non-null field ${fieldName} on ` +
+          description:
+            `A non-null field ${fieldName} on ` +
             `input type ${newType.name} was added.`,
         });
       }
@@ -400,41 +414,30 @@ function isChangeSafeForObjectOrInterfaceField(
 ): boolean {
   if (isNamedType(oldType)) {
     return (
-        // if they're both named types, see if their names are equivalent
-        isNamedType(newType) && oldType.name === newType.name
-      ) ||
-      (
-        // moving from nullable to non-null of the same underlying type is safe
-        newType instanceof GraphQLNonNull &&
-        isChangeSafeForObjectOrInterfaceField(
-          oldType,
-          newType.ofType,
-        )
-      );
+      // if they're both named types, see if their names are equivalent
+      (isNamedType(newType) && oldType.name === newType.name) ||
+      // moving from nullable to non-null of the same underlying type is safe
+      (newType instanceof GraphQLNonNull &&
+        isChangeSafeForObjectOrInterfaceField(oldType, newType.ofType))
+    );
   } else if (oldType instanceof GraphQLList) {
     return (
-        // if they're both lists, make sure the underlying types are compatible
-        newType instanceof GraphQLList &&
+      // if they're both lists, make sure the underlying types are compatible
+      (newType instanceof GraphQLList &&
         isChangeSafeForObjectOrInterfaceField(
           oldType.ofType,
           newType.ofType,
-        )
-      ) ||
-      (
-        // moving from nullable to non-null of the same underlying type is safe
-        newType instanceof GraphQLNonNull &&
-        isChangeSafeForObjectOrInterfaceField(
-          oldType,
-          newType.ofType,
-        )
-      );
+        )) ||
+      // moving from nullable to non-null of the same underlying type is safe
+      (newType instanceof GraphQLNonNull &&
+        isChangeSafeForObjectOrInterfaceField(oldType, newType.ofType))
+    );
   } else if (oldType instanceof GraphQLNonNull) {
     // if they're both non-null, make sure the underlying types are compatible
-    return newType instanceof GraphQLNonNull &&
-      isChangeSafeForObjectOrInterfaceField(
-        oldType.ofType,
-        newType.ofType,
-      );
+    return (
+      newType instanceof GraphQLNonNull &&
+      isChangeSafeForObjectOrInterfaceField(oldType.ofType, newType.ofType)
+    );
   }
   return false;
 }
@@ -448,29 +451,23 @@ function isChangeSafeForInputObjectFieldOrFieldArg(
     return isNamedType(newType) && oldType.name === newType.name;
   } else if (oldType instanceof GraphQLList) {
     // if they're both lists, make sure the underlying types are compatible
-    return newType instanceof GraphQLList &&
-      isChangeSafeForInputObjectFieldOrFieldArg(
-        oldType.ofType,
-        newType.ofType,
-      );
+    return (
+      newType instanceof GraphQLList &&
+      isChangeSafeForInputObjectFieldOrFieldArg(oldType.ofType, newType.ofType)
+    );
   } else if (oldType instanceof GraphQLNonNull) {
     return (
-        // if they're both non-null, make sure the underlying types are
-        // compatible
-        newType instanceof GraphQLNonNull &&
+      // if they're both non-null, make sure the underlying types are
+      // compatible
+      (newType instanceof GraphQLNonNull &&
         isChangeSafeForInputObjectFieldOrFieldArg(
           oldType.ofType,
           newType.ofType,
-        )
-      ) ||
-      (
-        // moving from non-null to nullable of the same underlying type is safe
-        !(newType instanceof GraphQLNonNull) &&
-        isChangeSafeForInputObjectFieldOrFieldArg(
-          oldType.ofType,
-          newType,
-        )
-      );
+        )) ||
+      // moving from non-null to nullable of the same underlying type is safe
+      (!(newType instanceof GraphQLNonNull) &&
+        isChangeSafeForInputObjectFieldOrFieldArg(oldType.ofType, newType))
+    );
   }
   return false;
 }
@@ -481,7 +478,7 @@ function isChangeSafeForInputObjectFieldOrFieldArg(
  */
 export function findTypesRemovedFromUnions(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -490,8 +487,10 @@ export function findTypesRemovedFromUnions(
   Object.keys(oldTypeMap).forEach(typeName => {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
-    if (!(oldType instanceof GraphQLUnionType) ||
-        !(newType instanceof GraphQLUnionType)) {
+    if (
+      !(oldType instanceof GraphQLUnionType) ||
+      !(newType instanceof GraphQLUnionType)
+    ) {
       return;
     }
     const typeNamesInNewUnion = Object.create(null);
@@ -502,7 +501,7 @@ export function findTypesRemovedFromUnions(
       if (!typeNamesInNewUnion[type.name]) {
         typesRemovedFromUnion.push({
           type: BreakingChangeType.TYPE_REMOVED_FROM_UNION,
-          description: `${type.name} was removed from union type ${typeName}.`
+          description: `${type.name} was removed from union type ${typeName}.`,
         });
       }
     });
@@ -516,7 +515,7 @@ export function findTypesRemovedFromUnions(
  */
 export function findTypesAddedToUnions(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<DangerousChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -525,8 +524,10 @@ export function findTypesAddedToUnions(
   Object.keys(newTypeMap).forEach(typeName => {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
-    if (!(oldType instanceof GraphQLUnionType) ||
-        !(newType instanceof GraphQLUnionType)) {
+    if (
+      !(oldType instanceof GraphQLUnionType) ||
+      !(newType instanceof GraphQLUnionType)
+    ) {
       return;
     }
     const typeNamesInOldUnion = Object.create(null);
@@ -537,7 +538,7 @@ export function findTypesAddedToUnions(
       if (!typeNamesInOldUnion[type.name]) {
         typesAddedToUnion.push({
           type: DangerousChangeType.TYPE_ADDED_TO_UNION,
-          description: `${type.name} was added to union type ${typeName}.`
+          description: `${type.name} was added to union type ${typeName}.`,
         });
       }
     });
@@ -550,7 +551,7 @@ export function findTypesAddedToUnions(
  */
 export function findValuesRemovedFromEnums(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -559,8 +560,10 @@ export function findValuesRemovedFromEnums(
   Object.keys(oldTypeMap).forEach(typeName => {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
-    if (!(oldType instanceof GraphQLEnumType) ||
-        !(newType instanceof GraphQLEnumType)) {
+    if (
+      !(oldType instanceof GraphQLEnumType) ||
+      !(newType instanceof GraphQLEnumType)
+    ) {
       return;
     }
     const valuesInNewEnum = Object.create(null);
@@ -571,7 +574,7 @@ export function findValuesRemovedFromEnums(
       if (!valuesInNewEnum[value.name]) {
         valuesRemovedFromEnums.push({
           type: BreakingChangeType.VALUE_REMOVED_FROM_ENUM,
-          description: `${value.name} was removed from enum type ${typeName}.`
+          description: `${value.name} was removed from enum type ${typeName}.`,
         });
       }
     });
@@ -585,7 +588,7 @@ export function findValuesRemovedFromEnums(
  */
 export function findValuesAddedToEnums(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<DangerousChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -594,8 +597,10 @@ export function findValuesAddedToEnums(
   Object.keys(oldTypeMap).forEach(typeName => {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
-    if (!(oldType instanceof GraphQLEnumType) ||
-        !(newType instanceof GraphQLEnumType)) {
+    if (
+      !(oldType instanceof GraphQLEnumType) ||
+      !(newType instanceof GraphQLEnumType)
+    ) {
       return;
     }
 
@@ -607,7 +612,7 @@ export function findValuesAddedToEnums(
       if (!valuesInOldEnum[value.name]) {
         valuesAddedToEnums.push({
           type: DangerousChangeType.VALUE_ADDED_TO_ENUM,
-          description: `${value.name} was added to enum type ${typeName}.`
+          description: `${value.name} was added to enum type ${typeName}.`,
         });
       }
     });
@@ -617,7 +622,7 @@ export function findValuesAddedToEnums(
 
 export function findInterfacesRemovedFromObjectTypes(
   oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema
+  newSchema: GraphQLSchema,
 ): Array<BreakingChange> {
   const oldTypeMap = oldSchema.getTypeMap();
   const newTypeMap = newSchema.getTypeMap();
@@ -639,8 +644,9 @@ export function findInterfacesRemovedFromObjectTypes(
       if (!newInterfaces.some(int => int.name === oldInterface.name)) {
         breakingChanges.push({
           type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
-          description: `${typeName} no longer implements interface ` +
-            `${oldInterface.name}.`
+          description:
+            `${typeName} no longer implements interface ` +
+            `${oldInterface.name}.`,
         });
       }
     });

--- a/src/utilities/findDeprecatedUsages.js
+++ b/src/utilities/findDeprecatedUsages.js
@@ -26,36 +26,43 @@ export function findDeprecatedUsages(
   const errors = [];
   const typeInfo = new TypeInfo(schema);
 
-  visit(ast, visitWithTypeInfo(typeInfo, {
-    Field(node) {
-      const fieldDef = typeInfo.getFieldDef();
-      if (fieldDef && fieldDef.isDeprecated) {
-        const parentType = typeInfo.getParentType();
-        if (parentType) {
-          const reason = fieldDef.deprecationReason;
-          errors.push(new GraphQLError(
-            `The field ${parentType.name}.${fieldDef.name} is deprecated.` +
-            (reason ? ' ' + reason : ''),
-            [ node ]
-          ));
+  visit(
+    ast,
+    visitWithTypeInfo(typeInfo, {
+      Field(node) {
+        const fieldDef = typeInfo.getFieldDef();
+        if (fieldDef && fieldDef.isDeprecated) {
+          const parentType = typeInfo.getParentType();
+          if (parentType) {
+            const reason = fieldDef.deprecationReason;
+            errors.push(
+              new GraphQLError(
+                `The field ${parentType.name}.${fieldDef.name} is deprecated.` +
+                  (reason ? ' ' + reason : ''),
+                [node],
+              ),
+            );
+          }
         }
-      }
-    },
-    EnumValue(node) {
-      const enumVal = typeInfo.getEnumValue();
-      if (enumVal && enumVal.isDeprecated) {
-        const type = getNamedType(typeInfo.getInputType());
-        if (type) {
-          const reason = enumVal.deprecationReason;
-          errors.push(new GraphQLError(
-            `The enum value ${type.name}.${enumVal.name} is deprecated.` +
-            (reason ? ' ' + reason : ''),
-            [ node ]
-          ));
+      },
+      EnumValue(node) {
+        const enumVal = typeInfo.getEnumValue();
+        if (enumVal && enumVal.isDeprecated) {
+          const type = getNamedType(typeInfo.getInputType());
+          if (type) {
+            const reason = enumVal.deprecationReason;
+            errors.push(
+              new GraphQLError(
+                `The enum value ${type.name}.${enumVal.name} is deprecated.` +
+                  (reason ? ' ' + reason : ''),
+                [node],
+              ),
+            );
+          }
         }
-      }
-    }
-  }));
+      },
+    }),
+  );
 
   return errors;
 }

--- a/src/utilities/getOperationAST.js
+++ b/src/utilities/getOperationAST.js
@@ -10,7 +10,6 @@
 import { OPERATION_DEFINITION } from '../language/kinds';
 import type { DocumentNode, OperationDefinitionNode } from '../language/ast';
 
-
 /**
  * Returns an operation AST given a document AST and optionally an operation
  * name. If a name is not provided, an operation is only returned if only one is
@@ -18,7 +17,7 @@ import type { DocumentNode, OperationDefinitionNode } from '../language/ast';
  */
 export function getOperationAST(
   documentAST: DocumentNode,
-  operationName: ?string
+  operationName: ?string,
 ): ?OperationDefinitionNode {
   let operation = null;
   for (let i = 0; i < documentAST.definitions.length; i++) {

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -90,10 +90,7 @@ export {
   findBreakingChanges,
   findDangerousChanges,
 } from './findBreakingChanges';
-export type {
-  BreakingChange,
-  DangerousChange,
-} from './findBreakingChanges';
+export type { BreakingChange, DangerousChange } from './findBreakingChanges';
 
 // Report all deprecated usage within a GraphQL document.
 export { findDeprecatedUsages } from './findDeprecatedUsages';

--- a/src/utilities/introspectionQuery.js
+++ b/src/utilities/introspectionQuery.js
@@ -9,7 +9,6 @@
 
 import type { DirectiveLocationEnum } from '../type/directives';
 
-
 export const introspectionQuery = `
   query IntrospectionQuery {
     __schema {
@@ -105,15 +104,15 @@ export const introspectionQuery = `
 `;
 
 export type IntrospectionQuery = {
-  __schema: IntrospectionSchema
+  __schema: IntrospectionSchema,
 };
 
 export type IntrospectionSchema = {
-  queryType: IntrospectionNamedTypeRef;
-  mutationType: ?IntrospectionNamedTypeRef;
-  subscriptionType: ?IntrospectionNamedTypeRef;
-  types: Array<IntrospectionType>;
-  directives: Array<IntrospectionDirective>;
+  queryType: IntrospectionNamedTypeRef,
+  mutationType: ?IntrospectionNamedTypeRef,
+  subscriptionType: ?IntrospectionNamedTypeRef,
+  types: Array<IntrospectionType>,
+  directives: Array<IntrospectionDirective>,
 };
 
 export type IntrospectionType =
@@ -125,46 +124,46 @@ export type IntrospectionType =
   | IntrospectionInputObjectType;
 
 export type IntrospectionScalarType = {
-  kind: 'SCALAR';
-  name: string;
-  description: ?string;
+  kind: 'SCALAR',
+  name: string,
+  description: ?string,
 };
 
 export type IntrospectionObjectType = {
-  kind: 'OBJECT';
-  name: string;
-  description: ?string;
-  fields: Array<IntrospectionField>;
-  interfaces: Array<IntrospectionNamedTypeRef>;
+  kind: 'OBJECT',
+  name: string,
+  description: ?string,
+  fields: Array<IntrospectionField>,
+  interfaces: Array<IntrospectionNamedTypeRef>,
 };
 
 export type IntrospectionInterfaceType = {
-  kind: 'INTERFACE';
-  name: string;
-  description: ?string;
-  fields: Array<IntrospectionField>;
-  possibleTypes: Array<IntrospectionNamedTypeRef>;
+  kind: 'INTERFACE',
+  name: string,
+  description: ?string,
+  fields: Array<IntrospectionField>,
+  possibleTypes: Array<IntrospectionNamedTypeRef>,
 };
 
 export type IntrospectionUnionType = {
-  kind: 'UNION';
-  name: string;
-  description: ?string;
-  possibleTypes: Array<IntrospectionNamedTypeRef>;
+  kind: 'UNION',
+  name: string,
+  description: ?string,
+  possibleTypes: Array<IntrospectionNamedTypeRef>,
 };
 
 export type IntrospectionEnumType = {
-  kind: 'ENUM';
-  name: string;
-  description: ?string;
-  enumValues: Array<IntrospectionEnumValue>;
+  kind: 'ENUM',
+  name: string,
+  description: ?string,
+  enumValues: Array<IntrospectionEnumValue>,
 };
 
 export type IntrospectionInputObjectType = {
-  kind: 'INPUT_OBJECT';
-  name: string;
-  description: ?string;
-  inputFields: Array<IntrospectionInputValue>;
+  kind: 'INPUT_OBJECT',
+  name: string,
+  description: ?string,
+  inputFields: Array<IntrospectionInputValue>,
 };
 
 export type IntrospectionTypeRef =
@@ -173,46 +172,46 @@ export type IntrospectionTypeRef =
   | IntrospectionNonNullTypeRef;
 
 export type IntrospectionNamedTypeRef = {
-  kind: string;
-  name: string;
+  kind: string,
+  name: string,
 };
 
 export type IntrospectionListTypeRef = {
-  kind: 'LIST';
-  ofType?: IntrospectionTypeRef;
+  kind: 'LIST',
+  ofType?: IntrospectionTypeRef,
 };
 
 export type IntrospectionNonNullTypeRef = {
-  kind: 'NON_NULL';
-  ofType?: IntrospectionTypeRef;
+  kind: 'NON_NULL',
+  ofType?: IntrospectionTypeRef,
 };
 
 export type IntrospectionField = {
-  name: string;
-  description: ?string;
-  args: Array<IntrospectionInputValue>;
-  type: IntrospectionTypeRef;
-  isDeprecated: boolean;
-  deprecationReason: ?string;
+  name: string,
+  description: ?string,
+  args: Array<IntrospectionInputValue>,
+  type: IntrospectionTypeRef,
+  isDeprecated: boolean,
+  deprecationReason: ?string,
 };
 
 export type IntrospectionInputValue = {
-  name: string;
-  description: ?string;
-  type: IntrospectionTypeRef;
-  defaultValue: ?string;
+  name: string,
+  description: ?string,
+  type: IntrospectionTypeRef,
+  defaultValue: ?string,
 };
 
 export type IntrospectionEnumValue = {
-  name: string;
-  description: ?string;
-  isDeprecated: boolean;
-  deprecationReason: ?string;
+  name: string,
+  description: ?string,
+  isDeprecated: boolean,
+  deprecationReason: ?string,
 };
 
 export type IntrospectionDirective = {
-  name: string;
-  description: ?string;
-  locations: Array<DirectiveLocationEnum>;
-  args: Array<IntrospectionInputValue>;
+  name: string,
+  description: ?string,
+  locations: Array<DirectiveLocationEnum>,
+  args: Array<IntrospectionInputValue>,
 };

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -20,7 +20,6 @@ import {
 } from '../type/definition';
 import type { GraphQLInputType } from '../type/definition';
 
-
 /**
  * Given a JavaScript value and a GraphQL type, determine if the value will be
  * accepted for that type. This is primarily useful for validating the
@@ -28,12 +27,12 @@ import type { GraphQLInputType } from '../type/definition';
  */
 export function isValidJSValue(
   value: mixed,
-  type: GraphQLInputType
+  type: GraphQLInputType,
 ): Array<string> {
   // A value must be provided if the type is non-null.
   if (type instanceof GraphQLNonNull) {
     if (isNullish(value)) {
-      return [ `Expected "${String(type)}", found null.` ];
+      return [`Expected "${String(type)}", found null.`];
     }
     return isValidJSValue(value, type.ofType);
   }
@@ -48,9 +47,12 @@ export function isValidJSValue(
     if (isCollection(value)) {
       const errors = [];
       forEach((value: any), (item, index) => {
-        errors.push.apply(errors, isValidJSValue(item, itemType).map(error =>
-          `In element #${index}: ${error}`
-        ));
+        errors.push.apply(
+          errors,
+          isValidJSValue(item, itemType).map(
+            error => `In element #${index}: ${error}`,
+          ),
+        );
       });
       return errors;
     }
@@ -60,7 +62,7 @@ export function isValidJSValue(
   // Input objects check each defined field.
   if (type instanceof GraphQLInputObjectType) {
     if (typeof value !== 'object' || value === null) {
-      return [ `Expected "${type.name}", found not an object.` ];
+      return [`Expected "${type.name}", found not an object.`];
     }
     const fields = type.getFields();
 
@@ -75,11 +77,13 @@ export function isValidJSValue(
 
     // Ensure every defined field is valid.
     Object.keys(fields).forEach(fieldName => {
-      const newErrors =
-        isValidJSValue((value: any)[fieldName], fields[fieldName].type);
-      errors.push(...(newErrors.map(error =>
-        `In field "${fieldName}": ${error}`
-      )));
+      const newErrors = isValidJSValue(
+        (value: any)[fieldName],
+        fields[fieldName].type,
+      );
+      errors.push(
+        ...newErrors.map(error => `In field "${fieldName}": ${error}`),
+      );
     });
 
     return errors;
@@ -87,7 +91,7 @@ export function isValidJSValue(
 
   invariant(
     type instanceof GraphQLScalarType || type instanceof GraphQLEnumType,
-    'Must be input type'
+    'Must be input type',
   );
 
   // Scalar/Enum input checks to ensure the type can parse the value to
@@ -95,14 +99,12 @@ export function isValidJSValue(
   try {
     const parseResult = type.parseValue(value);
     if (isNullish(parseResult) && !type.isValidValue(value)) {
-      return [
-        `Expected type "${type.name}", found ${JSON.stringify(value)}.`
-      ];
+      return [`Expected type "${type.name}", found ${JSON.stringify(value)}.`];
     }
   } catch (error) {
     return [
       `Expected type "${type.name}", found ${JSON.stringify(value)}: ` +
-      error.message
+        error.message,
     ];
   }
 

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -11,7 +11,7 @@ import { print } from '../language/printer';
 import type {
   ValueNode,
   ListValueNode,
-  ObjectValueNode
+  ObjectValueNode,
 } from '../language/ast';
 import * as Kind from '../language/kinds';
 import {
@@ -19,12 +19,11 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLList,
-  GraphQLNonNull
+  GraphQLNonNull,
 } from '../type/definition';
 import type { GraphQLInputType } from '../type/definition';
 import invariant from '../jsutils/invariant';
 import keyMap from '../jsutils/keyMap';
-
 
 /**
  * Utility for validators which determines if a value literal node is valid
@@ -35,17 +34,17 @@ import keyMap from '../jsutils/keyMap';
  */
 export function isValidLiteralValue(
   type: GraphQLInputType,
-  valueNode: ValueNode
+  valueNode: ValueNode,
 ): Array<string> {
   // A value must be provided if the type is non-null.
   if (type instanceof GraphQLNonNull) {
-    if (!valueNode || (valueNode.kind === Kind.NULL)) {
-      return [ `Expected "${String(type)}", found null.` ];
+    if (!valueNode || valueNode.kind === Kind.NULL) {
+      return [`Expected "${String(type)}", found null.`];
     }
     return isValidLiteralValue(type.ofType, valueNode);
   }
 
-  if (!valueNode || (valueNode.kind === Kind.NULL)) {
+  if (!valueNode || valueNode.kind === Kind.NULL) {
     return [];
   }
 
@@ -61,9 +60,9 @@ export function isValidLiteralValue(
     if (valueNode.kind === Kind.LIST) {
       return (valueNode: ListValueNode).values.reduce((acc, item, index) => {
         const errors = isValidLiteralValue(itemType, item);
-        return acc.concat(errors.map(error =>
-          `In element #${index}: ${error}`
-        ));
+        return acc.concat(
+          errors.map(error => `In element #${index}: ${error}`),
+        );
       }, []);
     }
     return isValidLiteralValue(itemType, valueNode);
@@ -72,7 +71,7 @@ export function isValidLiteralValue(
   // Input objects check each defined field and look for undefined fields.
   if (type instanceof GraphQLInputObjectType) {
     if (valueNode.kind !== Kind.OBJECT) {
-      return [ `Expected "${type.name}", found not an object.` ];
+      return [`Expected "${type.name}", found not an object.`];
     }
     const fields = type.getFields();
 
@@ -83,7 +82,7 @@ export function isValidLiteralValue(
     fieldNodes.forEach(providedFieldNode => {
       if (!fields[providedFieldNode.name.value]) {
         errors.push(
-          `In field "${providedFieldNode.name.value}": Unknown field.`
+          `In field "${providedFieldNode.name.value}": Unknown field.`,
         );
       }
     });
@@ -93,11 +92,9 @@ export function isValidLiteralValue(
     Object.keys(fields).forEach(fieldName => {
       const result = isValidLiteralValue(
         fields[fieldName].type,
-        fieldNodeMap[fieldName] && fieldNodeMap[fieldName].value
+        fieldNodeMap[fieldName] && fieldNodeMap[fieldName].value,
       );
-      errors.push(...(result.map(error =>
-        `In field "${fieldName}": ${error}`
-      )));
+      errors.push(...result.map(error => `In field "${fieldName}": ${error}`));
     });
 
     return errors;
@@ -105,12 +102,12 @@ export function isValidLiteralValue(
 
   invariant(
     type instanceof GraphQLScalarType || type instanceof GraphQLEnumType,
-    'Must be input type'
+    'Must be input type',
   );
 
   // Scalars determine if a literal values is valid.
   if (!type.isValidLiteral(valueNode)) {
-    return [ `Expected type "${type.name}", found ${print(valueNode)}.` ];
+    return [`Expected type "${type.name}", found ${print(valueNode)}.`];
   }
 
   return [];

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -25,7 +25,6 @@ import {
 import { GraphQLString } from '../type/scalars';
 import { DEFAULT_DEPRECATION_REASON } from '../type/directives';
 
-
 export function printSchema(schema: GraphQLSchema): string {
   return printFilteredSchema(schema, n => !isSpecDirective(n), isDefinedType);
 }
@@ -63,9 +62,10 @@ function isBuiltInScalar(typename: string): boolean {
 function printFilteredSchema(
   schema: GraphQLSchema,
   directiveFilter: (type: string) => boolean,
-  typeFilter: (type: string) => boolean
+  typeFilter: (type: string) => boolean,
 ): string {
-  const directives = schema.getDirectives()
+  const directives = schema
+    .getDirectives()
     .filter(directive => directiveFilter(directive.name));
   const typeMap = schema.getTypeMap();
   const types = Object.keys(typeMap)
@@ -73,10 +73,12 @@ function printFilteredSchema(
     .sort((name1, name2) => name1.localeCompare(name2))
     .map(typeName => typeMap[typeName]);
 
-  return [ printSchemaDefinition(schema) ].concat(
-    directives.map(printDirective),
-    types.map(printType)
-  ).filter(Boolean).join('\n\n') + '\n';
+  return (
+    [printSchemaDefinition(schema)]
+      .concat(directives.map(printDirective), types.map(printType))
+      .filter(Boolean)
+      .join('\n\n') + '\n'
+  );
 }
 
 function printSchemaDefinition(schema: GraphQLSchema): ?string {
@@ -152,65 +154,91 @@ export function printType(type: GraphQLType): string {
 }
 
 function printScalar(type: GraphQLScalarType): string {
-  return printDescription(type) +
-    `scalar ${type.name}`;
+  return printDescription(type) + `scalar ${type.name}`;
 }
 
 function printObject(type: GraphQLObjectType): string {
   const interfaces = type.getInterfaces();
-  const implementedInterfaces = interfaces.length ?
-    ' implements ' + interfaces.map(i => i.name).join(', ') : '';
-  return printDescription(type) +
+  const implementedInterfaces = interfaces.length
+    ? ' implements ' + interfaces.map(i => i.name).join(', ')
+    : '';
+  return (
+    printDescription(type) +
     `type ${type.name}${implementedInterfaces} {\n` +
-      printFields(type) + '\n' +
-    '}';
+    printFields(type) +
+    '\n' +
+    '}'
+  );
 }
 
 function printInterface(type: GraphQLInterfaceType): string {
-  return printDescription(type) +
+  return (
+    printDescription(type) +
     `interface ${type.name} {\n` +
-      printFields(type) + '\n' +
-    '}';
+    printFields(type) +
+    '\n' +
+    '}'
+  );
 }
 
 function printUnion(type: GraphQLUnionType): string {
-  return printDescription(type) +
-    `union ${type.name} = ${type.getTypes().join(' | ')}`;
+  return (
+    printDescription(type) +
+    `union ${type.name} = ${type.getTypes().join(' | ')}`
+  );
 }
 
 function printEnum(type: GraphQLEnumType): string {
-  return printDescription(type) +
+  return (
+    printDescription(type) +
     `enum ${type.name} {\n` +
-      printEnumValues(type.getValues()) + '\n' +
-    '}';
+    printEnumValues(type.getValues()) +
+    '\n' +
+    '}'
+  );
 }
 
 function printEnumValues(values): string {
-  return values.map((value, i) =>
-    printDescription(value, '  ', !i) + '  ' +
-    value.name + printDeprecated(value)
-  ).join('\n');
+  return values
+    .map(
+      (value, i) =>
+        printDescription(value, '  ', !i) +
+        '  ' +
+        value.name +
+        printDeprecated(value),
+    )
+    .join('\n');
 }
 
 function printInputObject(type: GraphQLInputObjectType): string {
   const fieldMap = type.getFields();
   const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
-  return printDescription(type) +
+  return (
+    printDescription(type) +
     `input ${type.name} {\n` +
-      fields.map((f, i) =>
-        printDescription(f, '  ', !i) + '  ' + printInputValue(f)
-      ).join('\n') + '\n' +
-    '}';
+    fields
+      .map((f, i) => printDescription(f, '  ', !i) + '  ' + printInputValue(f))
+      .join('\n') +
+    '\n' +
+    '}'
+  );
 }
 
 function printFields(type) {
   const fieldMap = type.getFields();
   const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
-  return fields.map((f, i) =>
-    printDescription(f, '  ', !i) + '  ' +
-    f.name + printArgs(f.args, '  ') + ': ' +
-    String(f.type) + printDeprecated(f)
-  ).join('\n');
+  return fields
+    .map(
+      (f, i) =>
+        printDescription(f, '  ', !i) +
+        '  ' +
+        f.name +
+        printArgs(f.args, '  ') +
+        ': ' +
+        String(f.type) +
+        printDeprecated(f),
+    )
+    .join('\n');
 }
 
 function printArgs(args, indentation = '') {
@@ -223,10 +251,21 @@ function printArgs(args, indentation = '') {
     return '(' + args.map(printInputValue).join(', ') + ')';
   }
 
-  return '(\n' + args.map((arg, i) =>
-    printDescription(arg, '  ' + indentation, !i) + '  ' + indentation +
-    printInputValue(arg)
-  ).join('\n') + '\n' + indentation + ')';
+  return (
+    '(\n' +
+    args
+      .map(
+        (arg, i) =>
+          printDescription(arg, '  ' + indentation, !i) +
+          '  ' +
+          indentation +
+          printInputValue(arg),
+      )
+      .join('\n') +
+    '\n' +
+    indentation +
+    ')'
+  );
 }
 
 function printInputValue(arg) {
@@ -238,9 +277,14 @@ function printInputValue(arg) {
 }
 
 function printDirective(directive) {
-  return printDescription(directive) +
-    'directive @' + directive.name + printArgs(directive.args) +
-    ' on ' + directive.locations.join(' | ');
+  return (
+    printDescription(directive) +
+    'directive @' +
+    directive.name +
+    printArgs(directive.args) +
+    ' on ' +
+    directive.locations.join(' | ')
+  );
 }
 
 function printDeprecated(fieldOrEnumVal) {
@@ -248,14 +292,12 @@ function printDeprecated(fieldOrEnumVal) {
   if (isNullish(reason)) {
     return '';
   }
-  if (
-    reason === '' ||
-    reason === DEFAULT_DEPRECATION_REASON
-  ) {
+  if (reason === '' || reason === DEFAULT_DEPRECATION_REASON) {
     return ' @deprecated';
   }
-  return ' @deprecated(reason: ' +
-    print(astFromValue(reason, GraphQLString)) + ')';
+  return (
+    ' @deprecated(reason: ' + print(astFromValue(reason, GraphQLString)) + ')'
+  );
 }
 
 function printDescription(def, indentation = '', firstInBlock = true): string {
@@ -281,13 +323,13 @@ function printDescription(def, indentation = '', firstInBlock = true): string {
 
 function breakLine(line: string, len: number): Array<string> {
   if (line.length < len + 5) {
-    return [ line ];
+    return [line];
   }
   const parts = line.split(new RegExp(`((?: |^).{15,${len - 40}}(?= |$))`));
   if (parts.length < 4) {
-    return [ line ];
+    return [line];
   }
-  const sublines = [ parts[0] + parts[1] + parts[2] ];
+  const sublines = [parts[0] + parts[1] + parts[2]];
   for (let i = 3; i < parts.length; i += 2) {
     sublines.push(parts[i].slice(1) + parts[i + 1]);
   }

--- a/src/utilities/separateOperations.js
+++ b/src/utilities/separateOperations.js
@@ -8,11 +8,8 @@
  */
 
 import { visit } from '../language/visitor';
-import type {ObjMap} from '../jsutils/ObjMap';
-import type {
-  DocumentNode,
-  OperationDefinitionNode,
-} from '../language/ast';
+import type { ObjMap } from '../jsutils/ObjMap';
+import type { DocumentNode, OperationDefinitionNode } from '../language/ast';
 
 /**
  * separateOperations accepts a single AST document which may contain many
@@ -21,7 +18,7 @@ import type {
  * refers to.
  */
 export function separateOperations(
-  documentAST: DocumentNode
+  documentAST: DocumentNode,
 ): ObjMap<DocumentNode> {
   const operations = [];
   const fragments = Object.create(null);
@@ -44,9 +41,10 @@ export function separateOperations(
     },
     FragmentSpread(node) {
       const toName = node.name.value;
-      (depGraph[fromName] ||
-        (depGraph[fromName] = Object.create(null)))[toName] = true;
-    }
+      (depGraph[fromName] || (depGraph[fromName] = Object.create(null)))[
+        toName
+      ] = true;
+    },
   });
 
   // For each operation, produce a new synthesized AST which includes only what
@@ -59,17 +57,17 @@ export function separateOperations(
 
     // The list of definition nodes to be included for this operation, sorted
     // to retain the same order as the original document.
-    const definitions = [ operation ];
+    const definitions = [operation];
     Object.keys(dependencies).forEach(name => {
       definitions.push(fragments[name]);
     });
     definitions.sort(
-      (n1, n2) => (positions.get(n1) || 0) - (positions.get(n2) || 0)
+      (n1, n2) => (positions.get(n1) || 0) - (positions.get(n2) || 0),
     );
 
     separatedDocumentASTs[operationName] = {
       kind: 'Document',
-      definitions
+      definitions,
     };
   });
 
@@ -88,7 +86,7 @@ function opName(operation: OperationDefinitionNode): string {
 function collectTransitiveDependencies(
   collected: ObjMap<boolean>,
   depGraph: DepGraph,
-  fromName: string
+  fromName: string,
 ): void {
   const immediateDeps = depGraph[fromName];
   if (immediateDeps) {

--- a/src/utilities/typeComparators.js
+++ b/src/utilities/typeComparators.js
@@ -13,14 +13,8 @@ import {
   GraphQLList,
   GraphQLNonNull,
 } from '../type/definition';
-import type {
-  GraphQLType,
-  GraphQLCompositeType
-} from '../type/definition';
-import type {
-  GraphQLSchema
-} from '../type/schema';
-
+import type { GraphQLType, GraphQLCompositeType } from '../type/definition';
+import type { GraphQLSchema } from '../type/schema';
 
 /**
  * Provided two types, return true if the types are equal (invariant).
@@ -52,7 +46,7 @@ export function isEqualType(typeA: GraphQLType, typeB: GraphQLType): boolean {
 export function isTypeSubTypeOf(
   schema: GraphQLSchema,
   maybeSubType: GraphQLType,
-  superType: GraphQLType
+  superType: GraphQLType,
 ): boolean {
   // Equivalent type is a valid subtype
   if (maybeSubType === superType) {
@@ -83,9 +77,11 @@ export function isTypeSubTypeOf(
 
   // If superType type is an abstract type, maybeSubType type may be a currently
   // possible object type.
-  if (isAbstractType(superType) &&
-      maybeSubType instanceof GraphQLObjectType &&
-      schema.isPossibleType(superType, maybeSubType)) {
+  if (
+    isAbstractType(superType) &&
+    maybeSubType instanceof GraphQLObjectType &&
+    schema.isPossibleType(superType, maybeSubType)
+  ) {
     return true;
   }
 
@@ -105,7 +101,7 @@ export function isTypeSubTypeOf(
 export function doTypesOverlap(
   schema: GraphQLSchema,
   typeA: GraphQLCompositeType,
-  typeB: GraphQLCompositeType
+  typeB: GraphQLCompositeType,
 ): boolean {
   // So flow is aware this is constant
   const _typeB = typeB;
@@ -119,9 +115,9 @@ export function doTypesOverlap(
     if (isAbstractType(_typeB)) {
       // If both types are abstract, then determine if there is any intersection
       // between possible concrete types of each.
-      return schema.getPossibleTypes(typeA).some(
-        type => schema.isPossibleType(_typeB, type)
-      );
+      return schema
+        .getPossibleTypes(typeA)
+        .some(type => schema.isPossibleType(_typeB, type));
     }
     // Determine if the latter type is a possible concrete type of the former.
     return schema.isPossibleType(typeA, _typeB);

--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -12,12 +12,10 @@ import * as Kind from '../language/kinds';
 import type {
   NamedTypeNode,
   ListTypeNode,
-  NonNullTypeNode
+  NonNullTypeNode,
 } from '../language/ast';
 import { GraphQLList, GraphQLNonNull } from '../type/definition';
-import type {
-  GraphQLNamedType,
-} from '../type/definition';
+import type { GraphQLNamedType } from '../type/definition';
 import type { GraphQLSchema } from '../type/schema';
 
 /**
@@ -30,18 +28,18 @@ import type { GraphQLSchema } from '../type/schema';
 /* eslint-disable no-redeclare */
 declare function typeFromASTType(
   schema: GraphQLSchema,
-  typeNode: NamedTypeNode
+  typeNode: NamedTypeNode,
 ): void | GraphQLNamedType;
 declare function typeFromASTType(
   schema: GraphQLSchema,
-  typeNode: ListTypeNode
+  typeNode: ListTypeNode,
 ): void | GraphQLList<*>;
 declare function typeFromASTType(
   schema: GraphQLSchema,
-  typeNode: NonNullTypeNode
+  typeNode: NonNullTypeNode,
 ): void | GraphQLNonNull<*>;
 function typeFromASTImpl(schema, typeNode) {
-/* eslint-enable no-redeclare */
+  /* eslint-enable no-redeclare */
   let innerType;
   if (typeNode.kind === Kind.LIST_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -11,7 +11,7 @@ import keyMap from '../jsutils/keyMap';
 import invariant from '../jsutils/invariant';
 import isNullish from '../jsutils/isNullish';
 import isInvalid from '../jsutils/isInvalid';
-import type {ObjMap} from '../jsutils/ObjMap';
+import type { ObjMap } from '../jsutils/ObjMap';
 import * as Kind from '../language/kinds';
 import {
   GraphQLScalarType,
@@ -27,7 +27,6 @@ import type {
   ListValueNode,
   ObjectValueNode,
 } from '../language/ast';
-
 
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
@@ -52,7 +51,7 @@ import type {
 export function valueFromAST(
   valueNode: ?ValueNode,
   type: GraphQLInputType,
-  variables?: ?ObjMap<mixed>
+  variables?: ?ObjMap<mixed>,
 ): mixed | void {
   if (!valueNode) {
     // When there is no node, then there is also no value.
@@ -111,7 +110,7 @@ export function valueFromAST(
     if (isInvalid(coercedValue)) {
       return; // Invalid: intentionally return no value.
     }
-    return [ coercedValue ];
+    return [coercedValue];
   }
 
   if (type instanceof GraphQLInputObjectType) {
@@ -122,7 +121,7 @@ export function valueFromAST(
     const fields = type.getFields();
     const fieldNodes = keyMap(
       (valueNode: ObjectValueNode).fields,
-      field => field.name.value
+      field => field.name.value,
     );
     const fieldNames = Object.keys(fields);
     for (let i = 0; i < fieldNames.length; i++) {
@@ -148,7 +147,7 @@ export function valueFromAST(
 
   invariant(
     type instanceof GraphQLScalarType || type instanceof GraphQLEnumType,
-    'Must be input type'
+    'Must be input type',
   );
 
   const parsed = type.parseLiteral(valueNode);
@@ -164,6 +163,8 @@ export function valueFromAST(
 // Returns true if the provided valueNode is a variable which is not defined
 // in the set of variables.
 function isMissingVariable(valueNode, variables) {
-  return valueNode.kind === Kind.VARIABLE &&
-    (!variables || isInvalid(variables[(valueNode: VariableNode).name.value]));
+  return (
+    valueNode.kind === Kind.VARIABLE &&
+    (!variables || isInvalid(variables[(valueNode: VariableNode).name.value]))
+  );
 }

--- a/src/validation/__tests__/ArgumentsOfCorrectType-test.js
+++ b/src/validation/__tests__/ArgumentsOfCorrectType-test.js
@@ -9,771 +9,896 @@ import { describe, it } from 'mocha';
 import { expectPassesRule, expectFailsRule } from './harness';
 import {
   ArgumentsOfCorrectType,
-  badValueMessage
+  badValueMessage,
 } from '../rules/ArgumentsOfCorrectType';
-
 
 function badValue(argName, typeName, value, line, column, errors) {
   let realErrors;
   if (!errors) {
-    realErrors = [
-      `Expected type "${typeName}", found ${value}.`
-    ];
+    realErrors = [`Expected type "${typeName}", found ${value}.`];
   } else {
     realErrors = errors;
   }
   return {
     message: badValueMessage(argName, typeName, value, realErrors),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
-
 describe('Validate: Argument values of correct type', () => {
-
   describe('Valid values', () => {
-
     it('Good int value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: 2)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Good negative int value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: -2)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Good boolean value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             booleanArgField(booleanArg: true)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Good string value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringArgField(stringArg: "foo")
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Good float value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             floatArgField(floatArg: 1.1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Good negative float value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             floatArgField(floatArg: -1.1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Int into Float', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             floatArgField(floatArg: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Int into ID', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             idArgField(idArg: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('String into ID', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             idArgField(idArg: "someIdString")
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Good enum value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: SIT)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Enum with undefined value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             enumArgField(enumArg: UNKNOWN)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Enum with null value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             enumArgField(enumArg: NO_FUR)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('null into nullable type', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: null)
           }
         }
-      `);
+      `,
+      );
 
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog(a: null, b: null, c:{ requiredField: true, intField: null }) {
             name
           }
         }
-      `);
+      `,
+      );
     });
-
   });
 
-
   describe('Invalid String values', () => {
-
     it('Int into String', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringArgField(stringArg: 1)
           }
         }
-      `, [
-        badValue('stringArg', 'String', '1', 4, 39)
-      ]);
+      `,
+        [badValue('stringArg', 'String', '1', 4, 39)],
+      );
     });
 
     it('Float into String', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringArgField(stringArg: 1.0)
           }
         }
-      `, [
-        badValue('stringArg', 'String', '1.0', 4, 39)
-      ]);
+      `,
+        [badValue('stringArg', 'String', '1.0', 4, 39)],
+      );
     });
 
     it('Boolean into String', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringArgField(stringArg: true)
           }
         }
-      `, [
-        badValue('stringArg', 'String', 'true', 4, 39)
-      ]);
+      `,
+        [badValue('stringArg', 'String', 'true', 4, 39)],
+      );
     });
 
     it('Unquoted String into String', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringArgField(stringArg: BAR)
           }
         }
-      `, [
-        badValue('stringArg', 'String', 'BAR', 4, 39)
-      ]);
+      `,
+        [badValue('stringArg', 'String', 'BAR', 4, 39)],
+      );
     });
-
   });
 
-
   describe('Invalid Int values', () => {
-
     it('String into Int', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: "3")
           }
         }
-      `, [
-        badValue('intArg', 'Int', '"3"', 4, 33)
-      ]);
+      `,
+        [badValue('intArg', 'Int', '"3"', 4, 33)],
+      );
     });
 
     it('Big Int into Int', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: 829384293849283498239482938)
           }
         }
-      `, [
-        badValue('intArg', 'Int', '829384293849283498239482938', 4, 33)
-      ]);
+      `,
+        [badValue('intArg', 'Int', '829384293849283498239482938', 4, 33)],
+      );
     });
 
     it('Unquoted String into Int', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: FOO)
           }
         }
-      `, [
-        badValue('intArg', 'Int', 'FOO', 4, 33)
-      ]);
+      `,
+        [badValue('intArg', 'Int', 'FOO', 4, 33)],
+      );
     });
 
     it('Simple Float into Int', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: 3.0)
           }
         }
-      `, [
-        badValue('intArg', 'Int', '3.0', 4, 33)
-      ]);
+      `,
+        [badValue('intArg', 'Int', '3.0', 4, 33)],
+      );
     });
 
     it('Float into Int', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             intArgField(intArg: 3.333)
           }
         }
-      `, [
-        badValue('intArg', 'Int', '3.333', 4, 33)
-      ]);
+      `,
+        [badValue('intArg', 'Int', '3.333', 4, 33)],
+      );
     });
-
   });
 
-
   describe('Invalid Float values', () => {
-
     it('String into Float', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             floatArgField(floatArg: "3.333")
           }
         }
-      `, [
-        badValue('floatArg', 'Float', '"3.333"', 4, 37)
-      ]);
+      `,
+        [badValue('floatArg', 'Float', '"3.333"', 4, 37)],
+      );
     });
 
     it('Boolean into Float', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             floatArgField(floatArg: true)
           }
         }
-      `, [
-        badValue('floatArg', 'Float', 'true', 4, 37)
-      ]);
+      `,
+        [badValue('floatArg', 'Float', 'true', 4, 37)],
+      );
     });
 
     it('Unquoted into Float', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             floatArgField(floatArg: FOO)
           }
         }
-      `, [
-        badValue('floatArg', 'Float', 'FOO', 4, 37)
-      ]);
+      `,
+        [badValue('floatArg', 'Float', 'FOO', 4, 37)],
+      );
     });
-
   });
 
-
   describe('Invalid Boolean value', () => {
-
     it('Int into Boolean', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             booleanArgField(booleanArg: 2)
           }
         }
-      `, [
-        badValue('booleanArg', 'Boolean', '2', 4, 41)
-      ]);
+      `,
+        [badValue('booleanArg', 'Boolean', '2', 4, 41)],
+      );
     });
 
     it('Float into Boolean', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             booleanArgField(booleanArg: 1.0)
           }
         }
-      `, [
-        badValue('booleanArg', 'Boolean', '1.0', 4, 41)
-      ]);
+      `,
+        [badValue('booleanArg', 'Boolean', '1.0', 4, 41)],
+      );
     });
 
     it('String into Boolean', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             booleanArgField(booleanArg: "true")
           }
         }
-      `, [
-        badValue('booleanArg', 'Boolean', '"true"', 4, 41)
-      ]);
+      `,
+        [badValue('booleanArg', 'Boolean', '"true"', 4, 41)],
+      );
     });
 
     it('Unquoted into Boolean', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             booleanArgField(booleanArg: TRUE)
           }
         }
-      `, [
-        badValue('booleanArg', 'Boolean', 'TRUE', 4, 41)
-      ]);
+      `,
+        [badValue('booleanArg', 'Boolean', 'TRUE', 4, 41)],
+      );
     });
-
   });
 
-
   describe('Invalid ID value', () => {
-
     it('Float into ID', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             idArgField(idArg: 1.0)
           }
         }
-      `, [
-        badValue('idArg', 'ID', '1.0', 4, 31)
-      ]);
+      `,
+        [badValue('idArg', 'ID', '1.0', 4, 31)],
+      );
     });
 
     it('Boolean into ID', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             idArgField(idArg: true)
           }
         }
-      `, [
-        badValue('idArg', 'ID', 'true', 4, 31)
-      ]);
+      `,
+        [badValue('idArg', 'ID', 'true', 4, 31)],
+      );
     });
 
     it('Unquoted into ID', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             idArgField(idArg: SOMETHING)
           }
         }
-      `, [
-        badValue('idArg', 'ID', 'SOMETHING', 4, 31)
-      ]);
+      `,
+        [badValue('idArg', 'ID', 'SOMETHING', 4, 31)],
+      );
     });
-
   });
 
-
   describe('Invalid Enum value', () => {
-
     it('Int into Enum', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: 2)
           }
         }
-      `, [
-        badValue('dogCommand', 'DogCommand', '2', 4, 41)
-      ]);
+      `,
+        [badValue('dogCommand', 'DogCommand', '2', 4, 41)],
+      );
     });
 
     it('Float into Enum', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: 1.0)
           }
         }
-      `, [
-        badValue('dogCommand', 'DogCommand', '1.0', 4, 41)
-      ]);
+      `,
+        [badValue('dogCommand', 'DogCommand', '1.0', 4, 41)],
+      );
     });
 
     it('String into Enum', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: "SIT")
           }
         }
-      `, [
-        badValue('dogCommand', 'DogCommand', '"SIT"', 4, 41)
-      ]);
+      `,
+        [badValue('dogCommand', 'DogCommand', '"SIT"', 4, 41)],
+      );
     });
 
     it('Boolean into Enum', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: true)
           }
         }
-      `, [
-        badValue('dogCommand', 'DogCommand', 'true', 4, 41)
-      ]);
+      `,
+        [badValue('dogCommand', 'DogCommand', 'true', 4, 41)],
+      );
     });
 
     it('Unknown Enum Value into Enum', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: JUGGLE)
           }
         }
-      `, [
-        badValue('dogCommand', 'DogCommand', 'JUGGLE', 4, 41)
-      ]);
+      `,
+        [badValue('dogCommand', 'DogCommand', 'JUGGLE', 4, 41)],
+      );
     });
 
     it('Different case Enum Value into Enum', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             doesKnowCommand(dogCommand: sit)
           }
         }
-      `, [
-        badValue('dogCommand', 'DogCommand', 'sit', 4, 41)
-      ]);
+      `,
+        [badValue('dogCommand', 'DogCommand', 'sit', 4, 41)],
+      );
     });
-
   });
 
-
   describe('Valid List value', () => {
-
     it('Good list value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringListArgField(stringListArg: ["one", null, "two"])
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Empty list value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringListArgField(stringListArg: [])
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Null value', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringListArgField(stringListArg: null)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Single value into List', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringListArgField(stringListArg: "one")
           }
         }
-      `);
+      `,
+      );
     });
-
   });
 
-
   describe('Invalid List value', () => {
-
     it('Incorrect item type', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringListArgField(stringListArg: ["one", 2])
           }
         }
-      `, [
-        badValue('stringListArg', '[String]', '["one", 2]', 4, 47, [
-          'In element #1: Expected type "String", found 2.'
-        ]),
-      ]);
+      `,
+        [
+          badValue('stringListArg', '[String]', '["one", 2]', 4, 47, [
+            'In element #1: Expected type "String", found 2.',
+          ]),
+        ],
+      );
     });
 
     it('Single value of incorrect type', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             stringListArgField(stringListArg: 1)
           }
         }
-      `, [
-        badValue('stringListArg', 'String', '1', 4, 47),
-      ]);
+      `,
+        [badValue('stringListArg', 'String', '1', 4, 47)],
+      );
     });
-
   });
 
-
   describe('Valid non-nullable value', () => {
-
     it('Arg on optional arg', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             isHousetrained(atOtherHomes: true)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('No Arg on optional arg', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog {
             isHousetrained
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple args', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleReqs(req1: 1, req2: 2)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple args reverse order', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleReqs(req2: 2, req1: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('No args on multiple optional', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleOpts
           }
         }
-      `);
+      `,
+      );
     });
 
     it('One arg on multiple optional', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleOpts(opt1: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Second arg on multiple optional', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleOpts(opt2: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple reqs on mixedList', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleOptAndReq(req1: 3, req2: 4)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple reqs and one opt on mixedList', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('All reqs and opts on mixedList', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
           }
         }
-      `);
+      `,
+      );
     });
-
   });
 
-
   describe('Invalid non-nullable value', () => {
-
     it('Incorrect value type', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleReqs(req2: "two", req1: "one")
           }
         }
-      `, [
-        badValue('req2', 'Int', '"two"', 4, 32),
-        badValue('req1', 'Int', '"one"', 4, 45),
-      ]);
+      `,
+        [
+          badValue('req2', 'Int', '"two"', 4, 32),
+          badValue('req1', 'Int', '"one"', 4, 45),
+        ],
+      );
     });
 
     it('Incorrect value and missing argument', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleReqs(req1: "one")
           }
         }
-      `, [
-        badValue('req1', 'Int', '"one"', 4, 32),
-      ]);
+      `,
+        [badValue('req1', 'Int', '"one"', 4, 32)],
+      );
     });
 
     it('Null value', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             multipleReqs(req1: null)
           }
         }
-      `, [
-        badValue('req1', 'Int!', 'null', 4, 32, [
-          'Expected "Int!", found null.'
-        ]),
-      ]);
+      `,
+        [
+          badValue('req1', 'Int!', 'null', 4, 32, [
+            'Expected "Int!", found null.',
+          ]),
+        ],
+      );
     });
-
   });
 
-
   describe('Valid input object value', () => {
-
     it('Optional arg, despite required field in type', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Partial object, only required', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: { requiredField: true })
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Partial object, required field can be falsey', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: { requiredField: false })
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Partial object, including required', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: { requiredField: true, intField: 4 })
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Full object', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: {
@@ -785,11 +910,14 @@ describe('Validate: Argument values of correct type', () => {
             })
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Full object with fields in different order', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: {
@@ -801,30 +929,34 @@ describe('Validate: Argument values of correct type', () => {
             })
           }
         }
-      `);
+      `,
+      );
     });
-
   });
 
-
   describe('Invalid input object value', () => {
-
     it('Partial object, missing required', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: { intField: 4 })
           }
         }
-      `, [
-        badValue('complexArg', 'ComplexInput', '{intField: 4}', 4, 41, [
-          'In field "requiredField": Expected "Boolean!", found null.'
-        ]),
-      ]);
+      `,
+        [
+          badValue('complexArg', 'ComplexInput', '{intField: 4}', 4, 41, [
+            'In field "requiredField": Expected "Boolean!", found null.',
+          ]),
+        ],
+      );
     });
 
     it('Partial object, invalid field type', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: {
@@ -833,21 +965,27 @@ describe('Validate: Argument values of correct type', () => {
             })
           }
         }
-      `, [
-        badValue(
-          'complexArg',
-          'ComplexInput',
-          '{stringListField: ["one", 2], requiredField: true}',
-          4,
-          41,
-          [ 'In field "stringListField": In element #1: ' +
-            'Expected type "String", found 2.' ]
-        ),
-      ]);
+      `,
+        [
+          badValue(
+            'complexArg',
+            'ComplexInput',
+            '{stringListField: ["one", 2], requiredField: true}',
+            4,
+            41,
+            [
+              'In field "stringListField": In element #1: ' +
+                'Expected type "String", found 2.',
+            ],
+          ),
+        ],
+      );
     });
 
     it('Partial object, unknown field arg', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           complicatedArgs {
             complexArgField(complexArg: {
@@ -856,24 +994,26 @@ describe('Validate: Argument values of correct type', () => {
             })
           }
         }
-      `, [
-        badValue(
-          'complexArg',
-          'ComplexInput',
-          '{requiredField: true, unknownField: "value"}',
-          4,
-          41,
-          [ 'In field "unknownField": Unknown field.' ]
-        ),
-      ]);
+      `,
+        [
+          badValue(
+            'complexArg',
+            'ComplexInput',
+            '{requiredField: true, unknownField: "value"}',
+            4,
+            41,
+            ['In field "unknownField": Unknown field.'],
+          ),
+        ],
+      );
     });
-
   });
 
   describe('Directive arguments', () => {
-
     it('with directives of valid types', () => {
-      expectPassesRule(ArgumentsOfCorrectType, `
+      expectPassesRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog @include(if: true) {
             name
@@ -882,22 +1022,25 @@ describe('Validate: Argument values of correct type', () => {
             name
           }
         }
-      `);
+      `,
+      );
     });
 
     it('with directive with incorrect types', () => {
-      expectFailsRule(ArgumentsOfCorrectType, `
+      expectFailsRule(
+        ArgumentsOfCorrectType,
+        `
         {
           dog @include(if: "yes") {
             name @skip(if: ENUM)
           }
         }
-      `, [
-        badValue('if', 'Boolean', '"yes"', 3, 28),
-        badValue('if', 'Boolean', 'ENUM', 4, 28),
-      ]);
+      `,
+        [
+          badValue('if', 'Boolean', '"yes"', 3, 28),
+          badValue('if', 'Boolean', 'ENUM', 4, 28),
+        ],
+      );
     });
-
   });
-
 });

--- a/src/validation/__tests__/DefaultValuesOfCorrectType-test.js
+++ b/src/validation/__tests__/DefaultValuesOfCorrectType-test.js
@@ -13,11 +13,10 @@ import {
   badValueForDefaultArgMessage,
 } from '../rules/DefaultValuesOfCorrectType';
 
-
 function defaultForNonNullArg(varName, typeName, guessTypeName, line, column) {
   return {
     message: defaultForNonNullArgMessage(varName, typeName, guessTypeName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
@@ -25,39 +24,44 @@ function defaultForNonNullArg(varName, typeName, guessTypeName, line, column) {
 function badValue(varName, typeName, val, line, column, errors) {
   let realErrors;
   if (!errors) {
-    realErrors = [
-      `Expected type "${typeName}", found ${val}.`
-    ];
+    realErrors = [`Expected type "${typeName}", found ${val}.`];
   } else {
     realErrors = errors;
   }
   return {
     message: badValueForDefaultArgMessage(varName, typeName, val, realErrors),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Variable default values of correct type', () => {
-
   it('variables with no default values', () => {
-    expectPassesRule(DefaultValuesOfCorrectType, `
+    expectPassesRule(
+      DefaultValuesOfCorrectType,
+      `
       query NullableValues($a: Int, $b: String, $c: ComplexInput) {
         dog { name }
       }
-    `);
+    `,
+    );
   });
 
   it('required variables without default values', () => {
-    expectPassesRule(DefaultValuesOfCorrectType, `
+    expectPassesRule(
+      DefaultValuesOfCorrectType,
+      `
       query RequiredValues($a: Int!, $b: String!) {
         dog { name }
       }
-    `);
+    `,
+    );
   });
 
   it('variables with valid default values', () => {
-    expectPassesRule(DefaultValuesOfCorrectType, `
+    expectPassesRule(
+      DefaultValuesOfCorrectType,
+      `
       query WithDefaultValues(
         $a: Int = 1,
         $b: String = "ok",
@@ -65,11 +69,14 @@ describe('Validate: Variable default values of correct type', () => {
       ) {
         dog { name }
       }
-    `);
+    `,
+    );
   });
 
   it('variables with valid default null values', () => {
-    expectPassesRule(DefaultValuesOfCorrectType, `
+    expectPassesRule(
+      DefaultValuesOfCorrectType,
+      `
       query WithDefaultValues(
         $a: Int = null,
         $b: String = null,
@@ -77,11 +84,14 @@ describe('Validate: Variable default values of correct type', () => {
       ) {
         dog { name }
       }
-    `);
+    `,
+    );
   });
 
   it('variables with invalid default null values', () => {
-    expectFailsRule(DefaultValuesOfCorrectType, `
+    expectFailsRule(
+      DefaultValuesOfCorrectType,
+      `
       query WithDefaultValues(
         $a: Int! = null,
         $b: String! = null,
@@ -89,36 +99,45 @@ describe('Validate: Variable default values of correct type', () => {
       ) {
         dog { name }
       }
-    `, [
-      defaultForNonNullArg('a', 'Int!', 'Int', 3, 20),
-      badValue('a', 'Int!', 'null', 3, 20, [
-        'Expected "Int!", found null.'
-      ]),
-      defaultForNonNullArg('b', 'String!', 'String', 4, 23),
-      badValue('b', 'String!', 'null', 4, 23, [
-        'Expected "String!", found null.'
-      ]),
-      badValue('c', 'ComplexInput', '{requiredField: null, intField: null}',
-        5, 28, [
-          'In field "requiredField": Expected "Boolean!", found null.'
-        ]
-      ),
-    ]);
+    `,
+      [
+        defaultForNonNullArg('a', 'Int!', 'Int', 3, 20),
+        badValue('a', 'Int!', 'null', 3, 20, ['Expected "Int!", found null.']),
+        defaultForNonNullArg('b', 'String!', 'String', 4, 23),
+        badValue('b', 'String!', 'null', 4, 23, [
+          'Expected "String!", found null.',
+        ]),
+        badValue(
+          'c',
+          'ComplexInput',
+          '{requiredField: null, intField: null}',
+          5,
+          28,
+          ['In field "requiredField": Expected "Boolean!", found null.'],
+        ),
+      ],
+    );
   });
 
   it('no required variables with default values', () => {
-    expectFailsRule(DefaultValuesOfCorrectType, `
+    expectFailsRule(
+      DefaultValuesOfCorrectType,
+      `
       query UnreachableDefaultValues($a: Int! = 3, $b: String! = "default") {
         dog { name }
       }
-    `, [
-      defaultForNonNullArg('a', 'Int!', 'Int', 2, 49),
-      defaultForNonNullArg('b', 'String!', 'String', 2, 66)
-    ]);
+    `,
+      [
+        defaultForNonNullArg('a', 'Int!', 'Int', 2, 49),
+        defaultForNonNullArg('b', 'String!', 'String', 2, 66),
+      ],
+    );
   });
 
   it('variables with invalid default values', () => {
-    expectFailsRule(DefaultValuesOfCorrectType, `
+    expectFailsRule(
+      DefaultValuesOfCorrectType,
+      `
       query InvalidDefaultValues(
         $a: Int = "one",
         $b: String = 4,
@@ -126,41 +145,50 @@ describe('Validate: Variable default values of correct type', () => {
       ) {
         dog { name }
       }
-    `, [
-      badValue('a', 'Int', '"one"', 3, 19, [
-        'Expected type "Int", found "one".'
-      ]),
-      badValue('b', 'String', '4', 4, 22, [
-        'Expected type "String", found 4.'
-      ]),
-      badValue('c', 'ComplexInput', '"notverycomplex"', 5, 28, [
-        'Expected "ComplexInput", found not an object.'
-      ])
-    ]);
+    `,
+      [
+        badValue('a', 'Int', '"one"', 3, 19, [
+          'Expected type "Int", found "one".',
+        ]),
+        badValue('b', 'String', '4', 4, 22, [
+          'Expected type "String", found 4.',
+        ]),
+        badValue('c', 'ComplexInput', '"notverycomplex"', 5, 28, [
+          'Expected "ComplexInput", found not an object.',
+        ]),
+      ],
+    );
   });
 
   it('complex variables missing required field', () => {
-    expectFailsRule(DefaultValuesOfCorrectType, `
+    expectFailsRule(
+      DefaultValuesOfCorrectType,
+      `
       query MissingRequiredField($a: ComplexInput = {intField: 3}) {
         dog { name }
       }
-    `, [
-      badValue('a', 'ComplexInput', '{intField: 3}', 2, 53, [
-        'In field "requiredField": Expected "Boolean!", found null.'
-      ])
-    ]);
+    `,
+      [
+        badValue('a', 'ComplexInput', '{intField: 3}', 2, 53, [
+          'In field "requiredField": Expected "Boolean!", found null.',
+        ]),
+      ],
+    );
   });
 
   it('list variables with invalid item', () => {
-    expectFailsRule(DefaultValuesOfCorrectType, `
+    expectFailsRule(
+      DefaultValuesOfCorrectType,
+      `
       query InvalidItem($a: [String] = ["one", 2]) {
         dog { name }
       }
-    `, [
-      badValue('a', '[String]', '["one", 2]', 2, 40, [
-        'In element #1: Expected type "String", found 2.'
-      ])
-    ]);
+    `,
+      [
+        badValue('a', '[String]', '["one", 2]', 2, 40, [
+          'In element #1: Expected type "String", found 2.',
+        ]),
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/FieldsOnCorrectType-test.js
+++ b/src/validation/__tests__/FieldsOnCorrectType-test.js
@@ -13,82 +13,100 @@ import {
   undefinedFieldMessage,
 } from '../rules/FieldsOnCorrectType';
 
-
 function undefinedField(
   field,
   type,
   suggestedTypes,
   suggestedFields,
   line,
-  column
+  column,
 ) {
   return {
     message: undefinedFieldMessage(
       field,
       type,
       suggestedTypes,
-      suggestedFields
+      suggestedFields,
     ),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Fields on correct type', () => {
-
   it('Object field selection', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment objectFieldSelection on Dog {
         __typename
         name
       }
-    `);
+    `,
+    );
   });
 
   it('Aliased object field selection', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment aliasedObjectFieldSelection on Dog {
         tn : __typename
         otherName : name
       }
-    `);
+    `,
+    );
   });
 
   it('Interface field selection', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment interfaceFieldSelection on Pet {
         __typename
         name
       }
-    `);
+    `,
+    );
   });
 
   it('Aliased interface field selection', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment interfaceFieldSelection on Pet {
         otherName : name
       }
-    `);
+    `,
+    );
   });
 
   it('Lying alias selection', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment lyingAliasSelection on Dog {
         name : nickname
       }
-    `);
+    `,
+    );
   });
 
   it('Ignores fields on unknown type', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment unknownSelection on UnknownType {
         unknownField
       }
-    `);
+    `,
+    );
   });
 
   it('reports errors when type is known again', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment typeKnownAgain on Pet {
         unknown_pet_field {
           ... on Cat {
@@ -96,156 +114,132 @@ describe('Validate: Fields on correct type', () => {
           }
         }
       }`,
-      [ undefinedField('unknown_pet_field', 'Pet', [], [], 3, 9),
-        undefinedField(
-          'unknown_cat_field',
-          'Cat',
-          [],
-          [],
-          5,
-          13
-        )
-      ]
+      [
+        undefinedField('unknown_pet_field', 'Pet', [], [], 3, 9),
+        undefinedField('unknown_cat_field', 'Cat', [], [], 5, 13),
+      ],
     );
   });
 
   it('Field not defined on fragment', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment fieldNotDefined on Dog {
         meowVolume
       }`,
-      [ undefinedField(
-          'meowVolume',
-          'Dog',
-          [],
-          [ 'barkVolume' ],
-          3,
-          9
-        )
-      ]
+      [undefinedField('meowVolume', 'Dog', [], ['barkVolume'], 3, 9)],
     );
   });
 
   it('Ignores deeply unknown field', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment deepFieldNotDefined on Dog {
         unknown_field {
           deeper_unknown_field
         }
       }`,
-      [ undefinedField(
-          'unknown_field',
-          'Dog',
-          [],
-          [],
-          3,
-          9
-        )
-      ]
+      [undefinedField('unknown_field', 'Dog', [], [], 3, 9)],
     );
   });
 
   it('Sub-field not defined', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment subFieldNotDefined on Human {
         pets {
           unknown_field
         }
       }`,
-      [ undefinedField('unknown_field', 'Pet', [], [], 4, 11) ]
+      [undefinedField('unknown_field', 'Pet', [], [], 4, 11)],
     );
   });
 
   it('Field not defined on inline fragment', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment fieldNotDefined on Pet {
         ... on Dog {
           meowVolume
         }
       }`,
-      [ undefinedField(
-          'meowVolume',
-          'Dog',
-          [],
-          [ 'barkVolume' ],
-          4,
-          11
-        )
-      ]
+      [undefinedField('meowVolume', 'Dog', [], ['barkVolume'], 4, 11)],
     );
   });
 
   it('Aliased field target not defined', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment aliasedFieldTargetNotDefined on Dog {
         volume : mooVolume
       }`,
-      [ undefinedField(
-          'mooVolume',
-          'Dog',
-          [],
-          [ 'barkVolume' ],
-          3,
-          9
-        )
-      ]
+      [undefinedField('mooVolume', 'Dog', [], ['barkVolume'], 3, 9)],
     );
   });
 
   it('Aliased lying field target not defined', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment aliasedLyingFieldTargetNotDefined on Dog {
         barkVolume : kawVolume
       }`,
-      [ undefinedField(
-          'kawVolume',
-          'Dog',
-          [],
-          [ 'barkVolume' ],
-          3,
-          9
-        )
-      ]
+      [undefinedField('kawVolume', 'Dog', [], ['barkVolume'], 3, 9)],
     );
   });
 
   it('Not defined on interface', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment notDefinedOnInterface on Pet {
         tailLength
       }`,
-      [ undefinedField('tailLength', 'Pet', [], [], 3, 9) ]
+      [undefinedField('tailLength', 'Pet', [], [], 3, 9)],
     );
   });
 
   it('Defined on implementors but not on interface', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment definedOnImplementorsButNotInterface on Pet {
         nickname
       }`,
-      [ undefinedField('nickname', 'Pet', [ 'Dog', 'Cat' ], [ 'name' ], 3, 9) ]
+      [undefinedField('nickname', 'Pet', ['Dog', 'Cat'], ['name'], 3, 9)],
     );
   });
 
   it('Meta field selection on union', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment directFieldSelectionOnUnion on CatOrDog {
         __typename
-      }`
+      }`,
     );
   });
 
   it('Direct field selection on union', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment directFieldSelectionOnUnion on CatOrDog {
         directField
       }`,
-      [ undefinedField('directField', 'CatOrDog', [], [], 3, 9) ]
+      [undefinedField('directField', 'CatOrDog', [], [], 3, 9)],
     );
   });
 
   it('Defined on implementors queried on union', () => {
-    expectFailsRule(FieldsOnCorrectType, `
+    expectFailsRule(
+      FieldsOnCorrectType,
+      `
       fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
         name
       }`,
@@ -253,17 +247,19 @@ describe('Validate: Fields on correct type', () => {
         undefinedField(
           'name',
           'CatOrDog',
-          [ 'Being', 'Pet', 'Canine', 'Dog', 'Cat' ],
+          ['Being', 'Pet', 'Canine', 'Dog', 'Cat'],
           [],
           3,
-          9
-        )
-      ]
+          9,
+        ),
+      ],
     );
   });
 
   it('valid field in inline fragment', () => {
-    expectPassesRule(FieldsOnCorrectType, `
+    expectPassesRule(
+      FieldsOnCorrectType,
+      `
       fragment objectFieldSelection on Pet {
         ... on Dog {
           name
@@ -272,64 +268,53 @@ describe('Validate: Fields on correct type', () => {
           name
         }
       }
-    `);
+    `,
+    );
   });
 
   describe('Fields on correct type error message', () => {
-
     it('Works with no suggestions', () => {
-      expect(
-        undefinedFieldMessage('f', 'T', [], [])
-      ).to.equal(
-        'Cannot query field "f" on type "T".'
+      expect(undefinedFieldMessage('f', 'T', [], [])).to.equal(
+        'Cannot query field "f" on type "T".',
       );
     });
 
     it('Works with no small numbers of type suggestions', () => {
-      expect(
-        undefinedFieldMessage('f', 'T', [ 'A', 'B' ], [])
-      ).to.equal(
+      expect(undefinedFieldMessage('f', 'T', ['A', 'B'], [])).to.equal(
         'Cannot query field "f" on type "T". ' +
-        'Did you mean to use an inline fragment on "A" or "B"?'
+          'Did you mean to use an inline fragment on "A" or "B"?',
       );
     });
 
     it('Works with no small numbers of field suggestions', () => {
-      expect(
-        undefinedFieldMessage('f', 'T', [], [ 'z', 'y' ])
-      ).to.equal(
-        'Cannot query field "f" on type "T". ' +
-        'Did you mean "z" or "y"?'
+      expect(undefinedFieldMessage('f', 'T', [], ['z', 'y'])).to.equal(
+        'Cannot query field "f" on type "T". ' + 'Did you mean "z" or "y"?',
       );
     });
 
     it('Only shows one set of suggestions at a time, preferring types', () => {
-      expect(
-        undefinedFieldMessage('f', 'T', [ 'A', 'B' ], [ 'z', 'y' ])
-      ).to.equal(
+      expect(undefinedFieldMessage('f', 'T', ['A', 'B'], ['z', 'y'])).to.equal(
         'Cannot query field "f" on type "T". ' +
-        'Did you mean to use an inline fragment on "A" or "B"?'
+          'Did you mean to use an inline fragment on "A" or "B"?',
       );
     });
 
     it('Limits lots of type suggestions', () => {
       expect(
-        undefinedFieldMessage('f', 'T', [ 'A', 'B', 'C', 'D', 'E', 'F' ], [])
+        undefinedFieldMessage('f', 'T', ['A', 'B', 'C', 'D', 'E', 'F'], []),
       ).to.equal(
         'Cannot query field "f" on type "T". ' +
-        'Did you mean to use an inline fragment on "A", "B", "C", "D", or "E"?'
+          'Did you mean to use an inline fragment on "A", "B", "C", "D", or "E"?',
       );
     });
 
     it('Limits lots of field suggestions', () => {
       expect(
-        undefinedFieldMessage('f', 'T', [], [ 'z', 'y', 'x', 'w', 'v', 'u' ])
+        undefinedFieldMessage('f', 'T', [], ['z', 'y', 'x', 'w', 'v', 'u']),
       ).to.equal(
         'Cannot query field "f" on type "T". ' +
-        'Did you mean "z", "y", "x", "w", or "v"?'
+          'Did you mean "z", "y", "x", "w", or "v"?',
       );
     });
-
   });
 });
-

--- a/src/validation/__tests__/FragmentsOnCompositeTypes-test.js
+++ b/src/validation/__tests__/FragmentsOnCompositeTypes-test.js
@@ -16,93 +16,124 @@ import {
 function error(fragName, typeName, line, column) {
   return {
     message: fragmentOnNonCompositeErrorMessage(fragName, typeName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Fragments on composite types', () => {
-
   it('object is valid fragment type', () => {
-    expectPassesRule(FragmentsOnCompositeTypes, `
+    expectPassesRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment validFragment on Dog {
         barks
       }
-    `);
+    `,
+    );
   });
 
   it('interface is valid fragment type', () => {
-    expectPassesRule(FragmentsOnCompositeTypes, `
+    expectPassesRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment validFragment on Pet {
         name
       }
-    `);
+    `,
+    );
   });
 
   it('object is valid inline fragment type', () => {
-    expectPassesRule(FragmentsOnCompositeTypes, `
+    expectPassesRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment validFragment on Pet {
         ... on Dog {
           barks
         }
       }
-    `);
+    `,
+    );
   });
 
   it('inline fragment without type is valid', () => {
-    expectPassesRule(FragmentsOnCompositeTypes, `
+    expectPassesRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment validFragment on Pet {
         ... {
           name
         }
       }
-    `);
+    `,
+    );
   });
 
   it('union is valid fragment type', () => {
-    expectPassesRule(FragmentsOnCompositeTypes, `
+    expectPassesRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment validFragment on CatOrDog {
         __typename
       }
-    `);
+    `,
+    );
   });
 
   it('scalar is invalid fragment type', () => {
-    expectFailsRule(FragmentsOnCompositeTypes, `
+    expectFailsRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment scalarFragment on Boolean {
         bad
       }
-    `, [ error('scalarFragment', 'Boolean', 2, 34) ]);
+    `,
+      [error('scalarFragment', 'Boolean', 2, 34)],
+    );
   });
 
   it('enum is invalid fragment type', () => {
-    expectFailsRule(FragmentsOnCompositeTypes, `
+    expectFailsRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment scalarFragment on FurColor {
         bad
       }
-    `, [ error('scalarFragment', 'FurColor', 2, 34) ]);
+    `,
+      [error('scalarFragment', 'FurColor', 2, 34)],
+    );
   });
 
   it('input object is invalid fragment type', () => {
-    expectFailsRule(FragmentsOnCompositeTypes, `
+    expectFailsRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment inputFragment on ComplexInput {
         stringField
       }
-    `, [ error('inputFragment', 'ComplexInput', 2, 33) ]);
+    `,
+      [error('inputFragment', 'ComplexInput', 2, 33)],
+    );
   });
 
   it('scalar is invalid inline fragment type', () => {
-    expectFailsRule(FragmentsOnCompositeTypes, `
+    expectFailsRule(
+      FragmentsOnCompositeTypes,
+      `
       fragment invalidFragment on Pet {
         ... on String {
           barks
         }
       }
-    `, [
-      { message: inlineFragmentOnNonCompositeErrorMessage('String'),
-        locations: [ { line: 3, column: 16 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: inlineFragmentOnNonCompositeErrorMessage('String'),
+          locations: [{ line: 3, column: 16 }],
+          path: undefined,
+        },
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/KnownArgumentNames-test.js
+++ b/src/validation/__tests__/KnownArgumentNames-test.js
@@ -13,11 +13,10 @@ import {
   unknownDirectiveArgMessage,
 } from '../rules/KnownArgumentNames';
 
-
 function unknownArg(argName, fieldName, typeName, suggestedArgs, line, column) {
   return {
     message: unknownArgMessage(argName, fieldName, typeName, suggestedArgs),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
@@ -27,59 +26,75 @@ function unknownDirectiveArg(
   directiveName,
   suggestedArgs,
   line,
-  column
+  column,
 ) {
   return {
     message: unknownDirectiveArgMessage(argName, directiveName, suggestedArgs),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Known argument names', () => {
-
   it('single arg is known', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       fragment argOnRequiredArg on Dog {
         doesKnowCommand(dogCommand: SIT)
       }
-    `);
+    `,
+    );
   });
 
   it('multiple args are known', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       fragment multipleArgs on ComplicatedArgs {
         multipleReqs(req1: 1, req2: 2)
       }
-    `);
+    `,
+    );
   });
 
   it('ignores args of unknown fields', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       fragment argOnUnknownField on Dog {
         unknownField(unknownArg: SIT)
       }
-    `);
+    `,
+    );
   });
 
   it('multiple args in reverse order are known', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       fragment multipleArgsReverseOrder on ComplicatedArgs {
         multipleReqs(req2: 2, req1: 1)
       }
-    `);
+    `,
+    );
   });
 
   it('no args on optional arg', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       fragment noArgOnOptionalArg on Dog {
         isHousetrained
       }
-    `);
+    `,
+    );
   });
 
   it('args are known deeply', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       {
         dog {
           doesKnowCommand(dogCommand: SIT)
@@ -92,50 +107,64 @@ describe('Validate: Known argument names', () => {
           }
         }
       }
-    `);
+    `,
+    );
   });
 
   it('directive args are known', () => {
-    expectPassesRule(KnownArgumentNames, `
+    expectPassesRule(
+      KnownArgumentNames,
+      `
       {
         dog @skip(if: true)
       }
-    `);
+    `,
+    );
   });
 
   it('undirective args are invalid', () => {
-    expectFailsRule(KnownArgumentNames, `
+    expectFailsRule(
+      KnownArgumentNames,
+      `
       {
         dog @skip(unless: true)
       }
-    `, [
-      unknownDirectiveArg('unless', 'skip', [], 3, 19),
-    ]);
+    `,
+      [unknownDirectiveArg('unless', 'skip', [], 3, 19)],
+    );
   });
 
   it('invalid arg name', () => {
-    expectFailsRule(KnownArgumentNames, `
+    expectFailsRule(
+      KnownArgumentNames,
+      `
       fragment invalidArgName on Dog {
         doesKnowCommand(unknown: true)
       }
-    `, [
-      unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 3, 25),
-    ]);
+    `,
+      [unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 3, 25)],
+    );
   });
 
   it('unknown args amongst known args', () => {
-    expectFailsRule(KnownArgumentNames, `
+    expectFailsRule(
+      KnownArgumentNames,
+      `
       fragment oneGoodArgOneInvalidArg on Dog {
         doesKnowCommand(whoknows: 1, dogCommand: SIT, unknown: true)
       }
-    `, [
-      unknownArg('whoknows', 'doesKnowCommand', 'Dog', [], 3, 25),
-      unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 3, 55),
-    ]);
+    `,
+      [
+        unknownArg('whoknows', 'doesKnowCommand', 'Dog', [], 3, 25),
+        unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 3, 55),
+      ],
+    );
   });
 
   it('unknown args deeply', () => {
-    expectFailsRule(KnownArgumentNames, `
+    expectFailsRule(
+      KnownArgumentNames,
+      `
       {
         dog {
           doesKnowCommand(unknown: true)
@@ -148,10 +177,11 @@ describe('Validate: Known argument names', () => {
           }
         }
       }
-    `, [
-      unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 4, 27),
-      unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 9, 31),
-    ]);
+    `,
+      [
+        unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 4, 27),
+        unknownArg('unknown', 'doesKnowCommand', 'Dog', [], 9, 31),
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/KnownDirectives-test.js
+++ b/src/validation/__tests__/KnownDirectives-test.js
@@ -16,11 +16,10 @@ import {
   misplacedDirectiveMessage,
 } from '../rules/KnownDirectives';
 
-
 function unknownDirective(directiveName, line, column) {
   return {
     message: unknownDirectiveMessage(directiveName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
@@ -28,15 +27,16 @@ function unknownDirective(directiveName, line, column) {
 function misplacedDirective(directiveName, placement, line, column) {
   return {
     message: misplacedDirectiveMessage(directiveName, placement),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Known directives', () => {
-
   it('with no directives', () => {
-    expectPassesRule(KnownDirectives, `
+    expectPassesRule(
+      KnownDirectives,
+      `
       query Foo {
         name
         ...Frag
@@ -45,11 +45,14 @@ describe('Validate: Known directives', () => {
       fragment Frag on Dog {
         name
       }
-    `);
+    `,
+    );
   });
 
   it('with known directives', () => {
-    expectPassesRule(KnownDirectives, `
+    expectPassesRule(
+      KnownDirectives,
+      `
       {
         dog @include(if: true) {
           name
@@ -58,23 +61,28 @@ describe('Validate: Known directives', () => {
           name
         }
       }
-    `);
+    `,
+    );
   });
 
   it('with unknown directive', () => {
-    expectFailsRule(KnownDirectives, `
+    expectFailsRule(
+      KnownDirectives,
+      `
       {
         dog @unknown(directive: "value") {
           name
         }
       }
-    `, [
-      unknownDirective('unknown', 3, 13)
-    ]);
+    `,
+      [unknownDirective('unknown', 3, 13)],
+    );
   });
 
   it('with many unknown directives', () => {
-    expectFailsRule(KnownDirectives, `
+    expectFailsRule(
+      KnownDirectives,
+      `
       {
         dog @unknown(directive: "value") {
           name
@@ -86,15 +94,19 @@ describe('Validate: Known directives', () => {
           }
         }
       }
-    `, [
-      unknownDirective('unknown', 3, 13),
-      unknownDirective('unknown', 6, 15),
-      unknownDirective('unknown', 8, 16)
-    ]);
+    `,
+      [
+        unknownDirective('unknown', 3, 13),
+        unknownDirective('unknown', 6, 15),
+        unknownDirective('unknown', 8, 16),
+      ],
+    );
   });
 
   it('with well placed directives', () => {
-    expectPassesRule(KnownDirectives, `
+    expectPassesRule(
+      KnownDirectives,
+      `
       query Foo @onQuery {
         name @include(if: true)
         ...Frag @include(if: true)
@@ -105,11 +117,14 @@ describe('Validate: Known directives', () => {
       mutation Bar @onMutation {
         someField
       }
-    `);
+    `,
+    );
   });
 
   it('with misplaced directives', () => {
-    expectFailsRule(KnownDirectives, `
+    expectFailsRule(
+      KnownDirectives,
+      `
       query Foo @include(if: true) {
         name @onQuery
         ...Frag @onQuery
@@ -118,18 +133,21 @@ describe('Validate: Known directives', () => {
       mutation Bar @onQuery {
         someField
       }
-    `, [
-      misplacedDirective('include', 'QUERY', 2, 17),
-      misplacedDirective('onQuery', 'FIELD', 3, 14),
-      misplacedDirective('onQuery', 'FRAGMENT_SPREAD', 4, 17),
-      misplacedDirective('onQuery', 'MUTATION', 7, 20),
-    ]);
+    `,
+      [
+        misplacedDirective('include', 'QUERY', 2, 17),
+        misplacedDirective('onQuery', 'FIELD', 3, 14),
+        misplacedDirective('onQuery', 'FRAGMENT_SPREAD', 4, 17),
+        misplacedDirective('onQuery', 'MUTATION', 7, 20),
+      ],
+    );
   });
 
   describe('within schema language', () => {
-
     it('with well placed directives', () => {
-      expectPassesRule(KnownDirectives, `
+      expectPassesRule(
+        KnownDirectives,
+        `
         type MyObj implements MyInterface @onObject {
           myField(myArg: Int @onArgumentDefinition): String @onFieldDefinition
         }
@@ -153,11 +171,14 @@ describe('Validate: Known directives', () => {
         schema @onSchema {
           query: MyQuery
         }
-      `);
+      `,
+      );
     });
 
     it('with misplaced directives', () => {
-      expectFailsRule(KnownDirectives, `
+      expectFailsRule(
+        KnownDirectives,
+        `
         type MyObj implements MyInterface @onInterface {
           myField(myArg: Int @onInputFieldDefinition): String @onInputFieldDefinition
         }
@@ -181,23 +202,48 @@ describe('Validate: Known directives', () => {
         schema @onObject {
           query: MyQuery
         }
-      `, [
-        misplacedDirective('onInterface', 'OBJECT', 2, 43),
-        misplacedDirective('onInputFieldDefinition', 'ARGUMENT_DEFINITION', 3, 30),
-        misplacedDirective('onInputFieldDefinition', 'FIELD_DEFINITION', 3, 63),
-        misplacedDirective('onEnum', 'SCALAR', 6, 25),
-        misplacedDirective('onObject', 'INTERFACE', 8, 31),
-        misplacedDirective('onInputFieldDefinition', 'ARGUMENT_DEFINITION', 9, 30),
-        misplacedDirective('onInputFieldDefinition', 'FIELD_DEFINITION', 9, 63),
-        misplacedDirective('onEnumValue', 'UNION', 12, 23),
-        misplacedDirective('onScalar', 'ENUM', 14, 21),
-        misplacedDirective('onUnion', 'ENUM_VALUE', 15, 20),
-        misplacedDirective('onEnum', 'INPUT_OBJECT', 18, 23),
-        misplacedDirective('onArgumentDefinition', 'INPUT_FIELD_DEFINITION', 19, 24),
-        misplacedDirective('onObject', 'SCHEMA', 22, 16),
-      ]);
+      `,
+        [
+          misplacedDirective('onInterface', 'OBJECT', 2, 43),
+          misplacedDirective(
+            'onInputFieldDefinition',
+            'ARGUMENT_DEFINITION',
+            3,
+            30,
+          ),
+          misplacedDirective(
+            'onInputFieldDefinition',
+            'FIELD_DEFINITION',
+            3,
+            63,
+          ),
+          misplacedDirective('onEnum', 'SCALAR', 6, 25),
+          misplacedDirective('onObject', 'INTERFACE', 8, 31),
+          misplacedDirective(
+            'onInputFieldDefinition',
+            'ARGUMENT_DEFINITION',
+            9,
+            30,
+          ),
+          misplacedDirective(
+            'onInputFieldDefinition',
+            'FIELD_DEFINITION',
+            9,
+            63,
+          ),
+          misplacedDirective('onEnumValue', 'UNION', 12, 23),
+          misplacedDirective('onScalar', 'ENUM', 14, 21),
+          misplacedDirective('onUnion', 'ENUM_VALUE', 15, 20),
+          misplacedDirective('onEnum', 'INPUT_OBJECT', 18, 23),
+          misplacedDirective(
+            'onArgumentDefinition',
+            'INPUT_FIELD_DEFINITION',
+            19,
+            24,
+          ),
+          misplacedDirective('onObject', 'SCHEMA', 22, 16),
+        ],
+      );
     });
-
   });
-
 });

--- a/src/validation/__tests__/KnownFragmentNames-test.js
+++ b/src/validation/__tests__/KnownFragmentNames-test.js
@@ -12,19 +12,19 @@ import {
   unknownFragmentMessage,
 } from '../rules/KnownFragmentNames';
 
-
 function undefFrag(fragName, line, column) {
   return {
     message: unknownFragmentMessage(fragName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Known fragment names', () => {
-
   it('known fragment names are valid', () => {
-    expectPassesRule(KnownFragmentNames, `
+    expectPassesRule(
+      KnownFragmentNames,
+      `
       {
         human(id: 4) {
           ...HumanFields1
@@ -46,11 +46,14 @@ describe('Validate: Known fragment names', () => {
       fragment HumanFields3 on Human {
         name
       }
-    `);
+    `,
+    );
   });
 
   it('unknown fragment names are invalid', () => {
-    expectFailsRule(KnownFragmentNames, `
+    expectFailsRule(
+      KnownFragmentNames,
+      `
       {
         human(id: 4) {
           ...UnknownFragment1
@@ -63,11 +66,12 @@ describe('Validate: Known fragment names', () => {
         name
         ...UnknownFragment3
       }
-    `, [
-      undefFrag('UnknownFragment1', 4, 14),
-      undefFrag('UnknownFragment2', 6, 16),
-      undefFrag('UnknownFragment3', 12, 12)
-    ]);
+    `,
+      [
+        undefFrag('UnknownFragment1', 4, 14),
+        undefFrag('UnknownFragment2', 6, 16),
+        undefFrag('UnknownFragment3', 12, 12),
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/KnownTypeNames-test.js
+++ b/src/validation/__tests__/KnownTypeNames-test.js
@@ -7,24 +7,21 @@
 
 import { describe, it } from 'mocha';
 import { expectPassesRule, expectFailsRule } from './harness';
-import {
-  KnownTypeNames,
-  unknownTypeMessage,
-} from '../rules/KnownTypeNames';
-
+import { KnownTypeNames, unknownTypeMessage } from '../rules/KnownTypeNames';
 
 function unknownType(typeName, suggestedTypes, line, column) {
   return {
     message: unknownTypeMessage(typeName, suggestedTypes),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Known type names', () => {
-
   it('known type names are valid', () => {
-    expectPassesRule(KnownTypeNames, `
+    expectPassesRule(
+      KnownTypeNames,
+      `
       query Foo($var: String, $required: [String!]!) {
         user(id: 4) {
           pets { ... on Pet { name }, ...PetFields, ... { name } }
@@ -33,11 +30,14 @@ describe('Validate: Known type names', () => {
       fragment PetFields on Pet {
         name
       }
-    `);
+    `,
+    );
   });
 
   it('unknown type names are invalid', () => {
-    expectFailsRule(KnownTypeNames, `
+    expectFailsRule(
+      KnownTypeNames,
+      `
       query Foo($var: JumbledUpLetters) {
         user(id: 4) {
           name
@@ -47,30 +47,19 @@ describe('Validate: Known type names', () => {
       fragment PetFields on Peettt {
         name
       }
-    `, [
-      unknownType(
-        'JumbledUpLetters',
-        [],
-        2,
-        23
-      ),
-      unknownType(
-        'Badger',
-        [],
-        5,
-        25
-      ),
-      unknownType(
-        'Peettt',
-        [ 'Pet' ],
-        8,
-        29
-      )
-    ]);
+    `,
+      [
+        unknownType('JumbledUpLetters', [], 2, 23),
+        unknownType('Badger', [], 5, 25),
+        unknownType('Peettt', ['Pet'], 8, 29),
+      ],
+    );
   });
 
   it('ignores type definitions', () => {
-    expectFailsRule(KnownTypeNames, `
+    expectFailsRule(
+      KnownTypeNames,
+      `
       type NotInTheSchema {
         field: FooBar
       }
@@ -86,14 +75,8 @@ describe('Validate: Known type names', () => {
           id
         }
       }
-    `, [
-      unknownType(
-        'NotInTheSchema',
-        [],
-        12,
-        23
-      ),
-    ]);
+    `,
+      [unknownType('NotInTheSchema', [], 12, 23)],
+    );
   });
-
 });

--- a/src/validation/__tests__/LoneAnonymousOperation-test.js
+++ b/src/validation/__tests__/LoneAnonymousOperation-test.js
@@ -12,35 +12,41 @@ import {
   anonOperationNotAloneMessage,
 } from '../rules/LoneAnonymousOperation';
 
-
 function anonNotAlone(line, column) {
   return {
     message: anonOperationNotAloneMessage(),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Anonymous operation must be alone', () => {
-
   it('no operations', () => {
-    expectPassesRule(LoneAnonymousOperation, `
+    expectPassesRule(
+      LoneAnonymousOperation,
+      `
       fragment fragA on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('one anon operation', () => {
-    expectPassesRule(LoneAnonymousOperation, `
+    expectPassesRule(
+      LoneAnonymousOperation,
+      `
       {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('multiple named operations', () => {
-    expectPassesRule(LoneAnonymousOperation, `
+    expectPassesRule(
+      LoneAnonymousOperation,
+      `
       query Foo {
         field
       }
@@ -48,58 +54,66 @@ describe('Validate: Anonymous operation must be alone', () => {
       query Bar {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('anon operation with fragment', () => {
-    expectPassesRule(LoneAnonymousOperation, `
+    expectPassesRule(
+      LoneAnonymousOperation,
+      `
       {
         ...Foo
       }
       fragment Foo on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('multiple anon operations', () => {
-    expectFailsRule(LoneAnonymousOperation, `
+    expectFailsRule(
+      LoneAnonymousOperation,
+      `
       {
         fieldA
       }
       {
         fieldB
       }
-    `, [
-      anonNotAlone(2, 7),
-      anonNotAlone(5, 7)
-    ]);
+    `,
+      [anonNotAlone(2, 7), anonNotAlone(5, 7)],
+    );
   });
 
   it('anon operation with a mutation', () => {
-    expectFailsRule(LoneAnonymousOperation, `
+    expectFailsRule(
+      LoneAnonymousOperation,
+      `
       {
         fieldA
       }
       mutation Foo {
         fieldB
       }
-    `, [
-      anonNotAlone(2, 7)
-    ]);
+    `,
+      [anonNotAlone(2, 7)],
+    );
   });
 
   it('anon operation with a subscription', () => {
-    expectFailsRule(LoneAnonymousOperation, `
+    expectFailsRule(
+      LoneAnonymousOperation,
+      `
       {
         fieldA
       }
       subscription Foo {
         fieldB
       }
-    `, [
-      anonNotAlone(2, 7)
-    ]);
+    `,
+      [anonNotAlone(2, 7)],
+    );
   });
-
 });

--- a/src/validation/__tests__/NoFragmentCycles-test.js
+++ b/src/validation/__tests__/NoFragmentCycles-test.js
@@ -9,33 +9,42 @@ import { describe, it } from 'mocha';
 import { expectPassesRule, expectFailsRule } from './harness';
 import { NoFragmentCycles, cycleErrorMessage } from '../rules/NoFragmentCycles';
 
-
 describe('Validate: No circular fragment spreads', () => {
-
   it('single reference is valid', () => {
-    expectPassesRule(NoFragmentCycles, `
+    expectPassesRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB }
       fragment fragB on Dog { name }
-    `);
+    `,
+    );
   });
 
   it('spreading twice is not circular', () => {
-    expectPassesRule(NoFragmentCycles, `
+    expectPassesRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB, ...fragB }
       fragment fragB on Dog { name }
-    `);
+    `,
+    );
   });
 
   it('spreading twice indirectly is not circular', () => {
-    expectPassesRule(NoFragmentCycles, `
+    expectPassesRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB, ...fragC }
       fragment fragB on Dog { ...fragC }
       fragment fragC on Dog { name }
-    `);
+    `,
+    );
   });
 
   it('double spread within abstract types', () => {
-    expectPassesRule(NoFragmentCycles, `
+    expectPassesRule(
+      NoFragmentCycles,
+      `
       fragment nameFragment on Pet {
         ... on Dog { name }
         ... on Cat { name }
@@ -45,76 +54,111 @@ describe('Validate: No circular fragment spreads', () => {
         ... on Dog { ...nameFragment }
         ... on Cat { ...nameFragment }
       }
-    `);
+    `,
+    );
   });
 
   it('does not false positive on unknown fragment', () => {
-    expectPassesRule(NoFragmentCycles, `
+    expectPassesRule(
+      NoFragmentCycles,
+      `
       fragment nameFragment on Pet {
         ...UnknownFragment
       }
-    `);
+    `,
+    );
   });
 
   it('spreading recursively within field fails', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Human { relatives { ...fragA } },
-    `, [
-      { message: cycleErrorMessage('fragA', []),
-        locations: [ { line: 2, column: 45 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', []),
+          locations: [{ line: 2, column: 45 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself directly', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragA }
-    `, [
-      { message: cycleErrorMessage('fragA', []),
-        locations: [ { line: 2, column: 31 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', []),
+          locations: [{ line: 2, column: 31 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself directly within inline fragment', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Pet {
         ... on Dog {
           ...fragA
         }
       }
-    `, [
-      { message: cycleErrorMessage('fragA', []),
-        locations: [ { line: 4, column: 11 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', []),
+          locations: [{ line: 4, column: 11 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself indirectly', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB }
       fragment fragB on Dog { ...fragA }
-    `, [
-      { message: cycleErrorMessage('fragA', [ 'fragB' ]),
-        locations: [ { line: 2, column: 31 }, { line: 3, column: 31 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', ['fragB']),
+          locations: [{ line: 2, column: 31 }, { line: 3, column: 31 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself indirectly reports opposite order', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragB on Dog { ...fragA }
       fragment fragA on Dog { ...fragB }
-    `, [
-      { message: cycleErrorMessage('fragB', [ 'fragA' ]),
-        locations: [ { line: 2, column: 31 }, { line: 3, column: 31 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragB', ['fragA']),
+          locations: [{ line: 2, column: 31 }, { line: 3, column: 31 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
-
   it('no spreading itself indirectly within inline fragment', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Pet {
         ... on Dog {
           ...fragB
@@ -125,15 +169,21 @@ describe('Validate: No circular fragment spreads', () => {
           ...fragA
         }
       }
-    `, [
-      { message: cycleErrorMessage('fragA', [ 'fragB' ]),
-        locations: [ { line: 4, column: 11 }, { line: 9, column: 11 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', ['fragB']),
+          locations: [{ line: 4, column: 11 }, { line: 9, column: 11 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself deeply', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB }
       fragment fragB on Dog { ...fragC }
       fragment fragC on Dog { ...fragO }
@@ -142,77 +192,119 @@ describe('Validate: No circular fragment spreads', () => {
       fragment fragZ on Dog { ...fragO }
       fragment fragO on Dog { ...fragP }
       fragment fragP on Dog { ...fragA, ...fragX }
-    `, [
-      { message:
-          cycleErrorMessage('fragA', [ 'fragB', 'fragC', 'fragO', 'fragP' ]),
-        locations: [
-          { line: 2, column: 31 },
-          { line: 3, column: 31 },
-          { line: 4, column: 31 },
-          { line: 8, column: 31 },
-          { line: 9, column: 31 } ],
-        path: undefined },
-      { message:
-          cycleErrorMessage('fragO', [ 'fragP', 'fragX', 'fragY', 'fragZ' ]),
-        locations: [
-          { line: 8, column: 31 },
-          { line: 9, column: 41 },
-          { line: 5, column: 31 },
-          { line: 6, column: 31 },
-          { line: 7, column: 31 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', [
+            'fragB',
+            'fragC',
+            'fragO',
+            'fragP',
+          ]),
+          locations: [
+            { line: 2, column: 31 },
+            { line: 3, column: 31 },
+            { line: 4, column: 31 },
+            { line: 8, column: 31 },
+            { line: 9, column: 31 },
+          ],
+          path: undefined,
+        },
+        {
+          message: cycleErrorMessage('fragO', [
+            'fragP',
+            'fragX',
+            'fragY',
+            'fragZ',
+          ]),
+          locations: [
+            { line: 8, column: 31 },
+            { line: 9, column: 41 },
+            { line: 5, column: 31 },
+            { line: 6, column: 31 },
+            { line: 7, column: 31 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself deeply two paths', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB, ...fragC }
       fragment fragB on Dog { ...fragA }
       fragment fragC on Dog { ...fragA }
-    `, [
-      { message: cycleErrorMessage('fragA', [ 'fragB' ]),
-        locations: [ { line: 2, column: 31 }, { line: 3, column: 31 } ],
-        path: undefined },
-      { message: cycleErrorMessage('fragA', [ 'fragC' ]),
-        locations: [ { line: 2, column: 41 }, { line: 4, column: 31 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', ['fragB']),
+          locations: [{ line: 2, column: 31 }, { line: 3, column: 31 }],
+          path: undefined,
+        },
+        {
+          message: cycleErrorMessage('fragA', ['fragC']),
+          locations: [{ line: 2, column: 41 }, { line: 4, column: 31 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself deeply two paths -- alt traverse order', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragC }
       fragment fragB on Dog { ...fragC }
       fragment fragC on Dog { ...fragA, ...fragB }
-    `, [
-      { message: cycleErrorMessage('fragA', [ 'fragC' ]),
-        locations: [ { line: 2, column: 31 }, { line: 4, column: 31 } ],
-        path: undefined },
-      { message: cycleErrorMessage('fragC', [ 'fragB' ]),
-        locations: [ { line: 4, column: 41 }, { line: 3, column: 31 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragA', ['fragC']),
+          locations: [{ line: 2, column: 31 }, { line: 4, column: 31 }],
+          path: undefined,
+        },
+        {
+          message: cycleErrorMessage('fragC', ['fragB']),
+          locations: [{ line: 4, column: 41 }, { line: 3, column: 31 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('no spreading itself deeply and immediately', () => {
-    expectFailsRule(NoFragmentCycles, `
+    expectFailsRule(
+      NoFragmentCycles,
+      `
       fragment fragA on Dog { ...fragB }
       fragment fragB on Dog { ...fragB, ...fragC }
       fragment fragC on Dog { ...fragA, ...fragB }
-    `, [
-      { message: cycleErrorMessage('fragB', []),
-        locations: [ { line: 3, column: 31 } ],
-        path: undefined },
-      { message: cycleErrorMessage('fragA', [ 'fragB', 'fragC' ]),
-        locations: [
-          { line: 2, column: 31 },
-          { line: 3, column: 41 },
-          { line: 4, column: 31 } ],
-        path: undefined },
-      { message: cycleErrorMessage('fragB', [ 'fragC' ]),
-        locations: [ { line: 3, column: 41 }, { line: 4, column: 41 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: cycleErrorMessage('fragB', []),
+          locations: [{ line: 3, column: 31 }],
+          path: undefined,
+        },
+        {
+          message: cycleErrorMessage('fragA', ['fragB', 'fragC']),
+          locations: [
+            { line: 2, column: 31 },
+            { line: 3, column: 41 },
+            { line: 4, column: 31 },
+          ],
+          path: undefined,
+        },
+        {
+          message: cycleErrorMessage('fragB', ['fragC']),
+          locations: [{ line: 3, column: 41 }, { line: 4, column: 41 }],
+          path: undefined,
+        },
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/NoUndefinedVariables-test.js
+++ b/src/validation/__tests__/NoUndefinedVariables-test.js
@@ -12,27 +12,30 @@ import {
   undefinedVarMessage,
 } from '../rules/NoUndefinedVariables';
 
-
 function undefVar(varName, l1, c1, opName, l2, c2) {
   return {
     message: undefinedVarMessage(varName, opName),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: No undefined variables', () => {
-
   it('all variables defined', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         field(a: $a, b: $b, c: $c)
       }
-    `);
+    `,
+    );
   });
 
   it('all variables deeply defined', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         field(a: $a) {
           field(b: $b) {
@@ -40,11 +43,14 @@ describe('Validate: No undefined variables', () => {
           }
         }
       }
-    `);
+    `,
+    );
   });
 
   it('all variables deeply in inline fragments defined', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         ... on Type {
           field(a: $a) {
@@ -56,11 +62,14 @@ describe('Validate: No undefined variables', () => {
           }
         }
       }
-    `);
+    `,
+    );
   });
 
   it('all variables in fragments deeply defined', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         ...FragA
       }
@@ -77,11 +86,14 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field(c: $c)
       }
-    `);
+    `,
+    );
   });
 
   it('variable within single fragment defined in multiple operations', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String) {
         ...FragA
       }
@@ -91,11 +103,14 @@ describe('Validate: No undefined variables', () => {
       fragment FragA on Type {
         field(a: $a)
       }
-    `);
+    `,
+    );
   });
 
   it('variable within fragments defined in operations', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String) {
         ...FragA
       }
@@ -108,11 +123,14 @@ describe('Validate: No undefined variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `);
+    `,
+    );
   });
 
   it('variable within recursive fragment defined', () => {
-    expectPassesRule(NoUndefinedVariables, `
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String) {
         ...FragA
       }
@@ -121,55 +139,65 @@ describe('Validate: No undefined variables', () => {
           ...FragA
         }
       }
-    `);
+    `,
+    );
   });
 
   it('variable not defined', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         field(a: $a, b: $b, c: $c, d: $d)
       }
-    `, [
-      undefVar('d', 3, 39, 'Foo', 2, 7)
-    ]);
+    `,
+      [undefVar('d', 3, 39, 'Foo', 2, 7)],
+    );
   });
 
   it('variable not defined by un-named query', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       {
         field(a: $a)
       }
-    `, [
-      undefVar('a', 3, 18, '', 2, 7)
-    ]);
+    `,
+      [undefVar('a', 3, 18, '', 2, 7)],
+    );
   });
 
   it('multiple variables not defined', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($b: String) {
         field(a: $a, b: $b, c: $c)
       }
-    `, [
-      undefVar('a', 3, 18, 'Foo', 2, 7),
-      undefVar('c', 3, 32, 'Foo', 2, 7)
-    ]);
+    `,
+      [undefVar('a', 3, 18, 'Foo', 2, 7), undefVar('c', 3, 32, 'Foo', 2, 7)],
+    );
   });
 
   it('variable in fragment not defined by un-named query', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       {
         ...FragA
       }
       fragment FragA on Type {
         field(a: $a)
       }
-    `, [
-      undefVar('a', 6, 18, '', 2, 7)
-    ]);
+    `,
+      [undefVar('a', 6, 18, '', 2, 7)],
+    );
   });
 
   it('variable in fragment not defined by operation', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String, $b: String) {
         ...FragA
       }
@@ -186,13 +214,15 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field(c: $c)
       }
-    `, [
-      undefVar('c', 16, 18, 'Foo', 2, 7)
-    ]);
+    `,
+      [undefVar('c', 16, 18, 'Foo', 2, 7)],
+    );
   });
 
   it('multiple variables in fragments not defined', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($b: String) {
         ...FragA
       }
@@ -209,14 +239,15 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field(c: $c)
       }
-    `, [
-      undefVar('a', 6, 18, 'Foo', 2, 7),
-      undefVar('c', 16, 18, 'Foo', 2, 7)
-    ]);
+    `,
+      [undefVar('a', 6, 18, 'Foo', 2, 7), undefVar('c', 16, 18, 'Foo', 2, 7)],
+    );
   });
 
   it('single variable in fragment not defined by multiple operations', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($a: String) {
         ...FragAB
       }
@@ -226,14 +257,15 @@ describe('Validate: No undefined variables', () => {
       fragment FragAB on Type {
         field(a: $a, b: $b)
       }
-    `, [
-      undefVar('b', 9, 25, 'Foo', 2, 7),
-      undefVar('b', 9, 25, 'Bar', 5, 7)
-    ]);
+    `,
+      [undefVar('b', 9, 25, 'Foo', 2, 7), undefVar('b', 9, 25, 'Bar', 5, 7)],
+    );
   });
 
   it('variables in fragment not defined by multiple operations', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($b: String) {
         ...FragAB
       }
@@ -243,14 +275,15 @@ describe('Validate: No undefined variables', () => {
       fragment FragAB on Type {
         field(a: $a, b: $b)
       }
-    `, [
-      undefVar('a', 9, 18, 'Foo', 2, 7),
-      undefVar('b', 9, 25, 'Bar', 5, 7)
-    ]);
+    `,
+      [undefVar('a', 9, 18, 'Foo', 2, 7), undefVar('b', 9, 25, 'Bar', 5, 7)],
+    );
   });
 
   it('variable in fragment used by other operation', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($b: String) {
         ...FragA
       }
@@ -263,14 +296,15 @@ describe('Validate: No undefined variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `, [
-      undefVar('a', 9, 18, 'Foo', 2, 7),
-      undefVar('b', 12, 18, 'Bar', 5, 7)
-    ]);
+    `,
+      [undefVar('a', 9, 18, 'Foo', 2, 7), undefVar('b', 12, 18, 'Bar', 5, 7)],
+    );
   });
 
   it('multiple undefined variables produce multiple errors', () => {
-    expectFailsRule(NoUndefinedVariables, `
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
       query Foo($b: String) {
         ...FragAB
       }
@@ -285,14 +319,15 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field2(c: $c)
       }
-    `, [
-      undefVar('a', 9, 19, 'Foo', 2, 7),
-      undefVar('a', 11, 19, 'Foo', 2, 7),
-      undefVar('c', 14, 19, 'Foo', 2, 7),
-      undefVar('b', 9, 26, 'Bar', 5, 7),
-      undefVar('b', 11, 26, 'Bar', 5, 7),
-      undefVar('c', 14, 19, 'Bar', 5, 7),
-    ]);
+    `,
+      [
+        undefVar('a', 9, 19, 'Foo', 2, 7),
+        undefVar('a', 11, 19, 'Foo', 2, 7),
+        undefVar('c', 14, 19, 'Foo', 2, 7),
+        undefVar('b', 9, 26, 'Bar', 5, 7),
+        undefVar('b', 11, 26, 'Bar', 5, 7),
+        undefVar('c', 14, 19, 'Bar', 5, 7),
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/NoUnusedFragments-test.js
+++ b/src/validation/__tests__/NoUnusedFragments-test.js
@@ -12,19 +12,19 @@ import {
   unusedFragMessage,
 } from '../rules/NoUnusedFragments';
 
-
 function unusedFrag(fragName, line, column) {
   return {
     message: unusedFragMessage(fragName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: No unused fragments', () => {
-
   it('all fragment names are used', () => {
-    expectPassesRule(NoUnusedFragments, `
+    expectPassesRule(
+      NoUnusedFragments,
+      `
       {
         human(id: 4) {
           ...HumanFields1
@@ -43,12 +43,14 @@ describe('Validate: No unused fragments', () => {
       fragment HumanFields3 on Human {
         name
       }
-    `);
+    `,
+    );
   });
 
-
   it('all fragment names are used by multiple operations', () => {
-    expectPassesRule(NoUnusedFragments, `
+    expectPassesRule(
+      NoUnusedFragments,
+      `
       query Foo {
         human(id: 4) {
           ...HumanFields1
@@ -69,11 +71,14 @@ describe('Validate: No unused fragments', () => {
       fragment HumanFields3 on Human {
         name
       }
-    `);
+    `,
+    );
   });
 
   it('contains unknown fragments', () => {
-    expectFailsRule(NoUnusedFragments, `
+    expectFailsRule(
+      NoUnusedFragments,
+      `
       query Foo {
         human(id: 4) {
           ...HumanFields1
@@ -100,14 +105,15 @@ describe('Validate: No unused fragments', () => {
       fragment Unused2 on Human {
         name
       }
-    `, [
-      unusedFrag('Unused1', 22, 7),
-      unusedFrag('Unused2', 25, 7),
-    ]);
+    `,
+      [unusedFrag('Unused1', 22, 7), unusedFrag('Unused2', 25, 7)],
+    );
   });
 
   it('contains unknown fragments with ref cycle', () => {
-    expectFailsRule(NoUnusedFragments, `
+    expectFailsRule(
+      NoUnusedFragments,
+      `
       query Foo {
         human(id: 4) {
           ...HumanFields1
@@ -136,14 +142,15 @@ describe('Validate: No unused fragments', () => {
         name
         ...Unused1
       }
-    `, [
-      unusedFrag('Unused1', 22, 7),
-      unusedFrag('Unused2', 26, 7),
-    ]);
+    `,
+      [unusedFrag('Unused1', 22, 7), unusedFrag('Unused2', 26, 7)],
+    );
   });
 
   it('contains unknown and undef fragments', () => {
-    expectFailsRule(NoUnusedFragments, `
+    expectFailsRule(
+      NoUnusedFragments,
+      `
       query Foo {
         human(id: 4) {
           ...bar
@@ -152,9 +159,8 @@ describe('Validate: No unused fragments', () => {
       fragment foo on Human {
         name
       }
-    `, [
-      unusedFrag('foo', 7, 7),
-    ]);
+    `,
+      [unusedFrag('foo', 7, 7)],
+    );
   });
-
 });

--- a/src/validation/__tests__/NoUnusedVariables-test.js
+++ b/src/validation/__tests__/NoUnusedVariables-test.js
@@ -12,27 +12,30 @@ import {
   unusedVariableMessage,
 } from '../rules/NoUnusedVariables';
 
-
 function unusedVar(varName, opName, line, column) {
   return {
     message: unusedVariableMessage(varName, opName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: No unused variables', () => {
-
   it('uses all variables', () => {
-    expectPassesRule(NoUnusedVariables, `
+    expectPassesRule(
+      NoUnusedVariables,
+      `
       query ($a: String, $b: String, $c: String) {
         field(a: $a, b: $b, c: $c)
       }
-    `);
+    `,
+    );
   });
 
   it('uses all variables deeply', () => {
-    expectPassesRule(NoUnusedVariables, `
+    expectPassesRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         field(a: $a) {
           field(b: $b) {
@@ -40,11 +43,14 @@ describe('Validate: No unused variables', () => {
           }
         }
       }
-    `);
+    `,
+    );
   });
 
   it('uses all variables deeply in inline fragments', () => {
-    expectPassesRule(NoUnusedVariables, `
+    expectPassesRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         ... on Type {
           field(a: $a) {
@@ -56,11 +62,14 @@ describe('Validate: No unused variables', () => {
           }
         }
       }
-    `);
+    `,
+    );
   });
 
   it('uses all variables in fragments', () => {
-    expectPassesRule(NoUnusedVariables, `
+    expectPassesRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         ...FragA
       }
@@ -77,11 +86,14 @@ describe('Validate: No unused variables', () => {
       fragment FragC on Type {
         field(c: $c)
       }
-    `);
+    `,
+    );
   });
 
   it('variable used by fragment in multiple operations', () => {
-    expectPassesRule(NoUnusedVariables, `
+    expectPassesRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String) {
         ...FragA
       }
@@ -94,11 +106,14 @@ describe('Validate: No unused variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `);
+    `,
+    );
   });
 
   it('variable used by recursive fragment', () => {
-    expectPassesRule(NoUnusedVariables, `
+    expectPassesRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String) {
         ...FragA
       }
@@ -107,32 +122,38 @@ describe('Validate: No unused variables', () => {
           ...FragA
         }
       }
-    `);
+    `,
+    );
   });
 
   it('variable not used', () => {
-    expectFailsRule(NoUnusedVariables, `
+    expectFailsRule(
+      NoUnusedVariables,
+      `
       query ($a: String, $b: String, $c: String) {
         field(a: $a, b: $b)
       }
-    `, [
-      unusedVar('c', null, 2, 38)
-    ]);
+    `,
+      [unusedVar('c', null, 2, 38)],
+    );
   });
 
   it('multiple variables not used', () => {
-    expectFailsRule(NoUnusedVariables, `
+    expectFailsRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         field(b: $b)
       }
-    `, [
-      unusedVar('a', 'Foo', 2, 17),
-      unusedVar('c', 'Foo', 2, 41)
-    ]);
+    `,
+      [unusedVar('a', 'Foo', 2, 17), unusedVar('c', 'Foo', 2, 41)],
+    );
   });
 
   it('variable not used in fragments', () => {
-    expectFailsRule(NoUnusedVariables, `
+    expectFailsRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         ...FragA
       }
@@ -149,13 +170,15 @@ describe('Validate: No unused variables', () => {
       fragment FragC on Type {
         field
       }
-    `, [
-      unusedVar('c', 'Foo', 2, 41)
-    ]);
+    `,
+      [unusedVar('c', 'Foo', 2, 41)],
+    );
   });
 
   it('multiple variables not used in fragments', () => {
-    expectFailsRule(NoUnusedVariables, `
+    expectFailsRule(
+      NoUnusedVariables,
+      `
       query Foo($a: String, $b: String, $c: String) {
         ...FragA
       }
@@ -172,14 +195,15 @@ describe('Validate: No unused variables', () => {
       fragment FragC on Type {
         field
       }
-    `, [
-      unusedVar('a', 'Foo', 2, 17),
-      unusedVar('c', 'Foo', 2, 41)
-    ]);
+    `,
+      [unusedVar('a', 'Foo', 2, 17), unusedVar('c', 'Foo', 2, 41)],
+    );
   });
 
   it('variable not used by unreferenced fragment', () => {
-    expectFailsRule(NoUnusedVariables, `
+    expectFailsRule(
+      NoUnusedVariables,
+      `
       query Foo($b: String) {
         ...FragA
       }
@@ -189,13 +213,15 @@ describe('Validate: No unused variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `, [
-      unusedVar('b', 'Foo', 2, 17)
-    ]);
+    `,
+      [unusedVar('b', 'Foo', 2, 17)],
+    );
   });
 
   it('variable not used by fragment used by other operation', () => {
-    expectFailsRule(NoUnusedVariables, `
+    expectFailsRule(
+      NoUnusedVariables,
+      `
       query Foo($b: String) {
         ...FragA
       }
@@ -208,10 +234,8 @@ describe('Validate: No unused variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `, [
-      unusedVar('b', 'Foo', 2, 17),
-      unusedVar('a', 'Bar', 5, 17)
-    ]);
+    `,
+      [unusedVar('b', 'Foo', 2, 17), unusedVar('a', 'Bar', 5, 17)],
+    );
   });
-
 });

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -11,7 +11,7 @@ import {
   expectPassesRule,
   expectFailsRule,
   expectFailsRuleWithSchema,
-  expectPassesRuleWithSchema
+  expectPassesRuleWithSchema,
 } from './harness';
 import {
   OverlappingFieldsCanBeMerged,
@@ -29,93 +29,121 @@ import {
 } from '../../type';
 
 describe('Validate: Overlapping fields can be merged', () => {
-
   it('unique fields', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment uniqueFields on Dog {
         name
         nickname
       }
-    `);
+    `,
+    );
   });
 
   it('identical fields', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment mergeIdenticalFields on Dog {
         name
         name
       }
-    `);
+    `,
+    );
   });
 
   it('identical fields with identical args', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {
         doesKnowCommand(dogCommand: SIT)
         doesKnowCommand(dogCommand: SIT)
       }
-    `);
+    `,
+    );
   });
 
   it('identical fields with identical directives', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment mergeSameFieldsWithSameDirectives on Dog {
         name @include(if: true)
         name @include(if: true)
       }
-    `);
+    `,
+    );
   });
 
   it('different args with different aliases', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment differentArgsWithDifferentAliases on Dog {
         knowsSit: doesKnowCommand(dogCommand: SIT)
         knowsDown: doesKnowCommand(dogCommand: DOWN)
       }
-    `);
+    `,
+    );
   });
 
   it('different directives with different aliases', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment differentDirectivesWithDifferentAliases on Dog {
         nameIfTrue: name @include(if: true)
         nameIfFalse: name @include(if: false)
       }
-    `);
+    `,
+    );
   });
 
   it('different skip/include directives accepted', () => {
     // Note: Differing skip/include directives don't create an ambiguous return
     // value and are acceptable in conditions where differing runtime values
     // may have the same desired effect of including or skipping a field.
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment differentDirectivesWithDifferentAliases on Dog {
         name @include(if: true)
         name @include(if: false)
       }
-    `);
+    `,
+    );
   });
 
   it('Same aliases with different field targets', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment sameAliasesWithDifferentFieldTargets on Dog {
         fido: name
         fido: nickname
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'fido',
-          'name and nickname are different fields'
-        ),
-        locations: [ { line: 3, column: 9 }, { line: 4, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage(
+            'fido',
+            'name and nickname are different fields',
+          ),
+          locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('Same aliases allowed on non-overlapping fields', () => {
     // This is valid since no object can be both a "Dog" and a "Cat", thus
     // these fields can never overlap.
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment sameAliasesWithDifferentFieldTargets on Pet {
         ... on Dog {
           name
@@ -124,77 +152,104 @@ describe('Validate: Overlapping fields can be merged', () => {
           name: nickname
         }
       }
-    `);
+    `,
+    );
   });
 
   it('Alias masking direct field access', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment aliasMaskingDirectFieldAccess on Dog {
         name: nickname
         name
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'name',
-          'nickname and name are different fields'
-        ),
-        locations: [ { line: 3, column: 9 }, { line: 4, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage(
+            'name',
+            'nickname and name are different fields',
+          ),
+          locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('different args, second adds an argument', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment conflictingArgs on Dog {
         doesKnowCommand
         doesKnowCommand(dogCommand: HEEL)
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'doesKnowCommand',
-          'they have differing arguments'
-        ),
-        locations: [ { line: 3, column: 9 }, { line: 4, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage(
+            'doesKnowCommand',
+            'they have differing arguments',
+          ),
+          locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('different args, second missing an argument', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment conflictingArgs on Dog {
         doesKnowCommand(dogCommand: SIT)
         doesKnowCommand
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'doesKnowCommand',
-          'they have differing arguments'
-        ),
-        locations: [ { line: 3, column: 9 }, { line: 4, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage(
+            'doesKnowCommand',
+            'they have differing arguments',
+          ),
+          locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('conflicting args', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment conflictingArgs on Dog {
         doesKnowCommand(dogCommand: SIT)
         doesKnowCommand(dogCommand: HEEL)
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'doesKnowCommand',
-          'they have differing arguments'
-        ),
-        locations: [ { line: 3, column: 9 }, { line: 4, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage(
+            'doesKnowCommand',
+            'they have differing arguments',
+          ),
+          locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('allows different args where no conflict is possible', () => {
     // This is valid since no object can be both a "Dog" and a "Cat", thus
     // these fields can never overlap.
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
       fragment conflictingArgs on Pet {
         ... on Dog {
           name(surname: true)
@@ -203,11 +258,14 @@ describe('Validate: Overlapping fields can be merged', () => {
           name
         }
       }
-    `);
+    `,
+    );
   });
 
   it('encounters conflict in fragments', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         ...A
         ...B
@@ -218,15 +276,21 @@ describe('Validate: Overlapping fields can be merged', () => {
       fragment B on Type {
         x: b
       }
-    `, [
-      { message: fieldsConflictMessage('x', 'a and b are different fields'),
-        locations: [ { line: 7, column: 9 }, { line: 10, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('x', 'a and b are different fields'),
+          locations: [{ line: 7, column: 9 }, { line: 10, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('reports each conflict once', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         f1 {
           ...A
@@ -248,21 +312,31 @@ describe('Validate: Overlapping fields can be merged', () => {
       fragment B on Type {
         x: b
       }
-    `, [
-      { message: fieldsConflictMessage('x', 'a and b are different fields'),
-        locations: [ { line: 18, column: 9 }, { line: 21, column: 9 } ],
-        path: undefined },
-      { message: fieldsConflictMessage('x', 'c and a are different fields'),
-        locations: [ { line: 14, column: 11 }, { line: 18, column: 9 } ],
-        path: undefined },
-      { message: fieldsConflictMessage('x', 'c and b are different fields'),
-        locations: [ { line: 14, column: 11 }, { line: 21, column: 9 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('x', 'a and b are different fields'),
+          locations: [{ line: 18, column: 9 }, { line: 21, column: 9 }],
+          path: undefined,
+        },
+        {
+          message: fieldsConflictMessage('x', 'c and a are different fields'),
+          locations: [{ line: 14, column: 11 }, { line: 18, column: 9 }],
+          path: undefined,
+        },
+        {
+          message: fieldsConflictMessage('x', 'c and b are different fields'),
+          locations: [{ line: 14, column: 11 }, { line: 21, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('deep conflict', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         field {
           x: a
@@ -271,21 +345,28 @@ describe('Validate: Overlapping fields can be merged', () => {
           x: b
         }
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'field', [ [ 'x', 'a and b are different fields' ] ]
-        ),
-        locations: [
-          { line: 3, column: 9 },
-          { line: 4, column: 11 },
-          { line: 6, column: 9 },
-          { line: 7, column: 11 } ],
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('field', [
+            ['x', 'a and b are different fields'],
+          ]),
+          locations: [
+            { line: 3, column: 9 },
+            { line: 4, column: 11 },
+            { line: 6, column: 9 },
+            { line: 7, column: 11 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('deep conflict with multiple issues', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         field {
           x: a
@@ -296,26 +377,31 @@ describe('Validate: Overlapping fields can be merged', () => {
           y: d
         }
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'field', [
-            [ 'x', 'a and b are different fields' ],
-            [ 'y', 'c and d are different fields' ]
-          ]
-        ),
-        locations: [
-          { line: 3, column: 9 },
-          { line: 4, column: 11 },
-          { line: 5, column: 11 },
-          { line: 7, column: 9 },
-          { line: 8, column: 11 },
-          { line: 9, column: 11 } ],
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('field', [
+            ['x', 'a and b are different fields'],
+            ['y', 'c and d are different fields'],
+          ]),
+          locations: [
+            { line: 3, column: 9 },
+            { line: 4, column: 11 },
+            { line: 5, column: 11 },
+            { line: 7, column: 9 },
+            { line: 8, column: 11 },
+            { line: 9, column: 11 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('very deep conflict', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         field {
           deepField {
@@ -328,24 +414,30 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'field',
-          [ [ 'deepField', [ [ 'x', 'a and b are different fields' ] ] ] ]
-        ),
-        locations: [
-          { line: 3, column: 9 },
-          { line: 4, column: 11 },
-          { line: 5, column: 13 },
-          { line: 8, column: 9 },
-          { line: 9, column: 11 },
-          { line: 10, column: 13 } ],
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('field', [
+            ['deepField', [['x', 'a and b are different fields']]],
+          ]),
+          locations: [
+            { line: 3, column: 9 },
+            { line: 4, column: 11 },
+            { line: 5, column: 13 },
+            { line: 8, column: 9 },
+            { line: 9, column: 11 },
+            { line: 10, column: 13 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('reports deep conflict to nearest common ancestor', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         field {
           deepField {
@@ -361,21 +453,28 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'deepField', [ [ 'x', 'a and b are different fields' ] ]
-        ),
-        locations: [
-          { line: 4, column: 11 },
-          { line: 5, column: 13 },
-          { line: 7, column: 11 },
-          { line: 8, column: 13 } ],
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('deepField', [
+            ['x', 'a and b are different fields'],
+          ]),
+          locations: [
+            { line: 4, column: 11 },
+            { line: 5, column: 13 },
+            { line: 7, column: 11 },
+            { line: 8, column: 13 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('reports deep conflict to nearest common ancestor in fragments', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         field {
           ...F
@@ -399,21 +498,28 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'deeperField', [ [ 'x', 'a and b are different fields' ] ]
-        ),
-        locations: [
-          { line: 12, column: 11 },
-          { line: 13, column: 13 },
-          { line: 15, column: 11 },
-          { line: 16, column: 13 } ],
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('deeperField', [
+            ['x', 'a and b are different fields'],
+          ]),
+          locations: [
+            { line: 12, column: 11 },
+            { line: 13, column: 13 },
+            { line: 15, column: 11 },
+            { line: 16, column: 13 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('reports deep conflict in nested fragments', () => {
-    expectFailsRule(OverlappingFieldsCanBeMerged, `
+    expectFailsRule(
+      OverlappingFieldsCanBeMerged,
+      `
       {
         field {
           ...F
@@ -436,24 +542,31 @@ describe('Validate: Overlapping fields can be merged', () => {
       fragment J on T {
         x: b
       }
-    `, [
-      { message: fieldsConflictMessage(
-          'field', [ [ 'x', 'a and b are different fields' ],
-                     [ 'y', 'c and d are different fields' ] ]
-        ),
-        locations: [
-          { line: 3, column: 9 },
-          { line: 11, column: 9 },
-          { line: 15, column: 9 },
-          { line: 6, column: 9 },
-          { line: 22, column: 9 },
-          { line: 18, column: 9 } ],
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          message: fieldsConflictMessage('field', [
+            ['x', 'a and b are different fields'],
+            ['y', 'c and d are different fields'],
+          ]),
+          locations: [
+            { line: 3, column: 9 },
+            { line: 11, column: 9 },
+            { line: 15, column: 9 },
+            { line: 6, column: 9 },
+            { line: 22, column: 9 },
+            { line: 18, column: 9 },
+          ],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('ignores unknown fragments', () => {
-    expectPassesRule(OverlappingFieldsCanBeMerged, `
+    expectPassesRule(
+      OverlappingFieldsCanBeMerged,
+      `
     {
       field
       ...Unknown
@@ -464,23 +577,23 @@ describe('Validate: Overlapping fields can be merged', () => {
       field
       ...OtherUnknown
     }
-    `);
+    `,
+    );
   });
 
   describe('return types must be unambiguous', () => {
-
     const SomeBox = new GraphQLInterfaceType({
       name: 'SomeBox',
       resolveType: () => StringBox,
       fields: () => ({
         deepBox: { type: SomeBox },
-        unrelatedField: { type: GraphQLString }
-      })
+        unrelatedField: { type: GraphQLString },
+      }),
     });
 
     const StringBox = new GraphQLObjectType({
       name: 'StringBox',
-      interfaces: [ SomeBox ],
+      interfaces: [SomeBox],
       fields: () => ({
         scalar: { type: GraphQLString },
         deepBox: { type: StringBox },
@@ -488,12 +601,12 @@ describe('Validate: Overlapping fields can be merged', () => {
         listStringBox: { type: new GraphQLList(StringBox) },
         stringBox: { type: StringBox },
         intBox: { type: IntBox },
-      })
+      }),
     });
 
     const IntBox = new GraphQLObjectType({
       name: 'IntBox',
-      interfaces: [ SomeBox ],
+      interfaces: [SomeBox],
       fields: () => ({
         scalar: { type: GraphQLInt },
         deepBox: { type: IntBox },
@@ -501,65 +614,67 @@ describe('Validate: Overlapping fields can be merged', () => {
         listStringBox: { type: new GraphQLList(StringBox) },
         stringBox: { type: StringBox },
         intBox: { type: IntBox },
-      })
+      }),
     });
 
     const NonNullStringBox1 = new GraphQLInterfaceType({
       name: 'NonNullStringBox1',
       resolveType: () => StringBox,
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) }
-      }
+        scalar: { type: new GraphQLNonNull(GraphQLString) },
+      },
     });
 
     const NonNullStringBox1Impl = new GraphQLObjectType({
       name: 'NonNullStringBox1Impl',
-      interfaces: [ SomeBox, NonNullStringBox1 ],
+      interfaces: [SomeBox, NonNullStringBox1],
       fields: {
         scalar: { type: new GraphQLNonNull(GraphQLString) },
         unrelatedField: { type: GraphQLString },
         deepBox: { type: SomeBox },
-      }
+      },
     });
 
     const NonNullStringBox2 = new GraphQLInterfaceType({
       name: 'NonNullStringBox2',
       resolveType: () => StringBox,
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) }
-      }
+        scalar: { type: new GraphQLNonNull(GraphQLString) },
+      },
     });
 
     const NonNullStringBox2Impl = new GraphQLObjectType({
       name: 'NonNullStringBox2Impl',
-      interfaces: [ SomeBox, NonNullStringBox2 ],
+      interfaces: [SomeBox, NonNullStringBox2],
       fields: {
         scalar: { type: new GraphQLNonNull(GraphQLString) },
         unrelatedField: { type: GraphQLString },
         deepBox: { type: SomeBox },
-      }
+      },
     });
 
     const Connection = new GraphQLObjectType({
       name: 'Connection',
       fields: {
         edges: {
-          type: new GraphQLList(new GraphQLObjectType({
-            name: 'Edge',
-            fields: {
-              node: {
-                type: new GraphQLObjectType({
-                  name: 'Node',
-                  fields: {
-                    id: { type: GraphQLID },
-                    name: { type: GraphQLString }
-                  }
-                })
-              }
-            }
-          }))
-        }
-      }
+          type: new GraphQLList(
+            new GraphQLObjectType({
+              name: 'Edge',
+              fields: {
+                node: {
+                  type: new GraphQLObjectType({
+                    name: 'Node',
+                    fields: {
+                      id: { type: GraphQLID },
+                      name: { type: GraphQLString },
+                    },
+                  }),
+                },
+              },
+            }),
+          ),
+        },
+      },
     });
 
     const schema = new GraphQLSchema({
@@ -567,10 +682,10 @@ describe('Validate: Overlapping fields can be merged', () => {
         name: 'QueryRoot',
         fields: () => ({
           someBox: { type: SomeBox },
-          connection: { type: Connection }
-        })
+          connection: { type: Connection },
+        }),
       }),
-      types: [ IntBox, StringBox, NonNullStringBox1Impl, NonNullStringBox2Impl ]
+      types: [IntBox, StringBox, NonNullStringBox1Impl, NonNullStringBox2Impl],
     });
 
     it('conflicting return types which potentially overlap', () => {
@@ -578,7 +693,10 @@ describe('Validate: Overlapping fields can be merged', () => {
       // type IntBox and the interface type NonNullStringBox1. While that
       // condition does not exist in the current schema, the schema could
       // expand in the future to allow this. Thus it is invalid.
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ...on IntBox {
@@ -589,21 +707,28 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'scalar',
-            'they return conflicting types Int and String!'
-          ),
-          locations: [ { line: 5, column: 15 }, { line: 8, column: 15 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage(
+              'scalar',
+              'they return conflicting types Int and String!',
+            ),
+            locations: [{ line: 5, column: 15 }, { line: 8, column: 15 }],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('compatible return shapes on different return types', () => {
       // In this case `deepBox` returns `SomeBox` in the first usage, and
       // `StringBox` in the second usage. These return types are not the same!
       // however this is valid because the return *shapes* are compatible.
-      expectPassesRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectPassesRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
       {
         someBox {
           ... on SomeBox {
@@ -618,11 +743,15 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-      `);
+      `,
+      );
     });
 
     it('disallows differing return types despite no overlap', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -633,18 +762,25 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'scalar',
-            'they return conflicting types Int and String'
-          ),
-          locations: [ { line: 5, column: 15 }, { line: 8, column: 15 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage(
+              'scalar',
+              'they return conflicting types Int and String',
+            ),
+            locations: [{ line: 5, column: 15 }, { line: 8, column: 15 }],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('reports correctly when a non-exclusive follows an exclusive', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -687,23 +823,29 @@ describe('Validate: Overlapping fields can be merged', () => {
         fragment Y on SomeBox {
           scalar: unrelatedField
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'other',
-            [ [ 'scalar', 'scalar and unrelatedField are different fields' ] ]
-          ),
-          locations: [
-            { line: 31, column: 11 },
-            { line: 39, column: 11 },
-            { line: 34, column: 11 },
-            { line: 42, column: 11 },
-          ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage('other', [
+              ['scalar', 'scalar and unrelatedField are different fields'],
+            ]),
+            locations: [
+              { line: 31, column: 11 },
+              { line: 39, column: 11 },
+              { line: 34, column: 11 },
+              { line: 42, column: 11 },
+            ],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('disallows differing return type nullability despite no overlap', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on NonNullStringBox1 {
@@ -714,18 +856,25 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'scalar',
-            'they return conflicting types String! and String'
-          ),
-          locations: [ { line: 5, column: 15 }, { line: 8, column: 15 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage(
+              'scalar',
+              'they return conflicting types String! and String',
+            ),
+            locations: [{ line: 5, column: 15 }, { line: 8, column: 15 }],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('disallows differing return type list despite no overlap', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -740,16 +889,23 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'box',
-            'they return conflicting types [StringBox] and StringBox'
-          ),
-          locations: [ { line: 5, column: 15 }, { line: 10, column: 15 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage(
+              'box',
+              'they return conflicting types [StringBox] and StringBox',
+            ),
+            locations: [{ line: 5, column: 15 }, { line: 10, column: 15 }],
+            path: undefined,
+          },
+        ],
+      );
 
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -764,18 +920,25 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'box',
-            'they return conflicting types StringBox and [StringBox]'
-          ),
-          locations: [ { line: 5, column: 15 }, { line: 10, column: 15 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage(
+              'box',
+              'they return conflicting types StringBox and [StringBox]',
+            ),
+            locations: [{ line: 5, column: 15 }, { line: 10, column: 15 }],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('disallows differing subfields', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -791,18 +954,25 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'val',
-            'scalar and unrelatedField are different fields'
-          ),
-          locations: [ { line: 6, column: 17 }, { line: 7, column: 17 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage(
+              'val',
+              'scalar and unrelatedField are different fields',
+            ),
+            locations: [{ line: 6, column: 17 }, { line: 7, column: 17 }],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('disallows differing deep return types despite no overlap', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -817,22 +987,29 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'box',
-            [ [ 'scalar', 'they return conflicting types String and Int' ] ]
-          ),
-          locations: [
-            { line: 5, column: 15 },
-            { line: 6, column: 17 },
-            { line: 10, column: 15 },
-            { line: 11, column: 17 } ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage('box', [
+              ['scalar', 'they return conflicting types String and Int'],
+            ]),
+            locations: [
+              { line: 5, column: 15 },
+              { line: 6, column: 17 },
+              { line: 10, column: 15 },
+              { line: 11, column: 17 },
+            ],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('allows non-conflicting overlaping types', () => {
-      expectPassesRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectPassesRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ... on IntBox {
@@ -843,11 +1020,15 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `);
+      `,
+      );
     });
 
     it('same wrapped scalar return types', () => {
-      expectPassesRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectPassesRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ...on NonNullStringBox1 {
@@ -858,22 +1039,30 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `);
+      `,
+      );
     });
 
     it('allows inline typeless fragments', () => {
-      expectPassesRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectPassesRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           a
           ... {
             a
           }
         }
-      `);
+      `,
+      );
     });
 
     it('compares deep types including list', () => {
-      expectFailsRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectFailsRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           connection {
             ...edgeID
@@ -892,25 +1081,31 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `, [
-        { message: fieldsConflictMessage(
-            'edges',
-            [ [ 'node', [ [ 'id', 'name and id are different fields' ] ] ] ]
-          ),
-          locations: [
-            { line: 5, column: 13 },
-            { line: 6, column: 15 },
-            { line: 7, column: 17 },
-            { line: 14, column: 11 },
-            { line: 15, column: 13 },
-            { line: 16, column: 15 },
-          ],
-          path: undefined }
-      ]);
+      `,
+        [
+          {
+            message: fieldsConflictMessage('edges', [
+              ['node', [['id', 'name and id are different fields']]],
+            ]),
+            locations: [
+              { line: 5, column: 13 },
+              { line: 6, column: 15 },
+              { line: 7, column: 17 },
+              { line: 14, column: 11 },
+              { line: 15, column: 13 },
+              { line: 16, column: 15 },
+            ],
+            path: undefined,
+          },
+        ],
+      );
     });
 
     it('ignores unknown types', () => {
-      expectPassesRuleWithSchema(schema, OverlappingFieldsCanBeMerged, `
+      expectPassesRuleWithSchema(
+        schema,
+        OverlappingFieldsCanBeMerged,
+        `
         {
           someBox {
             ...on UnknownType {
@@ -921,7 +1116,8 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         }
-      `);
+      `,
+      );
     });
 
     it('error message contains hint for alias conflict', () => {
@@ -930,7 +1126,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       const error = fieldsConflictMessage('x', 'a and b are different fields');
       expect(error).to.equal(
         'Fields "x" conflict because a and b are different fields. Use ' +
-        'different aliases on the fields to fetch both if this was intentional.'
+          'different aliases on the fields to fetch both if this was intentional.',
       );
     });
 
@@ -939,9 +1135,9 @@ describe('Validate: Overlapping fields can be merged', () => {
         name: 'Foo',
         fields: {
           constructor: {
-            type: GraphQLString
+            type: GraphQLString,
           },
-        }
+        },
       });
 
       const schemaWithKeywords = new GraphQLSchema({
@@ -949,7 +1145,7 @@ describe('Validate: Overlapping fields can be merged', () => {
           name: 'Query',
           fields: () => ({
             foo: { type: FooType },
-          })
+          }),
         }),
       });
 
@@ -960,9 +1156,8 @@ describe('Validate: Overlapping fields can be merged', () => {
           foo {
             constructor
           }
-        }`
+        }`,
       );
     });
   });
-
 });

--- a/src/validation/__tests__/PossibleFragmentSpreads-test.js
+++ b/src/validation/__tests__/PossibleFragmentSpreads-test.js
@@ -13,11 +13,10 @@ import {
   typeIncompatibleAnonSpreadMessage,
 } from '../rules/PossibleFragmentSpreads';
 
-
 function error(fragName, parentType, fragType, line, column) {
   return {
     message: typeIncompatibleSpreadMessage(fragName, parentType, fragType),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
@@ -25,167 +24,242 @@ function error(fragName, parentType, fragType, line, column) {
 function errorAnon(parentType, fragType, line, column) {
   return {
     message: typeIncompatibleAnonSpreadMessage(parentType, fragType),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Possible fragment spreads', () => {
-
   it('of the same object', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment objectWithinObject on Dog { ...dogFragment }
       fragment dogFragment on Dog { barkVolume }
-    `);
+    `,
+    );
   });
 
   it('of the same object with inline fragment', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment objectWithinObjectAnon on Dog { ... on Dog { barkVolume } }
-    `);
+    `,
+    );
   });
 
   it('object into an implemented interface', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment objectWithinInterface on Pet { ...dogFragment }
       fragment dogFragment on Dog { barkVolume }
-    `);
+    `,
+    );
   });
 
   it('object into containing union', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment objectWithinUnion on CatOrDog { ...dogFragment }
       fragment dogFragment on Dog { barkVolume }
-    `);
+    `,
+    );
   });
 
   it('union into contained object', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment unionWithinObject on Dog { ...catOrDogFragment }
       fragment catOrDogFragment on CatOrDog { __typename }
-    `);
+    `,
+    );
   });
 
   it('union into overlapping interface', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment unionWithinInterface on Pet { ...catOrDogFragment }
       fragment catOrDogFragment on CatOrDog { __typename }
-    `);
+    `,
+    );
   });
 
   it('union into overlapping union', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment unionWithinUnion on DogOrHuman { ...catOrDogFragment }
       fragment catOrDogFragment on CatOrDog { __typename }
-    `);
+    `,
+    );
   });
 
   it('interface into implemented object', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment interfaceWithinObject on Dog { ...petFragment }
       fragment petFragment on Pet { name }
-    `);
+    `,
+    );
   });
 
   it('interface into overlapping interface', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment interfaceWithinInterface on Pet { ...beingFragment }
       fragment beingFragment on Being { name }
-    `);
+    `,
+    );
   });
 
   it('interface into overlapping interface in inline fragment', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment interfaceWithinInterface on Pet { ... on Being { name } }
-    `);
+    `,
+    );
   });
 
   it('interface into overlapping union', () => {
-    expectPassesRule(PossibleFragmentSpreads, `
+    expectPassesRule(
+      PossibleFragmentSpreads,
+      `
       fragment interfaceWithinUnion on CatOrDog { ...petFragment }
       fragment petFragment on Pet { name }
-    `);
+    `,
+    );
   });
 
   it('different object into object', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidObjectWithinObject on Cat { ...dogFragment }
       fragment dogFragment on Dog { barkVolume }
-    `, [ error('dogFragment', 'Cat', 'Dog', 2, 51) ]);
+    `,
+      [error('dogFragment', 'Cat', 'Dog', 2, 51)],
+    );
   });
 
   it('different object into object in inline fragment', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidObjectWithinObjectAnon on Cat {
         ... on Dog { barkVolume }
       }
-    `, [ errorAnon('Cat', 'Dog', 3, 9) ]);
+    `,
+      [errorAnon('Cat', 'Dog', 3, 9)],
+    );
   });
 
   it('object into not implementing interface', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidObjectWithinInterface on Pet { ...humanFragment }
       fragment humanFragment on Human { pets { name } }
-    `, [ error('humanFragment', 'Pet', 'Human', 2, 54) ]);
+    `,
+      [error('humanFragment', 'Pet', 'Human', 2, 54)],
+    );
   });
 
   it('object into not containing union', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidObjectWithinUnion on CatOrDog { ...humanFragment }
       fragment humanFragment on Human { pets { name } }
-    `, [ error('humanFragment', 'CatOrDog', 'Human', 2, 55) ]);
+    `,
+      [error('humanFragment', 'CatOrDog', 'Human', 2, 55)],
+    );
   });
 
   it('union into not contained object', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidUnionWithinObject on Human { ...catOrDogFragment }
       fragment catOrDogFragment on CatOrDog { __typename }
-    `, [ error('catOrDogFragment', 'Human', 'CatOrDog', 2, 52) ]);
+    `,
+      [error('catOrDogFragment', 'Human', 'CatOrDog', 2, 52)],
+    );
   });
 
   it('union into non overlapping interface', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidUnionWithinInterface on Pet { ...humanOrAlienFragment }
       fragment humanOrAlienFragment on HumanOrAlien { __typename }
-    `, [ error('humanOrAlienFragment', 'Pet', 'HumanOrAlien', 2, 53) ]);
+    `,
+      [error('humanOrAlienFragment', 'Pet', 'HumanOrAlien', 2, 53)],
+    );
   });
 
   it('union into non overlapping union', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidUnionWithinUnion on CatOrDog { ...humanOrAlienFragment }
       fragment humanOrAlienFragment on HumanOrAlien { __typename }
-    `, [ error('humanOrAlienFragment', 'CatOrDog', 'HumanOrAlien', 2, 54) ]);
+    `,
+      [error('humanOrAlienFragment', 'CatOrDog', 'HumanOrAlien', 2, 54)],
+    );
   });
 
   it('interface into non implementing object', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidInterfaceWithinObject on Cat { ...intelligentFragment }
       fragment intelligentFragment on Intelligent { iq }
-    `, [ error('intelligentFragment', 'Cat', 'Intelligent', 2, 54) ]);
+    `,
+      [error('intelligentFragment', 'Cat', 'Intelligent', 2, 54)],
+    );
   });
 
   it('interface into non overlapping interface', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidInterfaceWithinInterface on Pet {
         ...intelligentFragment
       }
       fragment intelligentFragment on Intelligent { iq }
-    `, [ error('intelligentFragment', 'Pet', 'Intelligent', 3, 9) ]);
+    `,
+      [error('intelligentFragment', 'Pet', 'Intelligent', 3, 9)],
+    );
   });
 
   it('interface into non overlapping interface in inline fragment', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidInterfaceWithinInterfaceAnon on Pet {
         ...on Intelligent { iq }
       }
-    `, [ errorAnon('Pet', 'Intelligent', 3, 9) ]);
+    `,
+      [errorAnon('Pet', 'Intelligent', 3, 9)],
+    );
   });
 
   it('interface into non overlapping union', () => {
-    expectFailsRule(PossibleFragmentSpreads, `
+    expectFailsRule(
+      PossibleFragmentSpreads,
+      `
       fragment invalidInterfaceWithinUnion on HumanOrAlien { ...petFragment }
       fragment petFragment on Pet { name }
-    `, [ error('petFragment', 'HumanOrAlien', 'Pet', 2, 62) ]);
+    `,
+      [error('petFragment', 'HumanOrAlien', 'Pet', 2, 62)],
+    );
   });
-
 });

--- a/src/validation/__tests__/ProvidedNonNullArguments-test.js
+++ b/src/validation/__tests__/ProvidedNonNullArguments-test.js
@@ -13,11 +13,10 @@ import {
   missingDirectiveArgMessage,
 } from '../rules/ProvidedNonNullArguments';
 
-
 function missingFieldArg(fieldName, argName, typeName, line, column) {
   return {
     message: missingFieldArgMessage(fieldName, argName, typeName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
@@ -25,181 +24,220 @@ function missingFieldArg(fieldName, argName, typeName, line, column) {
 function missingDirectiveArg(directiveName, argName, typeName, line, column) {
   return {
     message: missingDirectiveArgMessage(directiveName, argName, typeName),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Provided required arguments', () => {
-
   it('ignores unknown arguments', () => {
-    expectPassesRule(ProvidedNonNullArguments, `
+    expectPassesRule(
+      ProvidedNonNullArguments,
+      `
       {
         dog {
           isHousetrained(unknownArgument: true)
         }
       }
-    `);
+    `,
+    );
   });
 
   describe('Valid non-nullable value', () => {
-
     it('Arg on optional arg', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           dog {
             isHousetrained(atOtherHomes: true)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('No Arg on optional arg', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           dog {
             isHousetrained
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple args', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleReqs(req1: 1, req2: 2)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple args reverse order', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleReqs(req2: 2, req1: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('No args on multiple optional', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleOpts
           }
         }
-      `);
+      `,
+      );
     });
 
     it('One arg on multiple optional', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleOpts(opt1: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Second arg on multiple optional', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleOpts(opt2: 1)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple reqs on mixedList', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleOptAndReq(req1: 3, req2: 4)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('Multiple reqs and one opt on mixedList', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
           }
         }
-      `);
+      `,
+      );
     });
 
     it('All reqs and opts on mixedList', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
           }
         }
-      `);
+      `,
+      );
     });
-
   });
 
-
   describe('Invalid non-nullable value', () => {
-
     it('Missing one non-nullable argument', () => {
-      expectFailsRule(ProvidedNonNullArguments, `
+      expectFailsRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleReqs(req2: 2)
           }
         }
-      `, [
-        missingFieldArg('multipleReqs', 'req1', 'Int!', 4, 13)
-      ]);
+      `,
+        [missingFieldArg('multipleReqs', 'req1', 'Int!', 4, 13)],
+      );
     });
 
     it('Missing multiple non-nullable arguments', () => {
-      expectFailsRule(ProvidedNonNullArguments, `
+      expectFailsRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleReqs
           }
         }
-      `, [
-        missingFieldArg('multipleReqs', 'req1', 'Int!', 4, 13),
-        missingFieldArg('multipleReqs', 'req2', 'Int!', 4, 13),
-      ]);
+      `,
+        [
+          missingFieldArg('multipleReqs', 'req1', 'Int!', 4, 13),
+          missingFieldArg('multipleReqs', 'req2', 'Int!', 4, 13),
+        ],
+      );
     });
 
     it('Incorrect value and missing argument', () => {
-      expectFailsRule(ProvidedNonNullArguments, `
+      expectFailsRule(
+        ProvidedNonNullArguments,
+        `
         {
           complicatedArgs {
             multipleReqs(req1: "one")
           }
         }
-      `, [
-        missingFieldArg('multipleReqs', 'req2', 'Int!', 4, 13),
-      ]);
+      `,
+        [missingFieldArg('multipleReqs', 'req2', 'Int!', 4, 13)],
+      );
     });
-
   });
 
   describe('Directive arguments', () => {
-
     it('ignores unknown directives', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           dog @unknown
         }
-      `);
+      `,
+      );
     });
 
     it('with directives of valid types', () => {
-      expectPassesRule(ProvidedNonNullArguments, `
+      expectPassesRule(
+        ProvidedNonNullArguments,
+        `
         {
           dog @include(if: true) {
             name
@@ -208,22 +246,25 @@ describe('Validate: Provided required arguments', () => {
             name
           }
         }
-      `);
+      `,
+      );
     });
 
     it('with directive with missing types', () => {
-      expectFailsRule(ProvidedNonNullArguments, `
+      expectFailsRule(
+        ProvidedNonNullArguments,
+        `
         {
           dog @include {
             name @skip
           }
         }
-      `, [
-        missingDirectiveArg('include', 'if', 'Boolean!', 3, 15),
-        missingDirectiveArg('skip', 'if', 'Boolean!', 4, 18)
-      ]);
+      `,
+        [
+          missingDirectiveArg('include', 'if', 'Boolean!', 3, 15),
+          missingDirectiveArg('skip', 'if', 'Boolean!', 4, 18),
+        ],
+      );
     });
-
   });
-
 });

--- a/src/validation/__tests__/ScalarLeafs-test.js
+++ b/src/validation/__tests__/ScalarLeafs-test.js
@@ -13,11 +13,10 @@ import {
   requiredSubselectionMessage,
 } from '../rules/ScalarLeafs';
 
-
 function noScalarSubselection(field, type, line, column) {
   return {
     message: noSubselectionAllowedMessage(field, type),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
@@ -25,88 +24,115 @@ function noScalarSubselection(field, type, line, column) {
 function missingObjSubselection(field, type, line, column) {
   return {
     message: requiredSubselectionMessage(field, type),
-    locations: [ { line, column } ],
+    locations: [{ line, column }],
     path: undefined,
   };
 }
 
 describe('Validate: Scalar leafs', () => {
-
   it('valid scalar selection', () => {
-    expectPassesRule(ScalarLeafs, `
+    expectPassesRule(
+      ScalarLeafs,
+      `
       fragment scalarSelection on Dog {
         barks
       }
-    `);
+    `,
+    );
   });
 
   it('object type missing selection', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       query directQueryOnObjectWithoutSubFields {
         human
       }
-    `, [ missingObjSubselection('human', 'Human', 3, 9) ]);
+    `,
+      [missingObjSubselection('human', 'Human', 3, 9)],
+    );
   });
 
   it('interface type missing selection', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       {
         human { pets }
       }
-    `, [ missingObjSubselection('pets', '[Pet]', 3, 17) ]);
+    `,
+      [missingObjSubselection('pets', '[Pet]', 3, 17)],
+    );
   });
 
   it('valid scalar selection with args', () => {
-    expectPassesRule(ScalarLeafs, `
+    expectPassesRule(
+      ScalarLeafs,
+      `
       fragment scalarSelectionWithArgs on Dog {
         doesKnowCommand(dogCommand: SIT)
       }
-    `);
+    `,
+    );
   });
 
   it('scalar selection not allowed on Boolean', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       fragment scalarSelectionsNotAllowedOnBoolean on Dog {
         barks { sinceWhen }
       }
     `,
-    [ noScalarSubselection('barks', 'Boolean', 3, 15) ] );
+      [noScalarSubselection('barks', 'Boolean', 3, 15)],
+    );
   });
 
   it('scalar selection not allowed on Enum', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       fragment scalarSelectionsNotAllowedOnEnum on Cat {
         furColor { inHexdec }
       }
     `,
-    [ noScalarSubselection('furColor', 'FurColor', 3, 18) ] );
+      [noScalarSubselection('furColor', 'FurColor', 3, 18)],
+    );
   });
 
   it('scalar selection not allowed with args', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       fragment scalarSelectionsNotAllowedWithArgs on Dog {
         doesKnowCommand(dogCommand: SIT) { sinceWhen }
       }
     `,
-    [ noScalarSubselection('doesKnowCommand', 'Boolean', 3, 42) ] );
+      [noScalarSubselection('doesKnowCommand', 'Boolean', 3, 42)],
+    );
   });
 
   it('Scalar selection not allowed with directives', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       fragment scalarSelectionsNotAllowedWithDirectives on Dog {
         name @include(if: true) { isAlsoHumanName }
       }
     `,
-    [ noScalarSubselection('name', 'String', 3, 33) ] );
+      [noScalarSubselection('name', 'String', 3, 33)],
+    );
   });
 
   it('Scalar selection not allowed with directives and args', () => {
-    expectFailsRule(ScalarLeafs, `
+    expectFailsRule(
+      ScalarLeafs,
+      `
       fragment scalarSelectionsNotAllowedWithDirectivesAndArgs on Dog {
         doesKnowCommand(dogCommand: SIT) @include(if: true) { sinceWhen }
       }
     `,
-    [ noScalarSubselection('doesKnowCommand', 'Boolean', 3, 61) ] );
+      [noScalarSubselection('doesKnowCommand', 'Boolean', 3, 61)],
+    );
   });
-
 });

--- a/src/validation/__tests__/SingleFieldSubscriptions-test.js
+++ b/src/validation/__tests__/SingleFieldSubscriptions-test.js
@@ -12,68 +12,92 @@ import {
   singleFieldOnlyMessage,
 } from '../rules/SingleFieldSubscriptions';
 
-
 describe('Validate: Subscriptions with single field', () => {
-
   it('valid subscription', () => {
-    expectPassesRule(SingleFieldSubscriptions, `
+    expectPassesRule(
+      SingleFieldSubscriptions,
+      `
       subscription ImportantEmails {
         importantEmails
       }
-    `);
+    `,
+    );
   });
 
   it('fails with more than one root field', () => {
-    expectFailsRule(SingleFieldSubscriptions, `
+    expectFailsRule(
+      SingleFieldSubscriptions,
+      `
       subscription ImportantEmails {
         importantEmails
         notImportantEmails
       }
-    `, [ {
-      message: singleFieldOnlyMessage('ImportantEmails'),
-      locations: [ { line: 4, column: 9 } ],
-      path: undefined,
-    } ]);
+    `,
+      [
+        {
+          message: singleFieldOnlyMessage('ImportantEmails'),
+          locations: [{ line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('fails with more than one root field including introspection', () => {
-    expectFailsRule(SingleFieldSubscriptions, `
+    expectFailsRule(
+      SingleFieldSubscriptions,
+      `
       subscription ImportantEmails {
         importantEmails
         __typename
       }
-    `, [ {
-      message: singleFieldOnlyMessage('ImportantEmails'),
-      locations: [ { line: 4, column: 9 } ],
-      path: undefined,
-    } ]);
+    `,
+      [
+        {
+          message: singleFieldOnlyMessage('ImportantEmails'),
+          locations: [{ line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('fails with many more than one root field', () => {
-    expectFailsRule(SingleFieldSubscriptions, `
+    expectFailsRule(
+      SingleFieldSubscriptions,
+      `
       subscription ImportantEmails {
         importantEmails
         notImportantEmails
         spamEmails
       }
-    `, [ {
-      message: singleFieldOnlyMessage('ImportantEmails'),
-      locations: [ { line: 4, column: 9 }, { line: 5, column: 9 } ],
-      path: undefined,
-    } ]);
+    `,
+      [
+        {
+          message: singleFieldOnlyMessage('ImportantEmails'),
+          locations: [{ line: 4, column: 9 }, { line: 5, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('fails with more than one root field in anonymous subscriptions', () => {
-    expectFailsRule(SingleFieldSubscriptions, `
+    expectFailsRule(
+      SingleFieldSubscriptions,
+      `
       subscription {
         importantEmails
         notImportantEmails
       }
-    `, [ {
-      message: singleFieldOnlyMessage(null),
-      locations: [ { line: 4, column: 9 } ],
-      path: undefined,
-    } ]);
+    `,
+      [
+        {
+          message: singleFieldOnlyMessage(null),
+          locations: [{ line: 4, column: 9 }],
+          path: undefined,
+        },
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/UniqueArgumentNames-test.js
+++ b/src/validation/__tests__/UniqueArgumentNames-test.js
@@ -12,130 +12,160 @@ import {
   duplicateArgMessage,
 } from '../rules/UniqueArgumentNames';
 
-
 function duplicateArg(argName, l1, c1, l2, c2) {
   return {
     message: duplicateArgMessage(argName),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: Unique argument names', () => {
-
   it('no arguments on field', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('no arguments on directive', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field @directive
       }
-    `);
+    `,
+    );
   });
 
   it('argument on field', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field(arg: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('argument on directive', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field @directive(arg: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('same argument on two fields', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         one: field(arg: "value")
         two: field(arg: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('same argument on field and directive', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field(arg: "value") @directive(arg: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('same argument on two directives', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field @directive1(arg: "value") @directive2(arg: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('multiple field arguments', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field(arg1: "value", arg2: "value", arg3: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('multiple directive arguments', () => {
-    expectPassesRule(UniqueArgumentNames, `
+    expectPassesRule(
+      UniqueArgumentNames,
+      `
       {
         field @directive(arg1: "value", arg2: "value", arg3: "value")
       }
-    `);
+    `,
+    );
   });
 
   it('duplicate field arguments', () => {
-    expectFailsRule(UniqueArgumentNames, `
+    expectFailsRule(
+      UniqueArgumentNames,
+      `
       {
         field(arg1: "value", arg1: "value")
       }
-    `, [
-      duplicateArg('arg1', 3, 15, 3, 30)
-    ]);
+    `,
+      [duplicateArg('arg1', 3, 15, 3, 30)],
+    );
   });
 
   it('many duplicate field arguments', () => {
-    expectFailsRule(UniqueArgumentNames, `
+    expectFailsRule(
+      UniqueArgumentNames,
+      `
       {
         field(arg1: "value", arg1: "value", arg1: "value")
       }
-    `, [
-      duplicateArg('arg1', 3, 15, 3, 30),
-      duplicateArg('arg1', 3, 15, 3, 45)
-    ]);
+    `,
+      [duplicateArg('arg1', 3, 15, 3, 30), duplicateArg('arg1', 3, 15, 3, 45)],
+    );
   });
 
   it('duplicate directive arguments', () => {
-    expectFailsRule(UniqueArgumentNames, `
+    expectFailsRule(
+      UniqueArgumentNames,
+      `
       {
         field @directive(arg1: "value", arg1: "value")
       }
-    `, [
-      duplicateArg('arg1', 3, 26, 3, 41)
-    ]);
+    `,
+      [duplicateArg('arg1', 3, 26, 3, 41)],
+    );
   });
 
   it('many duplicate directive arguments', () => {
-    expectFailsRule(UniqueArgumentNames, `
+    expectFailsRule(
+      UniqueArgumentNames,
+      `
       {
         field @directive(arg1: "value", arg1: "value", arg1: "value")
       }
-    `, [
-      duplicateArg('arg1', 3, 26, 3, 41),
-      duplicateArg('arg1', 3, 26, 3, 56)
-    ]);
+    `,
+      [duplicateArg('arg1', 3, 26, 3, 41), duplicateArg('arg1', 3, 26, 3, 56)],
+    );
   });
-
 });

--- a/src/validation/__tests__/UniqueDirectivesPerLocation-test.js
+++ b/src/validation/__tests__/UniqueDirectivesPerLocation-test.js
@@ -12,99 +12,125 @@ import {
   duplicateDirectiveMessage,
 } from '../rules/UniqueDirectivesPerLocation';
 
-
 function duplicateDirective(directiveName, l1, c1, l2, c2) {
   return {
     message: duplicateDirectiveMessage(directiveName),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: Directives Are Unique Per Location', () => {
-
   it('no directives', () => {
-    expectPassesRule(UniqueDirectivesPerLocation, `
+    expectPassesRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('unique directives in different locations', () => {
-    expectPassesRule(UniqueDirectivesPerLocation, `
+    expectPassesRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type @directiveA {
         field @directiveB
       }
-    `);
+    `,
+    );
   });
 
   it('unique directives in same locations', () => {
-    expectPassesRule(UniqueDirectivesPerLocation, `
+    expectPassesRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type @directiveA @directiveB {
         field @directiveA @directiveB
       }
-    `);
+    `,
+    );
   });
 
   it('same directives in different locations', () => {
-    expectPassesRule(UniqueDirectivesPerLocation, `
+    expectPassesRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type @directiveA {
         field @directiveA
       }
-    `);
+    `,
+    );
   });
 
   it('same directives in similar locations', () => {
-    expectPassesRule(UniqueDirectivesPerLocation, `
+    expectPassesRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type {
         field @directive
         field @directive
       }
-    `);
+    `,
+    );
   });
 
   it('duplicate directives in one location', () => {
-    expectFailsRule(UniqueDirectivesPerLocation, `
+    expectFailsRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type {
         field @directive @directive
       }
-    `, [
-      duplicateDirective('directive', 3, 15, 3, 26)
-    ]);
+    `,
+      [duplicateDirective('directive', 3, 15, 3, 26)],
+    );
   });
 
   it('many duplicate directives in one location', () => {
-    expectFailsRule(UniqueDirectivesPerLocation, `
+    expectFailsRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type {
         field @directive @directive @directive
       }
-    `, [
-      duplicateDirective('directive', 3, 15, 3, 26),
-      duplicateDirective('directive', 3, 15, 3, 37)
-    ]);
+    `,
+      [
+        duplicateDirective('directive', 3, 15, 3, 26),
+        duplicateDirective('directive', 3, 15, 3, 37),
+      ],
+    );
   });
 
   it('different duplicate directives in one location', () => {
-    expectFailsRule(UniqueDirectivesPerLocation, `
+    expectFailsRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type {
         field @directiveA @directiveB @directiveA @directiveB
       }
-    `, [
-      duplicateDirective('directiveA', 3, 15, 3, 39),
-      duplicateDirective('directiveB', 3, 27, 3, 51)
-    ]);
+    `,
+      [
+        duplicateDirective('directiveA', 3, 15, 3, 39),
+        duplicateDirective('directiveB', 3, 27, 3, 51),
+      ],
+    );
   });
 
   it('duplicate directives in many locations', () => {
-    expectFailsRule(UniqueDirectivesPerLocation, `
+    expectFailsRule(
+      UniqueDirectivesPerLocation,
+      `
       fragment Test on Type @directive @directive {
         field @directive @directive
       }
-    `, [
-      duplicateDirective('directive', 2, 29, 2, 40),
-      duplicateDirective('directive', 3, 15, 3, 26)
-    ]);
+    `,
+      [
+        duplicateDirective('directive', 2, 29, 2, 40),
+        duplicateDirective('directive', 3, 15, 3, 26),
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/UniqueFragmentNames-test.js
+++ b/src/validation/__tests__/UniqueFragmentNames-test.js
@@ -12,27 +12,30 @@ import {
   duplicateFragmentNameMessage,
 } from '../rules/UniqueFragmentNames';
 
-
 function duplicateFrag(fragName, l1, c1, l2, c2) {
   return {
     message: duplicateFragmentNameMessage(fragName),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: Unique fragment names', () => {
-
   it('no fragments', () => {
-    expectPassesRule(UniqueFragmentNames, `
+    expectPassesRule(
+      UniqueFragmentNames,
+      `
       {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('one fragment', () => {
-    expectPassesRule(UniqueFragmentNames, `
+    expectPassesRule(
+      UniqueFragmentNames,
+      `
       {
         ...fragA
       }
@@ -40,11 +43,14 @@ describe('Validate: Unique fragment names', () => {
       fragment fragA on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('many fragments', () => {
-    expectPassesRule(UniqueFragmentNames, `
+    expectPassesRule(
+      UniqueFragmentNames,
+      `
       {
         ...fragA
         ...fragB
@@ -59,11 +65,14 @@ describe('Validate: Unique fragment names', () => {
       fragment fragC on Type {
         fieldC
       }
-    `);
+    `,
+    );
   });
 
   it('inline fragments are always unique', () => {
-    expectPassesRule(UniqueFragmentNames, `
+    expectPassesRule(
+      UniqueFragmentNames,
+      `
       {
         ...on Type {
           fieldA
@@ -72,22 +81,28 @@ describe('Validate: Unique fragment names', () => {
           fieldB
         }
       }
-    `);
+    `,
+    );
   });
 
   it('fragment and operation named the same', () => {
-    expectPassesRule(UniqueFragmentNames, `
+    expectPassesRule(
+      UniqueFragmentNames,
+      `
       query Foo {
         ...Foo
       }
       fragment Foo on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('fragments named the same', () => {
-    expectFailsRule(UniqueFragmentNames, `
+    expectFailsRule(
+      UniqueFragmentNames,
+      `
       {
         ...fragA
       }
@@ -97,22 +112,23 @@ describe('Validate: Unique fragment names', () => {
       fragment fragA on Type {
         fieldB
       }
-    `, [
-      duplicateFrag('fragA', 5, 16, 8, 16)
-    ]);
+    `,
+      [duplicateFrag('fragA', 5, 16, 8, 16)],
+    );
   });
 
   it('fragments named the same without being referenced', () => {
-    expectFailsRule(UniqueFragmentNames, `
+    expectFailsRule(
+      UniqueFragmentNames,
+      `
       fragment fragA on Type {
         fieldA
       }
       fragment fragA on Type {
         fieldB
       }
-    `, [
-      duplicateFrag('fragA', 2, 16, 5, 16)
-    ]);
+    `,
+      [duplicateFrag('fragA', 2, 16, 5, 16)],
+    );
   });
-
 });

--- a/src/validation/__tests__/UniqueInputFieldNames-test.js
+++ b/src/validation/__tests__/UniqueInputFieldNames-test.js
@@ -12,43 +12,52 @@ import {
   duplicateInputFieldMessage,
 } from '../rules/UniqueInputFieldNames';
 
-
 function duplicateField(name, l1, c1, l2, c2) {
   return {
     message: duplicateInputFieldMessage(name),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: Unique input field names', () => {
-
   it('input object with fields', () => {
-    expectPassesRule(UniqueInputFieldNames, `
+    expectPassesRule(
+      UniqueInputFieldNames,
+      `
       {
         field(arg: { f: true })
       }
-    `);
+    `,
+    );
   });
 
   it('same input object within two args', () => {
-    expectPassesRule(UniqueInputFieldNames, `
+    expectPassesRule(
+      UniqueInputFieldNames,
+      `
       {
         field(arg1: { f: true }, arg2: { f: true })
       }
-    `);
+    `,
+    );
   });
 
   it('multiple input object fields', () => {
-    expectPassesRule(UniqueInputFieldNames, `
+    expectPassesRule(
+      UniqueInputFieldNames,
+      `
       {
         field(arg: { f1: "value", f2: "value", f3: "value" })
       }
-    `);
+    `,
+    );
   });
 
   it('allows for nested input objects with similar fields', () => {
-    expectPassesRule(UniqueInputFieldNames, `
+    expectPassesRule(
+      UniqueInputFieldNames,
+      `
       {
         field(arg: {
           deep: {
@@ -60,28 +69,31 @@ describe('Validate: Unique input field names', () => {
           id: 1
         })
       }
-    `);
+    `,
+    );
   });
 
   it('duplicate input object fields', () => {
-    expectFailsRule(UniqueInputFieldNames, `
+    expectFailsRule(
+      UniqueInputFieldNames,
+      `
       {
         field(arg: { f1: "value", f1: "value" })
       }
-    `, [
-      duplicateField('f1', 3, 22, 3, 35)
-    ]);
+    `,
+      [duplicateField('f1', 3, 22, 3, 35)],
+    );
   });
 
   it('many duplicate input object fields', () => {
-    expectFailsRule(UniqueInputFieldNames, `
+    expectFailsRule(
+      UniqueInputFieldNames,
+      `
       {
         field(arg: { f1: "value", f1: "value", f1: "value" })
       }
-    `, [
-      duplicateField('f1', 3, 22, 3, 35),
-      duplicateField('f1', 3, 22, 3, 48)
-    ]);
+    `,
+      [duplicateField('f1', 3, 22, 3, 35), duplicateField('f1', 3, 22, 3, 48)],
+    );
   });
-
 });

--- a/src/validation/__tests__/UniqueOperationNames-test.js
+++ b/src/validation/__tests__/UniqueOperationNames-test.js
@@ -12,43 +12,52 @@ import {
   duplicateOperationNameMessage,
 } from '../rules/UniqueOperationNames';
 
-
 function duplicateOp(opName, l1, c1, l2, c2) {
   return {
     message: duplicateOperationNameMessage(opName),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: Unique operation names', () => {
-
   it('no operations', () => {
-    expectPassesRule(UniqueOperationNames, `
+    expectPassesRule(
+      UniqueOperationNames,
+      `
       fragment fragA on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('one anon operation', () => {
-    expectPassesRule(UniqueOperationNames, `
+    expectPassesRule(
+      UniqueOperationNames,
+      `
       {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('one named operation', () => {
-    expectPassesRule(UniqueOperationNames, `
+    expectPassesRule(
+      UniqueOperationNames,
+      `
       query Foo {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('multiple operations', () => {
-    expectPassesRule(UniqueOperationNames, `
+    expectPassesRule(
+      UniqueOperationNames,
+      `
       query Foo {
         field
       }
@@ -56,11 +65,14 @@ describe('Validate: Unique operation names', () => {
       query Bar {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('multiple operations of different types', () => {
-    expectPassesRule(UniqueOperationNames, `
+    expectPassesRule(
+      UniqueOperationNames,
+      `
       query Foo {
         field
       }
@@ -72,57 +84,66 @@ describe('Validate: Unique operation names', () => {
       subscription Baz {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('fragment and operation named the same', () => {
-    expectPassesRule(UniqueOperationNames, `
+    expectPassesRule(
+      UniqueOperationNames,
+      `
       query Foo {
         ...Foo
       }
       fragment Foo on Type {
         field
       }
-    `);
+    `,
+    );
   });
 
   it('multiple operations of same name', () => {
-    expectFailsRule(UniqueOperationNames, `
+    expectFailsRule(
+      UniqueOperationNames,
+      `
       query Foo {
         fieldA
       }
       query Foo {
         fieldB
       }
-    `, [
-      duplicateOp('Foo', 2, 13, 5, 13)
-    ]);
+    `,
+      [duplicateOp('Foo', 2, 13, 5, 13)],
+    );
   });
 
   it('multiple ops of same name of different types (mutation)', () => {
-    expectFailsRule(UniqueOperationNames, `
+    expectFailsRule(
+      UniqueOperationNames,
+      `
       query Foo {
         fieldA
       }
       mutation Foo {
         fieldB
       }
-    `, [
-      duplicateOp('Foo', 2, 13, 5, 16)
-    ]);
+    `,
+      [duplicateOp('Foo', 2, 13, 5, 16)],
+    );
   });
 
   it('multiple ops of same name of different types (subscription)', () => {
-    expectFailsRule(UniqueOperationNames, `
+    expectFailsRule(
+      UniqueOperationNames,
+      `
       query Foo {
         fieldA
       }
       subscription Foo {
         fieldB
       }
-    `, [
-      duplicateOp('Foo', 2, 13, 5, 20)
-    ]);
+    `,
+      [duplicateOp('Foo', 2, 13, 5, 20)],
+    );
   });
-
 });

--- a/src/validation/__tests__/UniqueVariableNames-test.js
+++ b/src/validation/__tests__/UniqueVariableNames-test.js
@@ -12,35 +12,39 @@ import {
   duplicateVariableMessage,
 } from '../rules/UniqueVariableNames';
 
-
 function duplicateVariable(name, l1, c1, l2, c2) {
   return {
     message: duplicateVariableMessage(name),
-    locations: [ { line: l1, column: c1 }, { line: l2, column: c2 } ],
+    locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
     path: undefined,
   };
 }
 
 describe('Validate: Unique variable names', () => {
-
   it('unique variable names', () => {
-    expectPassesRule(UniqueVariableNames, `
+    expectPassesRule(
+      UniqueVariableNames,
+      `
       query A($x: Int, $y: String) { __typename }
       query B($x: String, $y: Int) { __typename }
-    `);
+    `,
+    );
   });
 
   it('duplicate variable names', () => {
-    expectFailsRule(UniqueVariableNames, `
+    expectFailsRule(
+      UniqueVariableNames,
+      `
       query A($x: Int, $x: Int, $x: String) { __typename }
       query B($x: String, $x: Int) { __typename }
       query C($x: Int, $x: Int) { __typename }
-    `, [
-      duplicateVariable('x', 2, 16, 2, 25),
-      duplicateVariable('x', 2, 16, 2, 34),
-      duplicateVariable('x', 3, 16, 3, 28),
-      duplicateVariable('x', 4, 16, 4, 25)
-    ]);
+    `,
+      [
+        duplicateVariable('x', 2, 16, 2, 25),
+        duplicateVariable('x', 2, 16, 2, 34),
+        duplicateVariable('x', 3, 16, 3, 28),
+        duplicateVariable('x', 4, 16, 4, 25),
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/VariablesAreInputTypes-test.js
+++ b/src/validation/__tests__/VariablesAreInputTypes-test.js
@@ -12,33 +12,43 @@ import {
   nonInputTypeOnVarMessage,
 } from '../rules/VariablesAreInputTypes';
 
-
 describe('Validate: Variables are input types', () => {
-
   it('input types are valid', () => {
-    expectPassesRule(VariablesAreInputTypes, `
+    expectPassesRule(
+      VariablesAreInputTypes,
+      `
       query Foo($a: String, $b: [Boolean!]!, $c: ComplexInput) {
         field(a: $a, b: $b, c: $c)
       }
-    `);
+    `,
+    );
   });
 
   it('output types are invalid', () => {
-    expectFailsRule(VariablesAreInputTypes, `
+    expectFailsRule(
+      VariablesAreInputTypes,
+      `
       query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {
         field(a: $a, b: $b, c: $c)
       }
-    `, [
-      { locations: [ { line: 2, column: 21 } ],
-        message: nonInputTypeOnVarMessage('a', 'Dog'),
-        path: undefined },
-      { locations: [ { line: 2, column: 30 } ],
-        message: nonInputTypeOnVarMessage('b', '[[CatOrDog!]]!'),
-        path: undefined },
-      { locations: [ { line: 2, column: 50 } ],
-        message: nonInputTypeOnVarMessage('c', 'Pet'),
-        path: undefined },
-    ]);
+    `,
+      [
+        {
+          locations: [{ line: 2, column: 21 }],
+          message: nonInputTypeOnVarMessage('a', 'Dog'),
+          path: undefined,
+        },
+        {
+          locations: [{ line: 2, column: 30 }],
+          message: nonInputTypeOnVarMessage('b', '[[CatOrDog!]]!'),
+          path: undefined,
+        },
+        {
+          locations: [{ line: 2, column: 50 }],
+          message: nonInputTypeOnVarMessage('c', 'Pet'),
+          path: undefined,
+        },
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/VariablesInAllowedPosition-test.js
+++ b/src/validation/__tests__/VariablesInAllowedPosition-test.js
@@ -12,22 +12,25 @@ import {
   badVarPosMessage,
 } from '../rules/VariablesInAllowedPosition';
 
-
 describe('Validate: Variables are in allowed positions', () => {
-
   it('Boolean => Boolean', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($booleanArg: Boolean)
       {
         complicatedArgs {
           booleanArgField(booleanArg: $booleanArg)
         }
       }
-    `);
+    `,
+    );
   });
 
   it('Boolean => Boolean within fragment', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       fragment booleanArgFrag on ComplicatedArgs {
         booleanArgField(booleanArg: $booleanArg)
       }
@@ -37,9 +40,12 @@ describe('Validate: Variables are in allowed positions', () => {
           ...booleanArgFrag
         }
       }
-    `);
+    `,
+    );
 
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($booleanArg: Boolean)
       {
         complicatedArgs {
@@ -49,22 +55,28 @@ describe('Validate: Variables are in allowed positions', () => {
       fragment booleanArgFrag on ComplicatedArgs {
         booleanArgField(booleanArg: $booleanArg)
       }
-    `);
+    `,
+    );
   });
 
   it('Boolean! => Boolean', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($nonNullBooleanArg: Boolean!)
       {
         complicatedArgs {
           booleanArgField(booleanArg: $nonNullBooleanArg)
         }
       }
-    `);
+    `,
+    );
   });
 
   it('Boolean! => Boolean within fragment', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       fragment booleanArgFrag on ComplicatedArgs {
         booleanArgField(booleanArg: $nonNullBooleanArg)
       }
@@ -75,120 +87,156 @@ describe('Validate: Variables are in allowed positions', () => {
           ...booleanArgFrag
         }
       }
-    `);
+    `,
+    );
   });
 
   it('Int => Int! with default', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($intArg: Int = 1)
       {
         complicatedArgs {
           nonNullIntArgField(nonNullIntArg: $intArg)
         }
       }
-    `);
+    `,
+    );
   });
 
   it('[String] => [String]', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringListVar: [String])
       {
         complicatedArgs {
           stringListArgField(stringListArg: $stringListVar)
         }
       }
-    `);
+    `,
+    );
   });
 
   it('[String!] => [String]', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringListVar: [String!])
       {
         complicatedArgs {
           stringListArgField(stringListArg: $stringListVar)
         }
       }
-    `);
+    `,
+    );
   });
 
   it('String => [String] in item position', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringVar: String)
       {
         complicatedArgs {
           stringListArgField(stringListArg: [$stringVar])
         }
       }
-    `);
+    `,
+    );
   });
 
   it('String! => [String] in item position', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringVar: String!)
       {
         complicatedArgs {
           stringListArgField(stringListArg: [$stringVar])
         }
       }
-    `);
+    `,
+    );
   });
 
   it('ComplexInput => ComplexInput', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($complexVar: ComplexInput)
       {
         complicatedArgs {
           complexArgField(complexArg: $complexVar)
         }
       }
-    `);
+    `,
+    );
   });
 
   it('ComplexInput => ComplexInput in field position', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($boolVar: Boolean = false)
       {
         complicatedArgs {
           complexArgField(complexArg: {requiredArg: $boolVar})
         }
       }
-    `);
+    `,
+    );
   });
 
   it('Boolean! => Boolean! in directive', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($boolVar: Boolean!)
       {
         dog @include(if: $boolVar)
       }
-    `);
+    `,
+    );
   });
 
   it('Boolean => Boolean! in directive with default', () => {
-    expectPassesRule(VariablesInAllowedPosition, `
+    expectPassesRule(
+      VariablesInAllowedPosition,
+      `
       query Query($boolVar: Boolean = false)
       {
         dog @include(if: $boolVar)
       }
-    `);
+    `,
+    );
   });
 
   it('Int => Int!', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       query Query($intArg: Int) {
         complicatedArgs {
           nonNullIntArgField(nonNullIntArg: $intArg)
         }
       }
-    `, [
-      { message: badVarPosMessage('intArg', 'Int', 'Int!'),
-        locations: [ { line: 2, column: 19 }, { line: 4, column: 45 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('intArg', 'Int', 'Int!'),
+          locations: [{ line: 2, column: 19 }, { line: 4, column: 45 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('Int => Int! within fragment', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       fragment nonNullIntArgFieldFrag on ComplicatedArgs {
         nonNullIntArgField(nonNullIntArg: $intArg)
       }
@@ -198,15 +246,21 @@ describe('Validate: Variables are in allowed positions', () => {
           ...nonNullIntArgFieldFrag
         }
       }
-    `, [
-      { message: badVarPosMessage('intArg', 'Int', 'Int!'),
-        locations: [ { line: 6, column: 19 }, { line: 3, column: 43 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('intArg', 'Int', 'Int!'),
+          locations: [{ line: 6, column: 19 }, { line: 3, column: 43 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('Int => Int! within nested fragment', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       fragment outerFrag on ComplicatedArgs {
         ...nonNullIntArgFieldFrag
       }
@@ -220,63 +274,90 @@ describe('Validate: Variables are in allowed positions', () => {
           ...outerFrag
         }
       }
-    `, [
-      { message: badVarPosMessage('intArg', 'Int', 'Int!'),
-        locations: [ { line: 10, column: 19 }, { line: 7, column: 43 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('intArg', 'Int', 'Int!'),
+          locations: [{ line: 10, column: 19 }, { line: 7, column: 43 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('String over Boolean', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringVar: String) {
         complicatedArgs {
           booleanArgField(booleanArg: $stringVar)
         }
       }
-    `, [
-      { message: badVarPosMessage('stringVar', 'String', 'Boolean'),
-        locations: [ { line: 2, column: 19 }, { line: 4, column: 39 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('stringVar', 'String', 'Boolean'),
+          locations: [{ line: 2, column: 19 }, { line: 4, column: 39 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('String => [String]', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringVar: String) {
         complicatedArgs {
           stringListArgField(stringListArg: $stringVar)
         }
       }
-    `, [
-      { message: badVarPosMessage('stringVar', 'String', '[String]'),
-        locations: [ { line: 2, column: 19 }, { line: 4, column: 45 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('stringVar', 'String', '[String]'),
+          locations: [{ line: 2, column: 19 }, { line: 4, column: 45 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('Boolean => Boolean! in directive', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       query Query($boolVar: Boolean) {
         dog @include(if: $boolVar)
       }
-    `, [
-      { message: badVarPosMessage('boolVar', 'Boolean', 'Boolean!'),
-        locations: [ { line: 2, column: 19 }, { line: 3, column: 26 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('boolVar', 'Boolean', 'Boolean!'),
+          locations: [{ line: 2, column: 19 }, { line: 3, column: 26 }],
+          path: undefined,
+        },
+      ],
+    );
   });
 
   it('String => Boolean! in directive', () => {
-    expectFailsRule(VariablesInAllowedPosition, `
+    expectFailsRule(
+      VariablesInAllowedPosition,
+      `
       query Query($stringVar: String) {
         dog @include(if: $stringVar)
       }
-    `, [
-      { message: badVarPosMessage('stringVar', 'String', 'Boolean!'),
-        locations: [ { line: 2, column: 19 }, { line: 3, column: 26 } ],
-        path: undefined }
-    ]);
+    `,
+      [
+        {
+          message: badVarPosMessage('stringVar', 'String', 'Boolean!'),
+          locations: [{ line: 2, column: 19 }, { line: 3, column: 26 }],
+          path: undefined,
+        },
+      ],
+    );
   });
-
 });

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -22,7 +22,7 @@ import {
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
-  GraphQLID
+  GraphQLID,
 } from '../../type';
 import {
   GraphQLDirective,
@@ -30,14 +30,13 @@ import {
   GraphQLSkipDirective,
 } from '../../type/directives';
 
-
 const Being = new GraphQLInterfaceType({
   name: 'Being',
   fields: () => ({
     name: {
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
-    }
+    },
   }),
 });
 
@@ -47,7 +46,7 @@ const Pet = new GraphQLInterfaceType({
     name: {
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
-    }
+    },
   }),
 });
 
@@ -57,7 +56,7 @@ const Canine = new GraphQLInterfaceType({
     name: {
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
-    }
+    },
   }),
 });
 
@@ -93,7 +92,7 @@ const Dog = new GraphQLObjectType({
         atOtherHomes: {
           type: GraphQLBoolean,
           defaultValue: true,
-        }
+        },
       },
     },
     isAtLocation: {
@@ -101,7 +100,7 @@ const Dog = new GraphQLObjectType({
       args: { x: { type: GraphQLInt }, y: { type: GraphQLInt } },
     },
   }),
-  interfaces: [ Being, Pet, Canine ],
+  interfaces: [Being, Pet, Canine],
 });
 
 const Cat = new GraphQLObjectType({
@@ -117,28 +116,28 @@ const Cat = new GraphQLObjectType({
     meowVolume: { type: GraphQLInt },
     furColor: { type: FurColor },
   }),
-  interfaces: [ Being, Pet ],
+  interfaces: [Being, Pet],
 });
 
 const CatOrDog = new GraphQLUnionType({
   name: 'CatOrDog',
-  types: [ Dog, Cat ],
+  types: [Dog, Cat],
   resolveType(/* value */) {
     // not used for validation
-  }
+  },
 });
 
 const Intelligent = new GraphQLInterfaceType({
   name: 'Intelligent',
   fields: {
-    iq: { type: GraphQLInt }
-  }
+    iq: { type: GraphQLInt },
+  },
 });
 
 const Human = new GraphQLObjectType({
   name: 'Human',
   isTypeOf: () => true,
-  interfaces: [ Being, Intelligent ],
+  interfaces: [Being, Intelligent],
   fields: () => ({
     name: {
       type: GraphQLString,
@@ -147,13 +146,13 @@ const Human = new GraphQLObjectType({
     pets: { type: new GraphQLList(Pet) },
     relatives: { type: new GraphQLList(Human) },
     iq: { type: GraphQLInt },
-  })
+  }),
 });
 
 const Alien = new GraphQLObjectType({
   name: 'Alien',
   isTypeOf: () => true,
-  interfaces: [ Being, Intelligent ],
+  interfaces: [Being, Intelligent],
   fields: {
     iq: { type: GraphQLInt },
     name: {
@@ -161,23 +160,23 @@ const Alien = new GraphQLObjectType({
       args: { surname: { type: GraphQLBoolean } },
     },
     numEyes: { type: GraphQLInt },
-  }
+  },
 });
 
 const DogOrHuman = new GraphQLUnionType({
   name: 'DogOrHuman',
-  types: [ Dog, Human ],
+  types: [Dog, Human],
   resolveType(/* value */) {
     // not used for validation
-  }
+  },
 });
 
 const HumanOrAlien = new GraphQLUnionType({
   name: 'HumanOrAlien',
-  types: [ Human, Alien ],
+  types: [Human, Alien],
   resolveType(/* value */) {
     // not used for validation
-  }
+  },
 });
 
 const FurColor = new GraphQLEnumType({
@@ -188,7 +187,7 @@ const FurColor = new GraphQLEnumType({
     TAN: { value: 2 },
     SPOTTED: { value: 3 },
     NO_FUR: { value: null },
-    UNKNOWN: { value: undefined }
+    UNKNOWN: { value: undefined },
   },
 });
 
@@ -200,7 +199,7 @@ const ComplexInput = new GraphQLInputObjectType({
     stringField: { type: GraphQLString },
     booleanField: { type: GraphQLBoolean },
     stringListField: { type: new GraphQLList(GraphQLString) },
-  }
+  },
 });
 
 const ComplicatedArgs = new GraphQLObjectType({
@@ -283,13 +282,12 @@ const ComplicatedArgs = new GraphQLObjectType({
   }),
 });
 
-
 const QueryRoot = new GraphQLObjectType({
   name: 'QueryRoot',
   fields: () => ({
     human: {
       args: { id: { type: GraphQLID } },
-      type: Human
+      type: Human,
     },
     alien: { type: Alien },
     dog: { type: Dog },
@@ -299,88 +297,88 @@ const QueryRoot = new GraphQLObjectType({
     dogOrHuman: { type: DogOrHuman },
     humanOrAlien: { type: HumanOrAlien },
     complicatedArgs: { type: ComplicatedArgs },
-  })
+  }),
 });
 
 export const testSchema = new GraphQLSchema({
   query: QueryRoot,
-  types: [ Cat, Dog, Human, Alien ],
+  types: [Cat, Dog, Human, Alien],
   directives: [
     GraphQLIncludeDirective,
     GraphQLSkipDirective,
     new GraphQLDirective({
       name: 'onQuery',
-      locations: [ 'QUERY' ],
+      locations: ['QUERY'],
     }),
     new GraphQLDirective({
       name: 'onMutation',
-      locations: [ 'MUTATION' ],
+      locations: ['MUTATION'],
     }),
     new GraphQLDirective({
       name: 'onSubscription',
-      locations: [ 'SUBSCRIPTION' ],
+      locations: ['SUBSCRIPTION'],
     }),
     new GraphQLDirective({
       name: 'onField',
-      locations: [ 'FIELD' ],
+      locations: ['FIELD'],
     }),
     new GraphQLDirective({
       name: 'onFragmentDefinition',
-      locations: [ 'FRAGMENT_DEFINITION' ],
+      locations: ['FRAGMENT_DEFINITION'],
     }),
     new GraphQLDirective({
       name: 'onFragmentSpread',
-      locations: [ 'FRAGMENT_SPREAD' ],
+      locations: ['FRAGMENT_SPREAD'],
     }),
     new GraphQLDirective({
       name: 'onInlineFragment',
-      locations: [ 'INLINE_FRAGMENT' ],
+      locations: ['INLINE_FRAGMENT'],
     }),
     new GraphQLDirective({
       name: 'onSchema',
-      locations: [ 'SCHEMA' ],
+      locations: ['SCHEMA'],
     }),
     new GraphQLDirective({
       name: 'onScalar',
-      locations: [ 'SCALAR' ],
+      locations: ['SCALAR'],
     }),
     new GraphQLDirective({
       name: 'onObject',
-      locations: [ 'OBJECT' ],
+      locations: ['OBJECT'],
     }),
     new GraphQLDirective({
       name: 'onFieldDefinition',
-      locations: [ 'FIELD_DEFINITION' ],
+      locations: ['FIELD_DEFINITION'],
     }),
     new GraphQLDirective({
       name: 'onArgumentDefinition',
-      locations: [ 'ARGUMENT_DEFINITION' ],
+      locations: ['ARGUMENT_DEFINITION'],
     }),
     new GraphQLDirective({
       name: 'onInterface',
-      locations: [ 'INTERFACE' ],
+      locations: ['INTERFACE'],
     }),
     new GraphQLDirective({
       name: 'onUnion',
-      locations: [ 'UNION' ],
+      locations: ['UNION'],
     }),
     new GraphQLDirective({
       name: 'onEnum',
-      locations: [ 'ENUM' ],
+      locations: ['ENUM'],
     }),
     new GraphQLDirective({
       name: 'onEnumValue',
-      locations: [ 'ENUM_VALUE' ],
+      locations: ['ENUM_VALUE'],
     }),
     new GraphQLDirective({
       name: 'onInputObject',
-      locations: [ 'INPUT_OBJECT' ],
+      locations: ['INPUT_OBJECT'],
     }),
     new GraphQLDirective({
       name: 'onInputFieldDefinition',
-      locations: [ 'INPUT_FIELD_DEFINITION' ],
+      locations: ['INPUT_FIELD_DEFINITION'],
     }),
-  ]
+  ],
 });
 
 function expectValid(schema, rules, queryString) {
@@ -395,17 +393,17 @@ function expectInvalid(schema, rules, queryString, expectedErrors) {
 }
 
 export function expectPassesRule(rule, queryString) {
-  return expectValid(testSchema, [ rule ], queryString);
+  return expectValid(testSchema, [rule], queryString);
 }
 
 export function expectFailsRule(rule, queryString, errors) {
-  return expectInvalid(testSchema, [ rule ], queryString, errors);
+  return expectInvalid(testSchema, [rule], queryString, errors);
 }
 
 export function expectPassesRuleWithSchema(schema, rule, queryString, errors) {
-  return expectValid(schema, [ rule ], queryString, errors);
+  return expectValid(schema, [rule], queryString, errors);
 }
 
 export function expectFailsRuleWithSchema(schema, rule, queryString, errors) {
-  return expectInvalid(schema, [ rule ], queryString, errors);
+  return expectInvalid(schema, [rule], queryString, errors);
 }

--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -12,16 +12,16 @@ import { validate, specifiedRules } from '../';
 import { parse } from '../../language';
 import { TypeInfo } from '../../utilities/TypeInfo';
 
-
 function expectValid(schema, queryString) {
   const errors = validate(schema, parse(queryString));
   expect(errors).to.deep.equal([], 'Should validate');
 }
 
 describe('Validate: Supports full validation', () => {
-
   it('validates queries', () => {
-    expectValid(testSchema, `
+    expectValid(
+      testSchema,
+      `
       query {
         catOrDog {
           ... on Cat {
@@ -32,12 +32,12 @@ describe('Validate: Supports full validation', () => {
           }
         }
       }
-    `);
+    `,
+    );
   });
 
   // NOTE: experimental
   it('validates using a custom TypeInfo', () => {
-
     // This TypeInfo will never return a valid field.
     const typeInfo = new TypeInfo(testSchema, () => null);
 
@@ -60,12 +60,11 @@ describe('Validate: Supports full validation', () => {
 
     expect(errorMessages).to.deep.equal([
       'Cannot query field "catOrDog" on type "QueryRoot". ' +
-      'Did you mean "catOrDog"?',
+        'Did you mean "catOrDog"?',
       'Cannot query field "furColor" on type "Cat". ' +
-      'Did you mean "furColor"?',
+        'Did you mean "furColor"?',
       'Cannot query field "isHousetrained" on type "Dog". ' +
-      'Did you mean "isHousetrained"?'
+        'Did you mean "isHousetrained"?',
     ]);
   });
-
 });

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -13,130 +13,126 @@ export { specifiedRules } from './specifiedRules';
 
 // Spec Section: "Argument Values Type Correctness"
 export {
-  ArgumentsOfCorrectType as ArgumentsOfCorrectTypeRule
+  ArgumentsOfCorrectType as ArgumentsOfCorrectTypeRule,
 } from './rules/ArgumentsOfCorrectType';
 
 // Spec Section: "Variable Default Values Are Correctly Typed"
 export {
-  DefaultValuesOfCorrectType as DefaultValuesOfCorrectTypeRule
+  DefaultValuesOfCorrectType as DefaultValuesOfCorrectTypeRule,
 } from './rules/DefaultValuesOfCorrectType';
 
 // Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"
 export {
-  FieldsOnCorrectType as FieldsOnCorrectTypeRule
+  FieldsOnCorrectType as FieldsOnCorrectTypeRule,
 } from './rules/FieldsOnCorrectType';
 
 // Spec Section: "Fragments on Composite Types"
 export {
-  FragmentsOnCompositeTypes as FragmentsOnCompositeTypesRule
+  FragmentsOnCompositeTypes as FragmentsOnCompositeTypesRule,
 } from './rules/FragmentsOnCompositeTypes';
 
 // Spec Section: "Argument Names"
 export {
-  KnownArgumentNames as KnownArgumentNamesRule
+  KnownArgumentNames as KnownArgumentNamesRule,
 } from './rules/KnownArgumentNames';
 
 // Spec Section: "Directives Are Defined"
 export {
-  KnownDirectives as KnownDirectivesRule
+  KnownDirectives as KnownDirectivesRule,
 } from './rules/KnownDirectives';
 
 // Spec Section: "Fragment spread target defined"
 export {
-  KnownFragmentNames as KnownFragmentNamesRule
+  KnownFragmentNames as KnownFragmentNamesRule,
 } from './rules/KnownFragmentNames';
 
 // Spec Section: "Fragment Spread Type Existence"
-export {
-  KnownTypeNames as KnownTypeNamesRule
-} from './rules/KnownTypeNames';
+export { KnownTypeNames as KnownTypeNamesRule } from './rules/KnownTypeNames';
 
 // Spec Section: "Lone Anonymous Operation"
 export {
-  LoneAnonymousOperation as LoneAnonymousOperationRule
+  LoneAnonymousOperation as LoneAnonymousOperationRule,
 } from './rules/LoneAnonymousOperation';
 
 // Spec Section: "Fragments must not form cycles"
 export {
-  NoFragmentCycles as NoFragmentCyclesRule
+  NoFragmentCycles as NoFragmentCyclesRule,
 } from './rules/NoFragmentCycles';
 
 // Spec Section: "All Variable Used Defined"
 export {
-  NoUndefinedVariables as NoUndefinedVariablesRule
+  NoUndefinedVariables as NoUndefinedVariablesRule,
 } from './rules/NoUndefinedVariables';
 
 // Spec Section: "Fragments must be used"
 export {
-  NoUnusedFragments as NoUnusedFragmentsRule
+  NoUnusedFragments as NoUnusedFragmentsRule,
 } from './rules/NoUnusedFragments';
 
 // Spec Section: "All Variables Used"
 export {
-  NoUnusedVariables as NoUnusedVariablesRule
+  NoUnusedVariables as NoUnusedVariablesRule,
 } from './rules/NoUnusedVariables';
 
 // Spec Section: "Field Selection Merging"
 export {
-  OverlappingFieldsCanBeMerged as OverlappingFieldsCanBeMergedRule
+  OverlappingFieldsCanBeMerged as OverlappingFieldsCanBeMergedRule,
 } from './rules/OverlappingFieldsCanBeMerged';
 
 // Spec Section: "Fragment spread is possible"
 export {
-  PossibleFragmentSpreads as PossibleFragmentSpreadsRule
+  PossibleFragmentSpreads as PossibleFragmentSpreadsRule,
 } from './rules/PossibleFragmentSpreads';
 
 // Spec Section: "Argument Optionality"
 export {
-  ProvidedNonNullArguments as ProvidedNonNullArgumentsRule
+  ProvidedNonNullArguments as ProvidedNonNullArgumentsRule,
 } from './rules/ProvidedNonNullArguments';
 
 // Spec Section: "Leaf Field Selections"
-export {
-  ScalarLeafs as ScalarLeafsRule
-} from './rules/ScalarLeafs';
+export { ScalarLeafs as ScalarLeafsRule } from './rules/ScalarLeafs';
 
 // Spec Section: "Subscriptions with Single Root Field"
 export {
-  SingleFieldSubscriptions as SingleFieldSubscriptionsRule
+  SingleFieldSubscriptions as SingleFieldSubscriptionsRule,
 } from './rules/SingleFieldSubscriptions';
 
 // Spec Section: "Argument Uniqueness"
 export {
-  UniqueArgumentNames as UniqueArgumentNamesRule
+  UniqueArgumentNames as UniqueArgumentNamesRule,
 } from './rules/UniqueArgumentNames';
 
 // Spec Section: "Directives Are Unique Per Location"
 export {
-  UniqueDirectivesPerLocation as UniqueDirectivesPerLocationRule
+  UniqueDirectivesPerLocation as UniqueDirectivesPerLocationRule,
 } from './rules/UniqueDirectivesPerLocation';
 
 // Spec Section: "Fragment Name Uniqueness"
 export {
-  UniqueFragmentNames as UniqueFragmentNamesRule
+  UniqueFragmentNames as UniqueFragmentNamesRule,
 } from './rules/UniqueFragmentNames';
 
 // Spec Section: "Input Object Field Uniqueness"
 export {
-  UniqueInputFieldNames as UniqueInputFieldNamesRule
+  UniqueInputFieldNames as UniqueInputFieldNamesRule,
 } from './rules/UniqueInputFieldNames';
 
 // Spec Section: "Operation Name Uniqueness"
 export {
-  UniqueOperationNames as UniqueOperationNamesRule
+  UniqueOperationNames as UniqueOperationNamesRule,
 } from './rules/UniqueOperationNames';
 
 // Spec Section: "Variable Uniqueness"
 export {
-  UniqueVariableNames as UniqueVariableNamesRule
+  UniqueVariableNames as UniqueVariableNamesRule,
 } from './rules/UniqueVariableNames';
 
 // Spec Section: "Variables are Input Types"
 export {
-  VariablesAreInputTypes as VariablesAreInputTypesRule
+  VariablesAreInputTypes as VariablesAreInputTypesRule,
 } from './rules/VariablesAreInputTypes';
 
 // Spec Section: "All Variable Usages Are Allowed"
 export {
-  VariablesInAllowedPosition as VariablesInAllowedPositionRule
+  VariablesInAllowedPosition as VariablesInAllowedPositionRule,
 } from './rules/VariablesInAllowedPosition';

--- a/src/validation/rules/ArgumentsOfCorrectType.js
+++ b/src/validation/rules/ArgumentsOfCorrectType.js
@@ -13,17 +13,14 @@ import { print } from '../../language/printer';
 import { isValidLiteralValue } from '../../utilities/isValidLiteralValue';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function badValueMessage(
   argName: string,
   type: GraphQLType,
   value: string,
-  verboseErrors?: string[]
+  verboseErrors?: string[],
 ): string {
   const message = verboseErrors ? '\n' + verboseErrors.join('\n') : '';
-  return (
-    `Argument "${argName}" has invalid value ${value}.${message}`
-  );
+  return `Argument "${argName}" has invalid value ${value}.${message}`;
 }
 
 /**
@@ -39,18 +36,20 @@ export function ArgumentsOfCorrectType(context: ValidationContext): any {
       if (argDef) {
         const errors = isValidLiteralValue(argDef.type, node.value);
         if (errors && errors.length > 0) {
-          context.reportError(new GraphQLError(
-            badValueMessage(
-              node.name.value,
-              argDef.type,
-              print(node.value),
-              errors
+          context.reportError(
+            new GraphQLError(
+              badValueMessage(
+                node.name.value,
+                argDef.type,
+                print(node.value),
+                errors,
+              ),
+              [node.value],
             ),
-            [ node.value ]
-          ));
+          );
         }
       }
       return false;
-    }
+    },
   };
 }

--- a/src/validation/rules/DefaultValuesOfCorrectType.js
+++ b/src/validation/rules/DefaultValuesOfCorrectType.js
@@ -14,26 +14,29 @@ import { GraphQLNonNull } from '../../type/definition';
 import { isValidLiteralValue } from '../../utilities/isValidLiteralValue';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function defaultForNonNullArgMessage(
   varName: string,
   type: GraphQLType,
-  guessType: GraphQLType
+  guessType: GraphQLType,
 ): string {
-  return `Variable "$${varName}" of type "${String(type)}" is required and ` +
+  return (
+    `Variable "$${varName}" of type "${String(type)}" is required and ` +
     'will not use the default value. ' +
-    `Perhaps you meant to use type "${String(guessType)}".`;
+    `Perhaps you meant to use type "${String(guessType)}".`
+  );
 }
 
 export function badValueForDefaultArgMessage(
   varName: string,
   type: GraphQLType,
   value: string,
-  verboseErrors?: string[]
+  verboseErrors?: string[],
 ): string {
   const message = verboseErrors ? '\n' + verboseErrors.join('\n') : '';
-  return `Variable "$${varName}" of type "${String(type)}" has invalid ` +
-    `default value ${value}.${message}`;
+  return (
+    `Variable "$${varName}" of type "${String(type)}" has invalid ` +
+    `default value ${value}.${message}`
+  );
 }
 
 /**
@@ -49,23 +52,27 @@ export function DefaultValuesOfCorrectType(context: ValidationContext): any {
       const defaultValue = node.defaultValue;
       const type = context.getInputType();
       if (type instanceof GraphQLNonNull && defaultValue) {
-        context.reportError(new GraphQLError(
-          defaultForNonNullArgMessage(name, type, type.ofType),
-          [ defaultValue ]
-        ));
+        context.reportError(
+          new GraphQLError(
+            defaultForNonNullArgMessage(name, type, type.ofType),
+            [defaultValue],
+          ),
+        );
       }
       if (type && defaultValue) {
         const errors = isValidLiteralValue(type, defaultValue);
         if (errors && errors.length > 0) {
-          context.reportError(new GraphQLError(
-            badValueForDefaultArgMessage(
-              name,
-              type,
-              print(defaultValue),
-              errors
+          context.reportError(
+            new GraphQLError(
+              badValueForDefaultArgMessage(
+                name,
+                type,
+                print(defaultValue),
+                errors,
+              ),
+              [defaultValue],
             ),
-            [ defaultValue ]
-          ));
+          );
         }
       }
       return false;

--- a/src/validation/rules/FragmentsOnCompositeTypes.js
+++ b/src/validation/rules/FragmentsOnCompositeTypes.js
@@ -14,19 +14,20 @@ import { isCompositeType } from '../../type/definition';
 import type { GraphQLType } from '../../type/definition';
 import { typeFromAST } from '../../utilities/typeFromAST';
 
-
 export function inlineFragmentOnNonCompositeErrorMessage(
-  type: GraphQLType
+  type: GraphQLType,
 ): string {
   return `Fragment cannot condition on non composite type "${String(type)}".`;
 }
 
 export function fragmentOnNonCompositeErrorMessage(
   fragName: string,
-  type: GraphQLType
+  type: GraphQLType,
 ): string {
-  return `Fragment "${fragName}" cannot condition on non composite ` +
-    `type "${String(type)}".`;
+  return (
+    `Fragment "${fragName}" cannot condition on non composite ` +
+    `type "${String(type)}".`
+  );
 }
 
 /**
@@ -42,24 +43,30 @@ export function FragmentsOnCompositeTypes(context: ValidationContext): any {
       if (node.typeCondition) {
         const type = typeFromAST(context.getSchema(), node.typeCondition);
         if (type && !isCompositeType(type)) {
-          context.reportError(new GraphQLError(
-            inlineFragmentOnNonCompositeErrorMessage(print(node.typeCondition)),
-            [ node.typeCondition ]
-          ));
+          context.reportError(
+            new GraphQLError(
+              inlineFragmentOnNonCompositeErrorMessage(
+                print(node.typeCondition),
+              ),
+              [node.typeCondition],
+            ),
+          );
         }
       }
     },
     FragmentDefinition(node) {
       const type = typeFromAST(context.getSchema(), node.typeCondition);
       if (type && !isCompositeType(type)) {
-        context.reportError(new GraphQLError(
-          fragmentOnNonCompositeErrorMessage(
-            node.name.value,
-            print(node.typeCondition)
+        context.reportError(
+          new GraphQLError(
+            fragmentOnNonCompositeErrorMessage(
+              node.name.value,
+              print(node.typeCondition),
+            ),
+            [node.typeCondition],
           ),
-          [ node.typeCondition ]
-        ));
+        );
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/KnownArgumentNames.js
+++ b/src/validation/rules/KnownArgumentNames.js
@@ -15,14 +15,14 @@ import suggestionList from '../../jsutils/suggestionList';
 import quotedOrList from '../../jsutils/quotedOrList';
 import * as Kind from '../../language/kinds';
 
-
 export function unknownArgMessage(
   argName: string,
   fieldName: string,
   typeName: string,
-  suggestedArgs: Array<string>
+  suggestedArgs: Array<string>,
 ): string {
-  let message = `Unknown argument "${argName}" on field "${fieldName}" of ` +
+  let message =
+    `Unknown argument "${argName}" on field "${fieldName}" of ` +
     `type "${typeName}".`;
   if (suggestedArgs.length) {
     message += ` Did you mean ${quotedOrList(suggestedArgs)}?`;
@@ -33,10 +33,9 @@ export function unknownArgMessage(
 export function unknownDirectiveArgMessage(
   argName: string,
   directiveName: string,
-  suggestedArgs: Array<string>
+  suggestedArgs: Array<string>,
 ): string {
-  let message =
-    `Unknown argument "${argName}" on directive "@${directiveName}".`;
+  let message = `Unknown argument "${argName}" on directive "@${directiveName}".`;
   if (suggestedArgs.length) {
     message += ` Did you mean ${quotedOrList(suggestedArgs)}?`;
   }
@@ -58,23 +57,25 @@ export function KnownArgumentNames(context: ValidationContext): any {
         if (fieldDef) {
           const fieldArgDef = find(
             fieldDef.args,
-            arg => arg.name === node.name.value
+            arg => arg.name === node.name.value,
           );
           if (!fieldArgDef) {
             const parentType = context.getParentType();
             invariant(parentType);
-            context.reportError(new GraphQLError(
-              unknownArgMessage(
-                node.name.value,
-                fieldDef.name,
-                parentType.name,
-                suggestionList(
+            context.reportError(
+              new GraphQLError(
+                unknownArgMessage(
                   node.name.value,
-                  fieldDef.args.map(arg => arg.name)
-                )
+                  fieldDef.name,
+                  parentType.name,
+                  suggestionList(
+                    node.name.value,
+                    fieldDef.args.map(arg => arg.name),
+                  ),
+                ),
+                [node],
               ),
-              [ node ]
-            ));
+            );
           }
         }
       } else if (argumentOf.kind === Kind.DIRECTIVE) {
@@ -82,23 +83,25 @@ export function KnownArgumentNames(context: ValidationContext): any {
         if (directive) {
           const directiveArgDef = find(
             directive.args,
-            arg => arg.name === node.name.value
+            arg => arg.name === node.name.value,
           );
           if (!directiveArgDef) {
-            context.reportError(new GraphQLError(
-              unknownDirectiveArgMessage(
-                node.name.value,
-                directive.name,
-                suggestionList(
+            context.reportError(
+              new GraphQLError(
+                unknownDirectiveArgMessage(
                   node.name.value,
-                  directive.args.map(arg => arg.name)
-                )
+                  directive.name,
+                  suggestionList(
+                    node.name.value,
+                    directive.args.map(arg => arg.name),
+                  ),
+                ),
+                [node],
               ),
-              [ node ]
-            ));
+            );
           }
         }
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/KnownDirectives.js
+++ b/src/validation/rules/KnownDirectives.js
@@ -13,14 +13,13 @@ import find from '../../jsutils/find';
 import * as Kind from '../../language/kinds';
 import { DirectiveLocation } from '../../type/directives';
 
-
 export function unknownDirectiveMessage(directiveName: string): string {
   return `Unknown directive "${directiveName}".`;
 }
 
 export function misplacedDirectiveMessage(
   directiveName: string,
-  location: string
+  location: string,
 ): string {
   return `Directive "${directiveName}" may not be used on ${location}.`;
 }
@@ -36,28 +35,31 @@ export function KnownDirectives(context: ValidationContext): any {
     Directive(node, key, parent, path, ancestors) {
       const directiveDef = find(
         context.getSchema().getDirectives(),
-        def => def.name === node.name.value
+        def => def.name === node.name.value,
       );
       if (!directiveDef) {
-        context.reportError(new GraphQLError(
-          unknownDirectiveMessage(node.name.value),
-          [ node ]
-        ));
+        context.reportError(
+          new GraphQLError(unknownDirectiveMessage(node.name.value), [node]),
+        );
         return;
       }
       const candidateLocation = getDirectiveLocationForASTPath(ancestors);
       if (!candidateLocation) {
-        context.reportError(new GraphQLError(
-          misplacedDirectiveMessage(node.name.value, node.type),
-          [ node ]
-        ));
+        context.reportError(
+          new GraphQLError(
+            misplacedDirectiveMessage(node.name.value, node.type),
+            [node],
+          ),
+        );
       } else if (directiveDef.locations.indexOf(candidateLocation) === -1) {
-        context.reportError(new GraphQLError(
-          misplacedDirectiveMessage(node.name.value, candidateLocation),
-          [ node ]
-        ));
+        context.reportError(
+          new GraphQLError(
+            misplacedDirectiveMessage(node.name.value, candidateLocation),
+            [node],
+          ),
+        );
       }
-    }
+    },
   };
 }
 
@@ -66,29 +68,44 @@ function getDirectiveLocationForASTPath(ancestors) {
   switch (appliedTo.kind) {
     case Kind.OPERATION_DEFINITION:
       switch (appliedTo.operation) {
-        case 'query': return DirectiveLocation.QUERY;
-        case 'mutation': return DirectiveLocation.MUTATION;
-        case 'subscription': return DirectiveLocation.SUBSCRIPTION;
+        case 'query':
+          return DirectiveLocation.QUERY;
+        case 'mutation':
+          return DirectiveLocation.MUTATION;
+        case 'subscription':
+          return DirectiveLocation.SUBSCRIPTION;
       }
       break;
-    case Kind.FIELD: return DirectiveLocation.FIELD;
-    case Kind.FRAGMENT_SPREAD: return DirectiveLocation.FRAGMENT_SPREAD;
-    case Kind.INLINE_FRAGMENT: return DirectiveLocation.INLINE_FRAGMENT;
-    case Kind.FRAGMENT_DEFINITION: return DirectiveLocation.FRAGMENT_DEFINITION;
-    case Kind.SCHEMA_DEFINITION: return DirectiveLocation.SCHEMA;
-    case Kind.SCALAR_TYPE_DEFINITION: return DirectiveLocation.SCALAR;
-    case Kind.OBJECT_TYPE_DEFINITION: return DirectiveLocation.OBJECT;
-    case Kind.FIELD_DEFINITION: return DirectiveLocation.FIELD_DEFINITION;
-    case Kind.INTERFACE_TYPE_DEFINITION: return DirectiveLocation.INTERFACE;
-    case Kind.UNION_TYPE_DEFINITION: return DirectiveLocation.UNION;
-    case Kind.ENUM_TYPE_DEFINITION: return DirectiveLocation.ENUM;
-    case Kind.ENUM_VALUE_DEFINITION: return DirectiveLocation.ENUM_VALUE;
+    case Kind.FIELD:
+      return DirectiveLocation.FIELD;
+    case Kind.FRAGMENT_SPREAD:
+      return DirectiveLocation.FRAGMENT_SPREAD;
+    case Kind.INLINE_FRAGMENT:
+      return DirectiveLocation.INLINE_FRAGMENT;
+    case Kind.FRAGMENT_DEFINITION:
+      return DirectiveLocation.FRAGMENT_DEFINITION;
+    case Kind.SCHEMA_DEFINITION:
+      return DirectiveLocation.SCHEMA;
+    case Kind.SCALAR_TYPE_DEFINITION:
+      return DirectiveLocation.SCALAR;
+    case Kind.OBJECT_TYPE_DEFINITION:
+      return DirectiveLocation.OBJECT;
+    case Kind.FIELD_DEFINITION:
+      return DirectiveLocation.FIELD_DEFINITION;
+    case Kind.INTERFACE_TYPE_DEFINITION:
+      return DirectiveLocation.INTERFACE;
+    case Kind.UNION_TYPE_DEFINITION:
+      return DirectiveLocation.UNION;
+    case Kind.ENUM_TYPE_DEFINITION:
+      return DirectiveLocation.ENUM;
+    case Kind.ENUM_VALUE_DEFINITION:
+      return DirectiveLocation.ENUM_VALUE;
     case Kind.INPUT_OBJECT_TYPE_DEFINITION:
       return DirectiveLocation.INPUT_OBJECT;
     case Kind.INPUT_VALUE_DEFINITION:
       const parentNode = ancestors[ancestors.length - 3];
-      return parentNode.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION ?
-        DirectiveLocation.INPUT_FIELD_DEFINITION :
-        DirectiveLocation.ARGUMENT_DEFINITION;
+      return parentNode.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
+        ? DirectiveLocation.INPUT_FIELD_DEFINITION
+        : DirectiveLocation.ARGUMENT_DEFINITION;
   }
 }

--- a/src/validation/rules/KnownFragmentNames.js
+++ b/src/validation/rules/KnownFragmentNames.js
@@ -10,7 +10,6 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function unknownFragmentMessage(fragName: string): string {
   return `Unknown fragment "${fragName}".`;
 }
@@ -27,11 +26,10 @@ export function KnownFragmentNames(context: ValidationContext): any {
       const fragmentName = node.name.value;
       const fragment = context.getFragment(fragmentName);
       if (!fragment) {
-        context.reportError(new GraphQLError(
-          unknownFragmentMessage(fragmentName),
-          [ node.name ]
-        ));
+        context.reportError(
+          new GraphQLError(unknownFragmentMessage(fragmentName), [node.name]),
+        );
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/KnownTypeNames.js
+++ b/src/validation/rules/KnownTypeNames.js
@@ -13,10 +13,9 @@ import suggestionList from '../../jsutils/suggestionList';
 import quotedOrList from '../../jsutils/quotedOrList';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function unknownTypeMessage(
   type: GraphQLType,
-  suggestedTypes: Array<string>
+  suggestedTypes: Array<string>,
 ): string {
   let message = `Unknown type "${String(type)}".`;
   if (suggestedTypes.length) {
@@ -49,12 +48,12 @@ export function KnownTypeNames(context: ValidationContext): any {
           new GraphQLError(
             unknownTypeMessage(
               typeName,
-              suggestionList(typeName, Object.keys(schema.getTypeMap()))
+              suggestionList(typeName, Object.keys(schema.getTypeMap())),
             ),
-            [ node ]
-          )
+            [node],
+          ),
         );
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/LoneAnonymousOperation.js
+++ b/src/validation/rules/LoneAnonymousOperation.js
@@ -11,7 +11,6 @@ import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import { OPERATION_DEFINITION } from '../../language/kinds';
 
-
 export function anonOperationNotAloneMessage(): string {
   return 'This anonymous operation must be the only defined operation.';
 }
@@ -27,15 +26,15 @@ export function LoneAnonymousOperation(context: ValidationContext): any {
   return {
     Document(node) {
       operationCount = node.definitions.filter(
-        definition => definition.kind === OPERATION_DEFINITION
+        definition => definition.kind === OPERATION_DEFINITION,
       ).length;
     },
     OperationDefinition(node) {
       if (!node.name && operationCount > 1) {
         context.reportError(
-          new GraphQLError(anonOperationNotAloneMessage(), [ node ])
+          new GraphQLError(anonOperationNotAloneMessage(), [node]),
         );
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/NoFragmentCycles.js
+++ b/src/validation/rules/NoFragmentCycles.js
@@ -11,10 +11,9 @@ import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import type { FragmentDefinitionNode } from '../../language/ast';
 
-
 export function cycleErrorMessage(
   fragName: string,
-  spreadNames: Array<string>
+  spreadNames: Array<string>,
 ): string {
   const via = spreadNames.length ? ' via ' + spreadNames.join(', ') : '';
   return `Cannot spread fragment "${fragName}" within itself${via}.`;
@@ -71,13 +70,12 @@ export function NoFragmentCycles(context: ValidationContext): any {
         spreadPath.pop();
       } else {
         const cyclePath = spreadPath.slice(cycleIndex);
-        context.reportError(new GraphQLError(
-          cycleErrorMessage(
-            spreadName,
-            cyclePath.map(s => s.name.value)
+        context.reportError(
+          new GraphQLError(
+            cycleErrorMessage(spreadName, cyclePath.map(s => s.name.value)),
+            cyclePath.concat(spreadNode),
           ),
-          cyclePath.concat(spreadNode)
-        ));
+        );
       }
     }
 

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -10,11 +10,10 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function undefinedVarMessage(varName: string, opName: ?string): string {
-  return opName ?
-    `Variable "$${varName}" is not defined by operation "${opName}".` :
-    `Variable "$${varName}" is not defined.`;
+  return opName
+    ? `Variable "$${varName}" is not defined by operation "${opName}".`
+    : `Variable "$${varName}" is not defined.`;
 }
 
 /**
@@ -37,19 +36,21 @@ export function NoUndefinedVariables(context: ValidationContext): any {
         usages.forEach(({ node }) => {
           const varName = node.name.value;
           if (variableNameDefined[varName] !== true) {
-            context.reportError(new GraphQLError(
-              undefinedVarMessage(
-                varName,
-                operation.name && operation.name.value
+            context.reportError(
+              new GraphQLError(
+                undefinedVarMessage(
+                  varName,
+                  operation.name && operation.name.value,
+                ),
+                [node, operation],
               ),
-              [ node, operation ]
-            ));
+            );
           }
         });
-      }
+      },
     },
     VariableDefinition(node) {
       variableNameDefined[node.variable.name.value] = true;
-    }
+    },
   };
 }

--- a/src/validation/rules/NoUnusedFragments.js
+++ b/src/validation/rules/NoUnusedFragments.js
@@ -10,7 +10,6 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function unusedFragMessage(fragName: string): string {
   return `Fragment "${fragName}" is never used.`;
 }
@@ -38,21 +37,22 @@ export function NoUnusedFragments(context: ValidationContext): any {
       leave() {
         const fragmentNameUsed = Object.create(null);
         operationDefs.forEach(operation => {
-          context.getRecursivelyReferencedFragments(operation).forEach(
-            fragment => { fragmentNameUsed[fragment.name.value] = true; }
-          );
+          context
+            .getRecursivelyReferencedFragments(operation)
+            .forEach(fragment => {
+              fragmentNameUsed[fragment.name.value] = true;
+            });
         });
 
         fragmentDefs.forEach(fragmentDef => {
           const fragName = fragmentDef.name.value;
           if (fragmentNameUsed[fragName] !== true) {
-            context.reportError(new GraphQLError(
-              unusedFragMessage(fragName),
-              [ fragmentDef ]
-            ));
+            context.reportError(
+              new GraphQLError(unusedFragMessage(fragName), [fragmentDef]),
+            );
           }
         });
-      }
-    }
+      },
+    },
   };
 }

--- a/src/validation/rules/NoUnusedVariables.js
+++ b/src/validation/rules/NoUnusedVariables.js
@@ -10,14 +10,13 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function unusedVariableMessage(
   varName: string,
-  opName: ?string
+  opName: ?string,
 ): string {
-  return opName ?
-    `Variable "$${varName}" is never used in operation "${opName}".` :
-    `Variable "$${varName}" is never used.`;
+  return opName
+    ? `Variable "$${varName}" is never used in operation "${opName}".`
+    : `Variable "$${varName}" is never used.`;
 }
 
 /**
@@ -46,16 +45,17 @@ export function NoUnusedVariables(context: ValidationContext): any {
         variableDefs.forEach(variableDef => {
           const variableName = variableDef.variable.name.value;
           if (variableNameUsed[variableName] !== true) {
-            context.reportError(new GraphQLError(
-              unusedVariableMessage(variableName, opName),
-              [ variableDef ]
-            ));
+            context.reportError(
+              new GraphQLError(unusedVariableMessage(variableName, opName), [
+                variableDef,
+              ]),
+            );
           }
         });
-      }
+      },
     },
     VariableDefinition(def) {
       variableDefs.push(def);
-    }
+    },
   };
 }

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -10,7 +10,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import find from '../../jsutils/find';
-import type {ObjMap} from '../../jsutils/ObjMap';
+import type { ObjMap } from '../../jsutils/ObjMap';
 import type {
   SelectionSetNode,
   FieldNode,
@@ -31,25 +31,31 @@ import type {
   GraphQLNamedType,
   GraphQLOutputType,
   GraphQLCompositeType,
-  GraphQLField
+  GraphQLField,
 } from '../../type/definition';
 import { typeFromAST } from '../../utilities/typeFromAST';
 
-
 export function fieldsConflictMessage(
   responseName: string,
-  reason: ConflictReasonMessage
+  reason: ConflictReasonMessage,
 ): string {
-  return `Fields "${responseName}" conflict because ${reasonMessage(reason)}` +
+  return (
+    `Fields "${responseName}" conflict because ${reasonMessage(reason)}` +
     '. Use different aliases on the fields to fetch both if this was ' +
-    'intentional.';
+    'intentional.'
+  );
 }
 
 function reasonMessage(reason: ConflictReasonMessage): string {
   if (Array.isArray(reason)) {
-    return reason.map(([ responseName, subreason ]) =>
-      `subfields "${responseName}" conflict because ${reasonMessage(subreason)}`
-    ).join(' and ');
+    return reason
+      .map(
+        ([responseName, subreason]) =>
+          `subfields "${responseName}" conflict because ${reasonMessage(
+            subreason,
+          )}`,
+      )
+      .join(' and ');
   }
   return reason;
 }
@@ -79,26 +85,27 @@ export function OverlappingFieldsCanBeMerged(context: ValidationContext): any {
         cachedFieldsAndFragmentNames,
         comparedFragments,
         context.getParentType(),
-        selectionSet
+        selectionSet,
       );
-      conflicts.forEach(
-        ([ [ responseName, reason ], fields1, fields2 ]) =>
-          context.reportError(new GraphQLError(
+      conflicts.forEach(([[responseName, reason], fields1, fields2]) =>
+        context.reportError(
+          new GraphQLError(
             fieldsConflictMessage(responseName, reason),
-            fields1.concat(fields2)
-          ))
+            fields1.concat(fields2),
+          ),
+        ),
       );
-    }
+    },
   };
 }
 
-type Conflict = [ ConflictReason, Array<FieldNode>, Array<FieldNode> ];
+type Conflict = [ConflictReason, Array<FieldNode>, Array<FieldNode>];
 // Field name and reason.
-type ConflictReason = [ string, ConflictReasonMessage ];
+type ConflictReason = [string, ConflictReasonMessage];
 // Reason is a string, or a nested list of conflicts.
 type ConflictReasonMessage = string | Array<ConflictReason>;
 // Tuple defining a field node in a context.
-type NodeAndDef = [ GraphQLCompositeType, FieldNode, ?GraphQLField<*, *> ];
+type NodeAndDef = [GraphQLCompositeType, FieldNode, ?GraphQLField<*, *>];
 // Map of array of those.
 type NodeAndDefCollection = ObjMap<Array<NodeAndDef>>;
 
@@ -165,15 +172,15 @@ function findConflictsWithinSelectionSet(
   cachedFieldsAndFragmentNames,
   comparedFragments: PairSet,
   parentType: ?GraphQLNamedType,
-  selectionSet: SelectionSetNode
+  selectionSet: SelectionSetNode,
 ): Array<Conflict> {
   const conflicts = [];
 
-  const [ fieldMap, fragmentNames ] = getFieldsAndFragmentNames(
+  const [fieldMap, fragmentNames] = getFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
     parentType,
-    selectionSet
+    selectionSet,
   );
 
   // (A) Find find all conflicts "within" the fields of this selection set.
@@ -183,7 +190,7 @@ function findConflictsWithinSelectionSet(
     conflicts,
     cachedFieldsAndFragmentNames,
     comparedFragments,
-    fieldMap
+    fieldMap,
   );
 
   // (B) Then collect conflicts between these fields and those represented by
@@ -196,7 +203,7 @@ function findConflictsWithinSelectionSet(
       comparedFragments,
       false,
       fieldMap,
-      fragmentNames[i]
+      fragmentNames[i],
     );
     // (C) Then compare this fragment with all other fragments found in this
     // selection set to collect conflicts between fragments spread together.
@@ -210,7 +217,7 @@ function findConflictsWithinSelectionSet(
         comparedFragments,
         false,
         fragmentNames[i],
-        fragmentNames[j]
+        fragmentNames[j],
       );
     }
   }
@@ -226,17 +233,17 @@ function collectConflictsBetweenFieldsAndFragment(
   comparedFragments: PairSet,
   areMutuallyExclusive: boolean,
   fieldMap: NodeAndDefCollection,
-  fragmentName: string
+  fragmentName: string,
 ): void {
   const fragment = context.getFragment(fragmentName);
   if (!fragment) {
     return;
   }
 
-  const [ fieldMap2, fragmentNames2 ] = getReferencedFieldsAndFragmentNames(
+  const [fieldMap2, fragmentNames2] = getReferencedFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
-    fragment
+    fragment,
   );
 
   // (D) First collect any conflicts between the provided collection of fields
@@ -248,7 +255,7 @@ function collectConflictsBetweenFieldsAndFragment(
     comparedFragments,
     areMutuallyExclusive,
     fieldMap,
-    fieldMap2
+    fieldMap2,
   );
 
   // (E) Then collect any conflicts between the provided collection of fields
@@ -261,7 +268,7 @@ function collectConflictsBetweenFieldsAndFragment(
       comparedFragments,
       areMutuallyExclusive,
       fieldMap,
-      fragmentNames2[i]
+      fragmentNames2[i],
     );
   }
 }
@@ -275,7 +282,7 @@ function collectConflictsBetweenFragments(
   comparedFragments: PairSet,
   areMutuallyExclusive: boolean,
   fragmentName1: string,
-  fragmentName2: string
+  fragmentName2: string,
 ): void {
   const fragment1 = context.getFragment(fragmentName1);
   const fragment2 = context.getFragment(fragmentName2);
@@ -296,15 +303,15 @@ function collectConflictsBetweenFragments(
   }
   comparedFragments.add(fragmentName1, fragmentName2, areMutuallyExclusive);
 
-  const [ fieldMap1, fragmentNames1 ] = getReferencedFieldsAndFragmentNames(
+  const [fieldMap1, fragmentNames1] = getReferencedFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
-    fragment1
+    fragment1,
   );
-  const [ fieldMap2, fragmentNames2 ] = getReferencedFieldsAndFragmentNames(
+  const [fieldMap2, fragmentNames2] = getReferencedFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
-    fragment2
+    fragment2,
   );
 
   // (F) First, collect all conflicts between these two collections of fields
@@ -316,7 +323,7 @@ function collectConflictsBetweenFragments(
     comparedFragments,
     areMutuallyExclusive,
     fieldMap1,
-    fieldMap2
+    fieldMap2,
   );
 
   // (G) Then collect conflicts between the first fragment and any nested
@@ -329,7 +336,7 @@ function collectConflictsBetweenFragments(
       comparedFragments,
       areMutuallyExclusive,
       fragmentName1,
-      fragmentNames2[j]
+      fragmentNames2[j],
     );
   }
 
@@ -343,7 +350,7 @@ function collectConflictsBetweenFragments(
       comparedFragments,
       areMutuallyExclusive,
       fragmentNames1[i],
-      fragmentName2
+      fragmentName2,
     );
   }
 }
@@ -359,21 +366,21 @@ function findConflictsBetweenSubSelectionSets(
   parentType1: ?GraphQLNamedType,
   selectionSet1: SelectionSetNode,
   parentType2: ?GraphQLNamedType,
-  selectionSet2: SelectionSetNode
+  selectionSet2: SelectionSetNode,
 ): Array<Conflict> {
   const conflicts = [];
 
-  const [ fieldMap1, fragmentNames1 ] = getFieldsAndFragmentNames(
+  const [fieldMap1, fragmentNames1] = getFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
     parentType1,
-    selectionSet1
+    selectionSet1,
   );
-  const [ fieldMap2, fragmentNames2 ] = getFieldsAndFragmentNames(
+  const [fieldMap2, fragmentNames2] = getFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
     parentType2,
-    selectionSet2
+    selectionSet2,
   );
 
   // (H) First, collect all conflicts between these two collections of field.
@@ -384,7 +391,7 @@ function findConflictsBetweenSubSelectionSets(
     comparedFragments,
     areMutuallyExclusive,
     fieldMap1,
-    fieldMap2
+    fieldMap2,
   );
 
   // (I) Then collect conflicts between the first collection of fields and
@@ -397,7 +404,7 @@ function findConflictsBetweenSubSelectionSets(
       comparedFragments,
       areMutuallyExclusive,
       fieldMap1,
-      fragmentNames2[j]
+      fragmentNames2[j],
     );
   }
 
@@ -411,7 +418,7 @@ function findConflictsBetweenSubSelectionSets(
       comparedFragments,
       areMutuallyExclusive,
       fieldMap2,
-      fragmentNames1[i]
+      fragmentNames1[i],
     );
   }
 
@@ -427,7 +434,7 @@ function findConflictsBetweenSubSelectionSets(
         comparedFragments,
         areMutuallyExclusive,
         fragmentNames1[i],
-        fragmentNames2[j]
+        fragmentNames2[j],
       );
     }
   }
@@ -440,7 +447,7 @@ function collectConflictsWithin(
   conflicts: Array<Conflict>,
   cachedFieldsAndFragmentNames,
   comparedFragments: PairSet,
-  fieldMap: NodeAndDefCollection
+  fieldMap: NodeAndDefCollection,
 ): void {
   // A field map is a keyed collection, where each key represents a response
   // name and the value at that key is a list of all fields which provide that
@@ -461,7 +468,7 @@ function collectConflictsWithin(
             false, // within one collection is never mutually exclusive
             responseName,
             fields[i],
-            fields[j]
+            fields[j],
           );
           if (conflict) {
             conflicts.push(conflict);
@@ -484,7 +491,7 @@ function collectConflictsBetween(
   comparedFragments: PairSet,
   parentFieldsAreMutuallyExclusive: boolean,
   fieldMap1: NodeAndDefCollection,
-  fieldMap2: NodeAndDefCollection
+  fieldMap2: NodeAndDefCollection,
 ): void {
   // A field map is a keyed collection, where each key represents a response
   // name and the value at that key is a list of all fields which provide that
@@ -504,7 +511,7 @@ function collectConflictsBetween(
             parentFieldsAreMutuallyExclusive,
             responseName,
             fields1[i],
-            fields2[j]
+            fields2[j],
           );
           if (conflict) {
             conflicts.push(conflict);
@@ -524,10 +531,10 @@ function findConflict(
   parentFieldsAreMutuallyExclusive: boolean,
   responseName: string,
   field1: NodeAndDef,
-  field2: NodeAndDef
+  field2: NodeAndDef,
 ): ?Conflict {
-  const [ parentType1, node1, def1 ] = field1;
-  const [ parentType2, node2, def2 ] = field2;
+  const [parentType1, node1, def1] = field1;
+  const [parentType2, node2, def2] = field2;
 
   // If it is known that two fields could not possibly apply at the same
   // time, due to the parent types, then it is safe to permit them to diverge
@@ -539,9 +546,9 @@ function findConflict(
   // thus may not safely diverge.
   const areMutuallyExclusive =
     parentFieldsAreMutuallyExclusive ||
-    parentType1 !== parentType2 &&
-    parentType1 instanceof GraphQLObjectType &&
-    parentType2 instanceof GraphQLObjectType;
+    (parentType1 !== parentType2 &&
+      parentType1 instanceof GraphQLObjectType &&
+      parentType2 instanceof GraphQLObjectType);
 
   // The return type for each field.
   const type1 = def1 && def1.type;
@@ -553,28 +560,30 @@ function findConflict(
     const name2 = node2.name.value;
     if (name1 !== name2) {
       return [
-        [ responseName, `${name1} and ${name2} are different fields` ],
-        [ node1 ],
-        [ node2 ]
+        [responseName, `${name1} and ${name2} are different fields`],
+        [node1],
+        [node2],
       ];
     }
 
     // Two field calls must have the same arguments.
     if (!sameArguments(node1.arguments || [], node2.arguments || [])) {
       return [
-        [ responseName, 'they have differing arguments' ],
-        [ node1 ],
-        [ node2 ]
+        [responseName, 'they have differing arguments'],
+        [node1],
+        [node2],
       ];
     }
   }
 
   if (type1 && type2 && doTypesConflict(type1, type2)) {
     return [
-      [ responseName,
-        `they return conflicting types ${String(type1)} and ${String(type2)}` ],
-      [ node1 ],
-      [ node2 ]
+      [
+        responseName,
+        `they return conflicting types ${String(type1)} and ${String(type2)}`,
+      ],
+      [node1],
+      [node2],
     ];
   }
 
@@ -592,7 +601,7 @@ function findConflict(
       getNamedType(type1),
       selectionSet1,
       getNamedType(type2),
-      selectionSet2
+      selectionSet2,
     );
     return subfieldConflicts(conflicts, responseName, node1, node2);
   }
@@ -600,7 +609,7 @@ function findConflict(
 
 function sameArguments(
   arguments1: Array<ArgumentNode>,
-  arguments2: Array<ArgumentNode>
+  arguments2: Array<ArgumentNode>,
 ): boolean {
   if (arguments1.length !== arguments2.length) {
     return false;
@@ -608,7 +617,7 @@ function sameArguments(
   return arguments1.every(argument1 => {
     const argument2 = find(
       arguments2,
-      argument => argument.name.value === argument1.name.value
+      argument => argument.name.value === argument1.name.value,
     );
     if (!argument2) {
       return false;
@@ -626,27 +635,27 @@ function sameValue(value1, value2) {
 // later recursively. However List and Non-Null types must match.
 function doTypesConflict(
   type1: GraphQLOutputType,
-  type2: GraphQLOutputType
+  type2: GraphQLOutputType,
 ): boolean {
   if (type1 instanceof GraphQLList) {
-    return type2 instanceof GraphQLList ?
-      doTypesConflict(type1.ofType, type2.ofType) :
-      true;
+    return type2 instanceof GraphQLList
+      ? doTypesConflict(type1.ofType, type2.ofType)
+      : true;
   }
   if (type2 instanceof GraphQLList) {
-    return type1 instanceof GraphQLList ?
-      doTypesConflict(type1.ofType, type2.ofType) :
-      true;
+    return type1 instanceof GraphQLList
+      ? doTypesConflict(type1.ofType, type2.ofType)
+      : true;
   }
   if (type1 instanceof GraphQLNonNull) {
-    return type2 instanceof GraphQLNonNull ?
-      doTypesConflict(type1.ofType, type2.ofType) :
-      true;
+    return type2 instanceof GraphQLNonNull
+      ? doTypesConflict(type1.ofType, type2.ofType)
+      : true;
   }
   if (type2 instanceof GraphQLNonNull) {
-    return type1 instanceof GraphQLNonNull ?
-      doTypesConflict(type1.ofType, type2.ofType) :
-      true;
+    return type1 instanceof GraphQLNonNull
+      ? doTypesConflict(type1.ofType, type2.ofType)
+      : true;
   }
   if (isLeafType(type1) || isLeafType(type2)) {
     return type1 !== type2;
@@ -661,8 +670,8 @@ function getFieldsAndFragmentNames(
   context: ValidationContext,
   cachedFieldsAndFragmentNames,
   parentType: ?GraphQLNamedType,
-  selectionSet: SelectionSetNode
-): [ NodeAndDefCollection, Array<string> ] {
+  selectionSet: SelectionSetNode,
+): [NodeAndDefCollection, Array<string>] {
   let cached = cachedFieldsAndFragmentNames.get(selectionSet);
   if (!cached) {
     const nodeAndDefs = Object.create(null);
@@ -672,9 +681,9 @@ function getFieldsAndFragmentNames(
       parentType,
       selectionSet,
       nodeAndDefs,
-      fragmentNames
+      fragmentNames,
     );
-    cached = [ nodeAndDefs, Object.keys(fragmentNames) ];
+    cached = [nodeAndDefs, Object.keys(fragmentNames)];
     cachedFieldsAndFragmentNames.set(selectionSet, cached);
   }
   return cached;
@@ -685,7 +694,7 @@ function getFieldsAndFragmentNames(
 function getReferencedFieldsAndFragmentNames(
   context: ValidationContext,
   cachedFieldsAndFragmentNames,
-  fragment: FragmentDefinitionNode
+  fragment: FragmentDefinitionNode,
 ) {
   // Short-circuit building a type from the node if possible.
   const cached = cachedFieldsAndFragmentNames.get(fragment.selectionSet);
@@ -698,7 +707,7 @@ function getReferencedFieldsAndFragmentNames(
     context,
     cachedFieldsAndFragmentNames,
     fragmentType,
-    fragment.selectionSet
+    fragment.selectionSet,
   );
 }
 
@@ -707,7 +716,7 @@ function _collectFieldsAndFragmentNames(
   parentType: ?GraphQLNamedType,
   selectionSet: SelectionSetNode,
   nodeAndDefs,
-  fragmentNames
+  fragmentNames,
 ): void {
   for (let i = 0; i < selectionSet.selections.length; i++) {
     const selection = selectionSet.selections[i];
@@ -715,31 +724,34 @@ function _collectFieldsAndFragmentNames(
       case Kind.FIELD:
         const fieldName = selection.name.value;
         let fieldDef;
-        if (parentType instanceof GraphQLObjectType ||
-            parentType instanceof GraphQLInterfaceType) {
+        if (
+          parentType instanceof GraphQLObjectType ||
+          parentType instanceof GraphQLInterfaceType
+        ) {
           fieldDef = parentType.getFields()[fieldName];
         }
-        const responseName =
-          selection.alias ? selection.alias.value : fieldName;
+        const responseName = selection.alias
+          ? selection.alias.value
+          : fieldName;
         if (!nodeAndDefs[responseName]) {
           nodeAndDefs[responseName] = [];
         }
-        nodeAndDefs[responseName].push([ parentType, selection, fieldDef ]);
+        nodeAndDefs[responseName].push([parentType, selection, fieldDef]);
         break;
       case Kind.FRAGMENT_SPREAD:
         fragmentNames[selection.name.value] = true;
         break;
       case Kind.INLINE_FRAGMENT:
         const typeCondition = selection.typeCondition;
-        const inlineFragmentType = typeCondition ?
-          typeFromAST(context.getSchema(), typeCondition) :
-          parentType;
+        const inlineFragmentType = typeCondition
+          ? typeFromAST(context.getSchema(), typeCondition)
+          : parentType;
         _collectFieldsAndFragmentNames(
           context,
           inlineFragmentType,
           selection.selectionSet,
           nodeAndDefs,
-          fragmentNames
+          fragmentNames,
         );
         break;
     }
@@ -752,19 +764,18 @@ function subfieldConflicts(
   conflicts: Array<Conflict>,
   responseName: string,
   node1: FieldNode,
-  node2: FieldNode
+  node2: FieldNode,
 ): ?Conflict {
   if (conflicts.length > 0) {
     return [
-      [ responseName, conflicts.map(([ reason ]) => reason) ],
+      [responseName, conflicts.map(([reason]) => reason)],
+      conflicts.reduce((allFields, [, fields1]) => allFields.concat(fields1), [
+        node1,
+      ]),
       conflicts.reduce(
-        (allFields, [ , fields1 ]) => allFields.concat(fields1),
-        [ node1 ]
+        (allFields, [, , fields2]) => allFields.concat(fields2),
+        [node2],
       ),
-      conflicts.reduce(
-        (allFields, [ , , fields2 ]) => allFields.concat(fields2),
-        [ node2 ]
-      )
     ];
   }
 }

--- a/src/validation/rules/PossibleFragmentSpreads.js
+++ b/src/validation/rules/PossibleFragmentSpreads.js
@@ -14,22 +14,25 @@ import { typeFromAST } from '../../utilities/typeFromAST';
 import { isCompositeType } from '../../type/definition';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function typeIncompatibleSpreadMessage(
   fragName: string,
   parentType: GraphQLType,
-  fragType: GraphQLType
+  fragType: GraphQLType,
 ): string {
-  return `Fragment "${fragName}" cannot be spread here as objects of ` +
-    `type "${String(parentType)}" can never be of type "${String(fragType)}".`;
+  return (
+    `Fragment "${fragName}" cannot be spread here as objects of ` +
+    `type "${String(parentType)}" can never be of type "${String(fragType)}".`
+  );
 }
 
 export function typeIncompatibleAnonSpreadMessage(
   parentType: GraphQLType,
-  fragType: GraphQLType
+  fragType: GraphQLType,
 ): string {
-  return 'Fragment cannot be spread here as objects of ' +
-    `type "${String(parentType)}" can never be of type "${String(fragType)}".`;
+  return (
+    'Fragment cannot be spread here as objects of ' +
+    `type "${String(parentType)}" can never be of type "${String(fragType)}".`
+  );
 }
 
 /**
@@ -44,28 +47,36 @@ export function PossibleFragmentSpreads(context: ValidationContext): any {
     InlineFragment(node) {
       const fragType = context.getType();
       const parentType = context.getParentType();
-      if (isCompositeType(fragType) &&
-          isCompositeType(parentType) &&
-          !doTypesOverlap(context.getSchema(), fragType, parentType)) {
-        context.reportError(new GraphQLError(
-          typeIncompatibleAnonSpreadMessage(parentType, fragType),
-          [ node ]
-        ));
+      if (
+        isCompositeType(fragType) &&
+        isCompositeType(parentType) &&
+        !doTypesOverlap(context.getSchema(), fragType, parentType)
+      ) {
+        context.reportError(
+          new GraphQLError(
+            typeIncompatibleAnonSpreadMessage(parentType, fragType),
+            [node],
+          ),
+        );
       }
     },
     FragmentSpread(node) {
       const fragName = node.name.value;
       const fragType = getFragmentType(context, fragName);
       const parentType = context.getParentType();
-      if (fragType &&
-          parentType &&
-          !doTypesOverlap(context.getSchema(), fragType, parentType)) {
-        context.reportError(new GraphQLError(
-          typeIncompatibleSpreadMessage(fragName, parentType, fragType),
-          [ node ]
-        ));
+      if (
+        fragType &&
+        parentType &&
+        !doTypesOverlap(context.getSchema(), fragType, parentType)
+      ) {
+        context.reportError(
+          new GraphQLError(
+            typeIncompatibleSpreadMessage(fragName, parentType, fragType),
+            [node],
+          ),
+        );
       }
-    }
+    },
   };
 }
 

--- a/src/validation/rules/ProvidedNonNullArguments.js
+++ b/src/validation/rules/ProvidedNonNullArguments.js
@@ -13,23 +13,26 @@ import keyMap from '../../jsutils/keyMap';
 import { GraphQLNonNull } from '../../type/definition';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function missingFieldArgMessage(
   fieldName: string,
   argName: string,
-  type: GraphQLType
+  type: GraphQLType,
 ): string {
-  return `Field "${fieldName}" argument "${argName}" of type ` +
-    `"${String(type)}" is required but not provided.`;
+  return (
+    `Field "${fieldName}" argument "${argName}" of type ` +
+    `"${String(type)}" is required but not provided.`
+  );
 }
 
 export function missingDirectiveArgMessage(
   directiveName: string,
   argName: string,
-  type: GraphQLType
+  type: GraphQLType,
 ): string {
-  return `Directive "@${directiveName}" argument "${argName}" of type ` +
-    `"${String(type)}" is required but not provided.`;
+  return (
+    `Directive "@${directiveName}" argument "${argName}" of type ` +
+    `"${String(type)}" is required but not provided.`
+  );
 }
 
 /**
@@ -53,17 +56,19 @@ export function ProvidedNonNullArguments(context: ValidationContext): any {
         fieldDef.args.forEach(argDef => {
           const argNode = argNodeMap[argDef.name];
           if (!argNode && argDef.type instanceof GraphQLNonNull) {
-            context.reportError(new GraphQLError(
-              missingFieldArgMessage(
-                node.name.value,
-                argDef.name,
-                argDef.type
+            context.reportError(
+              new GraphQLError(
+                missingFieldArgMessage(
+                  node.name.value,
+                  argDef.name,
+                  argDef.type,
+                ),
+                [node],
               ),
-              [ node ]
-            ));
+            );
           }
         });
-      }
+      },
     },
 
     Directive: {
@@ -79,17 +84,19 @@ export function ProvidedNonNullArguments(context: ValidationContext): any {
         directiveDef.args.forEach(argDef => {
           const argNode = argNodeMap[argDef.name];
           if (!argNode && argDef.type instanceof GraphQLNonNull) {
-            context.reportError(new GraphQLError(
-              missingDirectiveArgMessage(
-                node.name.value,
-                argDef.name,
-                argDef.type
+            context.reportError(
+              new GraphQLError(
+                missingDirectiveArgMessage(
+                  node.name.value,
+                  argDef.name,
+                  argDef.type,
+                ),
+                [node],
               ),
-              [ node ]
-            ));
+            );
           }
         });
-      }
-    }
+      },
+    },
   };
 }

--- a/src/validation/rules/ScalarLeafs.js
+++ b/src/validation/rules/ScalarLeafs.js
@@ -13,21 +13,24 @@ import type { FieldNode } from '../../language/ast';
 import { getNamedType, isLeafType } from '../../type/definition';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function noSubselectionAllowedMessage(
   fieldName: string,
-  type: GraphQLType
+  type: GraphQLType,
 ): string {
-  return `Field "${fieldName}" must not have a selection since ` +
-    `type "${String(type)}" has no subfields.`;
+  return (
+    `Field "${fieldName}" must not have a selection since ` +
+    `type "${String(type)}" has no subfields.`
+  );
 }
 
 export function requiredSubselectionMessage(
   fieldName: string,
-  type: GraphQLType
+  type: GraphQLType,
 ): string {
-  return `Field "${fieldName}" of type "${String(type)}" must have a ` +
-    `selection of subfields. Did you mean "${fieldName} { ... }"?`;
+  return (
+    `Field "${fieldName}" of type "${String(type)}" must have a ` +
+    `selection of subfields. Did you mean "${fieldName} { ... }"?`
+  );
 }
 
 /**
@@ -43,18 +46,22 @@ export function ScalarLeafs(context: ValidationContext): any {
       if (type) {
         if (isLeafType(getNamedType(type))) {
           if (node.selectionSet) {
-            context.reportError(new GraphQLError(
-              noSubselectionAllowedMessage(node.name.value, type),
-              [ node.selectionSet ]
-            ));
+            context.reportError(
+              new GraphQLError(
+                noSubselectionAllowedMessage(node.name.value, type),
+                [node.selectionSet],
+              ),
+            );
           }
         } else if (!node.selectionSet) {
-          context.reportError(new GraphQLError(
-            requiredSubselectionMessage(node.name.value, type),
-            [ node ]
-          ));
+          context.reportError(
+            new GraphQLError(
+              requiredSubselectionMessage(node.name.value, type),
+              [node],
+            ),
+          );
         }
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/SingleFieldSubscriptions.js
+++ b/src/validation/rules/SingleFieldSubscriptions.js
@@ -11,10 +11,11 @@ import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import type { OperationDefinitionNode } from '../../language/ast';
 
-
 export function singleFieldOnlyMessage(name: ?string): string {
-  return (name ? `Subscription "${name}" ` : 'Anonymous Subscription ') +
-    'must select only one top level field.';
+  return (
+    (name ? `Subscription "${name}" ` : 'Anonymous Subscription ') +
+    'must select only one top level field.'
+  );
 }
 
 /**
@@ -27,12 +28,14 @@ export function SingleFieldSubscriptions(context: ValidationContext): any {
     OperationDefinition(node: OperationDefinitionNode) {
       if (node.operation === 'subscription') {
         if (node.selectionSet.selections.length !== 1) {
-          context.reportError(new GraphQLError(
-            singleFieldOnlyMessage(node.name && node.name.value),
-            node.selectionSet.selections.slice(1)
-          ));
+          context.reportError(
+            new GraphQLError(
+              singleFieldOnlyMessage(node.name && node.name.value),
+              node.selectionSet.selections.slice(1),
+            ),
+          );
         }
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/UniqueArgumentNames.js
+++ b/src/validation/rules/UniqueArgumentNames.js
@@ -10,7 +10,6 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function duplicateArgMessage(argName: string): string {
   return `There can be only one argument named "${argName}".`;
 }
@@ -33,14 +32,16 @@ export function UniqueArgumentNames(context: ValidationContext): any {
     Argument(node) {
       const argName = node.name.value;
       if (knownArgNames[argName]) {
-        context.reportError(new GraphQLError(
-          duplicateArgMessage(argName),
-          [ knownArgNames[argName], node.name ]
-        ));
+        context.reportError(
+          new GraphQLError(duplicateArgMessage(argName), [
+            knownArgNames[argName],
+            node.name,
+          ]),
+        );
       } else {
         knownArgNames[argName] = node.name;
       }
       return false;
-    }
+    },
   };
 }

--- a/src/validation/rules/UniqueDirectivesPerLocation.js
+++ b/src/validation/rules/UniqueDirectivesPerLocation.js
@@ -10,10 +10,11 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function duplicateDirectiveMessage(directiveName: string): string {
-  return `The directive "${directiveName}" can only be used once at ` +
-    'this location.';
+  return (
+    `The directive "${directiveName}" can only be used once at ` +
+    'this location.'
+  );
 }
 
 /**
@@ -33,15 +34,17 @@ export function UniqueDirectivesPerLocation(context: ValidationContext): any {
         node.directives.forEach(directive => {
           const directiveName = directive.name.value;
           if (knownDirectives[directiveName]) {
-            context.reportError(new GraphQLError(
-              duplicateDirectiveMessage(directiveName),
-              [ knownDirectives[directiveName], directive ]
-            ));
+            context.reportError(
+              new GraphQLError(duplicateDirectiveMessage(directiveName), [
+                knownDirectives[directiveName],
+                directive,
+              ]),
+            );
           } else {
             knownDirectives[directiveName] = directive;
           }
         });
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/UniqueFragmentNames.js
+++ b/src/validation/rules/UniqueFragmentNames.js
@@ -10,7 +10,6 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function duplicateFragmentNameMessage(fragName: string): string {
   return `There can be only one fragment named "${fragName}".`;
 }
@@ -27,14 +26,16 @@ export function UniqueFragmentNames(context: ValidationContext): any {
     FragmentDefinition(node) {
       const fragmentName = node.name.value;
       if (knownFragmentNames[fragmentName]) {
-        context.reportError(new GraphQLError(
-          duplicateFragmentNameMessage(fragmentName),
-          [ knownFragmentNames[fragmentName], node.name ]
-        ));
+        context.reportError(
+          new GraphQLError(duplicateFragmentNameMessage(fragmentName), [
+            knownFragmentNames[fragmentName],
+            node.name,
+          ]),
+        );
       } else {
         knownFragmentNames[fragmentName] = node.name;
       }
       return false;
-    }
+    },
   };
 }

--- a/src/validation/rules/UniqueInputFieldNames.js
+++ b/src/validation/rules/UniqueInputFieldNames.js
@@ -10,7 +10,6 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function duplicateInputFieldMessage(fieldName: string): string {
   return `There can be only one input field named "${fieldName}".`;
 }
@@ -33,19 +32,21 @@ export function UniqueInputFieldNames(context: ValidationContext): any {
       },
       leave() {
         knownNames = knownNameStack.pop();
-      }
+      },
     },
     ObjectField(node) {
       const fieldName = node.name.value;
       if (knownNames[fieldName]) {
-        context.reportError(new GraphQLError(
-          duplicateInputFieldMessage(fieldName),
-          [ knownNames[fieldName], node.name ]
-        ));
+        context.reportError(
+          new GraphQLError(duplicateInputFieldMessage(fieldName), [
+            knownNames[fieldName],
+            node.name,
+          ]),
+        );
       } else {
         knownNames[fieldName] = node.name;
       }
       return false;
-    }
+    },
   };
 }

--- a/src/validation/rules/UniqueOperationNames.js
+++ b/src/validation/rules/UniqueOperationNames.js
@@ -10,7 +10,6 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 
-
 export function duplicateOperationNameMessage(operationName: string): string {
   return `There can be only one operation named "${operationName}".`;
 }
@@ -27,10 +26,12 @@ export function UniqueOperationNames(context: ValidationContext): any {
       const operationName = node.name;
       if (operationName) {
         if (knownOperationNames[operationName.value]) {
-          context.reportError(new GraphQLError(
-            duplicateOperationNameMessage(operationName.value),
-            [ knownOperationNames[operationName.value], operationName ]
-          ));
+          context.reportError(
+            new GraphQLError(
+              duplicateOperationNameMessage(operationName.value),
+              [knownOperationNames[operationName.value], operationName],
+            ),
+          );
         } else {
           knownOperationNames[operationName.value] = operationName;
         }

--- a/src/validation/rules/UniqueVariableNames.js
+++ b/src/validation/rules/UniqueVariableNames.js
@@ -11,7 +11,6 @@ import type { ValidationContext } from '../index';
 import type { VariableDefinitionNode } from '../../language/ast';
 import { GraphQLError } from '../../error';
 
-
 export function duplicateVariableMessage(variableName: string): string {
   return `There can be only one variable named "${variableName}".`;
 }
@@ -30,13 +29,15 @@ export function UniqueVariableNames(context: ValidationContext): any {
     VariableDefinition(node: VariableDefinitionNode) {
       const variableName = node.variable.name.value;
       if (knownVariableNames[variableName]) {
-        context.reportError(new GraphQLError(
-          duplicateVariableMessage(variableName),
-          [ knownVariableNames[variableName], node.variable.name ]
-        ));
+        context.reportError(
+          new GraphQLError(duplicateVariableMessage(variableName), [
+            knownVariableNames[variableName],
+            node.variable.name,
+          ]),
+        );
       } else {
         knownVariableNames[variableName] = node.variable.name;
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/VariablesAreInputTypes.js
+++ b/src/validation/rules/VariablesAreInputTypes.js
@@ -14,10 +14,9 @@ import { print } from '../../language/printer';
 import { isInputType } from '../../type/definition';
 import { typeFromAST } from '../../utilities/typeFromAST';
 
-
 export function nonInputTypeOnVarMessage(
   variableName: string,
-  typeName: string
+  typeName: string,
 ): string {
   return `Variable "$${variableName}" cannot be non-input type "${typeName}".`;
 }
@@ -36,11 +35,13 @@ export function VariablesAreInputTypes(context: ValidationContext): any {
       // If the variable type is not an input type, return an error.
       if (type && !isInputType(type)) {
         const variableName = node.variable.name.value;
-        context.reportError(new GraphQLError(
-          nonInputTypeOnVarMessage(variableName, print(node.type)),
-          [ node.type ]
-        ));
+        context.reportError(
+          new GraphQLError(
+            nonInputTypeOnVarMessage(variableName, print(node.type)),
+            [node.type],
+          ),
+        );
       }
-    }
+    },
   };
 }

--- a/src/validation/rules/VariablesInAllowedPosition.js
+++ b/src/validation/rules/VariablesInAllowedPosition.js
@@ -14,14 +14,15 @@ import { isTypeSubTypeOf } from '../../utilities/typeComparators';
 import { typeFromAST } from '../../utilities/typeFromAST';
 import type { GraphQLType } from '../../type/definition';
 
-
 export function badVarPosMessage(
   varName: string,
   varType: GraphQLType,
-  expectedType: GraphQLType
+  expectedType: GraphQLType,
 ): string {
-  return `Variable "$${varName}" of type "${String(varType)}" used in ` +
-    `position expecting type "${String(expectedType)}".`;
+  return (
+    `Variable "$${varName}" of type "${String(varType)}" used in ` +
+    `position expecting type "${String(expectedType)}".`
+  );
 }
 
 /**
@@ -53,24 +54,26 @@ export function VariablesInAllowedPosition(context: ValidationContext): any {
               varType &&
               !isTypeSubTypeOf(schema, effectiveType(varType, varDef), type)
             ) {
-              context.reportError(new GraphQLError(
-                badVarPosMessage(varName, varType, type),
-                [ varDef, node ]
-              ));
+              context.reportError(
+                new GraphQLError(badVarPosMessage(varName, varType, type), [
+                  varDef,
+                  node,
+                ]),
+              );
             }
           }
         });
-      }
+      },
     },
     VariableDefinition(node) {
       varDefMap[node.variable.name.value] = node;
-    }
+    },
   };
 }
 
 // If a variable definition has a default value, it's effectively non-null.
 function effectiveType(varType, varDef) {
-  return !varDef.defaultValue || varType instanceof GraphQLNonNull ?
-    varType :
-    new GraphQLNonNull(varType);
+  return !varDef.defaultValue || varType instanceof GraphQLNonNull
+    ? varType
+    : new GraphQLNonNull(varType);
 }

--- a/src/validation/specifiedRules.js
+++ b/src/validation/specifiedRules.js
@@ -59,9 +59,7 @@ import { NoUnusedVariables } from './rules/NoUnusedVariables';
 import { KnownDirectives } from './rules/KnownDirectives';
 
 // Spec Section: "Directives Are Unique Per Location"
-import {
-  UniqueDirectivesPerLocation
-} from './rules/UniqueDirectivesPerLocation';
+import { UniqueDirectivesPerLocation } from './rules/UniqueDirectivesPerLocation';
 
 // Spec Section: "Argument Names"
 import { KnownArgumentNames } from './rules/KnownArgumentNames';
@@ -82,9 +80,7 @@ import { DefaultValuesOfCorrectType } from './rules/DefaultValuesOfCorrectType';
 import { VariablesInAllowedPosition } from './rules/VariablesInAllowedPosition';
 
 // Spec Section: "Field Selection Merging"
-import {
-  OverlappingFieldsCanBeMerged
-} from './rules/OverlappingFieldsCanBeMerged';
+import { OverlappingFieldsCanBeMerged } from './rules/OverlappingFieldsCanBeMerged';
 
 // Spec Section: "Input Object Field Uniqueness"
 import { UniqueInputFieldNames } from './rules/UniqueInputFieldNames';

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -8,7 +8,7 @@
  */
 
 import invariant from '../jsutils/invariant';
-import type {ObjMap} from '../jsutils/ObjMap';
+import type { ObjMap } from '../jsutils/ObjMap';
 import { GraphQLError } from '../error';
 import { visit, visitInParallel, visitWithTypeInfo } from '../language/visitor';
 import * as Kind from '../language/kinds';
@@ -26,12 +26,11 @@ import type {
   GraphQLOutputType,
   GraphQLCompositeType,
   GraphQLField,
-  GraphQLArgument
+  GraphQLArgument,
 } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';
 import { TypeInfo } from '../utilities/TypeInfo';
 import { specifiedRules } from './specifiedRules';
-
 
 /**
  * Implements the "Validation" section of the spec.
@@ -60,13 +59,13 @@ export function validate(
   invariant(
     schema instanceof GraphQLSchema,
     'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
-    'not multiple versions of GraphQL installed in your node_modules directory.'
+      'not multiple versions of GraphQL installed in your node_modules directory.',
   );
   return visitUsingRules(
     schema,
     typeInfo || new TypeInfo(schema),
     ast,
-    rules || specifiedRules
+    rules || specifiedRules,
   );
 }
 
@@ -80,7 +79,7 @@ function visitUsingRules(
   schema: GraphQLSchema,
   typeInfo: TypeInfo,
   documentAST: DocumentNode,
-  rules: Array<any>
+  rules: Array<any>,
 ): Array<GraphQLError> {
   const context = new ValidationContext(schema, documentAST, typeInfo);
   const visitors = rules.map(rule => rule(context));
@@ -106,7 +105,7 @@ export class ValidationContext {
   _fragmentSpreads: Map<SelectionSetNode, Array<FragmentSpreadNode>>;
   _recursivelyReferencedFragments: Map<
     OperationDefinitionNode,
-    Array<FragmentDefinitionNode>
+    Array<FragmentDefinitionNode>,
   >;
   _variableUsages: Map<NodeWithSelectionSet, Array<VariableUsage>>;
   _recursiveVariableUsages: Map<OperationDefinitionNode, Array<VariableUsage>>;
@@ -114,7 +113,7 @@ export class ValidationContext {
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,
-    typeInfo: TypeInfo
+    typeInfo: TypeInfo,
   ): void {
     this._schema = schema;
     this._ast = ast;
@@ -145,13 +144,15 @@ export class ValidationContext {
   getFragment(name: string): ?FragmentDefinitionNode {
     let fragments = this._fragments;
     if (!fragments) {
-      this._fragments = fragments =
-        this.getDocument().definitions.reduce((frags, statement) => {
+      this._fragments = fragments = this.getDocument().definitions.reduce(
+        (frags, statement) => {
           if (statement.kind === Kind.FRAGMENT_DEFINITION) {
             frags[statement.name.value] = statement;
           }
           return frags;
-        }, Object.create(null));
+        },
+        Object.create(null),
+      );
     }
     return fragments[name];
   }
@@ -160,7 +161,7 @@ export class ValidationContext {
     let spreads = this._fragmentSpreads.get(node);
     if (!spreads) {
       spreads = [];
-      const setsToVisit: Array<SelectionSetNode> = [ node ];
+      const setsToVisit: Array<SelectionSetNode> = [node];
       while (setsToVisit.length !== 0) {
         const set = setsToVisit.pop();
         for (let i = 0; i < set.selections.length; i++) {
@@ -178,13 +179,13 @@ export class ValidationContext {
   }
 
   getRecursivelyReferencedFragments(
-    operation: OperationDefinitionNode
+    operation: OperationDefinitionNode,
   ): Array<FragmentDefinitionNode> {
     let fragments = this._recursivelyReferencedFragments.get(operation);
     if (!fragments) {
       fragments = [];
       const collectedNames = Object.create(null);
-      const nodesToVisit: Array<SelectionSetNode> = [ operation.selectionSet ];
+      const nodesToVisit: Array<SelectionSetNode> = [operation.selectionSet];
       while (nodesToVisit.length !== 0) {
         const node = nodesToVisit.pop();
         const spreads = this.getFragmentSpreads(node);
@@ -210,12 +211,15 @@ export class ValidationContext {
     if (!usages) {
       const newUsages = [];
       const typeInfo = new TypeInfo(this._schema);
-      visit(node, visitWithTypeInfo(typeInfo, {
-        VariableDefinition: () => false,
-        Variable(variable) {
-          newUsages.push({ node: variable, type: typeInfo.getInputType() });
-        }
-      }));
+      visit(
+        node,
+        visitWithTypeInfo(typeInfo, {
+          VariableDefinition: () => false,
+          Variable(variable) {
+            newUsages.push({ node: variable, type: typeInfo.getInputType() });
+          },
+        }),
+      );
       usages = newUsages;
       this._variableUsages.set(node, usages);
     }
@@ -223,7 +227,7 @@ export class ValidationContext {
   }
 
   getRecursiveVariableUsages(
-    operation: OperationDefinitionNode
+    operation: OperationDefinitionNode,
   ): Array<VariableUsage> {
     let usages = this._recursiveVariableUsages.get(operation);
     if (!usages) {
@@ -232,7 +236,7 @@ export class ValidationContext {
       for (let i = 0; i < fragments.length; i++) {
         Array.prototype.push.apply(
           usages,
-          this.getVariableUsages(fragments[i])
+          this.getVariableUsages(fragments[i]),
         );
       }
       this._recursiveVariableUsages.set(operation, usages);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,6 +1042,13 @@ eslint-plugin-flowtype@2.35.0:
   dependencies:
     lodash "^4.15.0"
 
+eslint-plugin-prettier@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -1177,6 +1184,10 @@ extsprintf@1.0.2:
 fast-deep-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz#96256a3bc975595eb36d82e9929d060d893439ff"
+
+fast-diff@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.2.tgz#4b62c42b8e03de3f848460b639079920695d0154"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
@@ -1681,6 +1692,10 @@ iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
+jest-docblock@^21.0.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+
 jodid25519@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
@@ -2126,6 +2141,10 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 private@^0.1.6:
   version "0.1.7"


### PR DESCRIPTION
I was surprised to see graphql-js wasn't using prettier yet when my code wasn't auto-formatted on save.

This adds prettier via eslint plugin and `yarn prettier` command using the options that most closely reflect the current formatting decisions.