### PR TITLE
fix: process is undefined when used in browser

### DIFF
--- a/src/jsutils/instanceOf.js
+++ b/src/jsutils/instanceOf.js
@@ -16,7 +16,8 @@ declare function instanceOf(
   constructor: mixed,
 ): boolean %checks(value instanceof constructor);
 
-export default (process && process.env.NODE_ENV !== 'production'
+export default (typeof process !== 'undefined' &&
+process.env.NODE_ENV !== 'production'
   ? // eslint-disable-next-line no-shadow
     function instanceOf(value: any, constructor: any) {
       if (value instanceof constructor) {


### PR DESCRIPTION
When this library is used in browser, global variable `process` is undefined. This issue is related to earlier #1058. 