### PR TITLE
Flow: Readonly errors

### DIFF
--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -8,7 +8,7 @@
  */
 
 import invariant from '../jsutils/invariant';
-import type { GraphQLError } from './GraphQLError';
+import type { GraphQLError, GraphQLErrorLocation } from './GraphQLError';
 
 /**
  * Given a GraphQLError, format it according to the rules described by the
@@ -25,12 +25,9 @@ export function formatError(error: GraphQLError): GraphQLFormattedError {
 }
 
 export type GraphQLFormattedError = {
-  message: string,
-  locations: ?Array<GraphQLErrorLocation>,
-  path: ?Array<string | number>,
-};
-
-export type GraphQLErrorLocation = {
-  line: number,
-  column: number,
+  +message: string,
+  +locations: $ReadOnlyArray<GraphQLErrorLocation> | void,
+  +path: $ReadOnlyArray<string | number> | void,
+  // Extensions
+  +[key: string]: mixed,
 };

--- a/src/error/index.js
+++ b/src/error/index.js
@@ -12,7 +12,5 @@ export { syntaxError } from './syntaxError';
 export { locatedError } from './locatedError';
 export { formatError } from './formatError';
 
-export type {
-  GraphQLFormattedError,
-  GraphQLErrorLocation,
-} from './formatError';
+export type { GraphQLErrorLocation } from './GraphQLError';
+export type { GraphQLFormattedError } from './formatError';

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -8,6 +8,7 @@
  */
 
 import { GraphQLError } from './GraphQLError';
+import type { ASTNode } from '../language/ast';
 
 /**
  * Given an arbitrary Error, presumably thrown while attempting to execute a
@@ -16,8 +17,8 @@ import { GraphQLError } from './GraphQLError';
  */
 export function locatedError(
   originalError: ?Error,
-  nodes: Array<*>,
-  path: Array<string | number>,
+  nodes: $ReadOnlyArray<ASTNode>,
+  path: $ReadOnlyArray<string | number>,
 ): GraphQLError {
   // Note: this uses a brand-check to support GraphQL errors originating from
   // other contexts.

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -101,7 +101,7 @@ export type ExecutionContext = {
  *   - `data` is the result of a successful execution of the query.
  */
 export type ExecutionResult = {
-  errors?: Array<GraphQLError>,
+  errors?: $ReadOnlyArray<GraphQLError>,
   data?: ObjMap<mixed>,
 };
 
@@ -235,7 +235,7 @@ function buildResponse(
  */
 export function responsePathAsArray(
   path: ResponsePath,
-): Array<string | number> {
+): $ReadOnlyArray<string | number> {
   const flattened = [];
   let curr = path;
   while (curr) {
@@ -663,7 +663,7 @@ function resolveField(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   source: mixed,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   path: ResponsePath,
 ): mixed {
   const fieldNode = fieldNodes[0];
@@ -708,7 +708,7 @@ function resolveField(
 export function buildResolveInfo(
   exeContext: ExecutionContext,
   fieldDef: GraphQLField<*, *>,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   parentType: GraphQLObjectType,
   path: ResponsePath,
 ): GraphQLResolveInfo {
@@ -733,7 +733,7 @@ export function buildResolveInfo(
 export function resolveFieldValueOrError<TSource>(
   exeContext: ExecutionContext,
   fieldDef: GraphQLField<TSource, *>,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   resolveFn: GraphQLFieldResolver<TSource, *>,
   source: TSource,
   info: GraphQLResolveInfo,
@@ -766,7 +766,7 @@ export function resolveFieldValueOrError<TSource>(
 function completeValueCatchingError(
   exeContext: ExecutionContext,
   returnType: GraphQLType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
@@ -820,7 +820,7 @@ function completeValueCatchingError(
 function completeValueWithLocatedError(
   exeContext: ExecutionContext,
   returnType: GraphQLType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
@@ -872,7 +872,7 @@ function completeValueWithLocatedError(
 function completeValue(
   exeContext: ExecutionContext,
   returnType: GraphQLType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
@@ -972,7 +972,7 @@ function completeValue(
 function completeListValue(
   exeContext: ExecutionContext,
   returnType: GraphQLList<*>,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
@@ -1034,7 +1034,7 @@ function completeLeafValue(returnType: GraphQLLeafType, result: mixed): mixed {
 function completeAbstractValue(
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
@@ -1085,7 +1085,7 @@ function ensureValidRuntimeType(
   runtimeTypeOrName: ?GraphQLObjectType | string,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   result: mixed,
 ): GraphQLObjectType {
@@ -1123,7 +1123,7 @@ function ensureValidRuntimeType(
 function completeObjectValue(
   exeContext: ExecutionContext,
   returnType: GraphQLObjectType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
@@ -1169,7 +1169,7 @@ function completeObjectValue(
 function invalidReturnTypeError(
   returnType: GraphQLObjectType,
   result: mixed,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
 ): GraphQLError {
   return new GraphQLError(
     `Expected value of type "${returnType.name}" but got: ${String(result)}.`,
@@ -1180,7 +1180,7 @@ function invalidReturnTypeError(
 function collectAndExecuteSubfields(
   exeContext: ExecutionContext,
   returnType: GraphQLObjectType,
-  fieldNodes: Array<FieldNode>,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -619,20 +619,23 @@ export type GraphQLFieldResolver<TSource, TContext> = (
   info: GraphQLResolveInfo,
 ) => mixed;
 
-export type GraphQLResolveInfo = {
-  fieldName: string,
-  fieldNodes: Array<FieldNode>,
-  returnType: GraphQLOutputType,
-  parentType: GraphQLObjectType,
-  path: ResponsePath,
-  schema: GraphQLSchema,
-  fragments: ObjMap<FragmentDefinitionNode>,
-  rootValue: mixed,
-  operation: OperationDefinitionNode,
-  variableValues: { [variable: string]: mixed },
-};
+export type GraphQLResolveInfo = {|
+  +fieldName: string,
+  +fieldNodes: $ReadOnlyArray<FieldNode>,
+  +returnType: GraphQLOutputType,
+  +parentType: GraphQLObjectType,
+  +path: ResponsePath,
+  +schema: GraphQLSchema,
+  +fragments: ObjMap<FragmentDefinitionNode>,
+  +rootValue: mixed,
+  +operation: OperationDefinitionNode,
+  +variableValues: { [variable: string]: mixed },
+|};
 
-export type ResponsePath = { prev: ResponsePath | void, key: string | number };
+export type ResponsePath = {|
+  +prev: ResponsePath | void,
+  +key: string | number,
+|};
 
 export type GraphQLFieldConfig<TSource, TContext> = {
   type: GraphQLOutputType,

--- a/src/validation/rules/ScalarLeafs.js
+++ b/src/validation/rules/ScalarLeafs.js
@@ -43,17 +43,18 @@ export function ScalarLeafs(context: ValidationContext): any {
   return {
     Field(node: FieldNode) {
       const type = context.getType();
+      const selectionSet = node.selectionSet;
       if (type) {
         if (isLeafType(getNamedType(type))) {
-          if (node.selectionSet) {
+          if (selectionSet) {
             context.reportError(
               new GraphQLError(
                 noSubselectionAllowedMessage(node.name.value, type),
-                [node.selectionSet],
+                [selectionSet],
               ),
             );
           }
-        } else if (!node.selectionSet) {
+        } else if (!selectionSet) {
           context.reportError(
             new GraphQLError(
               requiredSubselectionMessage(node.name.value, type),


### PR DESCRIPTION
This uses $ReadOnlyArray and `+` properties to ensure Errors are read-only, removing some use of `*`.