### PR TITLE
Make 'ASTDefinitionBuilder' responsible only for build types from AST

### DIFF
--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -176,22 +176,20 @@ export function buildASTSchema(
   const operationTypes = schemaDef
     ? getOperationTypes(schemaDef)
     : {
-        query: nodeMap.Query ? 'Query' : null,
-        mutation: nodeMap.Mutation ? 'Mutation' : null,
-        subscription: nodeMap.Subscription ? 'Subscription' : null,
+        query: nodeMap.Query,
+        mutation: nodeMap.Mutation,
+        subscription: nodeMap.Subscription,
       };
 
   const definitionBuilder = new ASTDefinitionBuilder(
     nodeMap,
     options,
-    typeName => {
-      throw new Error(`Type "${typeName}" not found in document.`);
+    typeRef => {
+      throw new Error(`Type "${typeRef.name.value}" not found in document.`);
     },
   );
 
-  const types = typeDefs.map(def =>
-    definitionBuilder.buildType(def.name.value),
-  );
+  const types = typeDefs.map(def => definitionBuilder.buildType(def));
 
   const directives = directiveDefs.map(def =>
     definitionBuilder.buildDirective(def),
@@ -242,17 +240,14 @@ export function buildASTSchema(
           `Specified ${operation} type "${typeName}" not found in document.`,
         );
       }
-      opTypes[operation] = typeName;
+      opTypes[operation] = operationType.type;
     });
     return opTypes;
   }
 }
 
 type TypeDefinitionsMap = ObjMap<TypeDefinitionNode>;
-type TypeResolver = (
-  typeName: string,
-  node?: ?NamedTypeNode,
-) => GraphQLNamedType;
+type TypeResolver = (typeRef: NamedTypeNode) => GraphQLNamedType;
 
 export class ASTDefinitionBuilder {
   _typeDefinitionsMap: TypeDefinitionsMap;
@@ -275,23 +270,19 @@ export class ASTDefinitionBuilder {
     );
   }
 
-  _buildType(typeName: string, typeNode?: ?NamedTypeNode): GraphQLNamedType {
+  buildType(node: NamedTypeNode | TypeDefinitionNode): GraphQLNamedType {
+    const typeName = node.name.value;
     if (!this._cache[typeName]) {
-      const defNode = this._typeDefinitionsMap[typeName];
-      if (defNode) {
-        this._cache[typeName] = this._makeSchemaDef(defNode);
+      if (node.kind === Kind.NAMED_TYPE) {
+        const defNode = this._typeDefinitionsMap[typeName];
+        this._cache[typeName] = defNode
+          ? this._makeSchemaDef(defNode)
+          : this._resolveType(node);
       } else {
-        this._cache[typeName] = this._resolveType(typeName, typeNode);
+        this._cache[typeName] = this._makeSchemaDef(node);
       }
     }
     return this._cache[typeName];
-  }
-
-  buildType(ref: string | NamedTypeNode): GraphQLNamedType {
-    if (typeof ref === 'string') {
-      return this._buildType(ref);
-    }
-    return this._buildType(ref.name.value, ref);
   }
 
   _buildWrappedType(typeNode: TypeNode): GraphQLType {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -286,7 +286,7 @@ export function extendSchema(
   }
 
   // To be called at most once per type. Only getExtendedType should call this.
-  function extendType<T: GraphQLNamedType>(type: T): T {
+  function extendType(type) {
     if (isIntrospectionType(type)) {
       // Introspection types are not extended.
       return type;

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -285,20 +285,23 @@ export function extendSchema(
     return (extendTypeCache[type.name]: any);
   }
 
-  // Should be called only once per type so only getExtendedType should call it.
+  // To be called at most once per type. Only getExtendedType should call this.
   function extendType<T: GraphQLNamedType>(type: T): T {
-    let extendedType = type;
-    if (!isIntrospectionType(type)) {
-      if (isObjectType(type)) {
-        extendedType = extendObjectType(type);
-      } else if (isInterfaceType(type)) {
-        extendedType = extendInterfaceType(type);
-      } else if (isUnionType(type)) {
-        extendedType = extendUnionType(type);
-      }
+    if (isIntrospectionType(type)) {
+      // Introspection types are not extended.
+      return type;
     }
-    // Workaround: Flow should figure out correct type, but it doesn't.
-    return (extendedType: any);
+    if (isObjectType(type)) {
+      return extendObjectType(type);
+    }
+    if (isInterfaceType(type)) {
+      return extendInterfaceType(type);
+    }
+    if (isUnionType(type)) {
+      return extendUnionType(type);
+    }
+    // This type is not yet extendable.
+    return type;
   }
 
   function extendObjectType(type: GraphQLObjectType): GraphQLObjectType {


### PR DESCRIPTION
It's part of #1199 
Its primary purpose is to make  'ASTDefinitionBuilder' responsible only for build types from AST.
It's not only made possible to extract `transformSchema` into the separate function but also make the code more modular and simple.