### PR TITLE
Covariant Wrapping Types

### DIFF
--- a/src/__tests__/starWarsSchema.js
+++ b/src/__tests__/starWarsSchema.js
@@ -110,7 +110,7 @@ const characterInterface = new GraphQLInterfaceType({
   description: 'A character in the Star Wars Trilogy',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLNonNull(GraphQLString),
       description: 'The id of the character.',
     },
     name: {
@@ -118,13 +118,13 @@ const characterInterface = new GraphQLInterfaceType({
       description: 'The name of the character.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: GraphQLList(characterInterface),
       description:
         'The friends of the character, or an empty list if they ' +
         'have none.',
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: GraphQLList(episodeEnum),
       description: 'Which movies they appear in.',
     },
     secretBackstory: {
@@ -159,7 +159,7 @@ const humanType = new GraphQLObjectType({
   description: 'A humanoid creature in the Star Wars universe.',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLNonNull(GraphQLString),
       description: 'The id of the human.',
     },
     name: {
@@ -167,13 +167,13 @@ const humanType = new GraphQLObjectType({
       description: 'The name of the human.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: GraphQLList(characterInterface),
       description:
         'The friends of the human, or an empty list if they have none.',
       resolve: human => getFriends(human),
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: GraphQLList(episodeEnum),
       description: 'Which movies they appear in.',
     },
     homePlanet: {
@@ -209,7 +209,7 @@ const droidType = new GraphQLObjectType({
   description: 'A mechanical creature in the Star Wars universe.',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLNonNull(GraphQLString),
       description: 'The id of the droid.',
     },
     name: {
@@ -217,13 +217,13 @@ const droidType = new GraphQLObjectType({
       description: 'The name of the droid.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: GraphQLList(characterInterface),
       description:
         'The friends of the droid, or an empty list if they have none.',
       resolve: droid => getFriends(droid),
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: GraphQLList(episodeEnum),
       description: 'Which movies they appear in.',
     },
     secretBackstory: {
@@ -275,7 +275,7 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the human',
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
         },
       },
       resolve: (root, { id }) => getHuman(id),
@@ -285,7 +285,7 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the droid',
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
         },
       },
       resolve: (root, { id }) => getDroid(id),

--- a/src/execution/__tests__/abstract-promise-test.js
+++ b/src/execution/__tests__/abstract-promise-test.js
@@ -72,7 +72,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -145,7 +145,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -217,7 +217,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -304,7 +304,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return Promise.resolve([
                 new Dog('Odie', true),
@@ -400,7 +400,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -489,7 +489,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -561,7 +561,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },

--- a/src/execution/__tests__/abstract-test.js
+++ b/src/execution/__tests__/abstract-test.js
@@ -72,7 +72,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -141,7 +141,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -226,7 +226,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -320,7 +320,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [
                 new Dog('Odie', true),
@@ -407,7 +407,7 @@ describe('Execute: Handles execution of abstract types', () => {
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: GraphQLList(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -202,8 +202,8 @@ describe('Execute: Handles basic execution tasks', () => {
       fields: {
         a: { type: GraphQLString },
         b: { type: GraphQLString },
-        c: { type: new GraphQLList(GraphQLString) },
-        deeper: { type: new GraphQLList(DataType) },
+        c: { type: GraphQLList(GraphQLString) },
+        deeper: { type: GraphQLList(DataType) },
       },
     });
 
@@ -448,7 +448,7 @@ describe('Execute: Handles basic execution tasks', () => {
           syncError: { type: GraphQLString },
           syncRawError: { type: GraphQLString },
           syncReturnError: { type: GraphQLString },
-          syncReturnErrorList: { type: new GraphQLList(GraphQLString) },
+          syncReturnErrorList: { type: GraphQLList(GraphQLString) },
           async: { type: GraphQLString },
           asyncReject: { type: GraphQLString },
           asyncRawReject: { type: GraphQLString },
@@ -550,7 +550,7 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Query',
         fields: {
           foods: {
-            type: new GraphQLList(
+            type: GraphQLList(
               new GraphQLObjectType({
                 name: 'Food',
                 fields: {
@@ -597,11 +597,11 @@ describe('Execute: Handles basic execution tasks', () => {
           resolve: () => ({}),
         },
         nonNullA: {
-          type: new GraphQLNonNull(A),
+          type: GraphQLNonNull(A),
           resolve: () => ({}),
         },
         throws: {
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
           resolve: () => {
             throw new Error('Catch me if you can');
           },
@@ -1034,7 +1034,7 @@ describe('Execute: Handles basic execution tasks', () => {
         name: 'Query',
         fields: {
           specials: {
-            type: new GraphQLList(SpecialType),
+            type: GraphQLList(SpecialType),
             resolve: rootValue => rootValue.specials,
           },
         },

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -70,7 +70,7 @@ describe('Execute: Accepts any iterable as list value', () => {
   it(
     'Accepts a Set as a List value',
     check(
-      new GraphQLList(GraphQLString),
+      GraphQLList(GraphQLString),
       new Set(['apple', 'banana', 'apple', 'coconut']),
       { data: { nest: { test: ['apple', 'banana', 'coconut'] } } },
     ),
@@ -84,7 +84,7 @@ describe('Execute: Accepts any iterable as list value', () => {
 
   it(
     'Accepts an Generator function as a List value',
-    check(new GraphQLList(GraphQLString), yieldItems(), {
+    check(GraphQLList(GraphQLString), yieldItems(), {
       data: { nest: { test: ['one', '2', 'true'] } },
     }),
   );
@@ -95,14 +95,14 @@ describe('Execute: Accepts any iterable as list value', () => {
 
   it(
     'Accepts function arguments as a List value',
-    check(new GraphQLList(GraphQLString), getArgs('one', 'two'), {
+    check(GraphQLList(GraphQLString), getArgs('one', 'two'), {
       data: { nest: { test: ['one', 'two'] } },
     }),
   );
 
   it(
     'Does not accept (Iterable) String-literal as a List value',
-    check(new GraphQLList(GraphQLString), 'Singluar', {
+    check(GraphQLList(GraphQLString), 'Singluar', {
       data: { nest: { test: null } },
       errors: [
         {
@@ -118,7 +118,7 @@ describe('Execute: Accepts any iterable as list value', () => {
 
 describe('Execute: Handles list nullability', () => {
   describe('[T]', () => {
-    const type = new GraphQLList(GraphQLInt);
+    const type = GraphQLList(GraphQLInt);
 
     describe('Array<T>', () => {
       it(
@@ -203,7 +203,7 @@ describe('Execute: Handles list nullability', () => {
   });
 
   describe('[T]!', () => {
-    const type = new GraphQLNonNull(new GraphQLList(GraphQLInt));
+    const type = GraphQLNonNull(GraphQLList(GraphQLInt));
 
     describe('Array<T>', () => {
       it(
@@ -311,7 +311,7 @@ describe('Execute: Handles list nullability', () => {
   });
 
   describe('[T!]', () => {
-    const type = new GraphQLList(new GraphQLNonNull(GraphQLInt));
+    const type = GraphQLList(GraphQLNonNull(GraphQLInt));
 
     describe('Array<T>', () => {
       it(
@@ -422,9 +422,7 @@ describe('Execute: Handles list nullability', () => {
   });
 
   describe('[T!]!', () => {
-    const type = new GraphQLNonNull(
-      new GraphQLList(new GraphQLNonNull(GraphQLInt)),
-    );
+    const type = GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLInt)));
 
     describe('Array<T>', () => {
       it(

--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -98,13 +98,13 @@ const dataType = new GraphQLObjectType({
   name: 'DataType',
   fields: () => ({
     sync: { type: GraphQLString },
-    nonNullSync: { type: new GraphQLNonNull(GraphQLString) },
+    nonNullSync: { type: GraphQLNonNull(GraphQLString) },
     promise: { type: GraphQLString },
-    nonNullPromise: { type: new GraphQLNonNull(GraphQLString) },
+    nonNullPromise: { type: GraphQLNonNull(GraphQLString) },
     nest: { type: dataType },
-    nonNullNest: { type: new GraphQLNonNull(dataType) },
+    nonNullNest: { type: GraphQLNonNull(dataType) },
     promiseNest: { type: dataType },
-    nonNullPromiseNest: { type: new GraphQLNonNull(dataType) },
+    nonNullPromiseNest: { type: GraphQLNonNull(dataType) },
   }),
 });
 const schema = new GraphQLSchema({

--- a/src/execution/__tests__/schema-test.js
+++ b/src/execution/__tests__/schema-test.js
@@ -49,12 +49,12 @@ describe('Execute: Handles execution with a complex schema', () => {
     const BlogArticle = new GraphQLObjectType({
       name: 'Article',
       fields: {
-        id: { type: new GraphQLNonNull(GraphQLString) },
+        id: { type: GraphQLNonNull(GraphQLString) },
         isPublished: { type: GraphQLBoolean },
         author: { type: BlogAuthor },
         title: { type: GraphQLString },
         body: { type: GraphQLString },
-        keywords: { type: new GraphQLList(GraphQLString) },
+        keywords: { type: GraphQLList(GraphQLString) },
       },
     });
 
@@ -67,7 +67,7 @@ describe('Execute: Handles execution with a complex schema', () => {
           resolve: (_, { id }) => article(id),
         },
         feed: {
-          type: new GraphQLList(BlogArticle),
+          type: GraphQLList(BlogArticle),
           resolve: () => [
             article(1),
             article(2),

--- a/src/execution/__tests__/union-interface-test.js
+++ b/src/execution/__tests__/union-interface-test.js
@@ -87,8 +87,8 @@ const PersonType = new GraphQLObjectType({
   interfaces: [NamedType],
   fields: {
     name: { type: GraphQLString },
-    pets: { type: new GraphQLList(PetType) },
-    friends: { type: new GraphQLList(NamedType) },
+    pets: { type: GraphQLList(PetType) },
+    friends: { type: GraphQLList(NamedType) },
   },
   isTypeOf: value => value instanceof Person,
 });
@@ -341,7 +341,7 @@ describe('Execute: Union and intersection types', () => {
       interfaces: [NamedType2],
       fields: {
         name: { type: GraphQLString },
-        friends: { type: new GraphQLList(NamedType2) },
+        friends: { type: GraphQLList(NamedType2) },
       },
     });
 

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -48,8 +48,8 @@ const TestInputObject = new GraphQLInputObjectType({
   name: 'TestInputObject',
   fields: {
     a: { type: GraphQLString },
-    b: { type: new GraphQLList(GraphQLString) },
-    c: { type: new GraphQLNonNull(GraphQLString) },
+    b: { type: GraphQLList(GraphQLString) },
+    c: { type: GraphQLNonNull(GraphQLString) },
     d: { type: TestComplexScalar },
   },
 });
@@ -57,8 +57,8 @@ const TestInputObject = new GraphQLInputObjectType({
 const TestNestedInputObject = new GraphQLInputObjectType({
   name: 'TestNestedInputObject',
   fields: {
-    na: { type: new GraphQLNonNull(TestInputObject) },
-    nb: { type: new GraphQLNonNull(GraphQLString) },
+    na: { type: GraphQLNonNull(TestInputObject) },
+    nb: { type: GraphQLNonNull(GraphQLString) },
   },
 });
 
@@ -77,7 +77,7 @@ const TestType = new GraphQLObjectType({
     },
     fieldWithNonNullableStringInput: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLNonNull(GraphQLString) } },
+      args: { input: { type: GraphQLNonNull(GraphQLString) } },
       resolve: (_, { input }) => input && JSON.stringify(input),
     },
     fieldWithDefaultArgumentValue: {
@@ -97,20 +97,20 @@ const TestType = new GraphQLObjectType({
     },
     list: {
       type: GraphQLString,
-      args: { input: { type: new GraphQLList(GraphQLString) } },
+      args: { input: { type: GraphQLList(GraphQLString) } },
       resolve: (_, { input }) => input && JSON.stringify(input),
     },
     nnList: {
       type: GraphQLString,
       args: {
-        input: { type: new GraphQLNonNull(new GraphQLList(GraphQLString)) },
+        input: { type: GraphQLNonNull(GraphQLList(GraphQLString)) },
       },
       resolve: (_, { input }) => input && JSON.stringify(input),
     },
     listNN: {
       type: GraphQLString,
       args: {
-        input: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+        input: { type: GraphQLList(GraphQLNonNull(GraphQLString)) },
       },
       resolve: (_, { input }) => input && JSON.stringify(input),
     },
@@ -118,9 +118,7 @@ const TestType = new GraphQLObjectType({
       type: GraphQLString,
       args: {
         input: {
-          type: new GraphQLNonNull(
-            new GraphQLList(new GraphQLNonNull(GraphQLString)),
-          ),
+          type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString))),
         },
       },
       resolve: (_, { input }) => input && JSON.stringify(input),

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -23,11 +23,10 @@ import {
 } from './values';
 import {
   GraphQLObjectType,
-  GraphQLList,
-  GraphQLNonNull,
   isAbstractType,
   isLeafType,
 } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import type {
   GraphQLType,
   GraphQLLeafType,

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -17,7 +17,9 @@ import { valueFromAST } from '../utilities/valueFromAST';
 import { isValidLiteralValue } from '../utilities/isValidLiteralValue';
 import * as Kind from '../language/kinds';
 import { print } from '../language/printer';
-import { isInputType, GraphQLNonNull } from '../type/definition';
+import { isInputType } from '../type/definition';
+import { GraphQLNonNull } from '../type/wrappers';
+
 import type { ObjMap } from '../jsutils/ObjMap';
 import type { GraphQLField } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -41,7 +41,7 @@ const InboxType = new GraphQLObjectType({
       type: GraphQLInt,
       resolve: inbox => inbox.emails.filter(email => email.unread).length,
     },
-    emails: { type: new GraphQLList(EmailType) },
+    emails: { type: GraphQLList(EmailType) },
   },
 });
 

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -820,7 +820,7 @@ describe('Introspection', () => {
       name: 'TestInputObject',
       fields: {
         a: { type: GraphQLString, defaultValue: 'foo' },
-        b: { type: new GraphQLList(GraphQLString) },
+        b: { type: GraphQLList(GraphQLString) },
         c: { type: GraphQLString, defaultValue: null },
       },
     });

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -68,9 +68,9 @@ const SomeInputObjectType = new GraphQLInputObjectType({
 
 function withModifiers(types) {
   return types
-    .concat(types.map(type => new GraphQLList(type)))
-    .concat(types.map(type => new GraphQLNonNull(type)))
-    .concat(types.map(type => new GraphQLNonNull(new GraphQLList(type))));
+    .concat(types.map(type => GraphQLList(type)))
+    .concat(types.map(type => GraphQLNonNull(type)))
+    .concat(types.map(type => GraphQLNonNull(GraphQLList(type))));
 }
 
 const outputTypes = withModifiers([
@@ -1684,70 +1684,6 @@ describe('Type System: Input Object fields must have input types', () => {
         `BadInputObject.badField field type must be Input Type but got: ${
           type
         }.`,
-      );
-    });
-  });
-});
-
-describe('Type System: List must accept GraphQL types', () => {
-  const types = withModifiers([
-    GraphQLString,
-    SomeScalarType,
-    SomeObjectType,
-    SomeUnionType,
-    SomeInterfaceType,
-    SomeEnumType,
-    SomeInputObjectType,
-  ]);
-
-  const notTypes = [{}, String, undefined, null];
-
-  types.forEach(type => {
-    it(`accepts an type as item type of list: ${type}`, () => {
-      expect(() => new GraphQLList(type)).not.to.throw();
-    });
-  });
-
-  notTypes.forEach(type => {
-    it(`rejects a non-type as item type of list: ${type}`, () => {
-      expect(() => new GraphQLList(type)).to.throw(
-        `Can only create List of a GraphQLType but got: ${type}.`,
-      );
-    });
-  });
-});
-
-describe('Type System: NonNull must accept GraphQL types', () => {
-  const nullableTypes = [
-    GraphQLString,
-    SomeScalarType,
-    SomeObjectType,
-    SomeUnionType,
-    SomeInterfaceType,
-    SomeEnumType,
-    SomeInputObjectType,
-    new GraphQLList(GraphQLString),
-    new GraphQLList(new GraphQLNonNull(GraphQLString)),
-  ];
-
-  const notNullableTypes = [
-    new GraphQLNonNull(GraphQLString),
-    {},
-    String,
-    undefined,
-    null,
-  ];
-
-  nullableTypes.forEach(type => {
-    it(`accepts an type as nullable type of non-null: ${type}`, () => {
-      expect(() => new GraphQLNonNull(type)).not.to.throw();
-    });
-  });
-
-  notNullableTypes.forEach(type => {
-    it(`rejects a non-type as nullable type of non-null: ${type}`, () => {
-      expect(() => new GraphQLNonNull(type)).to.throw(
-        `Can only create NonNull of a Nullable GraphQLType but got: ${type}.`,
       );
     });
   });

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -7,7 +7,9 @@
  * @flow
  */
 
-import { isInputType, GraphQLNonNull } from './definition';
+import { isInputType } from './definition';
+import { GraphQLNonNull } from './wrappers';
+
 import type {
   GraphQLFieldConfigArgumentMap,
   GraphQLArgument,
@@ -95,7 +97,7 @@ export const GraphQLIncludeDirective = new GraphQLDirective({
   ],
   args: {
     if: {
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLNonNull(GraphQLBoolean),
       description: 'Included when true.',
     },
   },
@@ -116,7 +118,7 @@ export const GraphQLSkipDirective = new GraphQLDirective({
   ],
   args: {
     if: {
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLNonNull(GraphQLBoolean),
       description: 'Skipped when true.',
     },
   },

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -37,9 +37,13 @@ export {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
+} from './definition';
+
+export {
+  // Type Wrappers
   GraphQLList,
   GraphQLNonNull,
-} from './definition';
+} from './wrappers';
 
 export {
   // Directives Definition

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -17,11 +17,10 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
   isAbstractType,
   isNamedType,
 } from './definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import { GraphQLString, GraphQLBoolean } from './scalars';
 import { DirectiveLocation } from '../language/directiveLocation';
 import type { GraphQLField, GraphQLType } from './definition';
@@ -36,7 +35,7 @@ export const __Schema = new GraphQLObjectType({
   fields: () => ({
     types: {
       description: 'A list of all types supported by this server.',
-      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__Type))),
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__Type))),
       resolve(schema) {
         const typeMap = schema.getTypeMap();
         return Object.keys(typeMap).map(key => typeMap[key]);
@@ -44,7 +43,7 @@ export const __Schema = new GraphQLObjectType({
     },
     queryType: {
       description: 'The type that query operations will be rooted at.',
-      type: new GraphQLNonNull(__Type),
+      type: GraphQLNonNull(__Type),
       resolve: schema => schema.getQueryType(),
     },
     mutationType: {
@@ -63,9 +62,7 @@ export const __Schema = new GraphQLObjectType({
     },
     directives: {
       description: 'A list of all directives supported by this server.',
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(__Directive)),
-      ),
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__Directive))),
       resolve: schema => schema.getDirectives(),
     },
   }),
@@ -82,24 +79,20 @@ export const __Directive = new GraphQLObjectType({
     'conditionally including or skipping a field. Directives provide this by ' +
     'describing additional information to the executor.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     locations: {
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(__DirectiveLocation)),
-      ),
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__DirectiveLocation))),
     },
     args: {
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(__InputValue)),
-      ),
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__InputValue))),
       resolve: directive => directive.args || [],
     },
     // NOTE: the following three fields are deprecated and are no longer part
     // of the GraphQL specification.
     onOperation: {
       deprecationReason: 'Use `locations`.',
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLNonNull(GraphQLBoolean),
       resolve: d =>
         d.locations.indexOf(DirectiveLocation.QUERY) !== -1 ||
         d.locations.indexOf(DirectiveLocation.MUTATION) !== -1 ||
@@ -107,7 +100,7 @@ export const __Directive = new GraphQLObjectType({
     },
     onFragment: {
       deprecationReason: 'Use `locations`.',
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLNonNull(GraphQLBoolean),
       resolve: d =>
         d.locations.indexOf(DirectiveLocation.FRAGMENT_SPREAD) !== -1 ||
         d.locations.indexOf(DirectiveLocation.INLINE_FRAGMENT) !== -1 ||
@@ -115,7 +108,7 @@ export const __Directive = new GraphQLObjectType({
     },
     onField: {
       deprecationReason: 'Use `locations`.',
-      type: new GraphQLNonNull(GraphQLBoolean),
+      type: GraphQLNonNull(GraphQLBoolean),
       resolve: d => d.locations.indexOf(DirectiveLocation.FIELD) !== -1,
     },
   }),
@@ -217,7 +210,7 @@ export const __Type = new GraphQLObjectType({
     'at runtime. List and NonNull types compose other types.',
   fields: () => ({
     kind: {
-      type: new GraphQLNonNull(__TypeKind),
+      type: GraphQLNonNull(__TypeKind),
       resolve(type) {
         if (type instanceof GraphQLScalarType) {
           return TypeKind.SCALAR;
@@ -242,7 +235,7 @@ export const __Type = new GraphQLObjectType({
     name: { type: GraphQLString },
     description: { type: GraphQLString },
     fields: {
-      type: new GraphQLList(new GraphQLNonNull(__Field)),
+      type: GraphQLList(GraphQLNonNull(__Field)),
       args: {
         includeDeprecated: { type: GraphQLBoolean, defaultValue: false },
       },
@@ -264,7 +257,7 @@ export const __Type = new GraphQLObjectType({
       },
     },
     interfaces: {
-      type: new GraphQLList(new GraphQLNonNull(__Type)),
+      type: GraphQLList(GraphQLNonNull(__Type)),
       resolve(type) {
         if (type instanceof GraphQLObjectType) {
           return type.getInterfaces();
@@ -272,7 +265,7 @@ export const __Type = new GraphQLObjectType({
       },
     },
     possibleTypes: {
-      type: new GraphQLList(new GraphQLNonNull(__Type)),
+      type: GraphQLList(GraphQLNonNull(__Type)),
       resolve(type, args, context, { schema }) {
         if (isAbstractType(type)) {
           return schema.getPossibleTypes(type);
@@ -280,7 +273,7 @@ export const __Type = new GraphQLObjectType({
       },
     },
     enumValues: {
-      type: new GraphQLList(new GraphQLNonNull(__EnumValue)),
+      type: GraphQLList(GraphQLNonNull(__EnumValue)),
       args: {
         includeDeprecated: { type: GraphQLBoolean, defaultValue: false },
       },
@@ -295,7 +288,7 @@ export const __Type = new GraphQLObjectType({
       },
     },
     inputFields: {
-      type: new GraphQLList(new GraphQLNonNull(__InputValue)),
+      type: GraphQLList(GraphQLNonNull(__InputValue)),
       resolve(type) {
         if (type instanceof GraphQLInputObjectType) {
           const fieldMap = type.getFields();
@@ -314,16 +307,14 @@ export const __Field = new GraphQLObjectType({
     'Object and Interface types are described by a list of Fields, each of ' +
     'which has a name, potentially a list of arguments, and a return type.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
     args: {
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(__InputValue)),
-      ),
+      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__InputValue))),
       resolve: field => field.args || [],
     },
-    type: { type: new GraphQLNonNull(__Type) },
-    isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },
+    type: { type: GraphQLNonNull(__Type) },
+    isDeprecated: { type: GraphQLNonNull(GraphQLBoolean) },
     deprecationReason: {
       type: GraphQLString,
     },
@@ -338,9 +329,9 @@ export const __InputValue = new GraphQLObjectType({
     'InputObject are represented as Input Values which describe their type ' +
     'and optionally a default value.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
-    type: { type: new GraphQLNonNull(__Type) },
+    type: { type: GraphQLNonNull(__Type) },
     defaultValue: {
       type: GraphQLString,
       description:
@@ -362,9 +353,9 @@ export const __EnumValue = new GraphQLObjectType({
     'a placeholder for a string or numeric value. However an Enum value is ' +
     'returned in a JSON response as a string.',
   fields: () => ({
-    name: { type: new GraphQLNonNull(GraphQLString) },
+    name: { type: GraphQLNonNull(GraphQLString) },
     description: { type: GraphQLString },
-    isDeprecated: { type: new GraphQLNonNull(GraphQLBoolean) },
+    isDeprecated: { type: GraphQLNonNull(GraphQLBoolean) },
     deprecationReason: {
       type: GraphQLString,
     },
@@ -440,7 +431,7 @@ export const __TypeKind = new GraphQLEnumType({
 
 export const SchemaMetaFieldDef: GraphQLField<*, *> = {
   name: '__schema',
-  type: new GraphQLNonNull(__Schema),
+  type: GraphQLNonNull(__Schema),
   description: 'Access the current type schema of this server.',
   args: [],
   resolve: (source, args, context, { schema }) => schema,
@@ -450,13 +441,13 @@ export const TypeMetaFieldDef: GraphQLField<*, *> = {
   name: '__type',
   type: __Type,
   description: 'Request the type information of a single type.',
-  args: [{ name: 'name', type: new GraphQLNonNull(GraphQLString) }],
+  args: [{ name: 'name', type: GraphQLNonNull(GraphQLString) }],
   resolve: (source, { name }, context, { schema }) => schema.getType(name),
 };
 
 export const TypeNameMetaFieldDef: GraphQLField<*, *> = {
   name: '__typename',
-  type: new GraphQLNonNull(GraphQLString),
+  type: GraphQLNonNull(GraphQLString),
   description: 'The name of the current Object type at runtime.',
   args: [],
   resolve: (source, args, context, { parentType }) => parentType.name,

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -12,9 +12,8 @@ import {
   GraphQLInputObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
-  GraphQLList,
-  GraphQLNonNull,
 } from './definition';
+import { GraphQLList, GraphQLNonNull } from './wrappers';
 import type {
   GraphQLType,
   GraphQLNamedType,

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -7,12 +7,8 @@
  * @flow
  */
 
-import {
-  GraphQLInterfaceType,
-  GraphQLObjectType,
-  GraphQLNonNull,
-  isType,
-} from './definition';
+import { GraphQLInterfaceType, GraphQLObjectType, isType } from './definition';
+import { GraphQLNonNull } from '../type/wrappers';
 import { GraphQLDirective } from './directives';
 import { GraphQLSchema } from './schema';
 import find from '../jsutils/find';

--- a/src/type/wrappers.js
+++ b/src/type/wrappers.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import invariant from '../jsutils/invariant';
+import { isType, assertType } from './definition';
+import type { GraphQLType, GraphQLNullableType } from './definition';
+
+/**
+ * List Type Wrapper
+ *
+ * A list is a wrapping type which points to another type.
+ * Lists are often created within the context of defining the fields of
+ * an object type.
+ *
+ * Example:
+ *
+ *     const PersonType = new GraphQLObjectType({
+ *       name: 'Person',
+ *       fields: () => ({
+ *         parents: { type: GraphQLList(PersonType) },
+ *         children: { type: GraphQLList(PersonType) },
+ *       })
+ *     })
+ *
+ */
+declare class GraphQLList<+T: GraphQLType> {
+  +ofType: T;
+  static <T>(ofType: T): GraphQLList<T>;
+  // Note: constructors cannot be used for covariant types. Drop the "new".
+  constructor(ofType: any): void;
+}
+// eslint-disable-next-line no-redeclare
+export function GraphQLList(ofType) {
+  if (this instanceof GraphQLList) {
+    assertType(ofType);
+    this.ofType = ofType;
+  } else {
+    return new GraphQLList(ofType);
+  }
+}
+
+// Also provide toJSON and inspect aliases for toString.
+const listProto: any = GraphQLList.prototype;
+listProto.toString = listProto.toJSON = listProto.inspect = function toString() {
+  return '[' + String(this.ofType) + ']';
+};
+
+/**
+ * Non-Null Type Wrapper
+ *
+ * A non-null is a wrapping type which points to another type.
+ * Non-null types enforce that their values are never null and can ensure
+ * an error is raised if this ever occurs during a request. It is useful for
+ * fields which you can make a strong guarantee on non-nullability, for example
+ * usually the id field of a database row will never be null.
+ *
+ * Example:
+ *
+ *     const RowType = new GraphQLObjectType({
+ *       name: 'Row',
+ *       fields: () => ({
+ *         id: { type: GraphQLNonNull(GraphQLString) },
+ *       })
+ *     })
+ *
+ * Note: the enforcement of non-nullability occurs within the executor.
+ */
+declare class GraphQLNonNull<+T: GraphQLNullableType> {
+  +ofType: T;
+  static <T>(ofType: T): GraphQLNonNull<T>;
+  // Note: constructors cannot be used for covariant types. Drop the "new".
+  constructor(ofType: any): void;
+}
+// eslint-disable-next-line no-redeclare
+export function GraphQLNonNull(ofType) {
+  if (this instanceof GraphQLNonNull) {
+    invariant(
+      isType(ofType) && !(ofType instanceof GraphQLNonNull),
+      `Can only create NonNull of a Nullable GraphQLType but got: ${String(
+        ofType,
+      )}.`,
+    );
+    this.ofType = ofType;
+  } else {
+    return new GraphQLNonNull(ofType);
+  }
+}
+
+// Also provide toJSON and inspect aliases for toString.
+const nonNullProto: any = GraphQLNonNull.prototype;
+nonNullProto.toString = nonNullProto.toJSON = nonNullProto.inspect = function toString() {
+  return String(this.ofType) + '!';
+};

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -18,8 +18,8 @@ import {
   GraphQLInterfaceType,
   GraphQLInputObjectType,
   GraphQLEnumType,
-  GraphQLList,
 } from '../type/definition';
+import { GraphQLList } from '../type/wrappers';
 import type {
   GraphQLType,
   GraphQLInputType,

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -50,7 +50,7 @@ describe('astFromValue', () => {
       value: true,
     });
 
-    const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
+    const NonNullBoolean = GraphQLNonNull(GraphQLBoolean);
     expect(astFromValue(0, NonNullBoolean)).to.deep.equal({
       kind: 'BooleanValue',
       value: false,
@@ -169,7 +169,7 @@ describe('astFromValue', () => {
   });
 
   it('does not converts NonNull values to NullValue', () => {
-    const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
+    const NonNullBoolean = GraphQLNonNull(GraphQLBoolean);
     expect(astFromValue(null, NonNullBoolean)).to.deep.equal(null);
   });
 
@@ -204,7 +204,7 @@ describe('astFromValue', () => {
 
   it('converts array values to List ASTs', () => {
     expect(
-      astFromValue(['FOO', 'BAR'], new GraphQLList(GraphQLString)),
+      astFromValue(['FOO', 'BAR'], GraphQLList(GraphQLString)),
     ).to.deep.equal({
       kind: 'ListValue',
       values: [
@@ -214,7 +214,7 @@ describe('astFromValue', () => {
     });
 
     expect(
-      astFromValue(['HELLO', 'GOODBYE'], new GraphQLList(myEnum)),
+      astFromValue(['HELLO', 'GOODBYE'], GraphQLList(myEnum)),
     ).to.deep.equal({
       kind: 'ListValue',
       values: [
@@ -225,7 +225,7 @@ describe('astFromValue', () => {
   });
 
   it('converts list singletons', () => {
-    expect(astFromValue('FOO', new GraphQLList(GraphQLString))).to.deep.equal({
+    expect(astFromValue('FOO', GraphQLList(GraphQLString))).to.deep.equal({
       kind: 'StringValue',
       value: 'FOO',
     });

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -287,17 +287,15 @@ describe('Type System: build schema from introspection', () => {
         name: 'ComplexFields',
         fields: {
           string: { type: GraphQLString },
-          listOfString: { type: new GraphQLList(GraphQLString) },
+          listOfString: { type: GraphQLList(GraphQLString) },
           nonNullString: {
-            type: new GraphQLNonNull(GraphQLString),
+            type: GraphQLNonNull(GraphQLString),
           },
           nonNullListOfString: {
-            type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+            type: GraphQLNonNull(GraphQLList(GraphQLString)),
           },
           nonNullListOfNonNullString: {
-            type: new GraphQLNonNull(
-              new GraphQLList(new GraphQLNonNull(GraphQLString)),
-            ),
+            type: GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLString))),
           },
         },
       }),
@@ -327,11 +325,11 @@ describe('Type System: build schema from introspection', () => {
             args: {
               listArg: {
                 description: 'This is an list of int arg',
-                type: new GraphQLList(GraphQLInt),
+                type: GraphQLList(GraphQLInt),
               },
               requiredArg: {
                 description: 'This is a required arg',
-                type: new GraphQLNonNull(GraphQLBoolean),
+                type: GraphQLNonNull(GraphQLBoolean),
               },
             },
           },
@@ -473,11 +471,11 @@ describe('Type System: build schema from introspection', () => {
       fields: {
         street: {
           description: 'What street is this address?',
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
         },
         city: {
           description: 'The city the address is within?',
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
         },
         country: {
           description: 'The country (blank will assume USA).',
@@ -533,7 +531,7 @@ describe('Type System: build schema from introspection', () => {
             type: GraphQLString,
             args: {
               listArg: {
-                type: new GraphQLList(GraphQLInt),
+                type: GraphQLList(GraphQLInt),
                 defaultValue: [1, 2, 3],
               },
             },
@@ -809,14 +807,12 @@ describe('Type System: build schema from introspection', () => {
           name: 'Query',
           fields: {
             foo: {
-              type: new GraphQLList(
-                new GraphQLList(
-                  new GraphQLList(
-                    new GraphQLList(
-                      new GraphQLList(
-                        new GraphQLList(
-                          new GraphQLList(new GraphQLList(GraphQLString)),
-                        ),
+              type: GraphQLList(
+                GraphQLList(
+                  GraphQLList(
+                    GraphQLList(
+                      GraphQLList(
+                        GraphQLList(GraphQLList(GraphQLList(GraphQLString))),
                       ),
                     ),
                   ),
@@ -839,13 +835,13 @@ describe('Type System: build schema from introspection', () => {
           name: 'Query',
           fields: {
             foo: {
-              type: new GraphQLList(
-                new GraphQLNonNull(
-                  new GraphQLList(
-                    new GraphQLNonNull(
-                      new GraphQLList(
-                        new GraphQLNonNull(
-                          new GraphQLList(new GraphQLNonNull(GraphQLString)),
+              type: GraphQLList(
+                GraphQLNonNull(
+                  GraphQLList(
+                    GraphQLNonNull(
+                      GraphQLList(
+                        GraphQLNonNull(
+                          GraphQLList(GraphQLNonNull(GraphQLString)),
                         ),
                       ),
                     ),
@@ -870,12 +866,12 @@ describe('Type System: build schema from introspection', () => {
           fields: {
             foo: {
               // e.g., fully non-null 3D matrix
-              type: new GraphQLNonNull(
-                new GraphQLList(
-                  new GraphQLNonNull(
-                    new GraphQLList(
-                      new GraphQLNonNull(
-                        new GraphQLList(new GraphQLNonNull(GraphQLString)),
+              type: GraphQLNonNull(
+                GraphQLList(
+                  GraphQLNonNull(
+                    GraphQLList(
+                      GraphQLNonNull(
+                        GraphQLList(GraphQLNonNull(GraphQLString)),
                       ),
                     ),
                   ),

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -41,7 +41,7 @@ const FooType = new GraphQLObjectType({
   fields: () => ({
     name: { type: GraphQLString },
     some: { type: SomeInterfaceType },
-    tree: { type: new GraphQLNonNull(new GraphQLList(FooType)) },
+    tree: { type: GraphQLNonNull(GraphQLList(FooType)) },
   }),
 });
 
@@ -83,7 +83,7 @@ const testSchema = new GraphQLSchema({
       someUnion: { type: SomeUnionType },
       someEnum: { type: SomeEnumType },
       someInterface: {
-        args: { id: { type: new GraphQLNonNull(GraphQLID) } },
+        args: { id: { type: GraphQLNonNull(GraphQLID) } },
         type: SomeInterfaceType,
       },
     }),

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -142,20 +142,20 @@ describe('findBreakingChanges', () => {
         field3: { type: GraphQLString },
         field4: { type: TypeA },
         field6: { type: GraphQLString },
-        field7: { type: new GraphQLList(GraphQLString) },
+        field7: { type: GraphQLList(GraphQLString) },
         field8: { type: GraphQLInt },
-        field9: { type: new GraphQLNonNull(GraphQLInt) },
-        field10: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
+        field9: { type: GraphQLNonNull(GraphQLInt) },
+        field10: { type: GraphQLNonNull(GraphQLList(GraphQLInt)) },
         field11: { type: GraphQLInt },
-        field12: { type: new GraphQLList(GraphQLInt) },
-        field13: { type: new GraphQLList(new GraphQLNonNull(GraphQLInt)) },
-        field14: { type: new GraphQLList(GraphQLInt) },
-        field15: { type: new GraphQLList(new GraphQLList(GraphQLInt)) },
-        field16: { type: new GraphQLNonNull(GraphQLInt) },
-        field17: { type: new GraphQLList(GraphQLInt) },
+        field12: { type: GraphQLList(GraphQLInt) },
+        field13: { type: GraphQLList(GraphQLNonNull(GraphQLInt)) },
+        field14: { type: GraphQLList(GraphQLInt) },
+        field15: { type: GraphQLList(GraphQLList(GraphQLInt)) },
+        field16: { type: GraphQLNonNull(GraphQLInt) },
+        field17: { type: GraphQLList(GraphQLInt) },
         field18: {
-          type: new GraphQLList(
-            new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt))),
+          type: GraphQLList(
+            GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLInt))),
           ),
         },
       },
@@ -167,22 +167,20 @@ describe('findBreakingChanges', () => {
         field3: { type: GraphQLBoolean },
         field4: { type: TypeB },
         field5: { type: GraphQLString },
-        field6: { type: new GraphQLList(GraphQLString) },
+        field6: { type: GraphQLList(GraphQLString) },
         field7: { type: GraphQLString },
-        field8: { type: new GraphQLNonNull(GraphQLInt) },
+        field8: { type: GraphQLNonNull(GraphQLInt) },
         field9: { type: GraphQLInt },
-        field10: { type: new GraphQLList(GraphQLInt) },
-        field11: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
-        field12: { type: new GraphQLList(new GraphQLNonNull(GraphQLInt)) },
-        field13: { type: new GraphQLList(GraphQLInt) },
-        field14: { type: new GraphQLList(new GraphQLList(GraphQLInt)) },
-        field15: { type: new GraphQLList(GraphQLInt) },
-        field16: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
-        field17: { type: new GraphQLNonNull(new GraphQLList(GraphQLInt)) },
+        field10: { type: GraphQLList(GraphQLInt) },
+        field11: { type: GraphQLNonNull(GraphQLList(GraphQLInt)) },
+        field12: { type: GraphQLList(GraphQLNonNull(GraphQLInt)) },
+        field13: { type: GraphQLList(GraphQLInt) },
+        field14: { type: GraphQLList(GraphQLList(GraphQLInt)) },
+        field15: { type: GraphQLList(GraphQLInt) },
+        field16: { type: GraphQLNonNull(GraphQLList(GraphQLInt)) },
+        field17: { type: GraphQLNonNull(GraphQLList(GraphQLInt)) },
         field18: {
-          type: new GraphQLList(
-            new GraphQLList(new GraphQLNonNull(GraphQLInt)),
-          ),
+          type: GraphQLList(GraphQLList(GraphQLNonNull(GraphQLInt))),
         },
       },
     });
@@ -266,47 +264,43 @@ describe('findBreakingChanges', () => {
           type: GraphQLBoolean,
         },
         field3: {
-          type: new GraphQLList(GraphQLString),
+          type: GraphQLList(GraphQLString),
         },
         field4: {
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
         },
         field5: {
           type: GraphQLString,
         },
         field6: {
-          type: new GraphQLList(GraphQLInt),
+          type: GraphQLList(GraphQLInt),
         },
         field7: {
-          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+          type: GraphQLNonNull(GraphQLList(GraphQLInt)),
         },
         field8: {
           type: GraphQLInt,
         },
         field9: {
-          type: new GraphQLList(GraphQLInt),
+          type: GraphQLList(GraphQLInt),
         },
         field10: {
-          type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          type: GraphQLList(GraphQLNonNull(GraphQLInt)),
         },
         field11: {
-          type: new GraphQLList(GraphQLInt),
+          type: GraphQLList(GraphQLInt),
         },
         field12: {
-          type: new GraphQLList(new GraphQLList(GraphQLInt)),
+          type: GraphQLList(GraphQLList(GraphQLInt)),
         },
         field13: {
-          type: new GraphQLNonNull(GraphQLInt),
+          type: GraphQLNonNull(GraphQLInt),
         },
         field14: {
-          type: new GraphQLList(
-            new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-          ),
+          type: GraphQLList(GraphQLNonNull(GraphQLList(GraphQLInt))),
         },
         field15: {
-          type: new GraphQLList(
-            new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-          ),
+          type: GraphQLList(GraphQLNonNull(GraphQLList(GraphQLInt))),
         },
       },
     });
@@ -323,38 +317,38 @@ describe('findBreakingChanges', () => {
           type: GraphQLString,
         },
         field5: {
-          type: new GraphQLNonNull(GraphQLString),
+          type: GraphQLNonNull(GraphQLString),
         },
         field6: {
-          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+          type: GraphQLNonNull(GraphQLList(GraphQLInt)),
         },
         field7: {
-          type: new GraphQLList(GraphQLInt),
+          type: GraphQLList(GraphQLInt),
         },
         field8: {
-          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+          type: GraphQLNonNull(GraphQLList(GraphQLInt)),
         },
         field9: {
-          type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          type: GraphQLList(GraphQLNonNull(GraphQLInt)),
         },
         field10: {
-          type: new GraphQLList(GraphQLInt),
+          type: GraphQLList(GraphQLInt),
         },
         field11: {
-          type: new GraphQLList(new GraphQLList(GraphQLInt)),
+          type: GraphQLList(GraphQLList(GraphQLInt)),
         },
         field12: {
-          type: new GraphQLList(GraphQLInt),
+          type: GraphQLList(GraphQLInt),
         },
         field13: {
-          type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+          type: GraphQLNonNull(GraphQLList(GraphQLInt)),
         },
         field14: {
-          type: new GraphQLList(new GraphQLList(GraphQLInt)),
+          type: GraphQLList(GraphQLList(GraphQLInt)),
         },
         field15: {
-          type: new GraphQLList(
-            new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(GraphQLInt))),
+          type: GraphQLList(
+            GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLInt))),
           ),
         },
       },
@@ -445,7 +439,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLString,
         },
         requiredField: {
-          type: new GraphQLNonNull(GraphQLInt),
+          type: GraphQLNonNull(GraphQLInt),
         },
         optionalField: {
           type: GraphQLBoolean,
@@ -665,47 +659,43 @@ describe('findBreakingChanges', () => {
               type: GraphQLString,
             },
             arg3: {
-              type: new GraphQLList(GraphQLString),
+              type: GraphQLList(GraphQLString),
             },
             arg4: {
               type: GraphQLString,
             },
             arg5: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLNonNull(GraphQLString),
             },
             arg6: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLNonNull(GraphQLString),
             },
             arg7: {
-              type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              type: GraphQLNonNull(GraphQLList(GraphQLInt)),
             },
             arg8: {
               type: GraphQLInt,
             },
             arg9: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLList(GraphQLInt),
             },
             arg10: {
-              type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+              type: GraphQLList(GraphQLNonNull(GraphQLInt)),
             },
             arg11: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLList(GraphQLInt),
             },
             arg12: {
-              type: new GraphQLList(new GraphQLList(GraphQLInt)),
+              type: GraphQLList(GraphQLList(GraphQLInt)),
             },
             arg13: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLNonNull(GraphQLInt),
             },
             arg14: {
-              type: new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-              ),
+              type: GraphQLList(GraphQLNonNull(GraphQLList(GraphQLInt))),
             },
             arg15: {
-              type: new GraphQLList(
-                new GraphQLNonNull(new GraphQLList(GraphQLInt)),
-              ),
+              type: GraphQLList(GraphQLNonNull(GraphQLList(GraphQLInt))),
             },
           },
         },
@@ -722,49 +712,47 @@ describe('findBreakingChanges', () => {
               type: GraphQLInt,
             },
             arg2: {
-              type: new GraphQLList(GraphQLString),
+              type: GraphQLList(GraphQLString),
             },
             arg3: {
               type: GraphQLString,
             },
             arg4: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLNonNull(GraphQLString),
             },
             arg5: {
               type: GraphQLInt,
             },
             arg6: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLNonNull(GraphQLInt),
             },
             arg7: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLList(GraphQLInt),
             },
             arg8: {
-              type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              type: GraphQLNonNull(GraphQLList(GraphQLInt)),
             },
             arg9: {
-              type: new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+              type: GraphQLList(GraphQLNonNull(GraphQLInt)),
             },
             arg10: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLList(GraphQLInt),
             },
             arg11: {
-              type: new GraphQLList(new GraphQLList(GraphQLInt)),
+              type: GraphQLList(GraphQLList(GraphQLInt)),
             },
             arg12: {
-              type: new GraphQLList(GraphQLInt),
+              type: GraphQLList(GraphQLInt),
             },
             arg13: {
-              type: new GraphQLNonNull(new GraphQLList(GraphQLInt)),
+              type: GraphQLNonNull(GraphQLList(GraphQLInt)),
             },
             arg14: {
-              type: new GraphQLList(new GraphQLList(GraphQLInt)),
+              type: GraphQLList(GraphQLList(GraphQLInt)),
             },
             arg15: {
-              type: new GraphQLList(
-                new GraphQLNonNull(
-                  new GraphQLList(new GraphQLNonNull(GraphQLInt)),
-                ),
+              type: GraphQLList(
+                GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLInt))),
               ),
             },
           },
@@ -872,7 +860,7 @@ describe('findBreakingChanges', () => {
               type: GraphQLString,
             },
             newRequiredArg: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLNonNull(GraphQLString),
             },
             newOptionalArg: {
               type: GraphQLInt,
@@ -926,7 +914,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLInt,
           args: {
             arg1: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLNonNull(GraphQLInt),
             },
             arg2: {
               type: inputType1a,
@@ -943,7 +931,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLInt,
           args: {
             arg1: {
-              type: new GraphQLNonNull(GraphQLInt),
+              type: GraphQLNonNull(GraphQLInt),
             },
             arg2: {
               type: inputType1b,
@@ -974,7 +962,7 @@ describe('findBreakingChanges', () => {
           type: GraphQLString,
           args: {
             name: {
-              type: new GraphQLNonNull(GraphQLString),
+              type: GraphQLNonNull(GraphQLString),
             },
           },
         },

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -42,11 +42,11 @@ function printSingleFieldSchema(fieldConfig) {
 }
 
 function listOf(type) {
-  return new GraphQLList(type);
+  return GraphQLList(type);
 }
 
 function nonNull(type) {
-  return new GraphQLNonNull(type);
+  return GraphQLNonNull(type);
 }
 
 describe('Type System Printer', () => {

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -32,27 +32,22 @@ describe('typeComparators', () => {
 
     it('lists of same type are equal', () => {
       expect(
-        isEqualType(new GraphQLList(GraphQLInt), new GraphQLList(GraphQLInt)),
+        isEqualType(GraphQLList(GraphQLInt), GraphQLList(GraphQLInt)),
       ).to.equal(true);
     });
 
     it('lists is not equal to item', () => {
-      expect(isEqualType(new GraphQLList(GraphQLInt), GraphQLInt)).to.equal(
-        false,
-      );
+      expect(isEqualType(GraphQLList(GraphQLInt), GraphQLInt)).to.equal(false);
     });
 
     it('non-null of same type are equal', () => {
       expect(
-        isEqualType(
-          new GraphQLNonNull(GraphQLInt),
-          new GraphQLNonNull(GraphQLInt),
-        ),
+        isEqualType(GraphQLNonNull(GraphQLInt), GraphQLNonNull(GraphQLInt)),
       ).to.equal(true);
     });
 
     it('non-null is not equal to nullable', () => {
-      expect(isEqualType(new GraphQLNonNull(GraphQLInt), GraphQLInt)).to.equal(
+      expect(isEqualType(GraphQLNonNull(GraphQLInt), GraphQLInt)).to.equal(
         false,
       );
     });
@@ -83,28 +78,28 @@ describe('typeComparators', () => {
     it('non-null is subtype of nullable', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLNonNull(GraphQLInt), GraphQLInt),
+        isTypeSubTypeOf(schema, GraphQLNonNull(GraphQLInt), GraphQLInt),
       ).to.equal(true);
     });
 
     it('nullable is not subtype of non-null', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLNonNull(GraphQLInt)),
+        isTypeSubTypeOf(schema, GraphQLInt, GraphQLNonNull(GraphQLInt)),
       ).to.equal(false);
     });
 
     it('item is not subtype of list', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLList(GraphQLInt)),
+        isTypeSubTypeOf(schema, GraphQLInt, GraphQLList(GraphQLInt)),
       ).to.equal(false);
     });
 
     it('list is not subtype of item', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLList(GraphQLInt), GraphQLInt),
+        isTypeSubTypeOf(schema, GraphQLList(GraphQLInt), GraphQLInt),
       ).to.equal(false);
     });
 

--- a/src/utilities/__tests__/valueFromAST-test.js
+++ b/src/utilities/__tests__/valueFromAST-test.js
@@ -80,15 +80,15 @@ describe('valueFromAST', () => {
   });
 
   // Boolean!
-  const nonNullBool = new GraphQLNonNull(GraphQLBoolean);
+  const nonNullBool = GraphQLNonNull(GraphQLBoolean);
   // [Boolean]
-  const listOfBool = new GraphQLList(GraphQLBoolean);
+  const listOfBool = GraphQLList(GraphQLBoolean);
   // [Boolean!]
-  const listOfNonNullBool = new GraphQLList(nonNullBool);
+  const listOfNonNullBool = GraphQLList(nonNullBool);
   // [Boolean]!
-  const nonNullListOfBool = new GraphQLNonNull(listOfBool);
+  const nonNullListOfBool = GraphQLNonNull(listOfBool);
   // [Boolean!]!
-  const nonNullListOfNonNullBool = new GraphQLNonNull(listOfNonNullBool);
+  const nonNullListOfNonNullBool = GraphQLNonNull(listOfNonNullBool);
 
   it('coerces to null unless non-null', () => {
     testCase(GraphQLBoolean, 'null', null);

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -29,9 +29,8 @@ import {
   GraphQLScalarType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
 } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import { GraphQLID } from '../type/scalars';
 
 /**

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -47,11 +47,11 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
   assertInputType,
   assertOutputType,
 } from '../type/definition';
+
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 
 import {
   GraphQLDirective,
@@ -99,12 +99,12 @@ function buildWrappedType(
   inputTypeNode: TypeNode,
 ): GraphQLType {
   if (inputTypeNode.kind === Kind.LIST_TYPE) {
-    return new GraphQLList(buildWrappedType(innerType, inputTypeNode.type));
+    return GraphQLList(buildWrappedType(innerType, inputTypeNode.type));
   }
   if (inputTypeNode.kind === Kind.NON_NULL_TYPE) {
     const wrappedType = buildWrappedType(innerType, inputTypeNode.type);
     invariant(!(wrappedType instanceof GraphQLNonNull), 'No nesting nonnull.');
-    return new GraphQLNonNull(wrappedType);
+    return GraphQLNonNull(wrappedType);
   }
   return innerType;
 }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -25,9 +25,9 @@ import {
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
 } from '../type/definition';
+
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 
 import type {
   GraphQLType,
@@ -109,7 +109,7 @@ export function buildClientSchema(
       if (!itemRef) {
         throw new Error('Decorated type deeper than introspection query.');
       }
-      return new GraphQLList(getType(itemRef));
+      return GraphQLList(getType(itemRef));
     }
     if (typeRef.kind === TypeKind.NON_NULL) {
       const nullableRef = typeRef.ofType;
@@ -121,7 +121,7 @@ export function buildClientSchema(
         !(nullableType instanceof GraphQLNonNull),
         'No nesting nonnull.',
       );
-      return new GraphQLNonNull(nullableType);
+      return GraphQLNonNull(nullableType);
     }
     if (!typeRef.name) {
       throw new Error('Unknown type reference: ' + JSON.stringify(typeRef));

--- a/src/utilities/coerceValue.js
+++ b/src/utilities/coerceValue.js
@@ -15,10 +15,9 @@ import type { ASTNode } from '../language/ast';
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
   GraphQLScalarType,
 } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import type { GraphQLInputType } from '../type/definition';
 
 type CoercedValue = {|

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -14,12 +14,11 @@ import { GraphQLError } from '../error/GraphQLError';
 import { GraphQLSchema } from '../type/schema';
 
 import {
-  GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
 } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 
 import { GraphQLDirective } from '../type/directives';
 
@@ -365,10 +364,10 @@ export function extendSchema(
 
   function extendFieldType<T: GraphQLType>(typeDef: T): T {
     if (typeDef instanceof GraphQLList) {
-      return (new GraphQLList(extendFieldType(typeDef.ofType)): any);
+      return (GraphQLList(extendFieldType(typeDef.ofType)): any);
     }
     if (typeDef instanceof GraphQLNonNull) {
-      return (new GraphQLNonNull(extendFieldType(typeDef.ofType)): any);
+      return (GraphQLNonNull(extendFieldType(typeDef.ofType)): any);
     }
     return getTypeFromDef(typeDef);
   }

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -13,11 +13,11 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
   GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLUnionType,
 } from '../type/definition';
+
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 
 import type {
   GraphQLNamedType,

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -18,9 +18,8 @@ import {
   GraphQLScalarType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
 } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import type { GraphQLInputType } from '../type/definition';
 import invariant from '../jsutils/invariant';
 import isInvalid from '../jsutils/isInvalid';

--- a/src/utilities/typeComparators.js
+++ b/src/utilities/typeComparators.js
@@ -7,12 +7,8 @@
  * @flow
  */
 
-import {
-  isAbstractType,
-  GraphQLObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-} from '../type/definition';
+import { isAbstractType, GraphQLObjectType } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import type { GraphQLType, GraphQLCompositeType } from '../type/definition';
 import type { GraphQLSchema } from '../type/schema';
 

--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -14,7 +14,7 @@ import type {
   ListTypeNode,
   NonNullTypeNode,
 } from '../language/ast';
-import { GraphQLList, GraphQLNonNull } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import type { GraphQLNamedType } from '../type/definition';
 import type { GraphQLSchema } from '../type/schema';
 
@@ -43,11 +43,11 @@ function typeFromASTImpl(schema, typeNode) {
   let innerType;
   if (typeNode.kind === Kind.LIST_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);
-    return innerType && new GraphQLList(innerType);
+    return innerType && GraphQLList(innerType);
   }
   if (typeNode.kind === Kind.NON_NULL_TYPE) {
     innerType = typeFromAST(schema, typeNode.type);
-    return innerType && new GraphQLNonNull(innerType);
+    return innerType && GraphQLNonNull(innerType);
   }
   invariant(typeNode.kind === Kind.NAMED_TYPE, 'Must be a named type.');
   return schema.getType(typeNode.name.value);

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -16,9 +16,8 @@ import {
   GraphQLScalarType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
 } from '../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import type { GraphQLInputType } from '../type/definition';
 import type {
   ValueNode,

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -597,7 +597,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         scalar: { type: GraphQLString },
         deepBox: { type: StringBox },
         unrelatedField: { type: GraphQLString },
-        listStringBox: { type: new GraphQLList(StringBox) },
+        listStringBox: { type: GraphQLList(StringBox) },
         stringBox: { type: StringBox },
         intBox: { type: IntBox },
       }),
@@ -610,7 +610,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         scalar: { type: GraphQLInt },
         deepBox: { type: IntBox },
         unrelatedField: { type: GraphQLString },
-        listStringBox: { type: new GraphQLList(StringBox) },
+        listStringBox: { type: GraphQLList(StringBox) },
         stringBox: { type: StringBox },
         intBox: { type: IntBox },
       }),
@@ -619,7 +619,7 @@ describe('Validate: Overlapping fields can be merged', () => {
     const NonNullStringBox1 = new GraphQLInterfaceType({
       name: 'NonNullStringBox1',
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) },
+        scalar: { type: GraphQLNonNull(GraphQLString) },
       },
     });
 
@@ -627,7 +627,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'NonNullStringBox1Impl',
       interfaces: [SomeBox, NonNullStringBox1],
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) },
+        scalar: { type: GraphQLNonNull(GraphQLString) },
         unrelatedField: { type: GraphQLString },
         deepBox: { type: SomeBox },
       },
@@ -636,7 +636,7 @@ describe('Validate: Overlapping fields can be merged', () => {
     const NonNullStringBox2 = new GraphQLInterfaceType({
       name: 'NonNullStringBox2',
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) },
+        scalar: { type: GraphQLNonNull(GraphQLString) },
       },
     });
 
@@ -644,7 +644,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'NonNullStringBox2Impl',
       interfaces: [SomeBox, NonNullStringBox2],
       fields: {
-        scalar: { type: new GraphQLNonNull(GraphQLString) },
+        scalar: { type: GraphQLNonNull(GraphQLString) },
         unrelatedField: { type: GraphQLString },
         deepBox: { type: SomeBox },
       },
@@ -654,7 +654,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       name: 'Connection',
       fields: {
         edges: {
-          type: new GraphQLList(
+          type: GraphQLList(
             new GraphQLObjectType({
               name: 'Edge',
               fields: {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -138,8 +138,8 @@ const Human = new GraphQLObjectType({
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
     },
-    pets: { type: new GraphQLList(Pet) },
-    relatives: { type: new GraphQLList(Human) },
+    pets: { type: GraphQLList(Pet) },
+    relatives: { type: GraphQLList(Human) },
     iq: { type: GraphQLInt },
   }),
 });
@@ -182,11 +182,11 @@ const FurColor = new GraphQLEnumType({
 const ComplexInput = new GraphQLInputObjectType({
   name: 'ComplexInput',
   fields: {
-    requiredField: { type: new GraphQLNonNull(GraphQLBoolean) },
+    requiredField: { type: GraphQLNonNull(GraphQLBoolean) },
     intField: { type: GraphQLInt },
     stringField: { type: GraphQLString },
     booleanField: { type: GraphQLBoolean },
-    stringListField: { type: new GraphQLList(GraphQLString) },
+    stringListField: { type: GraphQLList(GraphQLString) },
   },
 });
 
@@ -202,7 +202,7 @@ const ComplicatedArgs = new GraphQLObjectType({
     },
     nonNullIntArgField: {
       type: GraphQLString,
-      args: { nonNullIntArg: { type: new GraphQLNonNull(GraphQLInt) } },
+      args: { nonNullIntArg: { type: GraphQLNonNull(GraphQLInt) } },
     },
     stringArgField: {
       type: GraphQLString,
@@ -226,7 +226,7 @@ const ComplicatedArgs = new GraphQLObjectType({
     },
     stringListArgField: {
       type: GraphQLString,
-      args: { stringListArg: { type: new GraphQLList(GraphQLString) } },
+      args: { stringListArg: { type: GraphQLList(GraphQLString) } },
     },
     complexArgField: {
       type: GraphQLString,
@@ -235,8 +235,8 @@ const ComplicatedArgs = new GraphQLObjectType({
     multipleReqs: {
       type: GraphQLString,
       args: {
-        req1: { type: new GraphQLNonNull(GraphQLInt) },
-        req2: { type: new GraphQLNonNull(GraphQLInt) },
+        req1: { type: GraphQLNonNull(GraphQLInt) },
+        req2: { type: GraphQLNonNull(GraphQLInt) },
       },
     },
     multipleOpts: {
@@ -255,8 +255,8 @@ const ComplicatedArgs = new GraphQLObjectType({
     multipleOptAndReq: {
       type: GraphQLString,
       args: {
-        req1: { type: new GraphQLNonNull(GraphQLInt) },
-        req2: { type: new GraphQLNonNull(GraphQLInt) },
+        req1: { type: GraphQLNonNull(GraphQLInt) },
+        req2: { type: GraphQLNonNull(GraphQLInt) },
         opt1: {
           type: GraphQLInt,
           defaultValue: 0,

--- a/src/validation/rules/DefaultValuesOfCorrectType.js
+++ b/src/validation/rules/DefaultValuesOfCorrectType.js
@@ -10,7 +10,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import { print } from '../../language/printer';
-import { GraphQLNonNull } from '../../type/definition';
+import { GraphQLNonNull } from '../../type/wrappers';
 import { isValidLiteralValue } from '../../utilities/isValidLiteralValue';
 import type { GraphQLType } from '../../type/definition';
 

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -22,11 +22,10 @@ import { print } from '../../language/printer';
 import {
   getNamedType,
   isLeafType,
-  GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLInterfaceType,
 } from '../../type/definition';
+import { GraphQLList, GraphQLNonNull } from '../../type/wrappers';
 import type {
   GraphQLNamedType,
   GraphQLOutputType,

--- a/src/validation/rules/ProvidedNonNullArguments.js
+++ b/src/validation/rules/ProvidedNonNullArguments.js
@@ -10,7 +10,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import keyMap from '../../jsutils/keyMap';
-import { GraphQLNonNull } from '../../type/definition';
+import { GraphQLNonNull } from '../../type/wrappers';
 import type { GraphQLType } from '../../type/definition';
 
 export function missingFieldArgMessage(

--- a/src/validation/rules/VariablesInAllowedPosition.js
+++ b/src/validation/rules/VariablesInAllowedPosition.js
@@ -9,7 +9,7 @@
 
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
-import { GraphQLNonNull } from '../../type/definition';
+import { GraphQLNonNull } from '../../type/wrappers';
 import { isTypeSubTypeOf } from '../../utilities/typeComparators';
 import { typeFromAST } from '../../utilities/typeFromAST';
 import type { GraphQLType } from '../../type/definition';
@@ -75,5 +75,5 @@ export function VariablesInAllowedPosition(context: ValidationContext): any {
 function effectiveType(varType, varDef) {
   return !varDef.defaultValue || varType instanceof GraphQLNonNull
     ? varType
-    : new GraphQLNonNull(varType);
+    : GraphQLNonNull(varType);
 }


### PR DESCRIPTION
**Semi-breaking: Those using flow should (but are not required) to change from `new GraphQLList(t)` and `new GraphQLNonNull(t)` to `GraphQLList(t)` and `GraphQLNonNull(t)`**

Because class constructors are contravariant since flow/js lacks a "finally" keyword, we need to use functions to represent covariance in GraphQLList and GraphQLNonNull.

By having wrapping types be covariant, we can enable more checks and have more accurate predicates for refining types in GraphQL utilities.