### PR TITLE
[Bug Reproduce] Can't use undefined as enum value

### DIFF
--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -460,6 +460,7 @@ describe('Execute: Handles inputs', () => {
     it('allows custom enum values as inputs', () => {
       const result = executeQuery(`
         {
+          undefined: fieldWithEnumInput(input: UNDEFINED)
           null: fieldWithEnumInput(input: NULL)
           NaN: fieldWithEnumInput(input: NAN)
           false: fieldWithEnumInput(input: FALSE)
@@ -470,6 +471,7 @@ describe('Execute: Handles inputs', () => {
 
       expect(result).to.deep.equal({
         data: {
+          undefined: 'undefined',
           null: 'null',
           NaN: 'NaN',
           false: 'false',


### PR DESCRIPTION
**Extracted from #1267**

From #836 it looks like both `undefined` and `NaN` could be used as an enum values:
```js
const TestEnum = new GraphQLEnumType({
  name: 'TestEnum',
  values: {
    UNDEFINED: { value: undefined },
    NAN: { value: NaN },
  },
});
```
And run this query:
```graphql
{
  undefined: fieldWithEnumInput(input: UNDEFINED)
  NaN: fieldWithEnumInput(input: NAN)
}
```
It will result in:
```json
{
  "data": {
    "undefined": null,
    "NaN": null
  },
  "errors": [
    {
      "message": "Argument \"input\" has invalid value UNDEFINED.",
      "path": [ "undefined" ]
    }
    {
      "message": "Argument \"input\" has invalid value NAN.",
      "path": [ "NaN" ]
    }
  ]
}
```