### PR TITLE
Add 'yarn check --integrity' to CI tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "watch": "node ./resources/watch.js",
     "test": "npm run lint && npm run check && npm run testonly",
-    "test:ci": "npm run lint -- --no-cache && npm run check && npm run testonly:cover",
+    "test:ci": "yarn check --integrity && npm run lint -- --no-cache && npm run check && npm run testonly:cover",
     "testonly": "mocha --full-trace src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc npm run testonly",
     "lint": "eslint --cache --report-unused-disable-directives src",


### PR DESCRIPTION
To prevent situations similar to:
https://github.com/graphql/graphiql/pull/797