### PR TITLE
Move schema validation into separate step (type constructors)

### DIFF
--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -102,6 +102,16 @@ const ScalarType = new GraphQLScalarType({
   parseLiteral() {},
 });
 
+function schemaWithFieldType(type) {
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: { field: { type } },
+    }),
+    types: [type],
+  });
+}
+
 describe('Type System: Example', () => {
   it('defines a query only schema', () => {
     const BlogSchema = new GraphQLSchema({
@@ -270,7 +280,7 @@ describe('Type System: Example', () => {
     expect(schema.getTypeMap().NestedInputObject).to.equal(NestedInputObject);
   });
 
-  it("includes interfaces' subtypes in the type map", () => {
+  it('includes interface possible types in the type map', () => {
     const SomeInterface = new GraphQLInterfaceType({
       name: 'SomeInterface',
       fields: {
@@ -374,26 +384,13 @@ describe('Type System: Example', () => {
     });
   });
 
-  it('prohibits putting non-Object types in unions', () => {
-    const badUnionTypes = [
-      GraphQLInt,
-      GraphQLNonNull(GraphQLInt),
-      GraphQLList(GraphQLInt),
-      InterfaceType,
-      UnionType,
-      EnumType,
-      InputObjectType,
-    ];
-    badUnionTypes.forEach(x => {
-      expect(() =>
-        new GraphQLUnionType({ name: 'BadUnion', types: [x] }).getTypes(),
-      ).to.throw(
-        `BadUnion may only contain Object types, it cannot contain: ${x}.`,
-      );
-    });
+  it('prohibits nesting NonNull inside NonNull', () => {
+    expect(() => GraphQLNonNull(GraphQLNonNull(GraphQLInt))).to.throw(
+      'Expected Int! to be a GraphQL nullable type.',
+    );
   });
 
-  it("allows a thunk for Union's types", () => {
+  it('allows a thunk for Union member types', () => {
     const union = new GraphQLUnionType({
       name: 'ThunkUnion',
       types: () => [ObjectType],
@@ -470,6 +467,638 @@ describe('Type System: Example', () => {
   });
 });
 
+describe('Field config must be object', () => {
+  it('accepts an Object type with a field function', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields() {
+        return {
+          f: { type: GraphQLString },
+        };
+      },
+    });
+    expect(objType.getFields().f.type).to.equal(GraphQLString);
+  });
+
+  it('rejects an Object type field with undefined config', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        f: undefined,
+      },
+    });
+    expect(() => objType.getFields()).to.throw(
+      'SomeObject.f field config must be an object',
+    );
+  });
+
+  it('rejects an Object type with incorrectly typed fields', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: [{ field: GraphQLString }],
+    });
+    expect(() => objType.getFields()).to.throw(
+      'SomeObject fields must be an object with field names as keys or a ' +
+        'function which returns such an object.',
+    );
+  });
+
+  it('rejects an Object type with a field function that returns incorrect type', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields() {
+        return [{ field: GraphQLString }];
+      },
+    });
+    expect(() => objType.getFields()).to.throw(
+      'SomeObject fields must be an object with field names as keys or a ' +
+        'function which returns such an object.',
+    );
+  });
+});
+
+describe('Field arg config must be object', () => {
+  it('accepts an Object type with field args', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        goodField: {
+          type: GraphQLString,
+          args: {
+            goodArg: { type: GraphQLString },
+          },
+        },
+      },
+    });
+    expect(() => objType.getFields()).not.to.throw();
+  });
+
+  it('rejects an Object type with incorrectly typed field args', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        badField: {
+          type: GraphQLString,
+          args: [{ badArg: GraphQLString }],
+        },
+      },
+    });
+    expect(() => objType.getFields()).to.throw(
+      'SomeObject.badField args must be an object with argument names as keys.',
+    );
+  });
+
+  it('does not allow isDeprecated without deprecationReason on field', () => {
+    expect(() => {
+      const OldObject = new GraphQLObjectType({
+        name: 'OldObject',
+        fields: {
+          field: {
+            type: GraphQLString,
+            isDeprecated: true,
+          },
+        },
+      });
+
+      return schemaWithFieldType(OldObject);
+    }).to.throw(
+      'OldObject.field should provide "deprecationReason" instead ' +
+        'of "isDeprecated".',
+    );
+  });
+});
+
+describe('Object interfaces must be array', () => {
+  it('accepts an Object type with array interfaces', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      interfaces: [InterfaceType],
+      fields: { f: { type: GraphQLString } },
+    });
+    expect(objType.getInterfaces()[0]).to.equal(InterfaceType);
+  });
+
+  it('accepts an Object type with interfaces as a function returning an array', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      interfaces: () => [InterfaceType],
+      fields: { f: { type: GraphQLString } },
+    });
+    expect(objType.getInterfaces()[0]).to.equal(InterfaceType);
+  });
+
+  it('rejects an Object type with incorrectly typed interfaces', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      interfaces: {},
+      fields: { f: { type: GraphQLString } },
+    });
+    expect(() => objType.getInterfaces()).to.throw(
+      'SomeObject interfaces must be an Array or a function which returns an Array.',
+    );
+  });
+
+  it('rejects an Object type with interfaces as a function returning an incorrect type', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      interfaces() {
+        return {};
+      },
+      fields: { f: { type: GraphQLString } },
+    });
+    expect(() => objType.getInterfaces()).to.throw(
+      'SomeObject interfaces must be an Array or a function which returns an Array.',
+    );
+  });
+});
+
+describe('Type System: Object fields must have valid resolve values', () => {
+  function schemaWithObjectWithFieldResolver(resolveValue) {
+    const BadResolverType = new GraphQLObjectType({
+      name: 'BadResolver',
+      fields: {
+        badField: {
+          type: GraphQLString,
+          resolve: resolveValue,
+        },
+      },
+    });
+
+    return new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          f: { type: BadResolverType },
+        },
+      }),
+    });
+  }
+
+  it('accepts a lambda as an Object field resolver', () => {
+    expect(() => schemaWithObjectWithFieldResolver(() => ({}))).not.to.throw();
+  });
+
+  it('rejects an empty Object field resolver', () => {
+    expect(() => schemaWithObjectWithFieldResolver({})).to.throw(
+      'BadResolver.badField field resolver must be a function if provided, ' +
+        'but got: [object Object].',
+    );
+  });
+
+  it('rejects a constant scalar value resolver', () => {
+    expect(() => schemaWithObjectWithFieldResolver(0)).to.throw(
+      'BadResolver.badField field resolver must be a function if provided, ' +
+        'but got: 0.',
+    );
+  });
+});
+
+describe('Type System: Interface types must be resolvable', () => {
+  it('accepts an Interface type defining resolveType', () => {
+    expect(() => {
+      const AnotherInterfaceType = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        fields: { f: { type: GraphQLString } },
+      });
+
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: [AnotherInterfaceType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
+    }).not.to.throw();
+  });
+
+  it('accepts an Interface with implementing type defining isTypeOf', () => {
+    expect(() => {
+      const InterfaceTypeWithoutResolveType = new GraphQLInterfaceType({
+        name: 'InterfaceTypeWithoutResolveType',
+        fields: { f: { type: GraphQLString } },
+      });
+
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: [InterfaceTypeWithoutResolveType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
+    }).not.to.throw();
+  });
+
+  it('accepts an Interface type defining resolveType with implementing type defining isTypeOf', () => {
+    expect(() => {
+      const AnotherInterfaceType = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        fields: { f: { type: GraphQLString } },
+      });
+
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'SomeObject',
+          interfaces: [AnotherInterfaceType],
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
+    }).not.to.throw();
+  });
+
+  it('rejects an Interface type with an incorrect type for resolveType', () => {
+    expect(
+      () =>
+        new GraphQLInterfaceType({
+          name: 'AnotherInterface',
+          resolveType: {},
+          fields: { f: { type: GraphQLString } },
+        }),
+    ).to.throw('AnotherInterface must provide "resolveType" as a function.');
+  });
+});
+
+describe('Type System: Union types must be resolvable', () => {
+  const ObjectWithIsTypeOf = new GraphQLObjectType({
+    name: 'ObjectWithIsTypeOf',
+    fields: { f: { type: GraphQLString } },
+  });
+
+  it('accepts a Union type defining resolveType', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: [ObjectType],
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('accepts a Union of Object types defining isTypeOf', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: [ObjectWithIsTypeOf],
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('accepts a Union type defining resolveType of Object types defining isTypeOf', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: [ObjectWithIsTypeOf],
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('rejects an Interface type with an incorrect type for resolveType', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          resolveType: {},
+          types: [ObjectWithIsTypeOf],
+        }),
+      ),
+    ).to.throw('SomeUnion must provide "resolveType" as a function.');
+  });
+});
+
+describe('Type System: Scalar types must be serializable', () => {
+  it('accepts a Scalar type defining serialize', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('rejects a Scalar type not defining serialize', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+        }),
+      ),
+    ).to.throw(
+      'SomeScalar must provide "serialize" function. If this custom Scalar ' +
+        'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
+        'functions are also provided.',
+    );
+  });
+
+  it('rejects a Scalar type defining serialize with an incorrect type', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: {},
+        }),
+      ),
+    ).to.throw(
+      'SomeScalar must provide "serialize" function. If this custom Scalar ' +
+        'is also used as an input type, ensure "parseValue" and "parseLiteral" ' +
+        'functions are also provided.',
+    );
+  });
+
+  it('accepts a Scalar type defining parseValue and parseLiteral', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseValue: () => null,
+          parseLiteral: () => null,
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('rejects a Scalar type defining parseValue but not parseLiteral', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseValue: () => null,
+        }),
+      ),
+    ).to.throw(
+      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
+    );
+  });
+
+  it('rejects a Scalar type defining parseLiteral but not parseValue', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseLiteral: () => null,
+        }),
+      ),
+    ).to.throw(
+      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
+    );
+  });
+
+  it('rejects a Scalar type defining parseValue and parseLiteral with an incorrect type', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          serialize: () => null,
+          parseValue: {},
+          parseLiteral: {},
+        }),
+      ),
+    ).to.throw(
+      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
+    );
+  });
+});
+
+describe('Type System: Object types must be assertable', () => {
+  it('accepts an Object type with an isTypeOf function', () => {
+    expect(() => {
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'AnotherObject',
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
+    }).not.to.throw();
+  });
+
+  it('rejects an Object type with an incorrect type for isTypeOf', () => {
+    expect(() => {
+      schemaWithFieldType(
+        new GraphQLObjectType({
+          name: 'AnotherObject',
+          isTypeOf: {},
+          fields: { f: { type: GraphQLString } },
+        }),
+      );
+    }).to.throw('AnotherObject must provide "isTypeOf" as a function.');
+  });
+});
+
+describe('Type System: Union types must be array', () => {
+  it('accepts a Union type with array types', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: [ObjectType],
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('accepts a Union type with function returning an array of types', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: () => [ObjectType],
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('rejects a Union type without types', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+        }),
+      ),
+    ).not.to.throw();
+  });
+
+  it('rejects a Union type with incorrectly typed types', () => {
+    expect(() =>
+      schemaWithFieldType(
+        new GraphQLUnionType({
+          name: 'SomeUnion',
+          types: {
+            ObjectType,
+          },
+        }),
+      ),
+    ).to.throw(
+      'Must provide Array of types or a function which returns such an array ' +
+        'for Union SomeUnion.',
+    );
+  });
+});
+
+describe('Type System: Input Objects must have fields', () => {
+  it('accepts an Input Object type with fields', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: {
+        f: { type: GraphQLString },
+      },
+    });
+    expect(inputObjType.getFields().f.type).to.equal(GraphQLString);
+  });
+
+  it('accepts an Input Object type with a field function', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields() {
+        return {
+          f: { type: GraphQLString },
+        };
+      },
+    });
+    expect(inputObjType.getFields().f.type).to.equal(GraphQLString);
+  });
+
+  it('rejects an Input Object type with incorrect fields', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: [],
+    });
+    expect(() => inputObjType.getFields()).to.throw(
+      'SomeInputObject fields must be an object with field names as keys or a ' +
+        'function which returns such an object.',
+    );
+  });
+
+  it('rejects an Input Object type with fields function that returns incorrect type', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields() {
+        return [];
+      },
+    });
+    expect(() => inputObjType.getFields()).to.throw(
+      'SomeInputObject fields must be an object with field names as keys or a ' +
+        'function which returns such an object.',
+    );
+  });
+});
+
+describe('Type System: Input Object fields must not have resolvers', () => {
+  it('rejects an Input Object type with resolvers', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: {
+        f: {
+          type: GraphQLString,
+          resolve: () => {
+            return 0;
+          },
+        },
+      },
+    });
+    expect(() => inputObjType.getFields()).to.throw(
+      'SomeInputObject.f field type has a resolve property, ' +
+        'but Input Types cannot define resolvers.',
+    );
+  });
+
+  it('rejects an Input Object type with resolver constant', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: {
+        f: {
+          type: GraphQLString,
+          resolve: {},
+        },
+      },
+    });
+    expect(() => inputObjType.getFields()).to.throw(
+      'SomeInputObject.f field type has a resolve property, ' +
+        'but Input Types cannot define resolvers.',
+    );
+  });
+});
+
+describe('Type System: Enum types must be well defined', () => {
+  it('accepts a well defined Enum type with empty value definition', () => {
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: {
+        FOO: {},
+        BAR: {},
+      },
+    });
+    expect(enumType.getValue('FOO').value).to.equal('FOO');
+    expect(enumType.getValue('BAR').value).to.equal('BAR');
+  });
+
+  it('accepts a well defined Enum type with internal value definition', () => {
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: {
+        FOO: { value: 10 },
+        BAR: { value: 20 },
+      },
+    });
+    expect(enumType.getValue('FOO').value).to.equal(10);
+    expect(enumType.getValue('BAR').value).to.equal(20);
+  });
+
+  it('rejects an Enum type with incorrectly typed values', () => {
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: [{ FOO: 10 }],
+    });
+    expect(() => enumType.getValue()).to.throw(
+      'SomeEnum values must be an object with value names as keys.',
+    );
+  });
+
+  it('rejects an Enum type with missing value definition', () => {
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: { FOO: null },
+    });
+    expect(() => enumType.getValues()).to.throw(
+      'SomeEnum.FOO must refer to an object with a "value" key representing ' +
+        'an internal value but got: null.',
+    );
+  });
+
+  it('rejects an Enum type with incorrectly typed value definition', () => {
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: { FOO: 10 },
+    });
+    expect(() => enumType.getValues()).to.throw(
+      'SomeEnum.FOO must refer to an object with a "value" key representing ' +
+        'an internal value but got: 10.',
+    );
+  });
+
+  it('does not allow isDeprecated without deprecationReason on enum', () => {
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: {
+        FOO: {
+          isDeprecated: true,
+        },
+      },
+    });
+    expect(() => enumType.getValues()).to.throw(
+      'SomeEnum.FOO should provide "deprecationReason" instead ' +
+        'of "isDeprecated".',
+    );
+  });
+});
+
 describe('Type System: List must accept only types', () => {
   const types = [
     GraphQLString,
@@ -533,5 +1162,92 @@ describe('Type System: NonNull must only accept non-nullable types', () => {
         `Expected ${type} to be a GraphQL nullable type.`,
       );
     });
+  });
+});
+
+describe('Type System: A Schema must contain uniquely named types', () => {
+  it('rejects a Schema which redefines a built-in type', () => {
+    expect(() => {
+      const FakeString = new GraphQLScalarType({
+        name: 'String',
+        serialize: () => null,
+      });
+
+      const QueryType = new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          normal: { type: GraphQLString },
+          fake: { type: FakeString },
+        },
+      });
+
+      return new GraphQLSchema({ query: QueryType });
+    }).to.throw(
+      'Schema must contain unique named types but contains multiple types ' +
+        'named "String".',
+    );
+  });
+
+  it('rejects a Schema which defines an object type twice', () => {
+    expect(() => {
+      const A = new GraphQLObjectType({
+        name: 'SameName',
+        fields: { f: { type: GraphQLString } },
+      });
+
+      const B = new GraphQLObjectType({
+        name: 'SameName',
+        fields: { f: { type: GraphQLString } },
+      });
+
+      const QueryType = new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          a: { type: A },
+          b: { type: B },
+        },
+      });
+
+      return new GraphQLSchema({ query: QueryType });
+    }).to.throw(
+      'Schema must contain unique named types but contains multiple types ' +
+        'named "SameName".',
+    );
+  });
+
+  it('rejects a Schema which have same named objects implementing an interface', () => {
+    expect(() => {
+      const AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        fields: { f: { type: GraphQLString } },
+      });
+
+      const FirstBadObject = new GraphQLObjectType({
+        name: 'BadObject',
+        interfaces: [AnotherInterface],
+        fields: { f: { type: GraphQLString } },
+      });
+
+      const SecondBadObject = new GraphQLObjectType({
+        name: 'BadObject',
+        interfaces: [AnotherInterface],
+        fields: { f: { type: GraphQLString } },
+      });
+
+      const QueryType = new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          iface: { type: AnotherInterface },
+        },
+      });
+
+      return new GraphQLSchema({
+        query: QueryType,
+        types: [FirstBadObject, SecondBadObject],
+      });
+    }).to.throw(
+      'Schema must contain unique named types but contains multiple types ' +
+        'named "BadObject".',
+    );
   });
 });

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -7,17 +7,14 @@
  * @flow
  */
 
-import { isInputType } from './definition';
-import { GraphQLNonNull } from './wrappers';
-
 import type {
   GraphQLFieldConfigArgumentMap,
   GraphQLArgument,
 } from './definition';
+import { GraphQLNonNull } from './wrappers';
 import { GraphQLString, GraphQLBoolean } from './scalars';
 import instanceOf from '../jsutils/instanceOf';
 import invariant from '../jsutils/invariant';
-import { assertValidName } from '../utilities/assertValidName';
 import type { DirectiveDefinitionNode } from '../language/ast';
 import {
   DirectiveLocation,
@@ -47,16 +44,15 @@ export class GraphQLDirective {
   astNode: ?DirectiveDefinitionNode;
 
   constructor(config: GraphQLDirectiveConfig): void {
-    invariant(config.name, 'Directive must be named.');
-    assertValidName(config.name);
-    invariant(
-      Array.isArray(config.locations),
-      'Must provide locations for directive.',
-    );
     this.name = config.name;
     this.description = config.description;
     this.locations = config.locations;
     this.astNode = config.astNode;
+    invariant(config.name, 'Directive must be named.');
+    invariant(
+      Array.isArray(config.locations),
+      'Must provide locations for directive.',
+    );
 
     const args = config.args;
     if (!args) {
@@ -67,13 +63,7 @@ export class GraphQLDirective {
         `@${config.name} args must be an object with argument names as keys.`,
       );
       this.args = Object.keys(args).map(argName => {
-        assertValidName(argName);
         const arg = args[argName];
-        invariant(
-          isInputType(arg.type),
-          `@${config.name}(${argName}:) argument type must be ` +
-            `Input Type but got: ${String(arg.type)}.`,
-        );
         return {
           name: argName,
           description: arg.description === undefined ? null : arg.description,

--- a/src/utilities/__tests__/assertValidName-test.js
+++ b/src/utilities/__tests__/assertValidName-test.js
@@ -5,176 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { afterEach, beforeEach, describe, it } from 'mocha';
-import chai, { expect } from 'chai';
-import { formatWarning } from '../assertValidName';
-import dedent from '../../jsutils/dedent';
-
-/* eslint-disable no-console */
-
-/**
- * Convenience method for creating an Error object with a defined stack.
- */
-function createErrorObject(message, stack) {
-  const error = new Error(message);
-  error.stack = stack;
-  return error;
-}
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { assertValidName } from '../assertValidName';
 
 describe('assertValidName()', () => {
-  let assertValidName;
-  let noNameWarning;
-  let warn;
-
-  beforeEach(() => {
-    noNameWarning = process.env.GRAPHQL_NO_NAME_WARNING;
-    delete process.env.GRAPHQL_NO_NAME_WARNING;
-    warn = console.warn;
-    console.warn = chai.spy();
-
-    // Make sure module-internal state is reset for each test.
-    delete require.cache[require.resolve('../assertValidName')];
-    assertValidName = require('../assertValidName').assertValidName;
-  });
-
-  afterEach(() => {
-    console.warn = warn;
-    if (noNameWarning === undefined) {
-      delete process.env.GRAPHQL_NO_NAME_WARNING;
-    } else {
-      process.env.GRAPHQL_NO_NAME_WARNING = noNameWarning;
-    }
-  });
-
-  it('warns against use of leading double underscores', () => {
-    assertValidName('__bad');
-    /* eslint-disable no-unused-expressions */
-    expect(console.warn).to.have.been.called.once;
-    /* eslint-enable no-unused-expressions */
-    expect(console.warn.__spy.calls[0][0]).to.match(/must not begin with/);
-  });
-
-  it('warns exactly once even in the presence of multiple violations', () => {
-    assertValidName('__bad');
-    assertValidName('__alsoBad');
-    /* eslint-disable no-unused-expressions */
-    expect(console.warn).to.have.been.called.once;
-    /* eslint-enable no-unused-expressions */
+  it('throws for use of leading double underscores', () => {
+    expect(() => assertValidName('__bad')).to.throw(
+      '"__bad" must not begin with "__", which is reserved by GraphQL introspection.',
+    );
   });
 
   it('throws for non-strings', () => {
-    expect(() => assertValidName({})).to.throw(/Must be named/);
+    expect(() => assertValidName({})).to.throw(/Expected string/);
   });
 
   it('throws for names with invalid characters', () => {
     expect(() => assertValidName('>--()-->')).to.throw(/Names must match/);
-  });
-
-  it('does not warn during introspection', () => {
-    assertValidName('__bad', true);
-    expect(console.warn).not.to.have.been.called();
-  });
-
-  it('does not warn when GRAPHQL_NO_NAME_WARNING is in effect', () => {
-    process.env.GRAPHQL_NO_NAME_WARNING = '1';
-    assertValidName('__bad', true);
-    expect(console.warn).not.to.have.been.called();
-  });
-});
-
-describe('formatWarning()', () => {
-  it('formats given a Chrome-style stack property', () => {
-    const chromeStack = dedent`
-      Error: foo
-        at z (<anonymous>:1:21)
-        at y (<anonymous>:1:15)
-        at x (<anonymous>:1:15)
-        at <anonymous>:1:6`;
-    const error = createErrorObject('foo', chromeStack);
-    expect(formatWarning(error)).to.equal(
-      dedent`
-      foo
-        at z (<anonymous>:1:21)
-        at y (<anonymous>:1:15)
-        at x (<anonymous>:1:15)
-        at <anonymous>:1:6`,
-    );
-  });
-
-  it('formats given a Node-style stack property', () => {
-    const nodeStack = dedent`
-      Error: foo
-        at z (repl:1:29)
-        at y (repl:1:23)
-        at x (repl:1:23)
-        at repl:1:6
-        at ContextifyScript.Script.runInThisContext (vm.js:23:33)
-        at REPLServer.defaultEval (repl.js:340:29)
-        at bound (domain.js:280:14)
-        at REPLServer.runBound [as eval] (domain.js:293:12)
-        at REPLServer.onLine (repl.js:537:10)
-        at emitOne (events.js:101:20)`;
-    const error = createErrorObject('foo', nodeStack);
-    expect(formatWarning(error)).to.equal(
-      dedent`
-      foo
-        at z (repl:1:29)
-        at y (repl:1:23)
-        at x (repl:1:23)
-        at repl:1:6
-        at ContextifyScript.Script.runInThisContext (vm.js:23:33)
-        at REPLServer.defaultEval (repl.js:340:29)
-        at bound (domain.js:280:14)
-        at REPLServer.runBound [as eval] (domain.js:293:12)
-        at REPLServer.onLine (repl.js:537:10)
-        at emitOne (events.js:101:20)`,
-    );
-  });
-
-  it('formats given a Firefox-style stack property', () => {
-    const firefoxStack = dedent`
-      z@debugger eval code:1:20
-      y@debugger eval code:1:14
-      x@debugger eval code:1:14
-      @debugger eval code:1:5`;
-    const error = createErrorObject('foo', firefoxStack);
-    expect(formatWarning(error)).to.equal(
-      dedent`
-      foo
-      z@debugger eval code:1:20
-      y@debugger eval code:1:14
-      x@debugger eval code:1:14
-      @debugger eval code:1:5`,
-    );
-  });
-
-  it('formats given a Safari-style stack property', () => {
-    const safariStack = dedent`
-      z
-      y
-      x
-      global code
-      evaluateWithScopeExtension@[native code]
-      _evaluateOn
-      _evaluateAndWrap
-      evaluate`;
-    const error = createErrorObject('foo', safariStack);
-    expect(formatWarning(error)).to.equal(
-      dedent`
-      foo
-      z
-      y
-      x
-      global code
-      evaluateWithScopeExtension@[native code]
-      _evaluateOn
-      _evaluateAndWrap
-      evaluate`,
-    );
-  });
-
-  it('formats in the absence of a stack property', () => {
-    const error = createErrorObject('foo');
-    expect(formatWarning(error)).to.equal('foo');
   });
 });

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -970,18 +970,6 @@ describe('extendSchema', () => {
     );
   });
 
-  it('does not allow implementing an existing interface', () => {
-    const ast = parse(`
-      extend type Foo implements SomeInterface {
-        otherField: String
-      }
-    `);
-    expect(() => extendSchema(testSchema, ast)).to.throw(
-      'Type "Foo" already implements "SomeInterface". It cannot also be ' +
-        'implemented in this type extension.',
-    );
-  });
-
   it('does not allow referencing an unknown type', () => {
     const ast = parse(`
       extend type Bar {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -192,19 +192,22 @@ export function extendSchema(
   );
 
   // Get the root Query, Mutation, and Subscription object types.
+  // Note: While this could make early assertions to get the correctly
+  // typed values below, that would throw immediately while type system
+  // validation with validateSchema() will produce more actionable results.
   const existingQueryType = schema.getQueryType();
   const queryType = existingQueryType
-    ? definitionBuilder.buildObjectType(existingQueryType.name)
+    ? (definitionBuilder.buildType(existingQueryType.name): any)
     : null;
 
   const existingMutationType = schema.getMutationType();
   const mutationType = existingMutationType
-    ? definitionBuilder.buildObjectType(existingMutationType.name)
+    ? (definitionBuilder.buildType(existingMutationType.name): any)
     : null;
 
   const existingSubscriptionType = schema.getSubscriptionType();
   const subscriptionType = existingSubscriptionType
-    ? definitionBuilder.buildObjectType(existingSubscriptionType.name)
+    ? (definitionBuilder.buildType(existingSubscriptionType.name): any)
     : null;
 
   // Iterate through all types, getting the type definition for each, ensuring
@@ -312,15 +315,10 @@ export function extendSchema(
     if (extensions) {
       extensions.forEach(extension => {
         extension.interfaces.forEach(namedType => {
-          const interfaceName = namedType.name.value;
-          if (interfaces.some(def => def.name === interfaceName)) {
-            throw new GraphQLError(
-              `Type "${type.name}" already implements "${interfaceName}". ` +
-                'It cannot also be implemented in this type extension.',
-              [namedType],
-            );
-          }
-          interfaces.push(definitionBuilder.buildInterfaceType(namedType));
+          // Note: While this could make early assertions to get the correctly
+          // typed values, that would throw immediately while type system
+          // validation with validateSchema() will produce more actionable results.
+          interfaces.push((definitionBuilder.buildType(namedType): any));
         });
       });
     }


### PR DESCRIPTION
This is the second step of moving work from type constructors to the schema validation function.

Currently the implementation should be nearly complete, however there are a lot of tests to migration from expecting throwing exceptions to instead creating validation errors.

Closes #546 
Closes #1080 
Improves #1079 
Improves #719