### PR TITLE
build: Add new lines to "*.js" and "*.mjs" files

### DIFF
--- a/resources/build.js
+++ b/resources/build.js
@@ -36,15 +36,17 @@ if (require.main === module) {
   }
 }
 
+function babelBuild(srcPath, envName) {
+  return babel.transformFileSync(srcPath, { envName }).code + '\n';
+}
+
 function buildJSFile(filepath) {
   const srcPath = path.join('./src', filepath);
   const destPath = path.join('./dist', filepath);
-  const cjs = babel.transformFileSync(srcPath, { envName: 'cjs' });
-  const mjs = babel.transformFileSync(srcPath, { envName: 'mjs' });
 
   copyFile(srcPath, destPath + '.flow');
-  writeFile(destPath, cjs.code);
-  writeFile(destPath.replace(/\.js$/, '.mjs'), mjs.code);
+  writeFile(destPath, babelBuild(srcPath, 'cjs'));
+  writeFile(destPath.replace(/\.js$/, '.mjs'), babelBuild(srcPath, 'mjs'));
 }
 
 function buildPackageJSON() {


### PR DESCRIPTION
Makes "*.js" and "*.mjs" consistend with "*.js.flow" files and also
prevent diff artifacts, e.g.: https://github.com/graphql/graphql-js/commit/cf36cdbda2e9f884d35c5879e03370aab7a69c24#diff-0e28dd92524e3516b49eb5b753822f10R45