### PR TITLE
Extend kitchen-sink examples

### DIFF
--- a/src/language/__tests__/kitchen-sink.graphql
+++ b/src/language/__tests__/kitchen-sink.graphql
@@ -3,15 +3,15 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-query queryName($foo: ComplexType, $site: Site = MOBILE) {
+query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
   whoever123is: node(id: [123, 456]) {
     id ,
-    ... on User @defer {
+    ... on User @onInlineFragment {
       field2 {
         id ,
         alias: field1(first:10, after:$foo,) @include(if: $foo) {
           id,
-          ...frag
+          ...frag @onFragmentSpread
         }
       }
     }
@@ -24,15 +24,17 @@ query queryName($foo: ComplexType, $site: Site = MOBILE) {
   }
 }
 
-mutation likeStory {
-  like(story: 123) @defer {
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
     story {
-      id
+      id @onField
     }
   }
 }
 
-subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+subscription StoryLikeSubscription(
+  $input: StoryLikeSubscribeInput
+) @onSubscription {
   storyLikeSubscribe(input: $input) {
     story {
       likers {
@@ -45,7 +47,7 @@ subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
   }
 }
 
-fragment frag on Friend {
+fragment frag on Friend @onFragmentDefinition {
   foo(size: $size, bar: $b, obj: {key: "value", block: """
 
       block string uses \"""
@@ -57,3 +59,5 @@ fragment frag on Friend {
   unnamed(truthy: true, falsey: false, nullish: null),
   query
 }
+
+query { __typename }

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -156,15 +156,15 @@ describe('Printer: Query document', () => {
 
     expect(printed).to.equal(
       dedent(String.raw`
-      query queryName($foo: ComplexType, $site: Site = MOBILE) {
+      query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
         whoever123is: node(id: [123, 456]) {
           id
-          ... on User @defer {
+          ... on User @onInlineFragment {
             field2 {
               id
               alias: field1(first: 10, after: $foo) @include(if: $foo) {
                 id
-                ...frag
+                ...frag @onFragmentSpread
               }
             }
           }
@@ -177,15 +177,15 @@ describe('Printer: Query document', () => {
         }
       }
 
-      mutation likeStory {
-        like(story: 123) @defer {
+      mutation likeStory @onMutation {
+        like(story: 123) @onField {
           story {
-            id
+            id @onField
           }
         }
       }
 
-      subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+      subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) @onSubscription {
         storyLikeSubscribe(input: $input) {
           story {
             likers {
@@ -198,7 +198,7 @@ describe('Printer: Query document', () => {
         }
       }
 
-      fragment frag on Friend {
+      fragment frag on Friend @onFragmentDefinition {
         foo(size: $size, bar: $b, obj: {key: "value", block: """
           block string uses \"""
         """})
@@ -207,6 +207,10 @@ describe('Printer: Query document', () => {
       {
         unnamed(truthy: true, falsey: false, nullish: null)
         query
+      }
+
+      {
+        __typename
       }
     `),
     );

--- a/src/language/__tests__/schema-kitchen-sink.graphql
+++ b/src/language/__tests__/schema-kitchen-sink.graphql
@@ -13,6 +13,7 @@ This is a description
 of the `Foo` type.
 """
 type Foo implements Bar & Baz {
+  "Description of the `one` field."
   one: Type
   """
   This is a description of the `two` field.
@@ -23,6 +24,7 @@ type Foo implements Bar & Baz {
     """
     argument: InputType!
   ): Type
+  """This is a description of the `three` field."""
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
@@ -31,7 +33,7 @@ type Foo implements Bar & Baz {
 }
 
 type AnnotatedObject @onObject(arg: "value") {
-  annotatedField(arg: Type = "default" @onArg): Type @onField
+  annotatedField(arg: Type = "default" @onArgumentDefinition): Type @onField
 }
 
 type UndefinedType
@@ -48,7 +50,7 @@ interface Bar {
 }
 
 interface AnnotatedInterface @onInterface {
-  annotatedField(arg: Type @onArg): Type @onField
+  annotatedField(arg: Type @onArgumentDefinition): Type @onField
 }
 
 interface UndefinedInterface
@@ -59,7 +61,10 @@ extend interface Bar {
 
 extend interface Bar @onInterface
 
-union Feed = Story | Article | Advert
+union Feed =
+  | Story
+  | Article
+  | Advert
 
 union AnnotatedUnion @onUnion = A | B
 
@@ -78,8 +83,16 @@ scalar AnnotatedScalar @onScalar
 extend scalar CustomScalar @onScalar
 
 enum Site {
+  """
+  This is a description of the `DESKTOP` value
+  """
   DESKTOP
+
+  """This is a description of the `MOBILE` value"""
   MOBILE
+
+  "This is a description of the `WEB` value"
+  WEB
 }
 
 enum AnnotatedEnum @onEnum {
@@ -101,18 +114,23 @@ input InputType {
 }
 
 input AnnotatedInput @onInputObject {
-  annotatedField: Type @onField
+  annotatedField: Type @onInputFieldDefinition
 }
 
 input UndefinedInput
 
 extend input InputType {
-  other: Float = 1.23e4
+  other: Float = 1.23e4 @onInputFieldDefinition
 }
 
 extend input InputType @onInputObject
 
-directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+This is a description of the `@skip` directive
+"""
+directive @skip(
+  if: Boolean! @onArgumentDefinition
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!)
   on FIELD

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -57,6 +57,7 @@ describe('Printer: SDL document', () => {
       of the \`Foo\` type.
       """
       type Foo implements Bar & Baz {
+        "Description of the \`one\` field."
         one: Type
         """
         This is a description of the \`two\` field.
@@ -67,6 +68,9 @@ describe('Printer: SDL document', () => {
           """
           argument: InputType!
         ): Type
+        """
+        This is a description of the \`three\` field.
+        """
         three(argument: InputType, other: String): Int
         four(argument: String = "string"): String
         five(argument: [String] = ["string", "string"]): String
@@ -75,7 +79,7 @@ describe('Printer: SDL document', () => {
       }
 
       type AnnotatedObject @onObject(arg: "value") {
-        annotatedField(arg: Type = "default" @onArg): Type @onField
+        annotatedField(arg: Type = "default" @onArgumentDefinition): Type @onField
       }
 
       type UndefinedType
@@ -92,7 +96,7 @@ describe('Printer: SDL document', () => {
       }
 
       interface AnnotatedInterface @onInterface {
-        annotatedField(arg: Type @onArg): Type @onField
+        annotatedField(arg: Type @onArgumentDefinition): Type @onField
       }
 
       interface UndefinedInterface
@@ -122,8 +126,16 @@ describe('Printer: SDL document', () => {
       extend scalar CustomScalar @onScalar
 
       enum Site {
+        """
+        This is a description of the \`DESKTOP\` value
+        """
         DESKTOP
+        """
+        This is a description of the \`MOBILE\` value
+        """
         MOBILE
+        "This is a description of the \`WEB\` value"
+        WEB
       }
 
       enum AnnotatedEnum @onEnum {
@@ -145,18 +157,21 @@ describe('Printer: SDL document', () => {
       }
 
       input AnnotatedInput @onInputObject {
-        annotatedField: Type @onField
+        annotatedField: Type @onInputFieldDefinition
       }
 
       input UndefinedInput
 
       extend input InputType {
-        other: Float = 1.23e4
+        other: Float = 1.23e4 @onInputFieldDefinition
       }
 
       extend input InputType @onInputObject
 
-      directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+      """
+      This is a description of the \`@skip\` directive
+      """
+      directive @skip(if: Boolean! @onArgumentDefinition) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
       directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -461,11 +461,10 @@ describe('Visitor', () => {
     ]);
   });
 
-  const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
-    encoding: 'utf8',
-  });
-
   it('visits kitchen sink', () => {
+    const kitchenSink = readFileSync(join(__dirname, '/kitchen-sink.graphql'), {
+      encoding: 'utf8',
+    });
     const ast = parse(kitchenSink);
 
     const visited = [];
@@ -509,6 +508,10 @@ describe('Visitor', () => {
       ['enter', 'EnumValue', 'defaultValue', 'VariableDefinition'],
       ['leave', 'EnumValue', 'defaultValue', 'VariableDefinition'],
       ['leave', 'VariableDefinition', 1, undefined],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
       ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
       ['enter', 'Field', 0, undefined],
       ['enter', 'Name', 'alias', 'Field'],
@@ -587,6 +590,10 @@ describe('Visitor', () => {
       ['enter', 'FragmentSpread', 1, undefined],
       ['enter', 'Name', 'name', 'FragmentSpread'],
       ['leave', 'Name', 'name', 'FragmentSpread'],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
       ['leave', 'FragmentSpread', 1, undefined],
       ['leave', 'SelectionSet', 'selectionSet', 'Field'],
       ['leave', 'Field', 1, undefined],
@@ -629,6 +636,10 @@ describe('Visitor', () => {
       ['enter', 'OperationDefinition', 1, undefined],
       ['enter', 'Name', 'name', 'OperationDefinition'],
       ['leave', 'Name', 'name', 'OperationDefinition'],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
       ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
       ['enter', 'Field', 0, undefined],
       ['enter', 'Name', 'name', 'Field'],
@@ -651,6 +662,10 @@ describe('Visitor', () => {
       ['enter', 'Field', 0, undefined],
       ['enter', 'Name', 'name', 'Field'],
       ['leave', 'Name', 'name', 'Field'],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
       ['leave', 'Field', 0, undefined],
       ['leave', 'SelectionSet', 'selectionSet', 'Field'],
       ['leave', 'Field', 0, undefined],
@@ -671,6 +686,10 @@ describe('Visitor', () => {
       ['leave', 'Name', 'name', 'NamedType'],
       ['leave', 'NamedType', 'type', 'VariableDefinition'],
       ['leave', 'VariableDefinition', 0, undefined],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
       ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
       ['enter', 'Field', 0, undefined],
       ['enter', 'Name', 'name', 'Field'],
@@ -721,6 +740,10 @@ describe('Visitor', () => {
       ['enter', 'Name', 'name', 'NamedType'],
       ['leave', 'Name', 'name', 'NamedType'],
       ['leave', 'NamedType', 'typeCondition', 'FragmentDefinition'],
+      ['enter', 'Directive', 0, undefined],
+      ['enter', 'Name', 'name', 'Directive'],
+      ['leave', 'Name', 'name', 'Directive'],
+      ['leave', 'Directive', 0, undefined],
       ['enter', 'SelectionSet', 'selectionSet', 'FragmentDefinition'],
       ['enter', 'Field', 0, undefined],
       ['enter', 'Name', 'name', 'Field'],
@@ -792,6 +815,14 @@ describe('Visitor', () => {
       ['leave', 'Field', 1, undefined],
       ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
       ['leave', 'OperationDefinition', 4, undefined],
+      ['enter', 'OperationDefinition', 5, undefined],
+      ['enter', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['enter', 'Field', 0, undefined],
+      ['enter', 'Name', 'name', 'Field'],
+      ['leave', 'Name', 'name', 'Field'],
+      ['leave', 'Field', 0, undefined],
+      ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
+      ['leave', 'OperationDefinition', 5, undefined],
       ['leave', 'Document', undefined, undefined],
     ]);
   });


### PR DESCRIPTION
I was wondering if there is any place beyond definitions of query variables where directives would be useful and wanted to use kitchen sink as a playground.

But currently, it lacks a lot of language features so I updated it.
