### PR TITLE
Rename 'MaybePromise' to 'PromiseOrValue'

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -19,7 +19,7 @@ import memoize3 from '../jsutils/memoize3';
 import promiseForObject from '../jsutils/promiseForObject';
 import promiseReduce from '../jsutils/promiseReduce';
 import type { ObjMap } from '../jsutils/ObjMap';
-import type { MaybePromise } from '../jsutils/MaybePromise';
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 
 import { getOperationRootType } from '../utilities/getOperationRootType';
 import { typeFromAST } from '../utilities/typeFromAST';
@@ -144,7 +144,7 @@ export type ExecutionArgs = {|
 declare function execute(
   ExecutionArgs,
   ..._: []
-): MaybePromise<ExecutionResult>;
+): PromiseOrValue<ExecutionResult>;
 /* eslint-disable no-redeclare */
 declare function execute(
   schema: GraphQLSchema,
@@ -155,7 +155,7 @@ declare function execute(
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   typeResolver?: ?GraphQLTypeResolver<any, any>,
-): MaybePromise<ExecutionResult>;
+): PromiseOrValue<ExecutionResult>;
 export function execute(
   argsOrSchema,
   document,
@@ -239,7 +239,7 @@ function executeImpl(
  */
 function buildResponse(
   exeContext: ExecutionContext,
-  data: MaybePromise<ObjMap<mixed> | null>,
+  data: PromiseOrValue<ObjMap<mixed> | null>,
 ) {
   if (isPromise(data)) {
     return data.then(resolved => buildResponse(exeContext, resolved));
@@ -393,7 +393,7 @@ function executeOperation(
   exeContext: ExecutionContext,
   operation: OperationDefinitionNode,
   rootValue: mixed,
-): MaybePromise<ObjMap<mixed> | null> {
+): PromiseOrValue<ObjMap<mixed> | null> {
   const type = getOperationRootType(exeContext.schema, operation);
   const fields = collectFields(
     exeContext,
@@ -438,7 +438,7 @@ function executeFieldsSerially(
   sourceValue: mixed,
   path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
-): MaybePromise<ObjMap<mixed>> {
+): PromiseOrValue<ObjMap<mixed>> {
   return promiseReduce(
     Object.keys(fields),
     (results, responseName) => {
@@ -477,7 +477,7 @@ function executeFields(
   sourceValue: mixed,
   path: ResponsePath | void,
   fields: ObjMap<Array<FieldNode>>,
-): MaybePromise<ObjMap<mixed>> {
+): PromiseOrValue<ObjMap<mixed>> {
   const results = Object.create(null);
   let containsPromise = false;
 
@@ -653,7 +653,7 @@ function resolveField(
   source: mixed,
   fieldNodes: $ReadOnlyArray<FieldNode>,
   path: ResponsePath,
-): MaybePromise<mixed> {
+): PromiseOrValue<mixed> {
   const fieldNode = fieldNodes[0];
   const fieldName = fieldNode.name.value;
 
@@ -766,7 +766,7 @@ function completeValueCatchingError(
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
-): MaybePromise<mixed> {
+): PromiseOrValue<mixed> {
   try {
     let completed;
     if (isPromise(result)) {
@@ -844,7 +844,7 @@ function completeValue(
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
-): MaybePromise<mixed> {
+): PromiseOrValue<mixed> {
   // If result is an Error, throw a located error.
   if (result instanceof Error) {
     throw result;
@@ -939,7 +939,7 @@ function completeListValue(
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
-): MaybePromise<$ReadOnlyArray<mixed>> {
+): PromiseOrValue<$ReadOnlyArray<mixed>> {
   invariant(
     isCollection(result),
     `Expected Iterable, but did not find one for field ${
@@ -1001,7 +1001,7 @@ function completeAbstractValue(
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
-): MaybePromise<ObjMap<mixed>> {
+): PromiseOrValue<ObjMap<mixed>> {
   const resolveTypeFn = returnType.resolveType || exeContext.typeResolver;
   const contextValue = exeContext.contextValue;
   const runtimeType = resolveTypeFn(result, contextValue, info, returnType);
@@ -1088,7 +1088,7 @@ function completeObjectValue(
   info: GraphQLResolveInfo,
   path: ResponsePath,
   result: mixed,
-): MaybePromise<ObjMap<mixed>> {
+): PromiseOrValue<ObjMap<mixed>> {
   // If there is an isTypeOf predicate function, call it with the
   // current result. If isTypeOf returns false, then raise an error rather
   // than continuing execution.
@@ -1141,7 +1141,7 @@ function collectAndExecuteSubfields(
   fieldNodes: $ReadOnlyArray<FieldNode>,
   path: ResponsePath,
   result: mixed,
-): MaybePromise<ObjMap<mixed>> {
+): PromiseOrValue<ObjMap<mixed>> {
   // Collect sub-fields to execute to complete this value.
   const subFieldNodes = collectSubfields(exeContext, returnType, fieldNodes);
   return executeFields(exeContext, returnType, result, path, subFieldNodes);

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -19,7 +19,7 @@ import type {
 } from './type/definition';
 import type { GraphQLSchema } from './type/schema';
 import type { ExecutionResult } from './execution/execute';
-import type { MaybePromise } from './jsutils/MaybePromise';
+import type { PromiseOrValue } from './jsutils/PromiseOrValue';
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
@@ -188,7 +188,7 @@ function graphqlImpl(
   operationName,
   fieldResolver,
   typeResolver,
-): MaybePromise<ExecutionResult> {
+): PromiseOrValue<ExecutionResult> {
   // Validate Schema
   const schemaValidationErrors = validateSchema(schema);
   if (schemaValidationErrors.length > 0) {

--- a/src/jsutils/PromiseOrValue.js
+++ b/src/jsutils/PromiseOrValue.js
@@ -7,4 +7,4 @@
  * @flow strict
  */
 
-export type MaybePromise<+T> = Promise<T> | T;
+export type PromiseOrValue<+T> = Promise<T> | T;

--- a/src/jsutils/promiseReduce.js
+++ b/src/jsutils/promiseReduce.js
@@ -8,7 +8,7 @@
  */
 
 import isPromise from './isPromise';
-import type { MaybePromise } from './MaybePromise';
+import type { PromiseOrValue } from './PromiseOrValue';
 
 /**
  * Similar to Array.prototype.reduce(), however the reducing callback may return
@@ -19,9 +19,9 @@ import type { MaybePromise } from './MaybePromise';
  */
 export default function promiseReduce<T, U>(
   values: $ReadOnlyArray<T>,
-  callback: (U, T) => MaybePromise<U>,
-  initialValue: MaybePromise<U>,
-): MaybePromise<U> {
+  callback: (U, T) => PromiseOrValue<U>,
+  initialValue: PromiseOrValue<U>,
+): PromiseOrValue<U> {
   return values.reduce(
     (previous, value) =>
       isPromise(previous)

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -8,7 +8,7 @@
  */
 
 import { $$asyncIterator, getAsyncIterator } from 'iterall';
-import type { MaybePromise } from '../jsutils/MaybePromise';
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 
 /**
  * Given an AsyncIterable and a callback function, return an AsyncIterator
@@ -16,8 +16,8 @@ import type { MaybePromise } from '../jsutils/MaybePromise';
  */
 export default function mapAsyncIterator<T, U>(
   iterable: AsyncIterable<T>,
-  callback: T => MaybePromise<U>,
-  rejectCallback?: any => MaybePromise<U>,
+  callback: T => PromiseOrValue<U>,
+  rejectCallback?: any => PromiseOrValue<U>,
 ): AsyncGenerator<U, void, void> {
   const iterator = getAsyncIterator(iterable);
   let $return;
@@ -71,7 +71,7 @@ export default function mapAsyncIterator<T, U>(
 
 function asyncMapValue<T, U>(
   value: T,
-  callback: T => MaybePromise<U>,
+  callback: T => PromiseOrValue<U>,
 ): Promise<U> {
   return new Promise(resolve => resolve(callback(value)));
 }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -41,7 +41,7 @@ import type {
   ValueNode,
 } from '../language/ast';
 import type { GraphQLSchema } from './schema';
-import type { MaybePromise } from '../jsutils/MaybePromise';
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 
 // Predicates & Assertions
 
@@ -839,13 +839,13 @@ export type GraphQLTypeResolver<TSource, TContext> = (
   context: TContext,
   info: GraphQLResolveInfo,
   abstractType: GraphQLAbstractType,
-) => MaybePromise<?GraphQLObjectType | string>;
+) => PromiseOrValue<?GraphQLObjectType | string>;
 
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
   source: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
-) => MaybePromise<boolean>;
+) => PromiseOrValue<boolean>;
 
 export type GraphQLFieldResolver<
   TSource,


### PR DESCRIPTION
Suggested by @martijnwalraven
`MaybePromise` name confuses users into thinking: `execute`/`graphql` returns either Promise or null/undefined.
Also in our codebase, we frequently use `[Mm]aybe*` to represent optional things,
e.g.:
https://github.com/graphql/graphql-js/blob/8c96dc8276f2de27b8af9ffbd71a4597d483523f/src/language/visitor.js#L353
https://github.com/graphql/graphql-js/blob/8c96dc8276f2de27b8af9ffbd71a4597d483523f/src/language/printer.js#L244