### PR TITLE
Use AST abbreviation consistently

### DIFF
--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -28,44 +28,44 @@ describe('Printer: Query document', () => {
   });
 
   it('produces helpful error messages', () => {
-    const badAst1 = { random: 'Data' };
+    const badAST = { random: 'Data' };
     // $DisableFlowOnNegativeTest
-    expect(() => print(badAst1)).to.throw(
+    expect(() => print(badAST)).to.throw(
       'Invalid AST Node: { random: "Data" }',
     );
   });
 
   it('correctly prints non-query operations without name', () => {
-    const queryAstShorthanded = parse('query { id, name }');
-    expect(print(queryAstShorthanded)).to.equal(dedent`
+    const queryASTShorthanded = parse('query { id, name }');
+    expect(print(queryASTShorthanded)).to.equal(dedent`
       {
         id
         name
       }
     `);
 
-    const mutationAst = parse('mutation { id, name }');
-    expect(print(mutationAst)).to.equal(dedent`
+    const mutationAST = parse('mutation { id, name }');
+    expect(print(mutationAST)).to.equal(dedent`
       mutation {
         id
         name
       }
     `);
 
-    const queryAstWithArtifacts = parse(
+    const queryASTWithArtifacts = parse(
       'query ($foo: TestType) @testDirective { id, name }',
     );
-    expect(print(queryAstWithArtifacts)).to.equal(dedent`
+    expect(print(queryASTWithArtifacts)).to.equal(dedent`
       query ($foo: TestType) @testDirective {
         id
         name
       }
     `);
 
-    const mutationAstWithArtifacts = parse(
+    const mutationASTWithArtifacts = parse(
       'mutation ($foo: TestType) @testDirective { id, name }',
     );
-    expect(print(mutationAstWithArtifacts)).to.equal(dedent`
+    expect(print(mutationASTWithArtifacts)).to.equal(dedent`
       mutation ($foo: TestType) @testDirective {
         id
         name
@@ -74,10 +74,10 @@ describe('Printer: Query document', () => {
   });
 
   it('prints query with variable directives', () => {
-    const queryAstWithVariableDirective = parse(
+    const queryASTWithVariableDirective = parse(
       'query ($foo: TestType = {a: 123} @testDirective(if: true) @test) { id }',
     );
-    expect(print(queryAstWithVariableDirective)).to.equal(dedent`
+    expect(print(queryASTWithVariableDirective)).to.equal(dedent`
       query ($foo: TestType = {a: 123} @testDirective(if: true) @test) {
         id
       }
@@ -85,13 +85,13 @@ describe('Printer: Query document', () => {
   });
 
   it('Experimental: prints fragment with variable directives', () => {
-    const queryAstWithVariableDirective = parse(
+    const queryASTWithVariableDirective = parse(
       'fragment Foo($foo: TestType @test) on TestType @testDirective { id }',
       {
         experimentalFragmentVariables: true,
       },
     );
-    expect(print(queryAstWithVariableDirective)).to.equal(dedent`
+    expect(print(queryASTWithVariableDirective)).to.equal(dedent`
       fragment Foo($foo: TestType @test) on TestType @testDirective {
         id
       }
@@ -100,10 +100,10 @@ describe('Printer: Query document', () => {
 
   describe('block string', () => {
     it('correctly prints single-line with leading space', () => {
-      const mutationAstWithArtifacts = parse(
+      const mutationASTWithArtifacts = parse(
         '{ field(arg: """    space-led value""") }',
       );
-      expect(print(mutationAstWithArtifacts)).to.equal(dedent`
+      expect(print(mutationASTWithArtifacts)).to.equal(dedent`
         {
           field(arg: """    space-led value""")
         }
@@ -111,7 +111,7 @@ describe('Printer: Query document', () => {
     });
 
     it('correctly prints string with a first line indentation', () => {
-      const mutationAstWithArtifacts = parse(`
+      const mutationASTWithArtifacts = parse(`
         {
           field(arg: """
                 first
@@ -120,7 +120,7 @@ describe('Printer: Query document', () => {
           """)
         }
       `);
-      expect(print(mutationAstWithArtifacts)).to.equal(dedent`
+      expect(print(mutationASTWithArtifacts)).to.equal(dedent`
         {
           field(arg: """
                 first
@@ -132,13 +132,13 @@ describe('Printer: Query document', () => {
     });
 
     it('correctly prints single-line with leading space and quotation', () => {
-      const mutationAstWithArtifacts = parse(`
+      const mutationASTWithArtifacts = parse(`
         {
           field(arg: """    space-led value "quoted string"
           """)
         }
       `);
-      expect(print(mutationAstWithArtifacts)).to.equal(dedent`
+      expect(print(mutationASTWithArtifacts)).to.equal(dedent`
         {
           field(arg: """    space-led value "quoted string"
           """)

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -24,9 +24,9 @@ describe('Printer: SDL document', () => {
   });
 
   it('produces helpful error messages', () => {
-    const badAst1 = { random: 'Data' };
+    const badAST = { random: 'Data' };
     // $DisableFlowOnNegativeTest
-    expect(() => print(badAst1)).to.throw(
+    expect(() => print(badAST)).to.throw(
       'Invalid AST Node: { random: "Data" }',
     );
   });

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -128,7 +128,7 @@ describe('Visitor', () => {
 
     let selectionSet;
 
-    const editedAst = visit(ast, {
+    const editedAST = visit(ast, {
       OperationDefinition: {
         enter(node) {
           checkVisitorFnArgs(ast, arguments);
@@ -153,7 +153,7 @@ describe('Visitor', () => {
       },
     });
 
-    expect(editedAst).to.deep.equal({
+    expect(editedAST).to.deep.equal({
       ...ast,
       definitions: [
         {
@@ -170,7 +170,7 @@ describe('Visitor', () => {
 
     const { definitions } = ast;
 
-    const editedAst = visit(ast, {
+    const editedAST = visit(ast, {
       Document: {
         enter(node) {
           checkVisitorFnArgs(ast, arguments);
@@ -191,7 +191,7 @@ describe('Visitor', () => {
       },
     });
 
-    expect(editedAst).to.deep.equal({
+    expect(editedAST).to.deep.equal({
       ...ast,
       didEnter: true,
       didLeave: true,
@@ -200,7 +200,7 @@ describe('Visitor', () => {
 
   it('allows for editing on enter', () => {
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
-    const editedAst = visit(ast, {
+    const editedAST = visit(ast, {
       enter(node) {
         checkVisitorFnArgs(ast, arguments);
         if (node.kind === 'Field' && node.name.value === 'b') {
@@ -213,14 +213,14 @@ describe('Visitor', () => {
       parse('{ a, b, c { a, b, c } }', { noLocation: true }),
     );
 
-    expect(editedAst).to.deep.equal(
+    expect(editedAST).to.deep.equal(
       parse('{ a,    c { a,    c } }', { noLocation: true }),
     );
   });
 
   it('allows for editing on leave', () => {
     const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
-    const editedAst = visit(ast, {
+    const editedAST = visit(ast, {
       leave(node) {
         checkVisitorFnArgs(ast, arguments, /* isEdited */ true);
         if (node.kind === 'Field' && node.name.value === 'b') {
@@ -233,7 +233,7 @@ describe('Visitor', () => {
       parse('{ a, b, c { a, b, c } }', { noLocation: true }),
     );
 
-    expect(editedAst).to.deep.equal(
+    expect(editedAST).to.deep.equal(
       parse('{ a,    c { a,    c } }', { noLocation: true }),
     );
   });
@@ -1169,7 +1169,7 @@ describe('Visitor', () => {
       const visited = [];
 
       const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
-      const editedAst = visit(
+      const editedAST = visit(
         ast,
         visitInParallel([
           {
@@ -1197,7 +1197,7 @@ describe('Visitor', () => {
         parse('{ a, b, c { a, b, c } }', { noLocation: true }),
       );
 
-      expect(editedAst).to.deep.equal(
+      expect(editedAST).to.deep.equal(
         parse('{ a,    c { a,    c } }', { noLocation: true }),
       );
 
@@ -1233,7 +1233,7 @@ describe('Visitor', () => {
       const visited = [];
 
       const ast = parse('{ a, b, c { a, b, c } }', { noLocation: true });
-      const editedAst = visit(
+      const editedAST = visit(
         ast,
         visitInParallel([
           {
@@ -1261,7 +1261,7 @@ describe('Visitor', () => {
         parse('{ a, b, c { a, b, c } }', { noLocation: true }),
       );
 
-      expect(editedAst).to.deep.equal(
+      expect(editedAST).to.deep.equal(
         parse('{ a,    c { a,    c } }', { noLocation: true }),
       );
 
@@ -1392,7 +1392,7 @@ describe('Visitor', () => {
       const typeInfo = new TypeInfo(testSchema);
 
       const ast = parse('{ human(id: 4) { name, pets }, alien }');
-      const editedAst = visit(
+      const editedAST = visit(
         ast,
         visitWithTypeInfo(typeInfo, {
           enter(node) {
@@ -1454,7 +1454,7 @@ describe('Visitor', () => {
         print(parse('{ human(id: 4) { name, pets }, alien }')),
       );
 
-      expect(print(editedAst)).to.deep.equal(
+      expect(print(editedAST)).to.deep.equal(
         print(
           parse(
             '{ human(id: 4) { name, pets { __typename } }, alien { __typename } }',

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -111,7 +111,7 @@ async function createSubscription(pubsub, schema = emailSchema, ast, vars) {
     });
   }
 
-  const defaultAst = parse(`
+  const defaultAST = parse(`
     subscription ($priority: Int = 0) {
       importantEmail(priority: $priority) {
         email {
@@ -129,7 +129,7 @@ async function createSubscription(pubsub, schema = emailSchema, ast, vars) {
   // `subscribe` returns Promise<AsyncIterator | ExecutionResult>
   return {
     sendImportantEmail,
-    subscription: await subscribe(schema, ast || defaultAst, data, null, vars),
+    subscription: await subscribe(schema, ast || defaultAST, data, null, vars),
   };
 }
 


### PR DESCRIPTION
Should be consistent with public API, e.g. buildASTSchema