### PR TITLE
Add deprecation notices with explicit removal versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -316,7 +316,7 @@ export {
   // Produce the GraphQL query recommended for a full schema introspection.
   // Accepts optional IntrospectionOptions.
   getIntrospectionQuery,
-  // Deprecated: use getIntrospectionQuery
+  // @deprecated: use getIntrospectionQuery - will be removed in v15
   introspectionQuery,
   // Gets the target Operation from a Document
   getOperationAST,
@@ -357,9 +357,9 @@ export {
   TypeInfo,
   // Coerces a JavaScript value to a GraphQL type, or produces errors.
   coerceValue,
-  // @deprecated use coerceValue
+  // @deprecated use coerceValue - will be removed in v15
   isValidJSValue,
-  // Determine if AST values adhere to a GraphQL type.
+  // @deprecated use validation - will be removed in v15
   isValidLiteralValue,
   // Concatenates multiple AST together.
   concatAST,

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -84,7 +84,7 @@ export type ParseOptions = {
    * specification.
    *
    * This option is provided to ease adoption of the final SDL specification
-   * and will be removed in a future major release.
+   * and will be removed in v16.
    */
   allowLegacySDLEmptyFields?: boolean,
 
@@ -94,7 +94,7 @@ export type ParseOptions = {
    * current specification.
    *
    * This option is provided to ease adoption of the final SDL specification
-   * and will be removed in a future major release.
+   * and will be removed in v16.
    */
   allowLegacySDLImplementsInterfaces?: boolean,
 

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -10,7 +10,7 @@
 // The GraphQL query recommended for a full schema introspection.
 export {
   getIntrospectionQuery,
-  // Deprecated, use getIntrospectionQuery()
+  // @deprecated, use getIntrospectionQuery() - will be removed in v15
   introspectionQuery,
 } from './introspectionQuery';
 export type {
@@ -86,10 +86,10 @@ export { TypeInfo } from './TypeInfo';
 // Coerces a JavaScript value to a GraphQL type, or produces errors.
 export { coerceValue } from './coerceValue';
 
-// @deprecated use coerceValue
+// @deprecated use coerceValue - will be removed in v15
 export { isValidJSValue } from './isValidJSValue';
 
-// Determine if AST values adhere to a GraphQL type.
+// @deprecated use validation - will be removed in v15
 export { isValidLiteralValue } from './isValidLiteralValue';
 
 // Concatenates multiple AST together.

--- a/src/utilities/introspectionQuery.js
+++ b/src/utilities/introspectionQuery.js
@@ -112,6 +112,11 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   `;
 }
 
+/**
+ * Deprecated, call getIntrospectionQuery directly.
+ *
+ * This function will be removed in v15
+ */
 export const introspectionQuery = getIntrospectionQuery();
 
 export type IntrospectionQuery = {|

--- a/src/utilities/isValidJSValue.js
+++ b/src/utilities/isValidJSValue.js
@@ -12,6 +12,8 @@ import type { GraphQLInputType } from '../type/definition';
 
 /**
  * Deprecated. Use coerceValue() directly for richer information.
+ *
+ * This function will be removed in v15
  */
 export function isValidJSValue(
   value: mixed,

--- a/src/utilities/isValidLiteralValue.js
+++ b/src/utilities/isValidLiteralValue.js
@@ -21,6 +21,8 @@ import ValidationContext from '../validation/ValidationContext';
  * Utility which determines if a value literal node is valid for an input type.
  *
  * Deprecated. Rely on validation for documents containing literal values.
+ *
+ * This function will be removed in v15
  */
 export function isValidLiteralValue(
   type: GraphQLInputType,


### PR DESCRIPTION
Some methods have been marked as deprecated for a while - add explicit versions for each.

As recommended in #1383, this marks long deprecated methods as to be removed in v15, and newly deprecated options (legacy sdl) to be removed in v16