### PR TITLE
A union type cannot satisfy an interface even if each child type does

### DIFF
--- a/src/type/__tests__/validation-test.js
+++ b/src/type/__tests__/validation-test.js
@@ -1827,3 +1827,36 @@ describe('Objects must adhere to Interface they implement', () => {
     ]);
   });
 });
+
+describe('Type System: Union types can implement interfaces', () => {
+  it('accepts a union type as an implementation of an interface', () => {
+    const schema = buildSchema(`
+      type Query {
+        test: MyConnection
+      }
+      
+      interface Node {
+        id: ID
+      }
+      
+      interface Connection {
+        nodes: [Node]
+      }
+      
+      type NodeA implements Node {
+        id: ID
+      }
+      type NodeB implements Node {
+        id: ID
+      }
+      union MyNode =
+        | NodeA
+        | NodeB
+      
+      type MyConnection implements Connection {
+        nodes: [MyNode]
+      }
+    `);
+    expect(validateSchema(schema)).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
Below is a simplified example of my schema that is failing to validate:
```
type Query {
  test: MyConnection
}

interface Node {
  id: ID
}

interface Connection {
  nodes: [Node]
}

type NodeA implements Node {
  id: ID
}
type NodeB implements Node {
  id: ID
}
union MyNode =
  | NodeA
  | NodeB

type MyConnection implements Connection {
  nodes: [MyNode]
}
```

With error message:

```
"Interface field Connection.nodes expects type [Node] but MyConnection.nodes is type [MyNode].
```

It appears that the union type does not properly carry through that it implements the `Node` interface even though all its child types do. Is this expected behavior or an issue with the validator?