### PR TITLE
[WIP] Add 'sortIntrospectionQuery' utility function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -307,6 +307,8 @@ export {
   getIntrospectionQuery,
   // Deprecated: use getIntrospectionQuery
   introspectionQuery,
+  // Sort the result of Introspection Query.
+  sortIntrospectionQuery,
   // Gets the target Operation from a Document
   getOperationAST,
   // Build a GraphQLSchema from an introspection result.

--- a/src/utilities/__tests__/sortIntrospection-test.js
+++ b/src/utilities/__tests__/sortIntrospection-test.js
@@ -1,0 +1,321 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import dedent from '../../jsutils/dedent';
+import { graphqlSync } from '../../graphql';
+import { printSchema } from '../schemaPrinter';
+import { buildSchema } from '../buildASTSchema';
+import { buildClientSchema } from '../buildClientSchema';
+import { getIntrospectionQuery } from '../introspectionQuery';
+import { sortIntrospectionQuery } from '../sortIntrospection';
+
+function sortSDL(sdl) {
+  const schema = buildSchema(sdl);
+  const result = graphqlSync(schema, getIntrospectionQuery());
+  expect(result.errors).to.equal(undefined);
+  const introspection = sortIntrospectionQuery(result.data);
+  const sortedSchema = buildClientSchema(introspection);
+  return printSchema(sortedSchema);
+}
+
+describe('sortIntrospectionSchema', () => {
+  it('sort fields', () => {
+    const sorted = sortSDL(dedent`
+      input Bar {
+        barB: String
+        barA: String
+        barC: String
+      }
+
+      interface FooInterface {
+        fooB: String
+        fooA: String
+        fooC: String
+      }
+
+      type FooType implements FooInterface {
+        fooC: String
+        fooA: String
+        fooB: String
+      }
+
+      type Query {
+        dummy(arg: Bar): FooType
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      input Bar {
+        barA: String
+        barB: String
+        barC: String
+      }
+
+      interface FooInterface {
+        fooA: String
+        fooB: String
+        fooC: String
+      }
+
+      type FooType implements FooInterface {
+        fooA: String
+        fooB: String
+        fooC: String
+      }
+
+      type Query {
+        dummy(arg: Bar): FooType
+      }
+    `);
+  });
+
+  it('sort implemented interfaces', () => {
+    const sorted = sortSDL(dedent`
+      interface FooA {
+        dummy: String
+      }
+
+      interface FooB {
+        dummy: String
+      }
+
+      interface FooC {
+        dummy: String
+      }
+
+      type Query implements FooB & FooA & FooC {
+        dummy: String
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      interface FooA {
+        dummy: String
+      }
+
+      interface FooB {
+        dummy: String
+      }
+
+      interface FooC {
+        dummy: String
+      }
+
+      type Query implements FooA, FooB, FooC {
+        dummy: String
+      }
+    `);
+  });
+
+  it('sort types in union', () => {
+    const sorted = sortSDL(dedent`
+      type FooA {
+        dummy: String
+      }
+
+      type FooB {
+        dummy: String
+      }
+
+      type FooC {
+        dummy: String
+      }
+
+      union FooUnion = FooB | FooA | FooC
+
+      type Query {
+        dummy: FooUnion
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      type FooA {
+        dummy: String
+      }
+
+      type FooB {
+        dummy: String
+      }
+
+      type FooC {
+        dummy: String
+      }
+
+      union FooUnion = FooA | FooB | FooC
+
+      type Query {
+        dummy: FooUnion
+      }
+    `);
+  });
+
+  it('sort enum values', () => {
+    const sorted = sortSDL(dedent`
+      enum Foo {
+        B
+        C
+        A
+      }
+
+      type Query {
+        dummy: Foo
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      enum Foo {
+        A
+        B
+        C
+      }
+
+      type Query {
+        dummy: Foo
+      }
+    `);
+  });
+
+  it('sort field arguments', () => {
+    const sorted = sortSDL(dedent`
+      type Query {
+        dummy(argB: Int, argA: String, argC: Float): ID
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      type Query {
+        dummy(argA: String, argB: Int, argC: Float): ID
+      }
+    `);
+  });
+
+  it('sort types', () => {
+    const sorted = sortSDL(dedent`
+      type Query {
+        dummy(arg1: FooF, arg2: FooA, arg3: FooG): FooD
+      }
+
+      type FooC implements FooE {
+        dummy: String
+      }
+
+      enum FooG {
+        enumValue
+      }
+
+      scalar FooA
+
+      input FooF {
+        dummy: String
+      }
+
+      union FooD = FooC | FooB
+
+      interface FooE {
+        dummy: String
+      }
+
+      type FooB {
+        dummy: String
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      scalar FooA
+
+      type FooB {
+        dummy: String
+      }
+
+      type FooC implements FooE {
+        dummy: String
+      }
+
+      union FooD = FooB | FooC
+
+      interface FooE {
+        dummy: String
+      }
+
+      input FooF {
+        dummy: String
+      }
+
+      enum FooG {
+        enumValue
+      }
+
+      type Query {
+        dummy(arg1: FooF, arg2: FooA, arg3: FooG): FooD
+      }
+    `);
+  });
+
+  it('sort directive arguments', () => {
+    const sorted = sortSDL(dedent`
+      directive @test(argC: Float, argA: String, argB: Int) on FIELD
+
+      type Query {
+        dummy: String
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      directive @test(argA: String, argB: Int, argC: Float) on FIELD
+
+      type Query {
+        dummy: String
+      }
+    `);
+  });
+
+  it('sort directive locations', () => {
+    const sorted = sortSDL(dedent`
+      directive @test(argC: Float, argA: String, argB: Int) on UNION | FIELD | ENUM
+
+      type Query {
+        dummy: String
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      directive @test(argA: String, argB: Int, argC: Float) on ENUM | FIELD | UNION
+
+      type Query {
+        dummy: String
+      }
+    `);
+  });
+
+  it('sort directives', () => {
+    const sorted = sortSDL(dedent`
+      directive @fooC on FIELD
+
+      directive @fooB on UNION
+
+      directive @fooA on ENUM
+
+      type Query {
+        dummy: String
+      }
+    `);
+
+    expect(sorted).to.equal(dedent`
+      directive @fooA on ENUM
+
+      directive @fooB on UNION
+
+      directive @fooC on FIELD
+
+      type Query {
+        dummy: String
+      }
+    `);
+  });
+});

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -38,6 +38,9 @@ export type {
   IntrospectionDirective,
 } from './introspectionQuery';
 
+// Sort the result of Introspection Query.
+export { sortIntrospectionQuery } from './sortIntrospection';
+
 // Gets the target Operation from a Document
 export { getOperationAST } from './getOperationAST';
 

--- a/src/utilities/sortIntrospection.js
+++ b/src/utilities/sortIntrospection.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {
+  IntrospectionQuery,
+  IntrospectionType,
+  IntrospectionField,
+  IntrospectionDirective,
+} from './introspectionQuery';
+
+/**
+ * Sort the result of Introspection Query.
+ */
+export function sortIntrospectionQuery(
+  introspection: IntrospectionQuery,
+): IntrospectionQuery {
+  const schema = introspection.__schema;
+  return {
+    __schema: {
+      queryType: schema.queryType,
+      mutationType: schema.mutationType,
+      subscriptionType: schema.subscriptionType,
+      types: sortByName(schema.types, sortType),
+      directives: sortByName(schema.directives, sortDirective),
+    },
+  };
+}
+
+function sortDirective(
+  directive: IntrospectionDirective,
+): IntrospectionDirective {
+  return {
+    name: directive.name,
+    description: directive.description,
+    locations: sortBy(directive.locations, x => x),
+    args: sortByName(directive.args),
+  };
+}
+
+function sortType(type: IntrospectionType): IntrospectionType {
+  switch (type.kind) {
+    case 'OBJECT':
+      return {
+        kind: 'OBJECT',
+        name: type.name,
+        description: type.description,
+        fields: sortFields(type.fields),
+        interfaces: sortByName(type.interfaces),
+      };
+    case 'INTERFACE':
+      return {
+        kind: 'INTERFACE',
+        name: type.name,
+        description: type.description,
+        fields: sortFields(type.fields),
+        possibleTypes: sortByName(type.possibleTypes),
+      };
+    case 'UNION':
+      return {
+        kind: 'UNION',
+        name: type.name,
+        description: type.description,
+        possibleTypes: sortByName(type.possibleTypes),
+      };
+    case 'ENUM':
+      return {
+        kind: 'ENUM',
+        name: type.name,
+        description: type.description,
+        enumValues: sortByName(type.enumValues),
+      };
+    case 'INPUT_OBJECT':
+      return {
+        kind: 'INPUT_OBJECT',
+        name: type.name,
+        description: type.description,
+        inputFields: sortByName(type.inputFields),
+      };
+    case 'SCALAR':
+      return type;
+    default:
+      throw new Error('Unexpected value kind: ' + (type.kind: empty));
+  }
+}
+
+function sortFields(
+  fields: $ReadOnlyArray<IntrospectionField>,
+): $ReadOnlyArray<IntrospectionField> {
+  return sortByName(fields, field => ({
+    name: field.name,
+    description: field.description,
+    args: sortByName(field.args),
+    type: field.type,
+    isDeprecated: field.isDeprecated,
+    deprecationReason: field.deprecationReason,
+  }));
+}
+
+function sortByName<T: { +name: string }>(
+  array: $ReadOnlyArray<T>,
+  sortValue?: T => T,
+): $ReadOnlyArray<T> {
+  return sortBy(array, obj => obj.name, sortValue);
+}
+
+function sortBy<T>(
+  array: $ReadOnlyArray<T>,
+  mapToKey: T => string,
+  sortValue?: T => T,
+): $ReadOnlyArray<T> {
+  if (array == null || !Array.isArray(array)) {
+    return array;
+  }
+
+  const newArray = sortValue ? array.map(sortValue) : array.slice();
+  return newArray.sort((obj1, obj2) => {
+    const key1 = mapToKey(obj1);
+    const key2 = mapToKey(obj2);
+    return key1.localeCompare(key2);
+  });
+}


### PR DESCRIPTION
Based on discussion in #941 and #889
Some of GraphQL servers doesn't preserve the order of types/fields and we need to sort them to provide consistent results. I think it is the primary use case for schema sorting so it makes sense to sort the result of introspection query and it makes implementation super simple. 

As for other use-cases (e.g. tests) you can query introspection with `graphqlSync` then sort it and build sorted schema using `buildClientSchema`.