### PR TITLE
Fix unhandled error when parsing custom scalar literals.

### DIFF
--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -613,7 +613,7 @@ describe('Execute: Handles inputs', () => {
           {
             message:
               'Variable "$value" got invalid value [1,2,3].\nExpected type ' +
-              '"String", found [1,2,3]: String cannot represent an array value: [1,2,3]',
+              '"String", found [1,2,3]; String cannot represent an array value: [1,2,3]',
             locations: [{ line: 2, column: 31 }],
             path: undefined,
           },

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -475,7 +475,7 @@ describe('Subscription Initialization Phase', () => {
         {
           message:
             'Variable "$priority" got invalid value "meow".\nExpected ' +
-            'type "Int", found "meow": Int cannot represent non 32-bit signed ' +
+            'type "Int", found "meow"; Int cannot represent non 32-bit signed ' +
             'integer value: meow',
           locations: [{ line: 2, column: 21 }],
           path: undefined,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -332,11 +332,6 @@ export class GraphQLScalarType {
     return serializer(value);
   }
 
-  // Determines if an internal value is valid for this type.
-  isValidValue(value: mixed): boolean {
-    return !isInvalid(this.parseValue(value));
-  }
-
   // Parses an externally provided value to use as an input.
   parseValue(value: mixed): mixed {
     const parser = this._scalarConfig.parseValue;
@@ -344,11 +339,6 @@ export class GraphQLScalarType {
       return undefined;
     }
     return parser ? parser(value) : value;
-  }
-
-  // Determines if an internal value is valid for this type.
-  isValidLiteral(valueNode: ValueNode, variables: ?ObjMap<mixed>): boolean {
-    return !isInvalid(this.parseLiteral(valueNode, variables));
   }
 
   // Parses an externally provided literal value to use as an input.
@@ -919,12 +909,6 @@ export class GraphQLEnumType /* <T> */ {
     }
   }
 
-  isValidValue(value: mixed): boolean {
-    return (
-      typeof value === 'string' && this._getNameLookup()[value] !== undefined
-    );
-  }
-
   parseValue(value: mixed): ?any /* T */ {
     if (typeof value === 'string') {
       const enumValue = this._getNameLookup()[value];
@@ -932,14 +916,6 @@ export class GraphQLEnumType /* <T> */ {
         return enumValue.value;
       }
     }
-  }
-
-  isValidLiteral(valueNode: ValueNode, _variables: ?ObjMap<mixed>): boolean {
-    // Note: variables will be resolved to a value before calling this function.
-    return (
-      valueNode.kind === Kind.ENUM &&
-      this._getNameLookup()[valueNode.value] !== undefined
-    );
   }
 
   parseLiteral(valueNode: ValueNode, _variables: ?ObjMap<mixed>): ?any /* T */ {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -29,6 +29,7 @@ import {
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
 } from '../../type/directives';
+import { GraphQLScalarType } from '../../type/definition';
 
 const Being = new GraphQLInterfaceType({
   name: 'Being',
@@ -269,6 +270,19 @@ const ComplicatedArgs = new GraphQLObjectType({
   }),
 });
 
+const InvalidScalar = new GraphQLScalarType({
+  name: 'Invalid',
+  serialize(value) {
+    return value;
+  },
+  parseLiteral(node) {
+    throw new Error('Invalid scalar is always invalid: ' + node.value);
+  },
+  parseValue(node) {
+    throw new Error('Invalid scalar is always invalid: ' + node);
+  },
+});
+
 const QueryRoot = new GraphQLObjectType({
   name: 'QueryRoot',
   fields: () => ({
@@ -284,6 +298,12 @@ const QueryRoot = new GraphQLObjectType({
     dogOrHuman: { type: DogOrHuman },
     humanOrAlien: { type: HumanOrAlien },
     complicatedArgs: { type: ComplicatedArgs },
+    invalidArg: {
+      args: {
+        arg: { type: InvalidScalar },
+      },
+      type: GraphQLString,
+    },
   }),
 });
 

--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -36,6 +36,26 @@ describe('Validate: Supports full validation', () => {
     );
   });
 
+  it('detects bad scalar parse', () => {
+    const doc = `
+      query {
+        invalidArg(arg: "bad value")
+      }
+    `;
+
+    const errors = validate(testSchema, parse(doc));
+    expect(errors).to.deep.equal([
+      {
+        locations: [{ line: 3, column: 25 }],
+        message:
+          'Argument "arg" has invalid value "bad value".\n' +
+          'Expected type "Invalid", found "bad value"; ' +
+          'Invalid scalar is always invalid: bad value',
+        path: undefined,
+      },
+    ]);
+  });
+
   // NOTE: experimental
   it('validates using a custom TypeInfo', () => {
     // This TypeInfo will never return a valid field.


### PR DESCRIPTION
Fixes #910

This factors out the enum value validation from scalar value validation and ensures the same try/catch is used in isValidLiteralValue as isValidJSValue and protecting from errors in valueFromAST.