### PR TITLE
printError: fix padding of line numbers

### DIFF
--- a/src/error/__tests__/printError-test.js
+++ b/src/error/__tests__/printError-test.js
@@ -25,8 +25,8 @@ describe('printError', () => {
       Single digit line number with no padding
 
       Test (9:1)
-       9: *
-          ^
+      9: *
+         ^
     `);
 
     const doubleDigit = new GraphQLError(

--- a/src/error/__tests__/printError-test.js
+++ b/src/error/__tests__/printError-test.js
@@ -14,6 +14,37 @@ import { parse, Source } from '../../language';
 import dedent from '../../jsutils/dedent';
 
 describe('printError', () => {
+  it('prints an line numbers with correct padding', () => {
+    const singleDigit = new GraphQLError(
+      'Single digit line number with no padding',
+      null,
+      new Source('*', 'Test', { line: 9, column: 1 }),
+      [0],
+    );
+    expect(printError(singleDigit)).to.equal(dedent`
+      Single digit line number with no padding
+
+      Test (9:1)
+       9: *
+          ^
+    `);
+
+    const doubleDigit = new GraphQLError(
+      'Left padded first line number',
+      null,
+      new Source('*\n', 'Test', { line: 9, column: 1 }),
+      [0],
+    );
+    expect(printError(doubleDigit)).to.equal(dedent`
+      Left padded first line number
+
+      Test (9:1)
+       9: *
+          ^
+      10: 
+    `);
+  });
+
   it('prints an error with nodes from different sources', () => {
     const sourceA = parse(
       new Source(

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -7,6 +7,7 @@
 
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import dedent from '../../jsutils/dedent';
 import { Source } from '../source';
 import { createLexer, TokenKind } from '../lexer';
 
@@ -105,24 +106,25 @@ describe('Lexer', () => {
   it('errors respect whitespace', () => {
     let caughtError;
     try {
-      lexOne(`
-
-    ?
-
-
-`);
+      lexOne(dedent`
+      
+      
+          ?
+      
+      
+      `);
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError)).to.equal(
-      'Syntax Error: Cannot parse the unexpected character "?".\n' +
-        '\n' +
-        'GraphQL request (3:5)\n' +
-        '2: \n' +
-        '3:     ?\n' +
-        '       ^\n' +
-        '4: \n',
-    );
+    expect(String(caughtError)).to.equal(dedent`
+      Syntax Error: Cannot parse the unexpected character "?".
+
+      GraphQL request (3:5)
+      2: 
+      3:     ?
+             ^
+      4: 
+    `);
   });
 
   it('updates line numbers in error for file context', () => {
@@ -134,15 +136,15 @@ describe('Lexer', () => {
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError)).to.equal(
-      'Syntax Error: Cannot parse the unexpected character "?".\n' +
-        '\n' +
-        'foo.js (13:6)\n' +
-        '12: \n' +
-        '13:      ?\n' +
-        '         ^\n' +
-        '14: \n',
-    );
+    expect(String(caughtError)).to.equal(dedent`
+      Syntax Error: Cannot parse the unexpected character "?".
+
+      foo.js (13:6)
+      12: 
+      13:      ?
+               ^
+      14: 
+    `);
   });
 
   it('updates column numbers in error for file context', () => {
@@ -153,13 +155,13 @@ describe('Lexer', () => {
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError)).to.equal(
-      'Syntax Error: Cannot parse the unexpected character "?".\n' +
-        '\n' +
-        'foo.js (1:5)\n' +
-        '1:     ?\n' +
-        '       ^\n',
-    );
+    expect(String(caughtError)).to.equal(dedent`
+      Syntax Error: Cannot parse the unexpected character "?".
+
+      foo.js (1:5)
+      1:     ?
+             ^
+    `);
   });
 
   it('lexes strings', () => {


### PR DESCRIPTION
I noticed that if an error happens on the last line 9 lines string all line numbers are padded with extra space.
It's happening because the padding is calculated based on the size of next line number without checking if this line exists.
