### PR TITLE
fix elasticsearch errors being mistaken for graphql errors

### DIFF
--- a/src/error/__tests__/locatedError-test.js
+++ b/src/error/__tests__/locatedError-test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { GraphQLError } from '../../';
+import { locatedError } from '../locatedError';
+
+describe('locatedError', () => {
+
+  it('passes GraphQLError through', () => {
+    const e = new GraphQLError(
+      'msg',
+      null,
+      null,
+      null,
+      [ 'path', 3, 'to', 'field' ]
+    );
+
+    expect(locatedError(e, [], [])).to.deep.equal(e);
+  });
+
+  it('passes GraphQLError-ish through', () => {
+    const e = new Error('I have a different prototype chain');
+    e.locations = [];
+    e.path = [];
+    e.nodes = [];
+    e.source = null;
+    e.positions = [];
+    e.name = 'GraphQLError';
+
+    expect(locatedError(e, [], [])).to.deep.equal(e);
+  });
+
+  it('does not pass through elasticsearch-like errors', () => {
+    const e = new Error('I am from elasticsearch');
+    e.path = '/something/feed/_search';
+
+    expect(locatedError(e, [], [])).to.not.deep.equal(e);
+  });
+
+});

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -22,7 +22,7 @@ export function locatedError(
 ): GraphQLError {
   // Note: this uses a brand-check to support GraphQL errors originating from
   // other contexts.
-  if (originalError && originalError.path) {
+  if (originalError && Array.isArray(originalError.path)) {
     return (originalError: any);
   }
 


### PR DESCRIPTION
Elasticsearch [records its index path](https://github.com/elastic/elasticsearch-js/blob/6c4882681fe91c0c90901aa47f68b02dc9ed58f8/src/lib/transport.js#L298) and [attaches it to errors](https://github.com/elastic/elasticsearch-js/blob/14.x/src/lib/errors.js#L23). Its useful, but sadly that `path` property means that graphql-js assumes that an elasticsearch error is a GraphQLError, and so the index path gets leaked instead of the useful graphql query path.

The fix is to be a little bit stricter.

There is probably a better fix to recognise a GraphQLError across contexts, but this will at least improve the situation. Plus, the added tests should make any better solution easier to test.