### PR TITLE
Cleanup Enums

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -17,7 +17,7 @@ import type { ObjMap } from '../jsutils/ObjMap';
 import type { MaybePromise } from '../jsutils/MaybePromise';
 
 import { typeFromAST } from '../utilities/typeFromAST';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import {
   getVariableValues,
   getArgumentValues,

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -14,7 +14,7 @@ import keyMap from '../jsutils/keyMap';
 import { coerceValue } from '../utilities/coerceValue';
 import { typeFromAST } from '../utilities/typeFromAST';
 import { valueFromAST } from '../utilities/valueFromAST';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import { print } from '../language/printer';
 import { isInputType, isNonNullType } from '../type/definition';
 import type { ObjMap } from '../jsutils/ObjMap';

--- a/src/index.js
+++ b/src/index.js
@@ -247,6 +247,7 @@ export type {
   TypeExtensionNode,
   ObjectTypeExtensionNode,
   DirectiveDefinitionNode,
+  KindEnum,
   DirectiveLocationEnum,
 } from './language';
 

--- a/src/index.js
+++ b/src/index.js
@@ -248,6 +248,7 @@ export type {
   ObjectTypeExtensionNode,
   DirectiveDefinitionNode,
   KindEnum,
+  TokenKindEnum,
   DirectiveLocationEnum,
 } from './language';
 

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as Kind from '../kinds';
+import { Kind } from '../kinds';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { parse, parseValue, parseType } from '../parser';

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -15,7 +15,7 @@ import { join } from 'path';
 import { TypeInfo } from '../../utilities/TypeInfo';
 import { testSchema } from '../../validation/__tests__/harness';
 import { getNamedType, isCompositeType } from '../../type';
-import * as Kind from '../kinds';
+import { Kind } from '../kinds';
 
 function getNodeByPath(ast, path) {
   let result = ast;

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -8,6 +8,7 @@
  */
 
 import type { Source } from './source';
+import type { TokenKindEnum } from './lexer';
 
 /**
  * Contains a range of UTF-8 character offsets and token references that
@@ -41,35 +42,6 @@ export type Location = {
 };
 
 /**
- * Represents the different kinds of tokens in a GraphQL document.
- * This type is not inlined in `Token` to fix syntax highlighting on GitHub
- * *only*.
- */
-type TokenKind =
-  | '<SOF>'
-  | '<EOF>'
-  | '!'
-  | '$'
-  | '&'
-  | '('
-  | ')'
-  | '...'
-  | ':'
-  | '='
-  | '@'
-  | '['
-  | ']'
-  | '{'
-  | '|'
-  | '}'
-  | 'Name'
-  | 'Int'
-  | 'Float'
-  | 'String'
-  | 'BlockString'
-  | 'Comment';
-
-/**
  * Represents a range of characters represented by a lexical token
  * within a Source.
  */
@@ -77,7 +49,7 @@ export type Token = {
   /**
    * The kind of Token.
    */
-  +kind: TokenKind,
+  +kind: TokenKindEnum,
 
   /**
    * The character offset at which this Node begins.

--- a/src/language/directiveLocation.js
+++ b/src/language/directiveLocation.js
@@ -10,7 +10,7 @@
 /**
  * The set of allowed directive location values.
  */
-export const DirectiveLocation = {
+export const DirectiveLocation = Object.freeze({
   // Request Definitions
   QUERY: 'QUERY',
   MUTATION: 'MUTATION',
@@ -31,9 +31,9 @@ export const DirectiveLocation = {
   ENUM_VALUE: 'ENUM_VALUE',
   INPUT_OBJECT: 'INPUT_OBJECT',
   INPUT_FIELD_DEFINITION: 'INPUT_FIELD_DEFINITION',
-};
+});
 
 /**
  * The enum type representing the directive location values.
  */
-export type DirectiveLocationEnum = $Keys<typeof DirectiveLocation>;
+export type DirectiveLocationEnum = $Values<typeof DirectiveLocation>;

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -9,8 +9,8 @@
 
 export { getLocation } from './location';
 export type { SourceLocation } from './location';
-import * as Kind from './kinds';
-export { Kind };
+export { Kind } from './kinds';
+export type { KindEnum } from './kinds';
 export { createLexer, TokenKind } from './lexer';
 export { parse, parseValue, parseType } from './parser';
 export { print } from './printer';

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -24,7 +24,7 @@ export {
 } from './visitor';
 export type { ASTVisitor, Visitor, VisitFn, VisitorKeyMap } from './visitor';
 
-export type { Lexer } from './lexer';
+export type { Lexer, TokenKindEnum } from './lexer';
 export type { ParseOptions } from './parser';
 
 export type {

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -7,74 +7,74 @@
  * @flow
  */
 
-// Name
+/**
+ * The set of allowed kind values for AST nodes.
+ */
+export const Kind = Object.freeze({
+  // Name
+  NAME: 'Name',
 
-export const NAME = 'Name';
+  // Document
+  DOCUMENT: 'Document',
+  OPERATION_DEFINITION: 'OperationDefinition',
+  VARIABLE_DEFINITION: 'VariableDefinition',
+  VARIABLE: 'Variable',
+  SELECTION_SET: 'SelectionSet',
+  FIELD: 'Field',
+  ARGUMENT: 'Argument',
 
-// Document
+  // Fragments
+  FRAGMENT_SPREAD: 'FragmentSpread',
+  INLINE_FRAGMENT: 'InlineFragment',
+  FRAGMENT_DEFINITION: 'FragmentDefinition',
 
-export const DOCUMENT = 'Document';
-export const OPERATION_DEFINITION = 'OperationDefinition';
-export const VARIABLE_DEFINITION = 'VariableDefinition';
-export const VARIABLE = 'Variable';
-export const SELECTION_SET = 'SelectionSet';
-export const FIELD = 'Field';
-export const ARGUMENT = 'Argument';
+  // Values
+  INT: 'IntValue',
+  FLOAT: 'FloatValue',
+  STRING: 'StringValue',
+  BOOLEAN: 'BooleanValue',
+  NULL: 'NullValue',
+  ENUM: 'EnumValue',
+  LIST: 'ListValue',
+  OBJECT: 'ObjectValue',
+  OBJECT_FIELD: 'ObjectField',
 
-// Fragments
+  // Directives
+  DIRECTIVE: 'Directive',
 
-export const FRAGMENT_SPREAD = 'FragmentSpread';
-export const INLINE_FRAGMENT = 'InlineFragment';
-export const FRAGMENT_DEFINITION = 'FragmentDefinition';
+  // Types
+  NAMED_TYPE: 'NamedType',
+  LIST_TYPE: 'ListType',
+  NON_NULL_TYPE: 'NonNullType',
 
-// Values
+  // Type System Definitions
+  SCHEMA_DEFINITION: 'SchemaDefinition',
+  OPERATION_TYPE_DEFINITION: 'OperationTypeDefinition',
 
-export const INT = 'IntValue';
-export const FLOAT = 'FloatValue';
-export const STRING = 'StringValue';
-export const BOOLEAN = 'BooleanValue';
-export const NULL = 'NullValue';
-export const ENUM = 'EnumValue';
-export const LIST = 'ListValue';
-export const OBJECT = 'ObjectValue';
-export const OBJECT_FIELD = 'ObjectField';
+  // Type Definitions
+  SCALAR_TYPE_DEFINITION: 'ScalarTypeDefinition',
+  OBJECT_TYPE_DEFINITION: 'ObjectTypeDefinition',
+  FIELD_DEFINITION: 'FieldDefinition',
+  INPUT_VALUE_DEFINITION: 'InputValueDefinition',
+  INTERFACE_TYPE_DEFINITION: 'InterfaceTypeDefinition',
+  UNION_TYPE_DEFINITION: 'UnionTypeDefinition',
+  ENUM_TYPE_DEFINITION: 'EnumTypeDefinition',
+  ENUM_VALUE_DEFINITION: 'EnumValueDefinition',
+  INPUT_OBJECT_TYPE_DEFINITION: 'InputObjectTypeDefinition',
 
-// Directives
+  // Type Extensions
+  SCALAR_TYPE_EXTENSION: 'ScalarTypeExtension',
+  OBJECT_TYPE_EXTENSION: 'ObjectTypeExtension',
+  INTERFACE_TYPE_EXTENSION: 'InterfaceTypeExtension',
+  UNION_TYPE_EXTENSION: 'UnionTypeExtension',
+  ENUM_TYPE_EXTENSION: 'EnumTypeExtension',
+  INPUT_OBJECT_TYPE_EXTENSION: 'InputObjectTypeExtension',
 
-export const DIRECTIVE = 'Directive';
+  // Directive Definitions
+  DIRECTIVE_DEFINITION: 'DirectiveDefinition',
+});
 
-// Types
-
-export const NAMED_TYPE = 'NamedType';
-export const LIST_TYPE = 'ListType';
-export const NON_NULL_TYPE = 'NonNullType';
-
-// Type System Definitions
-
-export const SCHEMA_DEFINITION = 'SchemaDefinition';
-export const OPERATION_TYPE_DEFINITION = 'OperationTypeDefinition';
-
-// Type Definitions
-
-export const SCALAR_TYPE_DEFINITION = 'ScalarTypeDefinition';
-export const OBJECT_TYPE_DEFINITION = 'ObjectTypeDefinition';
-export const FIELD_DEFINITION = 'FieldDefinition';
-export const INPUT_VALUE_DEFINITION = 'InputValueDefinition';
-export const INTERFACE_TYPE_DEFINITION = 'InterfaceTypeDefinition';
-export const UNION_TYPE_DEFINITION = 'UnionTypeDefinition';
-export const ENUM_TYPE_DEFINITION = 'EnumTypeDefinition';
-export const ENUM_VALUE_DEFINITION = 'EnumValueDefinition';
-export const INPUT_OBJECT_TYPE_DEFINITION = 'InputObjectTypeDefinition';
-
-// Type Extensions
-
-export const SCALAR_TYPE_EXTENSION = 'ScalarTypeExtension';
-export const OBJECT_TYPE_EXTENSION = 'ObjectTypeExtension';
-export const INTERFACE_TYPE_EXTENSION = 'InterfaceTypeExtension';
-export const UNION_TYPE_EXTENSION = 'UnionTypeExtension';
-export const ENUM_TYPE_EXTENSION = 'EnumTypeExtension';
-export const INPUT_OBJECT_TYPE_EXTENSION = 'InputObjectTypeExtension';
-
-// Directive Definitions
-
-export const DIRECTIVE_DEFINITION = 'DirectiveDefinition';
+/**
+ * The enum type representing the possible kind values of AST nodes.
+ */
+export type KindEnum = $Values<typeof Kind>;

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -171,10 +171,6 @@ Tok.prototype.toJSON = Tok.prototype.inspect = function toJSON() {
   };
 };
 
-function literalTok(kind, position, line, col, prev) {
-  return new Tok(kind, position, position + kind.length, line, col, prev);
-}
-
 function printCharCode(code) {
   return (
     // NaN/undefined represents access beyond the end of the file.

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -171,6 +171,10 @@ Tok.prototype.toJSON = Tok.prototype.inspect = function toJSON() {
   };
 };
 
+function literalTok(kind, position, line, col, prev) {
+  return new Tok(kind, position, position + kind.length, line, col, prev);
+}
+
 function printCharCode(code) {
   return (
     // NaN/undefined represents access beyond the end of the file.
@@ -215,62 +219,58 @@ function readToken(lexer: Lexer<*>, prev: Token): Token {
     );
   }
 
-  function literalTok(kind: TokenKindEnum) {
-    return new Tok(kind, position, position + kind.length, line, col, prev);
-  }
-
   switch (code) {
     // !
     case 33:
-      return literalTok(TokenKind.BANG);
+      return literalTok(TokenKind.BANG, position, line, col, prev);
     // #
     case 35:
       return readComment(source, position, line, col, prev);
     // $
     case 36:
-      return literalTok(TokenKind.DOLLAR);
+      return literalTok(TokenKind.DOLLAR, position, line, col, prev);
     // &
     case 38:
-      return literalTok(TokenKind.AMP);
+      return literalTok(TokenKind.AMP, position, line, col, prev);
     // (
     case 40:
-      return literalTok(TokenKind.PAREN_L);
+      return literalTok(TokenKind.PAREN_L, position, line, col, prev);
     // )
     case 41:
-      return literalTok(TokenKind.PAREN_R);
+      return literalTok(TokenKind.PAREN_R, position, line, col, prev);
     // .
     case 46:
       if (
         charCodeAt.call(body, position + 1) === 46 &&
         charCodeAt.call(body, position + 2) === 46
       ) {
-        return literalTok(TokenKind.SPREAD);
+        return literalTok(TokenKind.SPREAD, position, line, col, prev);
       }
       break;
     // :
     case 58:
-      return literalTok(TokenKind.COLON);
+      return literalTok(TokenKind.COLON, position, line, col, prev);
     // =
     case 61:
-      return literalTok(TokenKind.EQUALS);
+      return literalTok(TokenKind.EQUALS, position, line, col, prev);
     // @
     case 64:
-      return literalTok(TokenKind.AT);
+      return literalTok(TokenKind.AT, position, line, col, prev);
     // [
     case 91:
-      return literalTok(TokenKind.BRACKET_L);
+      return literalTok(TokenKind.BRACKET_L, position, line, col, prev);
     // ]
     case 93:
-      return literalTok(TokenKind.BRACKET_R);
+      return literalTok(TokenKind.BRACKET_R, position, line, col, prev);
     // {
     case 123:
-      return literalTok(TokenKind.BRACE_L);
+      return literalTok(TokenKind.BRACE_L, position, line, col, prev);
     // |
     case 124:
-      return literalTok(TokenKind.PIPE);
+      return literalTok(TokenKind.PIPE, position, line, col, prev);
     // }
     case 125:
-      return literalTok(TokenKind.BRACE_R);
+      return literalTok(TokenKind.BRACE_R, position, line, col, prev);
     // A-Z _ a-z
     case 65:
     case 66:

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -11,7 +11,7 @@ import { Source } from './source';
 import { syntaxError } from '../error';
 import type { GraphQLError } from '../error';
 import { createLexer, TokenKind, getTokenDesc } from './lexer';
-import type { Lexer } from './lexer';
+import type { Lexer, TokenKindEnum } from './lexer';
 import type {
   Location,
   Token,
@@ -1426,7 +1426,7 @@ Loc.prototype.toJSON = Loc.prototype.inspect = function toJSON() {
 /**
  * Determines if the next token is of a given kind
  */
-function peek(lexer: Lexer<*>, kind: string): boolean {
+function peek(lexer: Lexer<*>, kind: TokenKindEnum): boolean {
   return lexer.token.kind === kind;
 }
 
@@ -1434,7 +1434,7 @@ function peek(lexer: Lexer<*>, kind: string): boolean {
  * If the next token is of the given kind, return true after advancing
  * the lexer. Otherwise, do not change the parser state and return false.
  */
-function skip(lexer: Lexer<*>, kind: string): boolean {
+function skip(lexer: Lexer<*>, kind: TokenKindEnum): boolean {
   const match = lexer.token.kind === kind;
   if (match) {
     lexer.advance();
@@ -1446,7 +1446,7 @@ function skip(lexer: Lexer<*>, kind: string): boolean {
  * If the next token is of the given kind, return that token after advancing
  * the lexer. Otherwise, do not change the parser state and throw an error.
  */
-function expect(lexer: Lexer<*>, kind: string): Token {
+function expect(lexer: Lexer<*>, kind: TokenKindEnum): Token {
   const token = lexer.token;
   if (token.kind === kind) {
     lexer.advance();
@@ -1498,9 +1498,9 @@ function unexpected(lexer: Lexer<*>, atToken?: ?Token): GraphQLError {
  */
 function any<T>(
   lexer: Lexer<*>,
-  openKind: string,
+  openKind: TokenKindEnum,
   parseFn: (lexer: Lexer<*>) => T,
-  closeKind: string,
+  closeKind: TokenKindEnum,
 ): Array<T> {
   expect(lexer, openKind);
   const nodes = [];
@@ -1518,9 +1518,9 @@ function any<T>(
  */
 function many<T>(
   lexer: Lexer<*>,
-  openKind: string,
+  openKind: TokenKindEnum,
   parseFn: (lexer: Lexer<*>) => T,
-  closeKind: string,
+  closeKind: TokenKindEnum,
 ): Array<T> {
   expect(lexer, openKind);
   const nodes = [parseFn(lexer)];

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -62,50 +62,7 @@ import type {
   DirectiveDefinitionNode,
 } from './ast';
 
-import {
-  NAME,
-  VARIABLE,
-  DOCUMENT,
-  OPERATION_DEFINITION,
-  VARIABLE_DEFINITION,
-  SELECTION_SET,
-  FIELD,
-  ARGUMENT,
-  FRAGMENT_SPREAD,
-  INLINE_FRAGMENT,
-  FRAGMENT_DEFINITION,
-  INT,
-  FLOAT,
-  STRING,
-  BOOLEAN,
-  NULL,
-  ENUM,
-  LIST,
-  OBJECT,
-  OBJECT_FIELD,
-  DIRECTIVE,
-  NAMED_TYPE,
-  LIST_TYPE,
-  NON_NULL_TYPE,
-  SCHEMA_DEFINITION,
-  OPERATION_TYPE_DEFINITION,
-  SCALAR_TYPE_DEFINITION,
-  OBJECT_TYPE_DEFINITION,
-  FIELD_DEFINITION,
-  INPUT_VALUE_DEFINITION,
-  INTERFACE_TYPE_DEFINITION,
-  UNION_TYPE_DEFINITION,
-  ENUM_TYPE_DEFINITION,
-  ENUM_VALUE_DEFINITION,
-  INPUT_OBJECT_TYPE_DEFINITION,
-  SCALAR_TYPE_EXTENSION,
-  OBJECT_TYPE_EXTENSION,
-  INTERFACE_TYPE_EXTENSION,
-  UNION_TYPE_EXTENSION,
-  ENUM_TYPE_EXTENSION,
-  INPUT_OBJECT_TYPE_EXTENSION,
-  DIRECTIVE_DEFINITION,
-} from './kinds';
+import { Kind } from './kinds';
 import { DirectiveLocation } from './directiveLocation';
 
 /**
@@ -224,7 +181,7 @@ export function parseType(
 function parseName(lexer: Lexer<*>): NameNode {
   const token = expect(lexer, TokenKind.NAME);
   return {
-    kind: NAME,
+    kind: Kind.NAME,
     value: ((token.value: any): string),
     loc: loc(lexer, token),
   };
@@ -244,7 +201,7 @@ function parseDocument(lexer: Lexer<*>): DocumentNode {
   } while (!skip(lexer, TokenKind.EOF));
 
   return {
-    kind: DOCUMENT,
+    kind: Kind.DOCUMENT,
     definitions,
     loc: loc(lexer, start),
   };
@@ -319,7 +276,7 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
   const start = lexer.token;
   if (peek(lexer, TokenKind.BRACE_L)) {
     return {
-      kind: OPERATION_DEFINITION,
+      kind: Kind.OPERATION_DEFINITION,
       operation: 'query',
       name: undefined,
       variableDefinitions: [],
@@ -334,7 +291,7 @@ function parseOperationDefinition(lexer: Lexer<*>): OperationDefinitionNode {
     name = parseName(lexer);
   }
   return {
-    kind: OPERATION_DEFINITION,
+    kind: Kind.OPERATION_DEFINITION,
     operation,
     name,
     variableDefinitions: parseVariableDefinitions(lexer),
@@ -378,7 +335,7 @@ function parseVariableDefinitions(
 function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
   const start = lexer.token;
   return {
-    kind: VARIABLE_DEFINITION,
+    kind: Kind.VARIABLE_DEFINITION,
     variable: parseVariable(lexer),
     type: (expect(lexer, TokenKind.COLON), parseTypeReference(lexer)),
     defaultValue: skip(lexer, TokenKind.EQUALS)
@@ -395,7 +352,7 @@ function parseVariable(lexer: Lexer<*>): VariableNode {
   const start = lexer.token;
   expect(lexer, TokenKind.DOLLAR);
   return {
-    kind: VARIABLE,
+    kind: Kind.VARIABLE,
     name: parseName(lexer),
     loc: loc(lexer, start),
   };
@@ -407,7 +364,7 @@ function parseVariable(lexer: Lexer<*>): VariableNode {
 function parseSelectionSet(lexer: Lexer<*>): SelectionSetNode {
   const start = lexer.token;
   return {
-    kind: SELECTION_SET,
+    kind: Kind.SELECTION_SET,
     selections: many(
       lexer,
       TokenKind.BRACE_L,
@@ -449,7 +406,7 @@ function parseField(lexer: Lexer<*>): FieldNode {
   }
 
   return {
-    kind: FIELD,
+    kind: Kind.FIELD,
     alias,
     name,
     arguments: parseArguments(lexer, false),
@@ -480,7 +437,7 @@ function parseArguments(
 function parseArgument(lexer: Lexer<*>): ArgumentNode {
   const start = lexer.token;
   return {
-    kind: ARGUMENT,
+    kind: Kind.ARGUMENT,
     name: parseName(lexer),
     value: (expect(lexer, TokenKind.COLON), parseValueLiteral(lexer, false)),
     loc: loc(lexer, start),
@@ -490,7 +447,7 @@ function parseArgument(lexer: Lexer<*>): ArgumentNode {
 function parseConstArgument(lexer: Lexer<*>): ArgumentNode {
   const start = lexer.token;
   return {
-    kind: ARGUMENT,
+    kind: Kind.ARGUMENT,
     name: parseName(lexer),
     value: (expect(lexer, TokenKind.COLON), parseConstValue(lexer)),
     loc: loc(lexer, start),
@@ -513,7 +470,7 @@ function parseFragment(
   expect(lexer, TokenKind.SPREAD);
   if (peek(lexer, TokenKind.NAME) && lexer.token.value !== 'on') {
     return {
-      kind: FRAGMENT_SPREAD,
+      kind: Kind.FRAGMENT_SPREAD,
       name: parseFragmentName(lexer),
       directives: parseDirectives(lexer, false),
       loc: loc(lexer, start),
@@ -525,7 +482,7 @@ function parseFragment(
     typeCondition = parseNamedType(lexer);
   }
   return {
-    kind: INLINE_FRAGMENT,
+    kind: Kind.INLINE_FRAGMENT,
     typeCondition,
     directives: parseDirectives(lexer, false),
     selectionSet: parseSelectionSet(lexer),
@@ -547,7 +504,7 @@ function parseFragmentDefinition(lexer: Lexer<*>): FragmentDefinitionNode {
   //   - fragment FragmentName VariableDefinitions? on TypeCondition Directives? SelectionSet
   if (lexer.options.experimentalFragmentVariables) {
     return {
-      kind: FRAGMENT_DEFINITION,
+      kind: Kind.FRAGMENT_DEFINITION,
       name: parseFragmentName(lexer),
       variableDefinitions: parseVariableDefinitions(lexer),
       typeCondition: (expectKeyword(lexer, 'on'), parseNamedType(lexer)),
@@ -557,7 +514,7 @@ function parseFragmentDefinition(lexer: Lexer<*>): FragmentDefinitionNode {
     };
   }
   return {
-    kind: FRAGMENT_DEFINITION,
+    kind: Kind.FRAGMENT_DEFINITION,
     name: parseFragmentName(lexer),
     typeCondition: (expectKeyword(lexer, 'on'), parseNamedType(lexer)),
     directives: parseDirectives(lexer, false),
@@ -606,14 +563,14 @@ function parseValueLiteral(lexer: Lexer<*>, isConst: boolean): ValueNode {
     case TokenKind.INT:
       lexer.advance();
       return {
-        kind: (INT: 'IntValue'),
+        kind: Kind.INT,
         value: ((token.value: any): string),
         loc: loc(lexer, token),
       };
     case TokenKind.FLOAT:
       lexer.advance();
       return {
-        kind: (FLOAT: 'FloatValue'),
+        kind: Kind.FLOAT,
         value: ((token.value: any): string),
         loc: loc(lexer, token),
       };
@@ -624,20 +581,20 @@ function parseValueLiteral(lexer: Lexer<*>, isConst: boolean): ValueNode {
       if (token.value === 'true' || token.value === 'false') {
         lexer.advance();
         return {
-          kind: (BOOLEAN: 'BooleanValue'),
+          kind: Kind.BOOLEAN,
           value: token.value === 'true',
           loc: loc(lexer, token),
         };
       } else if (token.value === 'null') {
         lexer.advance();
         return {
-          kind: (NULL: 'NullValue'),
+          kind: Kind.NULL,
           loc: loc(lexer, token),
         };
       }
       lexer.advance();
       return {
-        kind: (ENUM: 'EnumValue'),
+        kind: Kind.ENUM,
         value: ((token.value: any): string),
         loc: loc(lexer, token),
       };
@@ -654,7 +611,7 @@ function parseStringLiteral(lexer: Lexer<*>): StringValueNode {
   const token = lexer.token;
   lexer.advance();
   return {
-    kind: (STRING: 'StringValue'),
+    kind: Kind.STRING,
     value: ((token.value: any): string),
     block: token.kind === TokenKind.BLOCK_STRING,
     loc: loc(lexer, token),
@@ -678,7 +635,7 @@ function parseList(lexer: Lexer<*>, isConst: boolean): ListValueNode {
   const start = lexer.token;
   const item = isConst ? parseConstValue : parseValueValue;
   return {
-    kind: LIST,
+    kind: Kind.LIST,
     values: any(lexer, TokenKind.BRACKET_L, item, TokenKind.BRACKET_R),
     loc: loc(lexer, start),
   };
@@ -697,7 +654,7 @@ function parseObject(lexer: Lexer<*>, isConst: boolean): ObjectValueNode {
     fields.push(parseObjectField(lexer, isConst));
   }
   return {
-    kind: OBJECT,
+    kind: Kind.OBJECT,
     fields,
     loc: loc(lexer, start),
   };
@@ -709,7 +666,7 @@ function parseObject(lexer: Lexer<*>, isConst: boolean): ObjectValueNode {
 function parseObjectField(lexer: Lexer<*>, isConst: boolean): ObjectFieldNode {
   const start = lexer.token;
   return {
-    kind: OBJECT_FIELD,
+    kind: Kind.OBJECT_FIELD,
     name: parseName(lexer),
     value: (expect(lexer, TokenKind.COLON), parseValueLiteral(lexer, isConst)),
     loc: loc(lexer, start),
@@ -739,7 +696,7 @@ function parseDirective(lexer: Lexer<*>, isConst: boolean): DirectiveNode {
   const start = lexer.token;
   expect(lexer, TokenKind.AT);
   return {
-    kind: DIRECTIVE,
+    kind: Kind.DIRECTIVE,
     name: parseName(lexer),
     arguments: parseArguments(lexer, isConst),
     loc: loc(lexer, start),
@@ -761,7 +718,7 @@ export function parseTypeReference(lexer: Lexer<*>): TypeNode {
     type = parseTypeReference(lexer);
     expect(lexer, TokenKind.BRACKET_R);
     type = ({
-      kind: LIST_TYPE,
+      kind: Kind.LIST_TYPE,
       type,
       loc: loc(lexer, start),
     }: ListTypeNode);
@@ -770,7 +727,7 @@ export function parseTypeReference(lexer: Lexer<*>): TypeNode {
   }
   if (skip(lexer, TokenKind.BANG)) {
     return ({
-      kind: NON_NULL_TYPE,
+      kind: Kind.NON_NULL_TYPE,
       type,
       loc: loc(lexer, start),
     }: NonNullTypeNode);
@@ -784,7 +741,7 @@ export function parseTypeReference(lexer: Lexer<*>): TypeNode {
 export function parseNamedType(lexer: Lexer<*>): NamedTypeNode {
   const start = lexer.token;
   return {
-    kind: NAMED_TYPE,
+    kind: Kind.NAMED_TYPE,
     name: parseName(lexer),
     loc: loc(lexer, start),
   };
@@ -864,7 +821,7 @@ function parseSchemaDefinition(lexer: Lexer<*>): SchemaDefinitionNode {
     TokenKind.BRACE_R,
   );
   return {
-    kind: SCHEMA_DEFINITION,
+    kind: Kind.SCHEMA_DEFINITION,
     directives,
     operationTypes,
     loc: loc(lexer, start),
@@ -882,7 +839,7 @@ function parseOperationTypeDefinition(
   expect(lexer, TokenKind.COLON);
   const type = parseNamedType(lexer);
   return {
-    kind: OPERATION_TYPE_DEFINITION,
+    kind: Kind.OPERATION_TYPE_DEFINITION,
     operation,
     type,
     loc: loc(lexer, start),
@@ -899,7 +856,7 @@ function parseScalarTypeDefinition(lexer: Lexer<*>): ScalarTypeDefinitionNode {
   const name = parseName(lexer);
   const directives = parseDirectives(lexer, true);
   return {
-    kind: SCALAR_TYPE_DEFINITION,
+    kind: Kind.SCALAR_TYPE_DEFINITION,
     description,
     name,
     directives,
@@ -921,7 +878,7 @@ function parseObjectTypeDefinition(lexer: Lexer<*>): ObjectTypeDefinitionNode {
   const directives = parseDirectives(lexer, true);
   const fields = parseFieldsDefinition(lexer);
   return {
-    kind: OBJECT_TYPE_DEFINITION,
+    kind: Kind.OBJECT_TYPE_DEFINITION,
     description,
     name,
     interfaces,
@@ -986,7 +943,7 @@ function parseFieldDefinition(lexer: Lexer<*>): FieldDefinitionNode {
   const type = parseTypeReference(lexer);
   const directives = parseDirectives(lexer, true);
   return {
-    kind: FIELD_DEFINITION,
+    kind: Kind.FIELD_DEFINITION,
     description,
     name,
     arguments: args,
@@ -1022,7 +979,7 @@ function parseInputValueDef(lexer: Lexer<*>): InputValueDefinitionNode {
   }
   const directives = parseDirectives(lexer, true);
   return {
-    kind: INPUT_VALUE_DEFINITION,
+    kind: Kind.INPUT_VALUE_DEFINITION,
     description,
     name,
     type,
@@ -1046,7 +1003,7 @@ function parseInterfaceTypeDefinition(
   const directives = parseDirectives(lexer, true);
   const fields = parseFieldsDefinition(lexer);
   return {
-    kind: INTERFACE_TYPE_DEFINITION,
+    kind: Kind.INTERFACE_TYPE_DEFINITION,
     description,
     name,
     directives,
@@ -1067,7 +1024,7 @@ function parseUnionTypeDefinition(lexer: Lexer<*>): UnionTypeDefinitionNode {
   const directives = parseDirectives(lexer, true);
   const types = parseUnionMemberTypes(lexer);
   return {
-    kind: UNION_TYPE_DEFINITION,
+    kind: Kind.UNION_TYPE_DEFINITION,
     description,
     name,
     directives,
@@ -1105,7 +1062,7 @@ function parseEnumTypeDefinition(lexer: Lexer<*>): EnumTypeDefinitionNode {
   const directives = parseDirectives(lexer, true);
   const values = parseEnumValuesDefinition(lexer);
   return {
-    kind: ENUM_TYPE_DEFINITION,
+    kind: Kind.ENUM_TYPE_DEFINITION,
     description,
     name,
     directives,
@@ -1141,7 +1098,7 @@ function parseEnumValueDefinition(lexer: Lexer<*>): EnumValueDefinitionNode {
   const name = parseName(lexer);
   const directives = parseDirectives(lexer, true);
   return {
-    kind: ENUM_VALUE_DEFINITION,
+    kind: Kind.ENUM_VALUE_DEFINITION,
     description,
     name,
     directives,
@@ -1163,7 +1120,7 @@ function parseInputObjectTypeDefinition(
   const directives = parseDirectives(lexer, true);
   const fields = parseInputFieldsDefinition(lexer);
   return {
-    kind: INPUT_OBJECT_TYPE_DEFINITION,
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
     description,
     name,
     directives,
@@ -1229,7 +1186,7 @@ function parseScalarTypeExtension(lexer: Lexer<*>): ScalarTypeExtensionNode {
     throw unexpected(lexer);
   }
   return {
-    kind: SCALAR_TYPE_EXTENSION,
+    kind: Kind.SCALAR_TYPE_EXTENSION,
     name,
     directives,
     loc: loc(lexer, start),
@@ -1258,7 +1215,7 @@ function parseObjectTypeExtension(lexer: Lexer<*>): ObjectTypeExtensionNode {
     throw unexpected(lexer);
   }
   return {
-    kind: OBJECT_TYPE_EXTENSION,
+    kind: Kind.OBJECT_TYPE_EXTENSION,
     name,
     interfaces,
     directives,
@@ -1285,7 +1242,7 @@ function parseInterfaceTypeExtension(
     throw unexpected(lexer);
   }
   return {
-    kind: INTERFACE_TYPE_EXTENSION,
+    kind: Kind.INTERFACE_TYPE_EXTENSION,
     name,
     directives,
     fields,
@@ -1309,7 +1266,7 @@ function parseUnionTypeExtension(lexer: Lexer<*>): UnionTypeExtensionNode {
     throw unexpected(lexer);
   }
   return {
-    kind: UNION_TYPE_EXTENSION,
+    kind: Kind.UNION_TYPE_EXTENSION,
     name,
     directives,
     types,
@@ -1333,7 +1290,7 @@ function parseEnumTypeExtension(lexer: Lexer<*>): EnumTypeExtensionNode {
     throw unexpected(lexer);
   }
   return {
-    kind: ENUM_TYPE_EXTENSION,
+    kind: Kind.ENUM_TYPE_EXTENSION,
     name,
     directives,
     values,
@@ -1359,7 +1316,7 @@ function parseInputObjectTypeExtension(
     throw unexpected(lexer);
   }
   return {
-    kind: INPUT_OBJECT_TYPE_EXTENSION,
+    kind: Kind.INPUT_OBJECT_TYPE_EXTENSION,
     name,
     directives,
     fields,
@@ -1381,7 +1338,7 @@ function parseDirectiveDefinition(lexer: Lexer<*>): DirectiveDefinitionNode {
   expectKeyword(lexer, 'on');
   const locations = parseDirectiveLocations(lexer);
   return {
-    kind: DIRECTIVE_DEFINITION,
+    kind: Kind.DIRECTIVE_DEFINITION,
     description,
     name,
     arguments: args,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -11,7 +11,7 @@ import instanceOf from '../jsutils/instanceOf';
 import invariant from '../jsutils/invariant';
 import isInvalid from '../jsutils/isInvalid';
 import type { ObjMap } from '../jsutils/ObjMap';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import { valueFromASTUntyped } from '../utilities/valueFromASTUntyped';
 import type {
   ScalarTypeDefinitionNode,

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -8,7 +8,7 @@
  */
 
 import { GraphQLScalarType, isNamedType } from './definition';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 
 // As per the GraphQL Spec, Integers are only treated as valid when a valid
 // 32-bit signed integer, providing the broadest support across platforms.

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import {
   isObjectType,
   isInterfaceType,

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -12,7 +12,7 @@ import { forEach, isCollection } from 'iterall';
 import isNullish from '../jsutils/isNullish';
 import isInvalid from '../jsutils/isInvalid';
 import type { ValueNode } from '../language/ast';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import type { GraphQLInputType } from '../type/definition';
 import {
   isScalarType,

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -16,8 +16,7 @@ import { TokenKind } from '../language/lexer';
 import { parse } from '../language/parser';
 import type { Source } from '../language/source';
 import { getDirectiveValues } from '../execution/values';
-
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 
 import type {
   DocumentNode,

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -27,7 +27,7 @@ import { GraphQLList, GraphQLNonNull } from '../type/wrappers';
 
 import { GraphQLDirective } from '../type/directives';
 
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 
 import type { GraphQLType, GraphQLNamedType } from '../type/definition';
 

--- a/src/utilities/getOperationAST.js
+++ b/src/utilities/getOperationAST.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import { OPERATION_DEFINITION } from '../language/kinds';
+import { Kind } from '../language/kinds';
 import type { DocumentNode, OperationDefinitionNode } from '../language/ast';
 
 /**
@@ -22,7 +22,7 @@ export function getOperationAST(
   let operation = null;
   for (let i = 0; i < documentAST.definitions.length; i++) {
     const definition = documentAST.definitions[i];
-    if (definition.kind === OPERATION_DEFINITION) {
+    if (definition.kind === Kind.OPERATION_DEFINITION) {
       if (!operationName) {
         // If no operation name was provided, only return an Operation if there
         // is one defined in the document. Upon encountering the second, return

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -10,7 +10,7 @@
 import { TypeInfo } from './TypeInfo';
 import type { GraphQLError } from '../error/GraphQLError';
 import type { ValueNode } from '../language/ast';
-import { DOCUMENT } from '../language/kinds';
+import { Kind } from '../language/kinds';
 import { visit, visitWithTypeInfo } from '../language/visitor';
 import type { GraphQLInputType } from '../type/definition';
 import { GraphQLSchema } from '../type/schema';
@@ -27,7 +27,7 @@ export function isValidLiteralValue(
   valueNode: ValueNode,
 ): $ReadOnlyArray<GraphQLError> {
   const emptySchema = new GraphQLSchema({});
-  const emptyDoc = { kind: DOCUMENT, definitions: [] };
+  const emptyDoc = { kind: Kind.DOCUMENT, definitions: [] };
   const typeInfo = new TypeInfo(emptySchema, undefined, type);
   const context = new ValidationContext(emptySchema, emptyDoc, typeInfo);
   const visitor = ValuesOfCorrectType(context);

--- a/src/utilities/typeFromAST.js
+++ b/src/utilities/typeFromAST.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import type {
   NamedTypeNode,
   ListTypeNode,

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -10,7 +10,7 @@
 import keyMap from '../jsutils/keyMap';
 import isInvalid from '../jsutils/isInvalid';
 import type { ObjMap } from '../jsutils/ObjMap';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import {
   isScalarType,
   isEnumType,

--- a/src/utilities/valueFromASTUntyped.js
+++ b/src/utilities/valueFromASTUntyped.js
@@ -11,7 +11,7 @@
 import keyValMap from '../jsutils/keyValMap';
 import isInvalid from '../jsutils/isInvalid';
 import type { ObjMap } from '../jsutils/ObjMap';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import type { ValueNode } from '../language/ast';
 
 /**

--- a/src/validation/rules/ExecutableDefinitions.js
+++ b/src/validation/rules/ExecutableDefinitions.js
@@ -9,11 +9,7 @@
 
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
-import {
-  FRAGMENT_DEFINITION,
-  OPERATION_DEFINITION,
-  SCHEMA_DEFINITION,
-} from '../../language/kinds';
+import { Kind } from '../../language/kinds';
 import type { ASTVisitor } from '../../language/visitor';
 
 export function nonExecutableDefinitionMessage(defName: string): string {
@@ -31,13 +27,13 @@ export function ExecutableDefinitions(context: ValidationContext): ASTVisitor {
     Document(node) {
       node.definitions.forEach(definition => {
         if (
-          definition.kind !== OPERATION_DEFINITION &&
-          definition.kind !== FRAGMENT_DEFINITION
+          definition.kind !== Kind.OPERATION_DEFINITION &&
+          definition.kind !== Kind.FRAGMENT_DEFINITION
         ) {
           context.reportError(
             new GraphQLError(
               nonExecutableDefinitionMessage(
-                definition.kind === SCHEMA_DEFINITION
+                definition.kind === Kind.SCHEMA_DEFINITION
                   ? 'schema'
                   : definition.name.value,
               ),

--- a/src/validation/rules/KnownArgumentNames.js
+++ b/src/validation/rules/KnownArgumentNames.js
@@ -12,7 +12,7 @@ import { GraphQLError } from '../../error';
 import type { ASTVisitor } from '../../language/visitor';
 import suggestionList from '../../jsutils/suggestionList';
 import quotedOrList from '../../jsutils/quotedOrList';
-import { FIELD, DIRECTIVE } from '../../language/kinds';
+import { Kind } from '../../language/kinds';
 
 export function unknownArgMessage(
   argName: string,
@@ -53,7 +53,7 @@ export function KnownArgumentNames(context: ValidationContext): ASTVisitor {
       const argDef = context.getArgument();
       if (!argDef) {
         const argumentOf = ancestors[ancestors.length - 1];
-        if (argumentOf.kind === FIELD) {
+        if (argumentOf.kind === Kind.FIELD) {
           const fieldDef = context.getFieldDef();
           const parentType = context.getParentType();
           if (fieldDef && parentType) {
@@ -72,7 +72,7 @@ export function KnownArgumentNames(context: ValidationContext): ASTVisitor {
               ),
             );
           }
-        } else if (argumentOf.kind === DIRECTIVE) {
+        } else if (argumentOf.kind === Kind.DIRECTIVE) {
           const directive = context.getDirective();
           if (directive) {
             context.reportError(

--- a/src/validation/rules/KnownDirectives.js
+++ b/src/validation/rules/KnownDirectives.js
@@ -10,7 +10,7 @@
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
 import find from '../../jsutils/find';
-import * as Kind from '../../language/kinds';
+import { Kind } from '../../language/kinds';
 import { DirectiveLocation } from '../../language/directiveLocation';
 import type { ASTVisitor } from '../../language/visitor';
 

--- a/src/validation/rules/LoneAnonymousOperation.js
+++ b/src/validation/rules/LoneAnonymousOperation.js
@@ -9,7 +9,7 @@
 
 import type { ValidationContext } from '../index';
 import { GraphQLError } from '../../error';
-import { OPERATION_DEFINITION } from '../../language/kinds';
+import { Kind } from '../../language/kinds';
 import type { ASTVisitor } from '../../language/visitor';
 
 export function anonOperationNotAloneMessage(): string {
@@ -27,7 +27,7 @@ export function LoneAnonymousOperation(context: ValidationContext): ASTVisitor {
   return {
     Document(node) {
       operationCount = node.definitions.filter(
-        definition => definition.kind === OPERATION_DEFINITION,
+        definition => definition.kind === Kind.OPERATION_DEFINITION,
       ).length;
     },
     OperationDefinition(node) {

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -17,7 +17,7 @@ import type {
   ArgumentNode,
   FragmentDefinitionNode,
 } from '../../language/ast';
-import * as Kind from '../../language/kinds';
+import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
 import type { ASTVisitor } from '../../language/visitor';
 import {

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -11,7 +11,7 @@ import invariant from '../jsutils/invariant';
 import type { ObjMap } from '../jsutils/ObjMap';
 import { GraphQLError } from '../error';
 import { visit, visitInParallel, visitWithTypeInfo } from '../language/visitor';
-import * as Kind from '../language/kinds';
+import { Kind } from '../language/kinds';
 import type {
   DocumentNode,
   OperationDefinitionNode,


### PR DESCRIPTION
I converted `Kind` into an object and created `KindEnum` and `TokenKindEnum` types.
To do this I wrapped enums into `Object.freeze` as [required by Flow](https://github.com/facebook/flow/blame/master/Changelog.md#L107-L116).
It's safe to use `Object.freeze` since it supported by [all browsers](https://github.com/graphql/graphql-js/blob/master/.babelrc#L6-L12) supported by this lib:
![image](https://user-images.githubusercontent.com/8336157/34824334-bac5ac44-f6d6-11e7-896c-ec860abf33cc.png)

If for some reason `Object.freeze` can't be used in this lib I can wrap it into code comment as suggested here: https://github.com/facebook/flow/issues/5465#issuecomment-350422478