### PR TITLE
Make introspectionFromSchema options argument optional

### DIFF
--- a/src/utilities/__tests__/introspectionFromSchema-test.js
+++ b/src/utilities/__tests__/introspectionFromSchema-test.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
  */
 
 import { describe, it } from 'mocha';

--- a/src/utilities/introspectionFromSchema.js
+++ b/src/utilities/introspectionFromSchema.js
@@ -28,7 +28,7 @@ import type {
  */
 export function introspectionFromSchema(
   schema: GraphQLSchema,
-  options: IntrospectionOptions,
+  options?: IntrospectionOptions,
 ): IntrospectionQuery {
   const queryAST = parse(getIntrospectionQuery(options));
   const result = execute(schema, queryAST);


### PR DESCRIPTION
Allows to just write 
`introspectionFromSchema(schema)`
instead of 
`introspectionFromSchema(schema, {descriptions: true})`.