### PR TITLE
Make "nonnull-test.js" more explicit

### DIFF
--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -568,7 +568,7 @@ describe('Execute: handles non-nullable types', () => {
                 type: GraphQLNonNull(GraphQLString),
               },
             },
-            resolve: async (_, args) => {
+            resolve: (_, args) => {
               if (typeof args.cannotBeNull === 'string') {
                 return 'Passed: ' + args.cannotBeNull;
               }
@@ -578,8 +578,8 @@ describe('Execute: handles non-nullable types', () => {
       }),
     });
 
-    it('succeeds when passed non-null literal value', async () => {
-      const result = await execute({
+    it('succeeds when passed non-null literal value', () => {
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query {
@@ -595,8 +595,8 @@ describe('Execute: handles non-nullable types', () => {
       });
     });
 
-    it('succeeds when passed non-null variable value', async () => {
-      const result = await execute({
+    it('succeeds when passed non-null variable value', () => {
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query ($testVar: String!) {
@@ -615,8 +615,8 @@ describe('Execute: handles non-nullable types', () => {
       });
     });
 
-    it('succeeds when missing variable has default value', async () => {
-      const result = await execute({
+    it('succeeds when missing variable has default value', () => {
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query ($testVar: String = "default value") {
@@ -635,10 +635,10 @@ describe('Execute: handles non-nullable types', () => {
       });
     });
 
-    it('field error when missing non-null arg', async () => {
+    it('field error when missing non-null arg', () => {
       // Note: validation should identify this issue first (missing args rule)
       // however execution should still protect against this.
-      const result = await execute({
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query {
@@ -662,10 +662,10 @@ describe('Execute: handles non-nullable types', () => {
       });
     });
 
-    it('field error when non-null arg provided null', async () => {
+    it('field error when non-null arg provided null', () => {
       // Note: validation should identify this issue first (values of correct
       // type rule) however execution should still protect against this.
-      const result = await execute({
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query {
@@ -690,10 +690,10 @@ describe('Execute: handles non-nullable types', () => {
       });
     });
 
-    it('field error when non-null arg not provided variable value', async () => {
+    it('field error when non-null arg not provided variable value', () => {
       // Note: validation should identify this issue first (variables in allowed
       // position rule) however execution should still protect against this.
-      const result = await execute({
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query ($testVar: String) {
@@ -722,8 +722,8 @@ describe('Execute: handles non-nullable types', () => {
       });
     });
 
-    it('field error when non-null arg provided variable with explicit null value', async () => {
-      const result = await execute({
+    it('field error when non-null arg provided variable with explicit null value', () => {
+      const result = execute({
         schema: schemaWithNonNullArg,
         document: parse(`
           query ($testVar: String = "default value") {

--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -139,18 +139,19 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeSyncAndAsync(query, nullingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: { sync: null },
       });
     });
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: { sync: null },
         errors: [
           {
             message: syncError.message,
+            path: ['sync'],
             locations: [{ line: 3, column: 9 }],
           },
         ],
@@ -169,12 +170,13 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeSyncAndAsync(query, nullingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: { syncNest: null },
         errors: [
           {
             message:
               'Cannot return null for non-nullable field DataType.syncNonNull.',
+            path: ['syncNest', 'syncNonNull'],
             locations: [{ line: 4, column: 11 }],
           },
         ],
@@ -183,11 +185,12 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: { syncNest: null },
         errors: [
           {
             message: syncNonNullError.message,
+            path: ['syncNest', 'syncNonNull'],
             locations: [{ line: 4, column: 11 }],
           },
         ],
@@ -206,12 +209,13 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeSyncAndAsync(query, nullingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: { promiseNest: null },
         errors: [
           {
             message:
               'Cannot return null for non-nullable field DataType.syncNonNull.',
+            path: ['promiseNest', 'syncNonNull'],
             locations: [{ line: 4, column: 11 }],
           },
         ],
@@ -220,11 +224,12 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: { promiseNest: null },
         errors: [
           {
             message: syncNonNullError.message,
+            path: ['promiseNest', 'syncNonNull'],
             locations: [{ line: 4, column: 11 }],
           },
         ],
@@ -266,60 +271,72 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeQuery(query, nullingData);
-      expect(result).to.containSubset({ data });
+      expect(result).to.deep.equal({ data });
     });
 
     it('that throws', async () => {
       const result = await executeQuery(query, throwingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data,
         errors: [
           {
             message: syncError.message,
+            path: ['syncNest', 'sync'],
             locations: [{ line: 4, column: 11 }],
           },
           {
             message: syncError.message,
+            path: ['syncNest', 'syncNest', 'sync'],
             locations: [{ line: 6, column: 22 }],
           },
           {
             message: syncError.message,
+            path: ['syncNest', 'promiseNest', 'sync'],
             locations: [{ line: 7, column: 25 }],
           },
           {
             message: syncError.message,
+            path: ['promiseNest', 'sync'],
             locations: [{ line: 10, column: 11 }],
           },
           {
             message: syncError.message,
+            path: ['promiseNest', 'syncNest', 'sync'],
             locations: [{ line: 12, column: 22 }],
           },
           {
             message: syncError.message,
+            path: ['promiseNest', 'promiseNest', 'sync'],
             locations: [{ line: 13, column: 25 }],
           },
           {
             message: promiseError.message,
+            path: ['syncNest', 'promise'],
             locations: [{ line: 5, column: 11 }],
           },
           {
             message: promiseError.message,
+            path: ['syncNest', 'syncNest', 'promise'],
             locations: [{ line: 6, column: 27 }],
           },
           {
             message: promiseError.message,
+            path: ['syncNest', 'promiseNest', 'promise'],
             locations: [{ line: 7, column: 30 }],
           },
           {
             message: promiseError.message,
+            path: ['promiseNest', 'promise'],
             locations: [{ line: 11, column: 11 }],
           },
           {
             message: promiseError.message,
+            path: ['promiseNest', 'syncNest', 'promise'],
             locations: [{ line: 12, column: 27 }],
           },
           {
             message: promiseError.message,
+            path: ['promiseNest', 'promiseNest', 'promise'],
             locations: [{ line: 13, column: 30 }],
           },
         ],
@@ -385,27 +402,59 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeQuery(query, nullingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data,
         errors: [
           {
             message:
               'Cannot return null for non-nullable field DataType.syncNonNull.',
+            path: [
+              'syncNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNull',
+            ],
             locations: [{ line: 8, column: 19 }],
           },
           {
             message:
               'Cannot return null for non-nullable field DataType.syncNonNull.',
+            path: [
+              'promiseNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNull',
+            ],
             locations: [{ line: 19, column: 19 }],
           },
           {
             message:
               'Cannot return null for non-nullable field DataType.promiseNonNull.',
+            path: [
+              'anotherNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'promiseNonNull',
+            ],
             locations: [{ line: 30, column: 19 }],
           },
           {
             message:
               'Cannot return null for non-nullable field DataType.promiseNonNull.',
+            path: [
+              'anotherPromiseNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'promiseNonNull',
+            ],
             locations: [{ line: 41, column: 19 }],
           },
         ],
@@ -414,23 +463,55 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeQuery(query, throwingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data,
         errors: [
           {
             message: syncNonNullError.message,
+            path: [
+              'syncNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNull',
+            ],
             locations: [{ line: 8, column: 19 }],
           },
           {
             message: syncNonNullError.message,
+            path: [
+              'promiseNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNull',
+            ],
             locations: [{ line: 19, column: 19 }],
           },
           {
             message: promiseNonNullError.message,
+            path: [
+              'anotherNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'promiseNonNull',
+            ],
             locations: [{ line: 30, column: 19 }],
           },
           {
             message: promiseNonNullError.message,
+            path: [
+              'anotherPromiseNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'syncNonNullNest',
+              'promiseNonNullNest',
+              'promiseNonNull',
+            ],
             locations: [{ line: 41, column: 19 }],
           },
         ],
@@ -447,12 +528,13 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeSyncAndAsync(query, nullingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: null,
         errors: [
           {
             message:
               'Cannot return null for non-nullable field DataType.syncNonNull.',
+            path: ['syncNonNull'],
             locations: [{ line: 3, column: 9 }],
           },
         ],
@@ -461,11 +543,12 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expect(result).to.containSubset({
+      expect(result).to.deep.equal({
         data: null,
         errors: [
           {
             message: syncNonNullError.message,
+            path: ['syncNonNull'],
             locations: [{ line: 3, column: 9 }],
           },
         ],

--- a/src/execution/__tests__/nonnull-test.js
+++ b/src/execution/__tests__/nonnull-test.js
@@ -305,11 +305,6 @@ describe('Execute: handles non-nullable types', () => {
             locations: [{ line: 12, column: 22 }],
           },
           {
-            message: syncError.message,
-            path: ['promiseNest', 'promiseNest', 'sync'],
-            locations: [{ line: 13, column: 25 }],
-          },
-          {
             message: promiseError.message,
             path: ['syncNest', 'promise'],
             locations: [{ line: 5, column: 11 }],
@@ -318,6 +313,11 @@ describe('Execute: handles non-nullable types', () => {
             message: promiseError.message,
             path: ['syncNest', 'syncNest', 'promise'],
             locations: [{ line: 6, column: 27 }],
+          },
+          {
+            message: syncError.message,
+            path: ['promiseNest', 'promiseNest', 'sync'],
+            locations: [{ line: 13, column: 25 }],
           },
           {
             message: promiseError.message,


### PR DESCRIPTION
It was really hard to read those tests.
Moreover, explicit version is shorter and this PR increase line count only because I added `path` to every error.