### PR TITLE
RFC: Synchronous execution

### DIFF
--- a/src/execution/__tests__/sync-test.js
+++ b/src/execution/__tests__/sync-test.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { execute } from '../execute';
+import { parse } from '../../language';
+import { GraphQLSchema, GraphQLObjectType, GraphQLString } from '../../type';
+
+describe('Execute: synchronously when possible', () => {
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        syncField: {
+          type: GraphQLString,
+          resolve(rootValue) {
+            return rootValue;
+          },
+        },
+        asyncField: {
+          type: GraphQLString,
+          async resolve(rootValue) {
+            return await rootValue;
+          },
+        },
+      },
+    }),
+  });
+
+  it('does not return a Promise for initial errors', () => {
+    const doc = 'fragment Example on Query { syncField }';
+    const result = execute({
+      schema,
+      document: parse(doc),
+      rootValue: 'rootValue',
+    });
+    expect(result).to.deep.equal({
+      errors: [
+        {
+          message: 'Must provide an operation.',
+          locations: undefined,
+          path: undefined,
+        },
+      ],
+    });
+  });
+
+  it('does not return a Promise if fields are all synchronous', () => {
+    const doc = 'query Example { syncField }';
+    const result = execute({
+      schema,
+      document: parse(doc),
+      rootValue: 'rootValue',
+    });
+    expect(result).to.deep.equal({ data: { syncField: 'rootValue' } });
+  });
+
+  it('returns a Promise if any field is asynchronous', async () => {
+    const doc = 'query Example { syncField, asyncField }';
+    const result = execute({
+      schema,
+      document: parse(doc),
+      rootValue: 'rootValue',
+    });
+    expect(result).to.be.instanceOf(Promise);
+    expect(await result).to.deep.equal({
+      data: { syncField: 'rootValue', asyncField: 'rootValue' },
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@
  */
 
 // The primary entry point into fulfilling a GraphQL request.
-export { graphql } from './graphql';
+export { graphql, graphqlSync } from './graphql';
 
 // Create and operate on GraphQL type definitions and schema.
 export {


### PR DESCRIPTION
**This is a breaking change. Existing uses of execute() outside of async functions which assume a promise response will need to wrap in Promise.resolve()**

This allows `execute()` to return synchronously if all fields it encounters have synchronous resolvers. Notable this is the case for client-side introspection, querying from a cache, and other useful cases.

Also introduces `graphqlSync()` as a top level function which asserts sync behavior and includes validation.

Note that the top level `graphql()` function remains a Promise to minimize the breaking change, and that `validate()` has always been synchronous.