### PR TITLE
Option to resolve conflicts when extending schema

### DIFF
--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -999,4 +999,18 @@ describe('extendSchema', () => {
     });
 
   });
+
+  it('allows replacing existing field with resolveConflict function', () => {
+    const ast = parse(`
+      extend type Bar {
+        foo: Foo
+      }
+    `);
+    expect(() =>
+      extendSchema(testSchema, ast, { resolveConflict: orig => orig})
+    ).not.to.throw(
+      'Field "Bar.foo" already exists in the schema. It cannot also be ' +
+      'defined in this type extension.'
+    );
+  });
 });


### PR DESCRIPTION
I keep a copy of this `extendSchema` script so that I can add an argument to the field to choose which schema to go to (extended local schema, or original remote), not sure if there is general interest in doing similar things, but I will leave this here for discussion.