### PR TITLE
Extract 'identityFunc' function to be used instead of 'x => x'

### DIFF
--- a/src/jsutils/__tests__/identityFunc-test.js
+++ b/src/jsutils/__tests__/identityFunc-test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import identityFunc from '../identityFunc';
+
+describe('identityFunc', () => {
+  it('returns the first argument it receives', () => {
+    expect(identityFunc()).to.equal(undefined);
+    expect(identityFunc(undefined)).to.equal(undefined);
+    expect(identityFunc(null)).to.equal(null);
+
+    const obj = {};
+    expect(identityFunc(obj)).to.equal(obj);
+  });
+});

--- a/src/jsutils/identityFunc.js
+++ b/src/jsutils/identityFunc.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * Returns the first argument it receives.
+ */
+export default function identityFunc<T>(x: T): T {
+  return x;
+}

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -10,6 +10,8 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 
+import identityFunc from '../../jsutils/identityFunc';
+import { valueFromASTUntyped } from '../../utilities/valueFromASTUntyped';
 import {
   type GraphQLType,
   type GraphQLNullableType,
@@ -62,6 +64,16 @@ describe('Type System: Scalars', () => {
           parseLiteral: () => null,
         }),
     ).not.to.throw();
+  });
+
+  it('provides default methods if omitted', () => {
+    const scalar = new GraphQLScalarType({
+      name: 'Foo',
+      serialize: () => null,
+    });
+
+    expect(scalar.parseValue).to.equal(identityFunc);
+    expect(scalar.parseLiteral).to.equal(valueFromASTUntyped);
   });
 
   it('rejects a Scalar type not defining serialize', () => {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -10,6 +10,7 @@
 import objectEntries from '../polyfills/objectEntries';
 import defineToJSON from '../jsutils/defineToJSON';
 import defineToStringTag from '../jsutils/defineToStringTag';
+import identityFunc from '../jsutils/identityFunc';
 import instanceOf from '../jsutils/instanceOf';
 import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
@@ -559,7 +560,7 @@ export class GraphQLScalarType {
     this.name = config.name;
     this.description = config.description;
     this.serialize = config.serialize;
-    this.parseValue = config.parseValue || (value => value);
+    this.parseValue = config.parseValue || identityFunc;
     this.parseLiteral = config.parseLiteral || valueFromASTUntyped;
     this.astNode = config.astNode;
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -12,6 +12,7 @@ import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
 import keyMap from '../jsutils/keyMap';
 import keyValMap from '../jsutils/keyValMap';
+import identityFunc from '../jsutils/identityFunc';
 import { type ObjMap } from '../jsutils/ObjMap';
 import { valueFromAST } from './valueFromAST';
 import { assertValidSDL } from '../validation/validate';
@@ -399,7 +400,7 @@ export class ASTDefinitionBuilder {
       name: astNode.name.value,
       description: getDescription(astNode, this._options),
       astNode,
-      serialize: value => value,
+      serialize: identityFunc,
     });
   }
 

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -11,6 +11,7 @@ import objectValues from '../polyfills/objectValues';
 import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
+import identityFunc from '../jsutils/identityFunc';
 import { valueFromAST } from './valueFromAST';
 import { parseValue } from '../language/parser';
 import {
@@ -230,7 +231,7 @@ export function buildClientSchema(
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
-      serialize: value => value,
+      serialize: identityFunc,
     });
   }
 


### PR DESCRIPTION
In theory should result in slightly small memory footprint and faster
execution. In practice, it simplifies testing of scalar's default behaviour.