### PR TITLE
add mergeAST from GraphiQL, refactor using visit() [WIP]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -397,6 +397,8 @@ export {
   isValidLiteralValue,
   // Concatenates multiple AST together.
   concatAST,
+  // Inline named fragments from AST
+  inlineNamedFragments,
   // Separates an AST into an AST per Operation.
   separateOperations,
   // Strips characters that are not significant to the validity or execution

--- a/src/jsutils/uniqueBy.js
+++ b/src/jsutils/uniqueBy.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+/**
+ * Returns an array of unique values based on iteratee
+ * which is invoked for each element in array to generate
+ * the criterion by which uniqueness is computed.
+ *
+ * Simiar to _.uniqBy from lodash.
+ */
+export function uniqueBy(
+  array: $ReadOnlyArray<any>,
+  iteratee: (item: any) => any,
+) {
+  const FilteredMap = new Map();
+  const result = [];
+  for (const item of array) {
+    const uniqeValue = iteratee(item);
+    if (!FilteredMap.has(uniqeValue)) {
+      FilteredMap.set(uniqeValue, true);
+      result.push(item);
+    }
+  }
+  return result;
+}

--- a/src/utilities/__tests__/inlineNamedFragments-fixture.js
+++ b/src/utilities/__tests__/inlineNamedFragments-fixture.js
@@ -1,0 +1,189 @@
+/**
+ *  Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ *
+ */
+
+export const fixtures = [
+  {
+    desc: 'does not modify query with no fragments',
+    query: `
+      {
+        id
+      }`,
+    resultQuery: `
+      {
+        id
+      }
+      `,
+  },
+  {
+    desc: 'inlines simple nested fragment',
+    query: `
+      {
+        ...Fragment1
+      }
+
+      fragment Fragment1 on Test {
+        id
+      }`,
+    resultQuery: `
+      {
+        ... on Test {
+          id
+        }
+      }
+      `,
+  },
+  {
+    desc: 'inlines triple nested fragment',
+    query: `
+      {
+        ...Fragment1
+      }
+      
+      fragment Fragment1 on Test {
+        ...Fragment2
+      }
+      
+      fragment Fragment2 on Test {
+        ...Fragment3
+      }
+      
+      fragment Fragment3 on Test {
+        id
+      }`,
+    resultQuery: `
+      {
+        ... on Test {
+          ... on Test {
+            ... on Test {
+              id
+            }
+          }
+        }
+      }
+      `,
+  },
+  {
+    desc: 'inlines multiple fragments',
+    query: `
+      {
+        ...Fragment1
+        ...Fragment2
+        ...Fragment3
+      }
+
+      fragment Fragment1 on Test {
+        id
+      }
+
+      fragment Fragment2 on Test {
+        id
+      }
+
+      fragment Fragment3 on Test {
+        id
+      }`,
+    resultQuery: `
+      {
+        ... on Test {
+          id
+        }
+        ... on Test {
+          id
+        }
+        ... on Test {
+          id
+        }
+      }
+      `,
+  },
+  {
+    desc: 'inlines multiple fragments on multiple queries',
+    query: `
+      {
+        ...Fragment4
+        ...Fragment5
+      }
+
+      fragment Fragment5 on Test1 {
+        ...Fragment4
+      }
+
+      fragment Fragment4 on Test1 {
+        id
+      }`,
+    resultQuery: `
+      {
+        ... on Test1 {
+          id
+        }
+        ... on Test1 {
+          ... on Test1 {
+            id
+          }
+        }
+      }
+      `,
+  },
+  {
+    desc: 'reuses the same fragment',
+    query: `
+      fragment ProfileInfo on Person {
+        name
+        title
+        phone
+      }
+
+      {
+        person {
+          ...ProfileInfo
+          friend {
+            ...ProfileInfo
+          }
+        }
+      }`,
+    resultQuery: `
+      {
+        person {
+          ... on Person {
+            name
+            title
+            phone
+          }
+          friend {
+            ... on Person {
+              name
+              title
+              phone
+            }
+          }
+        }
+      }
+      `,
+  },
+  {
+    desc: 'removes duplicate fragment spreads',
+    query: `
+      {
+        ...Fragment1
+        ...Fragment1
+      }
+
+      fragment Fragment1 on Test {
+        id
+      }`,
+    resultQuery: `
+      {
+        ... on Test {
+          id
+        }
+      }
+      `,
+  },
+];

--- a/src/utilities/__tests__/inlineNamedFragments-test.js
+++ b/src/utilities/__tests__/inlineNamedFragments-test.js
@@ -1,0 +1,25 @@
+/**
+ *  Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import dedent from '../../jsutils/dedent';
+import { parse } from '../../language/parser';
+import { print } from '../../language/printer';
+import { inlineNamedFragments } from '../inlineNamedFragments';
+import { fixtures } from './inlineNamedFragments-fixture';
+
+describe('inlineNamedFragments', () => {
+  fixtures.forEach(fixture => {
+    it(fixture.desc, () => {
+      const result = print(inlineNamedFragments(parse(fixture.query)));
+      expect(result).to.equal(dedent(fixture.resultQuery));
+    });
+  });
+});

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -104,6 +104,9 @@ export { isValidLiteralValue } from './isValidLiteralValue';
 // Concatenates multiple AST together.
 export { concatAST } from './concatAST';
 
+// Inline named fragments from AST
+export { inlineNamedFragments } from './inlineNamedFragments';
+
 // Separates an AST into an AST per Operation.
 export { separateOperations } from './separateOperations';
 

--- a/src/utilities/inlineNamedFragments.js
+++ b/src/utilities/inlineNamedFragments.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import { type ObjMap } from '../jsutils/ObjMap';
+import { uniqueBy } from '../jsutils/uniqueBy';
+import { visit } from '../language/visitor';
+import {
+  type DocumentNode,
+  type FragmentDefinitionNode,
+} from '../language/ast';
+
+/**
+ * Given a document AST, inline all named fragment definitions
+ */
+export function inlineNamedFragments(documentAST: DocumentNode): DocumentNode {
+  const fragmentDefinitions: ObjMap<FragmentDefinitionNode> = Object.create(
+    null,
+  );
+
+  for (const definition of documentAST.definitions) {
+    if (definition.kind === 'FragmentDefinition') {
+      fragmentDefinitions[definition.name.value] = definition;
+    }
+  }
+
+  return visit(documentAST, {
+    FragmentSpread(node) {
+      return {
+        ...fragmentDefinitions[node.name.value],
+        kind: 'InlineFragment',
+      };
+    },
+    SelectionSet(node) {
+      return {
+        ...node,
+        selections: uniqueBy(
+          node.selections,
+          selection => selection.name.value,
+        ),
+      };
+    },
+    FragmentDefinition() {
+      return null;
+    },
+  });
+}


### PR DESCRIPTION
Accomplishes https://github.com/graphql/graphiql/issues/836, originally introduced via https://github.com/graphql/graphiql/pull/762 earlier this year, `mergeAST` is a handy utility for in-lining fragments for complex queries.

As per @IvanGoncharov's suggestion, I refactored it to use `language/visitor`'s `visit` function.  Good thing I'd been working with AST and visitors on another project using antlr4 earlier this year, or I would've been so lost here, haha. That said, GraphQL's `visit()` is so powerful, I'm blown away at how simple this was.

Thank you @RamonSaboya for the inspiration, and some solid unit tests, and an excellent idea all around.

I'm wondering if a `Set` would be a more appropriate data structure here?

**This is a WIP**, just learning about `visit()` and this is just a learning excercise for me. 
Not a huge priority to any part of the ecosystem currently, and a lot of important edge cases are still broken here.