### PR TITLE
ASTValidation covers all validation rules that do not use Schema

### DIFF
--- a/src/validation/rules/NoFragmentCycles.js
+++ b/src/validation/rules/NoFragmentCycles.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type { ValidationContext } from '../ValidationContext';
+import type { ASTValidationContext } from '../ValidationContext';
 import { GraphQLError } from '../../error/GraphQLError';
 import type { FragmentDefinitionNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
@@ -20,7 +20,7 @@ export function cycleErrorMessage(
   return `Cannot spread fragment "${fragName}" within itself${via}.`;
 }
 
-export function NoFragmentCycles(context: ValidationContext): ASTVisitor {
+export function NoFragmentCycles(context: ASTValidationContext): ASTVisitor {
   // Tracks already visited fragments to maintain O(N) and to ensure that cycles
   // are not redundantly reported.
   const visitedFrags = Object.create(null);

--- a/src/validation/rules/NoUnusedFragments.js
+++ b/src/validation/rules/NoUnusedFragments.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type { ValidationContext } from '../ValidationContext';
+import type { ASTValidationContext } from '../ValidationContext';
 import { GraphQLError } from '../../error/GraphQLError';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -21,7 +21,7 @@ export function unusedFragMessage(fragName: string): string {
  * A GraphQL document is only valid if all fragment definitions are spread
  * within operations, or spread within other fragments spread within operations.
  */
-export function NoUnusedFragments(context: ValidationContext): ASTVisitor {
+export function NoUnusedFragments(context: ASTValidationContext): ASTVisitor {
   const operationDefs = [];
   const fragmentDefs = [];
 


### PR DESCRIPTION
There are at least two different classes of validation rules:
- Validation that requires Schema information (e.g. `KnownTypeNames`)
- Validation that does not require any Schema information (e.g. `NoFragmentCycles)

This makes sure `NoFragmentCycles` and `NoUnusedFragments` can use the `ASTValidation`, as neither of these rules need schema information.