### PR TITLE
Limit maximum output of 'inspect'

### DIFF
--- a/src/jsutils/__tests__/inspect-test.js
+++ b/src/jsutils/__tests__/inspect-test.js
@@ -86,6 +86,27 @@ describe('inspect', () => {
     expect(inspect(map)).to.equal('{ a: true, b: null }');
   });
 
+  it('detect circular objects', () => {
+    const obj = {};
+    obj.self = obj;
+    obj.deepSelf = { self: obj };
+
+    expect(inspect(obj)).to.equal(
+      '{ self: [Circular], deepSelf: { self: [Circular] } }',
+    );
+
+    const array = [];
+    array[0] = array;
+    array[1] = [array];
+
+    expect(inspect(array)).to.equal('[[Circular], [[Circular]]]');
+
+    const mixed = { array: [] };
+    mixed.array[0] = mixed;
+
+    expect(inspect(mixed)).to.equal('{ array: [[Circular]] }');
+  });
+
   it('custom inspect', () => {
     const object = {
       inspect() {

--- a/src/jsutils/__tests__/inspect-test.js
+++ b/src/jsutils/__tests__/inspect-test.js
@@ -54,6 +54,18 @@ describe('inspect', () => {
     expect(inspect([null])).to.equal('[null]');
     expect(inspect([1, NaN])).to.equal('[1, NaN]');
     expect(inspect([['a', 'b'], 'c'])).to.equal('[["a", "b"], "c"]');
+
+    expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).to.equal(
+      '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]',
+    );
+
+    expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])).to.equal(
+      '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ... 1 more item]',
+    );
+
+    expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])).to.equal(
+      '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ... 2 more items]',
+    );
   });
 
   it('object', () => {

--- a/src/jsutils/__tests__/inspect-test.js
+++ b/src/jsutils/__tests__/inspect-test.js
@@ -96,6 +96,16 @@ describe('inspect', () => {
     expect(inspect(object)).to.equal('<custom inspect>');
   });
 
+  it('custom inspect that return `this` should work', () => {
+    const object = {
+      inspect() {
+        return this;
+      },
+    };
+
+    expect(inspect(object)).to.equal('{ inspect: [function inspect] }');
+  });
+
   it('custom symbol inspect is take precedence', () => {
     invariant(nodejsCustomInspectSymbol);
 

--- a/src/jsutils/__tests__/inspect-test.js
+++ b/src/jsutils/__tests__/inspect-test.js
@@ -55,6 +55,9 @@ describe('inspect', () => {
     expect(inspect([1, NaN])).to.equal('[1, NaN]');
     expect(inspect([['a', 'b'], 'c'])).to.equal('[["a", "b"], "c"]');
 
+    expect(inspect([[[]]])).to.equal('[[[]]]');
+    expect(inspect([[['a']]])).to.equal('[[[Array]]]');
+
     expect(inspect([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])).to.equal(
       '[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]',
     );
@@ -73,6 +76,9 @@ describe('inspect', () => {
     expect(inspect({ a: 1 })).to.equal('{ a: 1 }');
     expect(inspect({ a: 1, b: 2 })).to.equal('{ a: 1, b: 2 }');
     expect(inspect({ array: [null, 0] })).to.equal('{ array: [null, 0] }');
+
+    expect(inspect({ a: { b: {} } })).to.equal('{ a: { b: {} } }');
+    expect(inspect({ a: { b: { c: 1 } } })).to.equal('{ a: { b: [Object] } }');
 
     const map = Object.create(null);
     map['a'] = true;
@@ -124,5 +130,20 @@ describe('inspect', () => {
     };
 
     expect(inspect(object)).to.equal('Hello World!');
+  });
+
+  it('Use class names for the shortform of an object', () => {
+    class Foo {
+      foo: string;
+
+      constructor() {
+        this.foo = 'bar';
+      }
+    }
+
+    expect(inspect([[new Foo()]])).to.equal('[[[Foo]]]');
+
+    (Foo.prototype: any)[Symbol.toStringTag] = 'Bar';
+    expect(inspect([[new Foo()]])).to.equal('[[[Bar]]]');
   });
 });

--- a/src/jsutils/__tests__/inspect-test.js
+++ b/src/jsutils/__tests__/inspect-test.js
@@ -86,27 +86,6 @@ describe('inspect', () => {
     expect(inspect(map)).to.equal('{ a: true, b: null }');
   });
 
-  it('detect circular objects', () => {
-    const obj = {};
-    obj.self = obj;
-    obj.deepSelf = { self: obj };
-
-    expect(inspect(obj)).to.equal(
-      '{ self: [Circular], deepSelf: { self: [Circular] } }',
-    );
-
-    const array = [];
-    array[0] = array;
-    array[1] = [array];
-
-    expect(inspect(array)).to.equal('[[Circular], [[Circular]]]');
-
-    const mixed = { array: [] };
-    mixed.array[0] = mixed;
-
-    expect(inspect(mixed)).to.equal('{ array: [[Circular]] }');
-  });
-
   it('custom inspect', () => {
     const object = {
       inspect() {
@@ -161,6 +140,37 @@ describe('inspect', () => {
     };
 
     expect(inspect(object)).to.equal('Hello World!');
+  });
+
+  it('detect circular objects', () => {
+    const obj = {};
+    obj.self = obj;
+    obj.deepSelf = { self: obj };
+
+    expect(inspect(obj)).to.equal(
+      '{ self: [Circular], deepSelf: { self: [Circular] } }',
+    );
+
+    const array = [];
+    array[0] = array;
+    array[1] = [array];
+
+    expect(inspect(array)).to.equal('[[Circular], [[Circular]]]');
+
+    const mixed = { array: [] };
+    mixed.array[0] = mixed;
+
+    expect(inspect(mixed)).to.equal('{ array: [[Circular]] }');
+
+    const customA = {
+      inspect: () => customB,
+    };
+
+    const customB = {
+      inspect: () => customA,
+    };
+
+    expect(inspect(customA)).to.equal('[Circular]');
   });
 
   it('Use class names for the shortform of an object', () => {

--- a/src/jsutils/inspect.js
+++ b/src/jsutils/inspect.js
@@ -15,6 +15,10 @@ const MAX_ARRAY_LENGTH = 10;
  * Used to print values in error messages.
  */
 export default function inspect(value: mixed): string {
+  return formatValue(value);
+}
+
+function formatValue(value) {
   switch (typeof value) {
     case 'string':
       return JSON.stringify(value);
@@ -29,29 +33,45 @@ export default function inspect(value: mixed): string {
           const customValue = customInspectFn.call(value);
           return typeof customValue === 'string'
             ? customValue
-            : inspect(customValue);
+            : formatValue(customValue);
         } else if (Array.isArray(value)) {
-          return inspectArray(value);
+          return formatArray(value);
         }
 
-        const properties = Object.keys(value)
-          .map(k => `${k}: ${inspect(value[k])}`)
-          .join(', ');
-        return properties ? '{ ' + properties + ' }' : '{}';
+        return formatObject(value);
       }
+
       return String(value);
     default:
       return String(value);
   }
 }
 
-function inspectArray(array) {
+function formatObject(object) {
+  const keys = Object.keys(object);
+  if (keys.length === 0) {
+    return '{}';
+  }
+
+  const properties = keys.map(key => {
+    const value = formatValue(object[key]);
+    return key + ': ' + value;
+  });
+
+  return '{ ' + properties.join(', ') + ' }';
+}
+
+function formatArray(array) {
+  if (array.length === 0) {
+    return '[]';
+  }
+
   const len = Math.min(MAX_ARRAY_LENGTH, array.length);
   const remaining = array.length - len;
   const items = [];
 
   for (let i = 0; i < len; ++i) {
-    items.push(inspect(array[i]));
+    items.push(formatValue(array[i]));
   }
 
   if (remaining === 1) {

--- a/src/jsutils/inspect.js
+++ b/src/jsutils/inspect.js
@@ -32,9 +32,13 @@ function formatValue(value, recurseTimes) {
         if (customInspectFn) {
           // $FlowFixMe(>=0.90.0)
           const customValue = customInspectFn.call(value);
-          return typeof customValue === 'string'
-            ? customValue
-            : formatValue(customValue, recurseTimes);
+
+          // check for infinite recursion
+          if (customValue !== value) {
+            return typeof customValue === 'string'
+              ? customValue
+              : formatValue(customValue, recurseTimes);
+          }
         } else if (Array.isArray(value)) {
           return formatArray(value, recurseTimes);
         }

--- a/src/jsutils/inspect.js
+++ b/src/jsutils/inspect.js
@@ -9,6 +9,8 @@
 
 import nodejsCustomInspectSymbol from './nodejsCustomInspectSymbol';
 
+const MAX_ARRAY_LENGTH = 10;
+
 /**
  * Used to print values in error messages.
  */
@@ -29,7 +31,7 @@ export default function inspect(value: mixed): string {
             ? customValue
             : inspect(customValue);
         } else if (Array.isArray(value)) {
-          return '[' + value.map(inspect).join(', ') + ']';
+          return inspectArray(value);
         }
 
         const properties = Object.keys(value)
@@ -41,6 +43,24 @@ export default function inspect(value: mixed): string {
     default:
       return String(value);
   }
+}
+
+function inspectArray(array) {
+  const len = Math.min(MAX_ARRAY_LENGTH, array.length);
+  const remaining = array.length - len;
+  const items = [];
+
+  for (let i = 0; i < len; ++i) {
+    items.push(inspect(array[i]));
+  }
+
+  if (remaining === 1) {
+    items.push('... 1 more item');
+  } else if (remaining > 1) {
+    items.push(`... ${remaining} more items`);
+  }
+
+  return '[' + items.join(', ') + ']';
 }
 
 function getCustomFn(object) {


### PR DESCRIPTION
It's a partial fix for #1753 
I basically copied how Node.js `inspect` limits output but with different limits:
 * `10` array items instead of `100`
 * `2` levels of recursion instead of `3`

Note: Node.js `inspect` has no limits on the max number of properties inside the object so I didn't add it either.

@mjmahone Can you please take a look?

@Cito AFAIK Python version also has this problem. So it would be great if you also review it.

Note: It doesn't fully fix #1753 since you can still produce a huge number of errors but at least those error messages become shorter in most of the cases.