### PR TITLE
More accurate check for cache-hit in memoize3

### DIFF
--- a/src/jsutils/memoize3.js
+++ b/src/jsutils/memoize3.js
@@ -24,7 +24,7 @@ export default function memoize3<T: (a1: any, a2: any, a3: any) => any>(
       cache2 = cache1.get(a2);
       if (cache2) {
         const cachedValue = cache2.get(a3);
-        if (cachedValue) {
+        if (cachedValue !== undefined) {
           return cachedValue;
         }
       }


### PR DESCRIPTION
`WeakMap.get` returns `undefined` on cache miss. Checking for false instead of `undefined` could give a false cache-miss and recalculate when a false value is returned by the memoised function with those params.