### PR TITLE
Fix printError/locations for multiple nodes.

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -65,7 +65,10 @@ declare class GraphQLError extends Error {
   +nodes: $ReadOnlyArray<ASTNode> | void;
 
   /**
-   * The source GraphQL document corresponding to this error.
+   * The source GraphQL document for the first location of this error.
+   *
+   * Note that if this Error represents more than one node, the source may not
+   * represent nodes after the first node.
    */
   +source: Source | void;
 
@@ -121,9 +124,15 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   }
 
   let _locations;
-  const _source2 = _source; // seems here Flow need a const to resolve type.
-  if (_source2 && _positions) {
-    _locations = _positions.map(pos => getLocation(_source2, pos));
+  if (positions && source) {
+    _locations = positions.map(pos => getLocation(source, pos));
+  } else if (_nodes) {
+    _locations = _nodes.reduce((list, node) => {
+      if (node.loc) {
+        list.push(getLocation(node.loc.source, node.loc.start));
+      }
+      return list;
+    }, []);
   }
 
   Object.defineProperties(this, {

--- a/src/error/__tests__/printError-test.js
+++ b/src/error/__tests__/printError-test.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { GraphQLError } from '../GraphQLError';
+import { printError } from '../printError';
+import { parse, Source } from '../../language';
+import dedent from '../../jsutils/dedent';
+
+describe('printError', () => {
+  it('prints an error with nodes from different sources', () => {
+    const sourceA = parse(
+      new Source(
+        dedent`
+        type Foo {
+          field: String
+        }`,
+        'SourceA',
+      ),
+    );
+    const fieldTypeA = sourceA.definitions[0].fields[0].type;
+
+    const sourceB = parse(
+      new Source(
+        dedent`
+        type Foo {
+          field: Int
+        }`,
+        'SourceB',
+      ),
+    );
+    const fieldTypeB = sourceB.definitions[0].fields[0].type;
+
+    const error = new GraphQLError('Example error with two nodes', [
+      fieldTypeA,
+      fieldTypeB,
+    ]);
+
+    expect(printError(error)).to.equal(dedent`
+      Example error with two nodes
+
+      SourceA (2:10)
+      1: type Foo {
+      2:   field: String
+                  ^
+      3: }
+
+      SourceB (2:10)
+      1: type Foo {
+      2:   field: Int
+                  ^
+      3: }
+    `);
+  });
+});


### PR DESCRIPTION
If a GraphQLError represents multiple nodes across files (could happen for validation across multiple parsed files) then the reported locations and printError output can be incorrect for the second node. This ensures locations are derived from nodes whenever possible to get correct location and amends comment documentation.