### PR TITLE
Uniform parsing of queries with short-hand syntax with regular queries

### DIFF
--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -218,7 +218,7 @@ describe('Parser', () => {
           loc: { start: 0, end: 40 },
           operation: 'query',
           name: null,
-          variableDefinitions: null,
+          variableDefinitions: [],
           directives: [],
           selectionSet:
           { kind: Kind.SELECTION_SET,
@@ -288,7 +288,7 @@ describe('Parser', () => {
           loc: { start: 0, end: 29 },
           operation: 'query',
           name: null,
-          variableDefinitions: null,
+          variableDefinitions: [],
           directives: [],
           selectionSet:
           { kind: Kind.SELECTION_SET,

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -270,6 +270,56 @@ describe('Parser', () => {
     );
   });
 
+  it('creates ast from nameless query without variables', () => {
+
+    const source = new Source(`query {
+  node {
+    id
+  }
+}
+`);
+    const result = parse(source);
+
+    expect(result).to.containSubset(
+      { kind: Kind.DOCUMENT,
+        loc: { start: 0, end: 30 },
+        definitions:
+        [ { kind: Kind.OPERATION_DEFINITION,
+          loc: { start: 0, end: 29 },
+          operation: 'query',
+          name: null,
+          variableDefinitions: null,
+          directives: [],
+          selectionSet:
+          { kind: Kind.SELECTION_SET,
+            loc: { start: 6, end: 29 },
+            selections:
+            [ { kind: Kind.FIELD,
+              loc: { start: 10, end: 27 },
+              alias: null,
+              name:
+              { kind: Kind.NAME,
+                loc: { start: 10, end: 14 },
+                value: 'node' },
+              arguments: [],
+              directives: [],
+              selectionSet:
+              { kind: Kind.SELECTION_SET,
+                loc: { start: 15, end: 27 },
+                selections:
+                [ { kind: Kind.FIELD,
+                  loc: { start: 21, end: 23 },
+                  alias: null,
+                  name:
+                  { kind: Kind.NAME,
+                    loc: { start: 21, end: 23 },
+                    value: 'id' },
+                  arguments: [],
+                  directives: [],
+                  selectionSet: null } ] } } ] } } ] }
+    );
+  });
+
   it('allows parsing without source location information', () => {
     const source = new Source('{ id }');
     const result = parse(source, { noLocation: true });

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -282,7 +282,7 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
     };
   }
   const operation = parseOperationType(lexer);
-  let name;
+  let name = null;
   if (peek(lexer, TokenKind.NAME)) {
     name = parseName(lexer);
   }
@@ -317,7 +317,7 @@ function parseOperationType(lexer: Lexer<*>): OperationTypeNode {
  */
 function parseVariableDefinitions(
   lexer: Lexer<*>
-): Array<VariableDefinitionNode> {
+): ?Array<VariableDefinitionNode> {
   return peek(lexer, TokenKind.PAREN_L) ?
     many(
       lexer,
@@ -325,7 +325,7 @@ function parseVariableDefinitions(
       parseVariableDefinition,
       TokenKind.PAREN_R
     ) :
-    [];
+    null;
 }
 
 /**

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -275,17 +275,16 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
       kind: OPERATION_DEFINITION,
       operation: 'query',
       name: null,
-      variableDefinitions: null,
+      variableDefinitions: [],
       directives: [],
       selectionSet: parseSelectionSet(lexer),
       loc: loc(lexer, start)
     };
   }
   const operation = parseOperationType(lexer);
-  let name = null;
-  if (peek(lexer, TokenKind.NAME)) {
-    name = parseName(lexer);
-  }
+  const name = peek(lexer, TokenKind.NAME) ?
+    parseName(lexer) :
+    null;
   return {
     kind: OPERATION_DEFINITION,
     operation,
@@ -317,7 +316,7 @@ function parseOperationType(lexer: Lexer<*>): OperationTypeNode {
  */
 function parseVariableDefinitions(
   lexer: Lexer<*>
-): ?Array<VariableDefinitionNode> {
+): Array<VariableDefinitionNode> {
   return peek(lexer, TokenKind.PAREN_L) ?
     many(
       lexer,
@@ -325,7 +324,7 @@ function parseVariableDefinitions(
       parseVariableDefinition,
       TokenKind.PAREN_R
     ) :
-    null;
+    [];
 }
 
 /**


### PR DESCRIPTION
To date, parsing queries with short-hand syntax returns different results from parsing regular queries.

`parse('query{a{b}}')` returns
```
...
  name: undefined,
  variableDefinitions: [],
...
```
However, `parse('{a{b}}')` returns
```
...
  name: null,
  variableDefinitions: null,
...
```
![image](https://user-images.githubusercontent.com/5000549/32994954-21dc3b0e-cd98-11e7-8fa7-d4e7e8d4c2e0.png)

This shouldn't be the case. This PR made queries with short-hand syntax to be parsed as regular.

This inconsistency indirectly causes [this bug](https://github.com/graphql/graphiql/issues/234) to happen in GraphiQL. Despite that issue being closed, using GraphiQL without `express-graphql` still makes that bug to happen (with `null` value, actually, but this doesn't change much).

Closes #729.