### PR TITLE
Fix npm@6 warnings about deprecated "prepublish"

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build:mjs": "BABEL_MODULES=1 babel src --optional runtime --ignore __tests__ --out-dir dist/module/ && for file in $(find dist/module -name '*.js'); do mv \"$file\" `echo \"$file\" | sed 's/dist\\/module/dist/g; s/.js$/.mjs/g'`; done && rm -rf dist/module",
     "build:flow": "for file in $(find ./src -name '*.js' -not -path '*/__tests__*'); do cp \"$file\" `echo \"$file\" | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
     "preversion": ". ./resources/checkgit.sh && npm test",
-    "prepublish": ". ./resources/prepublish.sh",
+    "prepublishOnly": ". ./resources/prepublish.sh",
     "gitpublish": ". ./resources/gitpublish.sh"
   },
   "dependencies": {

--- a/resources/prepublish.sh
+++ b/resources/prepublish.sh
@@ -1,10 +1,3 @@
-# Because of a long-running npm issue (https://github.com/npm/npm/issues/3059)
-# prepublish runs after `npm install` and `npm pack`.
-# In order to only run prepublish before `npm publish`, we have to check argv.
-if node -e "process.exit(($npm_config_argv).original.length > 0 && ($npm_config_argv).original[0].indexOf('pu') === 0)"; then
-  exit 0;
-fi
-
 # Publishing to NPM is currently supported by Travis CI, which ensures that all
 # tests pass first and the deployed module contains the correct file structure.
 # In order to prevent inadvertently circumventing this, we ensure that a CI


### PR DESCRIPTION
NPM 6 produces this warning:
```js
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.
```

Yarn/NPM support new `prepublishOnly` property:
> As of npm@4.0.0, a new event has been introduced, prepare, that preserves this existing behavior. A new event, prepublishOnly has been added as a transitional strategy to allow users to avoid the confusing behavior of existing npm versions and only run on npm publish (for instance, running the tests one last time to ensure they're in good shape).

Currently NPM deploy done using:
https://github.com/graphql/graphql-js/blob/2eccaadfa95f3e50f5d0d1aba42c419a70c61fc5/.travis.yml#L34
which use NPM 5.