### PR TITLE
Read-only AST types

### DIFF
--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -186,7 +186,7 @@ export function getArgumentValues(
  */
 export function getDirectiveValues(
   directiveDef: GraphQLDirective,
-  node: { directives?: ?Array<DirectiveNode> },
+  node: { +directives?: $ReadOnlyArray<DirectiveNode> },
   variableValues?: ?ObjMap<mixed>,
 ): void | { [argument: string]: mixed } {
   const directiveNode =

--- a/src/jsutils/find.js
+++ b/src/jsutils/find.js
@@ -8,7 +8,7 @@
  */
 
 export default function find<T>(
-  list: Array<T>,
+  list: $ReadOnlyArray<T>,
   predicate: (item: T) => boolean,
 ): ?T {
   for (let i = 0; i < list.length; i++) {

--- a/src/jsutils/quotedOrList.js
+++ b/src/jsutils/quotedOrList.js
@@ -12,7 +12,7 @@ const MAX_LENGTH = 5;
 /**
  * Given [ A, B, C ] return '"A", "B", or "C"'.
  */
-export default function quotedOrList(items: Array<string>): string {
+export default function quotedOrList(items: $ReadOnlyArray<string>): string {
   const selected = items.slice(0, MAX_LENGTH);
   return selected
     .map(item => `"${item}"`)

--- a/src/jsutils/suggestionList.js
+++ b/src/jsutils/suggestionList.js
@@ -13,7 +13,7 @@
  */
 export default function suggestionList(
   input: string,
-  options: Array<string>,
+  options: $ReadOnlyArray<string>,
 ): Array<string> {
   const optionsByDistance = Object.create(null);
   const oLength = options.length;

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -221,7 +221,7 @@ describe('Parser', () => {
           kind: Kind.OPERATION_DEFINITION,
           loc: { start: 0, end: 40 },
           operation: 'query',
-          name: null,
+          name: undefined,
           variableDefinitions: [],
           directives: [],
           selectionSet: {
@@ -231,7 +231,7 @@ describe('Parser', () => {
               {
                 kind: Kind.FIELD,
                 loc: { start: 4, end: 38 },
-                alias: null,
+                alias: undefined,
                 name: {
                   kind: Kind.NAME,
                   loc: { start: 4, end: 8 },
@@ -261,7 +261,7 @@ describe('Parser', () => {
                     {
                       kind: Kind.FIELD,
                       loc: { start: 22, end: 24 },
-                      alias: null,
+                      alias: undefined,
                       name: {
                         kind: Kind.NAME,
                         loc: { start: 22, end: 24 },
@@ -269,12 +269,12 @@ describe('Parser', () => {
                       },
                       arguments: [],
                       directives: [],
-                      selectionSet: null,
+                      selectionSet: undefined,
                     },
                     {
                       kind: Kind.FIELD,
                       loc: { start: 30, end: 34 },
-                      alias: null,
+                      alias: undefined,
                       name: {
                         kind: Kind.NAME,
                         loc: { start: 30, end: 34 },
@@ -282,7 +282,7 @@ describe('Parser', () => {
                       },
                       arguments: [],
                       directives: [],
-                      selectionSet: null,
+                      selectionSet: undefined,
                     },
                   ],
                 },
@@ -311,7 +311,7 @@ describe('Parser', () => {
           kind: Kind.OPERATION_DEFINITION,
           loc: { start: 0, end: 29 },
           operation: 'query',
-          name: null,
+          name: undefined,
           variableDefinitions: [],
           directives: [],
           selectionSet: {
@@ -321,7 +321,7 @@ describe('Parser', () => {
               {
                 kind: Kind.FIELD,
                 loc: { start: 10, end: 27 },
-                alias: null,
+                alias: undefined,
                 name: {
                   kind: Kind.NAME,
                   loc: { start: 10, end: 14 },
@@ -336,7 +336,7 @@ describe('Parser', () => {
                     {
                       kind: Kind.FIELD,
                       loc: { start: 21, end: 23 },
-                      alias: null,
+                      alias: undefined,
                       name: {
                         kind: Kind.NAME,
                         loc: { start: 21, end: 23 },
@@ -344,7 +344,7 @@ describe('Parser', () => {
                       },
                       arguments: [],
                       directives: [],
-                      selectionSet: null,
+                      selectionSet: undefined,
                     },
                   ],
                 },

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -399,7 +399,7 @@ type Hello {
                 inputValueNode(
                   nameNode('flag', { start: 22, end: 26 }),
                   typeNode('Boolean', { start: 28, end: 35 }),
-                  null,
+                  undefined,
                   { start: 22, end: 35 },
                 ),
               ],
@@ -481,7 +481,7 @@ type Hello {
                     type: typeNode('String', { start: 31, end: 37 }),
                     loc: { start: 30, end: 38 },
                   },
-                  null,
+                  undefined,
                   { start: 22, end: 38 },
                 ),
               ],
@@ -518,13 +518,13 @@ type Hello {
                 inputValueNode(
                   nameNode('argOne', { start: 22, end: 28 }),
                   typeNode('Boolean', { start: 30, end: 37 }),
-                  null,
+                  undefined,
                   { start: 22, end: 37 },
                 ),
                 inputValueNode(
                   nameNode('argTwo', { start: 39, end: 45 }),
                   typeNode('Int', { start: 47, end: 50 }),
-                  null,
+                  undefined,
                   { start: 39, end: 50 },
                 ),
               ],
@@ -657,7 +657,7 @@ input Hello {
             inputValueNode(
               nameNode('world', { start: 17, end: 22 }),
               typeNode('String', { start: 24, end: 30 }),
-              null,
+              undefined,
               { start: 17, end: 30 },
             ),
           ],

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -17,27 +17,27 @@ export type Location = {
   /**
    * The character offset at which this Node begins.
    */
-  start: number,
+  +start: number,
 
   /**
    * The character offset at which this Node ends.
    */
-  end: number,
+  +end: number,
 
   /**
    * The Token at which this Node begins.
    */
-  startToken: Token,
+  +startToken: Token,
 
   /**
    * The Token at which this Node ends.
    */
-  endToken: Token,
+  +endToken: Token,
 
   /**
    * The Source document the AST represents.
    */
-  source: Source,
+  +source: Source,
 };
 
 /**
@@ -76,40 +76,40 @@ export type Token = {
   /**
    * The kind of Token.
    */
-  kind: TokenKind,
+  +kind: TokenKind,
 
   /**
    * The character offset at which this Node begins.
    */
-  start: number,
+  +start: number,
 
   /**
    * The character offset at which this Node ends.
    */
-  end: number,
+  +end: number,
 
   /**
    * The 1-indexed line number on which this Token appears.
    */
-  line: number,
+  +line: number,
 
   /**
    * The 1-indexed column number at which this Token begins.
    */
-  column: number,
+  +column: number,
 
   /**
    * For non-punctuation tokens, represents the interpreted value of the token.
    */
-  value: string | void,
+  +value: string | void,
 
   /**
    * Tokens exist as nodes in a double-linked-list amongst all tokens
    * including ignored tokens. <SOF> is always the first node and <EOF>
    * the last.
    */
-  prev: Token | null,
-  next: Token | null,
+  +prev: Token | null,
+  +next: Token | null,
 };
 
 /**
@@ -157,17 +157,17 @@ export type ASTNode =
 // Name
 
 export type NameNode = {
-  kind: 'Name',
-  loc?: Location,
-  value: string,
+  +kind: 'Name',
+  +loc?: Location,
+  +value: string,
 };
 
 // Document
 
 export type DocumentNode = {
-  kind: 'Document',
-  loc?: Location,
-  definitions: Array<DefinitionNode>,
+  +kind: 'Document',
+  +loc?: Location,
+  +definitions: Array<DefinitionNode>,
 };
 
 export type DefinitionNode =
@@ -176,29 +176,29 @@ export type DefinitionNode =
   | TypeSystemDefinitionNode; // experimental non-spec addition.
 
 export type OperationDefinitionNode = {
-  kind: 'OperationDefinition',
-  loc?: Location,
-  operation: OperationTypeNode,
-  name?: ?NameNode,
-  variableDefinitions?: ?Array<VariableDefinitionNode>,
-  directives?: ?Array<DirectiveNode>,
-  selectionSet: SelectionSetNode,
+  +kind: 'OperationDefinition',
+  +loc?: Location,
+  +operation: OperationTypeNode,
+  +name?: NameNode,
+  +variableDefinitions?: Array<VariableDefinitionNode>,
+  +directives?: Array<DirectiveNode>,
+  +selectionSet: SelectionSetNode,
 };
 
 export type OperationTypeNode = 'query' | 'mutation' | 'subscription';
 
 export type VariableDefinitionNode = {
-  kind: 'VariableDefinition',
-  loc?: Location,
-  variable: VariableNode,
-  type: TypeNode,
-  defaultValue?: ?ValueNode,
+  +kind: 'VariableDefinition',
+  +loc?: Location,
+  +variable: VariableNode,
+  +type: TypeNode,
+  +defaultValue?: ValueNode,
 };
 
 export type VariableNode = {
-  kind: 'Variable',
-  loc?: Location,
-  name: NameNode,
+  +kind: 'Variable',
+  +loc?: Location,
+  +name: NameNode,
 };
 
 export type SelectionSetNode = {
@@ -210,46 +210,46 @@ export type SelectionSetNode = {
 export type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
 
 export type FieldNode = {
-  kind: 'Field',
-  loc?: Location,
-  alias?: ?NameNode,
-  name: NameNode,
-  arguments?: ?Array<ArgumentNode>,
-  directives?: ?Array<DirectiveNode>,
-  selectionSet?: ?SelectionSetNode,
+  +kind: 'Field',
+  +loc?: Location,
+  +alias?: NameNode,
+  +name: NameNode,
+  +arguments?: Array<ArgumentNode>,
+  +directives?: Array<DirectiveNode>,
+  +selectionSet?: SelectionSetNode,
 };
 
 export type ArgumentNode = {
-  kind: 'Argument',
-  loc?: Location,
-  name: NameNode,
-  value: ValueNode,
+  +kind: 'Argument',
+  +loc?: Location,
+  +name: NameNode,
+  +value: ValueNode,
 };
 
 // Fragments
 
 export type FragmentSpreadNode = {
-  kind: 'FragmentSpread',
-  loc?: Location,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
+  +kind: 'FragmentSpread',
+  +loc?: Location,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
 };
 
 export type InlineFragmentNode = {
-  kind: 'InlineFragment',
-  loc?: Location,
-  typeCondition?: ?NamedTypeNode,
-  directives?: ?Array<DirectiveNode>,
-  selectionSet: SelectionSetNode,
+  +kind: 'InlineFragment',
+  +loc?: Location,
+  +typeCondition?: NamedTypeNode,
+  +directives?: Array<DirectiveNode>,
+  +selectionSet: SelectionSetNode,
 };
 
 export type FragmentDefinitionNode = {
-  kind: 'FragmentDefinition',
-  loc?: Location,
-  name: NameNode,
-  typeCondition: NamedTypeNode,
-  directives?: ?Array<DirectiveNode>,
-  selectionSet: SelectionSetNode,
+  +kind: 'FragmentDefinition',
+  +loc?: Location,
+  +name: NameNode,
+  +typeCondition: NamedTypeNode,
+  +directives?: Array<DirectiveNode>,
+  +selectionSet: SelectionSetNode,
 };
 
 // Values
@@ -266,67 +266,67 @@ export type ValueNode =
   | ObjectValueNode;
 
 export type IntValueNode = {
-  kind: 'IntValue',
-  loc?: Location,
-  value: string,
+  +kind: 'IntValue',
+  +loc?: Location,
+  +value: string,
 };
 
 export type FloatValueNode = {
-  kind: 'FloatValue',
-  loc?: Location,
-  value: string,
+  +kind: 'FloatValue',
+  +loc?: Location,
+  +value: string,
 };
 
 export type StringValueNode = {
-  kind: 'StringValue',
-  loc?: Location,
-  value: string,
-  block?: boolean,
+  +kind: 'StringValue',
+  +loc?: Location,
+  +value: string,
+  +block?: boolean,
 };
 
 export type BooleanValueNode = {
-  kind: 'BooleanValue',
-  loc?: Location,
-  value: boolean,
+  +kind: 'BooleanValue',
+  +loc?: Location,
+  +value: boolean,
 };
 
 export type NullValueNode = {
-  kind: 'NullValue',
-  loc?: Location,
+  +kind: 'NullValue',
+  +loc?: Location,
 };
 
 export type EnumValueNode = {
-  kind: 'EnumValue',
-  loc?: Location,
-  value: string,
+  +kind: 'EnumValue',
+  +loc?: Location,
+  +value: string,
 };
 
 export type ListValueNode = {
-  kind: 'ListValue',
-  loc?: Location,
-  values: Array<ValueNode>,
+  +kind: 'ListValue',
+  +loc?: Location,
+  +values: Array<ValueNode>,
 };
 
 export type ObjectValueNode = {
-  kind: 'ObjectValue',
-  loc?: Location,
-  fields: Array<ObjectFieldNode>,
+  +kind: 'ObjectValue',
+  +loc?: Location,
+  +fields: Array<ObjectFieldNode>,
 };
 
 export type ObjectFieldNode = {
-  kind: 'ObjectField',
-  loc?: Location,
-  name: NameNode,
-  value: ValueNode,
+  +kind: 'ObjectField',
+  +loc?: Location,
+  +name: NameNode,
+  +value: ValueNode,
 };
 
 // Directives
 
 export type DirectiveNode = {
-  kind: 'Directive',
-  loc?: Location,
-  name: NameNode,
-  arguments?: ?Array<ArgumentNode>,
+  +kind: 'Directive',
+  +loc?: Location,
+  +name: NameNode,
+  +arguments?: Array<ArgumentNode>,
 };
 
 // Type Reference
@@ -334,21 +334,21 @@ export type DirectiveNode = {
 export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
 
 export type NamedTypeNode = {
-  kind: 'NamedType',
-  loc?: Location,
-  name: NameNode,
+  +kind: 'NamedType',
+  +loc?: Location,
+  +name: NameNode,
 };
 
 export type ListTypeNode = {
-  kind: 'ListType',
-  loc?: Location,
-  type: TypeNode,
+  +kind: 'ListType',
+  +loc?: Location,
+  +type: TypeNode,
 };
 
 export type NonNullTypeNode = {
-  kind: 'NonNullType',
-  loc?: Location,
-  type: NamedTypeNode | ListTypeNode,
+  +kind: 'NonNullType',
+  +loc?: Location,
+  +type: NamedTypeNode | ListTypeNode,
 };
 
 // Type System Definition
@@ -360,17 +360,17 @@ export type TypeSystemDefinitionNode =
   | DirectiveDefinitionNode;
 
 export type SchemaDefinitionNode = {
-  kind: 'SchemaDefinition',
-  loc?: Location,
-  directives: Array<DirectiveNode>,
-  operationTypes: Array<OperationTypeDefinitionNode>,
+  +kind: 'SchemaDefinition',
+  +loc?: Location,
+  +directives: Array<DirectiveNode>,
+  +operationTypes: Array<OperationTypeDefinitionNode>,
 };
 
 export type OperationTypeDefinitionNode = {
-  kind: 'OperationTypeDefinition',
-  loc?: Location,
-  operation: OperationTypeNode,
-  type: NamedTypeNode,
+  +kind: 'OperationTypeDefinition',
+  +loc?: Location,
+  +operation: OperationTypeNode,
+  +type: NamedTypeNode,
 };
 
 // Type Definition
@@ -384,85 +384,85 @@ export type TypeDefinitionNode =
   | InputObjectTypeDefinitionNode;
 
 export type ScalarTypeDefinitionNode = {
-  kind: 'ScalarTypeDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
+  +kind: 'ScalarTypeDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
 };
 
 export type ObjectTypeDefinitionNode = {
-  kind: 'ObjectTypeDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  interfaces?: ?Array<NamedTypeNode>,
-  directives?: ?Array<DirectiveNode>,
-  fields: Array<FieldDefinitionNode>,
+  +kind: 'ObjectTypeDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +interfaces?: Array<NamedTypeNode>,
+  +directives?: Array<DirectiveNode>,
+  +fields: Array<FieldDefinitionNode>,
 };
 
 export type FieldDefinitionNode = {
-  kind: 'FieldDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  arguments: Array<InputValueDefinitionNode>,
-  type: TypeNode,
-  directives?: ?Array<DirectiveNode>,
+  +kind: 'FieldDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +arguments?: Array<InputValueDefinitionNode>,
+  +type: TypeNode,
+  +directives?: Array<DirectiveNode>,
 };
 
 export type InputValueDefinitionNode = {
-  kind: 'InputValueDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  type: TypeNode,
-  defaultValue?: ?ValueNode,
-  directives?: ?Array<DirectiveNode>,
+  +kind: 'InputValueDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +type: TypeNode,
+  +defaultValue?: ValueNode,
+  +directives?: Array<DirectiveNode>,
 };
 
 export type InterfaceTypeDefinitionNode = {
-  kind: 'InterfaceTypeDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
-  fields: Array<FieldDefinitionNode>,
+  +kind: 'InterfaceTypeDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
+  +fields: Array<FieldDefinitionNode>,
 };
 
 export type UnionTypeDefinitionNode = {
-  kind: 'UnionTypeDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
-  types: Array<NamedTypeNode>,
+  +kind: 'UnionTypeDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
+  +types: Array<NamedTypeNode>,
 };
 
 export type EnumTypeDefinitionNode = {
-  kind: 'EnumTypeDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
-  values: Array<EnumValueDefinitionNode>,
+  +kind: 'EnumTypeDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
+  +values: Array<EnumValueDefinitionNode>,
 };
 
 export type EnumValueDefinitionNode = {
-  kind: 'EnumValueDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
+  +kind: 'EnumValueDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
 };
 
 export type InputObjectTypeDefinitionNode = {
-  kind: 'InputObjectTypeDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  directives?: ?Array<DirectiveNode>,
-  fields: Array<InputValueDefinitionNode>,
+  +kind: 'InputObjectTypeDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +directives?: Array<DirectiveNode>,
+  +fields: Array<InputValueDefinitionNode>,
 };
 
 // Type Extensions
@@ -470,21 +470,21 @@ export type InputObjectTypeDefinitionNode = {
 export type TypeExtensionNode = ObjectTypeExtensionNode;
 
 export type ObjectTypeExtensionNode = {
-  kind: 'ObjectTypeExtension',
-  loc?: Location,
-  name: NameNode,
-  interfaces?: ?Array<NamedTypeNode>,
-  directives?: ?Array<DirectiveNode>,
-  fields?: ?Array<FieldDefinitionNode>,
+  +kind: 'ObjectTypeExtension',
+  +loc?: Location,
+  +name: NameNode,
+  +interfaces?: Array<NamedTypeNode>,
+  +directives?: Array<DirectiveNode>,
+  +fields?: Array<FieldDefinitionNode>,
 };
 
 // Directive Definitions
 
 export type DirectiveDefinitionNode = {
-  kind: 'DirectiveDefinition',
-  loc?: Location,
-  description?: ?StringValueNode,
-  name: NameNode,
-  arguments?: ?Array<InputValueDefinitionNode>,
-  locations: Array<NameNode>,
+  +kind: 'DirectiveDefinition',
+  +loc?: Location,
+  +description?: StringValueNode,
+  +name: NameNode,
+  +arguments?: Array<InputValueDefinitionNode>,
+  +locations: Array<NameNode>,
 };

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -48,7 +48,8 @@ function lookahead() {
   let token = this.token;
   if (token.kind !== EOF) {
     do {
-      token = token.next || (token.next = readToken(this, token));
+      // Note: next is only mutable during parsing, so we cast to allow this.
+      token = token.next || ((token: any).next = readToken(this, token));
     } while (token.kind === COMMENT);
   }
   return token;

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -257,7 +257,7 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
     return {
       kind: OPERATION_DEFINITION,
       operation: 'query',
-      name: null,
+      name: undefined,
       variableDefinitions: [],
       directives: [],
       selectionSet: parseSelectionSet(lexer),
@@ -265,7 +265,10 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
     };
   }
   const operation = parseOperationType(lexer);
-  const name = peek(lexer, TokenKind.NAME) ? parseName(lexer) : null;
+  let name;
+  if (peek(lexer, TokenKind.NAME)) {
+    name = parseName(lexer);
+  }
   return {
     kind: OPERATION_DEFINITION,
     operation,
@@ -316,7 +319,7 @@ function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
     type: (expect(lexer, TokenKind.COLON), parseTypeReference(lexer)),
     defaultValue: skip(lexer, TokenKind.EQUALS)
       ? parseValueLiteral(lexer, true)
-      : null,
+      : undefined,
     loc: loc(lexer, start),
   };
 }
@@ -378,7 +381,6 @@ function parseField(lexer: Lexer<*>): FieldNode {
     alias = nameOrAlias;
     name = parseName(lexer);
   } else {
-    alias = null;
     name = nameOrAlias;
   }
 
@@ -390,7 +392,7 @@ function parseField(lexer: Lexer<*>): FieldNode {
     directives: parseDirectives(lexer, false),
     selectionSet: peek(lexer, TokenKind.BRACE_L)
       ? parseSelectionSet(lexer)
-      : null,
+      : undefined,
     loc: loc(lexer, start),
   };
 }
@@ -453,7 +455,7 @@ function parseFragment(
       loc: loc(lexer, start),
     };
   }
-  let typeCondition = null;
+  let typeCondition;
   if (lexer.token.value === 'on') {
     lexer.advance();
     typeCondition = parseNamedType(lexer);
@@ -920,7 +922,7 @@ function parseInputValueDef(lexer: Lexer<*>): InputValueDefinitionNode {
   const name = parseName(lexer);
   expect(lexer, TokenKind.COLON);
   const type = parseTypeReference(lexer);
-  let defaultValue = null;
+  let defaultValue;
   if (skip(lexer, TokenKind.EQUALS)) {
     defaultValue = parseConstValue(lexer);
   }

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -21,9 +21,7 @@ import { getDirectiveValues } from '../execution/values';
 import * as Kind from '../language/kinds';
 
 import type {
-  Location,
   DocumentNode,
-  StringValueNode,
   TypeNode,
   NamedTypeNode,
   SchemaDefinitionNode,
@@ -325,7 +323,7 @@ export class ASTDefinitionBuilder {
     return {
       type: this._buildOutputType(field.type),
       description: getDescription(field, this._options),
-      args: this._makeInputValues(field.arguments),
+      args: field.arguments && this._makeInputValues(field.arguments),
       deprecationReason: getDeprecationReason(field),
       astNode: field,
     };
@@ -378,7 +376,7 @@ export class ASTDefinitionBuilder {
     );
   }
 
-  _makeInputValues(values: Array<InputValueDefinitionNode>) {
+  _makeInputValues(values: $ReadOnlyArray<InputValueDefinitionNode>) {
     return keyValMap(
       values,
       value => value.name.value,
@@ -468,10 +466,7 @@ function getDeprecationReason(
  *        Provide true to use preceding comments as the description.
  *
  */
-function getDescription(
-  node: { loc?: Location, description?: ?StringValueNode },
-  options: ?Options,
-): void | string {
+function getDescription(node, options: ?Options): void | string {
   if (node.description) {
     return node.description.value;
   }
@@ -483,7 +478,7 @@ function getDescription(
   }
 }
 
-function getLeadingCommentBlock(node: { loc?: Location }): void | string {
+function getLeadingCommentBlock(node): void | string {
   const loc = node.loc;
   if (!loc) {
     return;


### PR DESCRIPTION
**Potential breaking change: Where previously AST would produce `null`, it now produces `undefined`**

This tightens up the AST types to produce readonly covariant fields, $ReadOnlyArray in a couple places (not AST yet, perhaps in a future PR), and replaces `field?: ?Rule` with `field?: Rule` to exclude the possibility of `null` from `undefined` for optional rules, reducing complexity.