### PR TITLE
Add special case for legacy servers.

### DIFF
--- a/src/utilities/__tests__/assertValidName-test.js
+++ b/src/utilities/__tests__/assertValidName-test.js
@@ -23,4 +23,8 @@ describe('assertValidName()', () => {
   it('throws for names with invalid characters', () => {
     expect(() => assertValidName('>--()-->')).to.throw(/Names must match/);
   });
+
+  it('does not throw for legacy servers that use __configs__ introspection', () => {
+    expect(() => assertValidName('__configs__')).not.to.throw();
+  });
 });

--- a/src/utilities/assertValidName.js
+++ b/src/utilities/assertValidName.js
@@ -32,7 +32,15 @@ export function isValidNameError(
   node?: ASTNode | void,
 ): GraphQLError | void {
   invariant(typeof name === 'string', 'Expected string');
-  if (name.length > 1 && name[0] === '_' && name[1] === '_') {
+  if (
+    name.length > 1 &&
+    name[0] === '_' &&
+    name[1] === '_' &&
+    // Note: this special case is not part of the spec and exists only to
+    // support legacy server configurations. Do not rely on this special case
+    // as it may be removed at any time.
+    name !== '__configs__'
+  ) {
     return new GraphQLError(
       `Name "${name}" must not begin with "__", which is reserved by ` +
         'GraphQL introspection.',


### PR DESCRIPTION
Much older versions of GraphQL use `__configs__` as part of a pseudo-introspection meta programming layer. While this is technically against the spec, this adds temporary support.