### PR TITLE
(Potentially Breaking) Allow serializing scalars as null.

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -10,6 +10,7 @@
 import { forEach, isCollection } from 'iterall';
 import { GraphQLError, locatedError } from '../error';
 import invariant from '../jsutils/invariant';
+import isInvalid from '../jsutils/isInvalid';
 import isNullish from '../jsutils/isNullish';
 import type {ObjMap} from '../jsutils/ObjMap';
 
@@ -1013,7 +1014,7 @@ function completeLeafValue(
 ): mixed {
   invariant(returnType.serialize, 'Missing serialize method on type');
   const serializedResult = returnType.serialize(result);
-  if (isNullish(serializedResult)) {
+  if (isInvalid(serializedResult)) {
     throw new Error(
       `Expected a value of type "${String(returnType)}" but ` +
       `received: ${String(result)}`

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -294,12 +294,19 @@ function resolveThunk<T>(thunk: Thunk<T>): T {
  * Scalars (or Enums) and are defined with a name and a series of functions
  * used to parse input from ast or variables and to ensure validity.
  *
+ * If a type's serialize function does not return a value (i.e. it returns
+ * `undefined`) then an error will be raised and a `null` value will be returned
+ * in the response. If the serialize function returns `null`, then no error will
+ * be included in the response.
+ *
  * Example:
  *
  *     const OddType = new GraphQLScalarType({
  *       name: 'Odd',
  *       serialize(value) {
- *         return value % 2 === 1 ? value : null;
+ *         if (value % 2 === 1) {
+ *           return value;
+ *         }
  *       }
  *     });
  *
@@ -924,7 +931,9 @@ export class GraphQLEnumType/* <T> */ {
 
   serialize(value: any/* T */): ?string {
     const enumValue = this._getValueLookup().get(value);
-    return enumValue ? enumValue.name : null;
+    if (enumValue) {
+      return enumValue.name;
+    }
   }
 
   isValidValue(value: mixed): boolean {


### PR DESCRIPTION
This changes the check for null/undefined to a check for undefined to determine if scalar serialization was successful or not, allowing `null` to be returned from serialize() without indicating error.

This is potentially breaking for any existing custom scalar which returned `null` from `serialize()` to indicate failure. To account for this change, it should either throw an error or return `undefined`.

Fixes #1057
Closes #1066