### PR TITLE
Allow interfaces to have no implementors

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -1205,7 +1205,7 @@ describe('Type System: Interface fields must have output types', () => {
     ]);
   });
 
-  it('rejects an interface not implemented by at least one object', () => {
+  it('accepts an interface not implemented by at least one object', () => {
     const schema = buildSchema(`
       type Query {
         test: SomeInterface
@@ -1215,13 +1215,7 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expect(validateSchema(schema)).to.deep.equal([
-      {
-        message:
-          'Interface SomeInterface must be implemented by at least one Object type.',
-        locations: [{ line: 6, column: 7 }],
-      },
-    ]);
+    expect(validateSchema(schema)).to.deep.equal([]);
   });
 });
 

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -257,9 +257,6 @@ function validateTypes(context: SchemaValidationContext): void {
     } else if (isInterfaceType(type)) {
       // Ensure fields are valid.
       validateFields(context, type);
-
-      // Ensure Interfaces include at least 1 Object type.
-      validateInterfaces(context, type);
     } else if (isUnionType(type)) {
       // Ensure Unions include valid member types.
       validateUnionMembers(context, type);
@@ -365,21 +362,6 @@ function validateObjectInterfaces(
     implementedTypeNames[iface.name] = true;
     validateObjectImplementsInterface(context, object, iface);
   });
-}
-
-function validateInterfaces(
-  context: SchemaValidationContext,
-  iface: GraphQLInterfaceType,
-): void {
-  const possibleTypes = context.schema.getPossibleTypes(iface);
-
-  if (possibleTypes.length === 0) {
-    context.reportError(
-      `Interface ${iface.name} must be implemented ` +
-        `by at least one Object type.`,
-      iface.astNode,
-    );
-  }
 }
 
 function validateObjectImplementsInterface(


### PR DESCRIPTION
Reverts #1277, and implements spec removal from https://github.com/facebook/graphql/pull/459 (which reverts spec change https://github.com/facebook/graphql/pull/424). While it's an open question whether this validation is good, we need to provide an upgrade path for schemas that currently do not satisfy this validation rule.