### PR TITLE
RFC: Allow interfaces to implement other interfaces

### DIFF
--- a/src/__fixtures__/schema-kitchen-sink.graphql
+++ b/src/__fixtures__/schema-kitchen-sink.graphql
@@ -7,7 +7,7 @@ schema {
 This is a description
 of the `Foo` type.
 """
-type Foo implements Bar & Baz {
+type Foo implements Bar & Baz & Two {
   "Description of the `one` field."
   one: Type
   """
@@ -50,11 +50,17 @@ interface AnnotatedInterface @onInterface {
 
 interface UndefinedInterface
 
-extend interface Bar {
+extend interface Bar implements Two {
   two(argument: InputType!): Type
 }
 
 extend interface Bar @onInterface
+
+interface Baz implements Bar & Two {
+  one: Type
+  two(argument: InputType!): Type
+  four(argument: String = "string"): String
+}
 
 union Feed =
   | Story

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -583,7 +583,7 @@ function doesFragmentConditionMatch(
     return true;
   }
   if (isAbstractType(conditionalType)) {
-    return exeContext.schema.isPossibleType(conditionalType, type);
+    return exeContext.schema.isSubType(conditionalType, type);
   }
   return false;
 }
@@ -1021,7 +1021,7 @@ function ensureValidRuntimeType(
     );
   }
 
-  if (!exeContext.schema.isPossibleType(returnType, runtimeType)) {
+  if (!exeContext.schema.isSubType(returnType, runtimeType)) {
     throw new GraphQLError(
       `Runtime Object type "${runtimeType.name}" is not a possible type for "${returnType.name}".`,
       fieldNodes,

--- a/src/language/__tests__/schema-printer-test.js
+++ b/src/language/__tests__/schema-printer-test.js
@@ -47,7 +47,7 @@ describe('Printer: SDL document', () => {
       This is a description
       of the \`Foo\` type.
       """
-      type Foo implements Bar & Baz {
+      type Foo implements Bar & Baz & Two {
         "Description of the \`one\` field."
         one: Type
         """This is a description of the \`two\` field."""
@@ -86,11 +86,17 @@ describe('Printer: SDL document', () => {
 
       interface UndefinedInterface
 
-      extend interface Bar {
+      extend interface Bar implements Two {
         two(argument: InputType!): Type
       }
 
       extend interface Bar @onInterface
+
+      interface Baz implements Bar & Two {
+        one: Type
+        two(argument: InputType!): Type
+        four(argument: String = "string"): String
+      }
 
       union Feed = Story | Article | Advert
 

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -488,6 +488,7 @@ export type InterfaceTypeDefinitionNode = {
   +loc?: Location,
   +description?: StringValueNode,
   +name: NameNode,
+  +interfaces?: $ReadOnlyArray<NamedTypeNode>,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +fields?: $ReadOnlyArray<FieldDefinitionNode>,
   ...
@@ -589,6 +590,7 @@ export type InterfaceTypeExtensionNode = {
   +kind: 'InterfaceTypeExtension',
   +loc?: Location,
   +name: NameNode,
+  +interfaces?: $ReadOnlyArray<NamedTypeNode>,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +fields?: $ReadOnlyArray<FieldDefinitionNode>,
   ...

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -964,12 +964,14 @@ class Parser {
     const description = this.parseDescription();
     this.expectKeyword('interface');
     const name = this.parseName();
+    const interfaces = this.parseImplementsInterfaces();
     const directives = this.parseDirectives(true);
     const fields = this.parseFieldsDefinition();
     return {
       kind: Kind.INTERFACE_TYPE_DEFINITION,
       description,
       name,
+      interfaces,
       directives,
       fields,
       loc: this.loc(start),
@@ -1215,22 +1217,29 @@ class Parser {
 
   /**
    * InterfaceTypeExtension :
-   *   - extend interface Name Directives[Const]? FieldsDefinition
-   *   - extend interface Name Directives[Const]
+   *  - extend interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
+   *  - extend interface Name ImplementsInterfaces? Directives[Const]
+   *  - extend interface Name ImplementsInterfaces
    */
   parseInterfaceTypeExtension(): InterfaceTypeExtensionNode {
     const start = this._lexer.token;
     this.expectKeyword('extend');
     this.expectKeyword('interface');
     const name = this.parseName();
+    const interfaces = this.parseImplementsInterfaces();
     const directives = this.parseDirectives(true);
     const fields = this.parseFieldsDefinition();
-    if (directives.length === 0 && fields.length === 0) {
+    if (
+      interfaces.length === 0 &&
+      directives.length === 0 &&
+      fields.length === 0
+    ) {
       throw this.unexpected();
     }
     return {
       kind: Kind.INTERFACE_TYPE_EXTENSION,
       name,
+      interfaces,
       directives,
       fields,
       loc: this.loc(start),

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -148,8 +148,18 @@ const printDocASTReducer: any = {
       ),
   ),
 
-  InterfaceTypeDefinition: addDescription(({ name, directives, fields }) =>
-    join(['interface', name, join(directives, ' '), block(fields)], ' '),
+  InterfaceTypeDefinition: addDescription(
+    ({ name, interfaces, directives, fields }) =>
+      join(
+        [
+          'interface',
+          name,
+          wrap('implements ', join(interfaces, ' & ')),
+          join(directives, ' '),
+          block(fields),
+        ],
+        ' ',
+      ),
   ),
 
   UnionTypeDefinition: addDescription(({ name, directives, types }) =>
@@ -206,8 +216,17 @@ const printDocASTReducer: any = {
       ' ',
     ),
 
-  InterfaceTypeExtension: ({ name, directives, fields }) =>
-    join(['extend interface', name, join(directives, ' '), block(fields)], ' '),
+  InterfaceTypeExtension: ({ name, interfaces, directives, fields }) =>
+    join(
+      [
+        'extend interface',
+        name,
+        wrap('implements ', join(interfaces, ' & ')),
+        join(directives, ' '),
+        block(fields),
+      ],
+      ' ',
+    ),
 
   UnionTypeExtension: ({ name, directives, types }) =>
     join(

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -113,7 +113,13 @@ export const QueryDocumentKeys = {
     'defaultValue',
     'directives',
   ],
-  InterfaceTypeDefinition: ['description', 'name', 'directives', 'fields'],
+  InterfaceTypeDefinition: [
+    'description',
+    'name',
+    'interfaces',
+    'directives',
+    'fields',
+  ],
   UnionTypeDefinition: ['description', 'name', 'directives', 'types'],
   EnumTypeDefinition: ['description', 'name', 'directives', 'values'],
   EnumValueDefinition: ['description', 'name', 'directives'],
@@ -125,7 +131,7 @@ export const QueryDocumentKeys = {
 
   ScalarTypeExtension: ['name', 'directives'],
   ObjectTypeExtension: ['name', 'interfaces', 'directives', 'fields'],
-  InterfaceTypeExtension: ['name', 'directives', 'fields'],
+  InterfaceTypeExtension: ['name', 'interfaces', 'directives', 'fields'],
   UnionTypeExtension: ['name', 'directives', 'types'],
   EnumTypeExtension: ['name', 'directives', 'values'],
   InputObjectTypeExtension: ['name', 'directives', 'fields'],

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -441,6 +441,50 @@ describe('Type System: Interfaces', () => {
     ).not.to.throw();
   });
 
+  it('accepts an Interface type with an array of interfaces', () => {
+    const implementing = new GraphQLInterfaceType({
+      name: 'AnotherInterface',
+      fields: {},
+      interfaces: [InterfaceType],
+    });
+    expect(implementing.getInterfaces()).to.deep.equal([InterfaceType]);
+  });
+
+  it('accepts an Interface type with interfaces as a function returning an array', () => {
+    const implementing = new GraphQLInterfaceType({
+      name: 'AnotherInterface',
+      fields: {},
+      interfaces: () => [InterfaceType],
+    });
+    expect(implementing.getInterfaces()).to.deep.equal([InterfaceType]);
+  });
+
+  it('rejects an Interface type with incorrectly typed interfaces', () => {
+    const objType = new GraphQLInterfaceType({
+      name: 'AnotherInterface',
+      fields: {},
+      // $DisableFlowOnNegativeTest
+      interfaces: {},
+    });
+    expect(() => objType.getInterfaces()).to.throw(
+      'AnotherInterface interfaces must be an Array or a function which returns an Array.',
+    );
+  });
+
+  it('rejects an Interface type with interfaces as a function returning an incorrect type', () => {
+    const objType = new GraphQLInterfaceType({
+      name: 'AnotherInterface',
+      fields: {},
+      // $DisableFlowOnNegativeTest
+      interfaces() {
+        return {};
+      },
+    });
+    expect(() => objType.getInterfaces()).to.throw(
+      'AnotherInterface interfaces must be an Array or a function which returns an Array.',
+    );
+  });
+
   it('rejects an Interface type with an incorrect type for resolveType', () => {
     expect(
       () =>

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1357,7 +1357,7 @@ describe('Introspection', () => {
             },
             {
               description:
-                'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.',
+                'Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.',
               name: 'INTERFACE',
             },
             {

--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -181,6 +181,12 @@ describe('Type System: Schema', () => {
       const SomeInterface = new GraphQLInterfaceType({
         name: 'SomeInterface',
         fields: {},
+        interfaces: () => [AnotherInterface],
+      });
+
+      const AnotherInterface = new GraphQLInterfaceType({
+        name: 'AnotherInterface',
+        fields: {},
       });
 
       const SomeSubtype = new GraphQLObjectType({
@@ -192,6 +198,7 @@ describe('Type System: Schema', () => {
       const schema = new GraphQLSchema({ types: [SomeSubtype] });
 
       expect(schema.getType('SomeInterface')).to.equal(SomeInterface);
+      expect(schema.getType('AnotherInterface')).to.equal(AnotherInterface);
       expect(schema.getType('SomeSubtype')).to.equal(SomeSubtype);
     });
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -240,7 +240,7 @@ export const __Type = new GraphQLObjectType({
       interfaces: {
         type: GraphQLList(GraphQLNonNull(__Type)),
         resolve(type) {
-          if (isObjectType(type)) {
+          if (isObjectType(type) || isInterfaceType(type)) {
             return type.getInterfaces();
           }
         },
@@ -398,7 +398,7 @@ export const __TypeKind = new GraphQLEnumType({
     INTERFACE: {
       value: TypeKind.INTERFACE,
       description:
-        'Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.',
+        'Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.',
     },
     UNION: {
       value: TypeKind.UNION,

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -130,9 +130,8 @@ export class GraphQLSchema {
   _subscriptionType: ?GraphQLObjectType;
   _directives: $ReadOnlyArray<GraphQLDirective>;
   _typeMap: TypeMap;
-  _implementations: ObjMap<Array<GraphQLObjectType | GraphQLInterfaceType>>;
-  _objectImplementations: ObjMap<Array<GraphQLObjectType>>;
-  _possibleTypeMap: ObjMap<ObjMap<boolean>>;
+  _implementations: ObjMap<InterfaceImplementations>;
+  _subTypeMap: ObjMap<ObjMap<boolean>>;
   // Used as a cache for validateSchema().
   __validationErrors: ?$ReadOnlyArray<GraphQLError>;
 
@@ -188,36 +187,10 @@ export class GraphQLSchema {
     // Storing the resulting map for reference by the schema.
     this._typeMap = typeMap;
 
-    this._possibleTypeMap = Object.create(null);
+    this._subTypeMap = Object.create(null);
 
     // Keep track of all implementations by interface name.
-    this._implementations = Object.create(null);
-    this._objectImplementations = Object.create(null);
-    for (const type of objectValues(this._typeMap)) {
-      if (isObjectType(type) || isInterfaceType(type)) {
-        for (const iface of type.getInterfaces()) {
-          if (isInterfaceType(iface)) {
-            // Store implementations by objects and interfaces.
-            const impls = this._implementations[iface.name];
-            if (impls) {
-              impls.push(type);
-            } else {
-              this._implementations[iface.name] = [type];
-            }
-
-            // Store implementations by objects only.
-            if (isObjectType(type)) {
-              const objImpls = this._objectImplementations[iface.name];
-              if (objImpls) {
-                objImpls.push(type);
-              } else {
-                this._objectImplementations[iface.name] = [type];
-              }
-            }
-          }
-        }
-      }
-    }
+    this._implementations = collectImplementations(objectValues(typeMap));
   }
 
   getQueryType(): ?GraphQLObjectType {
@@ -243,39 +216,50 @@ export class GraphQLSchema {
   getPossibleTypes(
     abstractType: GraphQLAbstractType,
   ): $ReadOnlyArray<GraphQLObjectType> {
-    if (isUnionType(abstractType)) {
-      return abstractType.getTypes();
-    }
-
-    return this._objectImplementations[abstractType.name] || [];
+    return isUnionType(abstractType)
+      ? abstractType.getTypes()
+      : this.getImplementations(abstractType).objects;
   }
 
   getImplementations(
     interfaceType: GraphQLInterfaceType,
-  ): $ReadOnlyArray<GraphQLObjectType | GraphQLInterfaceType> {
-    return this._implementations[interfaceType.name] || [];
+  ): InterfaceImplementations {
+    return this._implementations[interfaceType.name];
   }
 
+  // @deprecated: use isSubType instead - will be removed in v16.
   isPossibleType(
     abstractType: GraphQLAbstractType,
     possibleType: GraphQLObjectType,
   ): boolean {
-    if (this._possibleTypeMap[abstractType.name] == null) {
-      const map = Object.create(null);
-      for (const type of this.getPossibleTypes(abstractType)) {
-        map[type.name] = true;
-      }
-      this._possibleTypeMap[abstractType.name] = map;
-    }
-
-    return this._possibleTypeMap[abstractType.name][possibleType.name] != null;
+    return this.isSubType(abstractType, possibleType);
   }
 
-  isImplementation(
-    interfaceType: GraphQLInterfaceType,
-    possibleType: GraphQLObjectType | GraphQLInterfaceType,
+  isSubType(
+    abstractType: GraphQLAbstractType,
+    maybeSubType: GraphQLObjectType | GraphQLInterfaceType,
   ): boolean {
-    return this.getImplementations(interfaceType).indexOf(possibleType) !== -1;
+    let map = this._subTypeMap[abstractType.name];
+    if (map === undefined) {
+      map = Object.create(null);
+
+      if (isUnionType(abstractType)) {
+        for (const type of abstractType.getTypes()) {
+          map[type.name] = true;
+        }
+      } else {
+        const implementations = this.getImplementations(abstractType);
+        for (const type of implementations.objects) {
+          map[type.name] = true;
+        }
+        for (const type of implementations.interfaces) {
+          map[type.name] = true;
+        }
+      }
+
+      this._subTypeMap[abstractType.name] = map;
+    }
+    return map[maybeSubType.name] !== undefined;
   }
 
   getDirectives(): $ReadOnlyArray<GraphQLDirective> {
@@ -313,6 +297,11 @@ defineToStringTag(GraphQLSchema);
 
 type TypeMap = ObjMap<GraphQLNamedType>;
 
+type InterfaceImplementations = {|
+  objects: $ReadOnlyArray<GraphQLObjectType>,
+  interfaces: $ReadOnlyArray<GraphQLInterfaceType>,
+|};
+
 export type GraphQLSchemaValidationOptions = {|
   /**
    * When building a schema from a GraphQL service's introspection result, it
@@ -335,6 +324,52 @@ export type GraphQLSchemaConfig = {|
   extensionASTNodes?: ?$ReadOnlyArray<SchemaExtensionNode>,
   ...GraphQLSchemaValidationOptions,
 |};
+
+function collectImplementations(
+  types: $ReadOnlyArray<GraphQLNamedType>,
+): ObjMap<InterfaceImplementations> {
+  const implementations = Object.create(null);
+
+  for (const type of types) {
+    if (isInterfaceType(type)) {
+      if (implementations[type.name] === undefined) {
+        implementations[type.name] = { objects: [], interfaces: [] };
+      }
+
+      // Store implementations by interface.
+      for (const iface of type.getInterfaces()) {
+        if (isInterfaceType(iface)) {
+          const impls = implementations[iface.name];
+          if (impls === undefined) {
+            implementations[iface.name] = {
+              objects: [],
+              interfaces: [type],
+            };
+          } else {
+            impls.interfaces.push(type);
+          }
+        }
+      }
+    } else if (isObjectType(type)) {
+      // Store implementations by objects.
+      for (const iface of type.getInterfaces()) {
+        if (isInterfaceType(iface)) {
+          const impls = implementations[iface.name];
+          if (impls === undefined) {
+            implementations[iface.name] = {
+              objects: [type],
+              interfaces: [],
+            };
+          } else {
+            impls.objects.push(type);
+          }
+        }
+      }
+    }
+  }
+
+  return implementations;
+}
 
 function typeMapReducer(map: TypeMap, type: ?GraphQLType): TypeMap {
   if (!type) {

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -235,10 +235,13 @@ function validateTypes(context: SchemaValidationContext): void {
       validateFields(context, type);
 
       // Ensure objects implement the interfaces they claim to.
-      validateObjectInterfaces(context, type);
+      validateInterfaces(context, type);
     } else if (isInterfaceType(type)) {
       // Ensure fields are valid.
       validateFields(context, type);
+
+      // Ensure interfaces implement the interfaces they claim to.
+      validateInterfaces(context, type);
     } else if (isUnionType(type)) {
       // Ensure Unions include valid member types.
       validateUnionMembers(context, type);
@@ -313,65 +316,75 @@ function validateFields(
   }
 }
 
-function validateObjectInterfaces(
+function validateInterfaces(
   context: SchemaValidationContext,
-  object: GraphQLObjectType,
+  type: GraphQLObjectType | GraphQLInterfaceType,
 ): void {
-  const implementedTypeNames = Object.create(null);
-  for (const iface of object.getInterfaces()) {
+  const ifaceTypeNames = Object.create(null);
+  for (const iface of type.getInterfaces()) {
     if (!isInterfaceType(iface)) {
       context.reportError(
-        `Type ${inspect(object)} must only implement Interface types, ` +
+        `Type ${inspect(type)} must only implement Interface types, ` +
           `it cannot implement ${inspect(iface)}.`,
-        getAllImplementsInterfaceNodes(object, iface),
+        getAllImplementsInterfaceNodes(type, iface),
       );
       continue;
     }
 
-    if (implementedTypeNames[iface.name]) {
+    if (type === iface) {
       context.reportError(
-        `Type ${object.name} can only implement ${iface.name} once.`,
-        getAllImplementsInterfaceNodes(object, iface),
+        `Type ${type.name} cannot implement itself because it would create a circular reference.`,
+        getAllImplementsInterfaceNodes(type, iface),
       );
       continue;
     }
-    implementedTypeNames[iface.name] = true;
 
-    validateObjectImplementsInterface(context, object, iface);
+    if (ifaceTypeNames[iface.name]) {
+      context.reportError(
+        `Type ${type.name} can only implement ${iface.name} once.`,
+        getAllImplementsInterfaceNodes(type, iface),
+      );
+      continue;
+    }
+
+    ifaceTypeNames[iface.name] = true;
+
+    validateTypeImplementsAncestors(context, type, iface);
+    validateTypeImplementsInterface(context, type, iface);
   }
 }
 
-function validateObjectImplementsInterface(
+function validateTypeImplementsInterface(
   context: SchemaValidationContext,
-  object: GraphQLObjectType,
+  type: GraphQLObjectType | GraphQLInterfaceType,
   iface: GraphQLInterfaceType,
 ): void {
-  const objectFieldMap = object.getFields();
+  const typeFieldMap = type.getFields();
 
   // Assert each interface field is implemented.
   for (const ifaceField of objectValues(iface.getFields())) {
     const fieldName = ifaceField.name;
-    const objectField = objectFieldMap[fieldName];
+    const typeField = typeFieldMap[fieldName];
 
-    // Assert interface field exists on object.
-    if (!objectField) {
+    // Assert interface field exists on type.
+    if (!typeField) {
       context.reportError(
-        `Interface field ${iface.name}.${fieldName} expected but ${object.name} does not provide it.`,
-        [ifaceField.astNode, ...getAllNodes(object)],
+        `Interface field ${iface.name}.${fieldName} expected but ${type.name} does not provide it.`,
+        [ifaceField.astNode, ...getAllNodes(type)],
       );
       continue;
     }
 
-    // Assert interface field type is satisfied by object field type, by being
+    // Assert interface field type is satisfied by type field type, by being
     // a valid subtype. (covariant)
-    if (!isTypeSubTypeOf(context.schema, objectField.type, ifaceField.type)) {
+    if (!isTypeSubTypeOf(context.schema, typeField.type, ifaceField.type)) {
       context.reportError(
         `Interface field ${iface.name}.${fieldName} expects type ` +
-          `${inspect(ifaceField.type)} but ${object.name}.${fieldName} ` +
-          `is type ${inspect(objectField.type)}.`,
+          `${inspect(ifaceField.type)} but ${type.name}.${fieldName} ` +
+          `is type ${inspect(typeField.type)}.`,
         [
           ifaceField.astNode && ifaceField.astNode.type,
-          objectField.astNode && objectField.astNode.type,
+          typeField.astNode && typeField.astNode.type,
         ],
       );
     }
@@ -379,13 +392,13 @@ function validateObjectImplementsInterface(
     // Assert each interface field arg is implemented.
     for (const ifaceArg of ifaceField.args) {
       const argName = ifaceArg.name;
-      const objectArg = find(objectField.args, arg => arg.name === argName);
+      const typeArg = find(typeField.args, arg => arg.name === argName);
 
       // Assert interface field arg exists on object field.
-      if (!objectArg) {
+      if (!typeArg) {
         context.reportError(
-          `Interface field argument ${iface.name}.${fieldName}(${argName}:) expected but ${object.name}.${fieldName} does not provide it.`,
-          [ifaceArg.astNode, objectField.astNode],
+          `Interface field argument ${iface.name}.${fieldName}(${argName}:) expected but ${type.name}.${fieldName} does not provide it.`,
+          [ifaceArg.astNode, typeField.astNode],
         );
         continue;
       }
@@ -393,15 +406,15 @@ function validateObjectImplementsInterface(
       // Assert interface field arg type matches object field arg type.
       // (invariant)
       // TODO: change to contravariant?
-      if (!isEqualType(ifaceArg.type, objectArg.type)) {
+      if (!isEqualType(ifaceArg.type, typeArg.type)) {
         context.reportError(
           `Interface field argument ${iface.name}.${fieldName}(${argName}:) ` +
             `expects type ${inspect(ifaceArg.type)} but ` +
-            `${object.name}.${fieldName}(${argName}:) is type ` +
-            `${inspect(objectArg.type)}.`,
+            `${type.name}.${fieldName}(${argName}:) is type ` +
+            `${inspect(typeArg.type)}.`,
           [
             ifaceArg.astNode && ifaceArg.astNode.type,
-            objectArg.astNode && objectArg.astNode.type,
+            typeArg.astNode && typeArg.astNode.type,
           ],
         );
       }
@@ -410,15 +423,36 @@ function validateObjectImplementsInterface(
     }
 
     // Assert additional arguments must not be required.
-    for (const objectArg of objectField.args) {
-      const argName = objectArg.name;
+    for (const typeArg of typeField.args) {
+      const argName = typeArg.name;
       const ifaceArg = find(ifaceField.args, arg => arg.name === argName);
-      if (!ifaceArg && isRequiredArgument(objectArg)) {
+      if (!ifaceArg && isRequiredArgument(typeArg)) {
         context.reportError(
-          `Object field ${object.name}.${fieldName} includes required argument ${argName} that is missing from the Interface field ${iface.name}.${fieldName}.`,
-          [objectArg.astNode, ifaceField.astNode],
+          `Object field ${type.name}.${fieldName} includes required argument ${argName} that is missing from the Interface field ${iface.name}.${fieldName}.`,
+          [typeArg.astNode, ifaceField.astNode],
         );
       }
+    }
+  }
+}
+
+function validateTypeImplementsAncestors(
+  context: SchemaValidationContext,
+  type: GraphQLObjectType | GraphQLInterfaceType,
+  iface: GraphQLInterfaceType,
+): void {
+  const ifaceInterfaces = type.getInterfaces();
+  for (const transitive of iface.getInterfaces()) {
+    if (ifaceInterfaces.indexOf(transitive) === -1) {
+      context.reportError(
+        transitive === type
+          ? `Type ${type.name} cannot implement ${iface.name} because it would create a circular reference.`
+          : `Type ${type.name} must implement ${transitive.name} because it is implemented by ${iface.name}.`,
+        [
+          ...getAllImplementsInterfaceNodes(iface, transitive),
+          ...getAllImplementsInterfaceNodes(type, iface),
+        ],
+      );
     }
   }
 }
@@ -589,7 +623,7 @@ function getAllSubNodes<T: ASTNode, K: ASTNode, L: ASTNode>(
 }
 
 function getAllImplementsInterfaceNodes(
-  type: GraphQLObjectType,
+  type: GraphQLObjectType | GraphQLInterfaceType,
   iface: GraphQLInterfaceType,
 ): $ReadOnlyArray<NamedTypeNode> {
   return getAllSubNodes(type, typeNode => typeNode.interfaces).filter(

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -285,6 +285,12 @@ describe('Schema Builder', () => {
     const sdl = dedent`
       interface EmptyInterface
     `;
+
+    const definition = parse(sdl).definitions[0];
+    expect(
+      definition.kind === 'InterfaceTypeDefinition' && definition.interfaces,
+    ).to.deep.equal([], 'The interfaces property must be an empty array.');
+
     expect(cycleSDL(sdl)).to.equal(sdl);
   });
 
@@ -295,6 +301,27 @@ describe('Schema Builder', () => {
       }
 
       interface WorldInterface {
+        str: String
+      }
+    `;
+    expect(cycleSDL(sdl)).to.equal(sdl);
+  });
+
+  it('Simple interface heirarchy', () => {
+    const sdl = dedent`
+      schema {
+        query: Child
+      }
+
+      interface Child implements Parent {
+        str: String
+      }
+
+      type Hello implements Parent & Child {
+        str: String
+      }
+
+      interface Parent {
         str: String
       }
     `;
@@ -627,6 +654,23 @@ describe('Schema Builder', () => {
 
       type Query {
         iface: Iface
+      }
+    `;
+    expect(cycleSDL(sdl)).to.equal(sdl);
+  });
+
+  it('Unreferenced interface implementing referenced interface', () => {
+    const sdl = dedent`
+      interface Child implements Parent {
+        key: String
+      }
+
+      interface Parent {
+        key: String
+      }
+
+      type Query {
+        iface: Parent
       }
     `;
     expect(cycleSDL(sdl)).to.equal(sdl);

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -41,18 +41,21 @@ const testSchema = buildSchema(`
   scalar SomeScalar
 
   interface SomeInterface {
-    name: String
     some: SomeInterface
   }
 
-  type Foo implements SomeInterface {
+  interface AnotherInterface implements SomeInterface {
     name: String
-    some: SomeInterface
+    some: AnotherInterface
+  }
+
+  type Foo implements AnotherInterface & SomeInterface {
+    name: String
+    some: AnotherInterface
     tree: [Foo]!
   }
 
   type Bar implements SomeInterface {
-    name: String
     some: SomeInterface
     foo: Foo
   }
@@ -194,9 +197,9 @@ describe('extendSchema', () => {
       }
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField: String
       }
@@ -633,9 +636,9 @@ describe('extendSchema', () => {
       }
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField(arg1: String, arg2: NewInputObj!): String
       }
@@ -655,9 +658,9 @@ describe('extendSchema', () => {
       }
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField(arg1: SomeEnum!): SomeEnum
       }
@@ -713,9 +716,9 @@ describe('extendSchema', () => {
       }
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newObject: NewObject
         newInterface: NewInterface
@@ -759,9 +762,9 @@ describe('extendSchema', () => {
       }
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
-      type Foo implements SomeInterface & NewInterface {
+      type Foo implements AnotherInterface & SomeInterface & NewInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         baz: String
       }
@@ -865,6 +868,10 @@ describe('extendSchema', () => {
         newField: String
       }
 
+      extend interface AnotherInterface {
+        newField: String
+      }
+
       extend type Bar {
         newField: String
       }
@@ -874,23 +881,61 @@ describe('extendSchema', () => {
       }
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
-      type Bar implements SomeInterface {
+      interface AnotherInterface implements SomeInterface {
         name: String
+        some: AnotherInterface
+        newField: String
+      }
+
+      type Bar implements SomeInterface {
         some: SomeInterface
         foo: Foo
         newField: String
       }
 
-      type Foo implements SomeInterface {
+      type Foo implements AnotherInterface & SomeInterface {
         name: String
-        some: SomeInterface
+        some: AnotherInterface
         tree: [Foo]!
         newField: String
       }
 
       interface SomeInterface {
-        name: String
         some: SomeInterface
+        newField: String
+      }
+    `);
+  });
+
+  it('extends interfaces by adding new implemted interfaces', () => {
+    const extendedSchema = extendTestSchema(`
+      interface NewInterface {
+        newField: String
+      }
+
+      extend interface AnotherInterface implements NewInterface {
+        newField: String
+      }
+
+      extend type Foo implements NewInterface {
+        newField: String
+      }
+    `);
+    expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
+      interface AnotherInterface implements SomeInterface & NewInterface {
+        name: String
+        some: AnotherInterface
+        newField: String
+      }
+
+      type Foo implements AnotherInterface & SomeInterface & NewInterface {
+        name: String
+        some: AnotherInterface
+        tree: [Foo]!
+        newField: String
+      }
+      
+      interface NewInterface {
         newField: String
       }
     `);
@@ -908,7 +953,6 @@ describe('extendSchema', () => {
 
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
       interface SomeInterface {
-        name: String
         some: SomeInterface
         newField: String
       }
@@ -927,7 +971,6 @@ describe('extendSchema', () => {
     `);
     expect(printTestSchemaChanges(extendedSchema)).to.equal(dedent`
       interface SomeInterface {
-        name: String
         some: SomeInterface
         newFieldA: Int
         newFieldB(test: Boolean): String

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -592,8 +592,29 @@ describe('findBreakingChanges', () => {
 
     expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([
       {
-        type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
+        type: BreakingChangeType.IMPLEMENTED_INTERFACE_REMOVED,
         description: 'Type1 no longer implements interface Interface1.',
+      },
+    ]);
+  });
+
+  it('should detect interfaces removed from interfaces', () => {
+    const oldSchema = buildSchema(`
+      interface Interface1
+
+      interface Interface2 implements Interface1
+    `);
+
+    const newSchema = buildSchema(`
+      interface Interface1
+
+      interface Interface2
+    `);
+
+    expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: BreakingChangeType.IMPLEMENTED_INTERFACE_REMOVED,
+        description: 'Interface2 no longer implements interface Interface1.',
       },
     ]);
   });
@@ -704,7 +725,7 @@ describe('findBreakingChanges', () => {
           'VALUE0 was removed from enum type EnumTypeThatLosesAValue.',
       },
       {
-        type: BreakingChangeType.INTERFACE_REMOVED_FROM_OBJECT,
+        type: BreakingChangeType.IMPLEMENTED_INTERFACE_REMOVED,
         description:
           'TypeThatLooseInterface1 no longer implements interface Interface1.',
       },
@@ -1021,8 +1042,32 @@ describe('findDangerousChanges', () => {
 
     expect(findDangerousChanges(oldSchema, newSchema)).to.deep.equal([
       {
-        type: DangerousChangeType.INTERFACE_ADDED_TO_OBJECT,
+        type: DangerousChangeType.IMPLEMENTED_INTERFACE_ADDED,
         description: 'NewInterface added to interfaces implemented by Type1.',
+      },
+    ]);
+  });
+
+  it('should detect interfaces added to interfaces', () => {
+    const oldSchema = buildSchema(`
+      interface OldInterface
+      interface NewInterface
+
+      interface Interface1 implements OldInterface
+    `);
+
+    const newSchema = buildSchema(`
+      interface OldInterface
+      interface NewInterface
+
+      interface Interface1 implements OldInterface & NewInterface
+    `);
+
+    expect(findDangerousChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: DangerousChangeType.IMPLEMENTED_INTERFACE_ADDED,
+        description:
+          'NewInterface added to interfaces implemented by Interface1.',
       },
     ]);
   });
@@ -1121,7 +1166,7 @@ describe('findDangerousChanges', () => {
           'Type1.field1 arg argThatChangesDefaultValue has changed defaultValue from "test" to "Test".',
       },
       {
-        type: DangerousChangeType.INTERFACE_ADDED_TO_OBJECT,
+        type: DangerousChangeType.IMPLEMENTED_INTERFACE_ADDED,
         description:
           'Interface1 added to interfaces implemented by TypeThatGainsInterface1.',
       },

--- a/src/utilities/__tests__/lexicographicSortSchema-test.js
+++ b/src/utilities/__tests__/lexicographicSortSchema-test.js
@@ -75,7 +75,7 @@ describe('lexicographicSortSchema', () => {
         dummy: String
       }
 
-      interface FooC {
+      interface FooC implements FooB & FooA {
         dummy: String
       }
 
@@ -93,7 +93,7 @@ describe('lexicographicSortSchema', () => {
         dummy: String
       }
 
-      interface FooC {
+      interface FooC implements FooA & FooB {
         dummy: String
       }
 

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -340,6 +340,61 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('Print Hierarchical Interface', () => {
+    const FooType = new GraphQLInterfaceType({
+      name: 'Foo',
+      fields: { str: { type: GraphQLString } },
+    });
+
+    const BaazType = new GraphQLInterfaceType({
+      name: 'Baaz',
+      interfaces: [FooType],
+      fields: {
+        int: { type: GraphQLInt },
+        str: { type: GraphQLString },
+      },
+    });
+
+    const BarType = new GraphQLObjectType({
+      name: 'Bar',
+      fields: {
+        str: { type: GraphQLString },
+        int: { type: GraphQLInt },
+      },
+      interfaces: [FooType, BaazType],
+    });
+
+    const Query = new GraphQLObjectType({
+      name: 'Query',
+      fields: { bar: { type: BarType } },
+    });
+
+    const Schema = new GraphQLSchema({
+      query: Query,
+      types: [BarType],
+    });
+    const output = printForTest(Schema);
+    expect(output).to.equal(dedent`
+      interface Baaz implements Foo {
+        int: Int
+        str: String
+      }
+
+      type Bar implements Foo & Baaz {
+        str: String
+        int: Int
+      }
+
+      interface Foo {
+        str: String
+      }
+
+      type Query {
+        bar: Bar
+      }
+    `);
+  });
+
   it('Print Unions', () => {
     const FooType = new GraphQLObjectType({
       name: 'Foo',
@@ -723,7 +778,7 @@ describe('Type System Printer', () => {
         OBJECT
 
         """
-        Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
+        Indicates this type is an interface. \`fields\`, \`interfaces\`, and \`possibleTypes\` are valid fields.
         """
         INTERFACE
 
@@ -929,7 +984,7 @@ describe('Type System Printer', () => {
         # Indicates this type is an object. \`fields\` and \`interfaces\` are valid fields.
         OBJECT
 
-        # Indicates this type is an interface. \`fields\` and \`possibleTypes\` are valid fields.
+        # Indicates this type is an interface. \`fields\`, \`interfaces\`, and \`possibleTypes\` are valid fields.
         INTERFACE
 
         # Indicates this type is a union. \`possibleTypes\` is a valid field.

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -110,7 +110,7 @@ describe('typeComparators', () => {
       expect(isTypeSubTypeOf(schema, member, union)).to.equal(true);
     });
 
-    it('implementation is subtype of interface', () => {
+    it('implementing object is subtype of interface', () => {
       const iface = new GraphQLInterfaceType({
         name: 'Interface',
         fields: {
@@ -126,6 +126,31 @@ describe('typeComparators', () => {
       });
       const schema = testSchema({ field: { type: impl } });
       expect(isTypeSubTypeOf(schema, impl, iface)).to.equal(true);
+    });
+
+    it('implementing interface is subtype of interface', () => {
+      const iface = new GraphQLInterfaceType({
+        name: 'Interface',
+        fields: {
+          field: { type: GraphQLString },
+        },
+      });
+      const iface2 = new GraphQLInterfaceType({
+        name: 'Interface2',
+        interfaces: [iface],
+        fields: {
+          field: { type: GraphQLString },
+        },
+      });
+      const impl = new GraphQLObjectType({
+        name: 'Object',
+        interfaces: [iface2, iface],
+        fields: {
+          field: { type: GraphQLString },
+        },
+      });
+      const schema = testSchema({ field: { type: impl } });
+      expect(isTypeSubTypeOf(schema, iface2, iface)).to.equal(true);
     });
   });
 });

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -346,7 +346,16 @@ export class ASTDefinitionBuilder {
   }
 
   _makeInterfaceDef(astNode: InterfaceTypeDefinitionNode) {
+    const interfaceNodes = astNode.interfaces;
     const fieldNodes = astNode.fields;
+
+    // Note: While this could make assertions to get the correctly typed
+    // values below, that would throw immediately while type system
+    // validation with validateSchema() will produce more actionable results.
+    const interfaces =
+      interfaceNodes && interfaceNodes.length > 0
+        ? () => interfaceNodes.map(ref => (this.getNamedType(ref): any))
+        : [];
 
     const fields =
       fieldNodes && fieldNodes.length > 0
@@ -356,6 +365,7 @@ export class ASTDefinitionBuilder {
     return new GraphQLInterfaceType({
       name: astNode.name.value,
       description: getDescription(astNode, this._options),
+      interfaces,
       fields,
       astNode,
     });

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -232,19 +232,37 @@ export function buildClientSchema(
     });
   }
 
+  function buildImplementationsList(
+    implementingIntrospection:
+      | IntrospectionObjectType
+      | IntrospectionInterfaceType,
+  ) {
+    // TODO: Temprorary workaround until GraphQL ecosystem will fully support
+    // 'interfaces' on interface types.
+    if (
+      implementingIntrospection.interfaces === null &&
+      implementingIntrospection.kind === TypeKind.INTERFACE
+    ) {
+      return [];
+    }
+
+    if (!implementingIntrospection.interfaces) {
+      throw new Error(
+        'Introspection result missing interfaces: ' +
+          inspect(implementingIntrospection),
+      );
+    }
+
+    return implementingIntrospection.interfaces.map(getInterfaceType);
+  }
+
   function buildObjectDef(
     objectIntrospection: IntrospectionObjectType,
   ): GraphQLObjectType {
-    if (!objectIntrospection.interfaces) {
-      throw new Error(
-        'Introspection result missing interfaces: ' +
-          inspect(objectIntrospection),
-      );
-    }
     return new GraphQLObjectType({
       name: objectIntrospection.name,
       description: objectIntrospection.description,
-      interfaces: () => objectIntrospection.interfaces.map(getInterfaceType),
+      interfaces: () => buildImplementationsList(objectIntrospection),
       fields: () => buildFieldDefMap(objectIntrospection),
     });
   }
@@ -255,6 +273,7 @@ export function buildClientSchema(
     return new GraphQLInterfaceType({
       name: interfaceIntrospection.name,
       description: interfaceIntrospection.description,
+      interfaces: () => buildImplementationsList(interfaceIntrospection),
       fields: () => buildFieldDefMap(interfaceIntrospection),
     });
   }

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -160,6 +160,9 @@ export type IntrospectionInterfaceType = {
   +name: string,
   +description?: ?string,
   +fields: $ReadOnlyArray<IntrospectionField>,
+  +interfaces: $ReadOnlyArray<
+    IntrospectionNamedTypeRef<IntrospectionInterfaceType>,
+  >,
   +possibleTypes: $ReadOnlyArray<
     IntrospectionNamedTypeRef<IntrospectionObjectType>,
   >,

--- a/src/utilities/lexicographicSortSchema.js
+++ b/src/utilities/lexicographicSortSchema.js
@@ -115,6 +115,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
       const config = type.toConfig();
       return new GraphQLInterfaceType({
         ...config,
+        interfaces: () => sortTypes(config.interfaces),
         fields: () => sortFields(config.fields),
       });
     } else if (isUnionType(type)) {

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -181,14 +181,20 @@ function printScalar(type: GraphQLScalarType, options): string {
   return printDescription(options, type) + `scalar ${type.name}`;
 }
 
-function printObject(type: GraphQLObjectType, options): string {
+function printImplementedInterfaces(
+  type: GraphQLObjectType | GraphQLInterfaceType,
+): string {
   const interfaces = type.getInterfaces();
-  const implementedInterfaces = interfaces.length
+  return interfaces.length
     ? ' implements ' + interfaces.map(i => i.name).join(' & ')
     : '';
+}
+
+function printObject(type: GraphQLObjectType, options): string {
   return (
     printDescription(options, type) +
-    `type ${type.name}${implementedInterfaces}` +
+    `type ${type.name}` +
+    printImplementedInterfaces(type) +
     printFields(options, type)
   );
 }
@@ -197,6 +203,7 @@ function printInterface(type: GraphQLInterfaceType, options): string {
   return (
     printDescription(options, type) +
     `interface ${type.name}` +
+    printImplementedInterfaces(type) +
     printFields(options, type)
   );
 }

--- a/src/utilities/typeComparators.js
+++ b/src/utilities/typeComparators.js
@@ -4,6 +4,7 @@ import { type GraphQLSchema } from '../type/schema';
 import {
   type GraphQLType,
   type GraphQLCompositeType,
+  isInterfaceType,
   isObjectType,
   isListType,
   isNonNullType,
@@ -69,6 +70,16 @@ export function isTypeSubTypeOf(
   if (isListType(maybeSubType)) {
     // If superType is not a list, maybeSubType must also be not a list.
     return false;
+  }
+
+  // If superType and maybeSubType are both interfaces, check if the latter
+  // implements the former.
+  if (
+    isInterfaceType(superType) &&
+    isInterfaceType(maybeSubType) &&
+    schema.isImplementation(superType, maybeSubType)
+  ) {
+    return true;
   }
 
   // If superType type is an abstract type, maybeSubType type may be a currently

--- a/src/utilities/typeComparators.js
+++ b/src/utilities/typeComparators.js
@@ -72,28 +72,13 @@ export function isTypeSubTypeOf(
     return false;
   }
 
-  // If superType and maybeSubType are both interfaces, check if the latter
-  // implements the former.
-  if (
-    isInterfaceType(superType) &&
-    isInterfaceType(maybeSubType) &&
-    schema.isImplementation(superType, maybeSubType)
-  ) {
-    return true;
-  }
-
-  // If superType type is an abstract type, maybeSubType type may be a currently
-  // possible object type.
-  if (
-    isAbstractType(superType) &&
-    isObjectType(maybeSubType) &&
-    schema.isPossibleType(superType, maybeSubType)
-  ) {
-    return true;
-  }
-
+  // If superType type is an abstract type, check if it is super type of maybeSubType.
   // Otherwise, the child type is not a valid subtype of the parent type.
-  return false;
+  return (
+    isAbstractType(superType) &&
+    (isInterfaceType(maybeSubType) || isObjectType(maybeSubType)) &&
+    schema.isSubType(superType, maybeSubType)
+  );
 }
 
 /**
@@ -121,15 +106,15 @@ export function doTypesOverlap(
       // between possible concrete types of each.
       return schema
         .getPossibleTypes(typeA)
-        .some(type => schema.isPossibleType(typeB, type));
+        .some(type => schema.isSubType(typeB, type));
     }
     // Determine if the latter type is a possible concrete type of the former.
-    return schema.isPossibleType(typeA, typeB);
+    return schema.isSubType(typeA, typeB);
   }
 
   if (isAbstractType(typeB)) {
     // Determine if the former type is a possible concrete type of the latter.
-    return schema.isPossibleType(typeB, typeA);
+    return schema.isSubType(typeB, typeA);
   }
 
   // Otherwise the types do not overlap.

--- a/src/validation/__tests__/FragmentsOnCompositeTypes-test.js
+++ b/src/validation/__tests__/FragmentsOnCompositeTypes-test.js
@@ -41,6 +41,16 @@ describe('Validate: Fragments on composite types', () => {
     `);
   });
 
+  it('interface is valid inline fragment type', () => {
+    expectValid(`
+      fragment validFragment on Mammal {
+        ... on Canine {
+          name
+        }
+      }
+    `);
+  });
+
   it('inline fragment without type is valid', () => {
     expectValid(`
       fragment validFragment on Pet {

--- a/src/validation/__tests__/harness.js
+++ b/src/validation/__tests__/harness.js
@@ -46,8 +46,22 @@ const Being = new GraphQLInterfaceType({
   }),
 });
 
+const Mammal = new GraphQLInterfaceType({
+  name: 'Mammal',
+  interfaces: [],
+  fields: () => ({
+    mother: {
+      type: Mammal,
+    },
+    father: {
+      type: Mammal,
+    },
+  }),
+});
+
 const Pet = new GraphQLInterfaceType({
   name: 'Pet',
+  interfaces: [Being],
   fields: () => ({
     name: {
       type: GraphQLString,
@@ -58,10 +72,17 @@ const Pet = new GraphQLInterfaceType({
 
 const Canine = new GraphQLInterfaceType({
   name: 'Canine',
+  interfaces: [Mammal, Being],
   fields: () => ({
     name: {
       type: GraphQLString,
       args: { surname: { type: GraphQLBoolean } },
+    },
+    mother: {
+      type: Canine,
+    },
+    father: {
+      type: Canine,
     },
   }),
 });
@@ -77,6 +98,7 @@ const DogCommand = new GraphQLEnumType({
 
 const Dog = new GraphQLObjectType({
   name: 'Dog',
+  interfaces: [Being, Pet, Mammal, Canine],
   fields: () => ({
     name: {
       type: GraphQLString,
@@ -104,8 +126,13 @@ const Dog = new GraphQLObjectType({
       type: GraphQLBoolean,
       args: { x: { type: GraphQLInt }, y: { type: GraphQLInt } },
     },
+    mother: {
+      type: Dog,
+    },
+    father: {
+      type: Dog,
+    },
   }),
-  interfaces: [Being, Pet, Canine],
 });
 
 const Cat = new GraphQLObjectType({

--- a/tstypes/language/ast.d.ts
+++ b/tstypes/language/ast.d.ts
@@ -452,6 +452,7 @@ export interface InterfaceTypeDefinitionNode {
   readonly loc?: Location;
   readonly description?: StringValueNode;
   readonly name: NameNode;
+  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
 }
@@ -544,6 +545,7 @@ export interface InterfaceTypeExtensionNode {
   readonly kind: 'InterfaceTypeExtension';
   readonly loc?: Location;
   readonly name: NameNode;
+  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
 }

--- a/tstypes/language/visitor.d.ts
+++ b/tstypes/language/visitor.d.ts
@@ -122,7 +122,14 @@ export const QueryDocumentKeys: {
     'defaultValue',
     'directives'
   ];
-  InterfaceTypeDefinition: ['description', 'name', 'directives', 'fields'];
+  // prettier-ignore
+  InterfaceTypeDefinition: [
+    'description',
+    'name',
+    'interfaces',
+    'directives',
+    'fields'
+  ];
   UnionTypeDefinition: ['description', 'name', 'directives', 'types'];
   EnumTypeDefinition: ['description', 'name', 'directives', 'values'];
   EnumValueDefinition: ['description', 'name', 'directives'];
@@ -134,7 +141,7 @@ export const QueryDocumentKeys: {
 
   ScalarTypeExtension: ['name', 'directives'];
   ObjectTypeExtension: ['name', 'interfaces', 'directives', 'fields'];
-  InterfaceTypeExtension: ['name', 'directives', 'fields'];
+  InterfaceTypeExtension: ['name', 'interfaces', 'directives', 'fields'];
   UnionTypeExtension: ['name', 'directives', 'types'];
   EnumTypeExtension: ['name', 'directives', 'values'];
   InputObjectTypeExtension: ['name', 'directives', 'fields'];

--- a/tstypes/type/definition.d.ts
+++ b/tstypes/type/definition.d.ts
@@ -562,8 +562,10 @@ export class GraphQLInterfaceType {
 
   constructor(config: GraphQLInterfaceTypeConfig<any, any>);
   getFields(): GraphQLFieldMap<any, any>;
+  getInterfaces(): GraphQLInterfaceType[];
 
   toConfig(): GraphQLInterfaceTypeConfig<any, any> & {
+    interfaces: GraphQLInterfaceType[];
     fields: GraphQLFieldConfigMap<any, any>;
     extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode>;
@@ -582,6 +584,7 @@ export interface GraphQLInterfaceTypeConfig<
 > {
   name: string;
   description?: Maybe<string>;
+  interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
   /**
    * Optionally provide a custom type resolver function. If one is not provided,

--- a/tstypes/type/schema.d.ts
+++ b/tstypes/type/schema.d.ts
@@ -6,6 +6,7 @@ import {
   GraphQLNamedType,
   GraphQLAbstractType,
   GraphQLObjectType,
+  GraphQLInterfaceType,
 } from './definition';
 
 /**
@@ -55,9 +56,18 @@ export class GraphQLSchema {
     abstractType: GraphQLAbstractType,
   ): ReadonlyArray<GraphQLObjectType>;
 
+  getImplementations(
+    interfaceType: GraphQLInterfaceType,
+  ): ReadonlyArray<GraphQLObjectType | GraphQLInterfaceType>;
+
   isPossibleType(
     abstractType: GraphQLAbstractType,
     possibleType: GraphQLObjectType,
+  ): boolean;
+
+  isImplementation(
+    interfaceType: GraphQLInterfaceType,
+    possibleType: GraphQLObjectType | GraphQLInterfaceType,
   ): boolean;
 
   getDirectives(): ReadonlyArray<GraphQLDirective>;

--- a/tstypes/type/schema.d.ts
+++ b/tstypes/type/schema.d.ts
@@ -52,22 +52,24 @@ export class GraphQLSchema {
   getSubscriptionType(): Maybe<GraphQLObjectType>;
   getTypeMap(): TypeMap;
   getType(name: string): Maybe<GraphQLNamedType>;
+
   getPossibleTypes(
     abstractType: GraphQLAbstractType,
   ): ReadonlyArray<GraphQLObjectType>;
 
   getImplementations(
     interfaceType: GraphQLInterfaceType,
-  ): ReadonlyArray<GraphQLObjectType | GraphQLInterfaceType>;
+  ): InterfaceImplementations;
 
+  // @deprecated: use isSubType instead - will be removed in v16.
   isPossibleType(
     abstractType: GraphQLAbstractType,
     possibleType: GraphQLObjectType,
   ): boolean;
 
-  isImplementation(
-    interfaceType: GraphQLInterfaceType,
-    possibleType: GraphQLObjectType | GraphQLInterfaceType,
+  isSubType(
+    abstractType: GraphQLAbstractType,
+    maybeSubType: GraphQLNamedType,
   ): boolean;
 
   getDirectives(): ReadonlyArray<GraphQLDirective>;
@@ -83,6 +85,11 @@ export class GraphQLSchema {
 }
 
 type TypeMap = { [key: string]: GraphQLNamedType };
+
+type InterfaceImplementations = {
+  objects: ReadonlyArray<GraphQLObjectType>;
+  interfaces: ReadonlyArray<GraphQLInterfaceType>;
+};
 
 export interface GraphQLSchemaValidationOptions {
   /**

--- a/tstypes/utilities/getIntrospectionQuery.d.ts
+++ b/tstypes/utilities/getIntrospectionQuery.d.ts
@@ -66,6 +66,9 @@ export interface IntrospectionInterfaceType {
   readonly name: string;
   readonly description?: Maybe<string>;
   readonly fields: ReadonlyArray<IntrospectionField>;
+  readonly interfaces: ReadonlyArray<
+    IntrospectionNamedTypeRef<IntrospectionInterfaceType>
+  >;
   readonly possibleTypes: ReadonlyArray<
     IntrospectionNamedTypeRef<IntrospectionObjectType>
   >;


### PR DESCRIPTION
This is an implementation of the RFC described by spec PR https://github.com/graphql/graphql-spec/pull/373

This is a successor to PR #1218 which had accumulated too many merge conflicts to bother fixing.