### PR TITLE
Mark all modules as having no side effects for bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "index",
   "module": "index.mjs",
+  "sideEffects": false,
   "homepage": "https://github.com/graphql/graphql-js",
   "bugs": {
     "url": "https://github.com/graphql/graphql-js/issues"


### PR DESCRIPTION
Context: I'm [experimenting](https://twitter.com/motiz88/status/985573076854288390) with ways to make `graphql-js`'s footprint smaller for the use case of executing requests directly on the client.

While I haven't audited all the code in this package (perhaps the big caveat of this PR), from what I've seen I feel safe concluding it's all written in a side-effect-free style, where all modules simply export sets of values ( / functions) which are fundamentally safe to cherry-pick.

On that assumption, this PR communicates this as a guarantee to bundlers via the `sideEffects` flag in `package.json` (introduced by Webpack 4). This enables further tree-shaking optimisations than Webpack is able to perform otherwise, particularly on re-exports, which `graphql-js` uses quite heavily. Anecdotally, this seems to have a similar effect on bundle size as does explicitly cherry-picking modules [via their internal paths](https://github.com/graphql/swapi-graphql/commit/924edf439f61634eec9a22cb0fb68e525e9b7418).