### PR TITLE
Exclude __fixtures__ from dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "build:clean": "rm -rf ./dist && mkdir ./dist",
     "build:cp": "cp README.md LICENSE ./dist",
     "build:package-json": "node ./resources/copy-package-json.js",
-    "build:cjs": "babel src --ignore '**/__tests__' --out-dir dist/",
-    "build:mjs": "BABEL_MODULES=1 babel src --ignore '**/__tests__' --out-dir dist/module/ && for file in $(find dist/module -name '*.js'); do mv \"$file\" `echo \"$file\" | sed 's/dist\\/module/dist/g; s/.js$/.mjs/g'`; done && rm -rf dist/module",
-    "build:flow": "for file in $(find ./src -name '*.js' -not -path '*/__tests__*'); do cp \"$file\" `echo \"$file\" | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
+    "build:cjs": "babel src --ignore 'src/__fixtures__,**/__tests__' --out-dir dist/",
+    "build:mjs": "BABEL_MODULES=1 babel src --ignore 'src/__fixtures__,**/__tests__' --out-dir dist/module/ && for file in $(find dist/module -name '*.js'); do mv \"$file\" `echo \"$file\" | sed 's/dist\\/module/dist/g; s/.js$/.mjs/g'`; done && rm -rf dist/module",
+    "build:flow": "for file in $(find ./src -name '*.js' -not -path '*/__fixtures__*' -not -path '*/__tests__*'); do cp \"$file\" `echo \"$file\" | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
     "preversion": ". ./resources/checkgit.sh && npm test",
     "prepublishOnly": ". ./resources/prepublish.sh",
     "gitpublish": ". ./resources/gitpublish.sh"


### PR DESCRIPTION
Currently `__fixtures__` include in NPM package:
https://github.com/graphql/graphql-js/tree/npm/__fixtures__
Cleanup from #1471
Don't like how it's make `package.json` less readable but it's a normal temporary solution.