### PR TITLE
Make `npm run watch` linting work right

### DIFF
--- a/resources/watch.js
+++ b/resources/watch.js
@@ -145,7 +145,7 @@ function lintFiles(filepaths) {
   return filepaths.reduce((prev, filepath) => prev.then(prevSuccess => {
     if (isJS(filepath)) {
       process.stdout.write('  ' + filepath + ' ...');
-      return exec('eslint', [srcPath(filepath)])
+      return exec('eslint', ['--rulesdir', './resources/lint', srcPath(filepath)])
         .catch(() => false)
         .then(success => {
           console.log(CLEARLINE + '  ' + (success ? CHECK : X)


### PR DESCRIPTION
Without this update, using `npm run watch` always gives this error:

```
  execution/execute.js ...
/home/osboxes/graphql-js/src/execution/execute.js
  1:1  error  Definition for rule 'no-async' was not found  no-async

✖ 1 problem (1 error, 0 warnings)

  ✘ execution/execute.js
```