### PR TITLE
DRY with MaybePromise

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -13,6 +13,7 @@ import invariant from '../jsutils/invariant';
 import isInvalid from '../jsutils/isInvalid';
 import isNullish from '../jsutils/isNullish';
 import type { ObjMap } from '../jsutils/ObjMap';
+import type { MaybePromise } from '../jsutils/MaybePromise';
 
 import { typeFromAST } from '../utilities/typeFromAST';
 import * as Kind from '../language/kinds';
@@ -133,7 +134,7 @@ export type ExecutionArgs = {|
 declare function execute(
   ExecutionArgs,
   ..._: []
-): Promise<ExecutionResult> | ExecutionResult;
+): MaybePromise<ExecutionResult>;
 /* eslint-disable no-redeclare */
 declare function execute(
   schema: GraphQLSchema,
@@ -143,7 +144,7 @@ declare function execute(
   variableValues?: ?{ [variable: string]: mixed },
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
-): Promise<ExecutionResult> | ExecutionResult;
+): MaybePromise<ExecutionResult>;
 export function execute(
   argsOrSchema,
   document,
@@ -222,7 +223,7 @@ function executeImpl(
  */
 function buildResponse(
   context: ExecutionContext,
-  data: Promise<ObjMap<mixed> | null> | ObjMap<mixed> | null,
+  data: MaybePromise<ObjMap<mixed> | null>,
 ) {
   const promise = getPromise(data);
   if (promise) {
@@ -376,7 +377,7 @@ function executeOperation(
   exeContext: ExecutionContext,
   operation: OperationDefinitionNode,
   rootValue: mixed,
-): Promise<ObjMap<mixed> | null> | ObjMap<mixed> | null {
+): MaybePromise<ObjMap<mixed> | null> {
   const type = getOperationRootType(exeContext.schema, operation);
   const fields = collectFields(
     exeContext,
@@ -503,7 +504,7 @@ function executeFields(
   sourceValue: mixed,
   path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
-): Promise<ObjMap<mixed>> | ObjMap<mixed> {
+): MaybePromise<ObjMap<mixed>> {
   let containsPromise = false;
 
   const finalResults = Object.keys(fields).reduce((results, responseName) => {

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -16,6 +16,7 @@ import type { Source } from './language/source';
 import type { GraphQLFieldResolver } from './type/definition';
 import type { GraphQLSchema } from './type/schema';
 import type { ExecutionResult } from './execution/execute';
+import type { MaybePromise } from './jsutils/MaybePromise';
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
@@ -168,7 +169,7 @@ function graphqlImpl(
   variableValues,
   operationName,
   fieldResolver,
-): Promise<ExecutionResult> | ExecutionResult {
+): MaybePromise<ExecutionResult> {
   // Validate Schema
   const schemaValidationErrors = validateSchema(schema);
   if (schemaValidationErrors.length > 0) {

--- a/src/jsutils/MaybePromise.js
+++ b/src/jsutils/MaybePromise.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export type MaybePromise<T> = Promise<T> | T;

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -8,6 +8,7 @@
  */
 
 import { $$asyncIterator, getAsyncIterator } from 'iterall';
+import type { MaybePromise } from '../jsutils/MaybePromise';
 
 /**
  * Given an AsyncIterable and a callback function, return an AsyncIterator
@@ -15,8 +16,8 @@ import { $$asyncIterator, getAsyncIterator } from 'iterall';
  */
 export default function mapAsyncIterator<T, U>(
   iterable: AsyncIterable<T>,
-  callback: T => Promise<U> | U,
-  rejectCallback?: any => Promise<U> | U,
+  callback: T => MaybePromise<U>,
+  rejectCallback?: any => MaybePromise<U>,
 ): AsyncGenerator<U, void, void> {
   const iterator = getAsyncIterator(iterable);
   let $return;
@@ -68,7 +69,7 @@ export default function mapAsyncIterator<T, U>(
 
 function asyncMapValue<T, U>(
   value: T,
-  callback: T => Promise<U> | U,
+  callback: T => MaybePromise<U>,
 ): Promise<U> {
   return new Promise(resolve => resolve(callback(value)));
 }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -31,6 +31,7 @@ import type {
   ValueNode,
 } from '../language/ast';
 import type { GraphQLSchema } from './schema';
+import type { MaybePromise } from '../jsutils/MaybePromise';
 import { GraphQLList, GraphQLNonNull } from './wrappers';
 
 // Predicates & Assertions
@@ -705,13 +706,13 @@ export type GraphQLTypeResolver<TSource, TContext> = (
   value: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
-) => ?GraphQLObjectType | string | Promise<?GraphQLObjectType | string>;
+) => MaybePromise<?GraphQLObjectType | string>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
   source: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
-) => boolean | Promise<boolean>;
+) => MaybePromise<boolean>;
 
 export type GraphQLFieldResolver<TSource, TContext> = (
   source: TSource,


### PR DESCRIPTION
`MaybePromise<T>` type, to avoid constantly declaring `Promise<some stuff> | some stuff`. Most visible in `execute.js` but also in a few other places.