### PR TITLE
Allow buildSchema() to take options.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -375,6 +375,7 @@ export {
 } from './utilities';
 
 export type {
+  BuildSchemaOptions,
   BreakingChange,
   DangerousChange,
   IntrospectionOptions,

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -14,6 +14,7 @@ import { valueFromAST } from './valueFromAST';
 import blockStringValue from '../language/blockStringValue';
 import { TokenKind } from '../language/lexer';
 import { parse } from '../language/parser';
+import type { ParseOptions } from '../language/parser';
 import type { Source } from '../language/source';
 import { getDirectiveValues } from '../execution/values';
 import { Kind } from '../language/kinds';
@@ -72,7 +73,7 @@ import type {
   GraphQLFieldConfig,
 } from '../type/definition';
 
-type Options = {|
+export type BuildSchemaOptions = {
   ...GraphQLSchemaValidationOptions,
 
   /**
@@ -83,7 +84,7 @@ type Options = {|
    * Default: false
    */
   commentDescriptions?: boolean,
-|};
+};
 
 function buildWrappedType(
   innerType: GraphQLType,
@@ -128,7 +129,7 @@ function getNamedTypeNode(typeNode: TypeNode): NamedTypeNode {
  */
 export function buildASTSchema(
   ast: DocumentNode,
-  options?: Options,
+  options?: BuildSchemaOptions,
 ): GraphQLSchema {
   if (!ast || ast.kind !== Kind.DOCUMENT) {
     throw new Error('Must provide a document ast.');
@@ -246,13 +247,13 @@ type TypeResolver = (typeRef: NamedTypeNode) => GraphQLNamedType;
 
 export class ASTDefinitionBuilder {
   _typeDefinitionsMap: TypeDefinitionsMap;
-  _options: ?Options;
+  _options: ?BuildSchemaOptions;
   _resolveType: TypeResolver;
   _cache: ObjMap<GraphQLNamedType>;
 
   constructor(
     typeDefinitionsMap: TypeDefinitionsMap,
-    options: ?Options,
+    options: ?BuildSchemaOptions,
     resolveType: TypeResolver,
   ) {
     this._typeDefinitionsMap = typeDefinitionsMap;
@@ -464,7 +465,7 @@ function getDeprecationReason(
  */
 export function getDescription(
   node: { +description?: StringValueNode, +loc?: Location },
-  options: ?Options,
+  options: ?BuildSchemaOptions,
 ): void | string {
   if (node.description) {
     return node.description.value;
@@ -503,6 +504,9 @@ function getLeadingCommentBlock(node): void | string {
  * A helper function to build a GraphQLSchema directly from a source
  * document.
  */
-export function buildSchema(source: string | Source): GraphQLSchema {
-  return buildASTSchema(parse(source));
+export function buildSchema(
+  source: string | Source,
+  options: BuildSchemaOptions & ParseOptions,
+): GraphQLSchema {
+  return buildASTSchema(parse(source, options), options);
 }

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -49,6 +49,7 @@ export { buildClientSchema } from './buildClientSchema';
 
 // Build a GraphQLSchema from GraphQL Schema language.
 export { buildASTSchema, buildSchema, getDescription } from './buildASTSchema';
+export type { BuildSchemaOptions } from './buildASTSchema';
 
 // Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
 export { extendSchema } from './extendSchema';


### PR DESCRIPTION
buildSchema() is essentially just short hand for buildASTSchema(parse()), however since both of these composed functions accept options, it's nice to allow buildSchema() to accept options as well - it accepts the combined set of options which it passes to both functions.

This also names and exports the options for buildASTSchema() such that they can be used in the same way by third party code.