### PR TITLE
Readonly AST: Use $ReadOnlyArray

### DIFF
--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -172,7 +172,7 @@ export type NameNode = {
 export type DocumentNode = {
   +kind: 'Document',
   +loc?: Location,
-  +definitions: Array<DefinitionNode>,
+  +definitions: $ReadOnlyArray<DefinitionNode>,
 };
 
 export type DefinitionNode =
@@ -185,8 +185,8 @@ export type OperationDefinitionNode = {
   +loc?: Location,
   +operation: OperationTypeNode,
   +name?: NameNode,
-  +variableDefinitions?: Array<VariableDefinitionNode>,
-  +directives?: Array<DirectiveNode>,
+  +variableDefinitions?: $ReadOnlyArray<VariableDefinitionNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet: SelectionSetNode,
 };
 
@@ -209,7 +209,7 @@ export type VariableNode = {
 export type SelectionSetNode = {
   kind: 'SelectionSet',
   loc?: Location,
-  selections: Array<SelectionNode>,
+  selections: $ReadOnlyArray<SelectionNode>,
 };
 
 export type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
@@ -219,8 +219,8 @@ export type FieldNode = {
   +loc?: Location,
   +alias?: NameNode,
   +name: NameNode,
-  +arguments?: Array<ArgumentNode>,
-  +directives?: Array<DirectiveNode>,
+  +arguments?: $ReadOnlyArray<ArgumentNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet?: SelectionSetNode,
 };
 
@@ -237,14 +237,14 @@ export type FragmentSpreadNode = {
   +kind: 'FragmentSpread',
   +loc?: Location,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 
 export type InlineFragmentNode = {
   +kind: 'InlineFragment',
   +loc?: Location,
   +typeCondition?: NamedTypeNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet: SelectionSetNode,
 };
 
@@ -253,7 +253,7 @@ export type FragmentDefinitionNode = {
   +loc?: Location,
   +name: NameNode,
   +typeCondition: NamedTypeNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet: SelectionSetNode,
 };
 
@@ -309,13 +309,13 @@ export type EnumValueNode = {
 export type ListValueNode = {
   +kind: 'ListValue',
   +loc?: Location,
-  +values: Array<ValueNode>,
+  +values: $ReadOnlyArray<ValueNode>,
 };
 
 export type ObjectValueNode = {
   +kind: 'ObjectValue',
   +loc?: Location,
-  +fields: Array<ObjectFieldNode>,
+  +fields: $ReadOnlyArray<ObjectFieldNode>,
 };
 
 export type ObjectFieldNode = {
@@ -331,7 +331,7 @@ export type DirectiveNode = {
   +kind: 'Directive',
   +loc?: Location,
   +name: NameNode,
-  +arguments?: Array<ArgumentNode>,
+  +arguments?: $ReadOnlyArray<ArgumentNode>,
 };
 
 // Type Reference
@@ -367,8 +367,8 @@ export type TypeSystemDefinitionNode =
 export type SchemaDefinitionNode = {
   +kind: 'SchemaDefinition',
   +loc?: Location,
-  +directives: Array<DirectiveNode>,
-  +operationTypes: Array<OperationTypeDefinitionNode>,
+  +directives: $ReadOnlyArray<DirectiveNode>,
+  +operationTypes: $ReadOnlyArray<OperationTypeDefinitionNode>,
 };
 
 export type OperationTypeDefinitionNode = {
@@ -393,7 +393,7 @@ export type ScalarTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 
 export type ObjectTypeDefinitionNode = {
@@ -401,9 +401,9 @@ export type ObjectTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +interfaces?: Array<NamedTypeNode>,
-  +directives?: Array<DirectiveNode>,
-  +fields?: Array<FieldDefinitionNode>,
+  +interfaces?: $ReadOnlyArray<NamedTypeNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
+  +fields?: $ReadOnlyArray<FieldDefinitionNode>,
 };
 
 export type FieldDefinitionNode = {
@@ -411,9 +411,9 @@ export type FieldDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +arguments?: Array<InputValueDefinitionNode>,
+  +arguments?: $ReadOnlyArray<InputValueDefinitionNode>,
   +type: TypeNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 
 export type InputValueDefinitionNode = {
@@ -423,7 +423,7 @@ export type InputValueDefinitionNode = {
   +name: NameNode,
   +type: TypeNode,
   +defaultValue?: ValueNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 
 export type InterfaceTypeDefinitionNode = {
@@ -431,8 +431,8 @@ export type InterfaceTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
-  +fields?: Array<FieldDefinitionNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
+  +fields?: $ReadOnlyArray<FieldDefinitionNode>,
 };
 
 export type UnionTypeDefinitionNode = {
@@ -440,8 +440,8 @@ export type UnionTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
-  +types?: Array<NamedTypeNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
+  +types?: $ReadOnlyArray<NamedTypeNode>,
 };
 
 export type EnumTypeDefinitionNode = {
@@ -449,8 +449,8 @@ export type EnumTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
-  +values?: Array<EnumValueDefinitionNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
+  +values?: $ReadOnlyArray<EnumValueDefinitionNode>,
 };
 
 export type EnumValueDefinitionNode = {
@@ -458,7 +458,7 @@ export type EnumValueDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
 };
 
 export type InputObjectTypeDefinitionNode = {
@@ -466,8 +466,8 @@ export type InputObjectTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +directives?: Array<DirectiveNode>,
-  +fields?: Array<InputValueDefinitionNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
+  +fields?: $ReadOnlyArray<InputValueDefinitionNode>,
 };
 
 // Type Extensions
@@ -484,48 +484,48 @@ export type ScalarTypeExtensionNode = {
   kind: 'ScalarTypeExtension',
   loc?: Location,
   name: NameNode,
-  directives?: Array<DirectiveNode>,
+  directives?: $ReadOnlyArray<DirectiveNode>,
 };
 
 export type ObjectTypeExtensionNode = {
   +kind: 'ObjectTypeExtension',
   +loc?: Location,
   +name: NameNode,
-  +interfaces?: Array<NamedTypeNode>,
-  +directives?: Array<DirectiveNode>,
-  +fields?: Array<FieldDefinitionNode>,
+  +interfaces?: $ReadOnlyArray<NamedTypeNode>,
+  +directives?: $ReadOnlyArray<DirectiveNode>,
+  +fields?: $ReadOnlyArray<FieldDefinitionNode>,
 };
 
 export type InterfaceTypeExtensionNode = {
   kind: 'InterfaceTypeExtension',
   loc?: Location,
   name: NameNode,
-  directives?: Array<DirectiveNode>,
-  fields?: Array<FieldDefinitionNode>,
+  directives?: $ReadOnlyArray<DirectiveNode>,
+  fields?: $ReadOnlyArray<FieldDefinitionNode>,
 };
 
 export type UnionTypeExtensionNode = {
   kind: 'UnionTypeExtension',
   loc?: Location,
   name: NameNode,
-  directives?: Array<DirectiveNode>,
-  types?: Array<NamedTypeNode>,
+  directives?: $ReadOnlyArray<DirectiveNode>,
+  types?: $ReadOnlyArray<NamedTypeNode>,
 };
 
 export type EnumTypeExtensionNode = {
   kind: 'EnumTypeExtension',
   loc?: Location,
   name: NameNode,
-  directives?: Array<DirectiveNode>,
-  values?: Array<EnumValueDefinitionNode>,
+  directives?: $ReadOnlyArray<DirectiveNode>,
+  values?: $ReadOnlyArray<EnumValueDefinitionNode>,
 };
 
 export type InputObjectTypeExtensionNode = {
   kind: 'InputObjectTypeExtension',
   loc?: Location,
   name: NameNode,
-  directives?: Array<DirectiveNode>,
-  fields?: Array<InputValueDefinitionNode>,
+  directives?: $ReadOnlyArray<DirectiveNode>,
+  fields?: $ReadOnlyArray<InputValueDefinitionNode>,
 };
 
 // Directive Definitions
@@ -535,6 +535,6 @@ export type DirectiveDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
-  +arguments?: Array<InputValueDefinitionNode>,
-  +locations: Array<NameNode>,
+  +arguments?: $ReadOnlyArray<InputValueDefinitionNode>,
+  +locations: $ReadOnlyArray<NameNode>,
 };

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -149,7 +149,7 @@ export const GraphQLDeprecatedDirective = new GraphQLDirective({
 /**
  * The full list of specified directives.
  */
-export const specifiedDirectives: Array<GraphQLDirective> = [
+export const specifiedDirectives: $ReadOnlyArray<*> = [
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -24,7 +24,7 @@ import {
 } from './definition';
 import { GraphQLString, GraphQLBoolean } from './scalars';
 import { DirectiveLocation } from '../language/directiveLocation';
-import type { GraphQLField, GraphQLNamedType, GraphQLType } from './definition';
+import type { GraphQLField, GraphQLType } from './definition';
 
 export const __Schema = new GraphQLObjectType({
   name: '__Schema',
@@ -462,7 +462,7 @@ export const TypeNameMetaFieldDef: GraphQLField<*, *> = {
   resolve: (source, args, context, { parentType }) => parentType.name,
 };
 
-export const introspectionTypes: Array<GraphQLNamedType> = [
+export const introspectionTypes: $ReadOnlyArray<*> = [
   __Schema,
   __Directive,
   __DirectiveLocation,

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -137,7 +137,7 @@ export const GraphQLID = new GraphQLScalarType({
   },
 });
 
-export const specifiedScalarTypes: Array<GraphQLScalarType> = [
+export const specifiedScalarTypes: $ReadOnlyArray<*> = [
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -59,7 +59,7 @@ export class GraphQLSchema {
   _queryType: GraphQLObjectType;
   _mutationType: ?GraphQLObjectType;
   _subscriptionType: ?GraphQLObjectType;
-  _directives: Array<GraphQLDirective>;
+  _directives: $ReadOnlyArray<GraphQLDirective>;
   _typeMap: TypeMap;
   _implementations: ObjMap<Array<GraphQLObjectType>>;
   _possibleTypeMap: ?ObjMap<ObjMap<boolean>>;
@@ -176,7 +176,7 @@ export class GraphQLSchema {
 
   getPossibleTypes(
     abstractType: GraphQLAbstractType,
-  ): Array<GraphQLObjectType> {
+  ): $ReadOnlyArray<GraphQLObjectType> {
     if (abstractType instanceof GraphQLUnionType) {
       return abstractType.getTypes();
     }
@@ -210,7 +210,7 @@ export class GraphQLSchema {
     return Boolean(possibleTypeMap[abstractType.name][possibleType.name]);
   }
 
-  getDirectives(): Array<GraphQLDirective> {
+  getDirectives(): $ReadOnlyArray<GraphQLDirective> {
     return this._directives;
   }
 

--- a/src/utilities/concatAST.js
+++ b/src/utilities/concatAST.js
@@ -14,7 +14,7 @@ import type { DocumentNode } from '../language/ast';
  * concatenate the ASTs together into batched AST, useful for validating many
  * GraphQL source files which together represent one conceptual application.
  */
-export function concatAST(asts: Array<DocumentNode>): DocumentNode {
+export function concatAST(asts: $ReadOnlyArray<DocumentNode>): DocumentNode {
   const batchDefinitions = [];
   for (let i = 0; i < asts.length; i++) {
     const definitions = asts[i].definitions;

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -637,8 +637,8 @@ function findConflict(
 }
 
 function sameArguments(
-  arguments1: Array<ArgumentNode>,
-  arguments2: Array<ArgumentNode>,
+  arguments1: $ReadOnlyArray<ArgumentNode>,
+  arguments2: $ReadOnlyArray<ArgumentNode>,
 ): boolean {
   if (arguments1.length !== arguments2.length) {
     return false;

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -51,9 +51,9 @@ import { specifiedRules } from './specifiedRules';
 export function validate(
   schema: GraphQLSchema,
   ast: DocumentNode,
-  rules?: Array<any>,
+  rules?: $ReadOnlyArray<any>,
   typeInfo?: TypeInfo,
-): Array<GraphQLError> {
+): $ReadOnlyArray<GraphQLError> {
   invariant(schema, 'Must provide schema');
   invariant(ast, 'Must provide document');
   invariant(
@@ -79,8 +79,8 @@ function visitUsingRules(
   schema: GraphQLSchema,
   typeInfo: TypeInfo,
   documentAST: DocumentNode,
-  rules: Array<any>,
-): Array<GraphQLError> {
+  rules: $ReadOnlyArray<any>,
+): $ReadOnlyArray<GraphQLError> {
   const context = new ValidationContext(schema, documentAST, typeInfo);
   const visitors = rules.map(rule => rule(context));
   // Visit the whole document with each instance of all provided rules.
@@ -102,13 +102,16 @@ export class ValidationContext {
   _typeInfo: TypeInfo;
   _errors: Array<GraphQLError>;
   _fragments: ObjMap<FragmentDefinitionNode>;
-  _fragmentSpreads: Map<SelectionSetNode, Array<FragmentSpreadNode>>;
+  _fragmentSpreads: Map<SelectionSetNode, $ReadOnlyArray<FragmentSpreadNode>>;
   _recursivelyReferencedFragments: Map<
     OperationDefinitionNode,
-    Array<FragmentDefinitionNode>,
+    $ReadOnlyArray<FragmentDefinitionNode>,
   >;
-  _variableUsages: Map<NodeWithSelectionSet, Array<VariableUsage>>;
-  _recursiveVariableUsages: Map<OperationDefinitionNode, Array<VariableUsage>>;
+  _variableUsages: Map<NodeWithSelectionSet, $ReadOnlyArray<VariableUsage>>;
+  _recursiveVariableUsages: Map<
+    OperationDefinitionNode,
+    $ReadOnlyArray<VariableUsage>,
+  >;
 
   constructor(
     schema: GraphQLSchema,
@@ -129,7 +132,7 @@ export class ValidationContext {
     this._errors.push(error);
   }
 
-  getErrors(): Array<GraphQLError> {
+  getErrors(): $ReadOnlyArray<GraphQLError> {
     return this._errors;
   }
 
@@ -157,7 +160,9 @@ export class ValidationContext {
     return fragments[name];
   }
 
-  getFragmentSpreads(node: SelectionSetNode): Array<FragmentSpreadNode> {
+  getFragmentSpreads(
+    node: SelectionSetNode,
+  ): $ReadOnlyArray<FragmentSpreadNode> {
     let spreads = this._fragmentSpreads.get(node);
     if (!spreads) {
       spreads = [];
@@ -180,7 +185,7 @@ export class ValidationContext {
 
   getRecursivelyReferencedFragments(
     operation: OperationDefinitionNode,
-  ): Array<FragmentDefinitionNode> {
+  ): $ReadOnlyArray<FragmentDefinitionNode> {
     let fragments = this._recursivelyReferencedFragments.get(operation);
     if (!fragments) {
       fragments = [];
@@ -206,7 +211,7 @@ export class ValidationContext {
     return fragments;
   }
 
-  getVariableUsages(node: NodeWithSelectionSet): Array<VariableUsage> {
+  getVariableUsages(node: NodeWithSelectionSet): $ReadOnlyArray<VariableUsage> {
     let usages = this._variableUsages.get(node);
     if (!usages) {
       const newUsages = [];
@@ -228,7 +233,7 @@ export class ValidationContext {
 
   getRecursiveVariableUsages(
     operation: OperationDefinitionNode,
-  ): Array<VariableUsage> {
+  ): $ReadOnlyArray<VariableUsage> {
     let usages = this._recursiveVariableUsages.get(operation);
     if (!usages) {
       usages = this.getVariableUsages(operation);


### PR DESCRIPTION
This is the second step of #1121 to ensure AST are readonly, marking all arrays as $ReadOnlyArray.