### PR TITLE
Change printError() to mark location before using ↓ instead of ^ after.

### DIFF
--- a/src/error/__tests__/printError-test.js
+++ b/src/error/__tests__/printError-test.js
@@ -28,8 +28,8 @@ describe('printError', () => {
       Single digit line number with no padding
 
       Test (9:1)
+         ↓
       9: *
-         ^
     `);
 
     const doubleDigit = new GraphQLError(
@@ -42,8 +42,8 @@ describe('printError', () => {
       Left padded first line number
 
       Test (9:1)
+          ↓
        9: *
-          ^
       10: 
     `);
   });
@@ -87,14 +87,14 @@ describe('printError', () => {
 
       SourceA (2:10)
       1: type Foo {
+                  ↓
       2:   field: String
-                  ^
       3: }
 
       SourceB (2:10)
       1: type Foo {
+                  ↓
       2:   field: Int
-                  ^
       3: }
     `);
   });

--- a/src/error/printError.js
+++ b/src/error/printError.js
@@ -64,8 +64,8 @@ function highlightSourceAtLocation(
     printPrefixedLines([
       // Lines specified like this: ["prefix", "string"],
       [`${lineNum - 1}: `, lines[lineIndex - 1]],
+      ['', whitespace(columnNum - 1) + '↓'],
       [`${lineNum}: `, lines[lineIndex]],
-      ['', whitespace(columnNum - 1) + '^'],
       [`${lineNum + 1}: `, lines[lineIndex + 1]],
     ])
   );

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -129,8 +129,8 @@ describe('Lexer', () => {
 
       GraphQL request (3:5)
       2: 
+             ↓
       3:     ?
-             ^
       4: 
     `);
   });
@@ -149,8 +149,8 @@ describe('Lexer', () => {
 
       foo.js (13:6)
       12: 
+               ↓
       13:      ?
-               ^
       14: 
     `);
   });
@@ -167,8 +167,8 @@ describe('Lexer', () => {
       Syntax Error: Cannot parse the unexpected character "?".
 
       foo.js (1:5)
+             ↓
       1:     ?
-             ^
     `);
   });
 

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -55,8 +55,8 @@ describe('Parser', () => {
       Syntax Error: Expected Name, found <EOF>
 
       GraphQL request (1:2)
+          ↓
       1: {
-          ^
     `);
 
     expectSyntaxError(
@@ -92,8 +92,8 @@ describe('Parser', () => {
       Syntax Error: Expected {, found <EOF>
 
       MyQuery.graphql (1:6)
+              ↓
       1: query
-              ^
     `);
   });
 


### PR DESCRIPTION
Queries, particularly [when compressed](https://twitter.com/jaydenseric/status/1103801032675549184), can have a long line length. In narrow viewports (small Terminal windows, etc.) this results in the query wrapping over multiple lines.

Previously the error line location was marked on a line after with sufficient padding and a `^` character. The problem is, when the line above wraps the marker points up at an incorrect location.

By putting the marker on a line before, not after, there is less chance it will point at the wrong location on the following line due to wrapping. At least if the error occurred anywhere in the first line wrap (fairly likely) the marker will be correct.

Also, the `↓` symbol on the line before is more intuitive because people read from top to bottom and the symbol itself is more semantic.

Before (incorrect locations marked):

<img width="624" alt="Screen Shot 2019-03-12 at 2 58 54 pm" src="https://user-images.githubusercontent.com/1754873/54173788-65e9f680-44d7-11e9-8d9c-7bd8c76ae0a8.png">

After (correct locations marked):

<img width="624" alt="Screen Shot 2019-03-12 at 2 57 47 pm" src="https://user-images.githubusercontent.com/1754873/54173807-7e5a1100-44d7-11e9-96f9-d9696e819f55.png">
