### PR TITLE
Prevent infinite recursion on invalid unions

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -356,6 +356,18 @@ describe('Schema Builder', () => {
     expect(output).to.equal(body);
   });
 
+  it('Can build recursive Union', () => {
+    const schema = buildSchema(dedent`
+      union Hello = Hello
+
+      type Query {
+        hello: Hello
+      }
+    `);
+    const errors = validateSchema(schema);
+    expect(errors.length).to.be.above(0);
+  });
+
   it('Specifying Union type using __typename', () => {
     const schema = buildSchema(dedent`
       type Query {

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -280,6 +280,19 @@ describe('extendSchema', () => {
     expect(unionField.type).to.equal(someUnionType);
   });
 
+  it('allows extension of union by adding itself', () => {
+    const extendedSchema = extendTestSchema(`
+      extend union SomeUnion = SomeUnion
+    `);
+
+    const errors = validateSchema(extendedSchema);
+    expect(errors.length).to.be.above(0);
+
+    expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
+      union SomeUnion = Foo | Biz | SomeUnion
+    `);
+  });
+
   it('extends inputs by adding new fields', () => {
     const extendedSchema = extendTestSchema(`
       extend input SomeInput {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -299,9 +299,6 @@ export function extendSchema(
         extendTypeCache[name] = extendEnumType(type);
       } else if (isInputObjectType(type)) {
         extendTypeCache[name] = extendInputObjectType(type);
-      } else {
-        // This type is not yet extendable.
-        extendTypeCache[name] = type;
       }
     }
     return (extendTypeCache[name]: any);

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -243,7 +243,7 @@ export function extendSchema(
     // that any type not directly referenced by a field will get created.
     ...objectValues(schema.getTypeMap()).map(type => extendNamedType(type)),
     // Do the same with new types.
-    ...astBuilder.buildTypes(objectValues(typeDefinitionMap)),
+    ...objectValues(typeDefinitionMap).map(type => astBuilder.buildType(type)),
   ];
 
   // Support both original legacy names and extended legacy names.


### PR DESCRIPTION
Even though recursive unions are invalid they trigger infinite recursion during buildSchema/extendSchema.
\+ small refactoring