### PR TITLE
Non-Scalar default dangerous change: Fix for #1566

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -1039,6 +1039,30 @@ describe('findDangerousChanges', () => {
         },
       ]);
     });
+    it("should return empty result if an argument's defaultValue is an Array and it's not changed", () => {
+      const oldSchema = buildSchema(`
+        type Type1 {
+          field1(name: [String!] = []): String
+        }
+
+        type Query {
+          field1: String
+        }
+      `);
+
+      const newSchema = buildSchema(`
+        type Type1 {
+          field1(name: [String!] = []): String
+        }
+
+        type Query {
+          field1: String
+        }
+      `);
+      expect(
+        findArgChanges(oldSchema, newSchema).dangerousChanges,
+      ).to.be.empty();
+    });
   });
 
   it('should detect if a value was added to an enum type', () => {

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -1041,27 +1041,59 @@ describe('findDangerousChanges', () => {
     });
     it("should return empty result if an argument's defaultValue is an Array and it's not changed", () => {
       const oldSchema = buildSchema(`
+        input Input1 {
+          inner_array: [String]
+          inner_input: Input2
+          inner_input_array: [Input2]
+        }
+
+        input Input2 {
+          string_field: String
+          int_field: Int
+        }
+
         type Type1 {
-          field1(name: [String!] = []): String
+          empty_array_default(arr: [String!] = []): String
+          value_array_default(arr: [[String]] = [["a", "b"], ["c", "d"]]): String
+          input_default(input: Input1 = {
+            inner_array: ["a", "b"]
+            inner_input: {string_field: "abc", int_field: 32}
+            inner_input_array: [{int_field: 10}]
+          }): String
         }
 
         type Query {
-          field1: String
+          t: Type1
         }
       `);
 
       const newSchema = buildSchema(`
+        input Input1 {
+          inner_array: [String]
+          inner_input: Input2
+          inner_input_array: [Input2]
+        }
+
+        input Input2 {
+          string_field: String
+          int_field: Int
+        }
+
         type Type1 {
-          field1(name: [String!] = []): String
+          empty_array_default(arr: [String!] = []): String
+          value_array_default(arr: [[String]] = [["a", "b"], ["c", "d"]]): String
+          input_default(input: Input1 = {
+            inner_array: ["a", "b"]
+            inner_input: {string_field: "abc", int_field: 32}
+            inner_input_array: [{int_field: 10}]
+          }): String
         }
 
         type Query {
-          field1: String
+          t: Type1
         }
       `);
-      expect(
-        findArgChanges(oldSchema, newSchema).dangerousChanges,
-      ).to.be.empty();
+      expect(findArgChanges(oldSchema, newSchema).dangerousChanges).to.eql([]);
     });
   });
 

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -232,8 +232,10 @@ export function findArgChanges(
                 `${oldArgDef.type.toString()} to ${newArgDef.type.toString()}`,
             });
           } else if (
-            oldArgDef.defaultValue !== undefined &&
-            oldArgDef.defaultValue !== newArgDef.defaultValue
+            !isChangeSafeForDefaultValue(
+              oldArgDef.defaultValue,
+              newArgDef.defaultValue,
+            )
           ) {
             dangerousChanges.push({
               type: DangerousChangeType.ARG_DEFAULT_VALUE_CHANGE,
@@ -493,6 +495,39 @@ function isChangeSafeForInputObjectFieldOrFieldArg(
         isChangeSafeForInputObjectFieldOrFieldArg(oldType.ofType, newType))
     );
   }
+  return false;
+}
+
+function isChangeSafeForDefaultValue(
+  oldDefaultValue: mixed,
+  newDefaultValue: ?mixed,
+): boolean {
+  if (oldDefaultValue === undefined) {
+    return true;
+  }
+
+  if (oldDefaultValue === newDefaultValue) {
+    return true;
+  }
+
+  if (
+    typeof oldDefaultValue === 'object' &&
+    typeof newDefaultValue === 'object'
+  ) {
+    if (Array.isArray(oldDefaultValue) !== Array.isArray(newDefaultValue)) {
+      return false;
+    }
+
+    for (const key in oldDefaultValue) {
+      if (
+        !isChangeSafeForDefaultValue(oldDefaultValue[key], newDefaultValue[key])
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   return false;
 }
 

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -499,7 +499,7 @@ function isChangeSafeForInputObjectFieldOrFieldArg(
 }
 
 function isChangeSafeForDefaultValue(
-  oldDefaultValue: mixed,
+  oldDefaultValue: ?mixed,
   newDefaultValue: ?mixed,
 ): boolean {
   if (oldDefaultValue === undefined) {
@@ -511,6 +511,8 @@ function isChangeSafeForDefaultValue(
   }
 
   if (
+    oldDefaultValue != null &&
+    newDefaultValue != null &&
     typeof oldDefaultValue === 'object' &&
     typeof newDefaultValue === 'object'
   ) {


### PR DESCRIPTION
@helloqiu identified in #1566 that our dangerous changes check was incorrectly saying any non-scalar default value was a dangerous change, even if the default value hadn't actually changed. This is because we need to check the default value change for deep equality, rather than just whether the objects are identical.