### PR TITLE
Simplify build steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,6 @@
   "name": "graphql",
   "version": "0.12.3",
   "description": "A Query Language and Runtime which can target any service.",
-  "contributors": [
-    "Lee Byron <lee@leebyron.com> (http://leebyron.com/)",
-    "Nicholas Schrock <schrockn@fb.com>",
-    "Daniel Schafer <dschafer@fb.com>"
-  ],
   "license": "MIT",
   "main": "index.js",
   "module": "module/index.js",
@@ -29,8 +24,9 @@
     "prettier": "prettier --write 'src/**/*.js'",
     "check": "flow check",
     "check-cover": "for file in {src/*.js,src/**/*.js}; do echo $file; flow coverage $file; done",
-    "build": "npm run build:clean && npm run build:npm && npm run build:npm-flow && npm run build:module && npm run build:module-flow && npm run build:package-json",
-    "build:clean": "rm -rf ./dist",
+    "build": "npm run build:clean && npm run build:cp && npm run build:npm && npm run build:npm-flow && npm run build:module && npm run build:module-flow && npm run build:package-json",
+    "build:clean": "rm -rf ./dist && mkdir ./dist",
+    "build:cp": "cp README.md LICENSE ./dist",
     "build:package-json": "node ./resources/copy-package-json.js",
     "build:npm": "babel src --optional runtime --ignore __tests__ --out-dir dist/",
     "build:npm-flow": "find ./src -name '*.js' -not -path '*/__tests__*' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",

--- a/resources/gitpublish.sh
+++ b/resources/gitpublish.sh
@@ -19,8 +19,6 @@ rm -rf npm/*
 
 # Copy over necessary files
 cp -r dist/* npm/
-cp README.md npm/
-cp LICENSE npm/
 
 # Reference current commit
 HEADREV=`git rev-parse HEAD`


### PR DESCRIPTION
This consolidates copying of flat files into the build step.

This also removes "contributors" from the package since that's super outdated and no longer relevant.