### PR TITLE
BREAKING: Remove deprecated introspection fields

### DIFF
--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -698,51 +698,6 @@ describe('Introspection', () => {
                   isDeprecated: false,
                   deprecationReason: null,
                 },
-                {
-                  name: 'onOperation',
-                  args: [],
-                  type: {
-                    kind: 'NON_NULL',
-                    name: null,
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'Boolean',
-                      ofType: null,
-                    },
-                  },
-                  isDeprecated: true,
-                  deprecationReason: 'Use `locations`.',
-                },
-                {
-                  name: 'onFragment',
-                  args: [],
-                  type: {
-                    kind: 'NON_NULL',
-                    name: null,
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'Boolean',
-                      ofType: null,
-                    },
-                  },
-                  isDeprecated: true,
-                  deprecationReason: 'Use `locations`.',
-                },
-                {
-                  name: 'onField',
-                  args: [],
-                  type: {
-                    kind: 'NON_NULL',
-                    name: null,
-                    ofType: {
-                      kind: 'SCALAR',
-                      name: 'Boolean',
-                      ofType: null,
-                    },
-                  },
-                  isDeprecated: true,
-                  deprecationReason: 'Use `locations`.',
-                },
               ],
               inputFields: null,
               interfaces: [],

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -100,29 +100,6 @@ export const __Directive = new GraphQLObjectType({
       type: GraphQLNonNull(GraphQLList(GraphQLNonNull(__InputValue))),
       resolve: directive => directive.args || [],
     },
-    // NOTE: the following three fields are deprecated and are no longer part
-    // of the GraphQL specification.
-    onOperation: {
-      deprecationReason: 'Use `locations`.',
-      type: GraphQLNonNull(GraphQLBoolean),
-      resolve: d =>
-        d.locations.indexOf(DirectiveLocation.QUERY) !== -1 ||
-        d.locations.indexOf(DirectiveLocation.MUTATION) !== -1 ||
-        d.locations.indexOf(DirectiveLocation.SUBSCRIPTION) !== -1,
-    },
-    onFragment: {
-      deprecationReason: 'Use `locations`.',
-      type: GraphQLNonNull(GraphQLBoolean),
-      resolve: d =>
-        d.locations.indexOf(DirectiveLocation.FRAGMENT_SPREAD) !== -1 ||
-        d.locations.indexOf(DirectiveLocation.INLINE_FRAGMENT) !== -1 ||
-        d.locations.indexOf(DirectiveLocation.FRAGMENT_DEFINITION) !== -1,
-    },
-    onField: {
-      deprecationReason: 'Use `locations`.',
-      type: GraphQLNonNull(GraphQLBoolean),
-      resolve: d => d.locations.indexOf(DirectiveLocation.FIELD) !== -1,
-    },
   }),
 });
 

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -648,9 +648,6 @@ describe('Type System Printer', () => {
         description: String
         locations: [__DirectiveLocation!]!
         args: [__InputValue!]!
-        onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
-        onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
-        onField: Boolean! @deprecated(reason: "Use \`locations\`.")
       }
 
       """
@@ -881,9 +878,6 @@ describe('Type System Printer', () => {
         description: String
         locations: [__DirectiveLocation!]!
         args: [__InputValue!]!
-        onOperation: Boolean! @deprecated(reason: "Use \`locations\`.")
-        onFragment: Boolean! @deprecated(reason: "Use \`locations\`.")
-        onField: Boolean! @deprecated(reason: "Use \`locations\`.")
       }
 
       # A Directive can be adjacent to many parts of the GraphQL language, a


### PR DESCRIPTION
These fields are holdovers from the first version of the spec, before directives had more control over their exact location and could be located in more places.

This is potentially breaking to any clients which relied on these fields, which will need to migrate to use the spec-compliant `locations` field before upgrading to a version including this patch

As described in #1383