### PR TITLE
Bring back `getDescription` export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -315,6 +315,8 @@ export {
   buildASTSchema,
   // Build a GraphQLSchema from a GraphQL schema language document.
   buildSchema,
+  // Get the description from a schema AST node.
+  getDescription,
   // Extends an existing GraphQLSchema from a parsed GraphQL Schema
   // language AST.
   extendSchema,

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -35,6 +35,8 @@ import type {
   EnumValueDefinitionNode,
   InputObjectTypeDefinitionNode,
   DirectiveDefinitionNode,
+  StringValueNode,
+  Location,
 } from '../language/ast';
 
 import type { DirectiveLocationEnum } from '../language/directiveLocation';
@@ -475,7 +477,10 @@ function getDeprecationReason(
  *        Provide true to use preceding comments as the description.
  *
  */
-function getDescription(node, options: ?Options): void | string {
+export function getDescription(
+  node: { +description?: StringValueNode, +loc?: Location },
+  options: ?Options,
+): void | string {
   if (node.description) {
     return node.description.value;
   }

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -45,7 +45,7 @@ export { getOperationAST } from './getOperationAST';
 export { buildClientSchema } from './buildClientSchema';
 
 // Build a GraphQLSchema from GraphQL Schema language.
-export { buildASTSchema, buildSchema } from './buildASTSchema';
+export { buildASTSchema, buildSchema, getDescription } from './buildASTSchema';
 
 // Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
 export { extendSchema } from './extendSchema';


### PR DESCRIPTION
We were using this in graphql-tools with graphql@0.11, would be nice to get it exported again!