### PR TITLE
Export ExecutableDefinitionNode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -205,6 +205,7 @@ export type {
   NameNode,
   DocumentNode,
   DefinitionNode,
+  ExecutableDefinitionNode,
   OperationDefinitionNode,
   OperationTypeNode,
   VariableDefinitionNode,

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -36,6 +36,7 @@ export type {
   NameNode,
   DocumentNode,
   DefinitionNode,
+  ExecutableDefinitionNode,
   OperationDefinitionNode,
   OperationTypeNode,
   VariableDefinitionNode,


### PR DESCRIPTION
Makes it easier to use standard fragment/operation definitions without pulling in schema definitions.