### PR TITLE
Add missing 'type' prefixes to imports

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -46,7 +46,7 @@ import type {
   ResponsePath,
   GraphQLList,
 } from '../type/definition';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import {
   SchemaMetaFieldDef,
   TypeMetaFieldDef,

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -22,7 +22,7 @@ import {
   resolveFieldValueOrError,
   responsePathAsArray,
 } from '../execution/execute';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import mapAsyncIterator from './mapAsyncIterator';
 
 import type { ObjMap } from '../jsutils/ObjMap';

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -26,8 +26,8 @@ import type {
   GraphQLArgument,
 } from '../type/definition';
 
-import { GraphQLDirective } from '../type/directives';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLDirective } from '../type/directives';
+import type { GraphQLSchema } from '../type/schema';
 import keyMap from '../jsutils/keyMap';
 
 import type { ObjMap } from '../jsutils/ObjMap';

--- a/src/utilities/findDeprecatedUsages.js
+++ b/src/utilities/findDeprecatedUsages.js
@@ -11,7 +11,7 @@ import { GraphQLError } from '../error/GraphQLError';
 import { visit, visitWithTypeInfo } from '../language/visitor';
 import type { DocumentNode } from '../language/ast';
 import { getNamedType } from '../type/definition';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import { TypeInfo } from './TypeInfo';
 
 /**

--- a/src/utilities/getOperationRootType.js
+++ b/src/utilities/getOperationRootType.js
@@ -12,7 +12,7 @@ import type {
   OperationDefinitionNode,
   OperationTypeDefinitionNode,
 } from '../language/ast';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLObjectType } from '../type/definition';
 
 /**

--- a/src/utilities/introspectionFromSchema.js
+++ b/src/utilities/introspectionFromSchema.js
@@ -9,7 +9,7 @@
 
 import invariant from '../jsutils/invariant';
 import { getIntrospectionQuery } from './introspectionQuery';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import { execute } from '../execution/execute';
 import { parse } from '../language/parser';
 import type {

--- a/src/validation/ValidationContext.js
+++ b/src/validation/ValidationContext.js
@@ -8,7 +8,7 @@
  */
 
 import type { ObjMap } from '../jsutils/ObjMap';
-import { GraphQLError } from '../error';
+import type { GraphQLError } from '../error';
 import { visit, visitWithTypeInfo } from '../language/visitor';
 import { Kind } from '../language/kinds';
 import type {
@@ -19,7 +19,7 @@ import type {
   FragmentSpreadNode,
   FragmentDefinitionNode,
 } from '../language/ast';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import type {
   GraphQLInputType,
   GraphQLOutputType,

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -8,11 +8,11 @@
  */
 
 import invariant from '../jsutils/invariant';
-import { GraphQLError } from '../error';
+import type { GraphQLError } from '../error';
 import { visit, visitInParallel, visitWithTypeInfo } from '../language/visitor';
 import type { DocumentNode } from '../language/ast';
 import type { ASTVisitor } from '../language/visitor';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
 import { assertValidSchema } from '../type/validate';
 import { TypeInfo } from '../utilities/TypeInfo';
 import { specifiedRules } from './specifiedRules';


### PR DESCRIPTION
Missing `type` prefix results in unused imports in generated code, e.g.:
https://github.com/graphql/graphql-js/blob/6ca4079f8cddc97365ea9f4b002ed79ff5bc97f6/validation/validate.mjs#L12