### PR TITLE
visit return any instead of mixed.

### DIFF
--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -225,7 +225,7 @@ export function visit(
   root: ASTNode,
   visitor: Visitor<ASTKindToNode>,
   visitorKeys: VisitorKeyMap<ASTKindToNode> = QueryDocumentKeys,
-): mixed {
+): any {
   /* eslint-disable no-undef-init */
   let stack: any = undefined;
   let inArray = Array.isArray(root);


### PR DESCRIPTION
Changing this from the (untyped) any to mixed is too severe a breaking change. Changing back to any ensures the visitor functions themselves remain checked but does not cause downstream usage to fail.