### PR TITLE
Visitor: fix description of "ancestors" arg + test

### DIFF
--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -74,7 +74,6 @@ describe('Visitor', () => {
         checkVisitorFnArgs(ast, arguments);
         visited.push(['enter', path.slice()]);
       },
-
       leave(node, key, parent, path) {
         checkVisitorFnArgs(ast, arguments);
         visited.push(['leave', path.slice()]);
@@ -93,6 +92,34 @@ describe('Visitor', () => {
       ['leave', ['definitions', 0]],
       ['leave', []],
     ]);
+  });
+
+  it('validates ancestors argument', () => {
+    const ast = parse('{ a }', { noLocation: true });
+    const nodesInPath = [];
+
+    visit(ast, {
+      enter(node, key, parent, path, ancestors) {
+        const inArray = typeof key === 'number';
+        const expectedAncestors = nodesInPath.slice(0, path.length - 1);
+        expect(ancestors).to.deep.equal(expectedAncestors);
+
+        if (inArray) {
+          nodesInPath.push(parent);
+        }
+        nodesInPath.push(node);
+      },
+      leave(node, key, parent, path, ancestors) {
+        const inArray = typeof key === 'number';
+        const expectedAncestors = nodesInPath.slice(0, path.length - 1);
+        expect(ancestors).to.deep.equal(expectedAncestors);
+
+        if (inArray) {
+          nodesInPath.pop();
+        }
+        nodesInPath.pop();
+      },
+    });
   });
 
   it('allows editing a node both on enter and on leave', () => {

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -96,28 +96,28 @@ describe('Visitor', () => {
 
   it('validates ancestors argument', () => {
     const ast = parse('{ a }', { noLocation: true });
-    const nodesInPath = [];
+    const visitedNodes = [];
 
     visit(ast, {
       enter(node, key, parent, path, ancestors) {
         const inArray = typeof key === 'number';
-        const expectedAncestors = nodesInPath.slice(0, path.length - 1);
-        expect(ancestors).to.deep.equal(expectedAncestors);
-
         if (inArray) {
-          nodesInPath.push(parent);
+          visitedNodes.push(parent);
         }
-        nodesInPath.push(node);
+        visitedNodes.push(node);
+
+        const expectedAncestors = visitedNodes.slice(0, -2);
+        expect(ancestors).to.deep.equal(expectedAncestors);
       },
       leave(node, key, parent, path, ancestors) {
-        const inArray = typeof key === 'number';
-        const expectedAncestors = nodesInPath.slice(0, path.length - 1);
+        const expectedAncestors = visitedNodes.slice(0, -2);
         expect(ancestors).to.deep.equal(expectedAncestors);
 
+        const inArray = typeof key === 'number';
         if (inArray) {
-          nodesInPath.pop();
+          visitedNodes.pop();
         }
-        nodesInPath.pop();
+        visitedNodes.pop();
       },
     });
   });

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -40,9 +40,9 @@ export type VisitFn<TAnyNode, TVisitedNode: TAnyNode = TAnyNode> = (
   parent: TAnyNode | $ReadOnlyArray<TAnyNode> | void,
   // The key path to get to this node from the root node.
   path: $ReadOnlyArray<string | number>,
-  // All nodes and Arrays visited before reaching this node.
+  // All nodes and Arrays visited before reaching parent of this node.
   // These correspond to array indices in `path`.
-  // Note: ancestors includes arrays which contain the visited node.
+  // Note: ancestors includes arrays which contain the parent of visited node.
   ancestors: $ReadOnlyArray<TAnyNode | $ReadOnlyArray<TAnyNode>>,
 ) => any;
 


### PR DESCRIPTION
This description is incorrect:
https://github.com/graphql/graphql-js/blob/86d33b49a92eda05ee9ca7b3a6fe3a449a21de4c/src/language/visitor.js#L43-L46

Since `ancestors` never includes parent, and it's already tested here:
https://github.com/graphql/graphql-js/blob/86d33b49a92eda05ee9ca7b3a6fe3a449a21de4c/src/language/__tests__/visitor-test.js#L54

But I added a separate test to make it more obvious.