### PR TITLE
Error: make 'path' and 'locations' enumerable only if present

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -151,7 +151,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       // By being enumerable, JSON.stringify will include `locations` in the
       // resulting output. This ensures that the simplest possible GraphQL
       // service adheres to the spec.
-      enumerable: true,
+      enumerable: Boolean(_locations),
     },
     path: {
       // Coercing falsey values to undefined ensures they will not be included
@@ -160,7 +160,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       // By being enumerable, JSON.stringify will include `path` in the
       // resulting output. This ensures that the simplest possible GraphQL
       // service adheres to the spec.
-      enumerable: true,
+      enumerable: Boolean(path),
     },
     nodes: {
       value: _nodes || undefined,

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -8,7 +8,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import { execute } from '../execute';
-import { formatError } from '../../error';
 import { parse } from '../../language';
 import {
   GraphQLSchema,
@@ -461,78 +460,79 @@ describe('Execute: Handles basic execution tasks', () => {
 
     const result = await execute(schema, ast, data);
 
-    expect(result.data).to.deep.equal({
-      sync: 'sync',
-      syncError: null,
-      syncRawError: null,
-      syncReturnError: null,
-      syncReturnErrorList: ['sync0', null, 'sync2', null],
-      async: 'async',
-      asyncReject: null,
-      asyncRawReject: null,
-      asyncEmptyReject: null,
-      asyncError: null,
-      asyncRawError: null,
-      asyncReturnError: null,
+    expect(result).to.deep.equal({
+      data: {
+        sync: 'sync',
+        syncError: null,
+        syncRawError: null,
+        syncReturnError: null,
+        syncReturnErrorList: ['sync0', null, 'sync2', null],
+        async: 'async',
+        asyncReject: null,
+        asyncRawReject: null,
+        asyncEmptyReject: null,
+        asyncError: null,
+        asyncRawError: null,
+        asyncReturnError: null,
+      },
+      errors: [
+        {
+          message: 'Error getting syncError',
+          locations: [{ line: 3, column: 7 }],
+          path: ['syncError'],
+        },
+        {
+          message: 'Error getting syncRawError',
+          locations: [{ line: 4, column: 7 }],
+          path: ['syncRawError'],
+        },
+        {
+          message: 'Error getting syncReturnError',
+          locations: [{ line: 5, column: 7 }],
+          path: ['syncReturnError'],
+        },
+        {
+          message: 'Error getting syncReturnErrorList1',
+          locations: [{ line: 6, column: 7 }],
+          path: ['syncReturnErrorList', 1],
+        },
+        {
+          message: 'Error getting syncReturnErrorList3',
+          locations: [{ line: 6, column: 7 }],
+          path: ['syncReturnErrorList', 3],
+        },
+        {
+          message: 'Error getting asyncReject',
+          locations: [{ line: 8, column: 7 }],
+          path: ['asyncReject'],
+        },
+        {
+          message: 'Error getting asyncRawReject',
+          locations: [{ line: 9, column: 7 }],
+          path: ['asyncRawReject'],
+        },
+        {
+          message: '',
+          locations: [{ line: 10, column: 7 }],
+          path: ['asyncEmptyReject'],
+        },
+        {
+          message: 'Error getting asyncError',
+          locations: [{ line: 11, column: 7 }],
+          path: ['asyncError'],
+        },
+        {
+          message: 'Error getting asyncRawError',
+          locations: [{ line: 12, column: 7 }],
+          path: ['asyncRawError'],
+        },
+        {
+          message: 'Error getting asyncReturnError',
+          locations: [{ line: 13, column: 7 }],
+          path: ['asyncReturnError'],
+        },
+      ],
     });
-
-    expect(result.errors && result.errors.map(formatError)).to.deep.equal([
-      {
-        message: 'Error getting syncError',
-        locations: [{ line: 3, column: 7 }],
-        path: ['syncError'],
-      },
-      {
-        message: 'Error getting syncRawError',
-        locations: [{ line: 4, column: 7 }],
-        path: ['syncRawError'],
-      },
-      {
-        message: 'Error getting syncReturnError',
-        locations: [{ line: 5, column: 7 }],
-        path: ['syncReturnError'],
-      },
-      {
-        message: 'Error getting syncReturnErrorList1',
-        locations: [{ line: 6, column: 7 }],
-        path: ['syncReturnErrorList', 1],
-      },
-      {
-        message: 'Error getting syncReturnErrorList3',
-        locations: [{ line: 6, column: 7 }],
-        path: ['syncReturnErrorList', 3],
-      },
-      {
-        message: 'Error getting asyncReject',
-        locations: [{ line: 8, column: 7 }],
-        path: ['asyncReject'],
-      },
-      {
-        message: 'Error getting asyncRawReject',
-        locations: [{ line: 9, column: 7 }],
-        path: ['asyncRawReject'],
-      },
-      {
-        message: 'An unknown error occurred.',
-        locations: [{ line: 10, column: 7 }],
-        path: ['asyncEmptyReject'],
-      },
-      {
-        message: 'Error getting asyncError',
-        locations: [{ line: 11, column: 7 }],
-        path: ['asyncError'],
-      },
-      {
-        message: 'Error getting asyncRawError',
-        locations: [{ line: 12, column: 7 }],
-        path: ['asyncRawError'],
-      },
-      {
-        message: 'Error getting asyncReturnError',
-        locations: [{ line: 13, column: 7 }],
-        path: ['asyncReturnError'],
-      },
-    ]);
   });
 
   it('nulls error subtree for promise rejection #1071', async () => {
@@ -720,13 +720,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     const result = await execute(schema, ast, data);
     expect(result).to.deep.equal({
-      errors: [
-        {
-          message: 'Must provide an operation.',
-          locations: undefined,
-          path: undefined,
-        },
-      ],
+      errors: [{ message: 'Must provide an operation.' }],
     });
   });
 
@@ -748,10 +742,7 @@ describe('Execute: Handles basic execution tasks', () => {
       errors: [
         {
           message:
-            'Must provide operation name if query contains ' +
-            'multiple operations.',
-          locations: undefined,
-          path: undefined,
+            'Must provide operation name if query contains multiple operations.',
         },
       ],
     });
@@ -775,13 +766,7 @@ describe('Execute: Handles basic execution tasks', () => {
       operationName: 'UnknownExample',
     });
     expect(result).to.deep.equal({
-      errors: [
-        {
-          message: 'Unknown operation named "UnknownExample".',
-          locations: undefined,
-          path: undefined,
-        },
-      ],
+      errors: [{ message: 'Unknown operation named "UnknownExample".' }],
     });
   });
 
@@ -1046,17 +1031,19 @@ describe('Execute: Handles basic execution tasks', () => {
     };
     const result = await execute(schema, query, value);
 
-    expect(result.data).to.deep.equal({
-      specials: [{ value: 'foo' }, null],
-    });
-    expect(result.errors).to.have.lengthOf(1);
-    expect(result.errors).to.containSubset([
-      {
-        message:
-          'Expected value of type "SpecialType" but got: [object Object].',
-        locations: [{ line: 1, column: 3 }],
+    expect(result).to.deep.equal({
+      data: {
+        specials: [{ value: 'foo' }, null],
       },
-    ]);
+      errors: [
+        {
+          message:
+            'Expected value of type "SpecialType" but got: [object Object].',
+          locations: [{ line: 1, column: 3 }],
+          path: ['specials', 1],
+        },
+      ],
+    });
   });
 
   it('executes ignoring invalid non-executable definitions', async () => {

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -7,7 +7,6 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { formatError } from '../../error';
 import { execute } from '../execute';
 import { parse } from '../../language';
 import {
@@ -48,18 +47,7 @@ function check(testType, testData, expected) {
     const ast = parse('{ nest { test } }');
 
     const response = await execute(schema, ast, data);
-
-    // Formatting errors for ease of test writing.
-    let result;
-    if (response.errors) {
-      result = {
-        data: response.data,
-        errors: response.errors.map(formatError),
-      };
-    } else {
-      result = response;
-    }
-    expect(result).to.deep.equal(expected);
+    expect(response).to.deep.equal(expected);
   };
 }
 

--- a/src/execution/__tests__/mutations-test.js
+++ b/src/execution/__tests__/mutations-test.js
@@ -167,33 +167,27 @@ describe('Execute: Handles mutation execution ordering', () => {
 
     const result = await execute(schema, parse(doc), new Root(6));
 
-    expect(result.data).to.deep.equal({
-      first: {
-        theNumber: 1,
+    expect(result).to.deep.equal({
+      data: {
+        first: { theNumber: 1 },
+        second: { theNumber: 2 },
+        third: null,
+        fourth: { theNumber: 4 },
+        fifth: { theNumber: 5 },
+        sixth: null,
       },
-      second: {
-        theNumber: 2,
-      },
-      third: null,
-      fourth: {
-        theNumber: 4,
-      },
-      fifth: {
-        theNumber: 5,
-      },
-      sixth: null,
+      errors: [
+        {
+          message: 'Cannot change the number',
+          locations: [{ line: 8, column: 7 }],
+          path: ['third'],
+        },
+        {
+          message: 'Cannot change the number',
+          locations: [{ line: 17, column: 7 }],
+          path: ['sixth'],
+        },
+      ],
     });
-
-    expect(result.errors).to.have.length(2);
-    expect(result.errors).to.containSubset([
-      {
-        message: 'Cannot change the number',
-        locations: [{ line: 8, column: 7 }],
-      },
-      {
-        message: 'Cannot change the number',
-        locations: [{ line: 17, column: 7 }],
-      },
-    ]);
   });
 });

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -270,7 +270,6 @@ describe('Execute: Handles inputs', () => {
                 '{"a":"foo","b":"bar","c":null}; ' +
                 'Expected non-nullable type String! not to be null at value.c.',
               locations: [{ line: 2, column: 16 }],
-              path: undefined,
             },
           ],
         });
@@ -286,7 +285,6 @@ describe('Execute: Handles inputs', () => {
                 'Variable "$input" got invalid value "foo bar"; ' +
                 'Expected type TestInputObject to be an object.',
               locations: [{ line: 2, column: 16 }],
-              path: undefined,
             },
           ],
         });
@@ -302,7 +300,6 @@ describe('Execute: Handles inputs', () => {
                 'Variable "$input" got invalid value {"a":"foo","b":"bar"}; ' +
                 'Field value.c of required type String! was not provided.',
               locations: [{ line: 2, column: 16 }],
-              path: undefined,
             },
           ],
         });
@@ -323,14 +320,12 @@ describe('Execute: Handles inputs', () => {
                 'Variable "$input" got invalid value {"na":{"a":"foo"}}; ' +
                 'Field value.na.c of required type String! was not provided.',
               locations: [{ line: 2, column: 18 }],
-              path: undefined,
             },
             {
               message:
                 'Variable "$input" got invalid value {"na":{"a":"foo"}}; ' +
                 'Field value.nb of required type String! was not provided.',
               locations: [{ line: 2, column: 18 }],
-              path: undefined,
             },
           ],
         });
@@ -350,7 +345,6 @@ describe('Execute: Handles inputs', () => {
                 '{"a":"foo","b":"bar","c":"baz","extra":"dog"}; ' +
                 'Field "extra" is not defined by type TestInputObject.',
               locations: [{ line: 2, column: 16 }],
-              path: undefined,
             },
           ],
         });
@@ -474,7 +468,6 @@ describe('Execute: Handles inputs', () => {
             message:
               'Variable "$value" of required type "String!" was not provided.',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -495,7 +488,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$value" got invalid value null; ' +
               'Expected non-nullable type String! not to be null.',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -563,7 +555,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$value" got invalid value [1,2,3]; Expected type ' +
               'String; String cannot represent an array value: [1,2,3]',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -656,7 +647,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$input" got invalid value null; ' +
               'Expected non-nullable type [String]! not to be null.',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -721,7 +711,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$input" got invalid value ["A",null,"B"]; ' +
               'Expected non-nullable type String! not to be null at value[1].',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -742,7 +731,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$input" got invalid value null; ' +
               'Expected non-nullable type [String!]! not to be null.',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -774,7 +762,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$input" got invalid value ["A",null,"B"]; ' +
               'Expected non-nullable type String! not to be null at value[1].',
             locations: [{ line: 2, column: 16 }],
-            path: undefined,
           },
         ],
       });
@@ -795,7 +782,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$input" expected value of type "TestType!" which ' +
               'cannot be used as an input type.',
             locations: [{ line: 2, column: 24 }],
-            path: undefined,
           },
         ],
       });
@@ -816,7 +802,6 @@ describe('Execute: Handles inputs', () => {
               'Variable "$input" expected value of type "UnknownType!" which ' +
               'cannot be used as an input type.',
             locations: [{ line: 2, column: 24 }],
-            path: undefined,
           },
         ],
       });

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -350,7 +350,6 @@ describe('Subscription Initialization Phase', () => {
         {
           message: 'The subscription field "unknownField" is not defined.',
           locations: [{ line: 3, column: 9 }],
-          path: undefined,
         },
       ],
     });
@@ -478,7 +477,6 @@ describe('Subscription Initialization Phase', () => {
             'type Int; Int cannot represent non 32-bit signed ' +
             'integer value: meow',
           locations: [{ line: 2, column: 21 }],
-          path: undefined,
         },
       ],
     });

--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -163,7 +163,6 @@ describe('Type System: Enum Values', () => {
           message:
             'Expected type Color, found "GREEN"; Did you mean the enum value GREEN?',
           locations: [{ line: 1, column: 23 }],
-          path: undefined,
         },
       ],
     });
@@ -178,7 +177,6 @@ describe('Type System: Enum Values', () => {
           message:
             'Expected type Color, found GREENISH; Did you mean the enum value GREEN?',
           locations: [{ line: 1, column: 23 }],
-          path: undefined,
         },
       ],
     });
@@ -193,7 +191,6 @@ describe('Type System: Enum Values', () => {
           message:
             'Expected type Color, found green; Did you mean the enum value GREEN?',
           locations: [{ line: 1, column: 23 }],
-          path: undefined,
         },
       ],
     });
@@ -222,7 +219,6 @@ describe('Type System: Enum Values', () => {
         {
           message: 'Expected type Color, found 1.',
           locations: [{ line: 1, column: 23 }],
-          path: undefined,
         },
       ],
     });
@@ -236,7 +232,6 @@ describe('Type System: Enum Values', () => {
         {
           message: 'Expected type Int, found GREEN.',
           locations: [{ line: 1, column: 22 }],
-          path: undefined,
         },
       ],
     });
@@ -280,7 +275,6 @@ describe('Type System: Enum Values', () => {
           message:
             'Variable "$color" got invalid value 2; Expected type Color.',
           locations: [{ line: 1, column: 8 }],
-          path: undefined,
         },
       ],
     });
@@ -297,7 +291,6 @@ describe('Type System: Enum Values', () => {
             'Variable "$color" of type "String!" used in position ' +
             'expecting type "Color".',
           locations: [{ line: 1, column: 8 }, { line: 1, column: 47 }],
-          path: undefined,
         },
       ],
     });
@@ -314,7 +307,6 @@ describe('Type System: Enum Values', () => {
             'Variable "$color" of type "Int!" used in position ' +
             'expecting type "Color".',
           locations: [{ line: 1, column: 8 }, { line: 1, column: 44 }],
-          path: undefined,
         },
       ],
     });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1198,7 +1198,7 @@ describe('Introspection', () => {
       }
     `;
 
-    return expect(graphqlSync(schema, request)).to.containSubset({
+    return expect(graphqlSync(schema, request)).to.deep.equal({
       errors: [
         {
           message: missingFieldArgMessage('__type', 'name', 'String!'),

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -187,10 +187,9 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Query root type must be provided.',
-        locations: undefined,
       },
     ]);
 
@@ -203,7 +202,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.containSubset([
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
       {
         message: 'Query root type must be provided.',
         locations: [{ line: 2, column: 7 }],
@@ -217,7 +216,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Query root type must be Object type, it cannot be Query.',
         locations: [{ line: 2, column: 7 }],
@@ -233,7 +232,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.containSubset([
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
       {
         message:
           'Query root type must be Object type, it cannot be SomeInputObject.',
@@ -252,7 +251,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Mutation root type must be Object type if provided, it cannot be Mutation.',
@@ -274,7 +273,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.containSubset([
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
       {
         message:
           'Mutation root type must be Object type if provided, it cannot be SomeInputObject.',
@@ -293,7 +292,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Subscription root type must be Object type if provided, it cannot be Subscription.',
@@ -315,7 +314,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.containSubset([
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
       {
         message:
           'Subscription root type must be Object type if provided, it cannot be SomeInputObject.',
@@ -329,7 +328,7 @@ describe('Type System: A Schema must have Object root types', () => {
       query: SomeObjectType,
       directives: ['somedirective'],
     });
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Expected directive but got: somedirective.',
       },
@@ -359,7 +358,7 @@ describe('Type System: Objects must have fields', () => {
 
       type IncompleteObject
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Type IncompleteObject must define one or more fields.',
         locations: [{ line: 6, column: 7 }],
@@ -372,7 +371,7 @@ describe('Type System: Objects must have fields', () => {
         fields: {},
       }),
     );
-    expect(validateSchema(manualSchema)).to.containSubset([
+    expect(validateSchema(manualSchema)).to.deep.equal([
       {
         message: 'Type IncompleteObject must define one or more fields.',
       },
@@ -386,7 +385,7 @@ describe('Type System: Objects must have fields', () => {
         },
       }),
     );
-    expect(validateSchema(manualSchema2)).to.containSubset([
+    expect(validateSchema(manualSchema2)).to.deep.equal([
       {
         message: 'Type IncompleteObject must define one or more fields.',
       },
@@ -400,7 +399,7 @@ describe('Type System: Objects must have fields', () => {
         fields: { 'bad-name-with-dashes': { type: GraphQLString } },
       }),
     );
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ' +
@@ -423,7 +422,7 @@ describe('Type System: Objects must have fields', () => {
       }),
       allowedLegacyNames: ['__badName'],
     });
-    expect(validateSchema(schemaBad)).to.containSubset([
+    expect(validateSchema(schemaBad)).to.deep.equal([
       {
         message:
           'Name "__badName" must not begin with "__", which is reserved by ' +
@@ -478,7 +477,7 @@ describe('Type System: Fields args must be properly named', () => {
       },
     });
     const schema = new GraphQLSchema({ query: QueryType });
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
@@ -517,7 +516,7 @@ describe('Type System: Union types must be valid', () => {
 
       union BadUnion
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Union type BadUnion must define one or more member types.',
         locations: [{ line: 6, column: 7 }],
@@ -544,7 +543,7 @@ describe('Type System: Union types must be valid', () => {
         | TypeB
         | TypeA
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Union type BadUnion can only include type TypeA once.',
         locations: [{ line: 15, column: 11 }, { line: 17, column: 11 }],
@@ -571,7 +570,7 @@ describe('Type System: Union types must be valid', () => {
         | String
         | TypeB
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Union type BadUnion can only include Object types, ' +
@@ -593,7 +592,7 @@ describe('Type System: Union types must be valid', () => {
       const badSchema = schemaWithFieldType(
         new GraphQLUnionType({ name: 'BadUnion', types: [memberType] }),
       );
-      expect(validateSchema(badSchema)).to.containSubset([
+      expect(validateSchema(badSchema)).to.deep.equal([
         {
           message:
             'Union type BadUnion can only include Object types, ' +
@@ -626,7 +625,7 @@ describe('Type System: Input Objects must have fields', () => {
 
       input SomeInputObject
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Input Object type SomeInputObject must define one or more fields.',
@@ -653,7 +652,7 @@ describe('Type System: Input Objects must have fields', () => {
         goodInputObject: SomeInputObject
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of SomeInputObject.badObject must be Input Type but got: SomeObject.',
@@ -677,7 +676,7 @@ describe('Type System: Enum types must be well defined', () => {
 
       enum SomeEnum
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Enum type SomeEnum must define one or more values.',
         locations: [{ line: 6, column: 7 }],
@@ -696,7 +695,7 @@ describe('Type System: Enum types must be well defined', () => {
         SOME_VALUE
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Enum type SomeEnum can include value SOME_VALUE only once.',
         locations: [{ line: 7, column: 9 }, { line: 8, column: 9 }],
@@ -717,7 +716,7 @@ describe('Type System: Enum types must be well defined', () => {
     }
 
     const schema1 = schemaWithEnum('#value');
-    expect(validateSchema(schema1)).to.containSubset([
+    expect(validateSchema(schema1)).to.deep.equal([
       {
         message:
           'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.',
@@ -725,7 +724,7 @@ describe('Type System: Enum types must be well defined', () => {
     ]);
 
     const schema2 = schemaWithEnum('1value');
-    expect(validateSchema(schema2)).to.containSubset([
+    expect(validateSchema(schema2)).to.deep.equal([
       {
         message:
           'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "1value" does not.',
@@ -733,7 +732,7 @@ describe('Type System: Enum types must be well defined', () => {
     ]);
 
     const schema3 = schemaWithEnum('KEBAB-CASE');
-    expect(validateSchema(schema3)).to.containSubset([
+    expect(validateSchema(schema3)).to.deep.equal([
       {
         message:
           'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "KEBAB-CASE" does not.',
@@ -741,17 +740,17 @@ describe('Type System: Enum types must be well defined', () => {
     ]);
 
     const schema4 = schemaWithEnum('true');
-    expect(validateSchema(schema4)).to.containSubset([
+    expect(validateSchema(schema4)).to.deep.equal([
       { message: 'Enum type SomeEnum cannot include value: true.' },
     ]);
 
     const schema5 = schemaWithEnum('false');
-    expect(validateSchema(schema5)).to.containSubset([
+    expect(validateSchema(schema5)).to.deep.equal([
       { message: 'Enum type SomeEnum cannot include value: false.' },
     ]);
 
     const schema6 = schemaWithEnum('null');
-    expect(validateSchema(schema6)).to.containSubset([
+    expect(validateSchema(schema6)).to.deep.equal([
       { message: 'Enum type SomeEnum cannot include value: null.' },
     ]);
   });
@@ -786,7 +785,7 @@ describe('Type System: Object fields must have output types', () => {
 
   it('rejects an empty Object field type', () => {
     const schema = schemaWithObjectFieldOfType(undefined);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of BadObject.badField must be Output Type but got: undefined.',
@@ -797,11 +796,9 @@ describe('Type System: Object fields must have output types', () => {
   notOutputTypes.forEach(type => {
     it(`rejects a non-output type as an Object field type: ${type}`, () => {
       const schema = schemaWithObjectFieldOfType(type);
-      expect(validateSchema(schema)).to.containSubset([
-        {
-          message: `The type of BadObject.badField must be Output Type but got: ${type}.`,
-        },
-      ]);
+      expect(validateSchema(schema)).to.deep.include({
+        message: `The type of BadObject.badField must be Output Type but got: ${type}.`,
+      });
     });
   });
 
@@ -815,7 +812,7 @@ describe('Type System: Object fields must have output types', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of Query.field must be Output Type but got: [SomeInputObject].',
@@ -834,12 +831,10 @@ describe('Type System: Objects can only implement unique interfaces', () => {
       }),
     });
 
-    expect(validateSchema(schema)).to.containSubset([
-      {
-        message:
-          'Type BadObject must only implement Interface types, it cannot implement undefined.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Type BadObject must only implement Interface types, it cannot implement undefined.',
+    });
   });
 
   it('rejects an Object implementing a non-Interface type', () => {
@@ -856,7 +851,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Type BadObject must only implement Interface types, it cannot implement SomeInputObject.',
@@ -879,7 +874,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message: 'Type AnotherObject can only implement AnotherInterface once.',
         locations: [{ line: 10, column: 37 }, { line: 10, column: 56 }],
@@ -905,7 +900,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
       schema,
       parse('extend type AnotherObject implements AnotherInterface'),
     );
-    expect(validateSchema(extendedSchema)).to.containSubset([
+    expect(validateSchema(extendedSchema)).to.deep.equal([
       {
         message: 'Type AnotherObject can only implement AnotherInterface once.',
         locations: [{ line: 10, column: 37 }, { line: 1, column: 38 }],
@@ -937,7 +932,7 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.containSubset([
+    expect(validateSchema(extendedSchema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.newField expected but AnotherObject does not provide it.',
@@ -972,7 +967,7 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.containSubset([
+    expect(validateSchema(extendedSchema)).to.deep.equal([
       {
         message:
           'Interface field argument AnotherInterface.newField(test:) expected but AnotherObject.newField does not provide it.',
@@ -1015,7 +1010,7 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.containSubset([
+    expect(validateSchema(extendedSchema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.newInterfaceField expects type NewInterface but AnotherObject.newInterfaceField is type MismatchingInterface.',
@@ -1062,7 +1057,7 @@ describe('Type System: Interface fields must have output types', () => {
 
   it('rejects an empty Interface field type', () => {
     const schema = schemaWithInterfaceFieldOfType(undefined);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of BadInterface.badField must be Output Type but got: undefined.',
@@ -1073,11 +1068,9 @@ describe('Type System: Interface fields must have output types', () => {
   notOutputTypes.forEach(type => {
     it(`rejects a non-output type as an Interface field type: ${type}`, () => {
       const schema = schemaWithInterfaceFieldOfType(type);
-      expect(validateSchema(schema)).to.containSubset([
-        {
-          message: `The type of BadInterface.badField must be Output Type but got: ${type}.`,
-        },
-      ]);
+      expect(validateSchema(schema)).to.deep.include({
+        message: `The type of BadInterface.badField must be Output Type but got: ${type}.`,
+      });
     });
   });
 
@@ -1095,7 +1088,7 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of SomeInterface.field must be Output Type but got: SomeInputObject.',
@@ -1157,7 +1150,7 @@ describe('Type System: Field arguments must have input types', () => {
 
   it('rejects an empty field arg type', () => {
     const schema = schemaWithArgOfType(undefined);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of BadObject.badField(badArg:) must be Input Type but got: undefined.',
@@ -1168,11 +1161,9 @@ describe('Type System: Field arguments must have input types', () => {
   notInputTypes.forEach(type => {
     it(`rejects a non-input type as a field arg type: ${type}`, () => {
       const schema = schemaWithArgOfType(type);
-      expect(validateSchema(schema)).to.containSubset([
-        {
-          message: `The type of BadObject.badField(badArg:) must be Input Type but got: ${type}.`,
-        },
-      ]);
+      expect(validateSchema(schema)).to.deep.include({
+        message: `The type of BadObject.badField(badArg:) must be Input Type but got: ${type}.`,
+      });
     });
   });
 
@@ -1186,7 +1177,7 @@ describe('Type System: Field arguments must have input types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of Query.test(arg:) must be Input Type but got: SomeObject.',
@@ -1229,7 +1220,7 @@ describe('Type System: Input Object fields must have input types', () => {
 
   it('rejects an empty input field type', () => {
     const schema = schemaWithInputFieldOfType(undefined);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of BadInputObject.badField must be Input Type but got: undefined.',
@@ -1240,11 +1231,9 @@ describe('Type System: Input Object fields must have input types', () => {
   notInputTypes.forEach(type => {
     it(`rejects a non-input type as an input field type: ${type}`, () => {
       const schema = schemaWithInputFieldOfType(type);
-      expect(validateSchema(schema)).to.containSubset([
-        {
-          message: `The type of BadInputObject.badField must be Input Type but got: ${type}.`,
-        },
-      ]);
+      expect(validateSchema(schema)).to.deep.include({
+        message: `The type of BadInputObject.badField must be Input Type but got: ${type}.`,
+      });
     });
   });
 
@@ -1262,7 +1251,7 @@ describe('Type System: Input Object fields must have input types', () => {
         bar: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
@@ -1339,7 +1328,7 @@ describe('Objects must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expected but ' +
@@ -1363,7 +1352,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String): Int
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type String but ' +
@@ -1390,7 +1379,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: B
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type A but ' +
@@ -1454,7 +1443,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field argument AnotherInterface.field(input:) expected ' +
@@ -1478,7 +1467,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field argument AnotherInterface.field(input:) expects ' +
@@ -1502,7 +1491,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): Int
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type String but ' +
@@ -1532,7 +1521,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String, anotherInput: String!): String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Object field argument AnotherObject.field(anotherInput:) is of ' +
@@ -1574,7 +1563,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type [String] ' +
@@ -1598,7 +1587,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: [String]
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type String but ' +
@@ -1639,7 +1628,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type String! ' +

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -187,11 +187,9 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Query root type must be provided.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Query root type must be provided.',
+    });
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -202,12 +200,10 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.equal([
-      {
-        message: 'Query root type must be provided.',
-        locations: [{ line: 2, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schemaWithDef)).to.deep.include({
+      message: 'Query root type must be provided.',
+      locations: [{ line: 2, column: 7 }],
+    });
   });
 
   it('rejects a Schema whose query root type is not an Object type', () => {
@@ -216,12 +212,10 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Query root type must be Object type, it cannot be Query.',
-        locations: [{ line: 2, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Query root type must be Object type, it cannot be Query.',
+      locations: [{ line: 2, column: 7 }],
+    });
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -232,13 +226,11 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.equal([
-      {
-        message:
-          'Query root type must be Object type, it cannot be SomeInputObject.',
-        locations: [{ line: 3, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schemaWithDef)).to.deep.include({
+      message:
+        'Query root type must be Object type, it cannot be SomeInputObject.',
+      locations: [{ line: 3, column: 16 }],
+    });
   });
 
   it('rejects a Schema whose mutation type is an input type', () => {
@@ -251,13 +243,11 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Mutation root type must be Object type if provided, it cannot be Mutation.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Mutation root type must be Object type if provided, it cannot be Mutation.',
+      locations: [{ line: 6, column: 7 }],
+    });
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -273,13 +263,11 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.equal([
-      {
-        message:
-          'Mutation root type must be Object type if provided, it cannot be SomeInputObject.',
-        locations: [{ line: 4, column: 19 }],
-      },
-    ]);
+    expect(validateSchema(schemaWithDef)).to.deep.include({
+      message:
+        'Mutation root type must be Object type if provided, it cannot be SomeInputObject.',
+      locations: [{ line: 4, column: 19 }],
+    });
   });
 
   it('rejects a Schema whose subscription type is an input type', () => {
@@ -292,13 +280,11 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Subscription root type must be Object type if provided, it cannot be Subscription.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Subscription root type must be Object type if provided, it cannot be Subscription.',
+      locations: [{ line: 6, column: 7 }],
+    });
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -314,13 +300,11 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.equal([
-      {
-        message:
-          'Subscription root type must be Object type if provided, it cannot be SomeInputObject.',
-        locations: [{ line: 4, column: 23 }],
-      },
-    ]);
+    expect(validateSchema(schemaWithDef)).to.deep.include({
+      message:
+        'Subscription root type must be Object type if provided, it cannot be SomeInputObject.',
+      locations: [{ line: 4, column: 23 }],
+    });
   });
 
   it('rejects a Schema whose directives are incorrectly typed', () => {
@@ -328,11 +312,9 @@ describe('Type System: A Schema must have Object root types', () => {
       query: SomeObjectType,
       directives: ['somedirective'],
     });
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Expected directive but got: somedirective.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Expected directive but got: somedirective.',
+    });
   });
 });
 
@@ -358,12 +340,10 @@ describe('Type System: Objects must have fields', () => {
 
       type IncompleteObject
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Type IncompleteObject must define one or more fields.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Type IncompleteObject must define one or more fields.',
+      locations: [{ line: 6, column: 7 }],
+    });
 
     const manualSchema = schemaWithFieldType(
       new GraphQLObjectType({
@@ -371,11 +351,9 @@ describe('Type System: Objects must have fields', () => {
         fields: {},
       }),
     );
-    expect(validateSchema(manualSchema)).to.deep.equal([
-      {
-        message: 'Type IncompleteObject must define one or more fields.',
-      },
-    ]);
+    expect(validateSchema(manualSchema)).to.deep.include({
+      message: 'Type IncompleteObject must define one or more fields.',
+    });
 
     const manualSchema2 = schemaWithFieldType(
       new GraphQLObjectType({
@@ -385,11 +363,9 @@ describe('Type System: Objects must have fields', () => {
         },
       }),
     );
-    expect(validateSchema(manualSchema2)).to.deep.equal([
-      {
-        message: 'Type IncompleteObject must define one or more fields.',
-      },
-    ]);
+    expect(validateSchema(manualSchema2)).to.deep.include({
+      message: 'Type IncompleteObject must define one or more fields.',
+    });
   });
 
   it('rejects an Object type with incorrectly named fields', () => {
@@ -399,13 +375,11 @@ describe('Type System: Objects must have fields', () => {
         fields: { 'bad-name-with-dashes': { type: GraphQLString } },
       }),
     );
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ' +
-          '"bad-name-with-dashes" does not.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ' +
+        '"bad-name-with-dashes" does not.',
+    });
   });
 
   it('accepts an Object type with explicitly allowed legacy named fields', () => {
@@ -422,13 +396,11 @@ describe('Type System: Objects must have fields', () => {
       }),
       allowedLegacyNames: ['__badName'],
     });
-    expect(validateSchema(schemaBad)).to.deep.equal([
-      {
-        message:
-          'Name "__badName" must not begin with "__", which is reserved by ' +
-          'GraphQL introspection.',
-      },
-    ]);
+    expect(validateSchema(schemaBad)).to.deep.include({
+      message:
+        'Name "__badName" must not begin with "__", which is reserved by ' +
+        'GraphQL introspection.',
+    });
     expect(validateSchema(schemaOk)).to.deep.equal([]);
   });
 
@@ -477,12 +449,10 @@ describe('Type System: Fields args must be properly named', () => {
       },
     });
     const schema = new GraphQLSchema({ query: QueryType });
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
+    });
   });
 });
 
@@ -516,12 +486,10 @@ describe('Type System: Union types must be valid', () => {
 
       union BadUnion
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Union type BadUnion must define one or more member types.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Union type BadUnion must define one or more member types.',
+      locations: [{ line: 6, column: 7 }],
+    });
   });
 
   it('rejects a Union type with duplicated member type', () => {
@@ -543,12 +511,10 @@ describe('Type System: Union types must be valid', () => {
         | TypeB
         | TypeA
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Union type BadUnion can only include type TypeA once.',
-        locations: [{ line: 15, column: 11 }, { line: 17, column: 11 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Union type BadUnion can only include type TypeA once.',
+      locations: [{ line: 15, column: 11 }, { line: 17, column: 11 }],
+    });
   });
 
   it('rejects a Union type with non-Object members types', () => {
@@ -570,14 +536,12 @@ describe('Type System: Union types must be valid', () => {
         | String
         | TypeB
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Union type BadUnion can only include Object types, ' +
-          'it cannot include String.',
-        locations: [{ line: 16, column: 11 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Union type BadUnion can only include Object types, ' +
+        'it cannot include String.',
+      locations: [{ line: 16, column: 11 }],
+    });
 
     const badUnionMemberTypes = [
       GraphQLString,
@@ -592,13 +556,11 @@ describe('Type System: Union types must be valid', () => {
       const badSchema = schemaWithFieldType(
         new GraphQLUnionType({ name: 'BadUnion', types: [memberType] }),
       );
-      expect(validateSchema(badSchema)).to.deep.equal([
-        {
-          message:
-            'Union type BadUnion can only include Object types, ' +
-            `it cannot include ${memberType}.`,
-        },
-      ]);
+      expect(validateSchema(badSchema)).to.deep.include({
+        message:
+          'Union type BadUnion can only include Object types, ' +
+          `it cannot include ${memberType}.`,
+      });
     });
   });
 });
@@ -625,13 +587,11 @@ describe('Type System: Input Objects must have fields', () => {
 
       input SomeInputObject
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Input Object type SomeInputObject must define one or more fields.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Input Object type SomeInputObject must define one or more fields.',
+      locations: [{ line: 6, column: 7 }],
+    });
   });
 
   it('rejects an Input Object type with incorrectly typed fields', () => {
@@ -652,7 +612,7 @@ describe('Type System: Input Objects must have fields', () => {
         goodInputObject: SomeInputObject
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
+    expect(validateSchema(schema)).to.deep.include.members([
       {
         message:
           'The type of SomeInputObject.badObject must be Input Type but got: SomeObject.',
@@ -676,12 +636,10 @@ describe('Type System: Enum types must be well defined', () => {
 
       enum SomeEnum
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Enum type SomeEnum must define one or more values.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Enum type SomeEnum must define one or more values.',
+      locations: [{ line: 6, column: 7 }],
+    });
   });
 
   it('rejects an Enum type with duplicate values', () => {
@@ -695,12 +653,10 @@ describe('Type System: Enum types must be well defined', () => {
         SOME_VALUE
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Enum type SomeEnum can include value SOME_VALUE only once.',
-        locations: [{ line: 7, column: 9 }, { line: 8, column: 9 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Enum type SomeEnum can include value SOME_VALUE only once.',
+      locations: [{ line: 7, column: 9 }, { line: 8, column: 9 }],
+    });
   });
 
   it('rejects an Enum type with incorrectly named values', () => {
@@ -716,43 +672,37 @@ describe('Type System: Enum types must be well defined', () => {
     }
 
     const schema1 = schemaWithEnum('#value');
-    expect(validateSchema(schema1)).to.deep.equal([
-      {
-        message:
-          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.',
-      },
-    ]);
+    expect(validateSchema(schema1)).to.deep.include({
+      message:
+        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.',
+    });
 
     const schema2 = schemaWithEnum('1value');
-    expect(validateSchema(schema2)).to.deep.equal([
-      {
-        message:
-          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "1value" does not.',
-      },
-    ]);
+    expect(validateSchema(schema2)).to.deep.include({
+      message:
+        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "1value" does not.',
+    });
 
     const schema3 = schemaWithEnum('KEBAB-CASE');
-    expect(validateSchema(schema3)).to.deep.equal([
-      {
-        message:
-          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "KEBAB-CASE" does not.',
-      },
-    ]);
+    expect(validateSchema(schema3)).to.deep.include({
+      message:
+        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "KEBAB-CASE" does not.',
+    });
 
     const schema4 = schemaWithEnum('true');
-    expect(validateSchema(schema4)).to.deep.equal([
-      { message: 'Enum type SomeEnum cannot include value: true.' },
-    ]);
+    expect(validateSchema(schema4)).to.deep.include({
+      message: 'Enum type SomeEnum cannot include value: true.',
+    });
 
     const schema5 = schemaWithEnum('false');
-    expect(validateSchema(schema5)).to.deep.equal([
-      { message: 'Enum type SomeEnum cannot include value: false.' },
-    ]);
+    expect(validateSchema(schema5)).to.deep.include({
+      message: 'Enum type SomeEnum cannot include value: false.',
+    });
 
     const schema6 = schemaWithEnum('null');
-    expect(validateSchema(schema6)).to.deep.equal([
-      { message: 'Enum type SomeEnum cannot include value: null.' },
-    ]);
+    expect(validateSchema(schema6)).to.deep.include({
+      message: 'Enum type SomeEnum cannot include value: null.',
+    });
   });
 });
 
@@ -785,12 +735,10 @@ describe('Type System: Object fields must have output types', () => {
 
   it('rejects an empty Object field type', () => {
     const schema = schemaWithObjectFieldOfType(undefined);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of BadObject.badField must be Output Type but got: undefined.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of BadObject.badField must be Output Type but got: undefined.',
+    });
   });
 
   notOutputTypes.forEach(type => {
@@ -812,13 +760,11 @@ describe('Type System: Object fields must have output types', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of Query.field must be Output Type but got: [SomeInputObject].',
-        locations: [{ line: 3, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of Query.field must be Output Type but got: [SomeInputObject].',
+      locations: [{ line: 3, column: 16 }],
+    });
   });
 });
 
@@ -851,13 +797,11 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Type BadObject must only implement Interface types, it cannot implement SomeInputObject.',
-        locations: [{ line: 10, column: 33 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Type BadObject must only implement Interface types, it cannot implement SomeInputObject.',
+      locations: [{ line: 10, column: 33 }],
+    });
   });
 
   it('rejects an Object implementing the same interface twice', () => {
@@ -874,12 +818,10 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message: 'Type AnotherObject can only implement AnotherInterface once.',
-        locations: [{ line: 10, column: 37 }, { line: 10, column: 56 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message: 'Type AnotherObject can only implement AnotherInterface once.',
+      locations: [{ line: 10, column: 37 }, { line: 10, column: 56 }],
+    });
   });
 
   it('rejects an Object implementing the same interface twice due to extension', () => {
@@ -900,12 +842,10 @@ describe('Type System: Objects can only implement unique interfaces', () => {
       schema,
       parse('extend type AnotherObject implements AnotherInterface'),
     );
-    expect(validateSchema(extendedSchema)).to.deep.equal([
-      {
-        message: 'Type AnotherObject can only implement AnotherInterface once.',
-        locations: [{ line: 10, column: 37 }, { line: 1, column: 38 }],
-      },
-    ]);
+    expect(validateSchema(extendedSchema)).to.deep.include({
+      message: 'Type AnotherObject can only implement AnotherInterface once.',
+      locations: [{ line: 10, column: 37 }, { line: 1, column: 38 }],
+    });
   });
 });
 
@@ -932,13 +872,11 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.newField expected but AnotherObject does not provide it.',
-        locations: [{ line: 3, column: 11 }, { line: 10, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(extendedSchema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.newField expected but AnotherObject does not provide it.',
+      locations: [{ line: 3, column: 11 }, { line: 10, column: 7 }],
+    });
   });
 
   it('rejects an Object implementing the extended interface due to missing field args', () => {
@@ -967,13 +905,11 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.deep.equal([
-      {
-        message:
-          'Interface field argument AnotherInterface.newField(test:) expected but AnotherObject.newField does not provide it.',
-        locations: [{ line: 3, column: 20 }, { line: 7, column: 11 }],
-      },
-    ]);
+    expect(validateSchema(extendedSchema)).to.deep.include({
+      message:
+        'Interface field argument AnotherInterface.newField(test:) expected but AnotherObject.newField does not provide it.',
+      locations: [{ line: 3, column: 20 }, { line: 7, column: 11 }],
+    });
   });
 
   it('rejects Objects implementing the extended interface due to mismatching interface type', () => {
@@ -1010,13 +946,11 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.newInterfaceField expects type NewInterface but AnotherObject.newInterfaceField is type MismatchingInterface.',
-        locations: [{ line: 3, column: 30 }, { line: 15, column: 30 }],
-      },
-    ]);
+    expect(validateSchema(extendedSchema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.newInterfaceField expects type NewInterface but AnotherObject.newInterfaceField is type MismatchingInterface.',
+      locations: [{ line: 3, column: 30 }, { line: 15, column: 30 }],
+    });
   });
 });
 
@@ -1057,12 +991,10 @@ describe('Type System: Interface fields must have output types', () => {
 
   it('rejects an empty Interface field type', () => {
     const schema = schemaWithInterfaceFieldOfType(undefined);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of BadInterface.badField must be Output Type but got: undefined.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of BadInterface.badField must be Output Type but got: undefined.',
+    });
   });
 
   notOutputTypes.forEach(type => {
@@ -1088,13 +1020,11 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of SomeInterface.field must be Output Type but got: SomeInputObject.',
-        locations: [{ line: 7, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of SomeInterface.field must be Output Type but got: SomeInputObject.',
+      locations: [{ line: 7, column: 16 }],
+    });
   });
 
   it('rejects an interface not implemented by at least one object', () => {
@@ -1107,13 +1037,11 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
-      {
-        message:
-          'Interface SomeInterface must be implemented by at least one Object type.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface SomeInterface must be implemented by at least one Object type.',
+      locations: [{ line: 6, column: 7 }],
+    });
   });
 });
 
@@ -1150,12 +1078,10 @@ describe('Type System: Field arguments must have input types', () => {
 
   it('rejects an empty field arg type', () => {
     const schema = schemaWithArgOfType(undefined);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of BadObject.badField(badArg:) must be Input Type but got: undefined.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of BadObject.badField(badArg:) must be Input Type but got: undefined.',
+    });
   });
 
   notInputTypes.forEach(type => {
@@ -1177,13 +1103,11 @@ describe('Type System: Field arguments must have input types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of Query.test(arg:) must be Input Type but got: SomeObject.',
-        locations: [{ line: 3, column: 19 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of Query.test(arg:) must be Input Type but got: SomeObject.',
+      locations: [{ line: 3, column: 19 }],
+    });
   });
 });
 
@@ -1220,12 +1144,10 @@ describe('Type System: Input Object fields must have input types', () => {
 
   it('rejects an empty input field type', () => {
     const schema = schemaWithInputFieldOfType(undefined);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of BadInputObject.badField must be Input Type but got: undefined.',
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of BadInputObject.badField must be Input Type but got: undefined.',
+    });
   });
 
   notInputTypes.forEach(type => {
@@ -1251,13 +1173,11 @@ describe('Type System: Input Object fields must have input types', () => {
         bar: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
-        locations: [{ line: 7, column: 14 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
+      locations: [{ line: 7, column: 14 }],
+    });
   });
 });
 
@@ -1328,14 +1248,12 @@ describe('Objects must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.field expected but ' +
-          'AnotherObject does not provide it.',
-        locations: [{ line: 7, column: 9 }, { line: 10, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.field expected but ' +
+        'AnotherObject does not provide it.',
+      locations: [{ line: 7, column: 9 }, { line: 10, column: 7 }],
+    });
   });
 
   it('rejects an Object with an incorrectly typed Interface field', () => {
@@ -1352,14 +1270,12 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String): Int
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.field expects type String but ' +
-          'AnotherObject.field is type Int.',
-        locations: [{ line: 7, column: 31 }, { line: 11, column: 31 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.field expects type String but ' +
+        'AnotherObject.field is type Int.',
+      locations: [{ line: 7, column: 31 }, { line: 11, column: 31 }],
+    });
   });
 
   it('rejects an Object with a differently typed Interface field', () => {
@@ -1379,14 +1295,12 @@ describe('Objects must adhere to Interface they implement', () => {
         field: B
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.field expects type A but ' +
-          'AnotherObject.field is type B.',
-        locations: [{ line: 10, column: 16 }, { line: 14, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.field expects type A but ' +
+        'AnotherObject.field is type B.',
+      locations: [{ line: 10, column: 16 }, { line: 14, column: 16 }],
+    });
   });
 
   it('accepts an Object with a subtyped Interface field (interface)', () => {
@@ -1443,14 +1357,12 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field argument AnotherInterface.field(input:) expected ' +
-          'but AnotherObject.field does not provide it.',
-        locations: [{ line: 7, column: 15 }, { line: 11, column: 9 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field argument AnotherInterface.field(input:) expected ' +
+        'but AnotherObject.field does not provide it.',
+      locations: [{ line: 7, column: 15 }, { line: 11, column: 9 }],
+    });
   });
 
   it('rejects an Object with an incorrectly typed Interface argument', () => {
@@ -1467,14 +1379,12 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field argument AnotherInterface.field(input:) expects ' +
-          'type String but AnotherObject.field(input:) is type Int.',
-        locations: [{ line: 7, column: 22 }, { line: 11, column: 22 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field argument AnotherInterface.field(input:) expects ' +
+        'type String but AnotherObject.field(input:) is type Int.',
+      locations: [{ line: 7, column: 22 }, { line: 11, column: 22 }],
+    });
   });
 
   it('rejects an Object with both an incorrectly typed field and argument', () => {
@@ -1491,7 +1401,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): Int
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
+    expect(validateSchema(schema)).to.deep.include.members([
       {
         message:
           'Interface field AnotherInterface.field expects type String but ' +
@@ -1521,15 +1431,13 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String, anotherInput: String!): String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Object field argument AnotherObject.field(anotherInput:) is of ' +
-          'required type String! but is not also provided by the Interface ' +
-          'field AnotherInterface.field.',
-        locations: [{ line: 11, column: 44 }, { line: 7, column: 9 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Object field argument AnotherObject.field(anotherInput:) is of ' +
+        'required type String! but is not also provided by the Interface ' +
+        'field AnotherInterface.field.',
+      locations: [{ line: 11, column: 44 }, { line: 7, column: 9 }],
+    });
   });
 
   it('accepts an Object with an equivalently wrapped Interface field type', () => {
@@ -1563,14 +1471,12 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.field expects type [String] ' +
-          'but AnotherObject.field is type String.',
-        locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.field expects type [String] ' +
+        'but AnotherObject.field is type String.',
+      locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
+    });
   });
 
   it('rejects an Object with a list Interface field non-list type', () => {
@@ -1587,14 +1493,12 @@ describe('Objects must adhere to Interface they implement', () => {
         field: [String]
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.field expects type String but ' +
-          'AnotherObject.field is type [String].',
-        locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.field expects type String but ' +
+        'AnotherObject.field is type [String].',
+      locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
+    });
   });
 
   it('accepts an Object with a subset non-null Interface field type', () => {
@@ -1628,13 +1532,11 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface field AnotherInterface.field expects type String! ' +
-          'but AnotherObject.field is type String.',
-        locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.include({
+      message:
+        'Interface field AnotherInterface.field expects type String! ' +
+        'but AnotherObject.field is type String.',
+      locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
+    });
   });
 });

--- a/src/utilities/__tests__/isValidLiteralValue-test.js
+++ b/src/utilities/__tests__/isValidLiteralValue-test.js
@@ -23,7 +23,6 @@ describe('isValidLiteralValue', () => {
       {
         message: 'Expected type Int, found "abc".',
         locations: [{ line: 1, column: 1 }],
-        path: undefined,
       },
     ]);
   });

--- a/src/validation/__tests__/ExecutableDefinitions-test.js
+++ b/src/validation/__tests__/ExecutableDefinitions-test.js
@@ -16,7 +16,6 @@ function nonExecutableDefinition(defName, line, column) {
   return {
     message: nonExecutableDefinitionMessage(defName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/FieldsOnCorrectType-test.js
+++ b/src/validation/__tests__/FieldsOnCorrectType-test.js
@@ -29,7 +29,6 @@ function undefinedField(
       suggestedFields,
     ),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/FragmentsOnCompositeTypes-test.js
+++ b/src/validation/__tests__/FragmentsOnCompositeTypes-test.js
@@ -17,7 +17,6 @@ function error(fragName, typeName, line, column) {
   return {
     message: fragmentOnNonCompositeErrorMessage(fragName, typeName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -131,7 +130,6 @@ describe('Validate: Fragments on composite types', () => {
         {
           message: inlineFragmentOnNonCompositeErrorMessage('String'),
           locations: [{ line: 3, column: 16 }],
-          path: undefined,
         },
       ],
     );

--- a/src/validation/__tests__/KnownArgumentNames-test.js
+++ b/src/validation/__tests__/KnownArgumentNames-test.js
@@ -17,7 +17,6 @@ function unknownArg(argName, fieldName, typeName, suggestedArgs, line, column) {
   return {
     message: unknownArgMessage(argName, fieldName, typeName, suggestedArgs),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -31,7 +30,6 @@ function unknownDirectiveArg(
   return {
     message: unknownDirectiveArgMessage(argName, directiveName, suggestedArgs),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/KnownDirectives-test.js
+++ b/src/validation/__tests__/KnownDirectives-test.js
@@ -17,7 +17,6 @@ function unknownDirective(directiveName, line, column) {
   return {
     message: unknownDirectiveMessage(directiveName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -25,7 +24,6 @@ function misplacedDirective(directiveName, placement, line, column) {
   return {
     message: misplacedDirectiveMessage(directiveName, placement),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/KnownFragmentNames-test.js
+++ b/src/validation/__tests__/KnownFragmentNames-test.js
@@ -16,7 +16,6 @@ function undefFrag(fragName, line, column) {
   return {
     message: unknownFragmentMessage(fragName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/KnownTypeNames-test.js
+++ b/src/validation/__tests__/KnownTypeNames-test.js
@@ -13,7 +13,6 @@ function unknownType(typeName, suggestedTypes, line, column) {
   return {
     message: unknownTypeMessage(typeName, suggestedTypes),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/LoneAnonymousOperation-test.js
+++ b/src/validation/__tests__/LoneAnonymousOperation-test.js
@@ -16,7 +16,6 @@ function anonNotAlone(line, column) {
   return {
     message: anonOperationNotAloneMessage(),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/NoFragmentCycles-test.js
+++ b/src/validation/__tests__/NoFragmentCycles-test.js
@@ -79,7 +79,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', []),
           locations: [{ line: 2, column: 45 }],
-          path: undefined,
         },
       ],
     );
@@ -95,7 +94,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', []),
           locations: [{ line: 2, column: 31 }],
-          path: undefined,
         },
       ],
     );
@@ -115,7 +113,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', []),
           locations: [{ line: 4, column: 11 }],
-          path: undefined,
         },
       ],
     );
@@ -132,7 +129,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', ['fragB']),
           locations: [{ line: 2, column: 31 }, { line: 3, column: 31 }],
-          path: undefined,
         },
       ],
     );
@@ -149,7 +145,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragB', ['fragA']),
           locations: [{ line: 2, column: 31 }, { line: 3, column: 31 }],
-          path: undefined,
         },
       ],
     );
@@ -174,7 +169,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', ['fragB']),
           locations: [{ line: 4, column: 11 }, { line: 9, column: 11 }],
-          path: undefined,
         },
       ],
     );
@@ -208,7 +202,6 @@ describe('Validate: No circular fragment spreads', () => {
             { line: 8, column: 31 },
             { line: 9, column: 31 },
           ],
-          path: undefined,
         },
         {
           message: cycleErrorMessage('fragO', [
@@ -224,7 +217,6 @@ describe('Validate: No circular fragment spreads', () => {
             { line: 6, column: 31 },
             { line: 7, column: 31 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -242,12 +234,10 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', ['fragB']),
           locations: [{ line: 2, column: 31 }, { line: 3, column: 31 }],
-          path: undefined,
         },
         {
           message: cycleErrorMessage('fragA', ['fragC']),
           locations: [{ line: 2, column: 41 }, { line: 4, column: 31 }],
-          path: undefined,
         },
       ],
     );
@@ -265,12 +255,10 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragA', ['fragC']),
           locations: [{ line: 2, column: 31 }, { line: 4, column: 31 }],
-          path: undefined,
         },
         {
           message: cycleErrorMessage('fragC', ['fragB']),
           locations: [{ line: 4, column: 41 }, { line: 3, column: 31 }],
-          path: undefined,
         },
       ],
     );
@@ -288,7 +276,6 @@ describe('Validate: No circular fragment spreads', () => {
         {
           message: cycleErrorMessage('fragB', []),
           locations: [{ line: 3, column: 31 }],
-          path: undefined,
         },
         {
           message: cycleErrorMessage('fragA', ['fragB', 'fragC']),
@@ -297,12 +284,10 @@ describe('Validate: No circular fragment spreads', () => {
             { line: 3, column: 41 },
             { line: 4, column: 31 },
           ],
-          path: undefined,
         },
         {
           message: cycleErrorMessage('fragB', ['fragC']),
           locations: [{ line: 3, column: 41 }, { line: 4, column: 41 }],
-          path: undefined,
         },
       ],
     );

--- a/src/validation/__tests__/NoUndefinedVariables-test.js
+++ b/src/validation/__tests__/NoUndefinedVariables-test.js
@@ -16,7 +16,6 @@ function undefVar(varName, l1, c1, opName, l2, c2) {
   return {
     message: undefinedVarMessage(varName, opName),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/NoUnusedFragments-test.js
+++ b/src/validation/__tests__/NoUnusedFragments-test.js
@@ -16,7 +16,6 @@ function unusedFrag(fragName, line, column) {
   return {
     message: unusedFragMessage(fragName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/NoUnusedVariables-test.js
+++ b/src/validation/__tests__/NoUnusedVariables-test.js
@@ -16,7 +16,6 @@ function unusedVar(varName, opName, line, column) {
   return {
     message: unusedVariableMessage(varName, opName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMerged-test.js
@@ -132,7 +132,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             'name and nickname are different fields',
           ),
           locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -172,7 +171,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             'nickname and name are different fields',
           ),
           locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -194,7 +192,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             'they have differing arguments',
           ),
           locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -216,7 +213,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             'they have differing arguments',
           ),
           locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -238,7 +234,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             'they have differing arguments',
           ),
           locations: [{ line: 3, column: 9 }, { line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -281,7 +276,6 @@ describe('Validate: Overlapping fields can be merged', () => {
         {
           message: fieldsConflictMessage('x', 'a and b are different fields'),
           locations: [{ line: 7, column: 9 }, { line: 10, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -317,17 +311,14 @@ describe('Validate: Overlapping fields can be merged', () => {
         {
           message: fieldsConflictMessage('x', 'a and b are different fields'),
           locations: [{ line: 18, column: 9 }, { line: 21, column: 9 }],
-          path: undefined,
         },
         {
           message: fieldsConflictMessage('x', 'c and a are different fields'),
           locations: [{ line: 14, column: 11 }, { line: 18, column: 9 }],
-          path: undefined,
         },
         {
           message: fieldsConflictMessage('x', 'c and b are different fields'),
           locations: [{ line: 14, column: 11 }, { line: 21, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -357,7 +348,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             { line: 6, column: 9 },
             { line: 7, column: 11 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -392,7 +382,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             { line: 8, column: 11 },
             { line: 9, column: 11 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -428,7 +417,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             { line: 9, column: 11 },
             { line: 10, column: 13 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -465,7 +453,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             { line: 7, column: 11 },
             { line: 8, column: 13 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -510,7 +497,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             { line: 15, column: 11 },
             { line: 16, column: 13 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -557,7 +543,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             { line: 22, column: 9 },
             { line: 18, column: 9 },
           ],
-          path: undefined,
         },
       ],
     );
@@ -712,7 +697,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               'they return conflicting types Int and String!',
             ),
             locations: [{ line: 5, column: 15 }, { line: 8, column: 15 }],
-            path: undefined,
           },
         ],
       );
@@ -767,7 +751,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               'they return conflicting types Int and String',
             ),
             locations: [{ line: 5, column: 15 }, { line: 8, column: 15 }],
-            path: undefined,
           },
         ],
       );
@@ -832,7 +815,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               { line: 34, column: 11 },
               { line: 42, column: 11 },
             ],
-            path: undefined,
           },
         ],
       );
@@ -861,7 +843,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               'they return conflicting types String! and String',
             ),
             locations: [{ line: 5, column: 15 }, { line: 8, column: 15 }],
-            path: undefined,
           },
         ],
       );
@@ -894,7 +875,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               'they return conflicting types [StringBox] and StringBox',
             ),
             locations: [{ line: 5, column: 15 }, { line: 10, column: 15 }],
-            path: undefined,
           },
         ],
       );
@@ -925,7 +905,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               'they return conflicting types StringBox and [StringBox]',
             ),
             locations: [{ line: 5, column: 15 }, { line: 10, column: 15 }],
-            path: undefined,
           },
         ],
       );
@@ -959,7 +938,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               'scalar and unrelatedField are different fields',
             ),
             locations: [{ line: 6, column: 17 }, { line: 7, column: 17 }],
-            path: undefined,
           },
         ],
       );
@@ -996,7 +974,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               { line: 10, column: 15 },
               { line: 11, column: 17 },
             ],
-            path: undefined,
           },
         ],
       );
@@ -1092,7 +1069,6 @@ describe('Validate: Overlapping fields can be merged', () => {
               { line: 15, column: 13 },
               { line: 16, column: 15 },
             ],
-            path: undefined,
           },
         ],
       );
@@ -1204,7 +1180,6 @@ describe('Validate: Overlapping fields can be merged', () => {
             'name and nickname are different fields',
           ),
           locations: [{ line: 4, column: 9 }, { line: 5, column: 9 }],
-          path: undefined,
         },
       ],
     );

--- a/src/validation/__tests__/PossibleFragmentSpreads-test.js
+++ b/src/validation/__tests__/PossibleFragmentSpreads-test.js
@@ -17,7 +17,6 @@ function error(fragName, parentType, fragType, line, column) {
   return {
     message: typeIncompatibleSpreadMessage(fragName, parentType, fragType),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -25,7 +24,6 @@ function errorAnon(parentType, fragType, line, column) {
   return {
     message: typeIncompatibleAnonSpreadMessage(parentType, fragType),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/ProvidedNonNullArguments-test.js
+++ b/src/validation/__tests__/ProvidedNonNullArguments-test.js
@@ -17,7 +17,6 @@ function missingFieldArg(fieldName, argName, typeName, line, column) {
   return {
     message: missingFieldArgMessage(fieldName, argName, typeName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -25,7 +24,6 @@ function missingDirectiveArg(directiveName, argName, typeName, line, column) {
   return {
     message: missingDirectiveArgMessage(directiveName, argName, typeName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/ScalarLeafs-test.js
+++ b/src/validation/__tests__/ScalarLeafs-test.js
@@ -17,7 +17,6 @@ function noScalarSubselection(field, type, line, column) {
   return {
     message: noSubselectionAllowedMessage(field, type),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -25,7 +24,6 @@ function missingObjSubselection(field, type, line, column) {
   return {
     message: requiredSubselectionMessage(field, type),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/SingleFieldSubscriptions-test.js
+++ b/src/validation/__tests__/SingleFieldSubscriptions-test.js
@@ -37,7 +37,6 @@ describe('Validate: Subscriptions with single field', () => {
         {
           message: singleFieldOnlyMessage('ImportantEmails'),
           locations: [{ line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -56,7 +55,6 @@ describe('Validate: Subscriptions with single field', () => {
         {
           message: singleFieldOnlyMessage('ImportantEmails'),
           locations: [{ line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -76,7 +74,6 @@ describe('Validate: Subscriptions with single field', () => {
         {
           message: singleFieldOnlyMessage('ImportantEmails'),
           locations: [{ line: 4, column: 9 }, { line: 5, column: 9 }],
-          path: undefined,
         },
       ],
     );
@@ -95,7 +92,6 @@ describe('Validate: Subscriptions with single field', () => {
         {
           message: singleFieldOnlyMessage(null),
           locations: [{ line: 4, column: 9 }],
-          path: undefined,
         },
       ],
     );

--- a/src/validation/__tests__/UniqueArgumentNames-test.js
+++ b/src/validation/__tests__/UniqueArgumentNames-test.js
@@ -16,7 +16,6 @@ function duplicateArg(argName, l1, c1, l2, c2) {
   return {
     message: duplicateArgMessage(argName),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/UniqueDirectivesPerLocation-test.js
+++ b/src/validation/__tests__/UniqueDirectivesPerLocation-test.js
@@ -16,7 +16,6 @@ function duplicateDirective(directiveName, l1, c1, l2, c2) {
   return {
     message: duplicateDirectiveMessage(directiveName),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/UniqueFragmentNames-test.js
+++ b/src/validation/__tests__/UniqueFragmentNames-test.js
@@ -16,7 +16,6 @@ function duplicateFrag(fragName, l1, c1, l2, c2) {
   return {
     message: duplicateFragmentNameMessage(fragName),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/UniqueInputFieldNames-test.js
+++ b/src/validation/__tests__/UniqueInputFieldNames-test.js
@@ -16,7 +16,6 @@ function duplicateField(name, l1, c1, l2, c2) {
   return {
     message: duplicateInputFieldMessage(name),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/UniqueOperationNames-test.js
+++ b/src/validation/__tests__/UniqueOperationNames-test.js
@@ -16,7 +16,6 @@ function duplicateOp(opName, l1, c1, l2, c2) {
   return {
     message: duplicateOperationNameMessage(opName),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/UniqueVariableNames-test.js
+++ b/src/validation/__tests__/UniqueVariableNames-test.js
@@ -16,7 +16,6 @@ function duplicateVariable(name, l1, c1, l2, c2) {
   return {
     message: duplicateVariableMessage(name),
     locations: [{ line: l1, column: c1 }, { line: l2, column: c2 }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/ValuesOfCorrectType-test.js
+++ b/src/validation/__tests__/ValuesOfCorrectType-test.js
@@ -19,7 +19,6 @@ function badValue(typeName, value, line, column, message) {
   return {
     message: badValueMessage(typeName, value, message),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -27,7 +26,6 @@ function requiredField(typeName, fieldName, fieldTypeName, line, column) {
   return {
     message: requiredFieldMessage(typeName, fieldName, fieldTypeName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 
@@ -35,7 +33,6 @@ function unknownField(typeName, fieldName, line, column, message) {
   return {
     message: unknownFieldMessage(typeName, fieldName, message),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/VariablesAreInputTypes-test.js
+++ b/src/validation/__tests__/VariablesAreInputTypes-test.js
@@ -36,17 +36,14 @@ describe('Validate: Variables are input types', () => {
         {
           locations: [{ line: 2, column: 21 }],
           message: nonInputTypeOnVarMessage('a', 'Dog'),
-          path: undefined,
         },
         {
           locations: [{ line: 2, column: 30 }],
           message: nonInputTypeOnVarMessage('b', '[[CatOrDog!]]!'),
-          path: undefined,
         },
         {
           locations: [{ line: 2, column: 50 }],
           message: nonInputTypeOnVarMessage('c', 'Pet'),
-          path: undefined,
         },
       ],
     );

--- a/src/validation/__tests__/VariablesDefaultValueAllowed-test.js
+++ b/src/validation/__tests__/VariablesDefaultValueAllowed-test.js
@@ -16,7 +16,6 @@ function defaultForRequiredVar(varName, typeName, guessTypeName, line, column) {
   return {
     message: defaultForRequiredVarMessage(varName, typeName, guessTypeName),
     locations: [{ line, column }],
-    path: undefined,
   };
 }
 

--- a/src/validation/__tests__/VariablesInAllowedPosition-test.js
+++ b/src/validation/__tests__/VariablesInAllowedPosition-test.js
@@ -227,7 +227,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('intArg', 'Int', 'Int!'),
           locations: [{ line: 2, column: 19 }, { line: 4, column: 45 }],
-          path: undefined,
         },
       ],
     );
@@ -251,7 +250,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('intArg', 'Int', 'Int!'),
           locations: [{ line: 6, column: 19 }, { line: 3, column: 43 }],
-          path: undefined,
         },
       ],
     );
@@ -279,7 +277,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('intArg', 'Int', 'Int!'),
           locations: [{ line: 10, column: 19 }, { line: 7, column: 43 }],
-          path: undefined,
         },
       ],
     );
@@ -299,7 +296,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('stringVar', 'String', 'Boolean'),
           locations: [{ line: 2, column: 19 }, { line: 4, column: 39 }],
-          path: undefined,
         },
       ],
     );
@@ -319,7 +315,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('stringVar', 'String', '[String]'),
           locations: [{ line: 2, column: 19 }, { line: 4, column: 45 }],
-          path: undefined,
         },
       ],
     );
@@ -337,7 +332,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('boolVar', 'Boolean', 'Boolean!'),
           locations: [{ line: 2, column: 19 }, { line: 3, column: 26 }],
-          path: undefined,
         },
       ],
     );
@@ -355,7 +349,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('stringVar', 'String', 'Boolean!'),
           locations: [{ line: 2, column: 19 }, { line: 3, column: 26 }],
-          path: undefined,
         },
       ],
     );
@@ -376,7 +369,6 @@ describe('Validate: Variables are in allowed positions', () => {
         {
           message: badVarPosMessage('stringListVar', '[String]', '[String!]'),
           locations: [{ line: 2, column: 19 }, { line: 5, column: 59 }],
-          path: undefined,
         },
       ],
     );

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -7,7 +7,6 @@
 
 import { expect } from 'chai';
 import { parse } from '../../language';
-import { formatError } from '../../error';
 import { validate } from '../validate';
 import {
   GraphQLSchema,
@@ -423,7 +422,7 @@ function expectValid(schema, rules, queryString) {
 function expectInvalid(schema, rules, queryString, expectedErrors) {
   const errors = validate(schema, parse(queryString), rules);
   expect(errors).to.have.length.of.at.least(1, 'Should not validate');
-  expect(errors.map(formatError)).to.deep.equal(expectedErrors);
+  expect(errors).to.deep.equal(expectedErrors);
   return errors;
 }
 

--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -50,7 +50,6 @@ describe('Validate: Supports full validation', () => {
         message:
           'Expected type Invalid, found "bad value"; ' +
           'Invalid scalar is always invalid: bad value',
-        path: undefined,
       },
     ]);
   });


### PR DESCRIPTION
Also cleanup tests from 'undefined' and 'containSubset'.

@leebyron I split up non-breaking changes from #1284 
I think they are useful by itself since they make tests more readable.