### PR TITLE
Fix 'astFromValue' to correctly handle integers and strings

### DIFF
--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -819,7 +819,7 @@ describe('Introspection', () => {
     const TestInputObject = new GraphQLInputObjectType({
       name: 'TestInputObject',
       fields: {
-        a: { type: GraphQLString, defaultValue: 'foo' },
+        a: { type: GraphQLString, defaultValue: 'tes\t de\fault' },
         b: { type: GraphQLList(GraphQLString) },
         c: { type: GraphQLString, defaultValue: null },
       },
@@ -839,15 +839,13 @@ describe('Introspection', () => {
     const schema = new GraphQLSchema({ query: TestType });
     const request = `
       {
-        __schema {
-          types {
-            kind
+        __type(name: "TestInputObject") {
+          kind
+          name
+          inputFields {
             name
-            inputFields {
-              name
-              type { ...TypeRef }
-              defaultValue
-            }
+            type { ...TypeRef }
+            defaultValue
           }
         }
       }
@@ -870,46 +868,42 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(graphqlSync(schema, request)).to.containSubset({
+    return expect(graphqlSync(schema, request)).to.deep.equal({
       data: {
-        __schema: {
-          types: [
+        __type: {
+          kind: 'INPUT_OBJECT',
+          name: 'TestInputObject',
+          inputFields: [
             {
-              kind: 'INPUT_OBJECT',
-              name: 'TestInputObject',
-              inputFields: [
-                {
-                  name: 'a',
-                  type: {
-                    kind: 'SCALAR',
-                    name: 'String',
-                    ofType: null,
-                  },
-                  defaultValue: '"foo"',
+              name: 'a',
+              type: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+              defaultValue: '"tes\\t de\\fault"',
+            },
+            {
+              name: 'b',
+              type: {
+                kind: 'LIST',
+                name: null,
+                ofType: {
+                  kind: 'SCALAR',
+                  name: 'String',
+                  ofType: null,
                 },
-                {
-                  name: 'b',
-                  type: {
-                    kind: 'LIST',
-                    name: null,
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'String',
-                      ofType: null,
-                    },
-                  },
-                  defaultValue: null,
-                },
-                {
-                  name: 'c',
-                  type: {
-                    kind: 'SCALAR',
-                    name: 'String',
-                    ofType: null,
-                  },
-                  defaultValue: 'null',
-                },
-              ],
+              },
+              defaultValue: null,
+            },
+            {
+              name: 'c',
+              type: {
+                kind: 'SCALAR',
+                name: 'String',
+                ofType: null,
+              },
+              defaultValue: 'null',
             },
           ],
         },

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -58,6 +58,11 @@ describe('astFromValue', () => {
   });
 
   it('converts Int values to Int ASTs', () => {
+    expect(astFromValue(-1, GraphQLInt)).to.deep.equal({
+      kind: 'IntValue',
+      value: '-1',
+    });
+
     expect(astFromValue(123.0, GraphQLInt)).to.deep.equal({
       kind: 'IntValue',
       value: '123',
@@ -81,6 +86,11 @@ describe('astFromValue', () => {
   });
 
   it('converts Float values to Int/Float ASTs', () => {
+    expect(astFromValue(-1, GraphQLFloat)).to.deep.equal({
+      kind: 'IntValue',
+      value: '-1',
+    });
+
     expect(astFromValue(123.0, GraphQLFloat)).to.deep.equal({
       kind: 'IntValue',
       value: '123',
@@ -115,7 +125,7 @@ describe('astFromValue', () => {
 
     expect(astFromValue('VA\nLUE', GraphQLString)).to.deep.equal({
       kind: 'StringValue',
-      value: 'VA\\nLUE',
+      value: 'VA\nLUE',
     });
 
     expect(astFromValue(123, GraphQLString)).to.deep.equal({
@@ -149,13 +159,28 @@ describe('astFromValue', () => {
     // Note: EnumValues cannot contain non-identifier characters
     expect(astFromValue('VA\nLUE', GraphQLID)).to.deep.equal({
       kind: 'StringValue',
-      value: 'VA\\nLUE',
+      value: 'VA\nLUE',
     });
 
     // Note: IntValues are used when possible.
+    expect(astFromValue(-1, GraphQLID)).to.deep.equal({
+      kind: 'IntValue',
+      value: '-1',
+    });
+
     expect(astFromValue(123, GraphQLID)).to.deep.equal({
       kind: 'IntValue',
       value: '123',
+    });
+
+    expect(astFromValue('123', GraphQLID)).to.deep.equal({
+      kind: 'IntValue',
+      value: '123',
+    });
+
+    expect(astFromValue('01', GraphQLID)).to.deep.equal({
+      kind: 'StringValue',
+      value: '01',
     });
 
     expect(astFromValue(false, GraphQLID)).to.deep.equal({

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -197,6 +197,22 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('Prints String Field With String Arg With Default', () => {
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      args: { argOne: { type: GraphQLString, defaultValue: 'tes\t de\fault' } },
+    });
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
+
+      type Root {
+        singleField(argOne: String = "tes\t de\fault"): String
+      }
+    `);
+  });
+
   it('Prints String Field With Int Arg With Default Null', () => {
     const output = printSingleFieldSchema({
       type: GraphQLString,


### PR DESCRIPTION
Currently `astFromValue` converts `-1` to float, `0000` to integer and also escapes strings when it shouldn't.