### PR TITLE
Improve introspection types + new getIntrospectionQuery()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,10 @@ export type { GraphQLFormattedError, GraphQLErrorLocation } from './error';
 
 // Utilities for operating on GraphQL type schema and parsed sources.
 export {
-  // The GraphQL query recommended for a full schema introspection.
+  // Produce the GraphQL query recommended for a full schema introspection.
+  // Accepts optional IntrospectionOptions.
+  getIntrospectionQuery,
+  // Deprecated: use getIntrospectionQuery
   introspectionQuery,
   // Gets the target Operation from a Document
   getOperationAST,
@@ -325,6 +328,7 @@ export {
 export type {
   BreakingChange,
   DangerousChange,
+  IntrospectionOptions,
   IntrospectionDirective,
   IntrospectionEnumType,
   IntrospectionEnumValue,

--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -15,7 +15,7 @@ import {
   GraphQLInt,
   GraphQLString,
   GraphQLBoolean,
-  introspectionQuery,
+  getIntrospectionQuery,
 } from '../../';
 
 describe('Type System: Enum Values', () => {
@@ -411,7 +411,7 @@ describe('Type System: Enum Values', () => {
   });
 
   it('can be introspected without error', async () => {
-    const result = await graphql(schema, introspectionQuery);
+    const result = await graphql(schema, getIntrospectionQuery());
     expect(result).to.not.have.property('errors');
   });
 });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -19,7 +19,7 @@ import {
   GraphQLEnumType,
 } from '../../';
 
-import { introspectionQuery } from '../../utilities/introspectionQuery';
+import { getIntrospectionQuery } from '../../utilities/introspectionQuery';
 
 describe('Introspection', () => {
   it('executes an introspection query', async () => {
@@ -33,7 +33,7 @@ describe('Introspection', () => {
     });
 
     return expect(
-      await graphql(EmptySchema, introspectionQuery),
+      await graphql(EmptySchema, getIntrospectionQuery()),
     ).to.containSubset({
       data: {
         __schema: {

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -8,7 +8,7 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { buildClientSchema } from '../buildClientSchema';
-import { introspectionQuery } from '../introspectionQuery';
+import { getIntrospectionQuery } from '../introspectionQuery';
 import {
   graphql,
   GraphQLSchema,
@@ -35,9 +35,15 @@ import { GraphQLDirective } from '../../type/directives';
 // query against the client-side schema, it should get a result identical to
 // what was returned by the server.
 async function testSchema(serverSchema) {
-  const initialIntrospection = await graphql(serverSchema, introspectionQuery);
+  const initialIntrospection = await graphql(
+    serverSchema,
+    getIntrospectionQuery(),
+  );
   const clientSchema = buildClientSchema(initialIntrospection.data);
-  const secondIntrospection = await graphql(clientSchema, introspectionQuery);
+  const secondIntrospection = await graphql(
+    clientSchema,
+    getIntrospectionQuery(),
+  );
   expect(secondIntrospection).to.deep.equal(initialIntrospection);
 }
 
@@ -126,7 +132,7 @@ describe('Type System: build schema from introspection', () => {
 
     await testSchema(schema);
 
-    const introspection = await graphql(schema, introspectionQuery);
+    const introspection = await graphql(schema, getIntrospectionQuery());
     const clientSchema = buildClientSchema(introspection.data);
 
     // Built-ins are used
@@ -407,7 +413,7 @@ describe('Type System: build schema from introspection', () => {
 
     await testSchema(schema);
 
-    const introspection = await graphql(schema, introspectionQuery);
+    const introspection = await graphql(schema, getIntrospectionQuery());
     const clientSchema = buildClientSchema(introspection.data);
     const clientFoodEnum = clientSchema.getType('Food');
 
@@ -658,7 +664,10 @@ describe('Type System: build schema from introspection', () => {
     };
 
     const clientSchema = buildClientSchema(oldIntrospection);
-    const secondIntrospection = await graphql(clientSchema, introspectionQuery);
+    const secondIntrospection = await graphql(
+      clientSchema,
+      getIntrospectionQuery(),
+    );
     expect(secondIntrospection.data).to.containSubset(newIntrospection);
   });
 
@@ -719,7 +728,7 @@ describe('Type System: build schema from introspection', () => {
       }),
     });
 
-    const introspection = await graphql(schema, introspectionQuery);
+    const introspection = await graphql(schema, getIntrospectionQuery());
     const clientSchema = buildClientSchema(introspection.data);
 
     const result = await graphql(
@@ -818,7 +827,7 @@ describe('Type System: build schema from introspection', () => {
         }),
       });
 
-      const introspection = await graphql(schema, introspectionQuery);
+      const introspection = await graphql(schema, getIntrospectionQuery());
       expect(() => buildClientSchema(introspection.data)).to.throw(
         'Decorated type deeper than introspection query.',
       );
@@ -848,7 +857,7 @@ describe('Type System: build schema from introspection', () => {
         }),
       });
 
-      const introspection = await graphql(schema, introspectionQuery);
+      const introspection = await graphql(schema, getIntrospectionQuery());
       expect(() => buildClientSchema(introspection.data)).to.throw(
         'Decorated type deeper than introspection query.',
       );
@@ -877,7 +886,7 @@ describe('Type System: build schema from introspection', () => {
         }),
       });
 
-      const introspection = await graphql(schema, introspectionQuery);
+      const introspection = await graphql(schema, getIntrospectionQuery());
       buildClientSchema(introspection.data);
     });
   });

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -8,8 +8,13 @@
  */
 
 // The GraphQL query recommended for a full schema introspection.
-export { introspectionQuery } from './introspectionQuery';
+export {
+  getIntrospectionQuery,
+  // Deprecated, use getIntrospectionQuery()
+  introspectionQuery,
+} from './introspectionQuery';
 export type {
+  IntrospectionOptions,
   IntrospectionQuery,
   IntrospectionSchema,
   IntrospectionType,


### PR DESCRIPTION
This adds a new function `getIntrospectionQuery()` which allows for some minor configuration over the resulting query text: to exclude descriptions if your use case does not require them.

It also updates the flow types to remove exact types for the kinds of `__Type` since they will have other fields that would be `null`.