### PR TITLE
Fix printed schema descriptions that end with a double quote (")

### DIFF
--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -26,6 +26,8 @@ import {
 } from '../../';
 import { GraphQLDirective } from '../../type/directives';
 import { DirectiveLocation } from '../../language/directiveLocation';
+import { parse } from '../../language/parser';
+import { GraphQLError } from '../../error/GraphQLError';
 
 function printForTest(schema) {
   const schemaText = printSchema(schema);
@@ -849,7 +851,20 @@ describe('Type System Printer', () => {
     `;
     expect(output).to.equal(introspectionSchema);
   });
-
+  it('Prints a parseable schema when a comment ends with a doublequote (")', () => {
+    const Root = new GraphQLObjectType({
+      name: 'Root',
+      fields: {
+        onlyField: {
+          type: GraphQLString,
+          description: 'This field is "awesome"',
+        },
+      },
+    });
+    const Schema = new GraphQLSchema({ query: Root });
+    const output = printSchema(Schema);
+    expect(() => parse(output)).not.to.throw(GraphQLError);
+  });
   it('Print Introspection Schema with comment descriptions', () => {
     const Query = new GraphQLObjectType({
       name: 'Query',

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -552,16 +552,12 @@ describe('Type System Printer', () => {
       description,
     });
     expect(output).to.equal(dedent`
-      schema {
-        query: Root
-      }
-
-      type Root {
+      type Query {
         """This field is awesome"""
         singleField: String
       }
     `);
-    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedRoot = buildSchema(output).getTypeMap()['Query'];
     const recreatedField = recreatedRoot.getFields()['singleField'];
     expect(recreatedField.description).to.equal(description);
   });
@@ -573,18 +569,14 @@ describe('Type System Printer', () => {
       description,
     });
     expect(output).to.equal(dedent`
-      schema {
-        query: Root
-      }
-
-      type Root {
+      type Query {
         """
         This field is "awesome"
         """
         singleField: String
       }
     `);
-    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedRoot = buildSchema(output).getTypeMap()['Query'];
     const recreatedField = recreatedRoot.getFields()['singleField'];
     expect(recreatedField.description).to.equal(description);
   });
@@ -596,17 +588,13 @@ describe('Type System Printer', () => {
       description,
     });
     expect(output).to.equal(dedent`
-      schema {
-        query: Root
-      }
-
-      type Root {
+      type Query {
         """    This field is "awesome"
         """
         singleField: String
       }
     `);
-    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedRoot = buildSchema(output).getTypeMap()['Query'];
     const recreatedField = recreatedRoot.getFields()['singleField'];
     expect(recreatedField.description).to.equal(description);
   });
@@ -856,16 +844,14 @@ describe('Type System Printer', () => {
       description,
     });
     expect(output).to.equal(dedent`
-      schema {
-        query: Root
-      }
-
-      type Root {
-        """This field is "awesome" """
+      type Query {
+        """
+        This field is "awesome"
+        """
         singleField: String
       }
     `);
-    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedRoot = buildSchema(output).getTypeMap()['Query'];
     const recreatedField = recreatedRoot.getFields()['singleField'];
 
     /* Note: Additional space added to prevent parser from confusing trailing double
@@ -873,7 +859,7 @@ describe('Type System Printer', () => {
      * affect result since descriptions are interpreted as Markdown so trailing
      * spaces are ignored.
      */
-    expect(recreatedField.description).to.equal(description + ' ');
+    expect(recreatedField.description).to.equal(description);
   });
   it('Print Introspection Schema with comment descriptions', () => {
     const Query = new GraphQLObjectType({

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -545,6 +545,72 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('One-line prints a short description', () => {
+    const description = 'This field is awesome';
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      description,
+    });
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
+
+      type Root {
+        """This field is awesome"""
+        singleField: String
+      }
+    `);
+    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedField = recreatedRoot.getFields()['singleField'];
+    expect(recreatedField.description).to.equal(description);
+  });
+
+  it('Does not one-line print a description that ends with a quote', () => {
+    const description = 'This field is "awesome"';
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      description,
+    });
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
+
+      type Root {
+        """
+        This field is "awesome"
+        """
+        singleField: String
+      }
+    `);
+    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedField = recreatedRoot.getFields()['singleField'];
+    expect(recreatedField.description).to.equal(description);
+  });
+
+  it('Preserves leading spaces when printing a description', () => {
+    const description = '    This field is "awesome"';
+    const output = printSingleFieldSchema({
+      type: GraphQLString,
+      description,
+    });
+    expect(output).to.equal(dedent`
+      schema {
+        query: Root
+      }
+
+      type Root {
+        """    This field is "awesome"
+        """
+        singleField: String
+      }
+    `);
+    const recreatedRoot = buildSchema(output).getTypeMap()['Root'];
+    const recreatedField = recreatedRoot.getFields()['singleField'];
+    expect(recreatedField.description).to.equal(description);
+  });
+
   it('Print Introspection Schema', () => {
     const Query = new GraphQLObjectType({
       name: 'Query',

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -366,7 +366,7 @@ function printDescription(
 }
 
 function escapeQuote(line) {
-  return line.replace(/"$/, '" ').replace(/"""/g, '\\"""');
+  return line.replace(/"""/g, '\\"""');
 }
 
 function printDescriptionWithComments(lines, indentation, firstInBlock) {

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -336,15 +336,30 @@ function printDescription(
     return printDescriptionWithComments(lines, indentation, firstInBlock);
   }
 
-  let description = indentation && !firstInBlock ? '\n' : '';
-  if (lines.length === 1 && lines[0].length < 70) {
-    description += indentation + '"""' + escapeQuote(lines[0]) + '"""\n';
-    return description;
+  let description =
+    indentation && !firstInBlock
+      ? '\n' + indentation + '"""'
+      : indentation + '"""';
+
+  // In some circumstances, a single line can be used for the description.
+  if (
+    lines.length === 1 &&
+    lines[0].length < 70 &&
+    lines[0][lines[0].length - 1] !== '"'
+  ) {
+    return description + escapeQuote(lines[0]) + '"""\n';
   }
 
-  description += indentation + '"""\n';
+  // Format a multi-line block quote to account for leading space.
+  const hasLeadingSpace = lines[0][0] === ' ' || lines[0][0] === '\t';
+  if (!hasLeadingSpace) {
+    description += '\n';
+  }
   for (let i = 0; i < lines.length; i++) {
-    description += indentation + escapeQuote(lines[i]) + '\n';
+    if (i !== 0 || !hasLeadingSpace) {
+      description += indentation;
+    }
+    description += escapeQuote(lines[i]) + '\n';
   }
   description += indentation + '"""\n';
   return description;

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -366,7 +366,7 @@ function printDescription(
 }
 
 function escapeQuote(line) {
-  return line.replace(/"""/g, '\\"""');
+  return line.replace(/"$/, '" ').replace(/"""/g, '\\"""');
 }
 
 function printDescriptionWithComments(lines, indentation, firstInBlock) {


### PR DESCRIPTION
Schemas printed with `printSchema` that contain descriptions ending with a double-quote character are not parseable and throw a `GraphQLError: Syntax Error: Unterminated string` because the SDL description ends with 4 contiguous double-quotes

I've included a failing test case:

```js
const Root = new GraphQLObjectType({
      name: 'Root',
      fields: {
        onlyField: {
          type: GraphQLString,
          description: 'This field is "awesome"',
        },
      },
    });
    const Schema = new GraphQLSchema({ query: Root });
    const output = printSchema(Schema);
    expect(() => parse(output)).not.to.throw(GraphQLError);
```