### PR TITLE
add testcases for nested list coercion

### DIFF
--- a/src/utilities/__tests__/coerceValue-test.js
+++ b/src/utilities/__tests__/coerceValue-test.js
@@ -12,6 +12,7 @@ import {
   GraphQLID,
   GraphQLInt,
   GraphQLFloat,
+  GraphQLList,
   GraphQLString,
   GraphQLEnumType,
   GraphQLInputObjectType,
@@ -237,14 +238,14 @@ describe('coerceValue', () => {
       expectValue(result).to.deep.equal({ foo: 123 });
     });
 
-    it('returns no error for a non-object type', () => {
+    it('returns an error for a non-object type', () => {
       const result = coerceValue(123, TestInputObject);
       expectErrors(result).to.deep.equal([
         'Expected type TestInputObject to be an object.',
       ]);
     });
 
-    it('returns no error for an invalid field', () => {
+    it('returns an error for an invalid field', () => {
       const result = coerceValue({ foo: 'abc' }, TestInputObject);
       expectErrors(result).to.deep.equal([
         'Expected type Int at value.foo; Int cannot represent non-integer value: "abc"',
@@ -281,6 +282,62 @@ describe('coerceValue', () => {
       expectErrors(result).to.deep.equal([
         'Field "bart" is not defined by type TestInputObject; did you mean bar?',
       ]);
+    });
+  });
+
+  describe('for GraphQLList', () => {
+    const TestList = GraphQLList(GraphQLInt);
+
+    it('returns no error for a valid input', () => {
+      const result = coerceValue([1, 2, 3], TestList);
+      expectValue(result).to.deep.equal([1, 2, 3]);
+    });
+
+    it('returns an error for an invalid input', () => {
+      const result = coerceValue([1, 'b', true], TestList);
+      expectErrors(result).to.deep.equal([
+        'Expected type Int at value[1]; Int cannot represent non-integer value: "b"',
+        'Expected type Int at value[2]; Int cannot represent non-integer value: true',
+      ]);
+    });
+
+    it('returns a list for a non-list value', () => {
+      const result = coerceValue(42, TestList);
+      expectValue(result).to.deep.equal([42]);
+    });
+
+    it('returns null for a null value', () => {
+      const result = coerceValue(null, TestList);
+      expectValue(result).to.deep.equal(null);
+    });
+  });
+
+  describe('for nested GraphQLList', () => {
+    const TestNestedList = GraphQLList(GraphQLList(GraphQLInt));
+
+    it('returns no error for a valid input', () => {
+      const result = coerceValue([[1], [2, 3]], TestNestedList);
+      expectValue(result).to.deep.equal([[1], [2, 3]]);
+    });
+
+    it('returns a list for a non-list value', () => {
+      const result = coerceValue(42, TestNestedList);
+      expectValue(result).to.deep.equal([[42]]);
+    });
+
+    it('returns null for a null value', () => {
+      const result = coerceValue(null, TestNestedList);
+      expectValue(result).to.deep.equal(null);
+    });
+
+    it('returns nested lists for nested non-list values', () => {
+      const result = coerceValue([1, 2, 3], TestNestedList);
+      expectValue(result).to.deep.equal([[1], [2], [3]]);
+    });
+
+    it('returns nested null for nested null values', () => {
+      const result = coerceValue([42, [null], null], TestNestedList);
+      expectValue(result).to.deep.equal([[42], [null], null]);
     });
   });
 });


### PR DESCRIPTION
Add some test cases to cover coercion of list values, especially nested lists where some non-list values are involved. These exercise the following special case from the [spec](http://facebook.github.io/graphql/June2018/#sec-Type-System.List):

> If the value passed as an input to a list type is not a list and not the null value, then the result of input coercion is a list of size one, where the single item value is the result of input coercion for the list’s item type on the provided value (note this may apply recursively for nested lists).

Most of these examples are copied directly from the spec. However, one of them actually coerces to a value different from what the example in the spec says, which I believe to be a mistake in the spec: https://github.com/facebook/graphql/pull/515

@IvanGoncharov what do you think?