### PR TITLE
Fix error when printing a `FieldDefinition` AST node without `arguments` field

### DIFF
--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -134,7 +134,7 @@ const printDocASTReducer = {
   ),
 
   FieldDefinition: addDescription(
-    ({ name, arguments: args, type, directives }) =>
+    ({ name, arguments: args = [], type, directives }) =>
       name +
       (args.every(arg => arg.indexOf('\n') === -1)
         ? wrap('(', join(args, ', '), ')')

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -134,11 +134,11 @@ const printDocASTReducer = {
   ),
 
   FieldDefinition: addDescription(
-    ({ name, arguments: args = [], type, directives }) =>
+    ({ name, arguments: args, type, directives }) =>
       name +
-      (args.every(arg => arg.indexOf('\n') === -1)
-        ? wrap('(', join(args, ', '), ')')
-        : wrap('(\n', indent(join(args, '\n')), '\n)')) +
+      (hasMultilineItems(args)
+        ? wrap('(\n', indent(join(args, '\n')), '\n)')
+        : wrap('(', join(args, ', '), ')')) +
       ': ' +
       type +
       wrap(' ', join(directives, ' ')),
@@ -184,9 +184,9 @@ const printDocASTReducer = {
     ({ name, arguments: args, locations }) =>
       'directive @' +
       name +
-      (args.every(arg => arg.indexOf('\n') === -1)
-        ? wrap('(', join(args, ', '), ')')
-        : wrap('(\n', indent(join(args, '\n')), '\n)')) +
+      (hasMultilineItems(args)
+        ? wrap('(\n', indent(join(args, '\n')), '\n)')
+        : wrap('(', join(args, ', '), ')')) +
       ' on ' +
       join(locations, ' | '),
   ),
@@ -264,6 +264,14 @@ function indent(maybeString) {
   return maybeString && '  ' + maybeString.replace(/\n/g, '\n  ');
 }
 
+function isMultiline(string) {
+  return string.indexOf('\n') !== -1;
+}
+
+function hasMultilineItems(maybeArray) {
+  return maybeArray && maybeArray.some(isMultiline);
+}
+
 /**
  * Print a block string in the indented block form by adding a leading and
  * trailing blank line. However, if a block string starts with whitespace and is
@@ -271,7 +279,7 @@ function indent(maybeString) {
  */
 function printBlockString(value, isDescription) {
   const escaped = value.replace(/"""/g, '\\"""');
-  return (value[0] === ' ' || value[0] === '\t') && value.indexOf('\n') === -1
-    ? `"""${escaped.replace(/"$/, '"\n')}"""`
-    : `"""\n${isDescription ? escaped : indent(escaped)}\n"""`;
+  return isMultiline(value) || (value[0] !== ' ' && value[0] !== '\t')
+    ? `"""\n${isDescription ? escaped : indent(escaped)}\n"""`
+    : `"""${escaped.replace(/"$/, '"\n')}"""`;
 }


### PR DESCRIPTION
I encountered a runtime type error while printing some hand-constructed `FieldDefinition` AST nodes which conform to the type spec.

### Problem

Type spec - declaring it's optional:

https://github.com/graphql/graphql-js/blob/26c9874107e65f19576aae0a32638287820f68aa/src/language/ast.js#L444

Printing implementation - requiring it:

https://github.com/graphql/graphql-js/blob/787422956c9554d12d063a41fe35705335ec6290/src/language/printer.js#L139

### Solution

This PR fixes this discrepancy in the implementation with a default value.

https://github.com/awfulaxolotl/graphql-js/blob/df56ba3eadbfbc282ae6262927dfaeb162662158/src/language/printer.js#L139