### PR TITLE
Add Node Predicates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -189,6 +189,16 @@ export {
   TokenKind,
   DirectiveLocation,
   BREAK,
+  // Predicates
+  isDefinitionNode,
+  isExecutableDefinitionNode,
+  isSelectionNode,
+  isValueNode,
+  isTypeNode,
+  isTypeSystemDefinitionNode,
+  isTypeDefinitionNode,
+  isTypeSystemExtensionNode,
+  isTypeExtensionNode,
 } from './language';
 
 export type {

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -88,5 +88,17 @@ export type {
   InputObjectTypeExtensionNode,
 } from './ast';
 
+export {
+  isDefinitionNode,
+  isExecutableDefinitionNode,
+  isSelectionNode,
+  isValueNode,
+  isTypeNode,
+  isTypeSystemDefinitionNode,
+  isTypeDefinitionNode,
+  isTypeSystemExtensionNode,
+  isTypeExtensionNode,
+} from './predicates';
+
 export { DirectiveLocation } from './directiveLocation';
 export type { DirectiveLocationEnum } from './directiveLocation';

--- a/src/language/predicates.js
+++ b/src/language/predicates.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { ASTNode } from './ast';
+import { Kind } from './kinds';
+
+export function isDefinitionNode(node: ASTNode): boolean %checks {
+  return (
+    isExecutableDefinitionNode(node) ||
+    isTypeSystemDefinitionNode(node) ||
+    isTypeSystemExtensionNode(node)
+  );
+}
+
+export function isExecutableDefinitionNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.OPERATION_DEFINITION ||
+    node.kind === Kind.FRAGMENT_DEFINITION
+  );
+}
+
+export function isSelectionNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.FIELD ||
+    node.kind === Kind.FRAGMENT_SPREAD ||
+    node.kind === Kind.INLINE_FRAGMENT
+  );
+}
+
+export function isValueNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.INT ||
+    node.kind === Kind.FLOAT ||
+    node.kind === Kind.STRING ||
+    node.kind === Kind.BOOLEAN ||
+    node.kind === Kind.NULL ||
+    node.kind === Kind.ENUM ||
+    node.kind === Kind.LIST ||
+    node.kind === Kind.OBJECT ||
+    node.kind === Kind.OBJECT_FIELD
+  );
+}
+
+export function isTypeNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.NAMED_TYPE ||
+    node.kind === Kind.LIST_TYPE ||
+    node.kind === Kind.NON_NULL_TYPE
+  );
+}
+
+export function isTypeSystemDefinitionNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.SCHEMA_DEFINITION ||
+    isTypeDefinitionNode(node) ||
+    node.kind === Kind.DIRECTIVE_DEFINITION
+  );
+}
+
+export function isTypeDefinitionNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.SCALAR_TYPE_DEFINITION ||
+    node.kind === Kind.OBJECT_TYPE_DEFINITION ||
+    node.kind === Kind.INTERFACE_TYPE_DEFINITION ||
+    node.kind === Kind.UNION_TYPE_DEFINITION ||
+    node.kind === Kind.ENUM_TYPE_DEFINITION ||
+    node.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
+  );
+}
+
+export function isTypeSystemExtensionNode(node: ASTNode): boolean %checks {
+  return node.kind === Kind.SCHEMA_EXTENSION || isTypeExtensionNode(node);
+}
+
+export function isTypeExtensionNode(node: ASTNode): boolean %checks {
+  return (
+    node.kind === Kind.SCALAR_TYPE_EXTENSION ||
+    node.kind === Kind.OBJECT_TYPE_EXTENSION ||
+    node.kind === Kind.INTERFACE_TYPE_EXTENSION ||
+    node.kind === Kind.UNION_TYPE_EXTENSION ||
+    node.kind === Kind.ENUM_TYPE_EXTENSION ||
+    node.kind === Kind.INPUT_OBJECT_TYPE_EXTENSION
+  );
+}

--- a/src/validation/rules/ExecutableDefinitions.js
+++ b/src/validation/rules/ExecutableDefinitions.js
@@ -10,6 +10,7 @@
 import type { ASTValidationContext } from '../ValidationContext';
 import { GraphQLError } from '../../error';
 import { Kind } from '../../language/kinds';
+import { isExecutableDefinitionNode } from '../../language/predicates';
 import type { ASTVisitor } from '../../language/visitor';
 
 export function nonExecutableDefinitionMessage(defName: string): string {
@@ -28,10 +29,7 @@ export function ExecutableDefinitions(
   return {
     Document(node) {
       for (const definition of node.definitions) {
-        if (
-          definition.kind !== Kind.OPERATION_DEFINITION &&
-          definition.kind !== Kind.FRAGMENT_DEFINITION
-        ) {
+        if (!isExecutableDefinitionNode(definition)) {
           context.reportError(
             new GraphQLError(
               nonExecutableDefinitionMessage(


### PR DESCRIPTION
For SDL validation rules I need to distinguish type definition node from type extension nodes.
\+ I saw same in couple other projects, e.g. `relay`:
https://github.com/facebook/relay/blob/04aac482538b83548c25e878205ecc1a581bcb25/packages/graphql-compiler/core/GraphQLSchemaUtils.js#L198-L203