### PR TITLE
fix #1277 ensure interface has at least 1 concrete type

### DIFF
--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -76,19 +76,6 @@ const Schema = new GraphQLSchema({
 });
 
 describe('Type System: Schema', () => {
-  describe('Getting possible types', () => {
-    it('throws human-reable error if schema.types is not defined', () => {
-      const checkPossible = () => {
-        return Schema.isPossibleType(InterfaceType, ImplementingType);
-      };
-      expect(checkPossible).to.throw(
-        'Could not find possible implementing types for Interface in schema. ' +
-          'Check that schema.types is defined and is an array of all possible ' +
-          'types in the schema.',
-      );
-    });
-  });
-
   describe('Type Map', () => {
     it('includes input types only used in directives', () => {
       expect(Schema.getTypeMap()).to.include.key('DirInput');

--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -23,12 +23,6 @@ const InterfaceType = new GraphQLInterfaceType({
   fields: { fieldName: { type: GraphQLString } },
 });
 
-const ImplementingType = new GraphQLObjectType({
-  name: 'Object',
-  interfaces: [InterfaceType],
-  fields: { fieldName: { type: GraphQLString, resolve: () => '' } },
-});
-
 const DirectiveInputType = new GraphQLInputObjectType({
   name: 'DirInput',
   fields: {

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -1087,6 +1087,25 @@ describe('Type System: Interface fields must have output types', () => {
       },
     ]);
   });
+
+  it('rejects an interface not implemented by at least one object', () => {
+    const schema = buildSchema(`
+      type Query {
+        test: SomeInterface
+      }
+
+      interface SomeInterface {
+        foo: String
+      }
+    `);
+    expect(validateSchema(schema)).to.containSubset([
+      {
+        message:
+          'Interface SomeInterface must be implemented by at least one Object type.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
+  });
 });
 
 describe('Type System: Field arguments must have input types', () => {

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -31,19 +31,20 @@ const SomeScalarType = new GraphQLScalarType({
   parseLiteral() {},
 });
 
+const SomeInterfaceType = new GraphQLInterfaceType({
+  name: 'SomeInterface',
+  fields: { f: { type: GraphQLString } },
+});
+
 const SomeObjectType = new GraphQLObjectType({
   name: 'SomeObject',
   fields: { f: { type: GraphQLString } },
+  interfaces: [SomeInterfaceType],
 });
 
 const SomeUnionType = new GraphQLUnionType({
   name: 'SomeUnion',
   types: [SomeObjectType],
-});
-
-const SomeInterfaceType = new GraphQLInterfaceType({
-  name: 'SomeInterface',
-  fields: { f: { type: GraphQLString } },
 });
 
 const SomeEnumType = new GraphQLEnumType({
@@ -772,6 +773,7 @@ describe('Type System: Object fields must have output types', () => {
           f: { type: BadObjectType },
         },
       }),
+      types: [SomeObjectType],
     });
   }
 
@@ -1016,6 +1018,14 @@ describe('Type System: Interface fields must have output types', () => {
       },
     });
 
+    const BadImplementingType = new GraphQLObjectType({
+      name: 'BadImplementing',
+      interfaces: [BadInterfaceType],
+      fields: {
+        badField: { type: fieldType },
+      },
+    });
+
     return new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
@@ -1023,6 +1033,7 @@ describe('Type System: Interface fields must have output types', () => {
           f: { type: BadInterfaceType },
         },
       }),
+      types: [BadImplementingType, SomeObjectType],
     });
   }
 

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -8,6 +8,7 @@
  */
 
 import {
+  isAbstractType,
   isObjectType,
   isInterfaceType,
   isUnionType,
@@ -159,6 +160,8 @@ export class GraphQLSchema {
             this._implementations[iface.name] = [type];
           }
         });
+      } else if (isAbstractType(type) && !this._implementations[type.name]) {
+        this._implementations[type.name] = [];
       }
     });
   }

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -206,12 +206,6 @@ export class GraphQLSchema {
 
     if (!possibleTypeMap[abstractType.name]) {
       const possibleTypes = this.getPossibleTypes(abstractType);
-      invariant(
-        Array.isArray(possibleTypes) && possibleTypes.length > 0,
-        `Could not find possible implementing types for ${abstractType.name} ` +
-          'in schema. Check that schema.types is defined and is an array of ' +
-          'all possible types in the schema.',
-      );
       possibleTypeMap[abstractType.name] = possibleTypes.reduce(
         (map, type) => ((map[type.name] = true), map),
         Object.create(null),

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -207,7 +207,7 @@ export class GraphQLSchema {
     if (!possibleTypeMap[abstractType.name]) {
       const possibleTypes = this.getPossibleTypes(abstractType);
       invariant(
-        Array.isArray(possibleTypes),
+        Array.isArray(possibleTypes) && possibleTypes.length > 0,
         `Could not find possible implementing types for ${abstractType.name} ` +
           'in schema. Check that schema.types is defined and is an array of ' +
           'all possible types in the schema.',

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -257,6 +257,9 @@ function validateTypes(context: SchemaValidationContext): void {
     } else if (isInterfaceType(type)) {
       // Ensure fields are valid.
       validateFields(context, type);
+
+      // Ensure Interfaces include at least 1 concrete type.
+      validateInterfaces(context, type);
     } else if (isUnionType(type)) {
       // Ensure Unions include valid member types.
       validateUnionMembers(context, type);
@@ -353,6 +356,21 @@ function validateObjectInterfaces(
     implementedTypeNames[iface.name] = true;
     validateObjectImplementsInterface(context, object, iface);
   });
+}
+
+function validateInterfaces(
+  context: SchemaValidationContext,
+  iface: GraphQLInterfaceType,
+): void {
+  const possibleTypes = context.schema.getPossibleTypes(iface);
+
+  if (possibleTypes.length === 0) {
+    context.reportError(
+      `No concrete types found for Interface type ${iface.name}. ` +
+        `If only referenced via abstraction, add concrete types to schema.types array`,
+      iface.astNode,
+    );
+  }
 }
 
 function validateObjectImplementsInterface(

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -258,7 +258,7 @@ function validateTypes(context: SchemaValidationContext): void {
       // Ensure fields are valid.
       validateFields(context, type);
 
-      // Ensure Interfaces include at least 1 concrete type.
+      // Ensure Interfaces include at least 1 Object type.
       validateInterfaces(context, type);
     } else if (isUnionType(type)) {
       // Ensure Unions include valid member types.
@@ -366,8 +366,7 @@ function validateInterfaces(
 
   if (possibleTypes.length === 0) {
     context.reportError(
-      `No concrete types found for Interface type ${iface.name}. ` +
-        `If only referenced via abstraction, add concrete types to schema.types array`,
+      `Interface ${iface.name} must be implemented by at least one object type.`,
       iface.astNode,
     );
   }

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -366,7 +366,8 @@ function validateInterfaces(
 
   if (possibleTypes.length === 0) {
     context.reportError(
-      `Interface ${iface.name} must be implemented by at least one object type.`,
+      `Interface ${iface.name} must be implemented` +
+        `by at least one Object type.`,
       iface.astNode,
     );
   }

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -366,7 +366,7 @@ function validateInterfaces(
 
   if (possibleTypes.length === 0) {
     context.reportError(
-      `Interface ${iface.name} must be implemented` +
+      `Interface ${iface.name} must be implemented ` +
         `by at least one Object type.`,
       iface.astNode,
     );


### PR DESCRIPTION
Changes:

- [ ] `getPossibleTypes` is now guaranteed to return an array, just like its flow typing says it does
- [ ] Validation ensures each interface has at least 1 object type
- [ ] Conforms to Spec, Type Validation, Rule 4: https://github.com/facebook/graphql/pull/424