### PR TITLE
findBreakingChanges tests: use buildSchema when possible

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -503,8 +503,20 @@ describe('findBreakingChanges', () => {
     const oldSchema = buildSchema(`
       type Type1 {
         field1(
-          arg1: String, arg2: String, arg3: [String], arg4: String, arg5: String!, arg6: String!, arg7: [Int]!,
-          arg8: Int, arg9: [Int], arg10: [Int!], arg11: [Int], arg12: [[Int]], arg13: Int!, arg14: [[Int]!],
+          arg1: String
+          arg2: String
+          arg3: [String]
+          arg4: String
+          arg5: String!
+          arg6: String!
+          arg7: [Int]!
+          arg8: Int
+          arg9: [Int]
+          arg10: [Int!]
+          arg11: [Int]
+          arg12: [[Int]]
+          arg13: Int!
+          arg14: [[Int]!]
           arg15: [[Int]!]
         ): String
       }
@@ -517,8 +529,21 @@ describe('findBreakingChanges', () => {
     const newSchema = buildSchema(`
       type Type1 {
         field1(
-          arg1: Int, arg2: [String], arg3: String, arg4: String!, arg5: Int, arg6: Int!, arg7: [Int], arg8: [Int]!,
-          arg9: [Int!], arg10: [Int], arg11: [[Int]], arg12: [Int], arg13: [Int]!, arg14: [[Int]], arg15: [[Int!]!]
+          arg1: Int
+          arg2: [String]
+          arg3: String
+          arg4: String!
+          arg5: Int
+          arg6: Int!
+          arg7: [Int]
+          arg8: [Int]!
+          arg9: [Int!]
+          arg10: [Int]
+          arg11: [[Int]]
+          arg12: [Int]
+          arg13: [Int]!
+          arg14: [[Int]]
+          arg15: [[Int!]!]
          ): String
       }
 


### PR DESCRIPTION
Instead of generating the schema by using the type constructors, this changes the tests to use `buildSchema` with the correct SDL for each test.

Related to https://github.com/graphql/graphql-js/issues/1341

SDL was generated using the following code:
```js
import { printSchema } from './index';

console.log(
  '    const oldSchema = buildSchema(`\n' +
  printSchema(oldSchema).split('\n').map(s => s.padStart(s.length + 6)).slice(0, -1).join('\n') +
  '\n    `);',
);
console.log('---');
console.log(
  '    const newSchema = buildSchema(`\n' +
  printSchema(newSchema).split('\n').map(s => s.padStart(s.length + 6)).slice(0, -1).join('\n') +
  '\n    `);',
);
```

So it's based solely on how the previous `oldSchema` and `newSchema` of each test case were printed by `printSchema`.