### PR TITLE
Export GraphQLArgs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@
  */
 
 // The primary entry point into fulfilling a GraphQL request.
+export type { GraphQLArgs } from './graphql';
 export { graphql, graphqlSync } from './graphql';
 
 // Create and operate on GraphQL type definitions and schema.


### PR DESCRIPTION
It's useful for building wrappers around `graphql` since you can reuse `GraphQLArgs` type. 
BTW, [ExecutionArgs](https://github.com/graphql/graphql-js/blob/master/src/index.js#L225) is also exported.