### PR TITLE
Sync tstypes/errors with flow

### DIFF
--- a/src/error/formatError.js
+++ b/src/error/formatError.js
@@ -22,9 +22,31 @@ export function formatError(error: GraphQLError): GraphQLFormattedError {
     : { message, locations, path };
 }
 
+/**
+ * @see https://github.com/graphql/graphql-spec/blob/master/spec/Section%207%20--%20Response.md#errors
+ */
 export type GraphQLFormattedError = {|
+  /**
+   * A short, human-readable summary of the problem that **SHOULD NOT** change
+   * from occurrence to occurrence of the problem, except for purposes of
+   * localization.
+   */
   +message: string,
+  /**
+   * If an error can be associated to a particular point in the requested
+   * GraphQL document, it should contain a list of locations.
+   */
   +locations: $ReadOnlyArray<SourceLocation> | void,
+  /**
+   * If an error can be associated to a particular field in the GraphQL result,
+   * it _must_ contain an entry with the key `path` that details the path of
+   * the response field which experienced the error. This allows clients to
+   * identify whether a null result is intentional or caused by a runtime error.
+   */
   +path: $ReadOnlyArray<string | number> | void,
+  /**
+   * Reserved for implementors to extend the protocol however they see fit,
+   * and hence there are no additional restrictions on its contents.
+   */
   +extensions?: { [key: string]: mixed, ... },
 |};

--- a/tstypes/error/GraphQLError.d.ts
+++ b/tstypes/error/GraphQLError.d.ts
@@ -1,8 +1,8 @@
 import Maybe from '../tsutils/Maybe';
-import { getLocation } from '../language';
+
 import { ASTNode } from '../language/ast';
 import { Source } from '../language/source';
-import { SourceLocation } from '../language/location';
+import { SourceLocation, getLocation } from '../language/location';
 
 /**
  * A GraphQLError describes an Error found during the parse, validate, or
@@ -11,6 +11,16 @@ import { SourceLocation } from '../language/location';
  * GraphQL document and/or execution result that correspond to the Error.
  */
 export class GraphQLError extends Error {
+  constructor(
+    message: string,
+    nodes?: ReadonlyArray<ASTNode> | ASTNode | undefined,
+    source?: Maybe<Source>,
+    positions?: Maybe<ReadonlyArray<number>>,
+    path?: Maybe<ReadonlyArray<string | number>>,
+    originalError?: Maybe<Error>,
+    extensions?: Maybe<{ [key: string]: any }>,
+  );
+
   /**
    * A message describing the Error for debugging purposes.
    *
@@ -47,6 +57,9 @@ export class GraphQLError extends Error {
 
   /**
    * The source GraphQL document corresponding to this error.
+   *
+   * Note that if this Error represents more than one node, the source may not
+   * represent nodes after the first node.
    */
   readonly source: Source | undefined;
 
@@ -65,14 +78,10 @@ export class GraphQLError extends Error {
    * Extension fields to add to the formatted error.
    */
   readonly extensions: { [key: string]: any } | undefined;
-
-  constructor(
-    message: string,
-    nodes?: ReadonlyArray<ASTNode> | ASTNode | undefined,
-    source?: Maybe<Source>,
-    positions?: Maybe<ReadonlyArray<number>>,
-    path?: Maybe<ReadonlyArray<string | number>>,
-    originalError?: Maybe<Error>,
-    extensions?: Maybe<{ [key: string]: any }>,
-  );
 }
+
+/**
+ * Prints a GraphQLError to a string, representing useful location information
+ * about the error's position in the source.
+ */
+export function printError(error: GraphQLError): string;

--- a/tstypes/error/formatError.d.ts
+++ b/tstypes/error/formatError.d.ts
@@ -1,5 +1,5 @@
-import { GraphQLError } from './GraphQLError';
 import { SourceLocation } from '../language/location';
+import { GraphQLError } from './GraphQLError';
 
 /**
  * Given a GraphQLError, format it according to the rules described by the

--- a/tstypes/error/index.d.ts
+++ b/tstypes/error/index.d.ts
@@ -1,5 +1,4 @@
-export { GraphQLError } from './GraphQLError';
+export { GraphQLError, printError } from './GraphQLError';
 export { syntaxError } from './syntaxError';
 export { locatedError } from './locatedError';
-export { printError } from './printError';
 export { formatError, GraphQLFormattedError } from './formatError';

--- a/tstypes/error/locatedError.d.ts
+++ b/tstypes/error/locatedError.d.ts
@@ -1,5 +1,5 @@
-import { GraphQLError } from './GraphQLError';
 import { ASTNode } from '../language/ast';
+import { GraphQLError } from './GraphQLError';
 
 /**
  * Given an arbitrary Error, presumably thrown while attempting to execute a

--- a/tstypes/error/printError.d.ts
+++ b/tstypes/error/printError.d.ts
@@ -1,7 +1,0 @@
-import { GraphQLError } from './GraphQLError';
-
-/**
- * Prints a GraphQLError to a string, representing useful location information
- * about the error's position in the source.
- */
-export function printError(error: GraphQLError): string;


### PR DESCRIPTION
One remaining diff is that in TS, we define `formatError` as
```ts
export interface GraphQLFormattedError<
  TExtensions extends Record<string, any> = Record<string, any>
> {
  readonly message: string;
  readonly locations?: ReadonlyArray<SourceLocation>;
  readonly path?: ReadonlyArray<string | number>;
  readonly extensions?: TExtensions;
}
``` 

whereas in flow, we define it like
```
export type GraphQLFormattedError = {|
  +message: string,
  +locations: $ReadOnlyArray<SourceLocation> | void,
  +path: $ReadOnlyArray<string | number> | void,
  +extensions?: { [key: string]: mixed, ... },
|};
```

(comments stripped)

Don't have much flow expereince, but playing in the [playground](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBTAHgBzgJwBcxCBPHDMAcXwEMcALARQBkAxAgW1sMIwBMAovnwEAPABVBWPgDsAzgEs4CgFxgA3mADaAawyl18wvkWyA5gF11nRVgEAaMADpXYAL5gAvJp37DYMamFtZgtvb8Tq7OHmAAfGDemgA+qIkA1JwY8vK05hhGJmbmDmlg6fAAxjzKamAAJABKGLT8APKyMKQAgiK0pGLhAgnJYABucIqRZek4PAzqTS3tnT19A0HFYKOyAK6cAEYY+CPjk9MZ2HJKKvIA-OpSMhgKtfKlye4A3GWJf-8AwFA4EgxKoGAYYi0dQ0ejMdhcHh8IQiAjoCHEA4wuiMVgcfDcXgCYSifBiOKoIA), its saying that adding a type parameter is a breaking change (must use `GraphQLFormattedError<>`, even though the type has a defualt)