### PR TITLE
Benchmark: always assume schema is valid

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-benchmark.js
+++ b/src/utilities/__tests__/buildASTSchema-benchmark.js
@@ -14,5 +14,5 @@ const schemaAST = parse(bigSchemaSDL);
 
 export const name = 'Build Schema from AST';
 export function measure() {
-  buildASTSchema(schemaAST);
+  buildASTSchema(schemaAST, { assumeValid: true });
 }

--- a/src/utilities/__tests__/buildClientSchema-benchmark.js
+++ b/src/utilities/__tests__/buildClientSchema-benchmark.js
@@ -11,5 +11,5 @@ import { buildClientSchema } from '../buildClientSchema';
 
 export const name = 'Build Schema from Introspection';
 export function measure() {
-  buildClientSchema(bigSchemaIntrospectionResult.data);
+  buildClientSchema(bigSchemaIntrospectionResult.data, { assumeValid: true });
 }


### PR DESCRIPTION
We measure SDL validation separately so it shouldn't affect benchmarks that measure schema build time.