### PR TITLE
buildClientSchema: add dev check for invalid introspection argument

### DIFF
--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -522,6 +522,18 @@ describe('Type System: build schema from introspection', () => {
       directive @SomeDirective on QUERY
     `);
 
+    it('throws when introspection is missing __schema property', () => {
+      // $DisableFlowOnNegativeTest
+      expect(() => buildClientSchema(null)).to.throw(
+        'Invalid or incomplete introspection result. Ensure that you are passing "data" property of introspection response and no "errors" was returned alongside: null',
+      );
+
+      // $DisableFlowOnNegativeTest
+      expect(() => buildClientSchema({})).to.throw(
+        'Invalid or incomplete introspection result. Ensure that you are passing "data" property of introspection response and no "errors" was returned alongside: {}',
+      );
+    });
+
     it('throws when referenced unknown type', () => {
       const introspection = introspectionFromSchema(dummySchema);
 

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -4,6 +4,7 @@ import objectValues from '../polyfills/objectValues';
 import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
+import isObjectLike from '../jsutils/isObjectLike';
 import { valueFromAST } from './valueFromAST';
 import { parseValue } from '../language/parser';
 import {
@@ -72,6 +73,12 @@ export function buildClientSchema(
   introspection: IntrospectionQuery,
   options?: Options,
 ): GraphQLSchema {
+  invariant(
+    isObjectLike(introspection) && isObjectLike(introspection.__schema),
+    'Invalid or incomplete introspection result. Ensure that you are passing "data" property of introspection response and no "errors" was returned alongside: ' +
+      inspect(introspection),
+  );
+
   // Get the schema from the introspection result.
   const schemaIntrospection = introspection.__schema;
 


### PR DESCRIPTION
Prevents situations like #1970