### PR TITLE
Fix orList to not use or and comma between last two elements

### DIFF
--- a/src/jsutils/__tests__/quotedOrList-test.js
+++ b/src/jsutils/__tests__/quotedOrList-test.js
@@ -23,12 +23,12 @@ describe('quotedOrList', () => {
   });
 
   it('Returns comma separated many item list', () => {
-    expect(quotedOrList(['A', 'B', 'C'])).to.equal('"A", "B", or "C"');
+    expect(quotedOrList(['A', 'B', 'C'])).to.equal('"A", "B" or "C"');
   });
 
   it('Limits to five items', () => {
     expect(quotedOrList(['A', 'B', 'C', 'D', 'E', 'F'])).to.equal(
-      '"A", "B", "C", "D", or "E"',
+      '"A", "B", "C", "D" or "E"',
     );
   });
 });

--- a/src/jsutils/orList.js
+++ b/src/jsutils/orList.js
@@ -17,7 +17,7 @@ export default function orList(items: $ReadOnlyArray<string>): string {
   return selected.reduce(
     (list, quoted, index) =>
       list +
-      (selected.length > 2 ? ', ' : ' ') +
+      (selected.length > 2 && index !== selected.length - 1 ? ', ' : ' ') +
       (index === selected.length - 1 ? 'or ' : '') +
       quoted,
   );

--- a/src/validation/__tests__/FieldsOnCorrectType-test.js
+++ b/src/validation/__tests__/FieldsOnCorrectType-test.js
@@ -304,7 +304,7 @@ describe('Validate: Fields on correct type', () => {
         undefinedFieldMessage('f', 'T', ['A', 'B', 'C', 'D', 'E', 'F'], []),
       ).to.equal(
         'Cannot query field "f" on type "T". ' +
-          'Did you mean to use an inline fragment on "A", "B", "C", "D", or "E"?',
+          'Did you mean to use an inline fragment on "A", "B", "C", "D" or "E"?',
       );
     });
 
@@ -313,7 +313,7 @@ describe('Validate: Fields on correct type', () => {
         undefinedFieldMessage('f', 'T', [], ['z', 'y', 'x', 'w', 'v', 'u']),
       ).to.equal(
         'Cannot query field "f" on type "T". ' +
-          'Did you mean "z", "y", "x", "w", or "v"?',
+          'Did you mean "z", "y", "x", "w" or "v"?',
       );
     });
   });


### PR DESCRIPTION
Fixes 

```js
"A", "B", "C", "D", or "E"
```

and remove the last comma which seems misplaced.