### PR TITLE
Match exact set of errors in schema validation tests

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -187,9 +187,11 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Query root type must be provided.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Query root type must be provided.',
+      },
+    ]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -200,10 +202,12 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.include({
-      message: 'Query root type must be provided.',
-      locations: [{ line: 2, column: 7 }],
-    });
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
+      {
+        message: 'Query root type must be provided.',
+        locations: [{ line: 2, column: 7 }],
+      },
+    ]);
   });
 
   it('rejects a Schema whose query root type is not an Object type', () => {
@@ -212,10 +216,12 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Query root type must be Object type, it cannot be Query.',
-      locations: [{ line: 2, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Query root type must be Object type, it cannot be Query.',
+        locations: [{ line: 2, column: 7 }],
+      },
+    ]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -226,11 +232,13 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.include({
-      message:
-        'Query root type must be Object type, it cannot be SomeInputObject.',
-      locations: [{ line: 3, column: 16 }],
-    });
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
+      {
+        message:
+          'Query root type must be Object type, it cannot be SomeInputObject.',
+        locations: [{ line: 3, column: 16 }],
+      },
+    ]);
   });
 
   it('rejects a Schema whose mutation type is an input type', () => {
@@ -243,11 +251,13 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Mutation root type must be Object type if provided, it cannot be Mutation.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Mutation root type must be Object type if provided, it cannot be Mutation.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -263,11 +273,13 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.include({
-      message:
-        'Mutation root type must be Object type if provided, it cannot be SomeInputObject.',
-      locations: [{ line: 4, column: 19 }],
-    });
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
+      {
+        message:
+          'Mutation root type must be Object type if provided, it cannot be SomeInputObject.',
+        locations: [{ line: 4, column: 19 }],
+      },
+    ]);
   });
 
   it('rejects a Schema whose subscription type is an input type', () => {
@@ -280,11 +292,13 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Subscription root type must be Object type if provided, it cannot be Subscription.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Subscription root type must be Object type if provided, it cannot be Subscription.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -300,11 +314,13 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expect(validateSchema(schemaWithDef)).to.deep.include({
-      message:
-        'Subscription root type must be Object type if provided, it cannot be SomeInputObject.',
-      locations: [{ line: 4, column: 23 }],
-    });
+    expect(validateSchema(schemaWithDef)).to.deep.equal([
+      {
+        message:
+          'Subscription root type must be Object type if provided, it cannot be SomeInputObject.',
+        locations: [{ line: 4, column: 23 }],
+      },
+    ]);
   });
 
   it('rejects a Schema whose directives are incorrectly typed', () => {
@@ -312,9 +328,11 @@ describe('Type System: A Schema must have Object root types', () => {
       query: SomeObjectType,
       directives: ['somedirective'],
     });
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Expected directive but got: somedirective.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Expected directive but got: somedirective.',
+      },
+    ]);
   });
 });
 
@@ -340,10 +358,12 @@ describe('Type System: Objects must have fields', () => {
 
       type IncompleteObject
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Type IncompleteObject must define one or more fields.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Type IncompleteObject must define one or more fields.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
 
     const manualSchema = schemaWithFieldType(
       new GraphQLObjectType({
@@ -351,9 +371,11 @@ describe('Type System: Objects must have fields', () => {
         fields: {},
       }),
     );
-    expect(validateSchema(manualSchema)).to.deep.include({
-      message: 'Type IncompleteObject must define one or more fields.',
-    });
+    expect(validateSchema(manualSchema)).to.deep.equal([
+      {
+        message: 'Type IncompleteObject must define one or more fields.',
+      },
+    ]);
 
     const manualSchema2 = schemaWithFieldType(
       new GraphQLObjectType({
@@ -363,9 +385,11 @@ describe('Type System: Objects must have fields', () => {
         },
       }),
     );
-    expect(validateSchema(manualSchema2)).to.deep.include({
-      message: 'Type IncompleteObject must define one or more fields.',
-    });
+    expect(validateSchema(manualSchema2)).to.deep.equal([
+      {
+        message: 'Type IncompleteObject must define one or more fields.',
+      },
+    ]);
   });
 
   it('rejects an Object type with incorrectly named fields', () => {
@@ -375,11 +399,13 @@ describe('Type System: Objects must have fields', () => {
         fields: { 'bad-name-with-dashes': { type: GraphQLString } },
       }),
     );
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ' +
-        '"bad-name-with-dashes" does not.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but ' +
+          '"bad-name-with-dashes" does not.',
+      },
+    ]);
   });
 
   it('accepts an Object type with explicitly allowed legacy named fields', () => {
@@ -396,11 +422,13 @@ describe('Type System: Objects must have fields', () => {
       }),
       allowedLegacyNames: ['__badName'],
     });
-    expect(validateSchema(schemaBad)).to.deep.include({
-      message:
-        'Name "__badName" must not begin with "__", which is reserved by ' +
-        'GraphQL introspection.',
-    });
+    expect(validateSchema(schemaBad)).to.deep.equal([
+      {
+        message:
+          'Name "__badName" must not begin with "__", which is reserved by ' +
+          'GraphQL introspection.',
+      },
+    ]);
     expect(validateSchema(schemaOk)).to.deep.equal([]);
   });
 
@@ -449,10 +477,12 @@ describe('Type System: Fields args must be properly named', () => {
       },
     });
     const schema = new GraphQLSchema({ query: QueryType });
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "bad-name-with-dashes" does not.',
+      },
+    ]);
   });
 });
 
@@ -486,10 +516,12 @@ describe('Type System: Union types must be valid', () => {
 
       union BadUnion
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Union type BadUnion must define one or more member types.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Union type BadUnion must define one or more member types.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
   });
 
   it('rejects a Union type with duplicated member type', () => {
@@ -511,10 +543,12 @@ describe('Type System: Union types must be valid', () => {
         | TypeB
         | TypeA
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Union type BadUnion can only include type TypeA once.',
-      locations: [{ line: 15, column: 11 }, { line: 17, column: 11 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Union type BadUnion can only include type TypeA once.',
+        locations: [{ line: 15, column: 11 }, { line: 17, column: 11 }],
+      },
+    ]);
   });
 
   it('rejects a Union type with non-Object members types', () => {
@@ -536,12 +570,14 @@ describe('Type System: Union types must be valid', () => {
         | String
         | TypeB
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Union type BadUnion can only include Object types, ' +
-        'it cannot include String.',
-      locations: [{ line: 16, column: 11 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Union type BadUnion can only include Object types, ' +
+          'it cannot include String.',
+        locations: [{ line: 16, column: 11 }],
+      },
+    ]);
 
     const badUnionMemberTypes = [
       GraphQLString,
@@ -556,11 +592,13 @@ describe('Type System: Union types must be valid', () => {
       const badSchema = schemaWithFieldType(
         new GraphQLUnionType({ name: 'BadUnion', types: [memberType] }),
       );
-      expect(validateSchema(badSchema)).to.deep.include({
-        message:
-          'Union type BadUnion can only include Object types, ' +
-          `it cannot include ${memberType}.`,
-      });
+      expect(validateSchema(badSchema)).to.deep.equal([
+        {
+          message:
+            'Union type BadUnion can only include Object types, ' +
+            `it cannot include ${memberType}.`,
+        },
+      ]);
     });
   });
 });
@@ -587,11 +625,13 @@ describe('Type System: Input Objects must have fields', () => {
 
       input SomeInputObject
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Input Object type SomeInputObject must define one or more fields.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Input Object type SomeInputObject must define one or more fields.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
   });
 
   it('rejects an Input Object type with incorrectly typed fields', () => {
@@ -612,7 +652,7 @@ describe('Type System: Input Objects must have fields', () => {
         goodInputObject: SomeInputObject
       }
     `);
-    expect(validateSchema(schema)).to.deep.include.members([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'The type of SomeInputObject.badObject must be Input Type but got: SomeObject.',
@@ -636,10 +676,12 @@ describe('Type System: Enum types must be well defined', () => {
 
       enum SomeEnum
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Enum type SomeEnum must define one or more values.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Enum type SomeEnum must define one or more values.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
   });
 
   it('rejects an Enum type with duplicate values', () => {
@@ -653,10 +695,12 @@ describe('Type System: Enum types must be well defined', () => {
         SOME_VALUE
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Enum type SomeEnum can include value SOME_VALUE only once.',
-      locations: [{ line: 7, column: 9 }, { line: 8, column: 9 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Enum type SomeEnum can include value SOME_VALUE only once.',
+        locations: [{ line: 7, column: 9 }, { line: 8, column: 9 }],
+      },
+    ]);
   });
 
   it('rejects an Enum type with incorrectly named values', () => {
@@ -672,37 +716,43 @@ describe('Type System: Enum types must be well defined', () => {
     }
 
     const schema1 = schemaWithEnum('#value');
-    expect(validateSchema(schema1)).to.deep.include({
-      message:
-        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.',
-    });
+    expect(validateSchema(schema1)).to.deep.equal([
+      {
+        message:
+          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "#value" does not.',
+      },
+    ]);
 
     const schema2 = schemaWithEnum('1value');
-    expect(validateSchema(schema2)).to.deep.include({
-      message:
-        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "1value" does not.',
-    });
+    expect(validateSchema(schema2)).to.deep.equal([
+      {
+        message:
+          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "1value" does not.',
+      },
+    ]);
 
     const schema3 = schemaWithEnum('KEBAB-CASE');
-    expect(validateSchema(schema3)).to.deep.include({
-      message:
-        'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "KEBAB-CASE" does not.',
-    });
+    expect(validateSchema(schema3)).to.deep.equal([
+      {
+        message:
+          'Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "KEBAB-CASE" does not.',
+      },
+    ]);
 
     const schema4 = schemaWithEnum('true');
-    expect(validateSchema(schema4)).to.deep.include({
-      message: 'Enum type SomeEnum cannot include value: true.',
-    });
+    expect(validateSchema(schema4)).to.deep.equal([
+      { message: 'Enum type SomeEnum cannot include value: true.' },
+    ]);
 
     const schema5 = schemaWithEnum('false');
-    expect(validateSchema(schema5)).to.deep.include({
-      message: 'Enum type SomeEnum cannot include value: false.',
-    });
+    expect(validateSchema(schema5)).to.deep.equal([
+      { message: 'Enum type SomeEnum cannot include value: false.' },
+    ]);
 
     const schema6 = schemaWithEnum('null');
-    expect(validateSchema(schema6)).to.deep.include({
-      message: 'Enum type SomeEnum cannot include value: null.',
-    });
+    expect(validateSchema(schema6)).to.deep.equal([
+      { message: 'Enum type SomeEnum cannot include value: null.' },
+    ]);
   });
 });
 
@@ -735,10 +785,12 @@ describe('Type System: Object fields must have output types', () => {
 
   it('rejects an empty Object field type', () => {
     const schema = schemaWithObjectFieldOfType(undefined);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of BadObject.badField must be Output Type but got: undefined.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of BadObject.badField must be Output Type but got: undefined.',
+      },
+    ]);
   });
 
   notOutputTypes.forEach(type => {
@@ -760,11 +812,13 @@ describe('Type System: Object fields must have output types', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of Query.field must be Output Type but got: [SomeInputObject].',
-      locations: [{ line: 3, column: 16 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of Query.field must be Output Type but got: [SomeInputObject].',
+        locations: [{ line: 3, column: 16 }],
+      },
+    ]);
   });
 });
 
@@ -797,11 +851,13 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Type BadObject must only implement Interface types, it cannot implement SomeInputObject.',
-      locations: [{ line: 10, column: 33 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Type BadObject must only implement Interface types, it cannot implement SomeInputObject.',
+        locations: [{ line: 10, column: 33 }],
+      },
+    ]);
   });
 
   it('rejects an Object implementing the same interface twice', () => {
@@ -818,10 +874,12 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message: 'Type AnotherObject can only implement AnotherInterface once.',
-      locations: [{ line: 10, column: 37 }, { line: 10, column: 56 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message: 'Type AnotherObject can only implement AnotherInterface once.',
+        locations: [{ line: 10, column: 37 }, { line: 10, column: 56 }],
+      },
+    ]);
   });
 
   it('rejects an Object implementing the same interface twice due to extension', () => {
@@ -842,10 +900,12 @@ describe('Type System: Objects can only implement unique interfaces', () => {
       schema,
       parse('extend type AnotherObject implements AnotherInterface'),
     );
-    expect(validateSchema(extendedSchema)).to.deep.include({
-      message: 'Type AnotherObject can only implement AnotherInterface once.',
-      locations: [{ line: 10, column: 37 }, { line: 1, column: 38 }],
-    });
+    expect(validateSchema(extendedSchema)).to.deep.equal([
+      {
+        message: 'Type AnotherObject can only implement AnotherInterface once.',
+        locations: [{ line: 10, column: 37 }, { line: 1, column: 38 }],
+      },
+    ]);
   });
 });
 
@@ -872,11 +932,13 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.newField expected but AnotherObject does not provide it.',
-      locations: [{ line: 3, column: 11 }, { line: 10, column: 7 }],
-    });
+    expect(validateSchema(extendedSchema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.newField expected but AnotherObject does not provide it.',
+        locations: [{ line: 3, column: 11 }, { line: 10, column: 7 }],
+      },
+    ]);
   });
 
   it('rejects an Object implementing the extended interface due to missing field args', () => {
@@ -905,11 +967,13 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.deep.include({
-      message:
-        'Interface field argument AnotherInterface.newField(test:) expected but AnotherObject.newField does not provide it.',
-      locations: [{ line: 3, column: 20 }, { line: 7, column: 11 }],
-    });
+    expect(validateSchema(extendedSchema)).to.deep.equal([
+      {
+        message:
+          'Interface field argument AnotherInterface.newField(test:) expected but AnotherObject.newField does not provide it.',
+        locations: [{ line: 3, column: 20 }, { line: 7, column: 11 }],
+      },
+    ]);
   });
 
   it('rejects Objects implementing the extended interface due to mismatching interface type', () => {
@@ -946,11 +1010,13 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expect(validateSchema(extendedSchema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.newInterfaceField expects type NewInterface but AnotherObject.newInterfaceField is type MismatchingInterface.',
-      locations: [{ line: 3, column: 30 }, { line: 15, column: 30 }],
-    });
+    expect(validateSchema(extendedSchema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.newInterfaceField expects type NewInterface but AnotherObject.newInterfaceField is type MismatchingInterface.',
+        locations: [{ line: 3, column: 30 }, { line: 15, column: 30 }],
+      },
+    ]);
   });
 });
 
@@ -991,10 +1057,12 @@ describe('Type System: Interface fields must have output types', () => {
 
   it('rejects an empty Interface field type', () => {
     const schema = schemaWithInterfaceFieldOfType(undefined);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of BadInterface.badField must be Output Type but got: undefined.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of BadInterface.badField must be Output Type but got: undefined.',
+      },
+    ]);
   });
 
   notOutputTypes.forEach(type => {
@@ -1020,11 +1088,13 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of SomeInterface.field must be Output Type but got: SomeInputObject.',
-      locations: [{ line: 7, column: 16 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of SomeInterface.field must be Output Type but got: SomeInputObject.',
+        locations: [{ line: 7, column: 16 }],
+      },
+    ]);
   });
 
   it('rejects an interface not implemented by at least one object', () => {
@@ -1037,11 +1107,13 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface SomeInterface must be implemented by at least one Object type.',
-      locations: [{ line: 6, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.containSubset([
+      {
+        message:
+          'Interface SomeInterface must be implemented by at least one Object type.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
   });
 });
 
@@ -1078,10 +1150,12 @@ describe('Type System: Field arguments must have input types', () => {
 
   it('rejects an empty field arg type', () => {
     const schema = schemaWithArgOfType(undefined);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of BadObject.badField(badArg:) must be Input Type but got: undefined.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of BadObject.badField(badArg:) must be Input Type but got: undefined.',
+      },
+    ]);
   });
 
   notInputTypes.forEach(type => {
@@ -1103,11 +1177,13 @@ describe('Type System: Field arguments must have input types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of Query.test(arg:) must be Input Type but got: SomeObject.',
-      locations: [{ line: 3, column: 19 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of Query.test(arg:) must be Input Type but got: SomeObject.',
+        locations: [{ line: 3, column: 19 }],
+      },
+    ]);
   });
 });
 
@@ -1144,10 +1220,12 @@ describe('Type System: Input Object fields must have input types', () => {
 
   it('rejects an empty input field type', () => {
     const schema = schemaWithInputFieldOfType(undefined);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of BadInputObject.badField must be Input Type but got: undefined.',
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of BadInputObject.badField must be Input Type but got: undefined.',
+      },
+    ]);
   });
 
   notInputTypes.forEach(type => {
@@ -1173,11 +1251,13 @@ describe('Type System: Input Object fields must have input types', () => {
         bar: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
-      locations: [{ line: 7, column: 14 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
+        locations: [{ line: 7, column: 14 }],
+      },
+    ]);
   });
 });
 
@@ -1248,12 +1328,14 @@ describe('Objects must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.field expected but ' +
-        'AnotherObject does not provide it.',
-      locations: [{ line: 7, column: 9 }, { line: 10, column: 7 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.field expected but ' +
+          'AnotherObject does not provide it.',
+        locations: [{ line: 7, column: 9 }, { line: 10, column: 7 }],
+      },
+    ]);
   });
 
   it('rejects an Object with an incorrectly typed Interface field', () => {
@@ -1270,12 +1352,14 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String): Int
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.field expects type String but ' +
-        'AnotherObject.field is type Int.',
-      locations: [{ line: 7, column: 31 }, { line: 11, column: 31 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.field expects type String but ' +
+          'AnotherObject.field is type Int.',
+        locations: [{ line: 7, column: 31 }, { line: 11, column: 31 }],
+      },
+    ]);
   });
 
   it('rejects an Object with a differently typed Interface field', () => {
@@ -1295,12 +1379,14 @@ describe('Objects must adhere to Interface they implement', () => {
         field: B
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.field expects type A but ' +
-        'AnotherObject.field is type B.',
-      locations: [{ line: 10, column: 16 }, { line: 14, column: 16 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.field expects type A but ' +
+          'AnotherObject.field is type B.',
+        locations: [{ line: 10, column: 16 }, { line: 14, column: 16 }],
+      },
+    ]);
   });
 
   it('accepts an Object with a subtyped Interface field (interface)', () => {
@@ -1357,12 +1443,14 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field argument AnotherInterface.field(input:) expected ' +
-        'but AnotherObject.field does not provide it.',
-      locations: [{ line: 7, column: 15 }, { line: 11, column: 9 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field argument AnotherInterface.field(input:) expected ' +
+          'but AnotherObject.field does not provide it.',
+        locations: [{ line: 7, column: 15 }, { line: 11, column: 9 }],
+      },
+    ]);
   });
 
   it('rejects an Object with an incorrectly typed Interface argument', () => {
@@ -1379,12 +1467,14 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field argument AnotherInterface.field(input:) expects ' +
-        'type String but AnotherObject.field(input:) is type Int.',
-      locations: [{ line: 7, column: 22 }, { line: 11, column: 22 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field argument AnotherInterface.field(input:) expects ' +
+          'type String but AnotherObject.field(input:) is type Int.',
+        locations: [{ line: 7, column: 22 }, { line: 11, column: 22 }],
+      },
+    ]);
   });
 
   it('rejects an Object with both an incorrectly typed field and argument', () => {
@@ -1401,7 +1491,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): Int
       }
     `);
-    expect(validateSchema(schema)).to.deep.include.members([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface field AnotherInterface.field expects type String but ' +
@@ -1431,13 +1521,15 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String, anotherInput: String!): String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Object field argument AnotherObject.field(anotherInput:) is of ' +
-        'required type String! but is not also provided by the Interface ' +
-        'field AnotherInterface.field.',
-      locations: [{ line: 11, column: 44 }, { line: 7, column: 9 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Object field argument AnotherObject.field(anotherInput:) is of ' +
+          'required type String! but is not also provided by the Interface ' +
+          'field AnotherInterface.field.',
+        locations: [{ line: 11, column: 44 }, { line: 7, column: 9 }],
+      },
+    ]);
   });
 
   it('accepts an Object with an equivalently wrapped Interface field type', () => {
@@ -1471,12 +1563,14 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.field expects type [String] ' +
-        'but AnotherObject.field is type String.',
-      locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.field expects type [String] ' +
+          'but AnotherObject.field is type String.',
+        locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
+      },
+    ]);
   });
 
   it('rejects an Object with a list Interface field non-list type', () => {
@@ -1493,12 +1587,14 @@ describe('Objects must adhere to Interface they implement', () => {
         field: [String]
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.field expects type String but ' +
-        'AnotherObject.field is type [String].',
-      locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.field expects type String but ' +
+          'AnotherObject.field is type [String].',
+        locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
+      },
+    ]);
   });
 
   it('accepts an Object with a subset non-null Interface field type', () => {
@@ -1532,11 +1628,13 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.include({
-      message:
-        'Interface field AnotherInterface.field expects type String! ' +
-        'but AnotherObject.field is type String.',
-      locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
-    });
+    expect(validateSchema(schema)).to.deep.equal([
+      {
+        message:
+          'Interface field AnotherInterface.field expects type String! ' +
+          'but AnotherObject.field is type String.',
+        locations: [{ line: 7, column: 16 }, { line: 11, column: 16 }],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
> Ideally these should detect the exact set of schema validation errors and we should write the test so that each test introduces only the validation error it expects to catch

@leebyron Done