### PR TITLE
Drop Node 9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 # https://github.com/nodejs/Release
 node_js:
   - '10'
-  - '9'
   - '8'
   - '6'
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mocha": "--check-leaks --full-trace --timeout 15000 src/**/__tests__/**/*-test.js"
   },
   "engines": {
-    "node": "6.x || 8.x || 9.x || >= 10.x"
+    "node": "6.x || 8.x || >= 10.x"
   },
   "scripts": {
     "watch": "babel-node ./resources/watch.js",


### PR DESCRIPTION
See: https://github.com/nodejs/Release#end-of-life-releases