### PR TITLE
Remove redundant Flow type casts

### DIFF
--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -24,7 +24,6 @@ import type { GraphQLSchema } from '../type/schema';
 import type {
   FieldNode,
   DirectiveNode,
-  VariableNode,
   VariableDefinitionNode,
 } from '../language/ast';
 
@@ -139,7 +138,7 @@ export function getArgumentValues(
         );
       }
     } else if (argumentNode.value.kind === Kind.VARIABLE) {
-      const variableName = (argumentNode.value: VariableNode).name.value;
+      const variableName = argumentNode.value.name.value;
       if (
         variableValues &&
         Object.prototype.hasOwnProperty.call(variableValues, variableName) &&

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -120,7 +120,7 @@ describe('Type System: Example', () => {
 
     expect(BlogSchema.getQueryType()).to.equal(BlogQuery);
 
-    const articleField = BlogQuery.getFields()[('article': string)];
+    const articleField = BlogQuery.getFields()['article'];
     expect(articleField && articleField.type).to.equal(BlogArticle);
     expect(articleField && articleField.type.name).to.equal('Article');
     expect(articleField && articleField.name).to.equal('article');
@@ -128,27 +128,23 @@ describe('Type System: Example', () => {
     const articleFieldType = articleField ? articleField.type : null;
 
     const titleField =
-      isObjectType(articleFieldType) &&
-      articleFieldType.getFields()[('title': string)];
+      isObjectType(articleFieldType) && articleFieldType.getFields()['title'];
     expect(titleField && titleField.name).to.equal('title');
     expect(titleField && titleField.type).to.equal(GraphQLString);
     expect(titleField && titleField.type.name).to.equal('String');
 
     const authorField =
-      isObjectType(articleFieldType) &&
-      articleFieldType.getFields()[('author': string)];
+      isObjectType(articleFieldType) && articleFieldType.getFields()['author'];
 
     const authorFieldType = authorField ? authorField.type : null;
     const recentArticleField =
       isObjectType(authorFieldType) &&
-      authorFieldType.getFields()[('recentArticle': string)];
+      authorFieldType.getFields()['recentArticle'];
 
     expect(recentArticleField && recentArticleField.type).to.equal(BlogArticle);
 
-    const feedField = BlogQuery.getFields()[('feed': string)];
-    expect(feedField && (feedField.type: GraphQLList).ofType).to.equal(
-      BlogArticle,
-    );
+    const feedField = BlogQuery.getFields()['feed'];
+    expect(feedField && feedField.type.ofType).to.equal(BlogArticle);
     expect(feedField && feedField.name).to.equal('feed');
   });
 
@@ -160,7 +156,7 @@ describe('Type System: Example', () => {
 
     expect(BlogSchema.getMutationType()).to.equal(BlogMutation);
 
-    const writeMutation = BlogMutation.getFields()[('writeArticle': string)];
+    const writeMutation = BlogMutation.getFields()['writeArticle'];
     expect(writeMutation && writeMutation.type).to.equal(BlogArticle);
     expect(writeMutation && writeMutation.type.name).to.equal('Article');
     expect(writeMutation && writeMutation.name).to.equal('writeArticle');
@@ -174,7 +170,7 @@ describe('Type System: Example', () => {
 
     expect(BlogSchema.getSubscriptionType()).to.equal(BlogSubscription);
 
-    const sub = BlogSubscription.getFields()[('articleSubscribe': string)];
+    const sub = BlogSubscription.getFields()['articleSubscribe'];
     expect(sub && sub.type).to.equal(BlogArticle);
     expect(sub && sub.type.name).to.equal('Article');
     expect(sub && sub.name).to.equal('articleSubscribe');

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -19,7 +19,6 @@ import type {
   GraphQLNamedType,
   GraphQLAbstractType,
   GraphQLObjectType,
-  GraphQLInterfaceType,
 } from './definition';
 import type { SchemaDefinitionNode } from '../language/ast';
 import {
@@ -189,7 +188,7 @@ export class GraphQLSchema {
     if (isUnionType(abstractType)) {
       return abstractType.getTypes();
     }
-    return this._implementations[(abstractType: GraphQLInterfaceType).name];
+    return this._implementations[abstractType.name];
   }
 
   isPossibleType(

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -20,12 +20,7 @@ import {
   isNonNullType,
 } from '../type/definition';
 import type { GraphQLInputType } from '../type/definition';
-import type {
-  ValueNode,
-  VariableNode,
-  ListValueNode,
-  ObjectValueNode,
-} from '../language/ast';
+import type { ValueNode } from '../language/ast';
 
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
@@ -71,7 +66,7 @@ export function valueFromAST(
   }
 
   if (valueNode.kind === Kind.VARIABLE) {
-    const variableName = (valueNode: VariableNode).name.value;
+    const variableName = valueNode.name.value;
     if (!variables || isInvalid(variables[variableName])) {
       // No valid return value.
       return;
@@ -86,7 +81,7 @@ export function valueFromAST(
     const itemType = type.ofType;
     if (valueNode.kind === Kind.LIST) {
       const coercedValues = [];
-      const itemNodes = (valueNode: ListValueNode).values;
+      const itemNodes = valueNode.values;
       for (let i = 0; i < itemNodes.length; i++) {
         if (isMissingVariable(itemNodes[i], variables)) {
           // If an array contains a missing variable, it is either coerced to
@@ -117,10 +112,7 @@ export function valueFromAST(
       return; // Invalid: intentionally return no value.
     }
     const coercedObj = Object.create(null);
-    const fieldNodes = keyMap(
-      (valueNode: ObjectValueNode).fields,
-      field => field.name.value,
-    );
+    const fieldNodes = keyMap(valueNode.fields, field => field.name.value);
     const fields = objectValues(type.getFields());
     for (let i = 0; i < fields.length; i++) {
       const field = fields[i];
@@ -178,6 +170,6 @@ export function valueFromAST(
 function isMissingVariable(valueNode, variables) {
   return (
     valueNode.kind === Kind.VARIABLE &&
-    (!variables || isInvalid(variables[(valueNode: VariableNode).name.value]))
+    (!variables || isInvalid(variables[valueNode.name.value]))
   );
 }


### PR DESCRIPTION
Not sure I catch all places since I used RegExp:
```sh
grep ' (.*: [A-Za-z0-9]*)[^ ]' -R src/ | grep -v any
```
Would be great if flow itself will produce errors/warnings on redundant casts. 