### PR TITLE
VariableDefinition Directives: hide behind experimental flag

### DIFF
--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -108,7 +108,9 @@ describe('Parser', () => {
 
   it('parses variable definition directives', () => {
     expect(() =>
-      parse('query Foo($x: Boolean = false @bar) { field }'),
+      parse('query Foo($x: Boolean = false @bar) { field }', {
+        experimentalVariableDefinitionDirectives: true,
+      }),
     ).to.not.throw();
   });
 

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -56,6 +56,7 @@ describe('Printer: Query document', () => {
 
     const queryAstWithArtifacts = parse(
       'query ($foo: TestType) @testDirective { id, name }',
+      { experimentalVariableDefinitionDirectives: true },
     );
     expect(print(queryAstWithArtifacts)).to.equal(dedent`
       query ($foo: TestType) @testDirective {
@@ -66,6 +67,7 @@ describe('Printer: Query document', () => {
 
     const queryAstWithVariableDirective = parse(
       'query ($foo: TestType = {a: 123} @testDirective(if: true) @test) { id }',
+      { experimentalVariableDefinitionDirectives: true },
     );
     expect(print(queryAstWithVariableDirective)).to.equal(dedent`
       query ($foo: TestType = {a: 123} @testDirective(if: true) @test) {

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -115,6 +115,17 @@ export type ParseOptions = {
    * future.
    */
   experimentalFragmentVariables?: boolean,
+
+  /**
+   * EXPERIMENTAL:
+   *
+   * If enabled, the parser understands directives on variable definitions:
+   *
+   * query Foo($var: String = "abc" @variable_definition_directive) {
+   *   ...
+   * }
+   */
+  experimentalVariableDefinitionDirectives?: boolean,
 };
 
 /**
@@ -336,6 +347,19 @@ function parseVariableDefinitions(
  */
 function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
   const start = lexer.token;
+  if (lexer.options.experimentalVariableDefinitionDirectives) {
+    return {
+      kind: Kind.VARIABLE_DEFINITION,
+      variable: parseVariable(lexer),
+      type: (expect(lexer, TokenKind.COLON), parseTypeReference(lexer)),
+      defaultValue: skip(lexer, TokenKind.EQUALS)
+        ? parseValueLiteral(lexer, true)
+        : undefined,
+      directives: parseDirectives(lexer, true),
+      loc: loc(lexer, start),
+    };
+  }
+
   return {
     kind: Kind.VARIABLE_DEFINITION,
     variable: parseVariable(lexer),
@@ -343,7 +367,6 @@ function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
     defaultValue: skip(lexer, TokenKind.EQUALS)
       ? parseValueLiteral(lexer, true)
       : undefined,
-    directives: parseDirectives(lexer, true),
     loc: loc(lexer, start),
   };
 }


### PR DESCRIPTION
Putting this behind an experimental flag, as @leebyron has reverted the GraphQL spec changes from https://github.com/facebook/graphql/pull/486. This can now go through normal RFC process to make it into the spec.