### PR TITLE
Replace all 'Array.forEach' with 'for of' cycle

### DIFF
--- a/src/error/printError.js
+++ b/src/error/printError.js
@@ -19,7 +19,7 @@ import type { GraphQLError } from './GraphQLError';
 export function printError(error: GraphQLError): string {
   const printedLocations = [];
   if (error.nodes) {
-    error.nodes.forEach(node => {
+    for (const node of error.nodes) {
       if (node.loc) {
         printedLocations.push(
           highlightSourceAtLocation(
@@ -28,12 +28,12 @@ export function printError(error: GraphQLError): string {
           ),
         );
       }
-    });
+    }
   } else if (error.source && error.locations) {
     const source = error.source;
-    error.locations.forEach(location => {
+    for (const location of error.locations) {
       printedLocations.push(highlightSourceAtLocation(source, location));
-    });
+    }
   }
   return printedLocations.length === 0
     ? error.message

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -96,11 +96,11 @@ export function getVariableValues(
           const coerced = coerceValue(value, varType, varDefNode);
           const coercionErrors = coerced.errors;
           if (coercionErrors) {
-            coercionErrors.forEach(error => {
+            for (const error of coercionErrors) {
               error.message =
                 `Variable "$${varName}" got invalid ` +
                 `value ${inspect(value)}; ${error.message}`;
-            });
+            }
             errors.push(...coercionErrors);
           } else {
             coercedValues[varName] = coerced.value;

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -151,7 +151,7 @@ describe('Parser', () => {
       'true',
       'false',
     ];
-    nonKeywords.forEach(keyword => {
+    for (const keyword of nonKeywords) {
       // You can't define or reference a fragment named `on`.
       const fragmentName = keyword !== 'on' ? keyword : 'a';
       const document = `
@@ -166,7 +166,7 @@ describe('Parser', () => {
       `;
 
       expect(() => parse(document)).to.not.throw();
-    });
+    }
   });
 
   it('parses anonymous mutation operations', () => {

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -45,7 +45,9 @@ export default function eventEmitterAsyncIterator(
     if (listening) {
       listening = false;
       eventEmitter.removeListener(eventName, pushValue);
-      pullQueue.forEach(resolve => resolve({ value: undefined, done: true }));
+      for (const resolve of pullQueue) {
+        resolve({ value: undefined, done: true });
+      }
       pullQueue.length = 0;
       pushQueue.length = 0;
     }

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -378,11 +378,11 @@ describe('Type System: Example', () => {
       [EnumType, true],
       [InputObjectType, true],
     ];
-    expected.forEach(([type, answer]) => {
+    for (const [type, answer] of expected) {
       expect(isInputType(type)).to.equal(answer);
       expect(isInputType(GraphQLList(type))).to.equal(answer);
       expect(isInputType(GraphQLNonNull(type))).to.equal(answer);
-    });
+    }
   });
 
   it('identifies output types', () => {
@@ -394,11 +394,11 @@ describe('Type System: Example', () => {
       [EnumType, true],
       [InputObjectType, false],
     ];
-    expected.forEach(([type, answer]) => {
+    for (const [type, answer] of expected) {
       expect(isOutputType(type)).to.equal(answer);
       expect(isOutputType(GraphQLList(type))).to.equal(answer);
       expect(isOutputType(GraphQLNonNull(type))).to.equal(answer);
-    });
+    }
   });
 
   it('prohibits nesting NonNull inside NonNull', () => {
@@ -1131,19 +1131,19 @@ describe('Type System: List must accept only types', () => {
 
   const notTypes = [{}, String, undefined, null];
 
-  types.forEach(type => {
+  for (const type of types) {
     it(`accepts an type as item type of list: ${type}`, () => {
       expect(() => GraphQLList(type)).not.to.throw();
     });
-  });
+  }
 
-  notTypes.forEach(type => {
+  for (const type of notTypes) {
     it(`rejects a non-type as item type of list: ${type}`, () => {
       expect(() => GraphQLList(type)).to.throw(
         `Expected ${inspect(type)} to be a GraphQL type.`,
       );
     });
-  });
+  }
 });
 
 describe('Type System: NonNull must only accept non-nullable types', () => {
@@ -1167,19 +1167,19 @@ describe('Type System: NonNull must only accept non-nullable types', () => {
     null,
   ];
 
-  nullableTypes.forEach(type => {
+  for (const type of nullableTypes) {
     it(`accepts an type as nullable type of non-null: ${type}`, () => {
       expect(() => GraphQLNonNull(type)).not.to.throw();
     });
-  });
+  }
 
-  notNullableTypes.forEach(type => {
+  for (const type of notNullableTypes) {
     it(`rejects a non-type as nullable type of non-null: ${type}`, () => {
       expect(() => GraphQLNonNull(type)).to.throw(
         `Expected ${inspect(type)} to be a GraphQL nullable type.`,
       );
     });
-  });
+  }
 });
 
 describe('Type System: A Schema must contain uniquely named types', () => {

--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -641,7 +641,7 @@ describe('Type System: Union types must be valid', () => {
       SomeEnumType,
       SomeInputObjectType,
     ];
-    badUnionMemberTypes.forEach(memberType => {
+    for (const memberType of badUnionMemberTypes) {
       const badSchema = schemaWithFieldType(
         new GraphQLUnionType({ name: 'BadUnion', types: [memberType] }),
       );
@@ -652,7 +652,7 @@ describe('Type System: Union types must be valid', () => {
             `it cannot include ${memberType}.`,
         },
       ]);
-    });
+    }
   });
 });
 
@@ -829,12 +829,12 @@ describe('Type System: Object fields must have output types', () => {
     });
   }
 
-  outputTypes.forEach(type => {
+  for (const type of outputTypes) {
     it(`accepts an output type as an Object field type: ${type}`, () => {
       const schema = schemaWithObjectFieldOfType(type);
       expect(validateSchema(schema)).to.deep.equal([]);
     });
-  });
+  }
 
   it('rejects an empty Object field type', () => {
     const schema = schemaWithObjectFieldOfType(undefined);
@@ -846,7 +846,7 @@ describe('Type System: Object fields must have output types', () => {
     ]);
   });
 
-  notOutputTypes.forEach(type => {
+  for (const type of notOutputTypes) {
     it(`rejects a non-output type as an Object field type: ${type}`, () => {
       const schema = schemaWithObjectFieldOfType(type);
       expect(validateSchema(schema)).to.deep.equal([
@@ -855,7 +855,7 @@ describe('Type System: Object fields must have output types', () => {
         },
       ]);
     });
-  });
+  }
 
   it('rejects a non-type value as an Object field type', () => {
     const schema = schemaWithObjectFieldOfType(Number);
@@ -1123,12 +1123,12 @@ describe('Type System: Interface fields must have output types', () => {
     });
   }
 
-  outputTypes.forEach(type => {
+  for (const type of outputTypes) {
     it(`accepts an output type as an Interface field type: ${type}`, () => {
       const schema = schemaWithInterfaceFieldOfType(type);
       expect(validateSchema(schema)).to.deep.equal([]);
     });
-  });
+  }
 
   it('rejects an empty Interface field type', () => {
     const schema = schemaWithInterfaceFieldOfType(undefined);
@@ -1144,7 +1144,7 @@ describe('Type System: Interface fields must have output types', () => {
     ]);
   });
 
-  notOutputTypes.forEach(type => {
+  for (const type of notOutputTypes) {
     it(`rejects a non-output type as an Interface field type: ${type}`, () => {
       const schema = schemaWithInterfaceFieldOfType(type);
       expect(validateSchema(schema)).to.deep.equal([
@@ -1156,7 +1156,7 @@ describe('Type System: Interface fields must have output types', () => {
         },
       ]);
     });
-  });
+  }
 
   it('rejects a non-type value as an Interface field type', () => {
     const schema = schemaWithInterfaceFieldOfType(Number);
@@ -1243,12 +1243,12 @@ describe('Type System: Field arguments must have input types', () => {
     });
   }
 
-  inputTypes.forEach(type => {
+  for (const type of inputTypes) {
     it(`accepts an input type as a field arg type: ${type}`, () => {
       const schema = schemaWithArgOfType(type);
       expect(validateSchema(schema)).to.deep.equal([]);
     });
-  });
+  }
 
   it('rejects an empty field arg type', () => {
     const schema = schemaWithArgOfType(undefined);
@@ -1260,7 +1260,7 @@ describe('Type System: Field arguments must have input types', () => {
     ]);
   });
 
-  notInputTypes.forEach(type => {
+  for (const type of notInputTypes) {
     it(`rejects a non-input type as a field arg type: ${type}`, () => {
       const schema = schemaWithArgOfType(type);
       expect(validateSchema(schema)).to.deep.equal([
@@ -1269,7 +1269,7 @@ describe('Type System: Field arguments must have input types', () => {
         },
       ]);
     });
-  });
+  }
 
   it('rejects a non-type value as a field arg type', () => {
     const schema = schemaWithArgOfType(Number);
@@ -1327,12 +1327,12 @@ describe('Type System: Input Object fields must have input types', () => {
     });
   }
 
-  inputTypes.forEach(type => {
+  for (const type of inputTypes) {
     it(`accepts an input type as an input field type: ${type}`, () => {
       const schema = schemaWithInputFieldOfType(type);
       expect(validateSchema(schema)).to.deep.equal([]);
     });
-  });
+  }
 
   it('rejects an empty input field type', () => {
     const schema = schemaWithInputFieldOfType(undefined);
@@ -1344,7 +1344,7 @@ describe('Type System: Input Object fields must have input types', () => {
     ]);
   });
 
-  notInputTypes.forEach(type => {
+  for (const type of notInputTypes) {
     it(`rejects a non-input type as an input field type: ${type}`, () => {
       const schema = schemaWithInputFieldOfType(type);
       expect(validateSchema(schema)).to.deep.equal([
@@ -1353,7 +1353,7 @@ describe('Type System: Input Object fields must have input types', () => {
         },
       ]);
     });
-  });
+  }
 
   it('rejects a non-type value as an input field type', () => {
     const schema = schemaWithInputFieldOfType(Number);

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -707,7 +707,7 @@ function defineFieldMap<TSource, TContext>(
   );
 
   const resultFieldMap = Object.create(null);
-  Object.keys(fieldMap).forEach(fieldName => {
+  for (const fieldName of Object.keys(fieldMap)) {
     const fieldConfig = fieldMap[fieldName];
     invariant(
       isPlainObj(fieldConfig),
@@ -749,7 +749,7 @@ function defineFieldMap<TSource, TContext>(
       });
     }
     resultFieldMap[fieldName] = field;
-  });
+  }
   return resultFieldMap;
 }
 
@@ -1241,7 +1241,7 @@ function defineInputFieldMap(
       'function which returns such an object.',
   );
   const resultFieldMap = Object.create(null);
-  Object.keys(fieldMap).forEach(fieldName => {
+  for (const fieldName of Object.keys(fieldMap)) {
     const field = {
       ...fieldMap[fieldName],
       name: fieldName,
@@ -1252,7 +1252,7 @@ function defineInputFieldMap(
         'Input Types cannot define resolvers.',
     );
     resultFieldMap[fieldName] = field;
-  });
+  }
   return resultFieldMap;
 }
 

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -155,10 +155,10 @@ export class GraphQLSchema {
 
     // Keep track of all implementations by interface name.
     this._implementations = Object.create(null);
-    Object.keys(this._typeMap).forEach(typeName => {
+    for (const typeName of Object.keys(this._typeMap)) {
       const type = this._typeMap[typeName];
       if (isObjectType(type)) {
-        type.getInterfaces().forEach(iface => {
+        for (const iface of type.getInterfaces()) {
           if (isInterfaceType(iface)) {
             const impls = this._implementations[iface.name];
             if (impls) {
@@ -167,11 +167,11 @@ export class GraphQLSchema {
               this._implementations[iface.name] = [type];
             }
           }
-        });
+        }
       } else if (isAbstractType(type) && !this._implementations[type.name]) {
         this._implementations[type.name] = [];
       }
-    });
+    }
   }
 
   getQueryType(): ?GraphQLObjectType {
@@ -296,19 +296,19 @@ function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   }
 
   if (isObjectType(type) || isInterfaceType(type)) {
-    objectValues(type.getFields()).forEach(field => {
+    for (const field of objectValues(type.getFields())) {
       if (field.args) {
         const fieldArgTypes = field.args.map(arg => arg.type);
         reducedMap = fieldArgTypes.reduce(typeMapReducer, reducedMap);
       }
       reducedMap = typeMapReducer(reducedMap, field.type);
-    });
+    }
   }
 
   if (isInputObjectType(type)) {
-    objectValues(type.getFields()).forEach(field => {
+    for (const field of objectValues(type.getFields())) {
       reducedMap = typeMapReducer(reducedMap, field.type);
-    });
+    }
   }
 
   return reducedMap;

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -86,7 +86,7 @@ export function astFromValue(value: mixed, type: GraphQLInputType): ?ValueNode {
     }
     const fields = objectValues(type.getFields());
     const fieldNodes = [];
-    fields.forEach(field => {
+    for (const field of fields) {
       const fieldValue = astFromValue(value[field.name], field.type);
       if (fieldValue) {
         fieldNodes.push({
@@ -95,7 +95,7 @@ export function astFromValue(value: mixed, type: GraphQLInputType): ?ValueNode {
           value: fieldValue,
         });
       }
-    });
+    }
     return { kind: Kind.OBJECT, fields: fieldNodes };
   }
 

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -230,7 +230,7 @@ export function buildASTSchema(
 
   function getOperationTypes(schema: SchemaDefinitionNode) {
     const opTypes = {};
-    schema.operationTypes.forEach(operationType => {
+    for (const operationType of schema.operationTypes) {
       const typeName = operationType.type.name.value;
       const operation = operationType.operation;
       if (opTypes[operation]) {
@@ -242,7 +242,7 @@ export function buildASTSchema(
         );
       }
       opTypes[operation] = operationType.type;
-    });
+    }
     return opTypes;
   }
 }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -216,9 +216,9 @@ export function extendSchema(
   };
 
   // Then, incorporate all schema extensions.
-  schemaExtensions.forEach(schemaExtension => {
+  for (const schemaExtension of schemaExtensions) {
     if (schemaExtension.operationTypes) {
-      schemaExtension.operationTypes.forEach(operationType => {
+      for (const operationType of schemaExtension.operationTypes) {
         const operation = operationType.operation;
         if (operationTypes[operation]) {
           throw new Error(`Must provide only one ${operation} type in schema.`);
@@ -228,9 +228,9 @@ export function extendSchema(
         // typed values, that would throw immediately while type system
         // validation with validateSchema() will produce more actionable results.
         operationTypes[operation] = (astBuilder.buildType(typeRef): any);
-      });
+      }
     }
-  });
+  }
 
   const schemaExtensionASTNodes = schemaExtensions
     ? schema.extensionASTNodes
@@ -345,7 +345,7 @@ export function extendSchema(
   function extendInputFieldMap(type: GraphQLInputObjectType) {
     const newFieldMap = Object.create(null);
     const oldFieldMap = type.getFields();
-    Object.keys(oldFieldMap).forEach(fieldName => {
+    for (const fieldName of Object.keys(oldFieldMap)) {
       const field = oldFieldMap[fieldName];
       newFieldMap[fieldName] = {
         description: field.description,
@@ -353,13 +353,13 @@ export function extendSchema(
         defaultValue: field.defaultValue,
         astNode: field.astNode,
       };
-    });
+    }
 
     // If there are any extensions to the fields, apply those here.
     const extensions = typeExtensionsMap[type.name];
     if (extensions) {
-      extensions.forEach(extension => {
-        extension.fields.forEach(field => {
+      for (const extension of extensions) {
+        for (const field of extension.fields) {
           const fieldName = field.name.value;
           if (oldFieldMap[fieldName]) {
             throw new GraphQLError(
@@ -369,8 +369,8 @@ export function extendSchema(
             );
           }
           newFieldMap[fieldName] = astBuilder.buildInputField(field);
-        });
-      });
+        }
+      }
     }
 
     return newFieldMap;
@@ -395,7 +395,7 @@ export function extendSchema(
   function extendValueMap(type: GraphQLEnumType) {
     const newValueMap = Object.create(null);
     const oldValueMap = keyMap(type.getValues(), value => value.name);
-    Object.keys(oldValueMap).forEach(valueName => {
+    for (const valueName of Object.keys(oldValueMap)) {
       const value = oldValueMap[valueName];
       newValueMap[valueName] = {
         name: value.name,
@@ -404,13 +404,13 @@ export function extendSchema(
         deprecationReason: value.deprecationReason,
         astNode: value.astNode,
       };
-    });
+    }
 
     // If there are any extensions to the values, apply those here.
     const extensions = typeExtensionsMap[type.name];
     if (extensions) {
-      extensions.forEach(extension => {
-        extension.values.forEach(value => {
+      for (const extension of extensions) {
+        for (const value of extension.values) {
           const valueName = value.name.value;
           if (oldValueMap[valueName]) {
             throw new GraphQLError(
@@ -420,8 +420,8 @@ export function extendSchema(
             );
           }
           newValueMap[valueName] = astBuilder.buildEnumValue(value);
-        });
-      });
+        }
+      }
     }
 
     return newValueMap;
@@ -509,14 +509,14 @@ export function extendSchema(
     // If there are any extensions to the union, apply those here.
     const extensions = typeExtensionsMap[type.name];
     if (extensions) {
-      extensions.forEach(extension => {
-        extension.types.forEach(namedType => {
+      for (const extension of extensions) {
+        for (const namedType of extension.types) {
           // Note: While this could make early assertions to get the correctly
           // typed values, that would throw immediately while type system
           // validation with validateSchema() will produce more actionable results.
           unionTypes.push((astBuilder.buildType(namedType): any));
-        });
-      });
+        }
+      }
     }
 
     return new GraphQLUnionType({
@@ -537,14 +537,14 @@ export function extendSchema(
     // If there are any extensions to the interfaces, apply those here.
     const extensions = typeExtensionsMap[type.name];
     if (extensions) {
-      extensions.forEach(extension => {
-        extension.interfaces.forEach(namedType => {
+      for (const extension of extensions) {
+        for (const namedType of extension.interfaces) {
           // Note: While this could make early assertions to get the correctly
           // typed values, that would throw immediately while type system
           // validation with validateSchema() will produce more actionable results.
           interfaces.push((astBuilder.buildType(namedType): any));
-        });
-      });
+        }
+      }
     }
 
     return interfaces;
@@ -553,7 +553,7 @@ export function extendSchema(
   function extendFieldMap(type: GraphQLObjectType | GraphQLInterfaceType) {
     const newFieldMap = Object.create(null);
     const oldFieldMap = type.getFields();
-    Object.keys(oldFieldMap).forEach(fieldName => {
+    for (const fieldName of Object.keys(oldFieldMap)) {
       const field = oldFieldMap[fieldName];
       newFieldMap[fieldName] = {
         description: field.description,
@@ -563,13 +563,13 @@ export function extendSchema(
         astNode: field.astNode,
         resolve: field.resolve,
       };
-    });
+    }
 
     // If there are any extensions to the fields, apply those here.
     const extensions = typeExtensionsMap[type.name];
     if (extensions) {
-      extensions.forEach(extension => {
-        extension.fields.forEach(field => {
+      for (const extension of extensions) {
+        for (const field of extension.fields) {
           const fieldName = field.name.value;
           if (oldFieldMap[fieldName]) {
             throw new GraphQLError(
@@ -579,8 +579,8 @@ export function extendSchema(
             );
           }
           newFieldMap[fieldName] = astBuilder.buildField(field);
-        });
-      });
+        }
+      }
     }
 
     return newFieldMap;

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -125,14 +125,14 @@ export function findRemovedTypes(
   const newTypeMap = newSchema.getTypeMap();
 
   const breakingChanges = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     if (!newTypeMap[typeName]) {
       breakingChanges.push({
         type: BreakingChangeType.TYPE_REMOVED,
         description: `${typeName} was removed.`,
       });
     }
-  });
+  }
   return breakingChanges;
 }
 
@@ -148,9 +148,9 @@ export function findTypesThatChangedKind(
   const newTypeMap = newSchema.getTypeMap();
 
   const breakingChanges = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     if (!newTypeMap[typeName]) {
-      return;
+      continue;
     }
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
@@ -162,7 +162,7 @@ export function findTypesThatChangedKind(
           `${typeKindName(oldType)} to ${typeKindName(newType)}.`,
       });
     }
-  });
+  }
   return breakingChanges;
 }
 
@@ -185,7 +185,7 @@ export function findArgChanges(
   const breakingChanges = [];
   const dangerousChanges = [];
 
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (
@@ -193,18 +193,18 @@ export function findArgChanges(
       !(isObjectType(newType) || isInterfaceType(newType)) ||
       newType.constructor !== oldType.constructor
     ) {
-      return;
+      continue;
     }
 
     const oldTypeFields: GraphQLFieldMap<*, *> = oldType.getFields();
     const newTypeFields: GraphQLFieldMap<*, *> = newType.getFields();
 
-    Object.keys(oldTypeFields).forEach(fieldName => {
+    for (const fieldName of Object.keys(oldTypeFields)) {
       if (!newTypeFields[fieldName]) {
-        return;
+        continue;
       }
 
-      oldTypeFields[fieldName].args.forEach(oldArgDef => {
+      for (const oldArgDef of oldTypeFields[fieldName].args) {
         const newArgs = newTypeFields[fieldName].args;
         const newArgDef = newArgs.find(arg => arg.name === oldArgDef.name);
 
@@ -241,9 +241,9 @@ export function findArgChanges(
             });
           }
         }
-      });
+      }
       // Check if a non-null arg was added to the field
-      newTypeFields[fieldName].args.forEach(newArgDef => {
+      for (const newArgDef of newTypeFields[fieldName].args) {
         const oldArgs = oldTypeFields[fieldName].args;
         const oldArgDef = oldArgs.find(arg => arg.name === newArgDef.name);
         if (!oldArgDef) {
@@ -263,9 +263,9 @@ export function findArgChanges(
             });
           }
         }
-      });
-    });
-  });
+      }
+    }
+  }
 
   return {
     breakingChanges,
@@ -303,7 +303,7 @@ export function findFieldsThatChangedTypeOnObjectOrInterfaceTypes(
   const newTypeMap = newSchema.getTypeMap();
 
   const breakingChanges = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (
@@ -311,12 +311,12 @@ export function findFieldsThatChangedTypeOnObjectOrInterfaceTypes(
       !(isObjectType(newType) || isInterfaceType(newType)) ||
       newType.constructor !== oldType.constructor
     ) {
-      return;
+      continue;
     }
 
     const oldTypeFieldsDef = oldType.getFields();
     const newTypeFieldsDef = newType.getFields();
-    Object.keys(oldTypeFieldsDef).forEach(fieldName => {
+    for (const fieldName of Object.keys(oldTypeFieldsDef)) {
       // Check if the field is missing on the type in the new schema.
       if (!(fieldName in newTypeFieldsDef)) {
         breakingChanges.push({
@@ -345,8 +345,8 @@ export function findFieldsThatChangedTypeOnObjectOrInterfaceTypes(
           });
         }
       }
-    });
-  });
+    }
+  }
   return breakingChanges;
 }
 
@@ -362,16 +362,16 @@ export function findFieldsThatChangedTypeOnInputObjectTypes(
 
   const breakingChanges = [];
   const dangerousChanges = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isInputObjectType(oldType) || !isInputObjectType(newType)) {
-      return;
+      continue;
     }
 
     const oldTypeFieldsDef = oldType.getFields();
     const newTypeFieldsDef = newType.getFields();
-    Object.keys(oldTypeFieldsDef).forEach(fieldName => {
+    for (const fieldName of Object.keys(oldTypeFieldsDef)) {
       // Check if the field is missing on the type in the new schema.
       if (!(fieldName in newTypeFieldsDef)) {
         breakingChanges.push({
@@ -401,9 +401,9 @@ export function findFieldsThatChangedTypeOnInputObjectTypes(
           });
         }
       }
-    });
+    }
     // Check if a field was added to the input object type
-    Object.keys(newTypeFieldsDef).forEach(fieldName => {
+    for (const fieldName of Object.keys(newTypeFieldsDef)) {
       if (!(fieldName in oldTypeFieldsDef)) {
         if (isNonNullType(newTypeFieldsDef[fieldName].type)) {
           breakingChanges.push({
@@ -421,8 +421,8 @@ export function findFieldsThatChangedTypeOnInputObjectTypes(
           });
         }
       }
-    });
-  });
+    }
+  }
   return {
     breakingChanges,
     dangerousChanges,
@@ -505,25 +505,25 @@ export function findTypesRemovedFromUnions(
   const newTypeMap = newSchema.getTypeMap();
 
   const typesRemovedFromUnion = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isUnionType(oldType) || !isUnionType(newType)) {
-      return;
+      continue;
     }
     const typeNamesInNewUnion = Object.create(null);
-    newType.getTypes().forEach(type => {
+    for (const type of newType.getTypes()) {
       typeNamesInNewUnion[type.name] = true;
-    });
-    oldType.getTypes().forEach(type => {
+    }
+    for (const type of oldType.getTypes()) {
       if (!typeNamesInNewUnion[type.name]) {
         typesRemovedFromUnion.push({
           type: BreakingChangeType.TYPE_REMOVED_FROM_UNION,
           description: `${type.name} was removed from union type ${typeName}.`,
         });
       }
-    });
-  });
+    }
+  }
   return typesRemovedFromUnion;
 }
 
@@ -539,25 +539,25 @@ export function findTypesAddedToUnions(
   const newTypeMap = newSchema.getTypeMap();
 
   const typesAddedToUnion = [];
-  Object.keys(newTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(newTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isUnionType(oldType) || !isUnionType(newType)) {
-      return;
+      continue;
     }
     const typeNamesInOldUnion = Object.create(null);
-    oldType.getTypes().forEach(type => {
+    for (const type of oldType.getTypes()) {
       typeNamesInOldUnion[type.name] = true;
-    });
-    newType.getTypes().forEach(type => {
+    }
+    for (const type of newType.getTypes()) {
       if (!typeNamesInOldUnion[type.name]) {
         typesAddedToUnion.push({
           type: DangerousChangeType.TYPE_ADDED_TO_UNION,
           description: `${type.name} was added to union type ${typeName}.`,
         });
       }
-    });
-  });
+    }
+  }
   return typesAddedToUnion;
 }
 /**
@@ -572,25 +572,25 @@ export function findValuesRemovedFromEnums(
   const newTypeMap = newSchema.getTypeMap();
 
   const valuesRemovedFromEnums = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isEnumType(oldType) || !isEnumType(newType)) {
-      return;
+      continue;
     }
     const valuesInNewEnum = Object.create(null);
-    newType.getValues().forEach(value => {
+    for (const value of newType.getValues()) {
       valuesInNewEnum[value.name] = true;
-    });
-    oldType.getValues().forEach(value => {
+    }
+    for (const value of oldType.getValues()) {
       if (!valuesInNewEnum[value.name]) {
         valuesRemovedFromEnums.push({
           type: BreakingChangeType.VALUE_REMOVED_FROM_ENUM,
           description: `${value.name} was removed from enum type ${typeName}.`,
         });
       }
-    });
-  });
+    }
+  }
   return valuesRemovedFromEnums;
 }
 
@@ -606,26 +606,26 @@ export function findValuesAddedToEnums(
   const newTypeMap = newSchema.getTypeMap();
 
   const valuesAddedToEnums = [];
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isEnumType(oldType) || !isEnumType(newType)) {
-      return;
+      continue;
     }
 
     const valuesInOldEnum = Object.create(null);
-    oldType.getValues().forEach(value => {
+    for (const value of oldType.getValues()) {
       valuesInOldEnum[value.name] = true;
-    });
-    newType.getValues().forEach(value => {
+    }
+    for (const value of newType.getValues()) {
       if (!valuesInOldEnum[value.name]) {
         valuesAddedToEnums.push({
           type: DangerousChangeType.VALUE_ADDED_TO_ENUM,
           description: `${value.name} was added to enum type ${typeName}.`,
         });
       }
-    });
-  });
+    }
+  }
   return valuesAddedToEnums;
 }
 
@@ -637,16 +637,16 @@ export function findInterfacesRemovedFromObjectTypes(
   const newTypeMap = newSchema.getTypeMap();
   const breakingChanges = [];
 
-  Object.keys(oldTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(oldTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isObjectType(oldType) || !isObjectType(newType)) {
-      return;
+      continue;
     }
 
     const oldInterfaces = oldType.getInterfaces();
     const newInterfaces = newType.getInterfaces();
-    oldInterfaces.forEach(oldInterface => {
+    for (const oldInterface of oldInterfaces) {
       if (!newInterfaces.some(int => int.name === oldInterface.name)) {
         breakingChanges.push({
           type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
@@ -655,8 +655,8 @@ export function findInterfacesRemovedFromObjectTypes(
             `${oldInterface.name}.`,
         });
       }
-    });
-  });
+    }
+  }
   return breakingChanges;
 }
 
@@ -668,16 +668,16 @@ export function findInterfacesAddedToObjectTypes(
   const newTypeMap = newSchema.getTypeMap();
   const interfacesAddedToObjectTypes = [];
 
-  Object.keys(newTypeMap).forEach(typeName => {
+  for (const typeName of Object.keys(newTypeMap)) {
     const oldType = oldTypeMap[typeName];
     const newType = newTypeMap[typeName];
     if (!isObjectType(oldType) || !isObjectType(newType)) {
-      return;
+      continue;
     }
 
     const oldInterfaces = oldType.getInterfaces();
     const newInterfaces = newType.getInterfaces();
-    newInterfaces.forEach(newInterface => {
+    for (const newInterface of newInterfaces) {
       if (!oldInterfaces.some(int => int.name === newInterface.name)) {
         interfacesAddedToObjectTypes.push({
           type: DangerousChangeType.INTERFACE_ADDED_TO_OBJECT,
@@ -686,8 +686,8 @@ export function findInterfacesAddedToObjectTypes(
             `by ${typeName}.`,
         });
       }
-    });
-  });
+    }
+  }
   return interfacesAddedToObjectTypes;
 }
 
@@ -698,14 +698,14 @@ export function findRemovedDirectives(
   const removedDirectives = [];
 
   const newSchemaDirectiveMap = getDirectiveMapForSchema(newSchema);
-  oldSchema.getDirectives().forEach(directive => {
+  for (const directive of oldSchema.getDirectives()) {
     if (!newSchemaDirectiveMap[directive.name]) {
       removedDirectives.push({
         type: BreakingChangeType.DIRECTIVE_REMOVED,
         description: `${directive.name} was removed`,
       });
     }
-  });
+  }
 
   return removedDirectives;
 }
@@ -717,11 +717,11 @@ function findRemovedArgsForDirective(
   const removedArgs = [];
   const newArgMap = getArgumentMapForDirective(newDirective);
 
-  oldDirective.args.forEach(arg => {
+  for (const arg of oldDirective.args) {
     if (!newArgMap[arg.name]) {
       removedArgs.push(arg);
     }
-  });
+  }
 
   return removedArgs;
 }
@@ -733,19 +733,19 @@ export function findRemovedDirectiveArgs(
   const removedDirectiveArgs = [];
   const oldSchemaDirectiveMap = getDirectiveMapForSchema(oldSchema);
 
-  newSchema.getDirectives().forEach(newDirective => {
+  for (const newDirective of newSchema.getDirectives()) {
     const oldDirective = oldSchemaDirectiveMap[newDirective.name];
     if (!oldDirective) {
-      return;
+      continue;
     }
 
-    findRemovedArgsForDirective(oldDirective, newDirective).forEach(arg => {
+    for (const arg of findRemovedArgsForDirective(oldDirective, newDirective)) {
       removedDirectiveArgs.push({
         type: BreakingChangeType.DIRECTIVE_ARG_REMOVED,
         description: `${arg.name} was removed from ${newDirective.name}`,
       });
-    });
-  });
+    }
+  }
 
   return removedDirectiveArgs;
 }
@@ -757,11 +757,11 @@ function findAddedArgsForDirective(
   const addedArgs = [];
   const oldArgMap = getArgumentMapForDirective(oldDirective);
 
-  newDirective.args.forEach(arg => {
+  for (const arg of newDirective.args) {
     if (!oldArgMap[arg.name]) {
       addedArgs.push(arg);
     }
-  });
+  }
 
   return addedArgs;
 }
@@ -773,15 +773,15 @@ export function findAddedNonNullDirectiveArgs(
   const addedNonNullableArgs = [];
   const oldSchemaDirectiveMap = getDirectiveMapForSchema(oldSchema);
 
-  newSchema.getDirectives().forEach(newDirective => {
+  for (const newDirective of newSchema.getDirectives()) {
     const oldDirective = oldSchemaDirectiveMap[newDirective.name];
     if (!oldDirective) {
-      return;
+      continue;
     }
 
-    findAddedArgsForDirective(oldDirective, newDirective).forEach(arg => {
+    for (const arg of findAddedArgsForDirective(oldDirective, newDirective)) {
       if (!isNonNullType(arg.type)) {
-        return;
+        continue;
       }
 
       addedNonNullableArgs.push({
@@ -790,8 +790,8 @@ export function findAddedNonNullDirectiveArgs(
           `A non-null arg ${arg.name} on directive ` +
           `${newDirective.name} was added`,
       });
-    });
-  });
+    }
+  }
 
   return addedNonNullableArgs;
 }
@@ -803,11 +803,11 @@ export function findRemovedLocationsForDirective(
   const removedLocations = [];
   const newLocationSet = new Set(newDirective.locations);
 
-  oldDirective.locations.forEach(oldLocation => {
+  for (const oldLocation of oldDirective.locations) {
     if (!newLocationSet.has(oldLocation)) {
       removedLocations.push(oldLocation);
     }
-  });
+  }
 
   return removedLocations;
 }
@@ -819,21 +819,22 @@ export function findRemovedDirectiveLocations(
   const removedLocations = [];
   const oldSchemaDirectiveMap = getDirectiveMapForSchema(oldSchema);
 
-  newSchema.getDirectives().forEach(newDirective => {
+  for (const newDirective of newSchema.getDirectives()) {
     const oldDirective = oldSchemaDirectiveMap[newDirective.name];
     if (!oldDirective) {
-      return;
+      continue;
     }
 
-    findRemovedLocationsForDirective(oldDirective, newDirective).forEach(
-      location => {
-        removedLocations.push({
-          type: BreakingChangeType.DIRECTIVE_LOCATION_REMOVED,
-          description: `${location} was removed from ${newDirective.name}`,
-        });
-      },
-    );
-  });
+    for (const location of findRemovedLocationsForDirective(
+      oldDirective,
+      newDirective,
+    )) {
+      removedLocations.push({
+        type: BreakingChangeType.DIRECTIVE_LOCATION_REMOVED,
+        description: `${location} was removed from ${newDirective.name}`,
+      });
+    }
+  }
 
   return removedLocations;
 }

--- a/src/utilities/separateOperations.js
+++ b/src/utilities/separateOperations.js
@@ -50,7 +50,7 @@ export function separateOperations(
   // For each operation, produce a new synthesized AST which includes only what
   // is necessary for completing that operation.
   const separatedDocumentASTs = Object.create(null);
-  operations.forEach(operation => {
+  for (const operation of operations) {
     const operationName = opName(operation);
     const dependencies = Object.create(null);
     collectTransitiveDependencies(dependencies, depGraph, operationName);
@@ -58,9 +58,9 @@ export function separateOperations(
     // The list of definition nodes to be included for this operation, sorted
     // to retain the same order as the original document.
     const definitions = [operation];
-    Object.keys(dependencies).forEach(name => {
+    for (const name of Object.keys(dependencies)) {
       definitions.push(fragments[name]);
-    });
+    }
     definitions.sort(
       (n1, n2) => (positions.get(n1) || 0) - (positions.get(n2) || 0),
     );
@@ -69,7 +69,7 @@ export function separateOperations(
       kind: 'Document',
       definitions,
     };
-  });
+  }
 
   return separatedDocumentASTs;
 }
@@ -90,11 +90,11 @@ function collectTransitiveDependencies(
 ): void {
   const immediateDeps = depGraph[fromName];
   if (immediateDeps) {
-    Object.keys(immediateDeps).forEach(toName => {
+    for (const toName of Object.keys(immediateDeps)) {
       if (!collected[toName]) {
         collected[toName] = true;
         collectTransitiveDependencies(collected, depGraph, toName);
       }
-    });
+    }
   }
 }

--- a/src/validation/rules/ExecutableDefinitions.js
+++ b/src/validation/rules/ExecutableDefinitions.js
@@ -25,7 +25,7 @@ export function nonExecutableDefinitionMessage(defName: string): string {
 export function ExecutableDefinitions(context: ValidationContext): ASTVisitor {
   return {
     Document(node) {
-      node.definitions.forEach(definition => {
+      for (const definition of node.definitions) {
         if (
           definition.kind !== Kind.OPERATION_DEFINITION &&
           definition.kind !== Kind.FRAGMENT_DEFINITION
@@ -42,7 +42,7 @@ export function ExecutableDefinitions(context: ValidationContext): ASTVisitor {
             ),
           );
         }
-      });
+      }
       return false;
     },
   };

--- a/src/validation/rules/FieldsOnCorrectType.js
+++ b/src/validation/rules/FieldsOnCorrectType.js
@@ -97,21 +97,21 @@ function getSuggestedTypeNames(
   if (isAbstractType(type)) {
     const suggestedObjectTypes = [];
     const interfaceUsageCount = Object.create(null);
-    schema.getPossibleTypes(type).forEach(possibleType => {
+    for (const possibleType of schema.getPossibleTypes(type)) {
       if (!possibleType.getFields()[fieldName]) {
-        return;
+        continue;
       }
       // This object type defines this field.
       suggestedObjectTypes.push(possibleType.name);
-      possibleType.getInterfaces().forEach(possibleInterface => {
+      for (const possibleInterface of possibleType.getInterfaces()) {
         if (!possibleInterface.getFields()[fieldName]) {
-          return;
+          continue;
         }
         // This interface type defines this field.
         interfaceUsageCount[possibleInterface.name] =
           (interfaceUsageCount[possibleInterface.name] || 0) + 1;
-      });
-    });
+      }
+    }
 
     // Suggest interface types based on how common they are.
     const suggestedInterfaceTypes = Object.keys(interfaceUsageCount).sort(

--- a/src/validation/rules/NoUndefinedVariables.js
+++ b/src/validation/rules/NoUndefinedVariables.js
@@ -34,7 +34,7 @@ export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
       leave(operation) {
         const usages = context.getRecursiveVariableUsages(operation);
 
-        usages.forEach(({ node }) => {
+        for (const { node } of usages) {
           const varName = node.name.value;
           if (variableNameDefined[varName] !== true) {
             context.reportError(
@@ -47,7 +47,7 @@ export function NoUndefinedVariables(context: ValidationContext): ASTVisitor {
               ),
             );
           }
-        });
+        }
       },
     },
     VariableDefinition(node) {

--- a/src/validation/rules/NoUnusedFragments.js
+++ b/src/validation/rules/NoUnusedFragments.js
@@ -37,22 +37,22 @@ export function NoUnusedFragments(context: ValidationContext): ASTVisitor {
     Document: {
       leave() {
         const fragmentNameUsed = Object.create(null);
-        operationDefs.forEach(operation => {
-          context
-            .getRecursivelyReferencedFragments(operation)
-            .forEach(fragment => {
-              fragmentNameUsed[fragment.name.value] = true;
-            });
-        });
+        for (const operation of operationDefs) {
+          for (const fragment of context.getRecursivelyReferencedFragments(
+            operation,
+          )) {
+            fragmentNameUsed[fragment.name.value] = true;
+          }
+        }
 
-        fragmentDefs.forEach(fragmentDef => {
+        for (const fragmentDef of fragmentDefs) {
           const fragName = fragmentDef.name.value;
           if (fragmentNameUsed[fragName] !== true) {
             context.reportError(
               new GraphQLError(unusedFragMessage(fragName), [fragmentDef]),
             );
           }
-        });
+        }
       },
     },
   };

--- a/src/validation/rules/NoUnusedVariables.js
+++ b/src/validation/rules/NoUnusedVariables.js
@@ -39,11 +39,11 @@ export function NoUnusedVariables(context: ValidationContext): ASTVisitor {
         const usages = context.getRecursiveVariableUsages(operation);
         const opName = operation.name ? operation.name.value : null;
 
-        usages.forEach(({ node }) => {
+        for (const { node } of usages) {
           variableNameUsed[node.name.value] = true;
-        });
+        }
 
-        variableDefs.forEach(variableDef => {
+        for (const variableDef of variableDefs) {
           const variableName = variableDef.variable.name.value;
           if (variableNameUsed[variableName] !== true) {
             context.reportError(
@@ -52,7 +52,7 @@ export function NoUnusedVariables(context: ValidationContext): ASTVisitor {
               ]),
             );
           }
-        });
+        }
       },
     },
     VariableDefinition(def) {

--- a/src/validation/rules/OverlappingFieldsCanBeMerged.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMerged.js
@@ -91,14 +91,14 @@ export function OverlappingFieldsCanBeMerged(
         context.getParentType(),
         selectionSet,
       );
-      conflicts.forEach(([[responseName, reason], fields1, fields2]) =>
+      for (const [[responseName, reason], fields1, fields2] of conflicts) {
         context.reportError(
           new GraphQLError(
             fieldsConflictMessage(responseName, reason),
             fields1.concat(fields2),
           ),
-        ),
-      );
+        );
+      }
     },
   };
 }
@@ -486,7 +486,7 @@ function collectConflictsWithin(
   // name and the value at that key is a list of all fields which provide that
   // response name. For every response name, if there are multiple fields, they
   // must be compared to find a potential conflict.
-  Object.keys(fieldMap).forEach(responseName => {
+  for (const responseName of Object.keys(fieldMap)) {
     const fields = fieldMap[responseName];
     // This compares every field in the list to every other field in this list
     // (except to itself). If the list only has one item, nothing needs to
@@ -509,7 +509,7 @@ function collectConflictsWithin(
         }
       }
     }
-  });
+  }
 }
 
 // Collect all Conflicts between two collections of fields. This is similar to,
@@ -531,7 +531,7 @@ function collectConflictsBetween(
   // response name. For any response name which appears in both provided field
   // maps, each field from the first field map must be compared to every field
   // in the second field map to find potential conflicts.
-  Object.keys(fieldMap1).forEach(responseName => {
+  for (const responseName of Object.keys(fieldMap1)) {
     const fields2 = fieldMap2[responseName];
     if (fields2) {
       const fields1 = fieldMap1[responseName];
@@ -552,7 +552,7 @@ function collectConflictsBetween(
         }
       }
     }
-  });
+  }
 }
 
 // Determines if there is a conflict between two particular fields, including

--- a/src/validation/rules/ProvidedRequiredArguments.js
+++ b/src/validation/rules/ProvidedRequiredArguments.js
@@ -56,7 +56,7 @@ export function ProvidedRequiredArguments(
         const argNodes = node.arguments || [];
 
         const argNodeMap = keyMap(argNodes, arg => arg.name.value);
-        fieldDef.args.forEach(argDef => {
+        for (const argDef of fieldDef.args) {
           const argNode = argNodeMap[argDef.name];
           if (
             !argNode &&
@@ -74,7 +74,7 @@ export function ProvidedRequiredArguments(
               ),
             );
           }
-        });
+        }
       },
     },
 
@@ -88,7 +88,7 @@ export function ProvidedRequiredArguments(
         const argNodes = node.arguments || [];
 
         const argNodeMap = keyMap(argNodes, arg => arg.name.value);
-        directiveDef.args.forEach(argDef => {
+        for (const argDef of directiveDef.args) {
           const argNode = argNodeMap[argDef.name];
           if (
             !argNode &&
@@ -106,7 +106,7 @@ export function ProvidedRequiredArguments(
               ),
             );
           }
-        });
+        }
       },
     },
   };

--- a/src/validation/rules/UniqueDirectivesPerLocation.js
+++ b/src/validation/rules/UniqueDirectivesPerLocation.js
@@ -38,7 +38,7 @@ export function UniqueDirectivesPerLocation(
       const directives: ?$ReadOnlyArray<DirectiveNode> = (node: any).directives;
       if (directives) {
         const knownDirectives = Object.create(null);
-        directives.forEach(directive => {
+        for (const directive of directives) {
           const directiveName = directive.name.value;
           if (knownDirectives[directiveName]) {
             context.reportError(
@@ -50,7 +50,7 @@ export function UniqueDirectivesPerLocation(
           } else {
             knownDirectives[directiveName] = directive;
           }
-        });
+        }
       }
     },
   };

--- a/src/validation/rules/ValuesOfCorrectType.js
+++ b/src/validation/rules/ValuesOfCorrectType.js
@@ -95,7 +95,7 @@ export function ValuesOfCorrectType(context: ValidationContext): ASTVisitor {
       // Ensure every required field exists.
       const inputFields = type.getFields();
       const fieldNodeMap = keyMap(node.fields, field => field.name.value);
-      Object.keys(inputFields).forEach(fieldName => {
+      for (const fieldName of Object.keys(inputFields)) {
         const fieldDef = inputFields[fieldName];
         const fieldType = fieldDef.type;
         const fieldNode = fieldNodeMap[fieldName];
@@ -111,7 +111,7 @@ export function ValuesOfCorrectType(context: ValidationContext): ASTVisitor {
             ),
           );
         }
-      });
+      }
     },
     ObjectField(node) {
       const parentType = getNamedType(context.getParentInputType());

--- a/src/validation/rules/VariablesInAllowedPosition.js
+++ b/src/validation/rules/VariablesInAllowedPosition.js
@@ -46,7 +46,7 @@ export function VariablesInAllowedPosition(
       leave(operation) {
         const usages = context.getRecursiveVariableUsages(operation);
 
-        usages.forEach(({ node, type, defaultValue }) => {
+        for (const { node, type, defaultValue } of usages) {
           const varName = node.name.value;
           const varDef = varDefMap[varName];
           if (varDef && type) {
@@ -75,7 +75,7 @@ export function VariablesInAllowedPosition(
               );
             }
           }
-        });
+        }
       },
     },
     VariableDefinition(node) {


### PR DESCRIPTION
> Is there a concrete reason to make this change? .forEach is how most things are done in this library, and I'd prefer to maintain consistency.

@mjmahone `for of` is 4x faster than `forEach` + arrow function: https://jsperf.com/for-of-vs-foreach5
If we enable `loose` mode for `for of` than it will be 12x speedup.
Also, `for of` don't force us to create closures so it should lower memory usage in recursive functions.

But more importantly, the main purpose of this library is to be the reference implementation of GraphQL so code readability is very important.