### PR TITLE
Add experimental support for parsing variable definitions in fragments

### DIFF
--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -391,6 +391,16 @@ describe('Parser', () => {
     expect(result.loc).to.equal(undefined);
   });
 
+  it('Experimental: allows parsing fragment defined variables', () => {
+    const source = new Source(
+      'fragment a($v: Boolean = false) on t { f(v: $v) }',
+    );
+    expect(() =>
+      parse(source, { experimentalFragmentVariables: true }),
+    ).to.not.throw();
+    expect(() => parse(source)).to.throw('Syntax Error');
+  });
+
   it('contains location information that only stringifys start/end', () => {
     const source = new Source('{ id }');
     const result = parse(source);

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -103,6 +103,22 @@ describe('Printer', () => {
     `);
   });
 
+  it('Experimental: correctly prints fragment defined variables', () => {
+    const fragmentWithVariable = parse(
+      `
+        fragment Foo($a: ComplexType, $b: Boolean = false) on TestType {
+          id
+        }
+      `,
+      { experimentalFragmentVariables: true },
+    );
+    expect(print(fragmentWithVariable)).to.equal(dedent`
+      fragment Foo($a: ComplexType, $b: Boolean = false) on TestType {
+        id
+      }
+    `);
+  });
+
   const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
     encoding: 'utf8',
   });

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -290,6 +290,53 @@ describe('Visitor', () => {
     ]);
   });
 
+  it('Experimental: visits variables defined in fragments', () => {
+    const ast = parse('fragment a($v: Boolean = false) on t { f }', {
+      experimentalFragmentVariables: true,
+    });
+    const visited = [];
+
+    visit(ast, {
+      enter(node) {
+        visited.push(['enter', node.kind, node.value]);
+      },
+      leave(node) {
+        visited.push(['leave', node.kind, node.value]);
+      },
+    });
+
+    expect(visited).to.deep.equal([
+      ['enter', 'Document', undefined],
+      ['enter', 'FragmentDefinition', undefined],
+      ['enter', 'Name', 'a'],
+      ['leave', 'Name', 'a'],
+      ['enter', 'VariableDefinition', undefined],
+      ['enter', 'Variable', undefined],
+      ['enter', 'Name', 'v'],
+      ['leave', 'Name', 'v'],
+      ['leave', 'Variable', undefined],
+      ['enter', 'NamedType', undefined],
+      ['enter', 'Name', 'Boolean'],
+      ['leave', 'Name', 'Boolean'],
+      ['leave', 'NamedType', undefined],
+      ['enter', 'BooleanValue', false],
+      ['leave', 'BooleanValue', false],
+      ['leave', 'VariableDefinition', undefined],
+      ['enter', 'NamedType', undefined],
+      ['enter', 'Name', 't'],
+      ['leave', 'Name', 't'],
+      ['leave', 'NamedType', undefined],
+      ['enter', 'SelectionSet', undefined],
+      ['enter', 'Field', undefined],
+      ['enter', 'Name', 'f'],
+      ['leave', 'Name', 'f'],
+      ['leave', 'Field', undefined],
+      ['leave', 'SelectionSet', undefined],
+      ['leave', 'FragmentDefinition', undefined],
+      ['leave', 'Document', undefined],
+    ]);
+  });
+
   const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
     encoding: 'utf8',
   });

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -252,6 +252,9 @@ export type FragmentDefinitionNode = {
   +kind: 'FragmentDefinition',
   +loc?: Location,
   +name: NameNode,
+  // Note: fragment variable definitions are experimental and may be changed
+  // or removed in the future.
+  +variableDefinitions?: $ReadOnlyArray<VariableDefinitionNode>,
   +typeCondition: NamedTypeNode,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet: SelectionSetNode,

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -64,9 +64,17 @@ const printDocASTReducer = {
       ' ',
     ),
 
-  FragmentDefinition: ({ name, typeCondition, directives, selectionSet }) =>
-    `fragment ${name} on ${typeCondition} ` +
-    wrap('', join(directives, ' '), ' ') +
+  FragmentDefinition: ({
+    name,
+    typeCondition,
+    variableDefinitions,
+    directives,
+    selectionSet,
+  }) =>
+    // Note: fragment variable definitions are experimental and may be changed
+    // or removed in the future.
+    `fragment ${name}${wrap('(', join(variableDefinitions, ', '), ')')} ` +
+    `on ${typeCondition} ${wrap('', join(directives, ' '), ' ')}` +
     selectionSet,
 
   // Value

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -23,7 +23,15 @@ export const QueryDocumentKeys = {
 
   FragmentSpread: ['name', 'directives'],
   InlineFragment: ['typeCondition', 'directives', 'selectionSet'],
-  FragmentDefinition: ['name', 'typeCondition', 'directives', 'selectionSet'],
+  FragmentDefinition: [
+    'name',
+    // Note: fragment variable definitions are experimental and may be changed
+    // or removed in the future.
+    'variableDefinitions',
+    'typeCondition',
+    'directives',
+    'selectionSet',
+  ],
 
   IntValue: [],
   FloatValue: [],


### PR DESCRIPTION
This PR adds experimental support for parsing variable definitions within a fragment declaration. If the `fragmentVariablesExperimental` flag is passed into the options for `parse` then the parser will accept `VariableDefinitions` placed after the `TypeCondition` and before any `Directives`. The syntax is identical to the usual query-defined variable definitions, and the parser will parse these into the optional `variableDefinitions` field on `FragmentDefinitionNode`.

Context:
There's been ongoing discussion on exploring this concept: https://github.com/facebook/graphql/issues/204. Note that this PR only supports parsing fragment variable definitions into the AST. It does not allow for passing variable values into a fragment spread. It at least gets a foot in the door for starting to explore further down this path.

An emergent pain point with the current system (where a query must define all variables used in its dependent fragments) is that adding a new variable reference to a commonly used fragment could involve updating the declarations of the dozens of queries that depend on that fragment. With this PR, it would become easy to implement a client side transform that would allow for variable defaults defined at the fragment level to be automatically hoisted to its dependent queries. For example, with

```
query q () {
  ...a
}

fragment a on t ($size: Int = 0) {
  f(size: $size)
}
```
the transform would automatically hoist the `$size` variable declaration into `query q` without the need to explicitly define it. This can be useful if `fragment a` is used by many queries.