### PR TITLE
Allows to add schema definition missing in the original schema

### DIFF
--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -93,6 +93,26 @@ const SomeInputType = new GraphQLInputObjectType({
   }),
 });
 
+const FooDirective = new GraphQLDirective({
+  name: 'foo',
+  args: {
+    input: { type: SomeInputType },
+  },
+  locations: [
+    DirectiveLocation.SCHEMA,
+    DirectiveLocation.SCALAR,
+    DirectiveLocation.OBJECT,
+    DirectiveLocation.FIELD_DEFINITION,
+    DirectiveLocation.ARGUMENT_DEFINITION,
+    DirectiveLocation.INTERFACE,
+    DirectiveLocation.UNION,
+    DirectiveLocation.ENUM,
+    DirectiveLocation.ENUM_VALUE,
+    DirectiveLocation.INPUT_OBJECT,
+    DirectiveLocation.INPUT_FIELD_DEFINITION,
+  ],
+});
+
 const testSchema = new GraphQLSchema({
   query: new GraphQLObjectType({
     name: 'Query',
@@ -112,27 +132,7 @@ const testSchema = new GraphQLSchema({
     }),
   }),
   types: [FooType, BarType],
-  directives: specifiedDirectives.concat([
-    new GraphQLDirective({
-      name: 'foo',
-      args: {
-        input: { type: SomeInputType },
-      },
-      locations: [
-        DirectiveLocation.SCHEMA,
-        DirectiveLocation.SCALAR,
-        DirectiveLocation.OBJECT,
-        DirectiveLocation.FIELD_DEFINITION,
-        DirectiveLocation.ARGUMENT_DEFINITION,
-        DirectiveLocation.INTERFACE,
-        DirectiveLocation.UNION,
-        DirectiveLocation.ENUM,
-        DirectiveLocation.ENUM_VALUE,
-        DirectiveLocation.INPUT_OBJECT,
-        DirectiveLocation.INPUT_FIELD_DEFINITION,
-      ],
-    }),
-  ]),
+  directives: specifiedDirectives.concat([FooDirective]),
 });
 
 function extendTestSchema(sdl, options) {
@@ -1288,22 +1288,14 @@ describe('extendSchema', () => {
 
     it('adds schema definition missing in the original schema', () => {
       let schema = new GraphQLSchema({
-        directives: [
-          new GraphQLDirective({
-            name: 'onSchema',
-            locations: ['SCHEMA'],
-          }),
-        ],
+        directives: [FooDirective],
+        types: [FooType],
       });
       expect(schema.getQueryType()).to.equal(undefined);
 
       const ast = parse(`
-        schema @onSchema {
+        schema @foo {
           query: Foo
-        }
-
-        type Foo {
-          bar: String
         }
       `);
       schema = extendSchema(schema, ast);


### PR DESCRIPTION
Split out from #1438

Allows to inject directives and types into SDL-based schema:

```js
import { GrapQLDateTime } from 'somepackage';
let schema = new GraphQLSchema({
  types: [GrapQLDateTime],
});

const ast = parse(`
  type Query {
    timestamp: DateTime
  }
`);
schema = extendSchema(schema, ast);
```

```js
let schema = new GraphQLSchema({
  directives: [
    new GraphQLDirective({
      name: 'onSchema',
      locations: ['SCHEMA'],
    }),
  ],
});

const ast = parse(`
  schema @onSchema {
    query: Foo
  }
  type Foo {
    bar: String
  }
`);
schema = extendSchema(schema, ast);
```
