### PR TITLE
Fix typo in AST predicates

### DIFF
--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -18,7 +18,6 @@ export const Kind = Object.freeze({
   DOCUMENT: 'Document',
   OPERATION_DEFINITION: 'OperationDefinition',
   VARIABLE_DEFINITION: 'VariableDefinition',
-  VARIABLE: 'Variable',
   SELECTION_SET: 'SelectionSet',
   FIELD: 'Field',
   ARGUMENT: 'Argument',
@@ -29,6 +28,7 @@ export const Kind = Object.freeze({
   FRAGMENT_DEFINITION: 'FragmentDefinition',
 
   // Values
+  VARIABLE: 'Variable',
   INT: 'IntValue',
   FLOAT: 'FloatValue',
   STRING: 'StringValue',

--- a/src/language/predicates.js
+++ b/src/language/predicates.js
@@ -35,6 +35,7 @@ export function isSelectionNode(node: ASTNode): boolean %checks {
 
 export function isValueNode(node: ASTNode): boolean %checks {
   return (
+    node.kind === Kind.VARIABLE ||
     node.kind === Kind.INT ||
     node.kind === Kind.FLOAT ||
     node.kind === Kind.STRING ||
@@ -42,8 +43,7 @@ export function isValueNode(node: ASTNode): boolean %checks {
     node.kind === Kind.NULL ||
     node.kind === Kind.ENUM ||
     node.kind === Kind.LIST ||
-    node.kind === Kind.OBJECT ||
-    node.kind === Kind.OBJECT_FIELD
+    node.kind === Kind.OBJECT
   );
 }
 


### PR DESCRIPTION
This was an easy mistake to make: the ordering in the `Kind` object made it seem like `Variable` belonged with `VariableDefinition`, when in fact it belongs with the values (as a variable definition defines that a value can be used).

Additionally, `ObjectField` is not itself a value: it's more of a key-value pair that itself contains a value.