### PR TITLE
Fixup: add Experimental note to variable-directive tests

### DIFF
--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -106,7 +106,7 @@ describe('Parser', () => {
     );
   });
 
-  it('parses variable definition directives', () => {
+  it('Experimental: parses variable definition directives', () => {
     expect(() =>
       parse('query Foo($x: Boolean = false @bar) { field }', {
         experimentalVariableDefinitionDirectives: true,

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -56,22 +56,11 @@ describe('Printer: Query document', () => {
 
     const queryAstWithArtifacts = parse(
       'query ($foo: TestType) @testDirective { id, name }',
-      { experimentalVariableDefinitionDirectives: true },
     );
     expect(print(queryAstWithArtifacts)).to.equal(dedent`
       query ($foo: TestType) @testDirective {
         id
         name
-      }
-    `);
-
-    const queryAstWithVariableDirective = parse(
-      'query ($foo: TestType = {a: 123} @testDirective(if: true) @test) { id }',
-      { experimentalVariableDefinitionDirectives: true },
-    );
-    expect(print(queryAstWithVariableDirective)).to.equal(dedent`
-      query ($foo: TestType = {a: 123} @testDirective(if: true) @test) {
-        id
       }
     `);
 
@@ -82,6 +71,33 @@ describe('Printer: Query document', () => {
       mutation ($foo: TestType) @testDirective {
         id
         name
+      }
+    `);
+  });
+
+  it('Experimental: prints query with variable directives', () => {
+    const queryAstWithVariableDirective = parse(
+      'query ($foo: TestType = {a: 123} @testDirective(if: true) @test) { id }',
+      { experimentalVariableDefinitionDirectives: true },
+    );
+    expect(print(queryAstWithVariableDirective)).to.equal(dedent`
+      query ($foo: TestType = {a: 123} @testDirective(if: true) @test) {
+        id
+      }
+    `);
+  });
+
+  it('Experimental: prints fragment with variable directives', () => {
+    const queryAstWithVariableDirective = parse(
+      'fragment Foo($foo: TestType @test) on TestType @testDirective { id }',
+      {
+        experimentalFragmentVariables: true,
+        experimentalVariableDefinitionDirectives: true,
+      },
+    );
+    expect(print(queryAstWithVariableDirective)).to.equal(dedent`
+      fragment Foo($foo: TestType @test) on TestType @testDirective {
+        id
       }
     `);
   });

--- a/src/validation/__tests__/KnownDirectives-test.js
+++ b/src/validation/__tests__/KnownDirectives-test.js
@@ -5,16 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { parse } from '../../language';
 import { buildSchema } from '../../utilities';
-import { validate } from '../validate';
 import {
   expectPassesRule,
   expectFailsRule,
   expectSDLErrorsFromRule,
-  testSchema,
 } from './harness';
 
 import {
@@ -145,19 +141,16 @@ describe('Validate: Known directives', () => {
     );
   });
 
-  it('with well placed variable definition directive', () => {
-    // Need to parse with experimental flag
-    const queryString = `
+  it('Experimental: with well placed variable definition directive', () => {
+    expectPassesRule(
+      KnownDirectives,
+      `
       query Foo($var: Boolean @onVariableDefinition) {
         name
       }
-    `;
-    const errors = validate(
-      testSchema,
-      parse(queryString, { experimentalVariableDefinitionDirectives: true }),
-      [KnownDirectives],
+      `,
+      { experimentalVariableDefinitionDirectives: true },
     );
-    expect(errors).to.deep.equal([], 'Should validate');
   });
 
   it('with misplaced directives', () => {
@@ -182,23 +175,17 @@ describe('Validate: Known directives', () => {
     );
   });
 
-  it('with misplaced variable definition directive', () => {
-    // Need to parse with experimental flag
-    const queryString = `
+  it('Experimental: with misplaced variable definition directive', () => {
+    expectFailsRule(
+      KnownDirectives,
+      `
       query Foo($var: Boolean @onField) {
         name
       }
-    `;
-    const errors = validate(
-      testSchema,
-      parse(queryString, { experimentalVariableDefinitionDirectives: true }),
-      [KnownDirectives],
+      `,
+      [misplacedDirective('onField', 'VARIABLE_DEFINITION', 2, 31)],
+      { experimentalVariableDefinitionDirectives: true },
     );
-    const expectedErrors = [
-      misplacedDirective('onField', 'VARIABLE_DEFINITION', 2, 31),
-    ];
-    expect(errors).to.have.length.of.at.least(1, 'Should not validate');
-    expect(errors).to.deep.equal(expectedErrors);
   });
 
   describe('within SDL', () => {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -381,24 +381,30 @@ export const testSchema = new GraphQLSchema({
   ],
 });
 
-function expectValid(schema, rule, queryString) {
-  const errors = validate(schema, parse(queryString), [rule]);
+function expectValid(schema, rule, queryString, options = {}) {
+  const errors = validate(schema, parse(queryString, options), [rule]);
   expect(errors).to.deep.equal([], 'Should validate');
 }
 
-function expectInvalid(schema, rule, queryString, expectedErrors) {
-  const errors = validate(schema, parse(queryString), [rule]);
+function expectInvalid(
+  schema,
+  rule,
+  queryString,
+  expectedErrors,
+  options = {},
+) {
+  const errors = validate(schema, parse(queryString, options), [rule]);
   expect(errors).to.have.length.of.at.least(1, 'Should not validate');
   expect(errors).to.deep.equal(expectedErrors);
   return errors;
 }
 
-export function expectPassesRule(rule, queryString) {
-  return expectValid(testSchema, rule, queryString);
+export function expectPassesRule(rule, queryString, options = {}) {
+  return expectValid(testSchema, rule, queryString, options);
 }
 
-export function expectFailsRule(rule, queryString, errors) {
-  return expectInvalid(testSchema, rule, queryString, errors);
+export function expectFailsRule(rule, queryString, errors, options = {}) {
+  return expectInvalid(testSchema, rule, queryString, errors, options);
 }
 
 export function expectPassesRuleWithSchema(schema, rule, queryString) {


### PR DESCRIPTION
Added a parsing option to the test harness `expectPassesRule` and `expectFailsRule` functions.

Also added experimental flags on all tests with variable definition directives.