### PR TITLE
Inspect non-error types to produce helpful error messages for failing resolvers

### DIFF
--- a/src/execution/__tests__/abstract-promise-test.js
+++ b/src/execution/__tests__/abstract-promise-test.js
@@ -546,7 +546,7 @@ describe('Execute: Handles execution of abstract types with promises', () => {
   it('resolveType can be caught', async () => {
     const PetType = new GraphQLInterfaceType({
       name: 'Pet',
-      resolveType: () => Promise.reject('We are testing this error'),
+      resolveType: () => Promise.reject(new Error('We are testing this error')),
       fields: {
         name: { type: GraphQLString },
       },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -349,14 +349,12 @@ describe('Execute: Handles basic execution tasks', () => {
           sync: { type: GraphQLString },
           syncError: { type: GraphQLString },
           syncRawError: { type: GraphQLString },
-          syncObjectError: { type: GraphQLString },
           syncReturnError: { type: GraphQLString },
           syncReturnErrorList: { type: GraphQLList(GraphQLString) },
           async: { type: GraphQLString },
           asyncReject: { type: GraphQLString },
           asyncRejectWithExtensions: { type: GraphQLString },
           asyncRawReject: { type: GraphQLString },
-          asyncObjectReject: { type: GraphQLString },
           asyncEmptyReject: { type: GraphQLString },
           asyncError: { type: GraphQLString },
           asyncRawError: { type: GraphQLString },
@@ -371,13 +369,11 @@ describe('Execute: Handles basic execution tasks', () => {
         sync
         syncError
         syncRawError
-        syncObjectError
         syncReturnError
         syncReturnErrorList
         async
         asyncReject
         asyncRawReject
-        asyncObjectReject
         asyncEmptyReject
         asyncError
         asyncRawError
@@ -396,10 +392,6 @@ describe('Execute: Handles basic execution tasks', () => {
       syncRawError() {
         // eslint-disable-next-line no-throw-literal
         throw 'Error getting syncRawError';
-      },
-      syncObjectError() {
-        // eslint-disable-next-line no-throw-literal
-        throw { message: 'Error getting syncObjectError' };
       },
       syncReturnError() {
         return new Error('Error getting syncReturnError');
@@ -422,9 +414,6 @@ describe('Execute: Handles basic execution tasks', () => {
       },
       asyncRawReject() {
         return Promise.reject('Error getting asyncRawReject');
-      },
-      asyncObjectReject() {
-        return Promise.reject({ message: 'Error getting asyncObjectReject' });
       },
       asyncEmptyReject() {
         return Promise.reject();
@@ -459,13 +448,11 @@ describe('Execute: Handles basic execution tasks', () => {
         sync: 'sync',
         syncError: null,
         syncRawError: null,
-        syncObjectError: null,
         syncReturnError: null,
         syncReturnErrorList: ['sync0', null, 'sync2', null],
         async: 'async',
         asyncReject: null,
         asyncRawReject: null,
-        asyncObjectReject: null,
         asyncEmptyReject: null,
         asyncError: null,
         asyncRawError: null,
@@ -484,65 +471,53 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['syncRawError'],
         },
         {
-          message:
-            'Unexpected error value: { message: "Error getting syncObjectError" }',
-          locations: [{ line: 6, column: 9 }],
-          path: ['syncObjectError'],
-        },
-        {
           message: 'Error getting syncReturnError',
-          locations: [{ line: 7, column: 9 }],
+          locations: [{ line: 6, column: 9 }],
           path: ['syncReturnError'],
         },
         {
           message: 'Error getting syncReturnErrorList1',
-          locations: [{ line: 8, column: 9 }],
+          locations: [{ line: 7, column: 9 }],
           path: ['syncReturnErrorList', 1],
         },
         {
           message: 'Error getting syncReturnErrorList3',
-          locations: [{ line: 8, column: 9 }],
+          locations: [{ line: 7, column: 9 }],
           path: ['syncReturnErrorList', 3],
         },
         {
           message: 'Error getting asyncReject',
-          locations: [{ line: 10, column: 9 }],
+          locations: [{ line: 9, column: 9 }],
           path: ['asyncReject'],
         },
         {
           message: 'Unexpected error value: "Error getting asyncRawReject"',
-          locations: [{ line: 11, column: 9 }],
+          locations: [{ line: 10, column: 9 }],
           path: ['asyncRawReject'],
         },
         {
-          message:
-            'Unexpected error value: { message: "Error getting asyncObjectReject" }',
-          locations: [{ line: 12, column: 9 }],
-          path: ['asyncObjectReject'],
-        },
-        {
           message: 'Unexpected error value: undefined',
-          locations: [{ line: 13, column: 9 }],
+          locations: [{ line: 11, column: 9 }],
           path: ['asyncEmptyReject'],
         },
         {
           message: 'Error getting asyncError',
-          locations: [{ line: 14, column: 9 }],
+          locations: [{ line: 12, column: 9 }],
           path: ['asyncError'],
         },
         {
           message: 'Unexpected error value: "Error getting asyncRawError"',
-          locations: [{ line: 15, column: 9 }],
+          locations: [{ line: 13, column: 9 }],
           path: ['asyncRawError'],
         },
         {
           message: 'Error getting asyncReturnError',
-          locations: [{ line: 16, column: 9 }],
+          locations: [{ line: 14, column: 9 }],
           path: ['asyncReturnError'],
         },
         {
           message: 'Error getting asyncReturnErrorWithExtensions',
-          locations: [{ line: 17, column: 9 }],
+          locations: [{ line: 15, column: 9 }],
           path: ['asyncReturnErrorWithExtensions'],
           extensions: { foo: 'bar' },
         },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -349,12 +349,14 @@ describe('Execute: Handles basic execution tasks', () => {
           sync: { type: GraphQLString },
           syncError: { type: GraphQLString },
           syncRawError: { type: GraphQLString },
+          syncObjectError: { type: GraphQLString },
           syncReturnError: { type: GraphQLString },
           syncReturnErrorList: { type: GraphQLList(GraphQLString) },
           async: { type: GraphQLString },
           asyncReject: { type: GraphQLString },
           asyncRejectWithExtensions: { type: GraphQLString },
           asyncRawReject: { type: GraphQLString },
+          asyncObjectReject: { type: GraphQLString },
           asyncEmptyReject: { type: GraphQLString },
           asyncError: { type: GraphQLString },
           asyncRawError: { type: GraphQLString },
@@ -369,11 +371,13 @@ describe('Execute: Handles basic execution tasks', () => {
         sync
         syncError
         syncRawError
+        syncObjectError
         syncReturnError
         syncReturnErrorList
         async
         asyncReject
         asyncRawReject
+        asyncObjectReject
         asyncEmptyReject
         asyncError
         asyncRawError
@@ -392,6 +396,10 @@ describe('Execute: Handles basic execution tasks', () => {
       syncRawError() {
         // eslint-disable-next-line no-throw-literal
         throw 'Error getting syncRawError';
+      },
+      syncObjectError() {
+        // eslint-disable-next-line no-throw-literal
+        throw { message: 'Error getting syncObjectError' };
       },
       syncReturnError() {
         return new Error('Error getting syncReturnError');
@@ -414,6 +422,10 @@ describe('Execute: Handles basic execution tasks', () => {
       },
       asyncRawReject() {
         return Promise.reject('Error getting asyncRawReject');
+      },
+      asyncObjectReject() {
+        // eslint-disable-next-line no-throw-literal
+        return Promise.reject({ message: 'Error getting asyncObjectReject' });
       },
       asyncEmptyReject() {
         return Promise.reject();
@@ -448,11 +460,13 @@ describe('Execute: Handles basic execution tasks', () => {
         sync: 'sync',
         syncError: null,
         syncRawError: null,
+        syncObjectError: null,
         syncReturnError: null,
         syncReturnErrorList: ['sync0', null, 'sync2', null],
         async: 'async',
         asyncReject: null,
         asyncRawReject: null,
+        asyncObjectReject: null,
         asyncEmptyReject: null,
         asyncError: null,
         asyncRawError: null,
@@ -471,53 +485,63 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['syncRawError'],
         },
         {
-          message: 'Error getting syncReturnError',
+          message: '{"message":"Error getting syncObjectError"}',
           locations: [{ line: 6, column: 9 }],
+          path: ['syncObjectError'],
+        },
+        {
+          message: 'Error getting syncReturnError',
+          locations: [{ line: 7, column: 9 }],
           path: ['syncReturnError'],
         },
         {
           message: 'Error getting syncReturnErrorList1',
-          locations: [{ line: 7, column: 9 }],
+          locations: [{ line: 8, column: 9 }],
           path: ['syncReturnErrorList', 1],
         },
         {
           message: 'Error getting syncReturnErrorList3',
-          locations: [{ line: 7, column: 9 }],
+          locations: [{ line: 8, column: 9 }],
           path: ['syncReturnErrorList', 3],
         },
         {
           message: 'Error getting asyncReject',
-          locations: [{ line: 9, column: 9 }],
+          locations: [{ line: 10, column: 9 }],
           path: ['asyncReject'],
         },
         {
           message: 'Error getting asyncRawReject',
-          locations: [{ line: 10, column: 9 }],
+          locations: [{ line: 11, column: 9 }],
           path: ['asyncRawReject'],
         },
         {
+          message: '{"message":"Error getting asyncObjectReject"}',
+          locations: [{ line: 12, column: 9 }],
+          path: ['asyncObjectReject'],
+        },
+        {
           message: '',
-          locations: [{ line: 11, column: 9 }],
+          locations: [{ line: 13, column: 9 }],
           path: ['asyncEmptyReject'],
         },
         {
           message: 'Error getting asyncError',
-          locations: [{ line: 12, column: 9 }],
+          locations: [{ line: 14, column: 9 }],
           path: ['asyncError'],
         },
         {
           message: 'Error getting asyncRawError',
-          locations: [{ line: 13, column: 9 }],
+          locations: [{ line: 15, column: 9 }],
           path: ['asyncRawError'],
         },
         {
           message: 'Error getting asyncReturnError',
-          locations: [{ line: 14, column: 9 }],
+          locations: [{ line: 16, column: 9 }],
           path: ['asyncReturnError'],
         },
         {
           message: 'Error getting asyncReturnErrorWithExtensions',
-          locations: [{ line: 15, column: 9 }],
+          locations: [{ line: 17, column: 9 }],
           path: ['asyncReturnErrorWithExtensions'],
           extensions: { foo: 'bar' },
         },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -479,12 +479,13 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['syncError'],
         },
         {
-          message: 'Error getting syncRawError',
+          message: 'Unexpected error value: "Error getting syncRawError"',
           locations: [{ line: 5, column: 9 }],
           path: ['syncRawError'],
         },
         {
-          message: '{ message: "Error getting syncObjectError" }',
+          message:
+            'Unexpected error value: { message: "Error getting syncObjectError" }',
           locations: [{ line: 6, column: 9 }],
           path: ['syncObjectError'],
         },
@@ -509,17 +510,18 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['asyncReject'],
         },
         {
-          message: 'Error getting asyncRawReject',
+          message: 'Unexpected error value: "Error getting asyncRawReject"',
           locations: [{ line: 11, column: 9 }],
           path: ['asyncRawReject'],
         },
         {
-          message: '{ message: "Error getting asyncObjectReject" }',
+          message:
+            'Unexpected error value: { message: "Error getting asyncObjectReject" }',
           locations: [{ line: 12, column: 9 }],
           path: ['asyncObjectReject'],
         },
         {
-          message: '',
+          message: 'Unexpected error value: undefined',
           locations: [{ line: 13, column: 9 }],
           path: ['asyncEmptyReject'],
         },
@@ -529,7 +531,7 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['asyncError'],
         },
         {
-          message: 'Error getting asyncRawError',
+          message: 'Unexpected error value: "Error getting asyncRawError"',
           locations: [{ line: 15, column: 9 }],
           path: ['asyncRawError'],
         },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -484,7 +484,7 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['syncRawError'],
         },
         {
-          message: '{"message":"Error getting syncObjectError"}',
+          message: '{ message: "Error getting syncObjectError" }',
           locations: [{ line: 6, column: 9 }],
           path: ['syncObjectError'],
         },
@@ -514,7 +514,7 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['asyncRawReject'],
         },
         {
-          message: '{"message":"Error getting asyncObjectReject"}',
+          message: '{ message: "Error getting asyncObjectReject" }',
           locations: [{ line: 12, column: 9 }],
           path: ['asyncObjectReject'],
         },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -424,7 +424,6 @@ describe('Execute: Handles basic execution tasks', () => {
         return Promise.reject('Error getting asyncRawReject');
       },
       asyncObjectReject() {
-        // eslint-disable-next-line no-throw-literal
         return Promise.reject({ message: 'Error getting asyncObjectReject' });
       },
       asyncEmptyReject() {

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -743,10 +743,7 @@ function asErrorInstance(error: mixed): Error {
   if (error instanceof Error) {
     return error;
   }
-  if (typeof error === 'object') {
-    return new Error(inspect(error));
-  }
-  return new Error(error || undefined);
+  return new Error('Unexpected error value: ' + inspect(error));
 }
 
 // This is a small wrapper around completeValue which detects and logs errors

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -744,7 +744,7 @@ function asErrorInstance(error: mixed): Error {
     return error;
   }
   if (typeof error === 'object') {
-    return new Error(JSON.stringify(error));
+    return new Error(inspect(error));
   }
   return new Error(error || undefined);
 }

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -744,7 +744,7 @@ function asErrorInstance(error: mixed): Error {
     return error;
   }
   if (error instanceof Object) {
-    return new Error(error.message || undefined);
+    return new Error(JSON.stringify(error));
   }
   return new Error(error || undefined);
 }

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -740,7 +740,13 @@ export function resolveFieldValueOrError<TSource>(
 // Sometimes a non-error is thrown, wrap it as an Error instance to ensure a
 // consistent Error interface.
 function asErrorInstance(error: mixed): Error {
-  return error instanceof Error ? error : new Error(error || undefined);
+  if (error instanceof Error) {
+    return error;
+  }
+  if (error instanceof Object) {
+    return new Error(error.message || undefined);
+  }
+  return new Error(error || undefined);
 }
 
 // This is a small wrapper around completeValue which detects and logs errors

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -743,7 +743,7 @@ function asErrorInstance(error: mixed): Error {
   if (error instanceof Error) {
     return error;
   }
-  if (error instanceof Object) {
+  if (typeof error === 'object') {
     return new Error(JSON.stringify(error));
   }
   return new Error(error || undefined);


### PR DESCRIPTION
This is a proposal to handle previously serialised error objects according to [section 7.1.2 of the spec](https://facebook.github.io/graphql/draft/#sec-Errors). The result of receiving an error as object, without being an instance of the Error type, is an error message of `[object Object]`. The serialisation problem can be observed when working with [remote executable schemas in Apollo GraphQL Tools](https://github.com/apollographql/graphql-tools/blob/master/src/stitching/makeRemoteExecutableSchema.ts), when throwing an Error in a remote resolver, it bubbles up as deserialised GraphQL Error according to the spec, but is not an Error instance.

A local resolver can also accidentally throw an Object/literal, which is valid JS, ~~but~~ and an error none-the-less.
```js
try { throw { message:'woohaa!' }; } catch(e) { console.log(e, 'Is Error:', e instanceof Error); }
// > { message: 'woohaa!' } 'Is Error:' false
```

My take is that GraphQL should handle valid error Objects, as the spec states:

> Every error must contain an entry with the key message with a string description of the error intended for the developer as a guide to understand and correct the error.

This may be fixed in graphql-tools, but I guess this is haunting other implementations as well. I'd event go as far as to deserialise the original stack trace.

I'll try to find a fix for remote executable schemas in apollograqphql/graphql-tools in the meantime, which could be a correct deserialisation in delegateToSchema.

EDIT: Heres a reproduction with apollo, resulting in an `[object Object]` error message in both cases https://github.com/kommander/graphql-bug