### PR TITLE
Use validation helper to check if GraphQLSchema instance

### DIFF
--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -12,6 +12,7 @@ import keyMap from '../jsutils/keyMap';
 import { ASTDefinitionBuilder } from './buildASTSchema';
 import { GraphQLError } from '../error/GraphQLError';
 import { GraphQLSchema } from '../type/schema';
+import { assertValidSchema } from '../type/validate';
 
 import {
   GraphQLList,
@@ -72,10 +73,7 @@ export function extendSchema(
   documentAST: DocumentNode,
   options?: Options,
 ): GraphQLSchema {
-  invariant(
-    schema instanceof GraphQLSchema,
-    'Must provide valid GraphQLSchema',
-  );
+  assertValidSchema(schema);
 
   invariant(
     documentAST && documentAST.kind === Kind.DOCUMENT,


### PR DESCRIPTION
Checks if schema is valid with the `assertValidSchema` helper instead of a simple instanceof check. This gives the developer actionable error messages when there are multiple versions of graphql in node_modules.