### PR TITLE
Make error handling consistent in createSourceEventStream

### DIFF
--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -298,6 +298,9 @@ export function createSourceEventStream(
       );
     });
   } catch (error) {
+    // As with reportGraphQLError above, if the error is a GraphQLError, report
+    // it as an ExecutionResult; otherwise treat it as a system-class error and
+    // re-throw it.
     return error instanceof GraphQLError
       ? Promise.resolve({ errors: [error] })
       : Promise.reject(error);

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -35,8 +35,9 @@ import { getOperationRootType } from '../utilities/getOperationRootType';
  * Implements the "Subscribe" algorithm described in the GraphQL specification.
  *
  * Returns a Promise which resolves to either an AsyncIterator (if successful)
- * or an ExecutionResult (client error). The promise will be rejected if a
- * server error occurs.
+ * or an ExecutionResult (error). The promise will be rejected if the schema or
+ * other arguments to this function are invalid, or if the resolved event stream
+ * is not an async iterable.
  *
  * If the client-provided arguments to this function do not result in a
  * compliant subscription, a GraphQL Response (ExecutionResult) with
@@ -171,7 +172,6 @@ function subscribeImpl(
             reportGraphQLError,
           )
         : ((resultOrStream: any): ExecutionResult),
-    reportGraphQLError,
   );
 }
 
@@ -179,11 +179,21 @@ function subscribeImpl(
  * Implements the "CreateSourceEventStream" algorithm described in the
  * GraphQL specification, resolving the subscription source event stream.
  *
- * Returns a Promise<AsyncIterable>.
+ * Returns a Promise which resolves to either an AsyncIterable (if successful)
+ * or an ExecutionResult (error). The promise will be rejected if the schema or
+ * other arguments to this function are invalid, or if the resolved event stream
+ * is not an async iterable.
  *
- * If the client-provided invalid arguments, the source stream could not be
- * created, or the resolver did not return an AsyncIterable, this function will
- * will throw an error, which should be caught and handled by the caller.
+ * If the client-provided arguments to this function do not result in a
+ * compliant subscription, a GraphQL Response (ExecutionResult) with
+ * descriptive errors and no data will be returned.
+ *
+ * If the the source stream could not be created due to faulty subscription
+ * resolver logic or underlying systems, the promise will resolve to a single
+ * ExecutionResult containing `errors` and no `data`.
+ *
+ * If the operation succeeded, the promise resolves to the AsyncIterable for the
+ * event stream returned by the resolver.
  *
  * A Source Event Stream represents a sequence of events, each of which triggers
  * a GraphQL execution for that event.
@@ -270,7 +280,11 @@ export function createSourceEventStream(
     return Promise.resolve(result).then(eventStream => {
       // If eventStream is an Error, rethrow a located error.
       if (eventStream instanceof Error) {
-        throw locatedError(eventStream, fieldNodes, responsePathAsArray(path));
+        return {
+          errors: [
+            locatedError(eventStream, fieldNodes, responsePathAsArray(path)),
+          ],
+        };
       }
 
       // Assert field returned an event stream, otherwise yield an error.
@@ -284,6 +298,8 @@ export function createSourceEventStream(
       );
     });
   } catch (error) {
-    return Promise.reject(error);
+    return error instanceof GraphQLError
+      ? Promise.resolve({ errors: [error] })
+      : Promise.reject(error);
   }
 }


### PR DESCRIPTION
Currently, errors in `createSourceEventStream` from `buildExecutionContext` will be returned in an `ExecutionResult`, while all other GraphQL errors will be thrown. This is inconsistent with the handling in `subscribe`, and makes it harder to build error handling logic, as there are then two ways to handle the same class of errors.

This makes the error handling consistent and updates the documentation to describe the new logic.

This is technically breaking, but is unlikely to cause problems for any properly-written code, as full error handling logic required handling resolved `ExecutionResult` objects with `errors` anyway.