### PR TITLE
Improve dedent (fixes #1202)

### DIFF
--- a/src/jsutils/__tests__/dedent-test.js
+++ b/src/jsutils/__tests__/dedent-test.js
@@ -94,4 +94,20 @@ describe('dedent', () => {
         me: User
       }`).to.equal('type Query {\n  me: User\n}');
   });
+
+  it('supports expression interpolation', () => {
+    const name = 'Luke Skywalker';
+    const age = 42;
+    expect(dedent`
+        {
+          "me": {
+            "name": "${name}"
+            "age": ${age}
+          }
+        }
+      `).to.equal(
+      '{\n  "me": {\n    "name": "Luke Skywalker"\n' +
+        '    "age": 42\n  }\n}\n',
+    );
+  });
 });

--- a/src/jsutils/__tests__/dedent-test.js
+++ b/src/jsutils/__tests__/dedent-test.js
@@ -11,7 +11,7 @@ import dedent from '../dedent';
 
 describe('dedent', () => {
   it('removes indentation in typical usage', () => {
-    expect(dedent`
+    const output = dedent`
       type Query {
         me: User
       }
@@ -20,94 +20,127 @@ describe('dedent', () => {
         id: ID
         name: String
       }
-      `).to.equal(
-      'type Query {\n  me: User\n}\n\n' +
-        'type User {\n  id: ID\n  name: String\n}\n',
+      `;
+    expect(output).to.equal(
+      [
+        'type Query {',
+        '  me: User',
+        '}',
+        '',
+        'type User {',
+        '  id: ID',
+        '  name: String',
+        '}',
+        '',
+      ].join('\n'),
     );
   });
 
   it('removes only the first level of indentation', () => {
-    expect(dedent`
+    const output = dedent`
             qux
               quux
                 quuux
                   quuuux
-      `).to.equal('qux\n  quux\n    quuux\n      quuuux\n');
+      `;
+    expect(output).to.equal(
+      ['qux', '  quux', '    quuux', '      quuuux', ''].join('\n'),
+    );
   });
 
   it('does not escape special characters', () => {
-    expect(dedent`
+    const output = dedent`
       type Root {
         field(arg: String = "wi\th de\fault"): String
       }
-      `).to.equal(
-      'type Root {\n  field(arg: String = "wi\th de\fault"): String\n}\n',
+      `;
+    expect(output).to.equal(
+      [
+        'type Root {',
+        '  field(arg: String = "wi\th de\fault"): String',
+        '}',
+        '',
+      ].join('\n'),
     );
   });
 
   it('also works as an ordinary function on strings', () => {
-    expect(
-      dedent(`
+    const output = dedent(`
       type Query {
         me: User
       }
-      `),
-    ).to.equal('type Query {\n  me: User\n}\n');
+      `);
+    expect(output).to.equal(['type Query {', '  me: User', '}', ''].join('\n'));
   });
 
   it('also removes indentation using tabs', () => {
-    expect(dedent`
+    const output = dedent`
         \t\t    type Query {
         \t\t      me: User
         \t\t    }
-      `).to.equal('type Query {\n  me: User\n}\n');
+      `;
+    expect(output).to.equal(['type Query {', '  me: User', '}', ''].join('\n'));
   });
 
   it('removes leading newlines', () => {
-    expect(dedent`
+    const output = dedent`
 
 
       type Query {
         me: User
-      }`).to.equal('type Query {\n  me: User\n}');
+      }`;
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
   });
 
   it('does not remove trailing newlines', () => {
-    expect(dedent`
+    const output = dedent`
       type Query {
         me: User
       }
 
-      `).to.equal('type Query {\n  me: User\n}\n\n');
+      `;
+    expect(output).to.equal(
+      ['type Query {', '  me: User', '}', '', ''].join('\n'),
+    );
   });
 
   it('removes all trailing spaces and tabs', () => {
-    expect(dedent`
+    const output = dedent`
       type Query {
         me: User
       }
-          \t\t  \t `).to.equal('type Query {\n  me: User\n}\n');
+          \t\t  \t `;
+    expect(output).to.equal(['type Query {', '  me: User', '}', ''].join('\n'));
   });
 
   it('works on text without leading newline', () => {
-    expect(dedent`      type Query {
+    const output = dedent`      type Query {
         me: User
-      }`).to.equal('type Query {\n  me: User\n}');
+      }`;
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
   });
 
   it('supports expression interpolation', () => {
     const name = 'Luke Skywalker';
     const age = 42;
-    expect(dedent`
+    const output = dedent`
         {
           "me": {
             "name": "${name}"
             "age": ${age}
           }
         }
-      `).to.equal(
-      '{\n  "me": {\n    "name": "Luke Skywalker"\n' +
-        '    "age": 42\n  }\n}\n',
+      `;
+    expect(output).to.equal(
+      [
+        '{',
+        '  "me": {',
+        '    "name": "Luke Skywalker"',
+        '    "age": 42',
+        '  }',
+        '}',
+        '',
+      ].join('\n'),
     );
   });
 });

--- a/src/jsutils/__tests__/dedent-test.js
+++ b/src/jsutils/__tests__/dedent-test.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import dedent from '../dedent';
+
+describe('dedent', () => {
+  it('removes indentation in typical usage', () => {
+    expect(dedent`
+      type Query {
+        me: User
+      }
+      
+      type User {
+        id: ID
+        name: String
+      }
+      `).to.equal(
+      'type Query {\n  me: User\n}\n\n' +
+        'type User {\n  id: ID\n  name: String\n}\n',
+    );
+  });
+
+  it('removes only the first level of indentation', () => {
+    expect(dedent`
+            qux
+              quux
+                quuux
+                  quuuux
+      `).to.equal('qux\n  quux\n    quuux\n      quuuux\n');
+  });
+
+  it('does not escape special characters', () => {
+    expect(dedent`
+      type Root {
+        field(arg: String = "wi\th de\fault"): String
+      }
+      `).to.equal(
+      'type Root {\n  field(arg: String = "wi\th de\fault"): String\n}\n',
+    );
+  });
+
+  it('also works as an ordinary function on strings', () => {
+    expect(
+      dedent(`
+      type Query {
+        me: User
+      }
+      `),
+    ).to.equal('type Query {\n  me: User\n}\n');
+  });
+
+  it('also removes indentation using tabs', () => {
+    expect(dedent`
+        \t\t    type Query {
+        \t\t      me: User
+        \t\t    }
+      `).to.equal('type Query {\n  me: User\n}\n');
+  });
+
+  it('removes leading newlines', () => {
+    expect(dedent`
+
+
+      type Query {
+        me: User
+      }`).to.equal('type Query {\n  me: User\n}');
+  });
+
+  it('does not remove trailing newlines', () => {
+    expect(dedent`
+      type Query {
+        me: User
+      }
+
+      `).to.equal('type Query {\n  me: User\n}\n\n');
+  });
+
+  it('removes all trailing spaces and tabs', () => {
+    expect(dedent`
+      type Query {
+        me: User
+      }
+          \t\t  \t `).to.equal('type Query {\n  me: User\n}\n');
+  });
+
+  it('works on text without leading newline', () => {
+    expect(dedent`      type Query {
+        me: User
+      }`).to.equal('type Query {\n  me: User\n}');
+  });
+});

--- a/src/jsutils/dedent.js
+++ b/src/jsutils/dedent.js
@@ -8,19 +8,19 @@
  */
 
 /**
- * fixes indentation by removing leading spaces from each line
+ * fixes indentation by removing leading spaces and tabs from each line
  */
 function fixIndent(str: string): string {
-  const indent = /^\n?( *)/.exec(str)[1]; // figure out indent
-  return str
-    .replace(RegExp('^' + indent, 'mg'), '') // remove indent
+  const trimmedStr = str
     .replace(/^\n*/m, '') //  remove leading newline
-    .replace(/ *$/, ''); // remove trailing spaces
+    .replace(/[ \t]*$/, ''); // remove trailing spaces and tabs
+  const indent = /^[ \t]*/.exec(trimmedStr)[0]; // figure out indent
+  return trimmedStr.replace(RegExp('^' + indent, 'mg'), ''); // remove indent
 }
 
 /**
  * An ES6 string tag that fixes indentation. Also removes leading newlines
- * but keeps trailing ones
+ * and trailing spaces and tabs, but keeps trailing newlines.
  *
  * Example usage:
  * const str = dedent`
@@ -31,19 +31,20 @@ function fixIndent(str: string): string {
  * str === "{\n  test\n}\n";
  */
 export default function dedent(
-  strings: string | { raw: [string] },
+  strings: string | Array<string>,
   ...values: Array<string>
-) {
-  const raw = typeof strings === 'string' ? [strings] : strings.raw;
-  let res = '';
-  // interpolation
-  for (let i = 0; i < raw.length; i++) {
-    res += raw[i].replace(/\\`/g, '`'); // handle escaped backticks
+): string {
+  // when used as an ordinary function, allow passing a singleton string
+  const strArray = typeof strings === 'string' ? [strings] : strings;
+  const numValues = values.length;
 
-    if (i < values.length) {
-      res += values[i];
+  const str = strArray.reduce((prev, cur, index) => {
+    let next = prev + cur;
+    if (index < numValues) {
+      next += values[index]; // interpolation
     }
-  }
+    return next;
+  }, '');
 
-  return fixIndent(res);
+  return fixIndent(str);
 }

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -145,7 +145,8 @@ describe('Printer: Query document', () => {
 
     const printed = print(ast);
 
-    expect(printed).to.equal(dedent`
+    expect(printed).to.equal(
+      dedent(String.raw`
       query queryName($foo: ComplexType, $site: Site = MOBILE) {
         whoever123is: node(id: [123, 456]) {
           id
@@ -190,7 +191,7 @@ describe('Printer: Query document', () => {
 
       fragment frag on Friend {
         foo(size: $size, bar: $b, obj: {key: "value", block: """
-          block string uses \\"""
+          block string uses \"""
         """})
       }
 
@@ -198,6 +199,7 @@ describe('Printer: Query document', () => {
         unnamed(truthy: true, falsey: false, nullish: null)
         query
       }
-    `);
+    `),
+    );
   });
 });

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -190,7 +190,7 @@ describe('Printer: Query document', () => {
 
       fragment frag on Friend {
         foo(size: $size, bar: $b, obj: {key: "value", block: """
-          block string uses \"""
+          block string uses \\"""
         """})
       }
 

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -206,15 +206,17 @@ describe('Type System Printer', () => {
       type: GraphQLString,
       args: { argOne: { type: GraphQLString, defaultValue: 'tes\t de\fault' } },
     });
-    expect(output).to.equal(dedent`
+    expect(output).to.equal(
+      dedent(String.raw`
       schema {
         query: Root
       }
 
       type Root {
-        singleField(argOne: String = "tes\\t de\\fault"): String
+        singleField(argOne: String = "tes\t de\fault"): String
       }
-    `);
+    `),
+    );
   });
 
   it('Prints String Field With Int Arg With Default Null', () => {

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -212,7 +212,7 @@ describe('Type System Printer', () => {
       }
 
       type Root {
-        singleField(argOne: String = "tes\t de\fault"): String
+        singleField(argOne: String = "tes\\t de\\fault"): String
       }
     `);
   });


### PR DESCRIPTION
As discussed in #1202, this changes the behavior of the dedent function that is used in unit tests to not return raw strings any more. Also added tests for the function itself.