### PR TITLE
Run tests on node 10. Drop support for node 4.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [["env", {
     "modules": false,
     "targets": {
-      "node": 4,
+      "node": 6,
       "browsers": [
         "ie 9",
         "ios 9",

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 
-# https://github.com/nodejs/LTS
+# https://github.com/nodejs/Release
 node_js:
+  - '10'
   - '9'
   - '8'
   - '6'
-  - '4'
 
 git:
   depth: 5

--- a/package.json
+++ b/package.json
@@ -14,6 +14,12 @@
     "type": "git",
     "url": "http://github.com/graphql/graphql-js.git"
   },
+  "options": {
+    "mocha": "--check-leaks --full-trace --timeout 15000 src/**/__tests__/**/*-test.js"
+  },
+  "engines": {
+    "node": "6.x || 8.x || 9.x || >= 10.x"
+  },
   "scripts": {
     "watch": "babel-node ./resources/watch.js",
     "test": "npm run lint && npm run check && npm run testonly",


### PR DESCRIPTION
Based on the discussion in #1005 next release should be `14.0.0`.
I think it's important to drop node 4.0 before this release.