### PR TITLE
Export 'GraphQLSchemaConfig' & 'GraphQLDirectiveConfig' types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,6 +138,7 @@ export type {
   GraphQLNullableType,
   GraphQLNamedType,
   Thunk,
+  GraphQLSchemaConfig,
   GraphQLArgument,
   GraphQLArgumentConfig,
   GraphQLEnumTypeConfig,
@@ -163,6 +164,7 @@ export type {
   GraphQLScalarTypeConfig,
   GraphQLTypeResolver,
   GraphQLUnionTypeConfig,
+  GraphQLDirectiveConfig,
 } from './type';
 
 // Parse and operate on GraphQL language source files.

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -76,7 +76,7 @@ export class GraphQLDirective {
   }
 }
 
-type GraphQLDirectiveConfig = {
+export type GraphQLDirectiveConfig = {
   name: string,
   description?: ?string,
   locations: Array<DirectiveLocationEnum>,

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -14,6 +14,8 @@ export {
   GraphQLSchema,
 } from './schema';
 
+export type { GraphQLSchemaConfig } from './schema';
+
 export {
   // Predicates
   isType,
@@ -83,6 +85,8 @@ export {
   // Constant Deprecation Reason
   DEFAULT_DEPRECATION_REASON,
 } from './directives';
+
+export type { GraphQLDirectiveConfig } from './directives';
 
 // Common built-in scalar instances.
 export {

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -209,7 +209,7 @@ export class GraphQLSchema {
 
 type TypeMap = ObjMap<GraphQLNamedType>;
 
-type GraphQLSchemaConfig = {
+export type GraphQLSchemaConfig = {
   query?: ?GraphQLObjectType,
   mutation?: ?GraphQLObjectType,
   subscription?: ?GraphQLObjectType,


### PR DESCRIPTION
I need them to do schema transformations.
All other `*Config` types already exported.