### PR TITLE
Allow use of legacy names for schema validation

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -407,6 +407,43 @@ describe('Type System: Objects must have fields', () => {
       },
     ]);
   });
+
+  it('accepts an Object type with explicitly allowed legacy named fields', () => {
+    const schemaBad = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: { __badName: { type: GraphQLString } },
+      }),
+    });
+    const schemaOk = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: { __badName: { type: GraphQLString } },
+      }),
+      allowedLegacyNames: ['__badName'],
+    });
+    expect(validateSchema(schemaBad)).to.containSubset([
+      {
+        message:
+          'Name "__badName" must not begin with "__", which is reserved by ' +
+          'GraphQL introspection.',
+      },
+    ]);
+    expect(validateSchema(schemaOk)).to.deep.equal([]);
+  });
+
+  it('throws with bad value for explicitly allowed legacy names', () => {
+    expect(
+      () =>
+        new GraphQLSchema({
+          query: new GraphQLObjectType({
+            name: 'Query',
+            fields: { __badName: { type: GraphQLString } },
+          }),
+          allowedLegacyNames: true,
+        }),
+    ).to.throw('"allowedLegacyNames" must be Array if provided but got: true.');
+  });
 });
 
 describe('Type System: Fields args must be properly named', () => {

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -81,6 +81,8 @@ export class GraphQLSchema {
   _possibleTypeMap: ?ObjMap<ObjMap<boolean>>;
   // Used as a cache for validateSchema().
   __validationErrors: ?$ReadOnlyArray<GraphQLError>;
+  // Referenced by validateSchema().
+  __allowedLegacyNames: ?$ReadOnlyArray<string>;
 
   constructor(config: GraphQLSchemaConfig): void {
     // If this schema was built from a source known to be valid, then it may be
@@ -103,6 +105,12 @@ export class GraphQLSchema {
         '"directives" must be Array if provided but got: ' +
           `${String(config.directives)}.`,
       );
+      invariant(
+        !config.allowedLegacyNames || Array.isArray(config.allowedLegacyNames),
+        '"allowedLegacyNames" must be Array if provided but got: ' +
+          `${String(config.allowedLegacyNames)}.`,
+      );
+      this.__allowedLegacyNames = config.allowedLegacyNames;
     }
 
     this._queryType = config.query;
@@ -228,6 +236,15 @@ type GraphQLSchemaConfig = {
   directives?: ?Array<GraphQLDirective>,
   astNode?: ?SchemaDefinitionNode,
   assumeValid?: boolean,
+  /**
+   * If provided, the schema will consider fields or types with names included
+   * in this list valid, even if they do not adhere to the specification's
+   * schema validation rules.
+   *
+   * This option is provided to ease adoption and may be removed in a future
+   * major release.
+   */
+  allowedLegacyNames?: ?Array<string>,
 };
 
 function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {


### PR DESCRIPTION
This offers an escape hatch for schema that are defined with legacy field names that were valid in older versions of the spec and no longer are via an explicit white-list.

Fixes #1184