### PR TITLE
BREAKING/BUGFIX Strict coercion of scalar types

### DIFF
--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -279,7 +279,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     const rootValue = { root: 'val' };
 
-    execute(schema, ast, rootValue, null, { var: 123 });
+    execute(schema, ast, rootValue, null, { var: 'abc' });
 
     expect(Object.keys(info)).to.deep.equal([
       'fieldName',
@@ -304,7 +304,7 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(info.schema).to.equal(schema);
     expect(info.rootValue).to.equal(rootValue);
     expect(info.operation).to.equal(ast.definitions[0]);
-    expect(info.variableValues).to.deep.equal({ var: '123' });
+    expect(info.variableValues).to.deep.equal({ var: 'abc' });
   });
 
   it('threads root value context correctly', () => {

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -694,7 +694,7 @@ describe('Execute: Handles inputs', () => {
           {
             message:
               'Variable "$value" got invalid value [1, 2, 3]; Expected type ' +
-              'String; String cannot represent an array value: [1, 2, 3]',
+              'String; String cannot represent a non string value: [1, 2, 3]',
             locations: [{ line: 2, column: 16 }],
           },
         ],

--- a/src/jsutils/isFinite.js
+++ b/src/jsutils/isFinite.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+declare function isFinite(value: mixed): boolean %checks(typeof value ===
+  'number');
+
+/* eslint-disable no-redeclare */
+// $FlowFixMe workaround for: https://github.com/facebook/flow/issues/4441
+const isFinite =
+  Number.isFinite ||
+  function(value) {
+    return typeof value === 'number' && isFinite(value);
+  };
+export default isFinite;

--- a/src/type/__tests__/serialization-test.js
+++ b/src/type/__tests__/serialization-test.js
@@ -60,7 +60,7 @@ describe('Type System: Scalar coercion', () => {
     );
     // Doesn't represent number
     expect(() => GraphQLInt.serialize('')).to.throw(
-      'Int cannot represent non-integer value: (empty string)',
+      'Int cannot represent non-integer value: ""',
     );
     expect(() => GraphQLInt.serialize(NaN)).to.throw(
       'Int cannot represent non-integer value: NaN',
@@ -95,26 +95,24 @@ describe('Type System: Scalar coercion', () => {
       'Float cannot represent non numeric value: "one"',
     );
     expect(() => GraphQLFloat.serialize('')).to.throw(
-      'Float cannot represent non numeric value: (empty string)',
+      'Float cannot represent non numeric value: ""',
     );
     expect(() => GraphQLFloat.serialize([5])).to.throw(
       'Float cannot represent an array value: [5]',
     );
   });
 
-  for (const scalar of [GraphQLString, GraphQLID]) {
-    it(`serializes output as ${scalar}`, () => {
-      expect(scalar.serialize('string')).to.equal('string');
-      expect(scalar.serialize(1)).to.equal('1');
-      expect(scalar.serialize(-1.1)).to.equal('-1.1');
-      expect(scalar.serialize(true)).to.equal('true');
-      expect(scalar.serialize(false)).to.equal('false');
+  it(`serializes output as String`, () => {
+    expect(GraphQLString.serialize('string')).to.equal('string');
+    expect(GraphQLString.serialize(1)).to.equal('1');
+    expect(GraphQLString.serialize(-1.1)).to.equal('-1.1');
+    expect(GraphQLString.serialize(true)).to.equal('true');
+    expect(GraphQLString.serialize(false)).to.equal('false');
 
-      expect(() => scalar.serialize([1])).to.throw(
-        'String cannot represent an array value: [1]',
-      );
-    });
-  }
+    expect(() => GraphQLString.serialize([1])).to.throw(
+      'String cannot represent an array value: [1]',
+    );
+  });
 
   it('serializes output as Boolean', () => {
     expect(GraphQLBoolean.serialize('string')).to.equal(true);
@@ -127,6 +125,48 @@ describe('Type System: Scalar coercion', () => {
 
     expect(() => GraphQLBoolean.serialize([false])).to.throw(
       'Boolean cannot represent an array value: [false]',
+    );
+  });
+
+  it('serializes output as ID', () => {
+    expect(GraphQLID.serialize('string')).to.equal('string');
+    expect(GraphQLID.serialize('false')).to.equal('false');
+    expect(GraphQLID.serialize('')).to.equal('');
+    expect(GraphQLID.serialize(123)).to.equal('123');
+    expect(GraphQLID.serialize(0)).to.equal('0');
+
+    const objValue = {
+      _id: 123,
+      valueOf() {
+        return this._id;
+      },
+    };
+    expect(GraphQLID.serialize(objValue)).to.equal('123');
+
+    const badObjValue = {
+      _id: false,
+      valueOf() {
+        return this._id;
+      },
+    };
+    expect(() => GraphQLID.serialize(badObjValue)).to.throw(
+      'ID cannot represent value: {_id: false, valueOf: [function valueOf]}',
+    );
+
+    expect(() => GraphQLID.serialize(true)).to.throw(
+      'ID cannot represent value: true',
+    );
+
+    expect(() => GraphQLID.serialize(-1.1)).to.throw(
+      'ID cannot represent value: -1.1',
+    );
+
+    expect(() => GraphQLID.serialize({})).to.throw(
+      'ID cannot represent value: {}',
+    );
+
+    expect(() => GraphQLID.serialize(['abc'])).to.throw(
+      'ID cannot represent value: ["abc"]',
     );
   });
 });

--- a/src/type/__tests__/serialization-test.js
+++ b/src/type/__tests__/serialization-test.js
@@ -110,7 +110,21 @@ describe('Type System: Scalar coercion', () => {
     expect(GraphQLString.serialize(false)).to.equal('false');
 
     expect(() => GraphQLString.serialize([1])).to.throw(
-      'String cannot represent an array value: [1]',
+      'String cannot represent value: [1]',
+    );
+
+    const badObjValue = {};
+    expect(() => GraphQLString.serialize(badObjValue)).to.throw(
+      'String cannot represent value: {}',
+    );
+
+    const stringableObjValue = {
+      valueOf() {
+        return 'something useful';
+      },
+    };
+    expect(GraphQLString.serialize(stringableObjValue)).to.equal(
+      'something useful',
     );
   });
 

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -183,10 +183,9 @@ describe('astFromValue', () => {
       value: '01',
     });
 
-    expect(astFromValue(false, GraphQLID)).to.deep.equal({
-      kind: 'StringValue',
-      value: 'false',
-    });
+    expect(() => astFromValue(false, GraphQLID)).to.throw(
+      'ID cannot represent value: false',
+    );
 
     expect(astFromValue(null, GraphQLID)).to.deep.equal({ kind: 'NullValue' });
 

--- a/src/utilities/__tests__/coerceValue-test.js
+++ b/src/utilities/__tests__/coerceValue-test.js
@@ -30,34 +30,48 @@ function expectErrors(result) {
 }
 
 describe('coerceValue', () => {
-  for (const scalar of [GraphQLString, GraphQLID]) {
-    describe(`for GraphQL${scalar}`, () => {
-      it('returns error for array input as string', () => {
-        const result = coerceValue([1, 2, 3], scalar);
-        expectErrors(result).to.deep.equal([
-          `Expected type ${scalar}; String cannot represent an array value: [1, 2, 3]`,
-        ]);
-      });
+  describe(`for GraphQLString`, () => {
+    it('returns error for array input as string', () => {
+      const result = coerceValue([1, 2, 3], GraphQLString);
+      expectErrors(result).to.deep.equal([
+        `Expected type String; String cannot represent a non string value: [1, 2, 3]`,
+      ]);
     });
-  }
+  });
+
+  describe(`for GraphQLID`, () => {
+    it('returns error for array input as string', () => {
+      const result = coerceValue([1, 2, 3], GraphQLID);
+      expectErrors(result).to.deep.equal([
+        `Expected type ID; ID cannot represent value: [1, 2, 3]`,
+      ]);
+    });
+  });
 
   describe('for GraphQLInt', () => {
-    it('returns no error for int input', () => {
-      const result = coerceValue('1', GraphQLInt);
+    it('returns value for integer', () => {
+      const result = coerceValue(1, GraphQLInt);
       expectValue(result).to.equal(1);
     });
 
-    it('returns no error for negative int input', () => {
-      const result = coerceValue('-1', GraphQLInt);
+    it('returns error for numeric looking string', () => {
+      const result = coerceValue('1', GraphQLInt);
+      expectErrors(result).to.deep.equal([
+        `Expected type Int; Int cannot represent non-integer value: "1"`,
+      ]);
+    });
+
+    it('returns value for negative int input', () => {
+      const result = coerceValue(-1, GraphQLInt);
       expectValue(result).to.equal(-1);
     });
 
-    it('returns no error for exponent input', () => {
-      const result = coerceValue('1e3', GraphQLInt);
+    it('returns value for exponent input', () => {
+      const result = coerceValue(1e3, GraphQLInt);
       expectValue(result).to.equal(1000);
     });
 
-    it('returns a single error for empty value', () => {
+    it('returns null for null value', () => {
       const result = coerceValue(null, GraphQLInt);
       expectValue(result).to.equal(null);
     });
@@ -65,7 +79,7 @@ describe('coerceValue', () => {
     it('returns a single error for empty string as value', () => {
       const result = coerceValue('', GraphQLInt);
       expectErrors(result).to.deep.equal([
-        'Expected type Int; Int cannot represent non-integer value: (empty string)',
+        'Expected type Int; Int cannot represent non-integer value: ""',
       ]);
     });
 
@@ -77,9 +91,9 @@ describe('coerceValue', () => {
     });
 
     it('returns a single error for float input as int', () => {
-      const result = coerceValue('1.5', GraphQLInt);
+      const result = coerceValue(1.5, GraphQLInt);
       expectErrors(result).to.deep.equal([
-        'Expected type Int; Int cannot represent non-integer value: "1.5"',
+        'Expected type Int; Int cannot represent non-integer value: 1.5',
       ]);
     });
 
@@ -104,7 +118,7 @@ describe('coerceValue', () => {
       ]);
     });
 
-    it('returns a single error for char input', () => {
+    it('returns a single error for string input', () => {
       const result = coerceValue('meow', GraphQLInt);
       expectErrors(result).to.deep.equal([
         'Expected type Int; Int cannot represent non-integer value: "meow"',
@@ -113,22 +127,29 @@ describe('coerceValue', () => {
   });
 
   describe('for GraphQLFloat', () => {
-    it('returns no error for int input', () => {
-      const result = coerceValue('1', GraphQLFloat);
+    it('returns value for integer', () => {
+      const result = coerceValue(1, GraphQLFloat);
       expectValue(result).to.equal(1);
     });
 
-    it('returns no error for exponent input', () => {
-      const result = coerceValue('1e3', GraphQLFloat);
+    it('returns value for decimal', () => {
+      const result = coerceValue(1.1, GraphQLFloat);
+      expectValue(result).to.equal(1.1);
+    });
+
+    it('returns value for exponent input', () => {
+      const result = coerceValue(1e3, GraphQLFloat);
       expectValue(result).to.equal(1000);
     });
 
-    it('returns no error for float input', () => {
-      const result = coerceValue('1.5', GraphQLFloat);
-      expectValue(result).to.equal(1.5);
+    it('returns error for numeric looking string', () => {
+      const result = coerceValue('1', GraphQLFloat);
+      expectErrors(result).to.deep.equal([
+        'Expected type Float; Float cannot represent non numeric value: "1"',
+      ]);
     });
 
-    it('returns a single error for empty value', () => {
+    it('returns null for null value', () => {
       const result = coerceValue(null, GraphQLFloat);
       expectValue(result).to.equal(null);
     });
@@ -136,7 +157,7 @@ describe('coerceValue', () => {
     it('returns a single error for empty string input', () => {
       const result = coerceValue('', GraphQLFloat);
       expectErrors(result).to.deep.equal([
-        'Expected type Float; Float cannot represent non numeric value: (empty string)',
+        'Expected type Float; Float cannot represent non numeric value: ""',
       ]);
     });
 


### PR DESCRIPTION
This no longer accepts incoming variable values in a potentially lossy way, mirroring the existing behavior for literals. This fixes an issue with GraphQL.js being not spec compliant.

This is breaking since servers which used to accept incorrect variable values will now return errors to clients.

Serialization of values is not affected in the same way, since this is not a client-visible behavior.

As a bonus, this adds unique serialization and coercion functions for the ID type, allowing to be more restrictive on numeric types and un-stringable object types, while directly supporting valueOf() methods (ala MongoDB). The changes to how the ID type serializes and coerces data could be potentially breaking.

Fixes #1324