### PR TITLE
Test: Missing subscription field should not be an "internal error"

### DIFF
--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -23,7 +23,6 @@ import {
   responsePathAsArray,
 } from '../execution/execute';
 import { GraphQLSchema } from '../type/schema';
-import invariant from '../jsutils/invariant';
 import mapAsyncIterator from './mapAsyncIterator';
 
 import type { ObjMap } from '../jsutils/ObjMap';
@@ -223,8 +222,15 @@ export function createSourceEventStream(
     const responseName = responseNames[0];
     const fieldNodes = fields[responseName];
     const fieldNode = fieldNodes[0];
-    const fieldDef = getFieldDef(schema, type, fieldNode.name.value);
-    invariant(fieldDef, 'This subscription is not defined by the schema.');
+    const fieldName = fieldNode.name.value;
+    const fieldDef = getFieldDef(schema, type, fieldName);
+
+    if (!fieldDef) {
+      throw new GraphQLError(
+        `The subscription field "${fieldName}" is not defined.`,
+        fieldNodes,
+      );
+    }
 
     // Call the `subscribe()` resolver or the default resolver to produce an
     // AsyncIterable yielding raw payloads.


### PR DESCRIPTION
A remaining issue with subscriptions is attempting to subscribe to a missing field. The existing implementation creates an internal error which is an improper blame since there is no possibility to fix it internally - it is an issue with the query.

For consistency with the same scenario for query/mutation operations, this simply returns nothing. I interpret the equivalent of "undefined" for a subscribe operation as an empty iteration.

Note: this will require spec changes, however spec changes are necessary either way to resolve the ambiguity of this exact scenario.