### PR TITLE
Fix printing of ASTs of argument definitions with descriptions.

### DIFF
--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -14,7 +14,15 @@ of the `Foo` type.
 """
 type Foo implements Bar & Baz {
   one: Type
-  two(argument: InputType!): Type
+  """
+  This is a description of the `two` field.
+  """
+  two(
+    """
+    This is a description of the `argument` argument.
+    """
+    argument: InputType!
+  ): Type
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -58,7 +58,15 @@ describe('Printer: SDL document', () => {
       """
       type Foo implements Bar & Baz {
         one: Type
-        two(argument: InputType!): Type
+        """
+        This is a description of the \`two\` field.
+        """
+        two(
+          """
+          This is a description of the \`argument\` argument.
+          """
+          argument: InputType!
+        ): Type
         three(argument: InputType, other: String): Int
         four(argument: String = "string"): String
         five(argument: [String] = ["string", "string"]): String

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -131,7 +131,9 @@ const printDocASTReducer = {
   FieldDefinition: addDescription(
     ({ name, arguments: args, type, directives }) =>
       name +
-      wrap('(', join(args, ', '), ')') +
+      (args.every(arg => arg.indexOf('\n') === -1)
+        ? wrap('(', join(args, ', '), ')')
+        : wrap('(\n', indent(join(args, '\n')), '\n)')) +
       ': ' +
       type +
       wrap(' ', join(directives, ' ')),
@@ -212,7 +214,9 @@ const printDocASTReducer = {
     ({ name, arguments: args, locations }) =>
       'directive @' +
       name +
-      wrap('(', join(args, ', '), ')') +
+      (args.every(arg => arg.indexOf('\n') === -1)
+        ? wrap('(', join(args, ', '), ')')
+        : wrap('(\n', indent(join(args, '\n')), '\n)')) +
       ' on ' +
       join(locations, ' | '),
   ),


### PR DESCRIPTION
Descriptions were not separated on their own lines, which made for technically parseable but hard to read output.

Fixes #1285