### PR TITLE
Fix typo in block string lexer tests

### DIFF
--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -301,11 +301,11 @@ describe('Lexer', () => {
     });
 
     expect(
-      lexOne('" white space "')
+      lexOne('""" white space """')
     ).to.containSubset({
-      kind: TokenKind.STRING,
+      kind: TokenKind.BLOCK_STRING,
       start: 0,
-      end: 15,
+      end: 19,
       value: ' white space '
     });
 


### PR DESCRIPTION
While looking over https://github.com/graphql/graphql-js/pull/926, I noticed what I believe is a bad copy/paste in the block string lexer tests.

cc @leebyron 