### PR TITLE
Fragment variables: enforce fragment variable validation

### DIFF
--- a/src/validation/ValidationContext.js
+++ b/src/validation/ValidationContext.js
@@ -155,7 +155,7 @@ export default class ValidationContext {
             const fragment = this.getFragment(fragName);
             if (
               fragment &&
-              !this.isExecutableDefinitionWithVariables(fragment)
+              !isExperimentalFragmentWithVariableDefinitions(fragment)
             ) {
               fragments.push(fragment);
               nodesToVisit.push(fragment.selectionSet);
@@ -244,15 +244,10 @@ export default class ValidationContext {
   getArgument(): ?GraphQLArgument {
     return this._typeInfo.getArgument();
   }
+}
 
-  // All OperationDefinitions, or FragmentDefinitions with variable definitions
-  isExecutableDefinitionWithVariables(
-    definition: ExecutableDefinitionNode,
-  ): boolean {
-    return (
-      definition.kind === Kind.OPERATION_DEFINITION ||
-      (definition.variableDefinitions != null &&
-        definition.variableDefinitions.length > 0)
-    );
-  }
+function isExperimentalFragmentWithVariableDefinitions(
+  ast: FragmentDefinitionNode,
+): boolean %checks {
+  return ast.variableDefinitions != null && ast.variableDefinitions.length > 0;
 }

--- a/src/validation/ValidationContext.js
+++ b/src/validation/ValidationContext.js
@@ -197,7 +197,7 @@ export default class ValidationContext {
    *
    * NOTE: if experimentalFragmentVariables are being used, it excludes all
    * fragments with their own variable definitions: these are considered their
-   * own "root" executable definition.
+   * own independent executable definition for the purposes of variable usage.
    */
   getRecursiveVariableUsages(
     definition: ExecutableDefinitionNode,

--- a/src/validation/__tests__/NoUndefinedVariables-test.js
+++ b/src/validation/__tests__/NoUndefinedVariables-test.js
@@ -329,4 +329,42 @@ describe('Validate: No undefined variables', () => {
       ],
     );
   });
+
+  // Experimental Fragment Variables
+  it('uses all variables in fragments with variable definitions', () => {
+    expectPassesRule(
+      NoUndefinedVariables,
+      `
+      fragment Foo($a: String, $b: String, $c: String) on Type {
+        ...FragA
+      }
+      fragment FragA on Type {
+        field(a: $a) {
+          ...FragB
+        }
+      }
+      fragment FragB on Type {
+        field(b: $b) {
+          ...FragC
+        }
+      }
+      fragment FragC on Type {
+        field(c: $c)
+      }
+    `,
+    );
+  });
+
+  it('variable used in fragment not defined', () => {
+    expectFailsRule(
+      NoUndefinedVariables,
+      `
+      fragment FragA($a: String) on Type {
+        field(a: $a)
+        field(b: $b)
+      }
+    `,
+      [undefVar('b', 4, 18, 'FragA', 2, 7)],
+    );
+  });
 });

--- a/src/validation/__tests__/NoUndefinedVariables-test.js
+++ b/src/validation/__tests__/NoUndefinedVariables-test.js
@@ -6,7 +6,12 @@
  */
 
 import { describe, it } from 'mocha';
-import { expectPassesRule, expectFailsRule } from './harness';
+import {
+  expectPassesRule,
+  expectFailsRule,
+  expectPassesRuleWithFragmentVariables,
+  expectFailsRuleWithFragmentVariables,
+} from './harness';
 import {
   NoUndefinedVariables,
   undefinedVarMessage,
@@ -332,7 +337,7 @@ describe('Validate: No undefined variables', () => {
 
   // Experimental Fragment Variables
   it('uses all variables in fragments with variable definitions', () => {
-    expectPassesRule(
+    expectPassesRuleWithFragmentVariables(
       NoUndefinedVariables,
       `
       fragment Foo($a: String, $b: String, $c: String) on Type {
@@ -356,7 +361,7 @@ describe('Validate: No undefined variables', () => {
   });
 
   it('variable used in fragment not defined', () => {
-    expectFailsRule(
+    expectFailsRuleWithFragmentVariables(
       NoUndefinedVariables,
       `
       fragment FragA($a: String) on Type {

--- a/src/validation/__tests__/NoUnusedVariables-test.js
+++ b/src/validation/__tests__/NoUnusedVariables-test.js
@@ -6,7 +6,12 @@
  */
 
 import { describe, it } from 'mocha';
-import { expectPassesRule, expectFailsRule } from './harness';
+import {
+  expectPassesRule,
+  expectFailsRule,
+  expectPassesRuleWithFragmentVariables,
+  expectFailsRuleWithFragmentVariables,
+} from './harness';
 import {
   NoUnusedVariables,
   unusedVariableMessage,
@@ -240,7 +245,7 @@ describe('Validate: No unused variables', () => {
 
   // Experimental Fragment Variables
   it('uses all variables in fragments with variable definitions', () => {
-    expectPassesRule(
+    expectPassesRuleWithFragmentVariables(
       NoUnusedVariables,
       `
       fragment Foo($a: String, $b: String, $c: String) on Type {
@@ -264,7 +269,7 @@ describe('Validate: No unused variables', () => {
   });
 
   it('variable not used by fragment', () => {
-    expectFailsRule(
+    expectFailsRuleWithFragmentVariables(
       NoUnusedVariables,
       `
       fragment FragA($a: String) on Type {
@@ -276,7 +281,7 @@ describe('Validate: No unused variables', () => {
   });
 
   it('variable used in query defined by fragment', () => {
-    expectFailsRule(
+    expectFailsRuleWithFragmentVariables(
       NoUnusedVariables,
       `
       query Foo($a: String) {
@@ -291,7 +296,7 @@ describe('Validate: No unused variables', () => {
     );
 
     it('variable defined in fragment used by query', () => {
-      expectFailsRule(
+      expectFailsRuleWithFragmentVariables(
         NoUnusedVariables,
         `
         query Foo($a: String) {

--- a/src/validation/__tests__/NoUnusedVariables-test.js
+++ b/src/validation/__tests__/NoUnusedVariables-test.js
@@ -237,4 +237,72 @@ describe('Validate: No unused variables', () => {
       [unusedVar('b', 'Foo', 2, 17), unusedVar('a', 'Bar', 5, 17)],
     );
   });
+
+  // Experimental Fragment Variables
+  it('uses all variables in fragments with variable definitions', () => {
+    expectPassesRule(
+      NoUnusedVariables,
+      `
+      fragment Foo($a: String, $b: String, $c: String) on Type {
+        ...FragA
+      }
+      fragment FragA on Type {
+        field(a: $a) {
+          ...FragB
+        }
+      }
+      fragment FragB on Type {
+        field(b: $b) {
+          ...FragC
+        }
+      }
+      fragment FragC on Type {
+        field(c: $c)
+      }
+    `,
+    );
+  });
+
+  it('variable not used by fragment', () => {
+    expectFailsRule(
+      NoUnusedVariables,
+      `
+      fragment FragA($a: String) on Type {
+        field
+      }
+    `,
+      [unusedVar('a', 'FragA', 2, 22)],
+    );
+  });
+
+  it('variable used in query defined by fragment', () => {
+    expectFailsRule(
+      NoUnusedVariables,
+      `
+      query Foo($a: String) {
+        field(a: $a)
+        ...FragA
+      }
+      fragment FragA($a: String) on Type {
+        field
+      }
+    `,
+      [unusedVar('a', 'FragA', 6, 22)],
+    );
+
+    it('variable defined in fragment used by query', () => {
+      expectFailsRule(
+        NoUnusedVariables,
+        `
+        query Foo($a: String) {
+          ...FragA
+        }
+        fragment FragA($a: String) on Type {
+          field(a: $a)
+        }
+      `,
+        [unusedVar('a', 'Foo', 1, 19)],
+      );
+    });
+  });
 });

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -421,20 +421,30 @@ export const testSchema = new GraphQLSchema({
   ],
 });
 
-function expectValid(schema, rules, queryString) {
+function expectValid(schema, rules, queryString, options = {}) {
   const errors = validate(
     schema,
-    parse(queryString, { experimentalFragmentVariables: true }),
+    parse(queryString, options),
     rules,
+    null, // default TypeInfo
+    options,
   );
   expect(errors).to.deep.equal([], 'Should validate');
 }
 
-function expectInvalid(schema, rules, queryString, expectedErrors) {
+function expectInvalid(
+  schema,
+  rules,
+  queryString,
+  expectedErrors,
+  options = {},
+) {
   const errors = validate(
     schema,
-    parse(queryString, { experimentalFragmentVariables: true }),
+    parse(queryString, options),
     rules,
+    null, // default TypeInfo
+    options,
   );
   expect(errors).to.have.length.of.at.least(1, 'Should not validate');
   expect(errors).to.deep.equal(expectedErrors);
@@ -455,4 +465,20 @@ export function expectPassesRuleWithSchema(schema, rule, queryString, errors) {
 
 export function expectFailsRuleWithSchema(schema, rule, queryString, errors) {
   return expectInvalid(schema, [rule], queryString, errors);
+}
+
+export function expectPassesRuleWithFragmentVariables(rule, queryString) {
+  return expectValid(testSchema, [rule], queryString, {
+    experimentalFragmentVariables: true,
+  });
+}
+
+export function expectFailsRuleWithFragmentVariables(
+  rule,
+  queryString,
+  errors,
+) {
+  return expectInvalid(testSchema, [rule], queryString, errors, {
+    experimentalFragmentVariables: true,
+  });
 }

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -422,12 +422,20 @@ export const testSchema = new GraphQLSchema({
 });
 
 function expectValid(schema, rules, queryString) {
-  const errors = validate(schema, parse(queryString), rules);
+  const errors = validate(
+    schema,
+    parse(queryString, { experimentalFragmentVariables: true }),
+    rules,
+  );
   expect(errors).to.deep.equal([], 'Should validate');
 }
 
 function expectInvalid(schema, rules, queryString, expectedErrors) {
-  const errors = validate(schema, parse(queryString), rules);
+  const errors = validate(
+    schema,
+    parse(queryString, { experimentalFragmentVariables: true }),
+    rules,
+  );
   expect(errors).to.have.length.of.at.least(1, 'Should not validate');
   expect(errors).to.deep.equal(expectedErrors);
   return errors;

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -26,9 +26,8 @@ export function undefinedVarMessage(varName: string, opName: ?string): string {
  * directly and via fragment spreads, are defined by that definition.
  *
  * NOTE: if experimentalFragmentVariables are used, then fragments with
- * variables defined are considered independent "executable definitions".
- * If a fragment defines at least 1 variable, it must define all recursively
- * used variables, excluding other fragments with variables defined.
+ * variable definitions will validate independently, and a variable is not
+ * "encountered" if it's only used in a child with variable definitions.
  */
 export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
   let variableNameDefined = Object.create(null);

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -28,7 +28,7 @@ export function undefinedVarMessage(varName: string, opName: ?string): string {
  * NOTE: if experimentalFragmentVariables are used, then fragments with
  * variables defined are considered independent "executable definitions".
  * If a fragment defines at least 1 variable, it must define all recursively
- * vused ariables, excluding other fragments with variables defined.
+ * used variables, excluding other fragments with variables defined.
  */
 export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
   let variableNameDefined = Object.create(null);

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -10,6 +10,7 @@
 import type ValidationContext from '../ValidationContext';
 import { GraphQLError } from '../../error';
 import type { ASTVisitor } from '../../language/visitor';
+import { Kind } from '../../language';
 import type { ExecutableDefinitionNode } from '../../language';
 
 export function undefinedVarMessage(varName: string, opName: ?string): string {
@@ -33,14 +34,14 @@ export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
   let variableNameDefined = Object.create(null);
 
   const executableDefinitionVisitor = {
-    enter(definition: ExecutableDefinitionNode) {
-      if (!context.isExecutableDefinitionWithVariables(definition)) {
-        return;
-      }
+    enter() {
       variableNameDefined = Object.create(null);
     },
     leave(definition: ExecutableDefinitionNode) {
-      if (!context.isExecutableDefinitionWithVariables(definition)) {
+      if (
+        definition.kind === Kind.FRAGMENT_DEFINITION &&
+        Object.keys(variableNameDefined).length === 0
+      ) {
         return;
       }
       const usages = context.getRecursiveVariableUsages(definition);

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -25,8 +25,9 @@ export function undefinedVarMessage(varName: string, opName: ?string): string {
  * directly and via fragment spreads, are defined by that definition.
  *
  * NOTE: if experimentalFragmentVariables are used, then fragments with
- * variables defined are considered an independent "executable definitions":
- * variables defined under them do not count as "within a fragment spread".
+ * variables defined are considered independent "executable definitions".
+ * If a fragment defines at least 1 variable, it must define all recursively
+ * vused ariables, excluding other fragments with variables defined.
  */
 export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
   let variableNameDefined = Object.create(null);

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -21,8 +21,12 @@ export function undefinedVarMessage(varName: string, opName: ?string): string {
 /**
  * No undefined variables
  *
- * A GraphQL operation is only valid if all variables encountered, both directly
- * and via fragment spreads, are defined by that operation.
+ * A GraphQL definition is only valid if all variables encountered, both
+ * directly and via fragment spreads, are defined by that definition.
+ *
+ * NOTE: if experimentalFragmentVariables are used, then fragments with
+ * variables defined are considered an independent "executable definitions":
+ * variables defined under them do not count as "within a fragment spread".
  */
 export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
   let variableNameDefined = Object.create(null);

--- a/src/validation/rules/NoUnusedVariables.js
+++ b/src/validation/rules/NoUnusedVariables.js
@@ -28,8 +28,9 @@ export function unusedVariableMessage(
  * definition are used, either directly or within a spread fragment.
  *
  * NOTE: if experimentalFragmentVariables are used, then fragments with
- * variables defined are considered an independent "executable definitions":
- * variables defined under them do not count as "within a fragment spread".
+ * variables defined are considered independent "executable definitions".
+ * So `query Foo` must not define `$a` when `$a` is only used inside
+ * `fragment FragA($a: Type)`
  */
 export function NoUnusedVariables(context: ValidationContext): ASTVisitor {
   let variableDefs = [];

--- a/src/validation/rules/NoUnusedVariables.js
+++ b/src/validation/rules/NoUnusedVariables.js
@@ -24,12 +24,12 @@ export function unusedVariableMessage(
 /**
  * No unused variables
  *
- * A GraphQL executable tree is only valid if all variables defined by that tree
- * are used, either directly or within a spread fragment.
+ * A GraphQL definition is only valid if all variables defined by that
+ * definition are used, either directly or within a spread fragment.
  *
  * NOTE: if experimentalFragmentVariables are used, then fragments with
- * variables defined are considered an independent "executable tree":
- * fragments defined under them do not count as "within a fragment spread".
+ * variables defined are considered an independent "executable definitions":
+ * variables defined under them do not count as "within a fragment spread".
  */
 export function NoUnusedVariables(context: ValidationContext): ASTVisitor {
   let variableDefs = [];

--- a/src/validation/rules/NoUnusedVariables.js
+++ b/src/validation/rules/NoUnusedVariables.js
@@ -9,6 +9,7 @@
 
 import type ValidationContext from '../ValidationContext';
 import { GraphQLError } from '../../error';
+import { Kind } from '../../language';
 import type { ExecutableDefinitionNode } from '../../language';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -36,14 +37,14 @@ export function NoUnusedVariables(context: ValidationContext): ASTVisitor {
   let variableDefs = [];
 
   const executableDefinitionVisitor = {
-    enter(definition: ExecutableDefinitionNode) {
-      if (!context.isExecutableDefinitionWithVariables(definition)) {
-        return;
-      }
+    enter() {
       variableDefs = [];
     },
     leave(definition: ExecutableDefinitionNode) {
-      if (!context.isExecutableDefinitionWithVariables(definition)) {
+      if (
+        definition.kind === Kind.FRAGMENT_DEFINITION &&
+        variableDefs.length === 0
+      ) {
         return;
       }
 

--- a/src/validation/rules/NoUnusedVariables.js
+++ b/src/validation/rules/NoUnusedVariables.js
@@ -29,7 +29,7 @@ export function unusedVariableMessage(
  * definition are used, either directly or within a spread fragment.
  *
  * NOTE: if experimentalFragmentVariables are used, then fragments with
- * variables defined are considered independent "executable definitions".
+ * variable definitions will validate independently.
  * So `query Foo` must not define `$a` when `$a` is only used inside
  * `fragment FragA($a: Type)`
  */

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -17,6 +17,7 @@ import { assertValidSchema } from '../type/validate';
 import { TypeInfo } from '../utilities/TypeInfo';
 import { specifiedRules } from './specifiedRules';
 import ValidationContext from './ValidationContext';
+import type { ValidationOptions } from './ValidationContext';
 
 /**
  * Implements the "Validation" section of the spec.
@@ -39,6 +40,7 @@ export function validate(
   ast: DocumentNode,
   rules?: $ReadOnlyArray<any>,
   typeInfo?: TypeInfo,
+  options?: ValidationOptions,
 ): $ReadOnlyArray<GraphQLError> {
   invariant(ast, 'Must provide document');
   // If the schema used for validation is invalid, throw an error.
@@ -48,6 +50,7 @@ export function validate(
     typeInfo || new TypeInfo(schema),
     ast,
     rules || specifiedRules,
+    options || {},
   );
 }
 
@@ -62,8 +65,9 @@ function visitUsingRules(
   typeInfo: TypeInfo,
   documentAST: DocumentNode,
   rules: $ReadOnlyArray<(ValidationContext) => ASTVisitor>,
+  options: ValidationOptions,
 ): $ReadOnlyArray<GraphQLError> {
-  const context = new ValidationContext(schema, documentAST, typeInfo);
+  const context = new ValidationContext(schema, documentAST, typeInfo, options);
   const visitors = rules.map(rule => rule(context));
   // Visit the whole document with each instance of all provided rules.
   visit(documentAST, visitWithTypeInfo(typeInfo, visitInParallel(visitors)));


### PR DESCRIPTION
Treats experimental fragments with variable definitions as their own top-level
"executable definition": this means a query cannot include a variable
definition found solely beneath a fragment-variable definition, and
a fragment must include all variable definitions that exist under it,
excluding other variables defined by other fragments.

Has no repercussions outside of fragment variable definitions, besides allowing recursive fragment lookups. One note: I am not sure how the `NoUnusedFragments` validation is supposed to work: internally we don't use it, as we have many use cases for unused fragments. I suspect fragments with variable definitions are a different definition type, and should always be treated as their own self-contained definition-trees (so we should be doing the same thing as below inside `NoUnusedFragments`). But I'm not positive about that behavior, whereas I am positive about the behavior of unused/undefined variables.