### PR TITLE
Execute: simplify + speedup

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -813,11 +813,7 @@ function completeValueCatchingError(
       // Note: we don't rely on a `catch` method, but we do expect "thenable"
       // to take a second callback for the error case.
       return completed.then(undefined, rawError => {
-        const error = locatedError(
-          asErrorInstance(rawError),
-          fieldNodes,
-          responsePathAsArray(path),
-        );
+        const error = locatedFieldError(rawError, fieldNodes, path);
 
         // If the field type is non-nullable, then it is resolved without any
         // protection from errors, however it still properly locates the error.
@@ -825,19 +821,15 @@ function completeValueCatchingError(
           throw error;
         }
 
-        // Otherwise, error protection is applied, logging the error and resolving
-        // a null value for this field if one is encountered.
+        // Otherwise, error protection is applied, logging the error and
+        // resolving a null value for this field if one is encountered.
         exeContext.errors.push(error);
         return null;
       });
     }
     return completed;
   } catch (rawError) {
-    const error = locatedError(
-      asErrorInstance(rawError),
-      fieldNodes,
-      responsePathAsArray(path),
-    );
+    const error = locatedFieldError(rawError, fieldNodes, path);
 
     // If the field type is non-nullable, then it is resolved without any
     // protection from errors, however it still properly locates the error.
@@ -850,6 +842,11 @@ function completeValueCatchingError(
     exeContext.errors.push(error);
     return null;
   }
+}
+
+function locatedFieldError(errorValue, fieldNodes, path) {
+  const error = asErrorInstance(errorValue);
+  return locatedError(error, fieldNodes, responsePathAsArray(path));
 }
 
 /**

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -814,34 +814,27 @@ function completeValueCatchingError(
       // to take a second callback for the error case.
       return completed.then(undefined, rawError => {
         const error = locatedFieldError(rawError, fieldNodes, path);
-
-        // If the field type is non-nullable, then it is resolved without any
-        // protection from errors, however it still properly locates the error.
-        if (isNonNullType(returnType)) {
-          throw error;
-        }
-
-        // Otherwise, error protection is applied, logging the error and
-        // resolving a null value for this field if one is encountered.
-        exeContext.errors.push(error);
-        return null;
+        return handleFieldError(error, returnType, exeContext);
       });
     }
     return completed;
   } catch (rawError) {
     const error = locatedFieldError(rawError, fieldNodes, path);
-
-    // If the field type is non-nullable, then it is resolved without any
-    // protection from errors, however it still properly locates the error.
-    if (isNonNullType(returnType)) {
-      throw error;
-    }
-
-    // Otherwise, error protection is applied, logging the error and resolving
-    // a null value for this field if one is encountered.
-    exeContext.errors.push(error);
-    return null;
+    return handleFieldError(error, returnType, exeContext);
   }
+}
+
+function handleFieldError(error, returnType, exeContext) {
+  // If the field type is non-nullable, then it is resolved without any
+  // protection from errors, however it still properly locates the error.
+  if (isNonNullType(returnType)) {
+    throw error;
+  }
+
+  // Otherwise, error protection is applied, logging the error and resolving
+  // a null value for this field if one is encountered.
+  exeContext.errors.push(error);
+  return null;
 }
 
 function locatedFieldError(errorValue, fieldNodes, path) {


### PR DESCRIPTION
For a feature, I'm working on I needed to understand how `execute` is working so I read through its implementation. I notice that `completeValueWithLocatedError` is called only from `completeValueCatchingError` and would be simpler to just merge them together.
So main reason of this PR is to remove one layout of try/catch & isPromise/then and make error handling more obvious.

To check that I didn't introduce any performance regressions I profiled modified version of [introspectionFromSchema-benchmark.js](https://github.com/graphql/graphql-js/blob/master/src/utilities/__tests__/introspectionFromSchema-benchmark.js)
During this profiling I discovered that hottest function is a fat arrow callback inside `executeFields` function:
```
Statistical profiling result from base3-v8.log, (9005 ticks, 439 unaccounted, 0 excluded).

 [Shared libraries]:
   ticks  total  nonlib   name
      9    0.1%          /usr/lib/system/libsystem_pthread.dylib
      2    0.0%          /usr/lib/system/libsystem_malloc.dylib

 [JavaScript]:
   ticks  total  nonlib   name
    892    9.9%    9.9%  LoadIC: A load IC from the snapshot
    850    9.4%    9.5%  LazyCompile: *<anonymous> /Users/ivang/dev/graphql-js/perf_test/baseDist/execution/execute.js:361:58
    436    4.8%    4.8%  LazyCompile: *completeValue /Users/ivang/dev/graphql-js/perf_test/baseDist/execution/execute.js:613:23
    345    3.8%    3.8%  Stub: CallApiGetterStub
    259    2.9%    2.9%  LazyCompile: *getArgumentValues /Users/ivang/dev/graphql-js/perf_test/baseDist/execution/values.js:101:27
    248    2.8%    2.8%  LazyCompile: *completeValueWithLocatedError /Users/ivang/dev/graphql-js/perf_test/baseDist/execution/execute.js:578:39
    231    2.6%    2.6%  Builtin: KeyedLoadIC_Megamorphic
    210    2.3%    2.3%  Builtin: ArrayReduce
    202    2.2%    2.2%  Stub: GetPropertyStub
    130    1.4%    1.4%  LazyCompile: *defaultFieldResolver /Users/ivang/dev/graphql-js/perf_test/baseDist/execution/execute.js:844:88
```
So I replaced `Array.reduce` with `for` cycle on `Object.keys` and together with removal of `completeValueWithLocatedError` it resulted in ~15% speedup(9005 ticks vs 7612 ticks), see profile:
```
Statistical profiling result from changed_beautiful-v8.log, (7612 ticks, 402 unaccounted, 0 excluded).

 [Shared libraries]:
   ticks  total  nonlib   name
      9    0.1%          /usr/lib/system/libsystem_pthread.dylib
      1    0.0%          /usr/lib/system/libsystem_platform.dylib
      1    0.0%          /usr/lib/system/libsystem_malloc.dylib

 [JavaScript]:
   ticks  total  nonlib   name
    823   10.8%   10.8%  LoadIC: A load IC from the snapshot
    551    7.2%    7.2%  LazyCompile: *completeObjectValue /Users/ivang/dev/graphql-js/perf_test/changedDist/execution/execute.js:732:29
    477    6.3%    6.3%  LazyCompile: *completeValue /Users/ivang/dev/graphql-js/perf_test/changedDist/execution/execute.js:611:23
    335    4.4%    4.4%  Stub: CallApiGetterStub
    279    3.7%    3.7%  LazyCompile: *getArgumentValues /Users/ivang/dev/graphql-js/perf_test/changedDist/execution/values.js:101:27
    247    3.2%    3.2%  Builtin: KeyedLoadIC_Megamorphic
    145    1.9%    1.9%  Stub: GetPropertyStub
    121    1.6%    1.6%  LazyCompile: *defaultFieldResolver /Users/ivang/dev/graphql-js/perf_test/changedDist/execution/execute.js:835:88
    100    1.3%    1.3%  LazyCompile: *getFieldDef /Users/ivang/dev/graphql-js/perf_test/changedDist/execution/execute.js:855:21
     91    1.2%    1.2%  Builtin: KeyedStoreIC_Megamorphic_Strict
     88    1.2%    1.2%  Builtin: FastNewClosure
     77    1.0%    1.0%  Builtin: ArrayReduce
     75    1.0%    1.0%  Builtin: WeakMapLookupHashIndex
```

Performance improvement achieved on a synthetic test and probably wouldn't account for any measurable speedup in most servers. Another small bonus is call stack reduction 1 call (2 calls if a value returned as a promise) for every field or item inside an array.

But most importantly this PR make it easier for a developer to trace how values are resolved/complete inside `execute`.