### PR TITLE
fix out of range return check for charCodeAt in lexer (NaN instead of null)

### DIFF
--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -402,7 +402,7 @@ function readComment(source, start, line, col, prev): Token {
   do {
     code = body.charCodeAt(++position);
   } while (
-    code !== NaN &&
+    !isNaN(code) &&
     // SourceCharacter but not LineTerminator
     (code > 0x001f || code === 0x0009)
   );
@@ -518,7 +518,7 @@ function readString(source, start, line, col, prev): Token {
 
   while (
     position < body.length &&
-    (code = body.charCodeAt(position)) !== NaN &&
+    !isNaN(code = body.charCodeAt(position)) &&
     // not LineTerminator
     code !== 0x000a &&
     code !== 0x000d
@@ -625,7 +625,7 @@ function readBlockString(source, start, line, col, prev, lexer): Token {
 
   while (
     position < body.length &&
-    (code = body.charCodeAt(position)) !== NaN
+    !isNaN(code = body.charCodeAt(position))
   ) {
     // Closing Triple-Quote (""")
     if (
@@ -737,7 +737,7 @@ function readName(source, start, line, col, prev): Token {
   let code = 0;
   while (
     position !== bodyLength &&
-    (code = body.charCodeAt(position)) !== NaN &&
+    !isNaN(code = body.charCodeAt(position)) &&
     (code === 95 || // _
     (code >= 48 && code <= 57) || // 0-9
     (code >= 65 && code <= 90) || // A-Z

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -402,7 +402,7 @@ function readComment(source, start, line, col, prev): Token {
   do {
     code = body.charCodeAt(++position);
   } while (
-    code !== null &&
+    code !== NaN &&
     // SourceCharacter but not LineTerminator
     (code > 0x001f || code === 0x0009)
   );
@@ -518,7 +518,7 @@ function readString(source, start, line, col, prev): Token {
 
   while (
     position < body.length &&
-    (code = body.charCodeAt(position)) !== null &&
+    (code = body.charCodeAt(position)) !== NaN &&
     // not LineTerminator
     code !== 0x000a &&
     code !== 0x000d
@@ -625,7 +625,7 @@ function readBlockString(source, start, line, col, prev, lexer): Token {
 
   while (
     position < body.length &&
-    (code = body.charCodeAt(position)) !== null
+    (code = body.charCodeAt(position)) !== NaN
   ) {
     // Closing Triple-Quote (""")
     if (
@@ -737,7 +737,7 @@ function readName(source, start, line, col, prev): Token {
   let code = 0;
   while (
     position !== bodyLength &&
-    (code = body.charCodeAt(position)) !== null &&
+    (code = body.charCodeAt(position)) !== NaN &&
     (code === 95 || // _
     (code >= 48 && code <= 57) || // 0-9
     (code >= 65 && code <= 90) || // A-Z

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -518,7 +518,7 @@ function readString(source, start, line, col, prev): Token {
 
   while (
     position < body.length &&
-    !isNaN(code = body.charCodeAt(position)) &&
+    !isNaN((code = body.charCodeAt(position))) &&
     // not LineTerminator
     code !== 0x000a &&
     code !== 0x000d
@@ -623,10 +623,7 @@ function readBlockString(source, start, line, col, prev, lexer): Token {
   let code = 0;
   let rawValue = '';
 
-  while (
-    position < body.length &&
-    !isNaN(code = body.charCodeAt(position))
-  ) {
+  while (position < body.length && !isNaN((code = body.charCodeAt(position)))) {
     // Closing Triple-Quote (""")
     if (
       code === 34 &&
@@ -737,7 +734,7 @@ function readName(source, start, line, col, prev): Token {
   let code = 0;
   while (
     position !== bodyLength &&
-    !isNaN(code = body.charCodeAt(position)) &&
+    !isNaN((code = body.charCodeAt(position))) &&
     (code === 95 || // _
     (code >= 48 && code <= 57) || // 0-9
     (code >= 65 && code <= 90) || // A-Z


### PR DESCRIPTION
According to the [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt#Return_value), `String.prototype.charCodeAt` will only ever return a `number` or `NaN`, never `null`.

This PR updates that check in each of the 4 places that it occurs.