### PR TITLE
Validate schema root types and directives

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -393,11 +393,18 @@ export function getOperationRootType(
 ): GraphQLObjectType {
   switch (operation.operation) {
     case 'query':
-      return schema.getQueryType();
+      const queryType = schema.getQueryType();
+      if (!queryType) {
+        throw new GraphQLError(
+          'Schema does not define the required query root type.',
+          [operation],
+        );
+      }
+      return queryType;
     case 'mutation':
       const mutationType = schema.getMutationType();
       if (!mutationType) {
-        throw new GraphQLError('Schema is not configured for mutations', [
+        throw new GraphQLError('Schema is not configured for mutations.', [
           operation,
         ]);
       }
@@ -405,14 +412,14 @@ export function getOperationRootType(
     case 'subscription':
       const subscriptionType = schema.getSubscriptionType();
       if (!subscriptionType) {
-        throw new GraphQLError('Schema is not configured for subscriptions', [
+        throw new GraphQLError('Schema is not configured for subscriptions.', [
           operation,
         ]);
       }
       return subscriptionType;
     default:
       throw new GraphQLError(
-        'Can only execute queries, mutations and subscriptions',
+        'Can only execute queries, mutations and subscriptions.',
         [operation],
       );
   }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -24,6 +24,7 @@ import type {
   EnumValueDefinitionNode,
   InputObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
+  InterfaceTypeExtensionNode,
   OperationDefinitionNode,
   FieldNode,
   FragmentDefinitionNode,
@@ -412,7 +413,7 @@ export class GraphQLObjectType {
   name: string;
   description: ?string;
   astNode: ?ObjectTypeDefinitionNode;
-  extensionASTNodes: Array<ObjectTypeExtensionNode>;
+  extensionASTNodes: ?Array<ObjectTypeExtensionNode>;
   isTypeOf: ?GraphQLIsTypeOfFn<*, *>;
 
   _typeConfig: GraphQLObjectTypeConfig<*, *>;
@@ -424,7 +425,7 @@ export class GraphQLObjectType {
     this.name = config.name;
     this.description = config.description;
     this.astNode = config.astNode;
-    this.extensionASTNodes = config.extensionASTNodes || [];
+    this.extensionASTNodes = config.extensionASTNodes;
     if (config.isTypeOf) {
       invariant(
         typeof config.isTypeOf === 'function',
@@ -474,20 +475,6 @@ function defineInterfaces(
     `${type.name} interfaces must be an Array or a function which returns ` +
       'an Array.',
   );
-
-  const implementedTypeNames = Object.create(null);
-  interfaces.forEach(iface => {
-    invariant(
-      iface instanceof GraphQLInterfaceType,
-      `${type.name} may only implement Interface types, it cannot ` +
-        `implement: ${String(iface)}.`,
-    );
-    invariant(
-      !implementedTypeNames[iface.name],
-      `${type.name} may declare it implements ${iface.name} only once.`,
-    );
-    implementedTypeNames[iface.name] = true;
-  });
   return interfaces;
 }
 
@@ -694,6 +681,7 @@ export class GraphQLInterfaceType {
   name: string;
   description: ?string;
   astNode: ?InterfaceTypeDefinitionNode;
+  extensionASTNodes: ?Array<InterfaceTypeExtensionNode>;
   resolveType: ?GraphQLTypeResolver<*, *>;
 
   _typeConfig: GraphQLInterfaceTypeConfig<*, *>;
@@ -704,6 +692,7 @@ export class GraphQLInterfaceType {
     this.name = config.name;
     this.description = config.description;
     this.astNode = config.astNode;
+    this.extensionASTNodes = config.extensionASTNodes;
     if (config.resolveType) {
       invariant(
         typeof config.resolveType === 'function',
@@ -744,6 +733,7 @@ export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
   resolveType?: ?GraphQLTypeResolver<TSource, TContext>,
   description?: ?string,
   astNode?: ?InterfaceTypeDefinitionNode,
+  extensionASTNodes?: ?Array<InterfaceTypeExtensionNode>,
 };
 
 /**

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -7,8 +7,24 @@
  * @flow
  */
 
+import {
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLNonNull,
+  isType,
+} from './definition';
+import { GraphQLDirective } from './directives';
 import { GraphQLSchema } from './schema';
-import type { GraphQLError } from '../error/GraphQLError';
+import find from '../jsutils/find';
+import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators';
+import type {
+  ASTNode,
+  FieldDefinitionNode,
+  InputValueDefinitionNode,
+  NamedTypeNode,
+  TypeNode,
+} from '../language/ast';
+import { GraphQLError } from '../error/GraphQLError';
 
 /**
  * Implements the "Type Validation" sub-sections of the specification's
@@ -55,12 +71,14 @@ spurious results.`);
   }
 
   // Validate the schema, producing a list of errors.
-  const errors = [];
-
-  // TODO actually validate the schema
+  const context = new SchemaValidationContext();
+  validateRootTypes(context, schema);
+  validateDirectives(context, schema);
+  validateTypes(context, schema);
 
   // Persist the results of validation before returning to ensure validation
   // does not run multiple times for this schema.
+  const errors = context.getErrors();
   schema.__validationErrors = errors;
   return errors;
 }
@@ -74,4 +92,295 @@ export function assertValidSchema(schema: GraphQLSchema): void {
   if (errors.length !== 0) {
     throw new Error(errors.map(error => error.message).join('\n\n'));
   }
+}
+
+class SchemaValidationContext {
+  _errors: Array<GraphQLError>;
+
+  constructor() {
+    this._errors = [];
+  }
+
+  reportError(
+    message: string,
+    nodes?: $ReadOnlyArray<?ASTNode> | ?ASTNode,
+  ): void {
+    const _nodes = (Array.isArray(nodes) ? nodes : [nodes]).filter(Boolean);
+    this._errors.push(new GraphQLError(message, _nodes));
+  }
+
+  getErrors(): $ReadOnlyArray<GraphQLError> {
+    return this._errors;
+  }
+}
+
+function validateRootTypes(context, schema) {
+  const queryType = schema.getQueryType();
+  if (!queryType) {
+    context.reportError(`Query root type must be provided.`, schema.astNode);
+  } else if (!(queryType instanceof GraphQLObjectType)) {
+    context.reportError(
+      `Query root type must be Object type but got: ${String(queryType)}.`,
+      getOperationTypeNode(schema, queryType, 'query'),
+    );
+  }
+
+  const mutationType = schema.getMutationType();
+  if (mutationType && !(mutationType instanceof GraphQLObjectType)) {
+    context.reportError(
+      'Mutation root type must be Object type if provided but got: ' +
+        `${String(mutationType)}.`,
+      getOperationTypeNode(schema, mutationType, 'mutation'),
+    );
+  }
+
+  const subscriptionType = schema.getSubscriptionType();
+  if (subscriptionType && !(subscriptionType instanceof GraphQLObjectType)) {
+    context.reportError(
+      'Subscription root type must be Object type if provided but got: ' +
+        `${String(subscriptionType)}.`,
+      getOperationTypeNode(schema, subscriptionType, 'subscription'),
+    );
+  }
+}
+
+function getOperationTypeNode(
+  schema: GraphQLSchema,
+  type: GraphQLObjectType,
+  operation: string,
+): ?ASTNode {
+  const astNode = schema.astNode;
+  const operationTypeNode =
+    astNode &&
+    astNode.operationTypes.find(
+      operationType => operationType.operation === operation,
+    );
+  return operationTypeNode ? operationTypeNode.type : type && type.astNode;
+}
+
+function validateDirectives(
+  context: SchemaValidationContext,
+  schema: GraphQLSchema,
+): void {
+  const directives = schema.getDirectives();
+  directives.forEach(directive => {
+    if (!(directive instanceof GraphQLDirective)) {
+      context.reportError(
+        `Expected directive but got: ${String(directive)}.`,
+        directive && directive.astNode,
+      );
+    }
+  });
+}
+
+function validateTypes(
+  context: SchemaValidationContext,
+  schema: GraphQLSchema,
+): void {
+  const typeMap = schema.getTypeMap();
+  Object.keys(typeMap).forEach(typeName => {
+    const type = typeMap[typeName];
+
+    // Ensure all provided types are in fact GraphQL type.
+    if (!isType(type)) {
+      context.reportError(
+        `Expected GraphQL type but got: ${String(type)}.`,
+        type && type.astNode,
+      );
+    }
+
+    // Ensure objects implement the interfaces they claim to.
+    if (type instanceof GraphQLObjectType) {
+      const implementedTypeNames = Object.create(null);
+
+      type.getInterfaces().forEach(iface => {
+        if (implementedTypeNames[iface.name]) {
+          context.reportError(
+            `${type.name} must declare it implements ${iface.name} only once.`,
+            getAllImplementsInterfaceNode(type, iface),
+          );
+        }
+        implementedTypeNames[iface.name] = true;
+        validateObjectImplementsInterface(context, schema, type, iface);
+      });
+    }
+  });
+}
+
+function validateObjectImplementsInterface(
+  context: SchemaValidationContext,
+  schema: GraphQLSchema,
+  object: GraphQLObjectType,
+  iface: GraphQLInterfaceType,
+): void {
+  if (!(iface instanceof GraphQLInterfaceType)) {
+    context.reportError(
+      `${String(object)} must only implement Interface types, it cannot ` +
+        `implement ${String(iface)}.`,
+      getImplementsInterfaceNode(object, iface),
+    );
+    return;
+  }
+
+  const objectFieldMap = object.getFields();
+  const ifaceFieldMap = iface.getFields();
+
+  // Assert each interface field is implemented.
+  Object.keys(ifaceFieldMap).forEach(fieldName => {
+    const objectField = objectFieldMap[fieldName];
+    const ifaceField = ifaceFieldMap[fieldName];
+
+    // Assert interface field exists on object.
+    if (!objectField) {
+      context.reportError(
+        `"${iface.name}" expects field "${fieldName}" but "${object.name}" ` +
+          'does not provide it.',
+        [getFieldNode(iface, fieldName), object.astNode],
+      );
+      // Continue loop over fields.
+      return;
+    }
+
+    // Assert interface field type is satisfied by object field type, by being
+    // a valid subtype. (covariant)
+    if (!isTypeSubTypeOf(schema, objectField.type, ifaceField.type)) {
+      context.reportError(
+        `${iface.name}.${fieldName} expects type ` +
+          `"${String(ifaceField.type)}" but ${object.name}.${fieldName} is ` +
+          `type "${String(objectField.type)}".`,
+        [
+          getFieldTypeNode(iface, fieldName),
+          getFieldTypeNode(object, fieldName),
+        ],
+      );
+    }
+
+    // Assert each interface field arg is implemented.
+    ifaceField.args.forEach(ifaceArg => {
+      const argName = ifaceArg.name;
+      const objectArg = find(objectField.args, arg => arg.name === argName);
+
+      // Assert interface field arg exists on object field.
+      if (!objectArg) {
+        context.reportError(
+          `${iface.name}.${fieldName} expects argument "${argName}" but ` +
+            `${object.name}.${fieldName} does not provide it.`,
+          [
+            getFieldArgNode(iface, fieldName, argName),
+            getFieldNode(object, fieldName),
+          ],
+        );
+        // Continue loop over arguments.
+        return;
+      }
+
+      // Assert interface field arg type matches object field arg type.
+      // (invariant)
+      // TODO: change to contravariant?
+      if (!isEqualType(ifaceArg.type, objectArg.type)) {
+        context.reportError(
+          `${iface.name}.${fieldName}(${argName}:) expects type ` +
+            `"${String(ifaceArg.type)}" but ` +
+            `${object.name}.${fieldName}(${argName}:) is type ` +
+            `"${String(objectArg.type)}".`,
+          [
+            getFieldArgTypeNode(iface, fieldName, argName),
+            getFieldArgTypeNode(object, fieldName, argName),
+          ],
+        );
+      }
+
+      // TODO: validate default values?
+    });
+
+    // Assert additional arguments must not be required.
+    objectField.args.forEach(objectArg => {
+      const argName = objectArg.name;
+      const ifaceArg = find(ifaceField.args, arg => arg.name === argName);
+      if (!ifaceArg && objectArg.type instanceof GraphQLNonNull) {
+        context.reportError(
+          `${object.name}.${fieldName}(${argName}:) is of required type ` +
+            `"${String(objectArg.type)}" but is not also provided by the ` +
+            `interface ${iface.name}.${fieldName}.`,
+          [
+            getFieldArgTypeNode(object, fieldName, argName),
+            getFieldNode(iface, fieldName),
+          ],
+        );
+      }
+    });
+  });
+}
+
+function getImplementsInterfaceNode(
+  type: GraphQLObjectType,
+  iface: GraphQLInterfaceType,
+): ?NamedTypeNode {
+  return getAllImplementsInterfaceNode(type, iface)[0];
+}
+
+function getAllImplementsInterfaceNode(
+  type: GraphQLObjectType,
+  iface: GraphQLInterfaceType,
+): Array<NamedTypeNode> {
+  const implementsNodes = [];
+  const astNodes = [type.astNode].concat(type.extensionASTNodes || []);
+  for (let i = 0; i < astNodes.length; i++) {
+    const astNode = astNodes[i];
+    if (astNode && astNode.interfaces) {
+      astNode.interfaces.forEach(node => {
+        if (node.name.value === iface.name) {
+          implementsNodes.push(node);
+        }
+      });
+    }
+  }
+  return implementsNodes;
+}
+
+function getFieldNode(
+  type: GraphQLObjectType | GraphQLInterfaceType,
+  fieldName: string,
+): ?FieldDefinitionNode {
+  const astNodes = [type.astNode].concat(type.extensionASTNodes || []);
+  for (let i = 0; i < astNodes.length; i++) {
+    const astNode = astNodes[i];
+    const fieldNode =
+      astNode &&
+      astNode.fields &&
+      astNode.fields.find(node => node.name.value === fieldName);
+    if (fieldNode) {
+      return fieldNode;
+    }
+  }
+}
+
+function getFieldTypeNode(
+  type: GraphQLObjectType | GraphQLInterfaceType,
+  fieldName: string,
+): ?TypeNode {
+  const fieldNode = getFieldNode(type, fieldName);
+  return fieldNode && fieldNode.type;
+}
+
+function getFieldArgNode(
+  type: GraphQLObjectType | GraphQLInterfaceType,
+  fieldName: string,
+  argName: string,
+): ?InputValueDefinitionNode {
+  const fieldNode = getFieldNode(type, fieldName);
+  return (
+    fieldNode &&
+    fieldNode.arguments &&
+    fieldNode.arguments.find(node => node.name.value === argName)
+  );
+}
+
+function getFieldArgTypeNode(
+  type: GraphQLObjectType | GraphQLInterfaceType,
+  fieldName: string,
+  argName: string,
+): ?TypeNode {
+  const fieldArgNode = getFieldArgNode(type, fieldName, argName);
+  return fieldArgNode && fieldArgNode.type;
 }

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -816,18 +816,6 @@ describe('Schema Builder', () => {
 });
 
 describe('Failures', () => {
-  it('Requires a schema definition or Query type', () => {
-    const body = dedent`
-      type Hello {
-        bar: Bar
-      }
-    `;
-    const doc = parse(body);
-    expect(() => buildASTSchema(doc)).to.throw(
-      'Must provide schema definition with query type or a type named Query.',
-    );
-  });
-
   it('Allows only a single schema definition', () => {
     const body = dedent`
       schema {
@@ -845,22 +833,6 @@ describe('Failures', () => {
     const doc = parse(body);
     expect(() => buildASTSchema(doc)).to.throw(
       'Must provide only one schema definition.',
-    );
-  });
-
-  it('Requires a query type', () => {
-    const body = dedent`
-      schema {
-        mutation: Hello
-      }
-
-      type Hello {
-        bar: Bar
-      }
-    `;
-    const doc = parse(body);
-    expect(() => buildASTSchema(doc)).to.throw(
-      'Must provide schema definition with query type or a type named Query.',
     );
   });
 

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -274,7 +274,7 @@ describe('extendSchema', () => {
     const testDirective = extendedTwiceSchema.getDirective('test');
 
     expect(query.extensionASTNodes).to.have.lengthOf(2);
-    expect(testType.extensionASTNodes).to.have.lengthOf(0);
+    expect(testType.extensionASTNodes).to.equal(undefined);
 
     const restoredExtensionAST = parse(
       print(query.extensionASTNodes[0]) +

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -214,19 +214,18 @@ export function buildASTSchema(
     directives.push(GraphQLDeprecatedDirective);
   }
 
-  if (!operationTypes.query) {
-    throw new Error(
-      'Must provide schema definition with query type or a type named Query.',
-    );
-  }
-
+  // Note: While this could make early assertions to get the correctly
+  // typed values below, that would throw immediately while type system
+  // validation with validateSchema() will produce more actionable results.
   return new GraphQLSchema({
-    query: definitionBuilder.buildObjectType(operationTypes.query),
+    query: operationTypes.query
+      ? (definitionBuilder.buildType(operationTypes.query): any)
+      : null,
     mutation: operationTypes.mutation
-      ? definitionBuilder.buildObjectType(operationTypes.mutation)
+      ? (definitionBuilder.buildType(operationTypes.mutation): any)
       : null,
     subscription: operationTypes.subscription
-      ? definitionBuilder.buildObjectType(operationTypes.subscription)
+      ? (definitionBuilder.buildType(operationTypes.subscription): any)
       : null,
     types,
     directives,
@@ -393,7 +392,10 @@ export class ASTDefinitionBuilder {
   _makeImplementedInterfaces(def: ObjectTypeDefinitionNode) {
     return (
       def.interfaces &&
-      def.interfaces.map(iface => this.buildInterfaceType(iface))
+      // Note: While this could make early assertions to get the correctly
+      // typed values, that would throw immediately while type system
+      // validation with validateSchema() will produce more actionable results.
+      def.interfaces.map(iface => (this.buildType(iface): any))
     );
   }
 

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -397,7 +397,9 @@ export function buildClientSchema(
   );
 
   // Get the root Query, Mutation, and Subscription types.
-  const queryType = getObjectType(schemaIntrospection.queryType);
+  const queryType = schemaIntrospection.queryType
+    ? getObjectType(schemaIntrospection.queryType)
+    : null;
 
   const mutationType = schemaIntrospection.mutationType
     ? getObjectType(schemaIntrospection.mutationType)

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -191,9 +191,10 @@ export function extendSchema(
   );
 
   // Get the root Query, Mutation, and Subscription object types.
-  const queryType = definitionBuilder.buildObjectType(
-    schema.getQueryType().name,
-  );
+  const existingQueryType = schema.getQueryType();
+  const queryType = existingQueryType
+    ? definitionBuilder.buildObjectType(existingQueryType.name)
+    : null;
 
   const existingMutationType = schema.getMutationType();
   const mutationType = existingMutationType
@@ -262,11 +263,11 @@ export function extendSchema(
 
   function extendObjectType(type: GraphQLObjectType): GraphQLObjectType {
     const name = type.name;
-    let extensionASTNodes = type.extensionASTNodes;
-    if (typeExtensionsMap[name]) {
-      extensionASTNodes = extensionASTNodes.concat(typeExtensionsMap[name]);
-    }
-
+    const extensionASTNodes = typeExtensionsMap[name]
+      ? type.extensionASTNodes
+        ? type.extensionASTNodes.concat(typeExtensionsMap[name])
+        : typeExtensionsMap[name]
+      : type.extensionASTNodes;
     return new GraphQLObjectType({
       name,
       description: type.description,


### PR DESCRIPTION
This moves validation out of GraphQLSchema's constructor (but not yet from other type constructors), which is responsible for root type validation and interface implementation checking.

Reduces time to construct GraphQLSchema significantly, shifting the time to validation.

This also allows for much looser rules within the schema builders, which implicitly validate while trying to adhere to flow types. Instead we use any casts to loosen the rules to defer that to validation where errors can be richer.

This also loosens the rule that a schema can only be constructed if it has a query type, moving that to validation as well. That makes flow typing slightly less nice, but allows for incremental schema building which is valuable

Improves #1079 
Partial #1080 
Closes #722