### PR TITLE
buildClientSchema: include standard type only if it is used

### DIFF
--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -92,7 +92,9 @@ export function buildClientSchema(
   );
 
   for (const stdType of [...specifiedScalarTypes, ...introspectionTypes]) {
-    typeMap[stdType.name] = stdType;
+    if (typeMap[stdType.name]) {
+      typeMap[stdType.name] = stdType;
+    }
   }
 
   // Get the root Query, Mutation, and Subscription types.


### PR DESCRIPTION
To be merged in `15.0.0`
Details: https://github.com/graphql/graphql-js/commit/183ff32bee4bc23eb23657f79f414c2400ecb06a#r32971387