### PR TITLE
RFC: Allow interfaces to implement other interfaces

### DIFF
--- a/src/execution/__tests__/union-interface-test.js
+++ b/src/execution/__tests__/union-interface-test.js
@@ -49,23 +49,46 @@ const NamedType = new GraphQLInterfaceType({
   },
 });
 
+const LifeType = new GraphQLInterfaceType({
+  name: 'Life',
+  fields: () => ({
+    progeny: { type: GraphQLList(LifeType) },
+  }),
+});
+
+const MammalType = new GraphQLInterfaceType({
+  name: 'Mammal',
+  interfaces: [LifeType],
+  fields: () => ({
+    progeny: { type: GraphQLList(MammalType) },
+    mother: { type: MammalType },
+    father: { type: MammalType },
+  }),
+});
+
 const DogType = new GraphQLObjectType({
   name: 'Dog',
-  interfaces: [NamedType],
-  fields: {
+  interfaces: [MammalType, LifeType, NamedType],
+  fields: () => ({
     name: { type: GraphQLString },
     barks: { type: GraphQLBoolean },
-  },
+    progeny: { type: GraphQLList(DogType) },
+    mother: { type: DogType },
+    father: { type: DogType },
+  }),
   isTypeOf: value => value instanceof Dog,
 });
 
 const CatType = new GraphQLObjectType({
   name: 'Cat',
-  interfaces: [NamedType],
-  fields: {
+  interfaces: [MammalType, LifeType, NamedType],
+  fields: () => ({
     name: { type: GraphQLString },
     meows: { type: GraphQLBoolean },
-  },
+    progeny: { type: GraphQLList(CatType) },
+    mother: { type: CatType },
+    father: { type: CatType },
+  }),
   isTypeOf: value => value instanceof Cat,
 });
 
@@ -84,12 +107,15 @@ const PetType = new GraphQLUnionType({
 
 const PersonType = new GraphQLObjectType({
   name: 'Person',
-  interfaces: [NamedType],
-  fields: {
+  interfaces: [NamedType, MammalType, LifeType],
+  fields: () => ({
     name: { type: GraphQLString },
     pets: { type: GraphQLList(PetType) },
     friends: { type: GraphQLList(NamedType) },
-  },
+    progeny: { type: GraphQLList(PersonType) },
+    mother: { type: PersonType },
+    father: { type: PersonType },
+  }),
   isTypeOf: value => value instanceof Person,
 });
 
@@ -116,6 +142,15 @@ describe('Execute: Union and intersection types', () => {
           enumValues { name }
           inputFields { name }
         }
+        Mammal: __type(name: "Mammal") {
+          kind
+          name
+          fields { name }
+          interfaces { name }
+          possibleTypes { name }
+          enumValues { name }
+          inputFields { name }
+        }
         Pet: __type(name: "Pet") {
           kind
           name
@@ -134,7 +169,16 @@ describe('Execute: Union and intersection types', () => {
           kind: 'INTERFACE',
           name: 'Named',
           fields: [{ name: 'name' }],
-          interfaces: null,
+          interfaces: [],
+          possibleTypes: [{ name: 'Person' }, { name: 'Dog' }, { name: 'Cat' }],
+          enumValues: null,
+          inputFields: null,
+        },
+        Mammal: {
+          kind: 'INTERFACE',
+          name: 'Mammal',
+          fields: [{ name: 'progeny' }, { name: 'mother' }, { name: 'father' }],
+          interfaces: [{ name: 'Life' }],
           possibleTypes: [{ name: 'Person' }, { name: 'Dog' }, { name: 'Cat' }],
           enumValues: null,
           inputFields: null,

--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -51,6 +51,12 @@ extend interface Bar {
 
 extend interface Bar @onInterface
 
+interface Baz implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  four(argument: String = "string"): String
+}
+
 union Feed = Story | Article | Advert
 
 union AnnotatedUnion @onUnion = A | B

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -95,6 +95,12 @@ describe('Printer: SDL document', () => {
 
       extend interface Bar @onInterface
 
+      interface Baz implements Bar {
+        one: Type
+        two(argument: InputType!): Type
+        four(argument: String = "string"): String
+      }
+
       union Feed = Story | Article | Advert
 
       union AnnotatedUnion @onUnion = A | B

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -458,6 +458,7 @@ export type InterfaceTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
+  +interfaces?: $ReadOnlyArray<NamedTypeNode>,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +fields?: $ReadOnlyArray<FieldDefinitionNode>,
 };
@@ -527,6 +528,7 @@ export type InterfaceTypeExtensionNode = {
   +kind: 'InterfaceTypeExtension',
   +loc?: Location,
   +name: NameNode,
+  +interfaces?: $ReadOnlyArray<NamedTypeNode>,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +fields?: $ReadOnlyArray<FieldDefinitionNode>,
 };

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -1000,12 +1000,14 @@ function parseInterfaceTypeDefinition(
   const description = parseDescription(lexer);
   expectKeyword(lexer, 'interface');
   const name = parseName(lexer);
+  const interfaces = parseImplementsInterfaces(lexer);
   const directives = parseDirectives(lexer, true);
   const fields = parseFieldsDefinition(lexer);
   return {
     kind: Kind.INTERFACE_TYPE_DEFINITION,
     description,
     name,
+    interfaces,
     directives,
     fields,
     loc: loc(lexer, start),
@@ -1226,8 +1228,9 @@ function parseObjectTypeExtension(lexer: Lexer<*>): ObjectTypeExtensionNode {
 
 /**
  * InterfaceTypeExtension :
- *   - extend interface Name Directives[Const]? FieldsDefinition
- *   - extend interface Name Directives[Const]
+ *   - extend interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
+ *   - extend interface Name ImplementsInterfaces? Directives[Const]
+ *   - extend interface Name ImplementsInterfaces
  */
 function parseInterfaceTypeExtension(
   lexer: Lexer<*>,
@@ -1236,14 +1239,20 @@ function parseInterfaceTypeExtension(
   expectKeyword(lexer, 'extend');
   expectKeyword(lexer, 'interface');
   const name = parseName(lexer);
+  const interfaces = parseImplementsInterfaces(lexer);
   const directives = parseDirectives(lexer, true);
   const fields = parseFieldsDefinition(lexer);
-  if (directives.length === 0 && fields.length === 0) {
+  if (
+    interfaces.length === 0 &&
+    directives.length === 0 &&
+    fields.length === 0
+  ) {
     throw unexpected(lexer);
   }
   return {
     kind: Kind.INTERFACE_TYPE_EXTENSION,
     name,
+    interfaces,
     directives,
     fields,
     loc: loc(lexer, start),

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -145,8 +145,18 @@ const printDocASTReducer = {
       ),
   ),
 
-  InterfaceTypeDefinition: addDescription(({ name, directives, fields }) =>
-    join(['interface', name, join(directives, ' '), block(fields)], ' '),
+  InterfaceTypeDefinition: addDescription(
+    ({ name, interfaces, directives, fields }) =>
+      join(
+        [
+          'interface',
+          name,
+          wrap('implements ', join(interfaces, ' & ')),
+          join(directives, ' '),
+          block(fields),
+        ],
+        ' ',
+      ),
   ),
 
   UnionTypeDefinition: addDescription(({ name, directives, types }) =>
@@ -188,8 +198,17 @@ const printDocASTReducer = {
       ' ',
     ),
 
-  InterfaceTypeExtension: ({ name, directives, fields }) =>
-    join(['extend interface', name, join(directives, ' '), block(fields)], ' '),
+  InterfaceTypeExtension: ({ name, interfaces, directives, fields }) =>
+    join(
+      [
+        'extend interface',
+        name,
+        wrap('implements ', join(interfaces, ' & ')),
+        join(directives, ' '),
+        block(fields),
+      ],
+      ' ',
+    ),
 
   UnionTypeExtension: ({ name, directives, types }) =>
     join(

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -117,7 +117,13 @@ export const QueryDocumentKeys = {
     'defaultValue',
     'directives',
   ],
-  InterfaceTypeDefinition: ['description', 'name', 'directives', 'fields'],
+  InterfaceTypeDefinition: [
+    'description',
+    'name',
+    'interfaces',
+    'directives',
+    'fields',
+  ],
   UnionTypeDefinition: ['description', 'name', 'directives', 'types'],
   EnumTypeDefinition: ['description', 'name', 'directives', 'values'],
   EnumValueDefinition: ['description', 'name', 'directives'],
@@ -125,7 +131,7 @@ export const QueryDocumentKeys = {
 
   ScalarTypeExtension: ['name', 'directives'],
   ObjectTypeExtension: ['name', 'interfaces', 'directives', 'fields'],
-  InterfaceTypeExtension: ['name', 'directives', 'fields'],
+  InterfaceTypeExtension: ['name', 'interfaces', 'directives', 'fields'],
   UnionTypeExtension: ['name', 'directives', 'types'],
   EnumTypeExtension: ['name', 'directives', 'values'],
   InputObjectTypeExtension: ['name', 'directives', 'fields'],

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -281,40 +281,60 @@ describe('Type System: Example', () => {
   });
 
   it('includes interface possible types in the type map', () => {
-    const SomeInterface = new GraphQLInterfaceType({
-      name: 'SomeInterface',
+    const ParentInterface = new GraphQLInterfaceType({
+      name: 'ParentInterface',
       fields: {
         f: { type: GraphQLInt },
       },
+    });
+
+    const ChildInterface = new GraphQLInterfaceType({
+      name: 'ChildInterface',
+      fields: {
+        f: { type: GraphQLInt },
+        g: { type: GraphQLInt },
+      },
+      interfaces: [ParentInterface],
     });
 
     const SomeSubtype = new GraphQLObjectType({
       name: 'SomeSubtype',
       fields: {
         f: { type: GraphQLInt },
+        g: { type: GraphQLInt },
       },
-      interfaces: [SomeInterface],
+      interfaces: [ParentInterface, ChildInterface],
     });
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          iface: { type: SomeInterface },
+          iface: { type: ParentInterface },
         },
       }),
       types: [SomeSubtype],
     });
 
+    expect(schema.getTypeMap().ChildInterface).to.equal(ChildInterface);
     expect(schema.getTypeMap().SomeSubtype).to.equal(SomeSubtype);
   });
 
   it("includes interfaces' thunk subtypes in the type map", () => {
-    const SomeInterface = new GraphQLInterfaceType({
-      name: 'SomeInterface',
+    const ParentInterface = new GraphQLInterfaceType({
+      name: 'ParentInterface',
       fields: {
         f: { type: GraphQLInt },
       },
+    });
+
+    const ChildInterface = new GraphQLInterfaceType({
+      name: 'ChildInterface',
+      fields: {
+        f: { type: GraphQLInt },
+        g: { type: GraphQLInt },
+      },
+      interfaces: () => [ParentInterface],
     });
 
     const SomeSubtype = new GraphQLObjectType({
@@ -322,19 +342,20 @@ describe('Type System: Example', () => {
       fields: {
         f: { type: GraphQLInt },
       },
-      interfaces: () => [SomeInterface],
+      interfaces: () => [ParentInterface, ChildInterface],
     });
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
         fields: {
-          iface: { type: SomeInterface },
+          iface: { type: ParentInterface },
         },
       }),
       types: [SomeSubtype],
     });
 
+    expect(schema.getTypeMap().ChildInterface).to.equal(ChildInterface);
     expect(schema.getTypeMap().SomeSubtype).to.equal(SomeSubtype);
   });
 

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1313,7 +1313,7 @@ describe('Introspection', () => {
             {
               description:
                 'Indicates this type is an interface. ' +
-                '`fields` and `possibleTypes` are valid fields.',
+                '`fields`, `interfaces`, and `possibleTypes` are valid fields.',
               name: 'INTERFACE',
             },
             {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -613,7 +613,7 @@ GraphQLObjectType.prototype.toJSON = GraphQLObjectType.prototype.inspect =
   GraphQLObjectType.prototype.toString;
 
 function defineInterfaces(
-  type: GraphQLObjectType,
+  type: GraphQLObjectType | GraphQLInterfaceType,
   interfacesThunk: Thunk<?Array<GraphQLInterfaceType>>,
 ): Array<GraphQLInterfaceType> {
   const interfaces = resolveThunk(interfacesThunk) || [];
@@ -825,6 +825,7 @@ export class GraphQLInterfaceType {
 
   _typeConfig: GraphQLInterfaceTypeConfig<*, *>;
   _fields: GraphQLFieldMap<*, *>;
+  _interfaces: Array<GraphQLInterfaceType>;
 
   constructor(config: GraphQLInterfaceTypeConfig<*, *>): void {
     this.name = config.name;
@@ -849,6 +850,13 @@ export class GraphQLInterfaceType {
     );
   }
 
+  getInterfaces(): Array<GraphQLInterfaceType> {
+    return (
+      this._interfaces ||
+      (this._interfaces = defineInterfaces(this, this._typeConfig.interfaces))
+    );
+  }
+
   toString(): string {
     return this.name;
   }
@@ -863,6 +871,7 @@ GraphQLInterfaceType.prototype.toJSON = GraphQLInterfaceType.prototype.inspect =
 
 export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
   name: string,
+  interfaces?: Thunk<?Array<GraphQLInterfaceType>>,
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>,
   /**
    * Optionally provide a custom type resolver function. If one is not provided,

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -257,7 +257,7 @@ export const __Type = new GraphQLObjectType({
     interfaces: {
       type: GraphQLList(GraphQLNonNull(__Type)),
       resolve(type) {
-        if (isObjectType(type)) {
+        if (isObjectType(type) || isInterfaceType(type)) {
           return type.getInterfaces();
         }
       },
@@ -389,7 +389,7 @@ export const __TypeKind = new GraphQLEnumType({
       value: TypeKind.INTERFACE,
       description:
         'Indicates this type is an interface. ' +
-        '`fields` and `possibleTypes` are valid fields.',
+        '`fields`, `interfaces`, and `possibleTypes` are valid fields.',
     },
     UNION: {
       value: TypeKind.UNION,

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -322,6 +322,28 @@ describe('Schema Builder', () => {
     expect(output).to.equal(body);
   });
 
+  it('Simple interface heirarchy', () => {
+    const body = dedent`
+      schema {
+        query: Child
+      }
+
+      interface Child implements Parent {
+        str: String
+      }
+
+      type Hello implements Parent & Child {
+        str: String
+      }
+
+      interface Parent {
+        str: String
+      }
+    `;
+    const output = cycleOutput(body, 'Hello');
+    expect(output).to.equal(body);
+  });
+
   it('Simple output enum', () => {
     const body = dedent`
       schema {
@@ -672,6 +694,24 @@ describe('Schema Builder', () => {
 
       type Query {
         iface: Iface
+      }
+    `;
+    const output = cycleOutput(body);
+    expect(output).to.equal(body);
+  });
+
+  it('Unreferenced interface implementing referenced interface', () => {
+    const body = dedent`
+      interface Child implements Parent {
+        key: String
+      }
+
+      interface Parent {
+        key: String
+      }
+
+      type Query {
+        iface: Parent
       }
     `;
     const output = cycleOutput(body);

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -44,6 +44,7 @@ async function testSchema(serverSchema) {
     clientSchema,
     getIntrospectionQuery(),
   );
+
   expect(secondIntrospection).to.deep.equal(initialIntrospection);
 }
 
@@ -207,6 +208,53 @@ describe('Type System: build schema from introspection', () => {
       name: 'Human',
       interfaces: [friendlyType],
       fields: () => ({
+        bestFriend: { type: friendlyType },
+      }),
+    });
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'WithInterface',
+        fields: {
+          friendly: { type: friendlyType },
+        },
+      }),
+      types: [dogType, humanType],
+    });
+
+    await testSchema(schema);
+  });
+
+  it('builds a schema with an interface heirarchy', async () => {
+    const namedType = new GraphQLInterfaceType({
+      name: 'Named',
+      fields: () => ({
+        name: { type: new GraphQLNonNull(GraphQLString) },
+      }),
+    });
+    const friendlyType = new GraphQLInterfaceType({
+      name: 'Friendly',
+      interfaces: [namedType],
+      fields: () => ({
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        bestFriend: {
+          type: friendlyType,
+          description: 'The best friend of this friendly thing',
+        },
+      }),
+    });
+    const dogType = new GraphQLObjectType({
+      name: 'Dog',
+      interfaces: [friendlyType, namedType],
+      fields: () => ({
+        name: { type: new GraphQLNonNull(GraphQLString) },
+        bestFriend: { type: friendlyType },
+      }),
+    });
+    const humanType = new GraphQLObjectType({
+      name: 'Human',
+      interfaces: [friendlyType, namedType],
+      fields: () => ({
+        name: { type: new GraphQLNonNull(GraphQLString) },
         bestFriend: { type: friendlyType },
       }),
     });

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -31,27 +31,35 @@ import {
 const SomeInterfaceType = new GraphQLInterfaceType({
   name: 'SomeInterface',
   fields: () => ({
-    name: { type: GraphQLString },
     some: { type: SomeInterfaceType },
+  }),
+});
+
+const AnotherInterfaceType = new GraphQLInterfaceType({
+  name: 'AnotherInterface',
+  interfaces: [SomeInterfaceType],
+  fields: () => ({
+    name: { type: GraphQLString },
+    some: { type: AnotherInterfaceType },
   }),
 });
 
 const FooType = new GraphQLObjectType({
   name: 'Foo',
-  interfaces: [SomeInterfaceType],
+  interfaces: [AnotherInterfaceType, SomeInterfaceType],
   fields: () => ({
     name: { type: GraphQLString },
-    some: { type: SomeInterfaceType },
+    some: { type: AnotherInterfaceType },
     tree: { type: GraphQLNonNull(GraphQLList(FooType)) },
   }),
 });
 
 const BarType = new GraphQLObjectType({
   name: 'Bar',
-  interfaces: [SomeInterfaceType],
+  interfaces: [AnotherInterfaceType, SomeInterfaceType],
   fields: () => ({
     name: { type: GraphQLString },
-    some: { type: SomeInterfaceType },
+    some: { type: AnotherInterfaceType },
     foo: { type: FooType },
   }),
 });
@@ -186,9 +194,14 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
@@ -196,9 +209,9 @@ describe('extendSchema', () => {
         fizz: String
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField: String
       }
@@ -216,7 +229,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -369,9 +381,14 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
@@ -379,9 +396,9 @@ describe('extendSchema', () => {
         fizz: String
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
       }
 
@@ -398,7 +415,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -427,9 +443,14 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
@@ -437,9 +458,9 @@ describe('extendSchema', () => {
         fizz: String
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField(arg1: String, arg2: NewInputObj!): String
       }
@@ -463,7 +484,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -482,9 +502,14 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
@@ -492,9 +517,9 @@ describe('extendSchema', () => {
         fizz: String
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField(arg1: SomeEnum!): SomeEnum
       }
@@ -512,7 +537,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -522,9 +546,9 @@ describe('extendSchema', () => {
 
   it('extends objects by adding implemented interfaces', () => {
     const ast = parse(`
-      extend type Biz implements SomeInterface {
+      extend type Biz implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
       }
     `);
     const originalPrint = printSchema(testSchema);
@@ -532,21 +556,26 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
-      type Biz implements SomeInterface {
+      type Biz implements AnotherInterface & SomeInterface {
         fizz: String
         name: String
-        some: SomeInterface
+        some: AnotherInterface
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
       }
 
@@ -563,7 +592,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -608,9 +636,14 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
@@ -618,9 +651,9 @@ describe('extendSchema', () => {
         fizz: String
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newObject: NewObject
         newInterface: NewInterface
@@ -664,7 +697,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -687,9 +719,14 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
@@ -697,9 +734,9 @@ describe('extendSchema', () => {
         fizz: String
       }
 
-      type Foo implements SomeInterface & NewInterface {
+      type Foo implements AnotherInterface & SomeInterface & NewInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         baz: String
       }
@@ -721,7 +758,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 
@@ -736,9 +772,13 @@ describe('extendSchema', () => {
       }
 
       extend type Biz implements SomeInterface {
-        name: String
         some: SomeInterface
         newFieldA: Int
+      }
+
+      extend type Biz implements AnotherInterface {
+        name: String
+        some: AnotherInterface
       }
 
       extend type Biz {
@@ -755,24 +795,29 @@ describe('extendSchema', () => {
     expect(extendedSchema).to.not.equal(testSchema);
     expect(printSchema(testSchema)).to.equal(originalPrint);
     expect(printSchema(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
+      }
+
+      type Bar implements AnotherInterface & SomeInterface {
+        name: String
+        some: AnotherInterface
         foo: Foo
       }
 
-      type Biz implements NewInterface & SomeInterface {
+      type Biz implements NewInterface & SomeInterface & AnotherInterface {
         fizz: String
         buzz: String
-        name: String
-        some: SomeInterface
+        some: AnotherInterface
         newFieldA: Int
+        name: String
         newFieldB: Float
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
       }
 
@@ -793,7 +838,6 @@ describe('extendSchema', () => {
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
       }
 

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -1055,6 +1055,51 @@ describe('findBreakingChanges', () => {
     ]);
   });
 
+  it('should detect interfaces removed from interfaces', () => {
+    const interface1 = new GraphQLInterfaceType({
+      name: 'Interface1',
+      fields: {
+        field1: { type: GraphQLString },
+      },
+    });
+    const oldInterfaceType = new GraphQLObjectType({
+      name: 'Interface2',
+      interfaces: [interface1],
+      fields: {
+        field1: {
+          type: GraphQLString,
+        },
+      },
+    });
+
+    const newInterfaceType = new GraphQLObjectType({
+      name: 'Interface2',
+      interfaces: [],
+      fields: {
+        field1: {
+          type: GraphQLString,
+        },
+      },
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [oldInterfaceType],
+    });
+
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [newInterfaceType],
+    });
+
+    expect(findInterfacesRemovedFromObjectTypes(oldSchema, newSchema)).to.eql([
+      {
+        description: 'Interface2 no longer implements interface Interface1.',
+        type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
+      },
+    ]);
+  });
+
   it('should detect all breaking changes', () => {
     const typeThatGetsRemoved = new GraphQLObjectType({
       name: 'TypeThatGetsRemoved',
@@ -1606,6 +1651,52 @@ describe('findDangerousChanges', () => {
     expect(findInterfacesAddedToObjectTypes(oldSchema, newSchema)).to.eql([
       {
         description: 'Interface1 added to interfaces implemented by Type1.',
+        type: DangerousChangeType.INTERFACE_ADDED_TO_OBJECT,
+      },
+    ]);
+  });
+
+  it('should detect interfaces added to interfaces', () => {
+    const interface1 = new GraphQLInterfaceType({
+      name: 'Interface1',
+      fields: {
+        field1: { type: GraphQLString },
+      },
+    });
+    const oldInterfaceType = new GraphQLObjectType({
+      name: 'Interface2',
+      interfaces: [],
+      fields: {
+        field1: {
+          type: GraphQLString,
+        },
+      },
+    });
+
+    const newInterfaceType = new GraphQLObjectType({
+      name: 'Interface2',
+      interfaces: [interface1],
+      fields: {
+        field1: {
+          type: GraphQLString,
+        },
+      },
+    });
+
+    const oldSchema = new GraphQLSchema({
+      query: queryType,
+      types: [oldInterfaceType],
+    });
+
+    const newSchema = new GraphQLSchema({
+      query: queryType,
+      types: [newInterfaceType],
+    });
+
+    expect(findInterfacesAddedToObjectTypes(oldSchema, newSchema)).to.eql([
+      {
+        description:
+          'Interface1 added to interfaces implemented by Interface2.',
         type: DangerousChangeType.INTERFACE_ADDED_TO_OBJECT,
       },
     ]);

--- a/src/utilities/__tests__/lexographicSortSchema-test.js
+++ b/src/utilities/__tests__/lexographicSortSchema-test.js
@@ -78,7 +78,7 @@ describe('lexographicSortSchema', () => {
         dummy: String
       }
 
-      interface FooC {
+      interface FooC implements FooB & FooA {
         dummy: String
       }
 
@@ -96,7 +96,7 @@ describe('lexographicSortSchema', () => {
         dummy: String
       }
 
-      interface FooC {
+      interface FooC implements FooA & FooB {
         dummy: String
       }
 

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -813,7 +813,7 @@ describe('Type System Printer', () => {
         OBJECT
 
         """
-        Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
+        Indicates this type is an interface. \`fields\`, \`interfaces\`, and \`possibleTypes\` are valid fields.
         """
         INTERFACE
 
@@ -1025,7 +1025,7 @@ describe('Type System Printer', () => {
         # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.
         OBJECT
 
-        # Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
+        # Indicates this type is an interface. \`fields\`, \`interfaces\`, and \`possibleTypes\` are valid fields.
         INTERFACE
 
         # Indicates this type is a union. \`possibleTypes\` is a valid field.

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -374,6 +374,61 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('Print Hierarchical Interface', () => {
+    const FooType = new GraphQLInterfaceType({
+      name: 'Foo',
+      fields: { str: { type: GraphQLString } },
+    });
+
+    const BaazType = new GraphQLInterfaceType({
+      name: 'Baaz',
+      interfaces: [FooType],
+      fields: {
+        int: { type: GraphQLInt },
+        str: { type: GraphQLString },
+      },
+    });
+
+    const BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: {
+        str: { type: GraphQLString },
+        int: { type: GraphQLInt },
+      },
+      interfaces: [FooType, BaazType],
+    });
+
+    const Query = new GraphQLObjectType({
+      name: 'Query',
+      fields: { bar: { type: BarType } },
+    });
+
+    const Schema = new GraphQLSchema({
+      query: Query,
+      types: [BarType],
+    });
+    const output = printForTest(Schema);
+    expect(output).to.equal(dedent`
+      interface Baaz implements Foo {
+        int: Int
+        str: String
+      }
+
+      type Bar implements Foo & Baaz {
+        str: String
+        int: Int
+      }
+
+      interface Foo {
+        str: String
+      }
+
+      type Query {
+        bar: Bar
+      }
+    `);
+  });
+
   it('Print Unions', () => {
     const FooType = new GraphQLObjectType({
       name: 'Foo',

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -115,7 +115,7 @@ describe('typeComparators', () => {
       expect(isTypeSubTypeOf(schema, member, union)).to.equal(true);
     });
 
-    it('implementation is subtype of interface', () => {
+    it('implementing object is subtype of interface', () => {
       const iface = new GraphQLInterfaceType({
         name: 'Interface',
         fields: {
@@ -124,6 +124,24 @@ describe('typeComparators', () => {
       });
       const impl = new GraphQLObjectType({
         name: 'Object',
+        interfaces: [iface],
+        fields: {
+          field: { type: GraphQLString },
+        },
+      });
+      const schema = testSchema({ field: { type: impl } });
+      expect(isTypeSubTypeOf(schema, impl, iface)).to.equal(true);
+    });
+
+    it('implementing interface is subtype of interface', () => {
+      const iface = new GraphQLInterfaceType({
+        name: 'Parent',
+        fields: {
+          field: { type: GraphQLString },
+        },
+      });
+      const impl = new GraphQLInterfaceType({
+        name: 'Child',
         interfaces: [iface],
         fields: {
           field: { type: GraphQLString },

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -368,7 +368,9 @@ export class ASTDefinitionBuilder {
       : {};
   }
 
-  _makeImplementedInterfaces(def: ObjectTypeDefinitionNode) {
+  _makeImplementedInterfaces(
+    def: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
+  ) {
     return (
       def.interfaces &&
       // Note: While this could make early assertions to get the correctly
@@ -402,6 +404,7 @@ export class ASTDefinitionBuilder {
       name: def.name.value,
       description: getDescription(def, this._options),
       fields: () => this._makeFieldDefMap(def),
+      interfaces: () => this._makeImplementedInterfaces(def),
       astNode: def,
     });
   }

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -238,6 +238,7 @@ export function buildClientSchema(
     return new GraphQLInterfaceType({
       name: interfaceIntrospection.name,
       description: interfaceIntrospection.description,
+      interfaces: interfaceIntrospection.interfaces.map(getInterfaceType),
       fields: () => buildFieldDefMap(interfaceIntrospection),
     });
   }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -289,6 +289,7 @@ export function extendSchema(
     return new GraphQLInterfaceType({
       name: type.name,
       description: type.description,
+      interfaces: () => extendImplementedInterfaces(type),
       fields: () => extendFieldMap(type),
       astNode: type.astNode,
       resolveType: type.resolveType,
@@ -306,7 +307,7 @@ export function extendSchema(
   }
 
   function extendImplementedInterfaces(
-    type: GraphQLObjectType,
+    type: GraphQLObjectType | GraphQLInterfaceType,
   ): Array<GraphQLInterfaceType> {
     const interfaces = type.getInterfaces().map(getTypeFromDef);
 

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -640,7 +640,11 @@ export function findInterfacesRemovedFromObjectTypes(
   Object.keys(oldTypeMap).forEach(typeName => {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
-    if (!isObjectType(oldType) || !isObjectType(newType)) {
+
+    if (
+      !(isObjectType(oldType) && isObjectType(newType)) ||
+      !(isInterfaceType(oldType) && isInterfaceType(newType))
+    ) {
       return;
     }
 

--- a/src/utilities/introspectionQuery.js
+++ b/src/utilities/introspectionQuery.js
@@ -167,6 +167,9 @@ export type IntrospectionInterfaceType = {
   +name: string,
   +description?: ?string,
   +fields: $ReadOnlyArray<IntrospectionField>,
+  +interfaces: $ReadOnlyArray<
+    IntrospectionNamedTypeRef<IntrospectionInterfaceType>,
+  >,
   +possibleTypes: $ReadOnlyArray<
     IntrospectionNamedTypeRef<IntrospectionObjectType>,
   >,

--- a/src/utilities/lexographicSortSchema.js
+++ b/src/utilities/lexographicSortSchema.js
@@ -134,6 +134,7 @@ export function lexographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     } else if (isInterfaceType(type)) {
       return new GraphQLInterfaceType({
         name: type.name,
+        interfaces: sortTypes(type.getInterfaces()),
         fields: sortFields(type.getFields()),
         resolveType: type.resolveType,
         description: type.description,

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -188,9 +188,13 @@ function printObject(type: GraphQLObjectType, options): string {
 }
 
 function printInterface(type: GraphQLInterfaceType, options): string {
+  const interfaces = type.getInterfaces();
+  const implementedInterfaces = interfaces.length
+    ? ' implements ' + interfaces.map(i => i.name).join(' & ')
+    : '';
   return (
     printDescription(options, type) +
-    `interface ${type.name} {\n` +
+    `interface ${type.name}${implementedInterfaces} {\n` +
     printFields(options, type) +
     '\n' +
     '}'

--- a/src/utilities/typeComparators.js
+++ b/src/utilities/typeComparators.js
@@ -8,6 +8,7 @@
  */
 
 import {
+  isInterfaceType,
   isObjectType,
   isListType,
   isNonNullType,
@@ -83,6 +84,16 @@ export function isTypeSubTypeOf(
     isAbstractType(superType) &&
     isObjectType(maybeSubType) &&
     schema.isPossibleType(superType, maybeSubType)
+  ) {
+    return true;
+  }
+
+  // If superType type is an abstract type, maybeSubType type may be a currently
+  // possible object type.
+  if (
+    isInterfaceType(superType) &&
+    (isObjectType(maybeSubType) || isInterfaceType(maybeSubType)) &&
+    schema.isPossibleImplementation(superType, maybeSubType)
   ) {
     return true;
   }

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -41,8 +41,21 @@ const Being = new GraphQLInterfaceType({
   }),
 });
 
+const Mammal = new GraphQLInterfaceType({
+  name: 'Mammal',
+  fields: () => ({
+    mother: {
+      type: Mammal,
+    },
+    father: {
+      type: Mammal,
+    },
+  }),
+});
+
 const Pet = new GraphQLInterfaceType({
   name: 'Pet',
+  interfaces: [Being],
   fields: () => ({
     name: {
       type: GraphQLString,
@@ -53,10 +66,17 @@ const Pet = new GraphQLInterfaceType({
 
 const Canine = new GraphQLInterfaceType({
   name: 'Canine',
+  interfaces: [Being, Mammal],
   fields: () => ({
     name: {
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
+    },
+    mother: {
+      type: Canine,
+    },
+    father: {
+      type: Canine,
     },
   }),
 });
@@ -99,8 +119,14 @@ const Dog = new GraphQLObjectType({
       type: GraphQLBoolean,
       args: { x: { type: GraphQLInt }, y: { type: GraphQLInt } },
     },
+    mother: {
+      type: Dog,
+    },
+    father: {
+      type: Dog,
+    },
   }),
-  interfaces: [Being, Pet, Canine],
+  interfaces: [Being, Pet, Mammal, Canine],
 });
 
 const Cat = new GraphQLObjectType({


### PR DESCRIPTION
This is the companion PR to the RFC facebook/graphql#373 which is tracked by issue facebook/graphql#295.

- [x] parser & tests
- [x] printer & tests
- [x] schema definitions & tests
- [x] schema validation & tests
- [x] possibleTypes must resolve to concrete types
- [x] schema introspection & tests
- [x] utilities
- [x] query validation & tests
- [x] query execution tests