### PR TITLE
`buildSchema` should be able to create fully featured schema

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -610,15 +610,19 @@ export type GraphQLScalarLiteralParser<TInternal> = (
   variables: ?ObjMap<mixed>,
 ) => ?TInternal;
 
-export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
-  name: string,
-  description?: ?string,
+export type GraphQLScalarTypeConverters<TInternal, TExternal> = {|
   // Serializes an internal value to include in a response.
   serialize?: GraphQLScalarSerializer<TExternal>,
   // Parses an externally provided value to use as an input.
   parseValue?: GraphQLScalarValueParser<TInternal>,
   // Parses an externally provided literal value to use as an input.
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>,
+|};
+
+export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
+  name: string,
+  ...GraphQLScalarTypeConverters<TInternal, TExternal>,
+  description?: ?string,
   astNode?: ?ScalarTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<ScalarTypeExtensionNode>,
 |};

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -74,6 +74,54 @@ describe('Schema Builder', () => {
     });
   });
 
+  it('can lookup type resolvers', () => {
+    const schema = buildSchema(
+      `
+      type Query {
+        mult(a: Int!, b: Int!): Int!
+      }
+    `,
+      {
+        resolvers: {
+          Query: {
+            mult: (_: { ... }, { a, b }) => a * b,
+          },
+        },
+      },
+    );
+
+    expect(graphqlSync(schema, '{ mult(a: 3, b: 4) }', null)).to.deep.equal({
+      data: { mult: 12 },
+    });
+  });
+
+  it('can lookup enum values', () => {
+    const schema = buildSchema(
+      `
+      enum Color { RED, GREEN, BLUE }
+      type Query {
+        colors: [Color!]!
+      }
+    `,
+      {
+        resolvers: {
+          Query: {
+            colors: () => [4, 2, 1],
+          },
+          Color: {
+            RED: 1,
+            GREEN: 2,
+            BLUE: 4,
+          },
+        },
+      },
+    );
+
+    expect(graphqlSync(schema, '{ colors }', null)).to.deep.equal({
+      data: { colors: ['BLUE', 'GREEN', 'RED'] },
+    });
+  });
+
   it('Empty type', () => {
     const sdl = dedent`
       type EmptyType

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -122,6 +122,38 @@ describe('Schema Builder', () => {
     });
   });
 
+  it('can define custom scalar converters', () => {
+    const schema = buildSchema(
+      `
+      scalar Uppercase
+      scalar Lowercase
+      type Query {
+        hello: Uppercase
+        lower(str: Lowercase!): String
+      }
+    `,
+      {
+        resolvers: {
+          Uppercase: {
+            serialize: (value: string) => value.toUpperCase(),
+          },
+          Lowercase: {
+            parseValue: (value: string) => value.toLowerCase(),
+          },
+          Query: {
+            lower: (_, { str }: { str: string, ... }) => str,
+          },
+        },
+      },
+    );
+
+    expect(
+      graphqlSync(schema, '{ hello lower(str: "World") }', { hello: 'hello' }),
+    ).to.deep.equal({
+      data: { hello: 'HELLO', lower: 'world' },
+    });
+  });
+
   it('Empty type', () => {
     const sdl = dedent`
       type EmptyType

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -112,16 +112,21 @@ export type BuildSchemaOptions = {
  * This takes the ast of a schema document produced by the parse function in
  * src/language/parser.js.
  *
- * If no schema definition is provided, then it will look for types named Query
- * and Mutation.
+ * If no schema definition is provided, then it will look for types named Query,
+ * Mutation and Subscription.
  *
- * Given that AST it constructs a GraphQLSchema. The resulting schema
- * has no resolve methods, so execution will use default resolvers.
+ * Given that AST it constructs a GraphQLSchema. The built schema will use
+ * resolve methods from `options.resolvers[typeName][fieldName]` if found.
+ * Otherwise it will use default resolvers.
  *
  * Accepts options as a second argument:
  *
  *    - commentDescriptions:
  *        Provide true to use preceding comments as the description.
+ *
+ *    - resolvers — map of named types
+ *      - Object, Interface — field resolvers
+ *      - Enum — External string → any internal value
  *
  */
 export function buildASTSchema(

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -6,7 +6,10 @@ import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
 import mapValue from '../jsutils/mapValue';
 import keyValMap from '../jsutils/keyValMap';
-import { ASTDefinitionBuilder } from './buildASTSchema';
+import {
+  type TypeFieldResolverMap,
+  ASTDefinitionBuilder,
+} from './buildASTSchema';
 import { assertValidSDLExtension } from '../validation/validate';
 import {
   type GraphQLSchemaValidationOptions,
@@ -70,6 +73,13 @@ type Options = {|
    * Default: false
    */
   assumeValidSDL?: boolean,
+
+  /**
+   * Object map of object maps to resolver funtions.
+   *
+   * Default: undefined
+   */
+  resolvers?: TypeFieldResolverMap,
 |};
 
 /**
@@ -341,7 +351,7 @@ export function extendSchema(
         ...keyValMap(
           fieldNodes,
           node => node.name.value,
-          node => astBuilder.buildField(node),
+          node => astBuilder.buildField(node, config.name),
         ),
       }),
       extensionASTNodes: config.extensionASTNodes.concat(extensions),
@@ -362,7 +372,7 @@ export function extendSchema(
         ...keyValMap(
           fieldNodes,
           node => node.name.value,
-          node => astBuilder.buildField(node),
+          node => astBuilder.buildField(node, config.name),
         ),
       }),
       extensionASTNodes: config.extensionASTNodes.concat(extensions),

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -314,7 +314,7 @@ export function extendSchema(
         ...keyValMap(
           valueNodes,
           value => value.name.value,
-          value => astBuilder.buildEnumValue(value),
+          value => astBuilder.buildEnumValue(value, config.name),
         ),
       },
       extensionASTNodes: config.extensionASTNodes.concat(extensions),


### PR DESCRIPTION
## `buildSchema`, `buildASTSchema` and `extendSchema`:

### DONE: :tada: 

- [x] can lookup for type field resolvers https://github.com/graphql/graphql-js/commit/9157529987f7f33ff7a1b0aedecace4e19e677dc
- [x] `enum` value lookup (exactly like previous) https://github.com/graphql/graphql-js/commit/1b0f68a8ba6b87e6b38a70424f63a7668ce864e7
- [x] tests https://github.com/graphql/graphql-js/pull/1987/commits/84adacf05643e11e46e67335b7e3369977a5e476 (object field resolver, enum values)
- [x] custom scalars + test https://github.com/graphql/graphql-js/pull/1987/commits/396098e7d9608f40d3f2c2f0e0e7fa341f62fcc4

### TO DO, need help:

- `isTypeOf` on ObjectType (should I follow `graphql-tools` with `__isTypeOf`?)
- `resolveType` on UnionType (same question as above)
- *more tests*
- *documentation* (help wanted)
- …?

Related: #1384 #1858

/cc @IvanGoncharov, @leebyron 