### PR TITLE
Cleanup contain subset

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "http://github.com/graphql/graphql-js.git"
   },
   "options": {
-    "mocha": "--require ./resources/mocha-bootload --check-leaks --full-trace --timeout 15000 src/**/__tests__/**/*-test.js"
+    "mocha": "--check-leaks --full-trace --timeout 15000 src/**/__tests__/**/*-test.js"
   },
   "scripts": {
     "watch": "babel-node ./resources/watch.js",
@@ -57,7 +57,6 @@
     "beautify-benchmark": "0.2.4",
     "benchmark": "2.1.4",
     "chai": "4.1.2",
-    "chai-subset": "1.6.0",
     "coveralls": "3.0.0",
     "eslint": "4.19.1",
     "eslint-plugin-babel": "4.1.2",

--- a/resources/mocha-bootload.js
+++ b/resources/mocha-bootload.js
@@ -1,9 +1,0 @@
-/**
- * Copyright (c) 2015-present, Facebook, Inc.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-var chai = require('chai');
-chai.use(require('chai-subset'));

--- a/src/language/__tests__/locationsToJSON.js
+++ b/src/language/__tests__/locationsToJSON.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export default function locationsToJSON(value: any): any {
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(locationsToJSON);
+  }
+
+  if (value.constructor.name === 'Loc') {
+    return value.toJSON();
+  }
+
+  if (value.constructor === Object) {
+    const result = {};
+    Object.keys(value).forEach(key => {
+      result[key] = locationsToJSON(value[key]);
+    });
+    return result;
+  }
+
+  return value;
+}

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -15,6 +15,7 @@ import { describe, it } from 'mocha';
 import { parse, parseValue, parseType } from '../parser';
 import { Source } from '../source';
 import dedent from '../../jsutils/dedent';
+import locationsToJSON from './locationsToJSON';
 
 function expectSyntaxError(text, message, location) {
   expect(() => parse(text))
@@ -211,15 +212,16 @@ describe('Parser', () => {
   });
 
   it('creates ast', () => {
-    const result = parse(`{
-  node(id: 4) {
-    id,
-    name
-  }
-}
-`);
+    const result = parse(dedent`
+      {
+        node(id: 4) {
+          id,
+          name
+        }
+      }
+    `);
 
-    expect(result).to.containSubset({
+    expect(locationsToJSON(result)).to.deep.equal({
       kind: Kind.DOCUMENT,
       loc: { start: 0, end: 41 },
       definitions: [
@@ -301,14 +303,15 @@ describe('Parser', () => {
   });
 
   it('creates ast from nameless query without variables', () => {
-    const result = parse(`query {
-  node {
-    id
-  }
-}
-`);
+    const result = parse(dedent`
+      query {
+        node {
+          id
+        }
+      }
+    `);
 
-    expect(result).to.containSubset({
+    expect(locationsToJSON(result)).to.deep.equal({
       kind: Kind.DOCUMENT,
       loc: { start: 0, end: 30 },
       definitions: [
@@ -398,14 +401,16 @@ describe('Parser', () => {
 
   describe('parseValue', () => {
     it('parses null value', () => {
-      expect(parseValue('null')).to.containSubset({
+      const result = parseValue('null');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.NULL,
         loc: { start: 0, end: 4 },
       });
     });
 
     it('parses list values', () => {
-      expect(parseValue('[123 "abc"]')).to.containSubset({
+      const result = parseValue('[123 "abc"]');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.LIST,
         loc: { start: 0, end: 11 },
         values: [
@@ -418,13 +423,15 @@ describe('Parser', () => {
             kind: Kind.STRING,
             loc: { start: 5, end: 10 },
             value: 'abc',
+            block: false,
           },
         ],
       });
     });
 
     it('parses block strings', () => {
-      expect(parseValue('["""long""" "short"]')).to.containSubset({
+      const result = parseValue('["""long""" "short"]');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.LIST,
         loc: { start: 0, end: 20 },
         values: [
@@ -447,7 +454,8 @@ describe('Parser', () => {
 
   describe('parseType', () => {
     it('parses well known types', () => {
-      expect(parseType('String')).to.containSubset({
+      const result = parseType('String');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.NAMED_TYPE,
         loc: { start: 0, end: 6 },
         name: {
@@ -459,7 +467,8 @@ describe('Parser', () => {
     });
 
     it('parses custom types', () => {
-      expect(parseType('MyType')).to.containSubset({
+      const result = parseType('MyType');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.NAMED_TYPE,
         loc: { start: 0, end: 6 },
         name: {
@@ -471,7 +480,8 @@ describe('Parser', () => {
     });
 
     it('parses list types', () => {
-      expect(parseType('[MyType]')).to.containSubset({
+      const result = parseType('[MyType]');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.LIST_TYPE,
         loc: { start: 0, end: 8 },
         type: {
@@ -487,7 +497,8 @@ describe('Parser', () => {
     });
 
     it('parses non-null types', () => {
-      expect(parseType('MyType!')).to.containSubset({
+      const result = parseType('MyType!');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.NON_NULL_TYPE,
         loc: { start: 0, end: 7 },
         type: {
@@ -503,7 +514,8 @@ describe('Parser', () => {
     });
 
     it('parses nested types', () => {
-      expect(parseType('[MyType!]')).to.containSubset({
+      const result = parseType('[MyType!]');
+      expect(locationsToJSON(result)).to.deep.equal({
         kind: Kind.LIST_TYPE,
         loc: { start: 0, end: 9 },
         type: {

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -31,9 +31,10 @@ describe('Introspection', () => {
         },
       }),
     });
-    const result = graphqlSync(EmptySchema, getIntrospectionQuery());
+    const query = getIntrospectionQuery({ descriptions: false });
+    const result = graphqlSync(EmptySchema, query);
 
-    expect(result).to.containSubset({
+    expect(result).to.deep.equal({
       data: {
         __schema: {
           mutationType: null,
@@ -45,8 +46,30 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: 'QueryRoot',
+              fields: [
+                {
+                  name: 'onlyField',
+                  args: [],
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+              ],
               inputFields: null,
               interfaces: [],
+              enumValues: null,
+              possibleTypes: null,
+            },
+            {
+              kind: 'SCALAR',
+              name: 'String',
+              fields: null,
+              inputFields: null,
+              interfaces: null,
               enumValues: null,
               possibleTypes: null,
             },
@@ -69,6 +92,7 @@ describe('Introspection', () => {
                         ofType: {
                           kind: 'OBJECT',
                           name: '__Type',
+                          ofType: null,
                         },
                       },
                     },
@@ -128,6 +152,7 @@ describe('Introspection', () => {
                         ofType: {
                           kind: 'OBJECT',
                           name: '__Directive',
+                          ofType: null,
                         },
                       },
                     },
@@ -366,15 +391,6 @@ describe('Introspection', () => {
             },
             {
               kind: 'SCALAR',
-              name: 'String',
-              fields: null,
-              inputFields: null,
-              interfaces: null,
-              enumValues: null,
-              possibleTypes: null,
-            },
-            {
-              kind: 'SCALAR',
               name: 'Boolean',
               fields: null,
               inputFields: null,
@@ -427,6 +443,7 @@ describe('Introspection', () => {
                         ofType: {
                           kind: 'OBJECT',
                           name: '__InputValue',
+                          ofType: null,
                         },
                       },
                     },
@@ -650,6 +667,7 @@ describe('Introspection', () => {
                         ofType: {
                           kind: 'ENUM',
                           name: '__DirectiveLocation',
+                          ofType: null,
                         },
                       },
                     },
@@ -672,6 +690,7 @@ describe('Introspection', () => {
                         ofType: {
                           kind: 'OBJECT',
                           name: '__InputValue',
+                          ofType: null,
                         },
                       },
                     },
@@ -740,30 +759,92 @@ describe('Introspection', () => {
                 {
                   name: 'QUERY',
                   isDeprecated: false,
+                  deprecationReason: null,
                 },
                 {
                   name: 'MUTATION',
                   isDeprecated: false,
+                  deprecationReason: null,
                 },
                 {
                   name: 'SUBSCRIPTION',
                   isDeprecated: false,
+                  deprecationReason: null,
                 },
                 {
                   name: 'FIELD',
                   isDeprecated: false,
+                  deprecationReason: null,
                 },
                 {
                   name: 'FRAGMENT_DEFINITION',
                   isDeprecated: false,
+                  deprecationReason: null,
                 },
                 {
                   name: 'FRAGMENT_SPREAD',
                   isDeprecated: false,
+                  deprecationReason: null,
                 },
                 {
                   name: 'INLINE_FRAGMENT',
                   isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'SCHEMA',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'SCALAR',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'OBJECT',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'FIELD_DEFINITION',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'ARGUMENT_DEFINITION',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'INTERFACE',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'UNION',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'ENUM',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'ENUM_VALUE',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'INPUT_OBJECT',
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'INPUT_FIELD_DEFINITION',
+                  isDeprecated: false,
+                  deprecationReason: null,
                 },
               ],
               possibleTypes: null,
@@ -804,6 +885,21 @@ describe('Introspection', () => {
                       name: 'Boolean',
                       ofType: null,
                     },
+                  },
+                },
+              ],
+            },
+            {
+              name: 'deprecated',
+              locations: ['FIELD_DEFINITION', 'ENUM_VALUE'],
+              args: [
+                {
+                  defaultValue: '"No longer supported"',
+                  name: 'reason',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
                   },
                 },
               ],

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -1162,7 +1162,7 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.containSubset([
+    expect(validateSchema(schema)).to.deep.equal([
       {
         message:
           'Interface SomeInterface must be implemented by at least one Object type.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,10 +910,6 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai-subset@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/chai-subset/-/chai-subset-1.6.0.tgz#a5d0ca14e329a79596ed70058b6646bd6988cfe9"
-
 chai@4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"


### PR DESCRIPTION
The only `containSubset` usage that can't be replaced with standard chai is the ability to compare ASTs. So I created `locationsToJSON` helper function which is calling `toJSON` on every instance of `Loc`.

Simplier alternative would be `JSON.parse(JSON.stringify(ast))` but it will remove all `undefined` from payload.