### PR TITLE
Perf: memoize collectSubfields

### DIFF
--- a/src/jsutils/memoize3.js
+++ b/src/jsutils/memoize3.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/**
+ * Memoizes the provided three-argument function.
+ */
+export default function memoize3<T: (a1: any, a2: any, a3: any) => any>(
+  fn: T,
+): T {
+  let cache0;
+  function memoized(a1, a2, a3) {
+    if (!cache0) {
+      cache0 = new WeakMap();
+    }
+    let cache1 = cache0.get(a1);
+    let cache2;
+    if (cache1) {
+      cache2 = cache1.get(a2);
+      if (cache2) {
+        const cachedValue = cache2.get(a3);
+        if (cachedValue) {
+          return cachedValue;
+        }
+      }
+    } else {
+      cache1 = new WeakMap();
+      cache0.set(a1, cache1);
+    }
+    if (!cache2) {
+      cache2 = new WeakMap();
+      cache1.set(a2, cache2);
+    }
+    const newValue = fn.apply(this, arguments);
+    cache2.set(a3, newValue);
+    return newValue;
+  }
+  return (memoized: any);
+}


### PR DESCRIPTION
Collecting subfields occurs after resolving a field's value and before resolving subfield values. This step collects fragment spreads and checks inline fragment conditions. When fetching a list of things, this step is computed with the same inputs and expecting the same outputs for each item in the list. Memoizing ensures the work is done at most once per type returned from a list.

I tested this against the introspection query (which is both synchronous and complex) against a large schema and saw a ~15%-25% reduction in runtime. In practice I don't expect most queries to see this level of speedup as most queries are limited by backend communication and not execution overhead.