### PR TITLE
Subscriptions: report resolver errors during initialization

### DIFF
--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -18,7 +18,7 @@ export function formatError(error: GraphQLError): GraphQLFormattedError {
   invariant(error, 'Received null or undefined error.');
   return {
     ...error.extensions,
-    message: error.message,
+    message: error.message || 'An unknown error occurred.',
     locations: error.locations,
     path: error.path,
   };

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -16,7 +16,7 @@ import type { ASTNode } from '../language/ast';
  * document responsible for the original Error.
  */
 export function locatedError(
-  originalError: ?Error,
+  originalError: Error,
   nodes: $ReadOnlyArray<ASTNode>,
   path: $ReadOnlyArray<string | number>,
 ): GraphQLError {
@@ -26,10 +26,8 @@ export function locatedError(
     return (originalError: any);
   }
 
-  const message =
-    (originalError && originalError.message) || 'An unknown error occurred.';
   return new GraphQLError(
-    message,
+    originalError && originalError.message,
     (originalError && (originalError: any).nodes) || nodes,
     originalError && (originalError: any).source,
     originalError && (originalError: any).positions,

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -26,9 +26,8 @@ export function locatedError(
     return (originalError: any);
   }
 
-  const message = originalError
-    ? originalError.message || String(originalError)
-    : 'An unknown error occurred.';
+  const message =
+    (originalError && originalError.message) || 'An unknown error occurred.';
   return new GraphQLError(
     message,
     (originalError && (originalError: any).nodes) || nodes,

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -753,7 +753,15 @@ export function resolveFieldValueOrError<TSource>(
     // used to represent an authenticated user, or request-specific caches.
     const context = exeContext.contextValue;
 
-    return resolveFn(source, args, context, info);
+    const result = resolveFn(source, args, context, info);
+    const promise = getPromise(result);
+    return !promise
+      ? result
+      : promise.then(undefined, error =>
+          // Sometimes a non-error is thrown, wrap it as an Error for a
+          // consistent interface.
+          Promise.resolve(error instanceof Error ? error : new Error(error)),
+        );
   } catch (error) {
     // Sometimes a non-error is thrown, wrap it as an Error for a
     // consistent interface.

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -234,6 +234,9 @@ export function createSourceEventStream(
 
     const info = buildResolveInfo(exeContext, fieldDef, fieldNodes, type, path);
 
+    // resolveFieldValueOrError implements the "ResolveFieldEventStream"
+    // algorithm from GraphQL specification. It differs from
+    // "ResolveFieldValue" due to providing a different `resolveFn`.
     const result = resolveFieldValueOrError(
       exeContext,
       fieldDef,
@@ -243,7 +246,7 @@ export function createSourceEventStream(
       info,
     );
 
-    // Coerce to Promise for easier error handling.
+    // Coerce to Promise for easier error handling and consistent return type.
     return Promise.resolve(result).then(eventStream => {
       // If eventStream is an Error, rethrow a located error.
       if (eventStream instanceof Error) {


### PR DESCRIPTION
Expanding on the tests to cover all forms of subscription resolver errors.