### PR TITLE
Use empty arrays instead of undefined properties

### DIFF
--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -88,7 +88,7 @@ export class GraphQLSchema {
   // Used as a cache for validateSchema().
   __validationErrors: ?$ReadOnlyArray<GraphQLError>;
   // Referenced by validateSchema().
-  __allowedLegacyNames: ?$ReadOnlyArray<string>;
+  __allowedLegacyNames: $ReadOnlyArray<string>;
 
   constructor(config: GraphQLSchemaConfig): void {
     // If this schema was built from a source known to be valid, then it may be
@@ -118,7 +118,7 @@ export class GraphQLSchema {
       );
     }
 
-    this.__allowedLegacyNames = config.allowedLegacyNames;
+    this.__allowedLegacyNames = config.allowedLegacyNames || [];
     this._queryType = config.query;
     this._mutationType = config.mutation;
     this._subscriptionType = config.subscription;

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -221,10 +221,7 @@ function validateName(
 ): void {
   // If a schema explicitly allows some legacy name which is no longer valid,
   // allow it to be assumed valid.
-  if (
-    context.schema.__allowedLegacyNames &&
-    context.schema.__allowedLegacyNames.indexOf(node.name) !== -1
-  ) {
+  if (context.schema.__allowedLegacyNames.indexOf(node.name) !== -1) {
     return;
   }
   // Ensure names are valid, however introspection types opt out.

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -237,12 +237,9 @@ export function extendSchema(
   ];
 
   // Support both original legacy names and extended legacy names.
-  const schemaAllowedLegacyNames = schema.__allowedLegacyNames;
-  const extendAllowedLegacyNames = options && options.allowedLegacyNames;
-  const allowedLegacyNames =
-    schemaAllowedLegacyNames && extendAllowedLegacyNames
-      ? schemaAllowedLegacyNames.concat(extendAllowedLegacyNames)
-      : schemaAllowedLegacyNames || extendAllowedLegacyNames;
+  const allowedLegacyNames = schema.__allowedLegacyNames.concat(
+    (options && options.allowedLegacyNames) || [],
+  );
 
   // Then produce and return a Schema with these types.
   return new GraphQLSchema({


### PR DESCRIPTION
This PR makes `extensionASTNodes` and `__allowedLegacyNames` fields to always be arrays similar to other places in this lib:
https://github.com/graphql/graphql-js/blob/499a75939f70c4863d44149371d6a99d57ff7c35/src/type/definition.js#L619
https://github.com/graphql/graphql-js/blob/499a75939f70c4863d44149371d6a99d57ff7c35/src/type/definition.js#L947