### PR TITLE
Don't check for specified scalars in removed types

### DIFF
--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -35,6 +35,8 @@ import keyMap from '../jsutils/keyMap';
 import type { ObjMap } from '../jsutils/ObjMap';
 import type { DirectiveLocationEnum } from '../language/directiveLocation';
 
+import { isSpecifiedScalarType } from '../type/scalars';
+
 export const BreakingChangeType = {
   FIELD_CHANGED_KIND: 'FIELD_CHANGED_KIND',
   FIELD_REMOVED: 'FIELD_REMOVED',
@@ -128,7 +130,7 @@ export function findRemovedTypes(
 
   const breakingChanges = [];
   for (const typeName of Object.keys(oldTypeMap)) {
-    if (!newTypeMap[typeName]) {
+    if (!newTypeMap[typeName] && !isSpecifiedScalarType(oldTypeMap[typeName])) {
       breakingChanges.push({
         type: BreakingChangeType.TYPE_REMOVED,
         description: `${typeName} was removed.`,


### PR DESCRIPTION
This PR includes a broken test (that I will update if approved). 

Not sure if you want to go this direction (please feel free to close if not), but having a specified scalar type removed from a schema is not an issue on it's own, and the breakage is already typically covered by a type changing on a field.

For example, changing a schema from 
```graphql
type Query {
  version: String
}
```
to 
```graphql
type Query {
  version: Int
}
```

Will include `"String was removed."` _and_ `"Query.version changed type from String to Int."` I think the first message is benign, where the second is not 🤷‍♂️ 

I can understand the reasoning for keeping it as is, since a lot of these checks could get super-complicated, but this change seems rather useful 🙂 
