### PR TITLE
[printError] Make location formatting IDE friendly

### DIFF
--- a/src/error/__tests__/printError-test.js
+++ b/src/error/__tests__/printError-test.js
@@ -27,7 +27,7 @@ describe('printError', () => {
     expect(printError(singleDigit)).to.equal(dedent`
       Single digit line number with no padding
 
-      Test (9:1)
+      Test:9:1
       9: *
          ^
     `);
@@ -41,7 +41,7 @@ describe('printError', () => {
     expect(printError(doubleDigit)).to.equal(dedent`
       Left padded first line number
 
-      Test (9:1)
+      Test:9:1
        9: *
           ^
       10: 
@@ -85,13 +85,13 @@ describe('printError', () => {
     expect(printError(error)).to.equal(dedent`
       Example error with two nodes
 
-      SourceA (2:10)
+      SourceA:2:10
       1: type Foo {
       2:   field: String
                   ^
       3: }
 
-      SourceB (2:10)
+      SourceB:2:10
       1: type Foo {
       2:   field: Int
                   ^

--- a/src/error/printError.js
+++ b/src/error/printError.js
@@ -59,7 +59,7 @@ function highlightSourceAtLocation(
 
   const lines = body.split(/\r\n|[\n\r]/g);
   return (
-    `${source.name} (${lineNum}:${columnNum})\n` +
+    `${source.name}:${lineNum}:${columnNum}\n` +
     printPrefixedLines([
       // Lines specified like this: ["prefix", "string"],
       [`${lineNum - 1}: `, lines[lineIndex - 1]],

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -127,7 +127,7 @@ describe('Lexer', () => {
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Cannot parse the unexpected character "?".
 
-      GraphQL request (3:5)
+      GraphQL request:3:5
       2: 
       3:     ?
              ^
@@ -147,7 +147,7 @@ describe('Lexer', () => {
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Cannot parse the unexpected character "?".
 
-      foo.js (13:6)
+      foo.js:13:6
       12: 
       13:      ?
                ^
@@ -166,7 +166,7 @@ describe('Lexer', () => {
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Cannot parse the unexpected character "?".
 
-      foo.js (1:5)
+      foo.js:1:5
       1:     ?
              ^
     `);

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -54,7 +54,7 @@ describe('Parser', () => {
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Expected Name, found <EOF>
 
-      GraphQL request (1:2)
+      GraphQL request:1:2
       1: {
           ^
     `);
@@ -91,7 +91,7 @@ describe('Parser', () => {
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Expected {, found <EOF>
 
-      MyQuery.graphql (1:6)
+      MyQuery.graphql:1:6
       1: query
               ^
     `);

--- a/src/utilities/__tests__/stripIgnoredCharacters-test.js
+++ b/src/utilities/__tests__/stripIgnoredCharacters-test.js
@@ -165,7 +165,7 @@ describe('stripIgnoredCharacters', () => {
     expectStripped('{ foo(arg: "\n"').toThrow(dedent`
       Syntax Error: Unterminated string.
 
-      GraphQL request (1:13)
+      GraphQL request:1:13
       1: { foo(arg: "
                      ^
       2: "


### PR DESCRIPTION
This is the format used by jest, flow, typescript, and many others.

As an example, this change [when used in relay](https://github.com/facebook/relay/pull/2752) changes the experience like so:

### Before

![relay-ide-friendly-errors-before](https://user-images.githubusercontent.com/2320/58881598-c5246500-86da-11e9-8acb-3039762e734b.gif)

### After

![relay-ide-friendly-errors-after](https://user-images.githubusercontent.com/2320/58881607-cb1a4600-86da-11e9-99fc-296473ec77b0.gif)
