### PR TITLE
 formatError: put all extensions inside 'extensions' property

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -86,7 +86,7 @@ declare class GraphQLError extends Error {
   /**
    * Extension fields to add to the formatted error.
    */
-  +extensions: ?{ [key: string]: mixed };
+  +extensions: { [key: string]: mixed } | void;
 }
 
 export function GraphQLError( // eslint-disable-line no-redeclare
@@ -135,6 +135,9 @@ export function GraphQLError( // eslint-disable-line no-redeclare
     }, []);
   }
 
+  const _extensions =
+    extensions || (originalError && (originalError: any).extensions);
+
   Object.defineProperties(this, {
     message: {
       value: message,
@@ -175,7 +178,13 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       value: originalError,
     },
     extensions: {
-      value: extensions || (originalError && (originalError: any).extensions),
+      // Coercing falsey values to undefined ensures they will not be included
+      // in JSON.stringify() when not provided.
+      value: _extensions || undefined,
+      // By being enumerable, JSON.stringify will include `path` in the
+      // resulting output. This ensures that the simplest possible GraphQL
+      // service adheres to the spec.
+      enumerable: Boolean(_extensions),
     },
   });
 

--- a/src/error/__tests__/GraphQLError-test.js
+++ b/src/error/__tests__/GraphQLError-test.js
@@ -136,7 +136,6 @@ describe('GraphQLError', () => {
       message: 'msg',
       locations: undefined,
       path: ['path', 3, 'to', 'field'],
-      extensions: undefined,
     });
   });
 

--- a/src/error/__tests__/GraphQLError-test.js
+++ b/src/error/__tests__/GraphQLError-test.js
@@ -136,6 +136,7 @@ describe('GraphQLError', () => {
       message: 'msg',
       locations: undefined,
       path: ['path', 3, 'to', 'field'],
+      extensions: undefined,
     });
   });
 
@@ -148,7 +149,7 @@ describe('GraphQLError', () => {
       message: 'msg',
       locations: undefined,
       path: undefined,
-      foo: 'bar',
+      extensions: { foo: 'bar' },
     });
   });
 });

--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -17,17 +17,19 @@ import type { SourceLocation } from '../language/location';
  */
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   invariant(error, 'Received null or undefined error.');
-  return {
-    message: error.message || 'An unknown error occurred.',
-    locations: error.locations,
-    path: error.path,
-    extensions: error.extensions,
-  };
+  const message = error.message || 'An unknown error occurred.';
+  const locations = error.locations;
+  const path = error.path;
+  const extensions = error.extensions;
+
+  return extensions
+    ? { message, locations, path, extensions }
+    : { message, locations, path };
 }
 
 export type GraphQLFormattedError = {|
   +message: string,
   +locations: $ReadOnlyArray<SourceLocation> | void,
   +path: $ReadOnlyArray<string | number> | void,
-  +extensions: { [key: string]: mixed } | void,
+  +extensions?: { [key: string]: mixed },
 |};

--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -18,17 +18,16 @@ import type { SourceLocation } from '../language/location';
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   invariant(error, 'Received null or undefined error.');
   return {
-    ...error.extensions,
     message: error.message || 'An unknown error occurred.',
     locations: error.locations,
     path: error.path,
+    extensions: error.extensions,
   };
 }
 
-export type GraphQLFormattedError = {
+export type GraphQLFormattedError = {|
   +message: string,
   +locations: $ReadOnlyArray<SourceLocation> | void,
   +path: $ReadOnlyArray<string | number> | void,
-  // Extensions
-  +[key: string]: mixed,
-};
+  +extensions: { [key: string]: mixed } | void,
+|};

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -382,6 +382,7 @@ describe('Execute: Handles basic execution tasks', () => {
       asyncError
       asyncRawError
       asyncReturnError
+      asyncReturnErrorWithExtensions
     }`;
 
     const data = {
@@ -435,6 +436,12 @@ describe('Execute: Handles basic execution tasks', () => {
       asyncReturnError() {
         return Promise.resolve(new Error('Error getting asyncReturnError'));
       },
+      asyncReturnErrorWithExtensions() {
+        const error = new Error('Error getting asyncReturnErrorWithExtensions');
+        error.extensions = { foo: 'bar' };
+
+        return Promise.resolve(error);
+      },
     };
 
     const ast = parse(doc);
@@ -449,11 +456,13 @@ describe('Execute: Handles basic execution tasks', () => {
           syncReturnErrorList: { type: GraphQLList(GraphQLString) },
           async: { type: GraphQLString },
           asyncReject: { type: GraphQLString },
+          asyncRejectWithExtensions: { type: GraphQLString },
           asyncRawReject: { type: GraphQLString },
           asyncEmptyReject: { type: GraphQLString },
           asyncError: { type: GraphQLString },
           asyncRawError: { type: GraphQLString },
           asyncReturnError: { type: GraphQLString },
+          asyncReturnErrorWithExtensions: { type: GraphQLString },
         },
       }),
     });
@@ -474,6 +483,7 @@ describe('Execute: Handles basic execution tasks', () => {
         asyncError: null,
         asyncRawError: null,
         asyncReturnError: null,
+        asyncReturnErrorWithExtensions: null,
       },
       errors: [
         {
@@ -530,6 +540,12 @@ describe('Execute: Handles basic execution tasks', () => {
           message: 'Error getting asyncReturnError',
           locations: [{ line: 13, column: 7 }],
           path: ['asyncReturnError'],
+        },
+        {
+          message: 'Error getting asyncReturnErrorWithExtensions',
+          locations: [{ line: 14, column: 7 }],
+          path: ['asyncReturnErrorWithExtensions'],
+          extensions: { foo: 'bar' },
         },
       ],
     });


### PR DESCRIPTION
Mirrors https://github.com/facebook/graphql/pull/407

This is breaking change, however, `extensions` is the relatively new feature that was added in `0.12.0`. 
Also, it could be easily workaround by providing `formatError` property to a server:
https://github.com/graphql/express-graphql#options
https://github.com/apollographql/apollo-server#options

Unintended changes: I didn't want to add `extensions: undefined` to every error inside tests so I refactored them.