### PR TITLE
[Spec] Move variable definition directive off of experimental flag

### DIFF
--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -108,11 +108,9 @@ describe('Parser', () => {
     );
   });
 
-  it('Experimental: parses variable definition directives', () => {
+  it('parses variable definition directives', () => {
     expect(() =>
-      parse('query Foo($x: Boolean = false @bar) { field }', {
-        experimentalVariableDefinitionDirectives: true,
-      }),
+      parse('query Foo($x: Boolean = false @bar) { field }'),
     ).to.not.throw();
   });
 

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -77,10 +77,9 @@ describe('Printer: Query document', () => {
     `);
   });
 
-  it('Experimental: prints query with variable directives', () => {
+  it('prints query with variable directives', () => {
     const queryAstWithVariableDirective = parse(
       'query ($foo: TestType = {a: 123} @testDirective(if: true) @test) { id }',
-      { experimentalVariableDefinitionDirectives: true },
     );
     expect(print(queryAstWithVariableDirective)).to.equal(dedent`
       query ($foo: TestType = {a: 123} @testDirective(if: true) @test) {
@@ -94,7 +93,6 @@ describe('Printer: Query document', () => {
       'fragment Foo($foo: TestType @test) on TestType @testDirective { id }',
       {
         experimentalFragmentVariables: true,
-        experimentalVariableDefinitionDirectives: true,
       },
     );
     expect(print(queryAstWithVariableDirective)).to.equal(dedent`

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -115,17 +115,6 @@ export type ParseOptions = {
    * future.
    */
   experimentalFragmentVariables?: boolean,
-
-  /**
-   * EXPERIMENTAL:
-   *
-   * If enabled, the parser understands directives on variable definitions:
-   *
-   * query Foo($var: String = "abc" @variable_definition_directive) {
-   *   ...
-   * }
-   */
-  experimentalVariableDefinitionDirectives?: boolean,
 };
 
 /**
@@ -341,19 +330,6 @@ function parseVariableDefinitions(
  */
 function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
   const start = lexer.token;
-  if (lexer.options.experimentalVariableDefinitionDirectives) {
-    return {
-      kind: Kind.VARIABLE_DEFINITION,
-      variable: parseVariable(lexer),
-      type: (expect(lexer, TokenKind.COLON), parseTypeReference(lexer)),
-      defaultValue: skip(lexer, TokenKind.EQUALS)
-        ? parseValueLiteral(lexer, true)
-        : undefined,
-      directives: parseDirectives(lexer, true),
-      loc: loc(lexer, start),
-    };
-  }
-
   return {
     kind: Kind.VARIABLE_DEFINITION,
     variable: parseVariable(lexer),
@@ -361,6 +337,7 @@ function parseVariableDefinition(lexer: Lexer<*>): VariableDefinitionNode {
     defaultValue: skip(lexer, TokenKind.EQUALS)
       ? parseValueLiteral(lexer, true)
       : undefined,
+    directives: parseDirectives(lexer, true),
     loc: loc(lexer, start),
   };
 }

--- a/src/validation/__tests__/KnownDirectives-test.js
+++ b/src/validation/__tests__/KnownDirectives-test.js
@@ -143,7 +143,7 @@ describe('Validate: Known directives', () => {
     );
   });
 
-  it('Experimental: with well placed variable definition directive', () => {
+  it('with well placed variable definition directive', () => {
     expectPassesRule(
       KnownDirectives,
       `
@@ -151,7 +151,6 @@ describe('Validate: Known directives', () => {
         name
       }
       `,
-      { experimentalVariableDefinitionDirectives: true },
     );
   });
 
@@ -177,7 +176,7 @@ describe('Validate: Known directives', () => {
     );
   });
 
-  it('Experimental: with misplaced variable definition directive', () => {
+  it('with misplaced variable definition directive', () => {
     expectFailsRule(
       KnownDirectives,
       `
@@ -186,7 +185,6 @@ describe('Validate: Known directives', () => {
       }
       `,
       [misplacedDirective('onField', 'VARIABLE_DEFINITION', 2, 31)],
-      { experimentalVariableDefinitionDirectives: true },
     );
   });
 


### PR DESCRIPTION
[Variable Definition Directives](https://github.com/facebook/graphql/pull/486) are part of the spec. So there is no need to hide them behind a feature flag anymore.

We should bump the minor version after merging this.