### PR TITLE
Works without experimental flow

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -124,8 +124,9 @@ export function GraphQLError( // eslint-disable-line no-redeclare
   }
 
   let _locations;
-  if (positions && source) {
-    _locations = positions.map(pos => getLocation(source, pos));
+  const immutableSource = source;
+  if (positions && immutableSource) {
+    _locations = positions.map(pos => getLocation(immutableSource, pos));
   } else if (_nodes) {
     _locations = _nodes.reduce((list, node) => {
       if (node.loc) {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -446,7 +446,7 @@ function resolveThunk<+T>(thunk: Thunk<T>): T {
  *
  */
 export class GraphQLScalarType {
-  +name: string;
+  name: string;
   description: ?string;
   astNode: ?ScalarTypeDefinitionNode;
 
@@ -559,7 +559,7 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
  *
  */
 export class GraphQLObjectType {
-  +name: string;
+  name: string;
   description: ?string;
   astNode: ?ObjectTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ObjectTypeExtensionNode>;
@@ -804,7 +804,7 @@ export type GraphQLFieldMap<TSource, TContext> = ObjMap<
  *
  */
 export class GraphQLInterfaceType {
-  +name: string;
+  name: string;
   description: ?string;
   astNode: ?InterfaceTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<InterfaceTypeExtensionNode>;
@@ -886,7 +886,7 @@ export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
  *
  */
 export class GraphQLUnionType {
-  +name: string;
+  name: string;
   description: ?string;
   astNode: ?UnionTypeDefinitionNode;
   resolveType: ?GraphQLTypeResolver<*, *>;
@@ -975,7 +975,7 @@ export type GraphQLUnionTypeConfig<TSource, TContext> = {
  * will be used as its internal value.
  */
 export class GraphQLEnumType /* <T> */ {
-  +name: string;
+  name: string;
   description: ?string;
   astNode: ?EnumTypeDefinitionNode;
 
@@ -1142,7 +1142,7 @@ export type GraphQLEnumValue /* <T> */ = {
  *
  */
 export class GraphQLInputObjectType {
-  +name: string;
+  name: string;
   description: ?string;
   astNode: ?InputObjectTypeDefinitionNode;
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -446,7 +446,7 @@ function resolveThunk<+T>(thunk: Thunk<T>): T {
  *
  */
 export class GraphQLScalarType {
-  name: string;
+  +name: string;
   description: ?string;
   astNode: ?ScalarTypeDefinitionNode;
 
@@ -559,7 +559,7 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
  *
  */
 export class GraphQLObjectType {
-  name: string;
+  +name: string;
   description: ?string;
   astNode: ?ObjectTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ObjectTypeExtensionNode>;
@@ -804,7 +804,7 @@ export type GraphQLFieldMap<TSource, TContext> = ObjMap<
  *
  */
 export class GraphQLInterfaceType {
-  name: string;
+  +name: string;
   description: ?string;
   astNode: ?InterfaceTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<InterfaceTypeExtensionNode>;
@@ -886,7 +886,7 @@ export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
  *
  */
 export class GraphQLUnionType {
-  name: string;
+  +name: string;
   description: ?string;
   astNode: ?UnionTypeDefinitionNode;
   resolveType: ?GraphQLTypeResolver<*, *>;
@@ -975,7 +975,7 @@ export type GraphQLUnionTypeConfig<TSource, TContext> = {
  * will be used as its internal value.
  */
 export class GraphQLEnumType /* <T> */ {
-  name: string;
+  +name: string;
   description: ?string;
   astNode: ?EnumTypeDefinitionNode;
 
@@ -1142,7 +1142,7 @@ export type GraphQLEnumValue /* <T> */ = {
  *
  */
 export class GraphQLInputObjectType {
-  name: string;
+  +name: string;
   description: ?string;
   astNode: ?InputObjectTypeDefinitionNode;
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -22,7 +22,6 @@ import {
   isListType,
   isNonNullType,
   isAbstractType,
-  isNamedType,
 } from './definition';
 import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 import { GraphQLString, GraphQLBoolean } from './scalars';

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -467,9 +467,23 @@ export const introspectionTypes: $ReadOnlyArray<*> = [
 
 export function isIntrospectionType(type: ?GraphQLType): boolean %checks {
   return (
-    isNamedType(type) &&
-    introspectionTypes.some(
-      introspectionType => introspectionType.name === type.name,
-    )
+    // Cannot use function calls to %checks unless flow's
+    // experimental.const_params=true is set.
+
+    // isNamedType(type)
+    type !== null &&
+    type !== undefined &&
+    !(type instanceof GraphQLList || type instanceof GraphQLNonNull) &&
+    // introspectionTypes.some(
+    //   introspectionType => introspectionType.name === type.name
+    // )
+    (__Schema.name === type.name ||
+      __Directive.name === type.name ||
+      __DirectiveLocation.name === type.name ||
+      __Type.name === type.name ||
+      __Field.name === type.name ||
+      __InputValue.name === type.name ||
+      __EnumValue.name === type.name ||
+      __TypeKind.name === type.name)
   );
 }

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -8,6 +8,7 @@
  */
 
 import { GraphQLScalarType, isNamedType } from './definition';
+import { GraphQLList, GraphQLNonNull } from './wrappers';
 import * as Kind from '../language/kinds';
 import type { GraphQLType } from './definition';
 
@@ -145,11 +146,22 @@ export const specifiedScalarTypes: $ReadOnlyArray<*> = [
   GraphQLID,
 ];
 
-export function isSpecifiedScalarType(type: ?GraphQLType): boolean %checks {
+export function isSpecifiedScalarType(
+  type: $ReadOnly<?GraphQLType>,
+): boolean %checks {
   return (
-    isNamedType(type) &&
-    specifiedScalarTypes.some(
-      specifiedScalarType => specifiedScalarType.name === type.name,
-    )
+    // Cannot use function calls to %checks unless flow's
+    // experimental.const_params=true is set.
+
+    // equivalent of isNamedType(type), given we only care about scalars
+    type instanceof GraphQLScalarType &&
+    // specifiedScalarTypes.some(
+    //   specifiedScalarType => specifiedScalarType.name === type.name
+    // )
+    (GraphQLString.name === type.name ||
+      GraphQLInt.name === type.name ||
+      GraphQLFloat.name === type.name ||
+      GraphQLBoolean.name === type.name ||
+      GraphQLID.name === type.name)
   );
 }

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -7,8 +7,7 @@
  * @flow
  */
 
-import { GraphQLScalarType, isNamedType } from './definition';
-import { GraphQLList, GraphQLNonNull } from './wrappers';
+import { GraphQLScalarType } from './definition';
 import * as Kind from '../language/kinds';
 import type { GraphQLType } from './definition';
 


### PR DESCRIPTION
For packages that do not use `experimental.const_params` in their `.flowconfig`, using v0.12.0 will cause them to have flow errors, as they treat arguments to functions as non-const. This fixes up all of the known cases.

To test, comment-out `experimental.const_params=true` from `.flowconfig`, and run flow.