### PR TITLE
Add 'objectValues' JS util function

### DIFF
--- a/src/jsutils/objectValues.js
+++ b/src/jsutils/objectValues.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type { ObjMap } from './ObjMap';
+
+declare function objectValues<T>(obj: ObjMap<T>): Array<T>;
+
+/* eslint-disable no-redeclare */
+// $FlowFixMe workaround for: https://github.com/facebook/flow/issues/2221
+const objectValues =
+  Object.values || (obj => Object.keys(obj).map(key => obj[key]));
+export default objectValues;

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -8,6 +8,7 @@
  */
 
 import isInvalid from '../jsutils/isInvalid';
+import objectValues from '../jsutils/objectValues';
 import { astFromValue } from '../utilities/astFromValue';
 import { print } from '../language/printer';
 import {
@@ -41,8 +42,7 @@ export const __Schema = new GraphQLObjectType({
       description: 'A list of all types supported by this server.',
       type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__Type))),
       resolve(schema) {
-        const typeMap = schema.getTypeMap();
-        return Object.keys(typeMap).map(key => typeMap[key]);
+        return objectValues(schema.getTypeMap());
       },
     },
     queryType: {
@@ -245,10 +245,7 @@ export const __Type = new GraphQLObjectType({
       },
       resolve(type, { includeDeprecated }) {
         if (isObjectType(type) || isInterfaceType(type)) {
-          const fieldMap = type.getFields();
-          let fields = Object.keys(fieldMap).map(
-            fieldName => fieldMap[fieldName],
-          );
+          let fields = objectValues(type.getFields());
           if (!includeDeprecated) {
             fields = fields.filter(field => !field.deprecationReason);
           }
@@ -292,8 +289,7 @@ export const __Type = new GraphQLObjectType({
       type: GraphQLList(GraphQLNonNull(__InputValue)),
       resolve(type) {
         if (isInputObjectType(type)) {
-          const fieldMap = type.getFields();
-          return Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
+          return objectValues(type.getFields());
         }
       },
     },

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -32,6 +32,7 @@ import { __Schema } from './introspection';
 import find from '../jsutils/find';
 import instanceOf from '../jsutils/instanceOf';
 import invariant from '../jsutils/invariant';
+import objectValues from '../jsutils/objectValues';
 import type { ObjMap } from '../jsutils/ObjMap';
 
 /**
@@ -275,10 +276,7 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   }
 
   if (isObjectType(type) || isInterfaceType(type)) {
-    const fieldMap = type.getFields();
-    Object.keys(fieldMap).forEach(fieldName => {
-      const field = fieldMap[fieldName];
-
+    objectValues(type.getFields()).forEach(field => {
       if (field.args) {
         const fieldArgTypes = field.args.map(arg => arg.type);
         reducedMap = fieldArgTypes.reduce(typeMapReducer, reducedMap);
@@ -288,9 +286,7 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   }
 
   if (isInputObjectType(type)) {
-    const fieldMap = type.getFields();
-    Object.keys(fieldMap).forEach(fieldName => {
-      const field = fieldMap[fieldName];
+    objectValues(type.getFields()).forEach(field => {
       reducedMap = typeMapReducer(reducedMap, field.type);
     });
   }

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -11,6 +11,7 @@ import { forEach, isCollection } from 'iterall';
 
 import isNullish from '../jsutils/isNullish';
 import isInvalid from '../jsutils/isInvalid';
+import objectValues from '../jsutils/objectValues';
 import type { ValueNode } from '../language/ast';
 import { Kind } from '../language/kinds';
 import type { GraphQLInputType } from '../type/definition';
@@ -85,15 +86,14 @@ export function astFromValue(value: mixed, type: GraphQLInputType): ?ValueNode {
     if (_value === null || typeof _value !== 'object') {
       return null;
     }
-    const fields = type.getFields();
+    const fields = objectValues(type.getFields());
     const fieldNodes = [];
-    Object.keys(fields).forEach(fieldName => {
-      const fieldType = fields[fieldName].type;
-      const fieldValue = astFromValue(_value[fieldName], fieldType);
+    fields.forEach(field => {
+      const fieldValue = astFromValue(_value[field.name], field.type);
       if (fieldValue) {
         fieldNodes.push({
           kind: Kind.OBJECT_FIELD,
-          name: { kind: Kind.NAME, value: fieldName },
+          name: { kind: Kind.NAME, value: field.name },
           value: fieldValue,
         });
       }

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -9,6 +9,7 @@
 
 import isNullish from '../jsutils/isNullish';
 import isInvalid from '../jsutils/isInvalid';
+import objectValues from '../jsutils/objectValues';
 import { astFromValue } from '../utilities/astFromValue';
 import { print } from '../language/printer';
 import type { GraphQLSchema } from '../type/schema';
@@ -79,9 +80,8 @@ function printFilteredSchema(
 ): string {
   const directives = schema.getDirectives().filter(directiveFilter);
   const typeMap = schema.getTypeMap();
-  const types = Object.keys(typeMap)
-    .sort((name1, name2) => name1.localeCompare(name2))
-    .map(typeName => typeMap[typeName])
+  const types = objectValues(typeMap)
+    .sort((type1, type2) => type1.name.localeCompare(type2.name))
     .filter(typeFilter);
 
   return (
@@ -227,8 +227,7 @@ function printEnumValues(values, options): string {
 }
 
 function printInputObject(type: GraphQLInputObjectType, options): string {
-  const fieldMap = type.getFields();
-  const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
+  const fields = objectValues(type.getFields());
   return (
     printDescription(options, type) +
     `input ${type.name} {\n` +
@@ -244,8 +243,7 @@ function printInputObject(type: GraphQLInputObjectType, options): string {
 }
 
 function printFields(options, type) {
-  const fieldMap = type.getFields();
-  const fields = Object.keys(fieldMap).map(fieldName => fieldMap[fieldName]);
+  const fields = objectValues(type.getFields());
   return fields
     .map(
       (f, i) =>

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -9,6 +9,7 @@
 
 import keyMap from '../jsutils/keyMap';
 import isInvalid from '../jsutils/isInvalid';
+import objectValues from '../jsutils/objectValues';
 import type { ObjMap } from '../jsutils/ObjMap';
 import { Kind } from '../language/kinds';
 import {
@@ -116,19 +117,17 @@ export function valueFromAST(
       return; // Invalid: intentionally return no value.
     }
     const coercedObj = Object.create(null);
-    const fields = type.getFields();
     const fieldNodes = keyMap(
       (valueNode: ObjectValueNode).fields,
       field => field.name.value,
     );
-    const fieldNames = Object.keys(fields);
-    for (let i = 0; i < fieldNames.length; i++) {
-      const fieldName = fieldNames[i];
-      const field = fields[fieldName];
-      const fieldNode = fieldNodes[fieldName];
+    const fields = objectValues(type.getFields());
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      const fieldNode = fieldNodes[field.name];
       if (!fieldNode || isMissingVariable(fieldNode.value, variables)) {
         if (!isInvalid(field.defaultValue)) {
-          coercedObj[fieldName] = field.defaultValue;
+          coercedObj[field.name] = field.defaultValue;
         } else if (isNonNullType(field.type)) {
           return; // Invalid: intentionally return no value.
         }
@@ -138,7 +137,7 @@ export function valueFromAST(
       if (isInvalid(fieldValue)) {
         return; // Invalid: intentionally return no value.
       }
-      coercedObj[fieldName] = fieldValue;
+      coercedObj[field.name] = fieldValue;
     }
     return coercedObj;
   }


### PR DESCRIPTION
Following pattern are frequently used in this lib: 
``` js
const objMap = ...
Object.keys(objMap).map(name => {
  const item = objMap[name];
  // ...
})
```
It can be greatly simplify with `Object.values` however [Flow can't hadle it well](https://github.com/facebook/flow/issues/2221) and IE doesn't implement it.
This PR adds `objectValues` substitution to use until we could switch to `Object.values`.

Plus it should give small performance boost from using native `Object.values` when possible.