### PR TITLE
Manually update 'version.js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "watch": "node ./resources/watch.js",
     "test": "npm run lint && npm run check && npm run testonly",
-    "test:ci": "yarn check --integrity && npm run lint -- --no-cache && npm run check && npm run testonly:cover",
+    "test:ci": "yarn check --integrity && npm run lint -- --no-cache && npm run check && npm run testonly:cover && npm run build",
     "testonly": "mocha --full-trace src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc npm run testonly",
     "lint": "eslint --cache --report-unused-disable-directives src resources",

--- a/resources/build.js
+++ b/resources/build.js
@@ -41,7 +41,7 @@ if (require.main === module) {
     'Version in package.json and version.js should match',
   );
 
-  writeFile('./dist/package.json', packageJSON);
+  writeFile('./dist/package.json', JSON.stringify(packageJSON, null, 2));
 }
 
 function babelBuild(srcPath, envName) {
@@ -71,5 +71,5 @@ function buildPackageJSON() {
     packageJSON.publishConfig = { tag: tag || 'latest' };
   }
 
-  return JSON.stringify(packageJSON, null, 2);
+  return packageJSON;
 }

--- a/src/version.js
+++ b/src/version.js
@@ -15,7 +15,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '14.3.0';
+export const version = '14.3.1';
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -23,6 +23,6 @@ export const version = '14.3.0';
 export const versionInfo = Object.freeze({
   major: 14,
   minor: 3,
-  patch: 0,
+  patch: 1,
   preReleaseTag: null,
 });


### PR DESCRIPTION
Happened because #1878 was authored before '14.3.1' release but merged
after it.
Also add 'npm run build' to CI to prevent simular problems in future