### PR TITLE
Use 'Object.freeze' consistently on all exported Array/Object constants

### DIFF
--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -136,7 +136,7 @@ export const QueryDocumentKeys = {
   InputObjectTypeExtension: ['name', 'directives', 'fields'],
 };
 
-export const BREAK = {};
+export const BREAK = Object.freeze({});
 
 /**
  * visit() will walk through an AST using a depth first traversal, calling

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -181,11 +181,11 @@ export const GraphQLDeprecatedDirective = new GraphQLDirective({
 /**
  * The full list of specified directives.
  */
-export const specifiedDirectives: $ReadOnlyArray<*> = [
+export const specifiedDirectives = Object.freeze([
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
-];
+]);
 
 export function isSpecifiedDirective(directive: mixed): boolean %checks {
   return (

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -385,7 +385,7 @@ export const __EnumValue = new GraphQLObjectType({
   }),
 });
 
-export const TypeKind = {
+export const TypeKind = Object.freeze({
   SCALAR: 'SCALAR',
   OBJECT: 'OBJECT',
   INTERFACE: 'INTERFACE',
@@ -394,7 +394,7 @@ export const TypeKind = {
   INPUT_OBJECT: 'INPUT_OBJECT',
   LIST: 'LIST',
   NON_NULL: 'NON_NULL',
-};
+});
 
 export const __TypeKind = new GraphQLEnumType({
   name: '__TypeKind',
@@ -473,7 +473,7 @@ export const TypeNameMetaFieldDef: GraphQLField<*, *> = {
   resolve: (source, args, context, { parentType }) => parentType.name,
 };
 
-export const introspectionTypes: $ReadOnlyArray<*> = [
+export const introspectionTypes = Object.freeze([
   __Schema,
   __Directive,
   __DirectiveLocation,
@@ -482,7 +482,7 @@ export const introspectionTypes: $ReadOnlyArray<*> = [
   __InputValue,
   __EnumValue,
   __TypeKind,
-];
+]);
 
 export function isIntrospectionType(type: mixed): boolean %checks {
   return (

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -245,13 +245,13 @@ export const GraphQLID = new GraphQLScalarType({
   },
 });
 
-export const specifiedScalarTypes: $ReadOnlyArray<*> = [
+export const specifiedScalarTypes = Object.freeze([
   GraphQLString,
   GraphQLInt,
   GraphQLFloat,
   GraphQLBoolean,
   GraphQLID,
-];
+]);
 
 export function isSpecifiedScalarType(type: mixed): boolean %checks {
   return (

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -27,7 +27,7 @@ import {
 } from '../type/definition';
 import { type GraphQLSchema } from '../type/schema';
 
-export const BreakingChangeType = {
+export const BreakingChangeType = Object.freeze({
   FIELD_CHANGED_KIND: 'FIELD_CHANGED_KIND',
   FIELD_REMOVED: 'FIELD_REMOVED',
   TYPE_CHANGED_KIND: 'TYPE_CHANGED_KIND',
@@ -43,16 +43,16 @@ export const BreakingChangeType = {
   DIRECTIVE_ARG_REMOVED: 'DIRECTIVE_ARG_REMOVED',
   DIRECTIVE_LOCATION_REMOVED: 'DIRECTIVE_LOCATION_REMOVED',
   REQUIRED_DIRECTIVE_ARG_ADDED: 'REQUIRED_DIRECTIVE_ARG_ADDED',
-};
+});
 
-export const DangerousChangeType = {
+export const DangerousChangeType = Object.freeze({
   ARG_DEFAULT_VALUE_CHANGE: 'ARG_DEFAULT_VALUE_CHANGE',
   VALUE_ADDED_TO_ENUM: 'VALUE_ADDED_TO_ENUM',
   INTERFACE_ADDED_TO_OBJECT: 'INTERFACE_ADDED_TO_OBJECT',
   TYPE_ADDED_TO_UNION: 'TYPE_ADDED_TO_UNION',
   OPTIONAL_INPUT_FIELD_ADDED: 'OPTIONAL_INPUT_FIELD_ADDED',
   OPTIONAL_ARG_ADDED: 'OPTIONAL_ARG_ADDED',
-};
+});
 
 export type BreakingChange = {
   type: $Keys<typeof BreakingChangeType>,

--- a/src/validation/specifiedRules.js
+++ b/src/validation/specifiedRules.js
@@ -7,11 +7,6 @@
  * @flow strict
  */
 
-import {
-  type ValidationRule,
-  type SDLValidationRule,
-} from './ValidationContext';
-
 // Spec Section: "Executable Definitions"
 import { ExecutableDefinitions } from './rules/ExecutableDefinitions';
 
@@ -102,7 +97,7 @@ import { UniqueInputFieldNames } from './rules/UniqueInputFieldNames';
  * The order of the rules in this list has been adjusted to lead to the
  * most clear output when encountering multiple validation errors.
  */
-export const specifiedRules: $ReadOnlyArray<ValidationRule> = [
+export const specifiedRules = Object.freeze([
   ExecutableDefinitions,
   UniqueOperationNames,
   LoneAnonymousOperation,
@@ -129,7 +124,7 @@ export const specifiedRules: $ReadOnlyArray<ValidationRule> = [
   VariablesInAllowedPosition,
   OverlappingFieldsCanBeMerged,
   UniqueInputFieldNames,
-];
+]);
 
 import { LoneSchemaDefinition } from './rules/LoneSchemaDefinition';
 import { UniqueOperationTypes } from './rules/UniqueOperationTypes';
@@ -140,7 +135,7 @@ import { UniqueDirectiveNames } from './rules/UniqueDirectiveNames';
 import { PossibleTypeExtensions } from './rules/PossibleTypeExtensions';
 
 // @internal
-export const specifiedSDLRules: $ReadOnlyArray<SDLValidationRule> = [
+export const specifiedSDLRules = Object.freeze([
   LoneSchemaDefinition,
   UniqueOperationTypes,
   UniqueTypeNames,
@@ -155,4 +150,4 @@ export const specifiedSDLRules: $ReadOnlyArray<SDLValidationRule> = [
   UniqueArgumentNames,
   UniqueInputFieldNames,
   ProvidedRequiredArgumentsOnDirectives,
-];
+]);


### PR DESCRIPTION
We already using 'Object.freeze' for many constants, e.g.:
https://github.com/graphql/graphql-js/blob/8c96dc8276f2de27b8af9ffbd71a4597d483523f/src/language/directiveLocation.js#L13
https://github.com/graphql/graphql-js/blob/8c96dc8276f2de27b8af9ffbd71a4597d483523f/src/language/kinds.js#L13
https://github.com/graphql/graphql-js/blob/dec3cc5d5133118cdb19bb90a0a770c835497835/src/language/lexer.js#L102

It helps issues with Flow since without Object.freeze it assumes that constants can be mutated