### PR TITLE
[WIP] Transfrorm schema API

### DIFF
--- a/src/utilities/lexicographicSortSchema.js
+++ b/src/utilities/lexicographicSortSchema.js
@@ -18,13 +18,13 @@ import {
   GraphQLEnumType,
   GraphQLInputObjectType,
 } from '../type/definition';
-import { transformSchema } from './transformSchema';
+import { SchemaTransformer } from './transformSchema';
 
 /**
  * Sort GraphQLSchema.
  */
 export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
-  return transformSchema(schema, {
+  const transformer = new SchemaTransformer(schema, {
     Schema(config) {
       return new GraphQLSchema({
         ...config,
@@ -74,6 +74,8 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
       });
     },
   });
+
+  return transformer.transformSchema();
 }
 
 function sortFields(fields) {

--- a/src/utilities/lexicographicSortSchema.js
+++ b/src/utilities/lexicographicSortSchema.js
@@ -8,173 +8,82 @@
  */
 
 import type { ObjMap } from '../jsutils/ObjMap';
-import keyValMap from '../jsutils/keyValMap';
-import objectValues from '../jsutils/objectValues';
 import { GraphQLSchema } from '../type/schema';
 import { GraphQLDirective } from '../type/directives';
-import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
-import type { GraphQLNamedType } from '../type/definition';
 import {
+  GraphQLScalarType,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  isListType,
-  isNonNullType,
-  isScalarType,
-  isObjectType,
-  isInterfaceType,
-  isUnionType,
-  isEnumType,
-  isInputObjectType,
 } from '../type/definition';
-import { isSpecifiedScalarType } from '../type/scalars';
-import { isIntrospectionType } from '../type/introspection';
+import { transformSchema } from './transformSchema';
 
 /**
  * Sort GraphQLSchema.
  */
 export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
-  const cache = Object.create(null);
-
-  const sortMaybeType = maybeType => maybeType && sortNamedType(maybeType);
-  return new GraphQLSchema({
-    types: sortTypes(objectValues(schema.getTypeMap())),
-    directives: sortByName(schema.getDirectives()).map(sortDirective),
-    query: sortMaybeType(schema.getQueryType()),
-    mutation: sortMaybeType(schema.getMutationType()),
-    subscription: sortMaybeType(schema.getSubscriptionType()),
-    astNode: schema.astNode,
-  });
-
-  function sortDirective(directive) {
-    return new GraphQLDirective({
-      name: directive.name,
-      description: directive.description,
-      locations: sortBy(directive.locations, x => x),
-      args: sortArgs(directive.args),
-      astNode: directive.astNode,
-    });
-  }
-
-  function sortArgs(args) {
-    return keyValMap(
-      sortByName(args),
-      arg => arg.name,
-      arg => ({
-        ...arg,
-        type: sortType(arg.type),
-      }),
-    );
-  }
-
-  function sortFields(fieldsMap) {
-    return sortObjMap(fieldsMap, field => ({
-      type: sortType(field.type),
-      args: sortArgs(field.args),
-      resolve: field.resolve,
-      subscribe: field.subscribe,
-      deprecationReason: field.deprecationReason,
-      description: field.description,
-      astNode: field.astNode,
-    }));
-  }
-
-  function sortInputFields(fieldsMap) {
-    return sortObjMap(fieldsMap, field => ({
-      type: sortType(field.type),
-      defaultValue: field.defaultValue,
-      description: field.description,
-      astNode: field.astNode,
-    }));
-  }
-
-  function sortType(type) {
-    if (isListType(type)) {
-      return new GraphQLList(sortType(type.ofType));
-    } else if (isNonNullType(type)) {
-      return new GraphQLNonNull(sortType(type.ofType));
-    }
-    return sortNamedType(type);
-  }
-
-  function sortTypes<T: GraphQLNamedType>(arr: Array<T>): Array<T> {
-    return sortByName(arr).map(sortNamedType);
-  }
-
-  function sortNamedType<T: GraphQLNamedType>(type: T): T {
-    if (isSpecifiedScalarType(type) || isIntrospectionType(type)) {
-      return type;
-    }
-
-    let sortedType = cache[type.name];
-    if (!sortedType) {
-      sortedType = sortNamedTypeImpl(type);
-      cache[type.name] = sortedType;
-    }
-    return ((sortedType: any): T);
-  }
-
-  function sortNamedTypeImpl(type) {
-    if (isScalarType(type)) {
-      return type;
-    } else if (isObjectType(type)) {
+  return transformSchema(schema, {
+    Schema(config) {
+      return new GraphQLSchema({
+        ...config,
+        types: sortByName(config.types),
+        directives: sortByName(config.directives),
+      });
+    },
+    Directive(config) {
+      return new GraphQLDirective({
+        ...config,
+        locations: sortBy(config.locations, x => x),
+        args: sortObjMap(config.args),
+      });
+    },
+    ScalarType(config) {
+      return new GraphQLScalarType(config);
+    },
+    ObjectType(config) {
       return new GraphQLObjectType({
-        name: type.name,
-        interfaces: () => sortTypes(type.getInterfaces()),
-        fields: () => sortFields(type.getFields()),
-        isTypeOf: type.isTypeOf,
-        description: type.description,
-        astNode: type.astNode,
-        extensionASTNodes: type.extensionASTNodes,
+        ...config,
+        fields: () => sortFields(config.fields()),
+        interfaces: () => sortByName(config.interfaces()),
       });
-    } else if (isInterfaceType(type)) {
+    },
+    InterfaceType(config) {
       return new GraphQLInterfaceType({
-        name: type.name,
-        fields: () => sortFields(type.getFields()),
-        resolveType: type.resolveType,
-        description: type.description,
-        astNode: type.astNode,
-        extensionASTNodes: type.extensionASTNodes,
+        ...config,
+        fields: () => sortFields(config.fields()),
       });
-    } else if (isUnionType(type)) {
+    },
+    UnionType(config) {
       return new GraphQLUnionType({
-        name: type.name,
-        types: () => sortTypes(type.getTypes()),
-        resolveType: type.resolveType,
-        description: type.description,
-        astNode: type.astNode,
+        ...config,
+        types: () => sortByName(config.types()),
       });
-    } else if (isEnumType(type)) {
+    },
+    EnumType(config) {
       return new GraphQLEnumType({
-        name: type.name,
-        values: keyValMap(
-          sortByName(type.getValues()),
-          val => val.name,
-          val => ({
-            value: val.value,
-            deprecationReason: val.deprecationReason,
-            description: val.description,
-            astNode: val.astNode,
-          }),
-        ),
-        description: type.description,
-        astNode: type.astNode,
+        ...config,
+        values: sortObjMap(config.values),
       });
-    } else if (isInputObjectType(type)) {
+    },
+    InputObjectType(config) {
       return new GraphQLInputObjectType({
-        name: type.name,
-        fields: () => sortInputFields(type.getFields()),
-        description: type.description,
-        astNode: type.astNode,
+        ...config,
+        fields: () => sortObjMap(config.fields()),
       });
-    }
-    throw new Error(`Unknown type: "${type}"`);
-  }
+    },
+  });
 }
 
-function sortObjMap<T, R>(map: ObjMap<T>, sortValueFn?: T => R): ObjMap<R> {
+function sortFields(fields) {
+  return sortObjMap(fields, field => ({
+    ...field,
+    args: sortObjMap(field.args),
+  }));
+}
+
+function sortObjMap<T>(map: ObjMap<T>, sortValueFn?: T => T): ObjMap<T> {
   const sortedMap = Object.create(null);
   const sortedKeys = sortBy(Object.keys(map), x => x);
   for (const key of sortedKeys) {
@@ -184,11 +93,11 @@ function sortObjMap<T, R>(map: ObjMap<T>, sortValueFn?: T => R): ObjMap<R> {
   return sortedMap;
 }
 
-function sortByName<T: { +name: string }>(array: $ReadOnlyArray<T>): Array<T> {
+function sortByName<T: { +name: string }>(array: Array<T>): Array<T> {
   return sortBy(array, obj => obj.name);
 }
 
-function sortBy<T>(array: $ReadOnlyArray<T>, mapToKey: T => string): Array<T> {
+function sortBy<T>(array: Array<T>, mapToKey: T => string): Array<T> {
   return array.slice().sort((obj1, obj2) => {
     const key1 = mapToKey(obj1);
     const key2 = mapToKey(obj2);

--- a/src/utilities/transformSchema.js
+++ b/src/utilities/transformSchema.js
@@ -1,0 +1,275 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type { ObjMap } from '../jsutils/ObjMap';
+import keyValMap from '../jsutils/keyValMap';
+import objectValues from '../jsutils/objectValues';
+import invariant from '../jsutils/invariant';
+import type { GraphQLSchemaConfig } from '../type/schema';
+import { GraphQLSchema } from '../type/schema';
+import { isSpecifiedScalarType } from '../type/scalars';
+import { isIntrospectionType } from '../type/introspection';
+import type { GraphQLDirectiveConfig } from '../type/directives';
+import { GraphQLDirective } from '../type/directives';
+import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
+import type {
+  GraphQLNamedType,
+  GraphQLScalarTypeConfig,
+  GraphQLObjectTypeConfig,
+  GraphQLInterfaceTypeConfig,
+  GraphQLUnionTypeConfig,
+  GraphQLEnumTypeConfig,
+  GraphQLInputObjectTypeConfig,
+} from '../type/definition';
+import {
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  isListType,
+  isNonNullType,
+  isScalarType,
+  isObjectType,
+  isInterfaceType,
+  isUnionType,
+  isEnumType,
+  isInputObjectType,
+} from '../type/definition';
+
+type ExactSchemaConfig = $Exact<GraphQLSchemaConfig> & {
+  types: Array<*>,
+  directives: Array<*>,
+};
+
+type ExactDirectiveConfig = $Exact<GraphQLDirectiveConfig> & {
+  args: ObjMap<*>,
+};
+
+type ExactScalarTypeConfig = $Exact<GraphQLScalarTypeConfig<*, *>>;
+
+type ExactObjectTypeConfig = $Exact<GraphQLObjectTypeConfig<*, *>> & {
+  fields: () => ObjMap<*>,
+  interfaces: () => Array<*>,
+  extensionASTNodes: $ReadOnlyArray<*>,
+};
+
+type ExactInterfaceTypeConfig = $Exact<GraphQLInterfaceTypeConfig<*, *>> & {
+  fields: () => ObjMap<*>,
+  extensionASTNodes: $ReadOnlyArray<*>,
+};
+
+type ExactUnionTypeConfig = $Exact<GraphQLUnionTypeConfig<*, *>> & {
+  types: () => Array<*>,
+};
+
+type ExactEnumTypeConfig = $Exact<GraphQLEnumTypeConfig>;
+
+type ExactInputObjectTypeConfig = $Exact<GraphQLInputObjectTypeConfig> & {
+  fields: () => ObjMap<*>,
+};
+
+type TypeTransformer = {
+  Schema?: (config: ExactSchemaConfig) => GraphQLSchema,
+  Directive?: (config: ExactDirectiveConfig) => GraphQLDirective,
+  ScalarType?: (config: ExactScalarTypeConfig) => GraphQLScalarType,
+  ObjectType?: (config: ExactObjectTypeConfig) => GraphQLObjectType,
+  InterfaceType?: (config: ExactInterfaceTypeConfig) => GraphQLInterfaceType,
+  UnionType?: (config: ExactUnionTypeConfig) => GraphQLUnionType,
+  EnumType?: (config: ExactEnumTypeConfig) => GraphQLEnumType,
+  InputObjectType?: (
+    config: ExactInputObjectTypeConfig,
+  ) => GraphQLInputObjectType,
+};
+
+export function transformSchema(
+  schema: GraphQLSchema,
+  transformer: TypeTransformer,
+): GraphQLSchema {
+  const cache: ObjMap<GraphQLNamedType> = Object.create(null);
+  const transformMaybeType = maybeType =>
+    maybeType && transformNamedType(maybeType);
+  const schemaConfig = {
+    types: objectValues(schema.getTypeMap()).map(transformNamedType),
+    directives: schema.getDirectives().map(transformDirective),
+    query: transformMaybeType(schema.getQueryType()),
+    mutation: transformMaybeType(schema.getMutationType()),
+    subscription: transformMaybeType(schema.getSubscriptionType()),
+    astNode: schema.astNode,
+  };
+  return transformer.Schema
+    ? transformer.Schema(schemaConfig)
+    : new GraphQLSchema(schemaConfig);
+
+  function transformDirective(directive) {
+    const config = {
+      name: directive.name,
+      description: directive.description,
+      locations: directive.locations,
+      args: transformArgs(directive.args),
+      astNode: directive.astNode,
+    };
+    return transformer.Directive
+      ? transformer.Directive(config)
+      : new GraphQLDirective(config);
+  }
+
+  function transformArgs(args) {
+    return keyValMap(
+      args,
+      arg => arg.name,
+      arg => ({
+        ...arg,
+        type: transformType(arg.type),
+      }),
+    );
+  }
+
+  function transformFields(fieldsMap) {
+    return () =>
+      mapValues(fieldsMap, field => ({
+        type: transformType(field.type),
+        args: transformArgs(field.args),
+        resolve: field.resolve,
+        subscribe: field.subscribe,
+        deprecationReason: field.deprecationReason,
+        description: field.description,
+        astNode: field.astNode,
+      }));
+  }
+
+  function transformInputFields(fieldsMap) {
+    return () =>
+      mapValues(fieldsMap, field => ({
+        type: transformType(field.type),
+        defaultValue: field.defaultValue,
+        description: field.description,
+        astNode: field.astNode,
+      }));
+  }
+
+  function transformType(type) {
+    if (isListType(type)) {
+      return new GraphQLList(transformType(type.ofType));
+    } else if (isNonNullType(type)) {
+      return new GraphQLNonNull(transformType(type.ofType));
+    }
+    return transformNamedType(type);
+  }
+
+  function transformTypes<T: GraphQLNamedType>(arr: Array<T>): () => Array<T> {
+    return () => arr.map(transformNamedType);
+  }
+
+  function transformNamedType<T: GraphQLNamedType>(type: T): T {
+    if (isSpecifiedScalarType(type) || isIntrospectionType(type)) {
+      return type;
+    }
+
+    let newType = cache[type.name];
+    if (!newType) {
+      newType = transformNamedTypeImpl(type);
+      cache[type.name] = newType;
+    }
+    invariant(type.constructor === newType.constructor);
+    invariant(type.name === newType.name);
+    return ((newType: any): T);
+  }
+
+  function transformNamedTypeImpl(type) {
+    if (isScalarType(type)) {
+      const config = {
+        name: type.name,
+        description: type.description,
+        astNode: type.astNode,
+        serialize: type._scalarConfig.serialize,
+        parseValue: type._scalarConfig.parseValue,
+        parseLiteral: type._scalarConfig.parseLiteral,
+      };
+      return transformer.ScalarType
+        ? transformer.ScalarType(config)
+        : new GraphQLScalarType(config);
+    } else if (isObjectType(type)) {
+      const config = {
+        name: type.name,
+        interfaces: transformTypes(type.getInterfaces()),
+        fields: transformFields(type.getFields()),
+        isTypeOf: type.isTypeOf,
+        description: type.description,
+        astNode: type.astNode,
+        extensionASTNodes: type.extensionASTNodes || [],
+      };
+      return transformer.ObjectType
+        ? transformer.ObjectType(config)
+        : new GraphQLObjectType(config);
+    } else if (isInterfaceType(type)) {
+      const config = {
+        name: type.name,
+        fields: transformFields(type.getFields()),
+        resolveType: type.resolveType,
+        description: type.description,
+        astNode: type.astNode,
+        extensionASTNodes: type.extensionASTNodes || [],
+      };
+      return transformer.InterfaceType
+        ? transformer.InterfaceType(config)
+        : new GraphQLInterfaceType(config);
+    } else if (isUnionType(type)) {
+      const config = {
+        name: type.name,
+        types: transformTypes(type.getTypes()),
+        resolveType: type.resolveType,
+        description: type.description,
+        astNode: type.astNode,
+      };
+      return transformer.UnionType
+        ? transformer.UnionType(config)
+        : new GraphQLUnionType(config);
+    } else if (isEnumType(type)) {
+      const config = {
+        name: type.name,
+        values: keyValMap(
+          type.getValues(),
+          val => val.name,
+          val => ({
+            value: val.value,
+            deprecationReason: val.deprecationReason,
+            description: val.description,
+            astNode: val.astNode,
+          }),
+        ),
+        description: type.description,
+        astNode: type.astNode,
+      };
+      return transformer.EnumType
+        ? transformer.EnumType(config)
+        : new GraphQLEnumType(config);
+    } else if (isInputObjectType(type)) {
+      const config = {
+        name: type.name,
+        fields: transformInputFields(type.getFields()),
+        description: type.description,
+        astNode: type.astNode,
+      };
+      return transformer.InputObjectType
+        ? transformer.InputObjectType(config)
+        : new GraphQLInputObjectType(config);
+    }
+    throw new Error(`Unknown type: "${type}"`);
+  }
+}
+
+function mapValues<T, R>(obj: ObjMap<T>, valFn: T => R): ObjMap<R> {
+  const newObj = Object.create(null);
+  for (const name of Object.keys(obj)) {
+    newObj[name] = valFn(obj[name]);
+  }
+  return newObj;
+}


### PR DESCRIPTION
As discussed in #1185 I rewrote sort function to sort `GraphQLSchema`.
In a process, I notice that `sortSchema` duplicates > 50% of code from `extendSchema` so I decided to extract common part.
After this change, `extendSchema` became way simpler and #1095 trivial to implement.
To make this PR easier to review I split it into two commits one implementing `sortSchema` and another changing `extendSchema`.

@leebyron What do you think?