### PR TITLE
[Bug Reproduce] Can't use undefined and NaN as enum values

### DIFF
--- a/src/utilities/__tests__/valueFromAST-test.js
+++ b/src/utilities/__tests__/valueFromAST-test.js
@@ -66,6 +66,7 @@ describe('valueFromAST', () => {
       BLUE: { value: 3 },
       NULL: { value: null },
       UNDEFINED: { value: undefined },
+      NAN: { value: NaN },
     },
   });
 
@@ -77,6 +78,7 @@ describe('valueFromAST', () => {
     testCase(testEnum, 'null', null);
     testCase(testEnum, 'NULL', null);
     testCase(testEnum, 'UNDEFINED', undefined);
+    testCase(testEnum, 'NAN', NaN);
   });
 
   // Boolean!


### PR DESCRIPTION
I clean up some existing tests but the main purpose of this PR is to report problem with enum values(test case added in 9452661).

From #836 it looks like both `undefined` and `NaN` could be used as an enum values:
```js
const TestEnum = new GraphQLEnumType({
  name: 'TestEnum',
  values: {
    UNDEFINED: { value: undefined },
    NAN: { value: NaN },
  },
});
```
And run this query:
```graphql
{
  undefined: fieldWithEnumInput(input: UNDEFINED)
  NaN: fieldWithEnumInput(input: NAN)
}
```
It will result in:
```json
{
  "data": {
    "undefined": null,
    "NaN": null
  },
  "errors": [
    {
      "message": "Argument \"input\" has invalid value UNDEFINED.",
      "path": [ "undefined" ]
    }
    {
      "message": "Argument \"input\" has invalid value NAN.",
      "path": [ "NaN" ]
    }
  ]
}
```

Because of this check:
https://github.com/graphql/graphql-js/blob/a62eea88d5844a3bd9725c0f3c30950a78727f3e/src/execution/values.js#L164-L165

This issue can't be easily fixed because both `undefined` and `NaN` are invalid according to `isInvalid` function.

I would be happy to help with fixing this issue but I don't know how to fix it correctly. 
**My main question is why `valueFromAST ` can't just throw on errors?**