### PR TITLE
Convert 'GraphQL*Config' to exact types

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -589,7 +589,7 @@ export class GraphQLScalarType {
 defineToStringTag(GraphQLScalarType);
 defineToJSON(GraphQLScalarType);
 
-export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
+export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   name: string,
   description?: ?string,
   astNode?: ?ScalarTypeDefinitionNode,
@@ -599,7 +599,7 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
     valueNode: ValueNode,
     variables: ?ObjMap<mixed>,
   ) => ?TInternal,
-};
+|};
 
 /**
  * Object Type Definition
@@ -768,7 +768,7 @@ function isValidResolver(resolver: mixed): boolean {
   return resolver == null || typeof resolver === 'function';
 }
 
-export type GraphQLObjectTypeConfig<TSource, TContext> = {
+export type GraphQLObjectTypeConfig<TSource, TContext> = {|
   name: string,
   interfaces?: Thunk<?Array<GraphQLInterfaceType>>,
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>,
@@ -776,7 +776,7 @@ export type GraphQLObjectTypeConfig<TSource, TContext> = {
   description?: ?string,
   astNode?: ?ObjectTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<ObjectTypeExtensionNode>,
-};
+|};
 
 export type GraphQLTypeResolver<TSource, TContext> = (
   value: TSource,
@@ -823,7 +823,7 @@ export type GraphQLFieldConfig<
   TSource,
   TContext,
   TArgs = { [argument: string]: any },
-> = {
+> = {|
   type: GraphQLOutputType,
   args?: GraphQLFieldConfigArgumentMap,
   resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>,
@@ -831,16 +831,16 @@ export type GraphQLFieldConfig<
   deprecationReason?: ?string,
   description?: ?string,
   astNode?: ?FieldDefinitionNode,
-};
+|};
 
 export type GraphQLFieldConfigArgumentMap = ObjMap<GraphQLArgumentConfig>;
 
-export type GraphQLArgumentConfig = {
+export type GraphQLArgumentConfig = {|
   type: GraphQLInputType,
   defaultValue?: mixed,
   description?: ?string,
   astNode?: ?InputValueDefinitionNode,
-};
+|};
 
 export type GraphQLFieldConfigMap<TSource, TContext> = ObjMap<
   GraphQLFieldConfig<TSource, TContext>,
@@ -934,7 +934,7 @@ export class GraphQLInterfaceType {
 defineToStringTag(GraphQLInterfaceType);
 defineToJSON(GraphQLInterfaceType);
 
-export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
+export type GraphQLInterfaceTypeConfig<TSource, TContext> = {|
   name: string,
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>,
   /**
@@ -946,7 +946,7 @@ export type GraphQLInterfaceTypeConfig<TSource, TContext> = {
   description?: ?string,
   astNode?: ?InterfaceTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<InterfaceTypeExtensionNode>,
-};
+|};
 
 /**
  * Union Type Definition
@@ -1025,7 +1025,7 @@ function defineTypes(
   return types;
 }
 
-export type GraphQLUnionTypeConfig<TSource, TContext> = {
+export type GraphQLUnionTypeConfig<TSource, TContext> = {|
   name: string,
   types: Thunk<Array<GraphQLObjectType>>,
   /**
@@ -1037,7 +1037,7 @@ export type GraphQLUnionTypeConfig<TSource, TContext> = {
   description?: ?string,
   astNode?: ?UnionTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<UnionTypeExtensionNode>,
-};
+|};
 
 /**
  * Enum Type Definition
@@ -1158,24 +1158,24 @@ function defineEnumValues(
   });
 }
 
-export type GraphQLEnumTypeConfig /* <T> */ = {
+export type GraphQLEnumTypeConfig /* <T> */ = {|
   name: string,
   values: GraphQLEnumValueConfigMap /* <T> */,
   description?: ?string,
   astNode?: ?EnumTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<EnumTypeExtensionNode>,
-};
+|};
 
 export type GraphQLEnumValueConfigMap /* <T> */ = ObjMap<
   GraphQLEnumValueConfig /* <T> */,
 >;
 
-export type GraphQLEnumValueConfig /* <T> */ = {
+export type GraphQLEnumValueConfig /* <T> */ = {|
   value?: any /* T */,
   deprecationReason?: ?string,
   description?: ?string,
   astNode?: ?EnumValueDefinitionNode,
-};
+|};
 
 export type GraphQLEnumValue /* <T> */ = {
   name: string,
@@ -1260,20 +1260,20 @@ export class GraphQLInputObjectType {
 defineToStringTag(GraphQLInputObjectType);
 defineToJSON(GraphQLInputObjectType);
 
-export type GraphQLInputObjectTypeConfig = {
+export type GraphQLInputObjectTypeConfig = {|
   name: string,
   fields: Thunk<GraphQLInputFieldConfigMap>,
   description?: ?string,
   astNode?: ?InputObjectTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<InputObjectTypeExtensionNode>,
-};
+|};
 
-export type GraphQLInputFieldConfig = {
+export type GraphQLInputFieldConfig = {|
   type: GraphQLInputType,
   defaultValue?: mixed,
   description?: ?string,
   astNode?: ?InputValueDefinitionNode,
-};
+|};
 
 export type GraphQLInputFieldConfigMap = ObjMap<GraphQLInputFieldConfig>;
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -33,7 +33,6 @@ import type { GraphQLField } from './definition';
 
 export const __Schema = new GraphQLObjectType({
   name: '__Schema',
-  isIntrospection: true,
   description:
     'A GraphQL Schema defines the capabilities of a GraphQL server. It ' +
     'exposes all available types and directives on the server, as well as ' +
@@ -75,7 +74,6 @@ export const __Schema = new GraphQLObjectType({
 
 export const __Directive = new GraphQLObjectType({
   name: '__Directive',
-  isIntrospection: true,
   description:
     'A Directive provides a way to describe alternate runtime execution and ' +
     'type validation behavior in a GraphQL document.' +
@@ -105,7 +103,6 @@ export const __Directive = new GraphQLObjectType({
 
 export const __DirectiveLocation = new GraphQLEnumType({
   name: '__DirectiveLocation',
-  isIntrospection: true,
   description:
     'A Directive can be adjacent to many parts of the GraphQL language, a ' +
     '__DirectiveLocation describes one such possible adjacencies.',
@@ -187,7 +184,6 @@ export const __DirectiveLocation = new GraphQLEnumType({
 
 export const __Type = new GraphQLObjectType({
   name: '__Type',
-  isIntrospection: true,
   description:
     'The fundamental unit of any GraphQL Schema is the type. There are ' +
     'many kinds of types in GraphQL as represented by the `__TypeKind` enum.' +
@@ -293,7 +289,6 @@ export const __Type = new GraphQLObjectType({
 
 export const __Field = new GraphQLObjectType({
   name: '__Field',
-  isIntrospection: true,
   description:
     'Object and Interface types are described by a list of Fields, each of ' +
     'which has a name, potentially a list of arguments, and a return type.',
@@ -327,7 +322,6 @@ export const __Field = new GraphQLObjectType({
 
 export const __InputValue = new GraphQLObjectType({
   name: '__InputValue',
-  isIntrospection: true,
   description:
     'Arguments provided to Fields or Directives and the input fields of an ' +
     'InputObject are represented as Input Values which describe their type ' +
@@ -360,7 +354,6 @@ export const __InputValue = new GraphQLObjectType({
 
 export const __EnumValue = new GraphQLObjectType({
   name: '__EnumValue',
-  isIntrospection: true,
   description:
     'One possible value for a given Enum. Enum values are unique values, not ' +
     'a placeholder for a string or numeric value. However an Enum value is ' +
@@ -398,7 +391,6 @@ export const TypeKind = {
 
 export const __TypeKind = new GraphQLEnumType({
   name: '__TypeKind',
-  isIntrospection: true,
   description: 'An enum describing what kind of type a given `__Type` is.',
   values: {
     SCALAR: {

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -333,7 +333,6 @@ export function buildClientSchema(
       ? valueFromAST(parseValue(inputValueIntrospection.defaultValue), type)
       : undefined;
     return {
-      name: inputValueIntrospection.name,
       description: inputValueIntrospection.description,
       type,
       defaultValue,


### PR DESCRIPTION
I was wondering why #1390 happened and I think we need to make config types exact.
This PR dependence on #1390 and should be merged after it.