### PR TITLE
[validation] Add "onError" option to allow for custom error handling behavior when performing validation

### DIFF
--- a/src/validation/ValidationContext.js
+++ b/src/validation/ValidationContext.js
@@ -8,21 +8,21 @@ import { Kind } from '../language/kinds';
 import { type ASTVisitor, visit, visitWithTypeInfo } from '../language/visitor';
 import {
   type DocumentNode,
-  type FragmentDefinitionNode,
-  type FragmentSpreadNode,
   type OperationDefinitionNode,
-  type SelectionSetNode,
   type VariableNode,
+  type SelectionSetNode,
+  type FragmentSpreadNode,
+  type FragmentDefinitionNode,
 } from '../language/ast';
 
 import { type GraphQLSchema } from '../type/schema';
 import { type GraphQLDirective } from '../type/directives';
 import {
-  type GraphQLArgument,
-  type GraphQLCompositeType,
-  type GraphQLField,
   type GraphQLInputType,
   type GraphQLOutputType,
+  type GraphQLCompositeType,
+  type GraphQLField,
+  type GraphQLArgument,
 } from '../type/definition';
 
 import { TypeInfo } from '../utilities/TypeInfo';

--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -74,4 +74,29 @@ describe('Validate: Supports full validation', () => {
       'Cannot query field "isHousetrained" on type "Dog". Did you mean "isHousetrained"?',
     ]);
   });
+
+  it('properly calls onError callback when passed', () => {
+    const doc = parse(`
+      query {
+        cat {
+          name
+          someNonExistentField
+        }
+        dog {
+          name
+          anotherNonExistentField
+        }
+      }
+    `);
+
+    const expectedNumberOfErrors = 2;
+    let errorCount = 0;
+    validate(testSchema, doc, specifiedRules, undefined, (err, ctx) => {
+      expect(err).to.not.be.a('null');
+      expect(ctx).to.not.be.a('null');
+      expect(ctx.getErrors()).to.be.length(++errorCount);
+    });
+
+    expect(errorCount).to.be.equal(expectedNumberOfErrors);
+  });
 });

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -14,10 +14,10 @@ import { TypeInfo } from '../utilities/TypeInfo';
 
 import { specifiedRules, specifiedSDLRules } from './specifiedRules';
 import {
-  SDLValidationContext,
   type SDLValidationRule,
-  ValidationContext,
   type ValidationRule,
+  SDLValidationContext,
+  ValidationContext,
 } from './ValidationContext';
 
 /**


### PR DESCRIPTION
**TL;DR:** This PR adds an "onError" argument to the `validate` function that allows for custom error handling when performing validation. A user can use this in many ways -- for instance, they can use this callback to bail early, and prevent performing potentially expensive validation operations hundreds or thousands of times in environments where detailed error messages are less important.

We _should_ fix the root cause of the slowness that I describe below, however -- it's risky to have a utility like this enabled in production, given that it gets slower and slower the more types you have and the more errors you have in your query.

Read on for the story of why I decided to implement this. 😀

----

At Airbnb, we have a GraphQL server that acts as a gateway to many other GraphQL servers -- the schemas are stitched together from these downstream services to build a single schema that's used by our clients.

Today, in our staging environment, one of the downstream services published a broken schema that caused queries to the gateway to start failing with validation errors. When this happened, we saw the gateway's measured overhead (essentially the time it takes to do anything GraphQL-related that isn't fetching data from downstream services) jump by about 3000%:

![image](https://user-images.githubusercontent.com/131916/62511143-20500200-b7c7-11e9-9507-c216ba188da9.png)

After getting alerted on a this issue, I captured a trace. This is what I saw:

![image](https://user-images.githubusercontent.com/131916/62511150-28a83d00-b7c7-11e9-8da8-db4c826a1f46.png)

Zooming in a bit:

![image](https://user-images.githubusercontent.com/131916/62511158-2f36b480-b7c7-11e9-8734-11621fcf8875.png)

It turned out that the `suggestionList` utility, which uses the Levenshtein distance algorithm to build a list of suggestions for a given type or argument name, was being called many times as the validation visitor failed to find the types that were lost in the main schema due to the broken schema from the downstream service.

To give an idea of scale -- we have a moderately large GraphQL schema with about ~3000 types, and many of the type names are very long, with an average length of 27 characters.

After some investigation (and building a repro case), it seemed like the options were to either fix the `suggestionList` algorithm to do something more efficient, or allow bailing out early. This PR is an implementation of the latter. 

At Airbnb, we disable introspection on our production GraphQL endpoint and point our internal GraphiQL instance at a production mirror that's only available internally. The idea with this PR is that we will make validation bail early so that we can take steps to make sure the validation time doesn't increase with the number of errors in the query.
