### PR TITLE
Maintain allowed legacy names when extending a schema.

### DIFF
--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -90,6 +90,7 @@ const testSchema = new GraphQLSchema({
     }),
   }),
   types: [FooType, BarType],
+  allowedLegacyNames: ['__badName'],
 });
 
 describe('extendSchema', () => {
@@ -992,6 +993,16 @@ describe('extendSchema', () => {
       'Cannot extend type "UnknownType" because it does not exist in the ' +
         'existing schema.',
     );
+  });
+
+  it('maintains configuration of the original schema object', () => {
+    const ast = parse(`
+      extend type Query {
+        __badName: String
+      }
+    `);
+    const schema = extendSchema(testSchema, ast);
+    expect(schema.__allowedLegacyNames).to.eql(['__badName']);
   });
 
   describe('does not allow extending a non-object type', () => {

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -90,7 +90,6 @@ const testSchema = new GraphQLSchema({
     }),
   }),
   types: [FooType, BarType],
-  allowedLegacyNames: ['__badName'],
 });
 
 describe('extendSchema', () => {
@@ -996,12 +995,21 @@ describe('extendSchema', () => {
   });
 
   it('maintains configuration of the original schema object', () => {
+    const testSchemaWithLegacyNames = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: () => ({
+          id: { type: GraphQLID },
+        }),
+      }),
+      allowedLegacyNames: ['__badName'],
+    });
     const ast = parse(`
       extend type Query {
         __badName: String
       }
     `);
-    const schema = extendSchema(testSchema, ast);
+    const schema = extendSchema(testSchemaWithLegacyNames, ast);
     expect(schema.__allowedLegacyNames).to.deep.equal(['__badName']);
   });
 

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -1002,7 +1002,7 @@ describe('extendSchema', () => {
       }
     `);
     const schema = extendSchema(testSchema, ast);
-    expect(schema.__allowedLegacyNames).to.eql(['__badName']);
+    expect(schema.__allowedLegacyNames).to.deep.equal(['__badName']);
   });
 
   describe('does not allow extending a non-object type', () => {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -231,7 +231,7 @@ export function extendSchema(
     directives: getMergedDirectives(),
     astNode: schema.astNode,
     allowedLegacyNames:
-      schema.__allowedLegacyNames && schema.__allowedLegacyNames.slice(0),
+      schema.__allowedLegacyNames && schema.__allowedLegacyNames.slice(),
   });
 
   // Below are functions used for producing this schema that have closed over

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -230,6 +230,8 @@ export function extendSchema(
     types,
     directives: getMergedDirectives(),
     astNode: schema.astNode,
+    allowedLegacyNames:
+      schema.__allowedLegacyNames && schema.__allowedLegacyNames.slice(0),
   });
 
   // Below are functions used for producing this schema that have closed over


### PR DESCRIPTION
v0.13.0-rc.1 adds the `allowedLegacyNames` option from #1194. Unfortunately, while trying to make a PR for [Relay](https://github.com/facebook/relay) that adds support for this, it turns out that Relay internally uses `extendSchema` from `graphql-js` but that function does not maintain this option and thus the new schema still complains.

This PR addresses that, it would be nice if this could go into a v0.13.0-rc.2 release.