### PR TITLE
Add Extra Tests for findArgChanges

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -1039,6 +1039,30 @@ describe('findDangerousChanges', () => {
         },
       ]);
     });
+    it("should return empty result if an argument's defaultValue is an Array and it's not changed", () => {
+      const oldSchema = buildSchema(`
+        type Type1 {
+          field1(name: [String!] = []): String
+        }
+
+        type Query {
+          field1: String
+        }
+      `);
+
+      const newSchema = buildSchema(`
+        type Type1 {
+          field1(name: [String!] = []): String
+        }
+
+        type Query {
+          field1: String
+        }
+      `);
+      expect(
+        findArgChanges(oldSchema, newSchema).dangerousChanges,
+      ).to.be.empty();
+    });
   });
 
   it('should detect if a value was added to an enum type', () => {


### PR DESCRIPTION
Add test for running `findArgChanges` with schema which field's default value is an array.
This PR also reproduces a bug of `findArgChanges`.