### PR TITLE
Call 'toJSON' if present for ID and String serialize

### DIFF
--- a/src/type/__tests__/serialization-test.js
+++ b/src/type/__tests__/serialization-test.js
@@ -111,11 +111,19 @@ describe('Type System: Scalar coercion', () => {
 
     const stringableObjValue = {
       valueOf() {
-        return 'something useful';
+        return 'valueOf string';
+      },
+      toJSON() {
+        return 'toJSON string';
       },
     };
     expect(GraphQLString.serialize(stringableObjValue)).to.equal(
-      'something useful',
+      'valueOf string',
+    );
+
+    delete stringableObjValue.valueOf;
+    expect(GraphQLString.serialize(stringableObjValue)).to.equal(
+      'toJSON string',
     );
 
     expect(() => GraphQLString.serialize(NaN)).to.throw(
@@ -163,13 +171,19 @@ describe('Type System: Scalar coercion', () => {
     expect(GraphQLID.serialize(0)).to.equal('0');
     expect(GraphQLID.serialize(-1)).to.equal('-1');
 
-    const objValue = {
+    const serializableObjValue = {
       _id: 123,
       valueOf() {
         return this._id;
       },
+      toJSON() {
+        return `ID:${this._id}`;
+      },
     };
-    expect(GraphQLID.serialize(objValue)).to.equal('123');
+    expect(GraphQLID.serialize(serializableObjValue)).to.equal('123');
+
+    delete serializableObjValue.valueOf;
+    expect(GraphQLID.serialize(serializableObjValue)).to.equal('ID:123');
 
     const badObjValue = {
       _id: false,


### PR DESCRIPTION
Fixes #1518 

`class ObjectId` doesn't have `valueOf` only `toString` and `toJSON`:
https://github.com/mongodb/js-bson/blob/5acdebf7a63ed02d3bc1eb8481cdcb709fb5c886/lib/objectid.js#L213-L215

We can't use `toString` because:
```js
class A {}
const a = new A();
a.toString()
// '[object Object]'
```

So I added support for `toJSON`.