### PR TITLE
[flow] Add generics for scalar class

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -532,7 +532,7 @@ function resolveThunk<+T>(thunk: Thunk<T>): T {
  *     });
  *
  */
-export class GraphQLScalarType<TInternal, TExternal> {
+export class GraphQLScalarType<TInternal = any, TExternal = any> {
   name: string;
   description: ?string;
   serialize: GraphQLScalarSerializer<TExternal>;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -532,16 +532,16 @@ function resolveThunk<+T>(thunk: Thunk<T>): T {
  *     });
  *
  */
-export class GraphQLScalarType {
+export class GraphQLScalarType<TInternal, TExternal> {
   name: string;
   description: ?string;
-  serialize: GraphQLScalarSerializer<*>;
-  parseValue: GraphQLScalarValueParser<*>;
-  parseLiteral: GraphQLScalarLiteralParser<*>;
+  serialize: GraphQLScalarSerializer<TExternal>;
+  parseValue: GraphQLScalarValueParser<TInternal>;
+  parseLiteral: GraphQLScalarLiteralParser<TInternal>;
   astNode: ?ScalarTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ScalarTypeExtensionNode>;
 
-  constructor(config: GraphQLScalarTypeConfig<*, *>): void {
+  constructor(config: GraphQLScalarTypeConfig<TInternal, TExternal>): void {
     this.name = config.name;
     this.description = config.description;
     this.serialize = config.serialize;

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -58,7 +58,7 @@ function coerceInt(value: mixed): number {
   return value;
 }
 
-export const GraphQLInt = new GraphQLScalarType({
+export const GraphQLInt = new GraphQLScalarType<number>({
   name: 'Int',
   description:
     'The `Int` scalar type represents non-fractional signed whole numeric ' +
@@ -102,7 +102,7 @@ function coerceFloat(value: mixed): number {
   return value;
 }
 
-export const GraphQLFloat = new GraphQLScalarType({
+export const GraphQLFloat = new GraphQLScalarType<number>({
   name: 'Float',
   description:
     'The `Float` scalar type represents signed double-precision fractional ' +
@@ -146,7 +146,7 @@ function coerceString(value: mixed): string {
   return value;
 }
 
-export const GraphQLString = new GraphQLScalarType({
+export const GraphQLString = new GraphQLScalarType<string>({
   name: 'String',
   description:
     'The `String` scalar type represents textual data, represented as UTF-8 ' +
@@ -180,7 +180,7 @@ function coerceBoolean(value: mixed): boolean {
   return value;
 }
 
-export const GraphQLBoolean = new GraphQLScalarType({
+export const GraphQLBoolean = new GraphQLScalarType<boolean>({
   name: 'Boolean',
   description: 'The `Boolean` scalar type represents `true` or `false`.',
   serialize: serializeBoolean,
@@ -214,7 +214,7 @@ function coerceID(value: mixed): string {
   throw new TypeError(`ID cannot represent value: ${inspect(value)}`);
 }
 
-export const GraphQLID = new GraphQLScalarType({
+export const GraphQLID = new GraphQLScalarType<string>({
   name: 'ID',
   description:
     'The `ID` scalar type represents a unique identifier, often used to ' +


### PR DESCRIPTION
> **Disclaimer**: Was asked to submit a PR here in order to match my PR at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28419

Basically I want to add the option to specify generics on `GraphQLScalarType`, and not just `GraphQLScalarTypeConfig`

Not sure how to resolve the following issue in flow though

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ src/type/definition.js:49:5

Cannot use GraphQLScalarType [1] without 0-2 type arguments.

      46│  * These are all of the possible kinds of types.
      47│  */
      48│ export type GraphQLType =
      49│   | GraphQLScalarType
      50│   | GraphQLObjectType
      51│   | GraphQLInterfaceType
      52│   | GraphQLUnionType
        :
 [1] 535│ export class GraphQLScalarType<TInternal = any, TExternal = any> {
```

I would not want to create a change that forces users to add `<>` to their code - Is there a way in flow to make the generics totally optional as in TypeScript?
