### PR TITLE
Make 'parseLiteral' optional and use wrapped 'parseValue' by default

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -561,7 +561,10 @@ export class GraphQLScalarType {
     this.description = config.description;
     this.serialize = config.serialize || identityFunc;
     this.parseValue = config.parseValue || identityFunc;
-    this.parseLiteral = config.parseLiteral || valueFromASTUntyped;
+    this.parseLiteral =
+      config.parseLiteral ||
+      (node => this.parseValue(valueFromASTUntyped(node)));
+
     this.astNode = config.astNode;
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);
     invariant(typeof config.name === 'string', 'Must provide name.');
@@ -570,7 +573,8 @@ export class GraphQLScalarType {
       `${this.name} must provide "serialize" function. If this custom Scalar ` +
         'is also used as an input type, ensure "parseValue" and "parseLiteral" functions are also provided.',
     );
-    if (config.parseValue || config.parseLiteral) {
+
+    if (config.parseLiteral) {
       invariant(
         typeof config.parseValue === 'function' &&
           typeof config.parseLiteral === 'function',

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -9,7 +9,7 @@
 
 import { expect } from 'chai';
 import inspect from '../../jsutils/inspect';
-import { parse, print } from '../../language';
+import { parse } from '../../language';
 import { validate, validateSDL } from '../validate';
 import {
   type ValidationRule,
@@ -293,9 +293,6 @@ const ComplicatedArgs = new GraphQLObjectType({
 
 const InvalidScalar = new GraphQLScalarType({
   name: 'Invalid',
-  parseLiteral(valueNode) {
-    throw new Error(`Invalid scalar is always invalid: ${print(valueNode)}`);
-  },
   parseValue(value) {
     throw new Error(`Invalid scalar is always invalid: ${inspect(value)}`);
   },


### PR DESCRIPTION
Motivation:
https://github.com/graphql/graphql-js/issues/500
https://github.com/graphql/graphql-js/pull/1827#discussion_r280658590