### PR TITLE
Switch from coveralls to codecov for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@
 .nyc_output
 node_modules
 coverage
+coverage.lcov
 dist
 npm

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "scripts": {
     "watch": "node ./resources/watch.js",
     "test": "npm run lint && npm run check && npm run testonly",
-    "test:ci": "npm run lint && npm run check && npm run testonly:coveralls",
+    "test:ci": "npm run lint && npm run check && npm run testonly:codecov",
     "t": "mocha --require @babel/register --require @babel/polyfill",
     "testonly": "mocha --throw-deprecation --require @babel/register --require @babel/polyfill --check-leaks --full-trace --timeout 15000 src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc --reporter html --reporter text-summary -- npm run testonly",
-    "testonly:coveralls": "nyc --silent -- npm run testonly && nyc report --reporter text-lcov | coveralls",
+    "testonly:codecov": "nyc --silent -- npm run testonly && nyc report --reporter text-lcov > coverage.lcov && codecov",
     "lint": "eslint --report-unused-disable-directives src || (printf '\\033[33mTry: \\033[7m npm run lint -- --fix \\033[0m\\n' && exit 1)",
     "benchmark": "node ./resources/benchmark.js",
     "prettier": "prettier --write --list-different 'src/**/*.js'",
@@ -47,6 +47,7 @@
     "gitpublish": ". ./resources/gitpublish.sh"
   },
   "dependencies": {
+    "codecov": "^3.1.0",
     "iterall": "^1.2.2"
   },
   "devDependencies": {
@@ -60,7 +61,6 @@
     "beautify-benchmark": "0.2.4",
     "benchmark": "2.1.4",
     "chai": "4.2.0",
-    "coveralls": "3.0.2",
     "eslint": "5.12.1",
     "eslint-plugin-flowtype": "3.2.1",
     "eslint-plugin-prettier": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -737,6 +737,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+  integrity sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1089,6 +1094,17 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+codecov@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.1.0.tgz#340bd968d361f256976b5af782dd8ba9f82bc849"
+  integrity sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==
+  dependencies:
+    argv "^0.0.2"
+    ignore-walk "^3.0.1"
+    js-yaml "^3.12.0"
+    request "^2.87.0"
+    urlgrey "^0.4.4"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3260,7 +3276,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request@^2.85.0:
+request@^2.85.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -3853,6 +3869,11 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+urlgrey@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
+  integrity sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Switches from using coveralls, which hasn't been updated in almost a year and does not support Node 11, to codecov.

This commit will be tested by seeing:
1. Our Travis CI works on node 11
2. Coverage reports are uploaded via Travis CI

It's unclear based on codecov docs whether a special token is required when running through Travis CI.