### PR TITLE
CI: fix nyc doesn't proxy error status from mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "t": "mocha --require babel-register --require babel-polyfill",
     "testonly": "mocha --require babel-register --require babel-polyfill --check-leaks --full-trace --timeout 15000 src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc --reporter html --reporter text-summary -- npm run testonly",
-    "testonly:coveralls": "nyc --reporter text-lcov npm run testonly | coveralls",
+    "testonly:coveralls": "nyc --silent -- npm run testonly && nyc report --reporter text-lcov | coveralls",
     "lint": "eslint --rulesdir ./resources/lint src || (printf '\\033[33mTry: \\033[7m npm run lint -- --fix \\033[0m\\n' && exit 1)",
     "benchmark": "node ./resources/benchmark.js",
     "prettier": "prettier --write 'src/**/*.js'",


### PR DESCRIPTION
This PR fixes issue introduced in #1342
It results in one node version always being green even if others will fail:
![image](https://user-images.githubusercontent.com/8336157/40189311-c9cb8c68-5a04-11e8-9539-881e2747a258.png)
https://travis-ci.org/graphql/graphql-js/builds/379852096?utm_source=github_status&utm_medium=notification

Fix is based on this comment: https://github.com/istanbuljs/nyc/issues/433#issuecomment-260173503
