### PR TITLE
 Allow to override default type resolver

### DIFF
--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -7,7 +7,12 @@
  * @flow strict
  */
 
-export { execute, defaultFieldResolver, responsePathAsArray } from './execute';
+export {
+  execute,
+  defaultFieldResolver,
+  defaultTypeResolver,
+  responsePathAsArray,
+} from './execute';
 export { getDirectiveValues } from './values';
 
 export type { ExecutionArgs, ExecutionResult } from './execute';

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -13,7 +13,10 @@ import { validate } from './validation/validate';
 import { execute } from './execution/execute';
 import type { ObjMap } from './jsutils/ObjMap';
 import type { Source } from './language/source';
-import type { GraphQLFieldResolver } from './type/definition';
+import type {
+  GraphQLFieldResolver,
+  GraphQLTypeResolver,
+} from './type/definition';
 import type { GraphQLSchema } from './type/schema';
 import type { ExecutionResult } from './execution/execute';
 import type { MaybePromise } from './jsutils/MaybePromise';
@@ -61,6 +64,7 @@ export type GraphQLArgs = {|
   variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
+  typeResolver?: ?GraphQLTypeResolver<any, any>,
 |};
 declare function graphql(GraphQLArgs, ..._: []): Promise<ExecutionResult>;
 /* eslint-disable no-redeclare */
@@ -72,6 +76,7 @@ declare function graphql(
   variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
+  typeResolver?: ?GraphQLTypeResolver<any, any>,
 ): Promise<ExecutionResult>;
 export function graphql(
   argsOrSchema,
@@ -81,6 +86,7 @@ export function graphql(
   variableValues,
   operationName,
   fieldResolver,
+  typeResolver,
 ) {
   /* eslint-enable no-redeclare */
   // Always return a Promise for a consistent API.
@@ -96,6 +102,7 @@ export function graphql(
             argsOrSchema.variableValues,
             argsOrSchema.operationName,
             argsOrSchema.fieldResolver,
+            argsOrSchema.typeResolver,
           )
         : graphqlImpl(
             argsOrSchema,
@@ -105,6 +112,7 @@ export function graphql(
             variableValues,
             operationName,
             fieldResolver,
+            typeResolver,
           ),
     ),
   );
@@ -126,6 +134,7 @@ declare function graphqlSync(
   variableValues?: ?ObjMap<mixed>,
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
+  typeResolver?: ?GraphQLTypeResolver<any, any>,
 ): ExecutionResult;
 export function graphqlSync(
   argsOrSchema,
@@ -135,6 +144,7 @@ export function graphqlSync(
   variableValues,
   operationName,
   fieldResolver,
+  typeResolver,
 ) {
   /* eslint-enable no-redeclare */
   // Extract arguments from object args if provided.
@@ -148,6 +158,7 @@ export function graphqlSync(
           argsOrSchema.variableValues,
           argsOrSchema.operationName,
           argsOrSchema.fieldResolver,
+          argsOrSchema.typeResolver,
         )
       : graphqlImpl(
           argsOrSchema,
@@ -157,6 +168,7 @@ export function graphqlSync(
           variableValues,
           operationName,
           fieldResolver,
+          typeResolver,
         );
 
   // Assert that the execution was synchronous.
@@ -175,6 +187,7 @@ function graphqlImpl(
   variableValues,
   operationName,
   fieldResolver,
+  typeResolver,
 ): MaybePromise<ExecutionResult> {
   // Validate Schema
   const schemaValidationErrors = validateSchema(schema);
@@ -205,5 +218,6 @@ function graphqlImpl(
     variableValues,
     operationName,
     fieldResolver,
+    typeResolver,
   );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -281,6 +281,7 @@ export type {
 export {
   execute,
   defaultFieldResolver,
+  defaultTypeResolver,
   responsePathAsArray,
   getDirectiveValues,
 } from './execution';

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -832,6 +832,7 @@ export type GraphQLTypeResolver<TSource, TContext> = (
   value: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
+  abstractType: GraphQLAbstractType,
 ) => MaybePromise<?GraphQLObjectType | string>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (


### PR DESCRIPTION
Having global default `typeResolver` is very useful for writing GraphQL proxies and for mocking missing types. For example it would be very easy to mock types with missing resolver like this:
```js
import {
  defaultFieldResolver,
  defaultTypeResolver,
} from 'graphql';

function mockFieldResolver(value, args, ctx, info) {
  const default = defaultFieldResolver(value, args, ctx, info);
  return default === undefined ? mockType(info.returnType) : default;
}

function mockType(type) {
  //...
  if (type === GraphQLString) {
    return 'mock string';
  }
}

function mockTypeResolver(value, ctx, info) {
  const defaultType = defaultTypeResolver(value, ctx, info);
  if (defaultType === undefined) {
    const types = info.schema.getPossibleTypes(info.valueType);
    const random = Math.floor(Math.random() * (types.length - 1))
    return types[random];
  }
  return defaultType;
}

const result = graphql({
  schema, 
  source,
  fieldResolver: mockFieldResolver,
  typeResolver: mockTypeResolver,
});
```