### PR TITLE
getTypeMap() does not include input types used in directives

### DIFF
--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -10,6 +10,8 @@ import {
   GraphQLInterfaceType,
   GraphQLObjectType,
   GraphQLString,
+  GraphQLInputObjectType,
+  GraphQLDirective,
 } from '../';
 
 import { describe, it } from 'mocha';
@@ -26,6 +28,25 @@ const ImplementingType = new GraphQLObjectType({
   fields: { fieldName: { type: GraphQLString, resolve: () => '' } },
 });
 
+const DirectiveInputType = new GraphQLInputObjectType({
+  name: 'DirInput',
+  fields: {
+    field: {
+      type: GraphQLString,
+    },
+  },
+});
+
+const Directive = new GraphQLDirective({
+  name: 'dir',
+  locations: ['OBJECT'],
+  args: {
+    arg: {
+      type: DirectiveInputType,
+    },
+  },
+});
+
 const Schema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: 'Query',
@@ -38,6 +59,7 @@ const Schema = new GraphQLSchema({
       },
     },
   }),
+  directives: [Directive],
 });
 
 describe('Type System: Schema', () => {
@@ -51,6 +73,12 @@ describe('Type System: Schema', () => {
           'Check that schema.types is defined and is an array of all possible ' +
           'types in the schema.',
       );
+    });
+  });
+
+  describe('Type Map', () => {
+    it('includes input types only used in directives', () => {
+      expect(Schema.getTypeMap()).to.include.key('DirInput');
     });
   });
 });

--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -16,6 +16,7 @@ import {
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import { GraphQLList } from '../wrappers';
 
 const InterfaceType = new GraphQLInterfaceType({
   name: 'Interface',
@@ -37,12 +38,24 @@ const DirectiveInputType = new GraphQLInputObjectType({
   },
 });
 
+const WrappedDirectiveInputType = new GraphQLInputObjectType({
+  name: 'WrappedDirInput',
+  fields: {
+    field: {
+      type: GraphQLString,
+    },
+  },
+});
+
 const Directive = new GraphQLDirective({
   name: 'dir',
   locations: ['OBJECT'],
   args: {
     arg: {
       type: DirectiveInputType,
+    },
+    argList: {
+      type: new GraphQLList(WrappedDirectiveInputType),
     },
   },
 });
@@ -79,6 +92,7 @@ describe('Type System: Schema', () => {
   describe('Type Map', () => {
     it('includes input types only used in directives', () => {
       expect(Schema.getTypeMap()).to.include.key('DirInput');
+      expect(Schema.getTypeMap()).to.include.key('WrappedDirInput');
     });
   });
 });

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -13,7 +13,6 @@ import {
   isUnionType,
   isInputObjectType,
   isWrappingType,
-  getNamedType,
 } from './definition';
 import type {
   GraphQLType,
@@ -126,14 +125,17 @@ export class GraphQLSchema {
       initialTypes = initialTypes.concat(types);
     }
 
-    initialTypes = initialTypes.concat(
-      ...this._directives.map(directive => getDirectiveArgTypes(directive)),
-    );
+    // Keep track of all types referenced within the schema.
+    let typeMap: TypeMap = Object.create(null);
 
-    this._typeMap = initialTypes.reduce(
-      typeMapReducer,
-      (Object.create(null): TypeMap),
-    );
+    // First by deeply visiting all initial types.
+    typeMap = initialTypes.reduce(typeMapReducer, typeMap);
+
+    // Then by deeply visiting all directive types.
+    typeMap = this._directives.reduce(typeMapDirectiveReducer, typeMap);
+
+    // Storing the resulting map for reference by the schema.
+    this._typeMap = typeMap;
 
     // Keep track of all implementations by interface name.
     this._implementations = Object.create(null);
@@ -279,10 +281,16 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   return reducedMap;
 }
 
-function getDirectiveArgTypes(directive: GraphQLDirective) {
-  // directives are not validated until validateSchema() is called, so be defensive
+function typeMapDirectiveReducer(
+  map: TypeMap,
+  directive: ?GraphQLDirective,
+): TypeMap {
+  // Directives are not validated until validateSchema() is called.
   if (!isDirective(directive)) {
-    return [];
+    return map;
   }
-  return directive.args.map(arg => arg.type);
+  return directive.args.reduce(
+    (_map, arg) => typeMapReducer(_map, arg.type),
+    map,
+  );
 }


### PR DESCRIPTION
The result of `getTypeMap()` recursively includes all types referenced by root types, so I would expect it to include types referenced by directives, too.

If this is not intended, I think a test asserting the opposite would be a good idea.