### PR TITLE
feat(scalar): add generics to scalars

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -423,7 +423,7 @@ function executeOperation(
  */
 function executeFieldsSerially(
   exeContext: ExecutionContext,
-  parentType: GraphQLObjectType,
+  parentType: GraphQLObjectType<*, *>,
   sourceValue: mixed,
   path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
@@ -462,7 +462,7 @@ function executeFieldsSerially(
  */
 function executeFields(
   exeContext: ExecutionContext,
-  parentType: GraphQLObjectType,
+  parentType: GraphQLObjectType<*, *>,
   sourceValue: mixed,
   path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
@@ -511,7 +511,7 @@ function executeFields(
  */
 export function collectFields(
   exeContext: ExecutionContext,
-  runtimeType: GraphQLObjectType,
+  runtimeType: GraphQLObjectType<*, *>,
   selectionSet: SelectionSetNode,
   fields: ObjMap<Array<FieldNode>>,
   visitedFragmentNames: ObjMap<boolean>,
@@ -607,7 +607,7 @@ function shouldIncludeNode(
 function doesFragmentConditionMatch(
   exeContext: ExecutionContext,
   fragment: FragmentDefinitionNode | InlineFragmentNode,
-  type: GraphQLObjectType,
+  type: GraphQLObjectType<*, *>,
 ): boolean {
   const typeConditionNode = fragment.typeCondition;
   if (!typeConditionNode) {
@@ -638,7 +638,7 @@ function getFieldEntryKey(node: FieldNode): string {
  */
 function resolveField(
   exeContext: ExecutionContext,
-  parentType: GraphQLObjectType,
+  parentType: GraphQLObjectType<*, *>,
   source: mixed,
   fieldNodes: $ReadOnlyArray<FieldNode>,
   path: ResponsePath,
@@ -686,7 +686,7 @@ export function buildResolveInfo(
   exeContext: ExecutionContext,
   fieldDef: GraphQLField<*, *>,
   fieldNodes: $ReadOnlyArray<FieldNode>,
-  parentType: GraphQLObjectType,
+  parentType: GraphQLObjectType<*, *>,
   path: ResponsePath,
 ): GraphQLResolveInfo {
   // The resolve function's optional fourth argument is a collection of
@@ -1030,13 +1030,13 @@ function completeAbstractValue(
 }
 
 function ensureValidRuntimeType(
-  runtimeTypeOrName: ?GraphQLObjectType | string,
+  runtimeTypeOrName: ?GraphQLObjectType<*, *> | string,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
   fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   result: mixed,
-): GraphQLObjectType {
+): GraphQLObjectType<*, *> {
   const runtimeType =
     typeof runtimeTypeOrName === 'string'
       ? exeContext.schema.getType(runtimeTypeOrName)
@@ -1069,7 +1069,7 @@ function ensureValidRuntimeType(
  */
 function completeObjectValue(
   exeContext: ExecutionContext,
-  returnType: GraphQLObjectType,
+  returnType: GraphQLObjectType<*, *>,
   fieldNodes: $ReadOnlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   path: ResponsePath,
@@ -1111,7 +1111,7 @@ function completeObjectValue(
 }
 
 function invalidReturnTypeError(
-  returnType: GraphQLObjectType,
+  returnType: GraphQLObjectType<*, *>,
   result: mixed,
   fieldNodes: $ReadOnlyArray<FieldNode>,
 ): GraphQLError {
@@ -1123,7 +1123,7 @@ function invalidReturnTypeError(
 
 function collectAndExecuteSubfields(
   exeContext: ExecutionContext,
-  returnType: GraphQLObjectType,
+  returnType: GraphQLObjectType<*, *>,
   fieldNodes: $ReadOnlyArray<FieldNode>,
   path: ResponsePath,
   result: mixed,
@@ -1141,7 +1141,7 @@ function collectAndExecuteSubfields(
 const collectSubfields = memoize3(_collectSubfields);
 function _collectSubfields(
   exeContext: ExecutionContext,
-  returnType: GraphQLObjectType,
+  returnType: GraphQLObjectType<*, *>,
   fieldNodes: $ReadOnlyArray<FieldNode>,
 ): ObjMap<Array<FieldNode>> {
   let subFieldNodes = Object.create(null);
@@ -1176,7 +1176,7 @@ function defaultResolveTypeFn(
   contextValue: mixed,
   info: GraphQLResolveInfo,
   abstractType: GraphQLAbstractType,
-): MaybePromise<?GraphQLObjectType | string> {
+): MaybePromise<?GraphQLObjectType<*, *> | string> {
   // First, look for `__typename`.
   if (
     value !== null &&
@@ -1248,7 +1248,7 @@ export const defaultFieldResolver: GraphQLFieldResolver<any, *> = function(
  */
 export function getFieldDef(
   schema: GraphQLSchema,
-  parentType: GraphQLObjectType,
+  parentType: GraphQLObjectType<*, *>,
   fieldName: string,
 ): ?GraphQLField<*, *> {
   if (

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -46,7 +46,7 @@ import type { MaybePromise } from '../jsutils/MaybePromise';
  * These are all of the possible kinds of types.
  */
 export type GraphQLType =
-  | GraphQLScalarType
+  | GraphQLScalarType<>
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
@@ -84,7 +84,7 @@ export function isScalarType(type) {
   return instanceOf(type, GraphQLScalarType);
 }
 
-export function assertScalarType(type: mixed): GraphQLScalarType {
+export function assertScalarType(type: mixed): GraphQLScalarType<> {
   invariant(
     isScalarType(type),
     `Expected ${inspect(type)} to be a GraphQL Scalar type.`,
@@ -201,12 +201,12 @@ export function assertNonNullType(type: mixed): GraphQLNonNull<any> {
  * These types may be used as input types for arguments and directives.
  */
 export type GraphQLInputType =
-  | GraphQLScalarType
+  | GraphQLScalarType<>
   | GraphQLEnumType
   | GraphQLInputObjectType
   | GraphQLList<GraphQLInputType>
   | GraphQLNonNull<
-      | GraphQLScalarType
+      | GraphQLScalarType<>
       | GraphQLEnumType
       | GraphQLInputObjectType
       | GraphQLList<GraphQLInputType>,
@@ -233,14 +233,14 @@ export function assertInputType(type: mixed): GraphQLInputType {
  * These types may be used as output types as the result of fields.
  */
 export type GraphQLOutputType =
-  | GraphQLScalarType
+  | GraphQLScalarType<>
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
   | GraphQLEnumType
   | GraphQLList<GraphQLOutputType>
   | GraphQLNonNull<
-      | GraphQLScalarType
+      | GraphQLScalarType<>
       | GraphQLObjectType
       | GraphQLInterfaceType
       | GraphQLUnionType
@@ -270,7 +270,7 @@ export function assertOutputType(type: mixed): GraphQLOutputType {
 /**
  * These types may describe types which may be leaf values.
  */
-export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
+export type GraphQLLeafType = GraphQLScalarType<> | GraphQLEnumType;
 
 export function isLeafType(type: mixed): boolean %checks {
   return isScalarType(type) || isEnumType(type);
@@ -423,7 +423,7 @@ export function assertWrappingType(type: mixed): GraphQLWrappingType {
  * These types can all accept null as a value.
  */
 export type GraphQLNullableType =
-  | GraphQLScalarType
+  | GraphQLScalarType<>
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
@@ -458,7 +458,7 @@ export function getNullableType(type) {
  * These named types do not include modifiers like List or NonNull.
  */
 export type GraphQLNamedType =
-  | GraphQLScalarType
+  | GraphQLScalarType<>
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
@@ -532,12 +532,12 @@ function resolveThunk<+T>(thunk: Thunk<T>): T {
  *     });
  *
  */
-export class GraphQLScalarType {
+export class GraphQLScalarType<TInternal = any, TExternal = TInternal> {
   name: string;
   description: ?string;
-  serialize: GraphQLScalarSerializer<*>;
-  parseValue: GraphQLScalarValueParser<*>;
-  parseLiteral: GraphQLScalarLiteralParser<*>;
+  serialize: GraphQLScalarSerializer<TExternal>;
+  parseValue: GraphQLScalarValueParser<TInternal>;
+  parseLiteral: GraphQLScalarLiteralParser<TInternal>;
   astNode: ?ScalarTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ScalarTypeExtensionNode>;
 

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -146,7 +146,7 @@ function coerceString(value: mixed): string {
   return value;
 }
 
-export const GraphQLString = new GraphQLScalarType<string>({
+export const GraphQLString = new GraphQLScalarType({
   name: 'String',
   description:
     'The `String` scalar type represents textual data, represented as UTF-8 ' +
@@ -180,7 +180,7 @@ function coerceBoolean(value: mixed): boolean {
   return value;
 }
 
-export const GraphQLBoolean = new GraphQLScalarType<boolean>({
+export const GraphQLBoolean = new GraphQLScalarType({
   name: 'Boolean',
   description: 'The `Boolean` scalar type represents `true` or `false`.',
   serialize: serializeBoolean,
@@ -214,7 +214,7 @@ function coerceID(value: mixed): string {
   throw new TypeError(`ID cannot represent value: ${inspect(value)}`);
 }
 
-export const GraphQLID = new GraphQLScalarType<string>({
+export const GraphQLID = new GraphQLScalarType<string | number>({
   name: 'ID',
   description:
     'The `ID` scalar type represents a unique identifier, often used to ' +

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -58,7 +58,7 @@ function coerceInt(value: mixed): number {
   return value;
 }
 
-export const GraphQLInt = new GraphQLScalarType({
+export const GraphQLInt = new GraphQLScalarType<number>({
   name: 'Int',
   description:
     'The `Int` scalar type represents non-fractional signed whole numeric ' +
@@ -102,7 +102,7 @@ function coerceFloat(value: mixed): number {
   return value;
 }
 
-export const GraphQLFloat = new GraphQLScalarType({
+export const GraphQLFloat = new GraphQLScalarType<number>({
   name: 'Float',
   description:
     'The `Float` scalar type represents signed double-precision fractional ' +
@@ -146,7 +146,7 @@ function coerceString(value: mixed): string {
   return value;
 }
 
-export const GraphQLString = new GraphQLScalarType({
+export const GraphQLString = new GraphQLScalarType<string>({
   name: 'String',
   description:
     'The `String` scalar type represents textual data, represented as UTF-8 ' +
@@ -180,7 +180,7 @@ function coerceBoolean(value: mixed): boolean {
   return value;
 }
 
-export const GraphQLBoolean = new GraphQLScalarType({
+export const GraphQLBoolean = new GraphQLScalarType<boolean>({
   name: 'Boolean',
   description: 'The `Boolean` scalar type represents `true` or `false`.',
   serialize: serializeBoolean,
@@ -214,7 +214,7 @@ function coerceID(value: mixed): string {
   throw new TypeError(`ID cannot represent value: ${inspect(value)}`);
 }
 
-export const GraphQLID = new GraphQLScalarType({
+export const GraphQLID = new GraphQLScalarType<string>({
   name: 'ID',
   description:
     'The `ID` scalar type represents a unique identifier, often used to ' +

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -79,12 +79,12 @@ export function isSchema(schema) {
 export class GraphQLSchema {
   astNode: ?SchemaDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<SchemaExtensionNode>;
-  _queryType: ?GraphQLObjectType;
-  _mutationType: ?GraphQLObjectType;
-  _subscriptionType: ?GraphQLObjectType;
+  _queryType: ?GraphQLObjectType<*, *>;
+  _mutationType: ?GraphQLObjectType<*, *>;
+  _subscriptionType: ?GraphQLObjectType<*, *>;
   _directives: $ReadOnlyArray<GraphQLDirective>;
   _typeMap: TypeMap;
-  _implementations: ObjMap<Array<GraphQLObjectType>>;
+  _implementations: ObjMap<Array<GraphQLObjectType<*, *>>>;
   _possibleTypeMap: ?ObjMap<ObjMap<boolean>>;
   // Used as a cache for validateSchema().
   __validationErrors: ?$ReadOnlyArray<GraphQLError>;
@@ -174,15 +174,15 @@ export class GraphQLSchema {
     }
   }
 
-  getQueryType(): ?GraphQLObjectType {
+  getQueryType(): ?GraphQLObjectType<*, *> {
     return this._queryType;
   }
 
-  getMutationType(): ?GraphQLObjectType {
+  getMutationType(): ?GraphQLObjectType<*, *> {
     return this._mutationType;
   }
 
-  getSubscriptionType(): ?GraphQLObjectType {
+  getSubscriptionType(): ?GraphQLObjectType<*, *> {
     return this._subscriptionType;
   }
 
@@ -196,7 +196,7 @@ export class GraphQLSchema {
 
   getPossibleTypes(
     abstractType: GraphQLAbstractType,
-  ): $ReadOnlyArray<GraphQLObjectType> {
+  ): $ReadOnlyArray<GraphQLObjectType<*, *>> {
     if (isUnionType(abstractType)) {
       return abstractType.getTypes();
     }
@@ -205,7 +205,7 @@ export class GraphQLSchema {
 
   isPossibleType(
     abstractType: GraphQLAbstractType,
-    possibleType: GraphQLObjectType,
+    possibleType: GraphQLObjectType<*, *>,
   ): boolean {
     let possibleTypeMap = this._possibleTypeMap;
     if (!possibleTypeMap) {
@@ -258,9 +258,9 @@ export type GraphQLSchemaValidationOptions = {|
 |};
 
 export type GraphQLSchemaConfig = {|
-  query?: ?GraphQLObjectType,
-  mutation?: ?GraphQLObjectType,
-  subscription?: ?GraphQLObjectType,
+  query?: ?GraphQLObjectType<*, *>,
+  mutation?: ?GraphQLObjectType<*, *>,
+  subscription?: ?GraphQLObjectType<*, *>,
   types?: ?Array<GraphQLNamedType>,
   directives?: ?Array<GraphQLDirective>,
   astNode?: ?SchemaDefinitionNode,

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -152,7 +152,7 @@ function validateRootTypes(context) {
 
 function getOperationTypeNode(
   schema: GraphQLSchema,
-  type: GraphQLObjectType,
+  type: GraphQLObjectType<*, *>,
   operation: string,
 ): ?ASTNode {
   const operationNodes = getAllSubNodes(schema, node => node.operationTypes);
@@ -268,7 +268,7 @@ function validateTypes(context: SchemaValidationContext): void {
 
 function validateFields(
   context: SchemaValidationContext,
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
 ): void {
   const fields = objectValues(type.getFields());
 
@@ -335,7 +335,7 @@ function validateFields(
 
 function validateObjectInterfaces(
   context: SchemaValidationContext,
-  object: GraphQLObjectType,
+  object: GraphQLObjectType<*, *>,
 ): void {
   const implementedTypeNames = Object.create(null);
   for (const iface of object.getInterfaces()) {
@@ -362,7 +362,7 @@ function validateObjectInterfaces(
 
 function validateObjectImplementsInterface(
   context: SchemaValidationContext,
-  object: GraphQLObjectType,
+  object: GraphQLObjectType<*, *>,
   iface: GraphQLInterfaceType,
 ): void {
   const objectFieldMap = object.getFields();
@@ -587,14 +587,14 @@ function getAllSubNodes<T: ASTNode, K: ASTNode, L: ASTNode>(
 }
 
 function getImplementsInterfaceNode(
-  type: GraphQLObjectType,
+  type: GraphQLObjectType<*, *>,
   iface: GraphQLInterfaceType,
 ): ?NamedTypeNode {
   return getAllImplementsInterfaceNodes(type, iface)[0];
 }
 
 function getAllImplementsInterfaceNodes(
-  type: GraphQLObjectType,
+  type: GraphQLObjectType<*, *>,
   iface: GraphQLInterfaceType,
 ): $ReadOnlyArray<NamedTypeNode> {
   return getAllSubNodes(type, typeNode => typeNode.interfaces).filter(
@@ -603,14 +603,14 @@ function getAllImplementsInterfaceNodes(
 }
 
 function getFieldNode(
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
   fieldName: string,
 ): ?FieldDefinitionNode {
   return getAllFieldNodes(type, fieldName)[0];
 }
 
 function getAllFieldNodes(
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
   fieldName: string,
 ): $ReadOnlyArray<FieldDefinitionNode> {
   return getAllSubNodes(type, typeNode => typeNode.fields).filter(
@@ -619,7 +619,7 @@ function getAllFieldNodes(
 }
 
 function getFieldTypeNode(
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
   fieldName: string,
 ): ?TypeNode {
   const fieldNode = getFieldNode(type, fieldName);
@@ -627,7 +627,7 @@ function getFieldTypeNode(
 }
 
 function getFieldArgNode(
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
   fieldName: string,
   argName: string,
 ): ?InputValueDefinitionNode {
@@ -635,7 +635,7 @@ function getFieldArgNode(
 }
 
 function getAllFieldArgNodes(
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
   fieldName: string,
   argName: string,
 ): $ReadOnlyArray<InputValueDefinitionNode> {
@@ -652,7 +652,7 @@ function getAllFieldArgNodes(
 }
 
 function getFieldArgTypeNode(
-  type: GraphQLObjectType | GraphQLInterfaceType,
+  type: GraphQLObjectType<*, *> | GraphQLInterfaceType,
   fieldName: string,
   argName: string,
 ): ?TypeNode {

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -201,7 +201,7 @@ export function buildClientSchema(
 
   function buildScalarDef(
     scalarIntrospection: IntrospectionScalarType,
-  ): GraphQLScalarType {
+  ): GraphQLScalarType<> {
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -161,7 +161,7 @@ export function buildClientSchema(
 
   function getObjectType(
     typeRef: IntrospectionNamedTypeRef<IntrospectionObjectType>,
-  ): GraphQLObjectType {
+  ): GraphQLObjectType<*, *> {
     const type = getType(typeRef);
     return assertObjectType(type);
   }
@@ -201,7 +201,7 @@ export function buildClientSchema(
 
   function buildScalarDef(
     scalarIntrospection: IntrospectionScalarType,
-  ): GraphQLScalarType<> {
+  ): GraphQLScalarType<*, *> {
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
@@ -211,7 +211,7 @@ export function buildClientSchema(
 
   function buildObjectDef(
     objectIntrospection: IntrospectionObjectType,
-  ): GraphQLObjectType {
+  ): GraphQLObjectType<*, *> {
     if (!objectIntrospection.interfaces) {
       throw new Error(
         'Introspection result missing interfaces: ' +

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -426,7 +426,7 @@ export function extendSchema(
     return newValueMap;
   }
 
-  function extendScalarType(type: GraphQLScalarType): GraphQLScalarType {
+  function extendScalarType(type: GraphQLScalarType<>): GraphQLScalarType<> {
     const name = type.name;
     const extensionASTNodes = typeExtensionsMap[name]
       ? type.extensionASTNodes

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -426,7 +426,7 @@ export function extendSchema(
     return newValueMap;
   }
 
-  function extendScalarType(type: GraphQLScalarType<>): GraphQLScalarType<> {
+  function extendScalarType(type: GraphQLScalarType<*, *>): GraphQLScalarType<*, *> {
     const name = type.name;
     const extensionASTNodes = typeExtensionsMap[name]
       ? type.extensionASTNodes
@@ -444,7 +444,7 @@ export function extendSchema(
     });
   }
 
-  function extendObjectType(type: GraphQLObjectType): GraphQLObjectType {
+  function extendObjectType(type: GraphQLObjectType<*, *>): GraphQLObjectType<*, *> {
     const name = type.name;
     const extensionASTNodes = typeExtensionsMap[name]
       ? type.extensionASTNodes
@@ -515,7 +515,7 @@ export function extendSchema(
 
   function extendPossibleTypes(
     type: GraphQLUnionType,
-  ): Array<GraphQLObjectType> {
+  ): Array<GraphQLObjectType<*, *>> {
     const possibleTypes = type.getTypes().map(extendNamedType);
 
     // If there are any extensions to the union, apply those here.
@@ -534,7 +534,7 @@ export function extendSchema(
   }
 
   function extendImplementedInterfaces(
-    type: GraphQLObjectType,
+    type: GraphQLObjectType<*, *>,
   ): Array<GraphQLInterfaceType> {
     const interfaces = type.getInterfaces().map(extendNamedType);
 
@@ -554,7 +554,7 @@ export function extendSchema(
     return interfaces;
   }
 
-  function extendFieldMap(type: GraphQLObjectType | GraphQLInterfaceType) {
+  function extendFieldMap(type: GraphQLObjectType<*, *> | GraphQLInterfaceType) {
     const newFieldMap = Object.create(null);
     const oldFieldMap = type.getFields();
     for (const fieldName of Object.keys(oldFieldMap)) {

--- a/src/utilities/getOperationRootType.js
+++ b/src/utilities/getOperationRootType.js
@@ -21,7 +21,7 @@ import type { GraphQLObjectType } from '../type/definition';
 export function getOperationRootType(
   schema: GraphQLSchema,
   operation: OperationDefinitionNode | OperationTypeDefinitionNode,
-): GraphQLObjectType {
+): GraphQLObjectType<*, *> {
   switch (operation.operation) {
     case 'query':
       const queryType = schema.getQueryType();

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -179,7 +179,7 @@ export function printType(type: GraphQLNamedType, options?: Options): string {
   throw new Error(`Unknown type: ${(type: empty)}.`);
 }
 
-function printScalar(type: GraphQLScalarType, options): string {
+function printScalar(type: GraphQLScalarType<>, options): string {
   return printDescription(options, type) + `scalar ${type.name}`;
 }
 

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -179,11 +179,11 @@ export function printType(type: GraphQLNamedType, options?: Options): string {
   throw new Error(`Unknown type: ${(type: empty)}.`);
 }
 
-function printScalar(type: GraphQLScalarType<>, options): string {
+function printScalar(type: GraphQLScalarType<*, *>, options): string {
   return printDescription(options, type) + `scalar ${type.name}`;
 }
 
-function printObject(type: GraphQLObjectType, options): string {
+function printObject(type: GraphQLObjectType<*, *>, options): string {
   const interfaces = type.getInterfaces();
   const implementedInterfaces = interfaces.length
     ? ' implements ' + interfaces.map(i => i.name).join(' & ')


### PR DESCRIPTION
based on https://github.com/gtkatakura/fullstack-challenge/commit/36cc1050768e29824f7c7114d22c131d43aefef9

and https://github.com/graphql/graphql-js/pull/1487
and https://github.com/graphql/graphql-js/pull/576
and https://github.com/graphql/graphql-js/pull/914

only 2 flow erros to fix

![image](https://user-images.githubusercontent.com/2005841/45520207-acf86880-b78e-11e8-94b7-e6632400941f.png)


for the first one, we can do this

```
this.parseValue = config.parseValue || (value => (value: any): TInternal);
```

for the second one, we can add a type param to valueFromASTUntyped or try to type cast the function (not sure if this is possible)