### PR TITLE
Minor spelling errors in PossibleTpyeExtensions

### DIFF
--- a/src/validation/__tests__/PossibleTypeExtensions-test.js
+++ b/src/validation/__tests__/PossibleTypeExtensions-test.js
@@ -71,7 +71,7 @@ describe('Validate: Possible type extensions', () => {
     `);
   });
 
-  it('many extension per type', () => {
+  it('many extensions per type', () => {
     expectValidSDL(`
       scalar FooScalar
       type FooObject
@@ -96,7 +96,7 @@ describe('Validate: Possible type extensions', () => {
     `);
   });
 
-  it('extending unknow type', () => {
+  it('extending unknown type', () => {
     expectSDLErrors(`
       type Known
 
@@ -116,7 +116,7 @@ describe('Validate: Possible type extensions', () => {
     ]);
   });
 
-  it('doesnot consider non-type definitions', () => {
+  it('does not consider non-type definitions', () => {
     expectSDLErrors(`
       query Foo { __typename }
       fragment Foo on Query { __typename }

--- a/src/validation/rules/PossibleTypeExtensions.js
+++ b/src/validation/rules/PossibleTypeExtensions.js
@@ -44,7 +44,7 @@ export function extendingDifferentTypeKindMessage(
 /**
  * Possible type extension
  *
- * A type extension is only valid if the type defined and have the same kind.
+ * A type extension is only valid if the type is defined and has the same kind.
  */
 export function PossibleTypeExtensions(
   context: SDLValidationContext,


### PR DESCRIPTION
Fixed minor spelling issues in JSDoc string and test names.