### PR TITLE
memoise wrapper values

### DIFF
--- a/src/type/wrappers.js
+++ b/src/type/wrappers.js
@@ -34,12 +34,19 @@ declare class GraphQLList<+T: GraphQLType> {
   // Note: constructors cannot be used for covariant types. Drop the "new".
   constructor(ofType: any): void;
 }
+const listCache = new WeakMap();
 // eslint-disable-next-line no-redeclare
 export function GraphQLList(ofType) {
   if (this instanceof GraphQLList) {
     this.ofType = assertType(ofType);
   } else {
-    return new GraphQLList(ofType);
+    const cachedValue = listCache.get(ofType);
+    if (cachedValue !== undefined) {
+      return cachedValue;
+    }
+    const newValue = new GraphQLList(ofType);
+    listCache.set(ofType, newValue);
+    return newValue;
   }
 }
 
@@ -75,12 +82,19 @@ declare class GraphQLNonNull<+T: GraphQLNullableType> {
   // Note: constructors cannot be used for covariant types. Drop the "new".
   constructor(ofType: any): void;
 }
+const nnCache = new WeakMap();
 // eslint-disable-next-line no-redeclare
 export function GraphQLNonNull(ofType) {
   if (this instanceof GraphQLNonNull) {
     this.ofType = assertNullableType(ofType);
   } else {
-    return new GraphQLNonNull(ofType);
+    const cachedValue = nnCache.get(ofType);
+    if (cachedValue !== undefined) {
+      return cachedValue;
+    }
+    const newValue = new GraphQLNonNull(ofType);
+    nnCache.set(ofType, newValue);
+    return newValue;
   }
 }
 


### PR DESCRIPTION
In a similar spirit to #1130, and extracted from code written updating #1054: use `WeakMap` to cache `GraphQLList` and `GraphQLNonNull` wrappers for any given type, so that the wrapper function will always return the same instance. This will make type-comparisons able to be quicker, and avoid constructing unnecessary duplicates.