### PR TITLE
Sync type TS definitions with Flow

### DIFF
--- a/tstypes/index.d.ts
+++ b/tstypes/index.d.ts
@@ -128,7 +128,6 @@ export {
   GraphQLIsTypeOfFn,
   GraphQLObjectTypeConfig,
   GraphQLResolveInfo,
-  ResponsePath,
   GraphQLScalarTypeConfig,
   GraphQLTypeResolver,
   GraphQLUnionTypeConfig,

--- a/tstypes/jsutils/Path.d.ts
+++ b/tstypes/jsutils/Path.d.ts
@@ -1,0 +1,14 @@
+export type Path = {
+  prev: Path | void;
+  key: string | number;
+};
+
+/**
+ * Given a Path and a key, return a new Path containing the new key.
+ */
+export function addPath(prev: Path | undefined, key: string | number): Path;
+
+/**
+ * Given a Path, return an Array of the path keys.
+ */
+export function pathToArray(path: Path): Array<string | number>;

--- a/tstypes/type/definition.d.ts
+++ b/tstypes/type/definition.d.ts
@@ -288,7 +288,7 @@ export class GraphQLScalarType {
   serialize: GraphQLScalarSerializer<any>;
   parseValue: GraphQLScalarValueParser<any>;
   parseLiteral: GraphQLScalarLiteralParser<any>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
   constructor(config: GraphQLScalarTypeConfig<any, any>);
@@ -297,7 +297,7 @@ export class GraphQLScalarType {
     serialize: GraphQLScalarSerializer<any>;
     parseValue: GraphQLScalarValueParser<any>;
     parseLiteral: GraphQLScalarLiteralParser<any>;
-    extensions: Maybe<Record<string, any>>;
+    extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
   };
 
@@ -326,7 +326,7 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   parseValue?: GraphQLScalarValueParser<TInternal>;
   // Parses an externally provided literal value to use as an input.
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
 }
@@ -376,7 +376,7 @@ export class GraphQLObjectType<
   name: string;
   description: Maybe<string>;
   isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
-  extensions: Maybe<GraphQLIsTypeOfFn<any, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 
@@ -410,7 +410,7 @@ export interface GraphQLObjectTypeConfig<
   interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
   isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
@@ -469,7 +469,7 @@ export interface GraphQLFieldConfig<
   resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   deprecationReason?: Maybe<string>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<FieldDefinitionNode>;
 }
 
@@ -481,7 +481,7 @@ export interface GraphQLArgumentConfig {
   description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: any;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 
@@ -507,7 +507,7 @@ export interface GraphQLField<
   subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   isDeprecated?: boolean;
   deprecationReason?: Maybe<string>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<FieldDefinitionNode>;
 }
 
@@ -516,7 +516,7 @@ export interface GraphQLArgument {
   description: Maybe<string>;
   type: GraphQLInputType;
   defaultValue: any;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<InputValueDefinitionNode>;
 }
 
@@ -553,7 +553,7 @@ export class GraphQLInterfaceType {
   name: string;
   description: Maybe<string>;
   resolveType: Maybe<GraphQLTypeResolver<any, any>>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<InterfaceTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 
@@ -563,7 +563,7 @@ export class GraphQLInterfaceType {
 
   toConfig(): GraphQLInterfaceTypeConfig<any, any> & {
     fields: GraphQLFieldConfigMap<any, any>;
-    extensions: Maybe<Record<string, any>>;
+    extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode>;
   };
 
@@ -587,7 +587,7 @@ export interface GraphQLInterfaceTypeConfig<
    * Object type.
    */
   resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext, TArgs>>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<InterfaceTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 }
@@ -619,7 +619,7 @@ export class GraphQLUnionType {
   name: string;
   description: Maybe<string>;
   resolveType: Maybe<GraphQLTypeResolver<any, any>>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<UnionTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<UnionTypeExtensionNode>>;
 
@@ -647,7 +647,7 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
    * Object type.
    */
   resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext>>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<UnionTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<UnionTypeExtensionNode>>;
 }
@@ -676,7 +676,7 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
 export class GraphQLEnumType {
   name: string;
   description: Maybe<string>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 
@@ -703,7 +703,7 @@ export interface GraphQLEnumTypeConfig {
   name: string;
   description?: Maybe<string>;
   values: GraphQLEnumValueConfigMap;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 }
@@ -716,7 +716,7 @@ export interface GraphQLEnumValueConfig {
   description?: Maybe<string>;
   value?: any;
   deprecationReason?: Maybe<string>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
 }
 
@@ -726,7 +726,7 @@ export interface GraphQLEnumValue {
   value: any;
   isDeprecated?: boolean;
   deprecationReason: Maybe<string>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
 }
 
@@ -753,7 +753,7 @@ export interface GraphQLEnumValue {
 export class GraphQLInputObjectType {
   name: string;
   description: Maybe<string>;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
   constructor(config: GraphQLInputObjectTypeConfig);
@@ -761,7 +761,7 @@ export class GraphQLInputObjectType {
 
   toConfig(): GraphQLInputObjectTypeConfig & {
     fields: GraphQLInputFieldConfigMap;
-    extensions: Maybe<Record<string, any>>;
+    extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
   };
 
@@ -774,7 +774,7 @@ export interface GraphQLInputObjectTypeConfig {
   name: string;
   description?: Maybe<string>;
   fields: Thunk<GraphQLInputFieldConfigMap>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
 }
@@ -783,7 +783,7 @@ export interface GraphQLInputFieldConfig {
   description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: any;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 
@@ -796,7 +796,7 @@ export interface GraphQLInputField {
   description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: any;
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 

--- a/tstypes/type/definition.d.ts
+++ b/tstypes/type/definition.d.ts
@@ -1,5 +1,6 @@
 import Maybe from '../tsutils/Maybe';
 import { PromiseOrValue } from '../jsutils/PromiseOrValue';
+import { Path } from '../jsutils/Path';
 import {
   ScalarTypeDefinitionNode,
   ObjectTypeDefinitionNode,
@@ -75,6 +76,7 @@ export function assertNonNullType(type: any): GraphQLNonNull<any>;
 /**
  * These types may be used as input types for arguments and directives.
  */
+// TS_SPECIFIC: TS does not allow recursive type definitions, hence the `any`s
 export type GraphQLInputType =
   | GraphQLScalarType
   | GraphQLEnumType
@@ -94,6 +96,7 @@ export function assertInputType(type: any): GraphQLInputType;
 /**
  * These types may be used as output types as the result of fields.
  */
+// TS_SPECIFIC: TS does not allow recursive type definitions, hence the `any`s
 export type GraphQLOutputType =
   | GraphQLScalarType
   | GraphQLObjectType
@@ -285,13 +288,16 @@ export class GraphQLScalarType {
   serialize: GraphQLScalarSerializer<any>;
   parseValue: GraphQLScalarValueParser<any>;
   parseLiteral: GraphQLScalarLiteralParser<any>;
+  extensions: Maybe<Record<string, any>>;
   astNode: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
   constructor(config: GraphQLScalarTypeConfig<any, any>);
 
   toConfig(): GraphQLScalarTypeConfig<any, any> & {
+    serialize: GraphQLScalarSerializer<any>;
     parseValue: GraphQLScalarValueParser<any>;
     parseLiteral: GraphQLScalarLiteralParser<any>;
+    extensions: Maybe<Record<string, any>>;
     extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
   };
 
@@ -320,6 +326,7 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   parseValue?: GraphQLScalarValueParser<TInternal>;
   // Parses an externally provided literal value to use as an input.
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
 }
@@ -368,9 +375,10 @@ export class GraphQLObjectType<
 > {
   name: string;
   description: Maybe<string>;
+  isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
+  extensions: Maybe<GraphQLIsTypeOfFn<any, any>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
-  isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
 
   constructor(config: GraphQLObjectTypeConfig<TSource, TContext, TArgs>);
   getFields(): GraphQLFieldMap<any, TContext, TArgs>;
@@ -387,20 +395,27 @@ export class GraphQLObjectType<
   inspect(): string;
 }
 
+export function argsToArgsConfig(
+  args: ReadonlyArray<GraphQLArgument>,
+): GraphQLFieldConfigArgumentMap;
+
+// TS_SPECIFIC: TArgs
 export interface GraphQLObjectTypeConfig<
   TSource,
   TContext,
   TArgs = { [key: string]: any }
 > {
   name: string;
+  description?: Maybe<string>;
   interfaces?: Thunk<Maybe<GraphQLInterfaceType[]>>;
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
   isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
 
+// TS_SPECIFIC: TArgs
 export type GraphQLTypeResolver<
   TSource,
   TContext,
@@ -435,7 +450,7 @@ export interface GraphQLResolveInfo {
   readonly fieldNodes: ReadonlyArray<FieldNode>;
   readonly returnType: GraphQLOutputType;
   readonly parentType: GraphQLObjectType;
-  readonly path: ResponsePath;
+  readonly path: Path;
   readonly schema: GraphQLSchema;
   readonly fragments: { [key: string]: FragmentDefinitionNode };
   readonly rootValue: any;
@@ -443,22 +458,18 @@ export interface GraphQLResolveInfo {
   readonly variableValues: { [variableName: string]: any };
 }
 
-export type ResponsePath = {
-  readonly prev: ResponsePath | undefined;
-  readonly key: string | number;
-};
-
 export interface GraphQLFieldConfig<
   TSource,
   TContext,
   TArgs = { [argName: string]: any }
 > {
+  description?: Maybe<string>;
   type: GraphQLOutputType;
   args?: GraphQLFieldConfigArgumentMap;
   resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   deprecationReason?: Maybe<string>;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<FieldDefinitionNode>;
 }
 
@@ -467,12 +478,14 @@ export type GraphQLFieldConfigArgumentMap = {
 };
 
 export interface GraphQLArgumentConfig {
+  description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: any;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 
+// TS_SPECIFIC: TArgs
 export type GraphQLFieldConfigMap<
   TSource,
   TContext,
@@ -494,19 +507,22 @@ export interface GraphQLField<
   subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   isDeprecated?: boolean;
   deprecationReason?: Maybe<string>;
+  extensions: Maybe<Record<string, any>>;
   astNode?: Maybe<FieldDefinitionNode>;
 }
 
 export interface GraphQLArgument {
   name: string;
+  description: Maybe<string>;
   type: GraphQLInputType;
-  defaultValue?: any;
-  description?: Maybe<string>;
-  astNode?: Maybe<InputValueDefinitionNode>;
+  defaultValue: any;
+  extensions: Maybe<Record<string, any>>;
+  astNode: Maybe<InputValueDefinitionNode>;
 }
 
 export function isRequiredArgument(arg: GraphQLArgument): boolean;
 
+// TS_SPECIFIC: TArgs
 export type GraphQLFieldMap<
   TSource,
   TContext,
@@ -536,9 +552,10 @@ export type GraphQLFieldMap<
 export class GraphQLInterfaceType {
   name: string;
   description: Maybe<string>;
+  resolveType: Maybe<GraphQLTypeResolver<any, any>>;
+  extensions: Maybe<Record<string, any>>;
   astNode?: Maybe<InterfaceTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
-  resolveType: Maybe<GraphQLTypeResolver<any, any>>;
 
   constructor(config: GraphQLInterfaceTypeConfig<any, any>);
 
@@ -546,6 +563,7 @@ export class GraphQLInterfaceType {
 
   toConfig(): GraphQLInterfaceTypeConfig<any, any> & {
     fields: GraphQLFieldConfigMap<any, any>;
+    extensions: Maybe<Record<string, any>>;
     extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode>;
   };
 
@@ -554,12 +572,14 @@ export class GraphQLInterfaceType {
   inspect(): string;
 }
 
+// TS_SPECIFIC: TArgs
 export interface GraphQLInterfaceTypeConfig<
   TSource,
   TContext,
   TArgs = { [key: string]: any }
 > {
   name: string;
+  description?: Maybe<string>;
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext, TArgs>>;
   /**
    * Optionally provide a custom type resolver function. If one is not provided,
@@ -567,7 +587,7 @@ export interface GraphQLInterfaceTypeConfig<
    * Object type.
    */
   resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext, TArgs>>;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<InterfaceTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 }
@@ -598,9 +618,10 @@ export interface GraphQLInterfaceTypeConfig<
 export class GraphQLUnionType {
   name: string;
   description: Maybe<string>;
+  resolveType: Maybe<GraphQLTypeResolver<any, any>>;
+  extensions: Maybe<Record<string, any>>;
   astNode: Maybe<UnionTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<UnionTypeExtensionNode>>;
-  resolveType: Maybe<GraphQLTypeResolver<any, any>>;
 
   constructor(config: GraphQLUnionTypeConfig<any, any>);
 
@@ -618,6 +639,7 @@ export class GraphQLUnionType {
 
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
   name: string;
+  description?: Maybe<string>;
   types: Thunk<GraphQLObjectType[]>;
   /**
    * Optionally provide a custom type resolver function. If one is not provided,
@@ -625,7 +647,7 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
    * Object type.
    */
   resolveType?: Maybe<GraphQLTypeResolver<TSource, TContext>>;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<UnionTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<UnionTypeExtensionNode>>;
 }
@@ -654,6 +676,7 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
 export class GraphQLEnumType {
   name: string;
   description: Maybe<string>;
+  extensions: Maybe<Record<string, any>>;
   astNode: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 
@@ -678,8 +701,9 @@ export class GraphQLEnumType {
 
 export interface GraphQLEnumTypeConfig {
   name: string;
-  values: GraphQLEnumValueConfigMap;
   description?: Maybe<string>;
+  values: GraphQLEnumValueConfigMap;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 }
@@ -689,19 +713,21 @@ export type GraphQLEnumValueConfigMap = {
 };
 
 export interface GraphQLEnumValueConfig {
+  description?: Maybe<string>;
   value?: any;
   deprecationReason?: Maybe<string>;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
 }
 
 export interface GraphQLEnumValue {
   name: string;
   description: Maybe<string>;
+  value: any;
   isDeprecated?: boolean;
   deprecationReason: Maybe<string>;
+  extensions: Maybe<Record<string, any>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
-  value: any;
 }
 
 /**
@@ -727,6 +753,7 @@ export interface GraphQLEnumValue {
 export class GraphQLInputObjectType {
   name: string;
   description: Maybe<string>;
+  extensions: Maybe<Record<string, any>>;
   astNode: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
   constructor(config: GraphQLInputObjectTypeConfig);
@@ -734,6 +761,7 @@ export class GraphQLInputObjectType {
 
   toConfig(): GraphQLInputObjectTypeConfig & {
     fields: GraphQLInputFieldConfigMap;
+    extensions: Maybe<Record<string, any>>;
     extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
   };
 
@@ -744,16 +772,18 @@ export class GraphQLInputObjectType {
 
 export interface GraphQLInputObjectTypeConfig {
   name: string;
-  fields: Thunk<GraphQLInputFieldConfigMap>;
   description?: Maybe<string>;
+  fields: Thunk<GraphQLInputFieldConfigMap>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
 }
 
 export interface GraphQLInputFieldConfig {
+  description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: any;
-  description?: Maybe<string>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 
@@ -763,9 +793,10 @@ export type GraphQLInputFieldConfigMap = {
 
 export interface GraphQLInputField {
   name: string;
+  description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: any;
-  description?: Maybe<string>;
+  extensions: Maybe<Record<string, any>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 

--- a/tstypes/type/directives.d.ts
+++ b/tstypes/type/directives.d.ts
@@ -7,7 +7,7 @@ import { DirectiveLocationEnum } from '../language/directiveLocation';
  * Test if the given value is a GraphQL directive.
  */
 export function isDirective(directive: any): directive is GraphQLDirective;
-
+export function assertDirective(directive: any): GraphQLDirective;
 /**
  * Directives are used by the GraphQL runtime as a way of modifying execution
  * behavior. Type system creators will usually not create these directly.
@@ -18,12 +18,17 @@ export class GraphQLDirective {
   locations: DirectiveLocationEnum[];
   isRepeatable: boolean;
   args: GraphQLArgument[];
+  extensions?: Maybe<Record<string, any>>;
   astNode: Maybe<DirectiveDefinitionNode>;
 
   constructor(config: GraphQLDirectiveConfig);
 
+  toString(): string;
+
   toConfig(): GraphQLDirectiveConfig & {
     args: GraphQLFieldConfigArgumentMap;
+    extensions?: Maybe<Record<string, any>>;
+    isRepeatable: boolean;
   };
 }
 
@@ -33,6 +38,7 @@ export interface GraphQLDirectiveConfig {
   locations: DirectiveLocationEnum[];
   args?: Maybe<GraphQLFieldConfigArgumentMap>;
   isRepeatable?: Maybe<boolean>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<DirectiveDefinitionNode>;
 }
 
@@ -61,4 +67,6 @@ export const GraphQLDeprecatedDirective: GraphQLDirective;
  */
 export const specifiedDirectives: ReadonlyArray<GraphQLDirective>;
 
-export function isSpecifiedDirective(directive: GraphQLDirective): boolean;
+export function isSpecifiedDirective(
+  directive: any,
+): directive is GraphQLDirective;

--- a/tstypes/type/directives.d.ts
+++ b/tstypes/type/directives.d.ts
@@ -18,7 +18,7 @@ export class GraphQLDirective {
   locations: DirectiveLocationEnum[];
   isRepeatable: boolean;
   args: GraphQLArgument[];
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<DirectiveDefinitionNode>;
 
   constructor(config: GraphQLDirectiveConfig);
@@ -27,7 +27,7 @@ export class GraphQLDirective {
 
   toConfig(): GraphQLDirectiveConfig & {
     args: GraphQLFieldConfigArgumentMap;
-    extensions?: Maybe<Record<string, any>>;
+    extensions?: Maybe<Readonly<Record<string, any>>>;
     isRepeatable: boolean;
   };
 }
@@ -38,7 +38,7 @@ export interface GraphQLDirectiveConfig {
   locations: DirectiveLocationEnum[];
   args?: Maybe<GraphQLFieldConfigArgumentMap>;
   isRepeatable?: Maybe<boolean>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<DirectiveDefinitionNode>;
 }
 

--- a/tstypes/type/index.d.ts
+++ b/tstypes/type/index.d.ts
@@ -92,7 +92,6 @@ export {
   GraphQLIsTypeOfFn,
   GraphQLObjectTypeConfig,
   GraphQLResolveInfo,
-  ResponsePath,
   GraphQLScalarTypeConfig,
   GraphQLTypeResolver,
   GraphQLUnionTypeConfig,

--- a/tstypes/type/index.d.ts
+++ b/tstypes/type/index.d.ts
@@ -1,6 +1,8 @@
 export {
   // Predicate
   isSchema,
+  // Assertion
+  assertSchema,
   // GraphQL Schema definition
   GraphQLSchema,
   GraphQLSchemaConfig,
@@ -102,6 +104,8 @@ export {
 export {
   // Predicate
   isDirective,
+  // Assertion
+  assertDirective,
   // Directives Definition
   GraphQLDirective,
   // Built-in Directives defined by the Spec

--- a/tstypes/type/introspection.d.ts
+++ b/tstypes/type/introspection.d.ts
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLField, GraphQLEnumType } from './definition';
+import {
+  GraphQLObjectType,
+  GraphQLField,
+  GraphQLEnumType,
+  GraphQLType,
+} from './definition';
 
 export const __Schema: GraphQLObjectType;
 export const __Directive: GraphQLObjectType;
@@ -30,8 +35,6 @@ export const SchemaMetaFieldDef: GraphQLField<any, any>;
 export const TypeMetaFieldDef: GraphQLField<any, any>;
 export const TypeNameMetaFieldDef: GraphQLField<any, any>;
 
-export const introspectionTypes: ReadonlyArray<
-  GraphQLObjectType | GraphQLEnumType
->;
+export const introspectionTypes: ReadonlyArray<GraphQLType>;
 
 export function isIntrospectionType(type: any): boolean;

--- a/tstypes/type/introspection.d.ts
+++ b/tstypes/type/introspection.d.ts
@@ -1,14 +1,4 @@
-import {
-  GraphQLScalarType,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-} from './definition';
-import { GraphQLField } from './definition';
+import { GraphQLObjectType, GraphQLField, GraphQLEnumType } from './definition';
 
 export const __Schema: GraphQLObjectType;
 export const __Directive: GraphQLObjectType;
@@ -40,6 +30,8 @@ export const SchemaMetaFieldDef: GraphQLField<any, any>;
 export const TypeMetaFieldDef: GraphQLField<any, any>;
 export const TypeNameMetaFieldDef: GraphQLField<any, any>;
 
-export const introspectionTypes: ReadonlyArray<any>;
+export const introspectionTypes: ReadonlyArray<
+  GraphQLObjectType | GraphQLEnumType
+>;
 
 export function isIntrospectionType(type: any): boolean;

--- a/tstypes/type/scalars.d.ts
+++ b/tstypes/type/scalars.d.ts
@@ -8,4 +8,4 @@ export const GraphQLID: GraphQLScalarType;
 
 export const specifiedScalarTypes: ReadonlyArray<GraphQLScalarType>;
 
-export function isSpecifiedScalarType(type: unknown): type is GraphQLScalarType;
+export function isSpecifiedScalarType(type: any): type is GraphQLScalarType;

--- a/tstypes/type/scalars.d.ts
+++ b/tstypes/type/scalars.d.ts
@@ -8,4 +8,4 @@ export const GraphQLID: GraphQLScalarType;
 
 export const specifiedScalarTypes: ReadonlyArray<GraphQLScalarType>;
 
-export function isSpecifiedScalarType(type: GraphQLScalarType): boolean;
+export function isSpecifiedScalarType(type: unknown): type is GraphQLScalarType;

--- a/tstypes/type/schema.d.ts
+++ b/tstypes/type/schema.d.ts
@@ -41,7 +41,7 @@ export function assertSchema(schema: any): GraphQLSchema;
  *
  */
 export class GraphQLSchema {
-  extensions: Maybe<Record<string, any>>;
+  extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<SchemaDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<SchemaExtensionNode>>;
 
@@ -67,7 +67,7 @@ export class GraphQLSchema {
   toConfig(): GraphQLSchemaConfig & {
     types: GraphQLNamedType[];
     directives: GraphQLDirective[];
-    extensions: Maybe<Record<string, any>>;
+    extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<SchemaExtensionNode>;
     assumeValid: boolean;
     allowedLegacyNames: ReadonlyArray<string>;
@@ -102,7 +102,7 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
   subscription?: Maybe<GraphQLObjectType>;
   types?: Maybe<GraphQLNamedType[]>;
   directives?: Maybe<GraphQLDirective[]>;
-  extensions?: Maybe<Record<string, any>>;
+  extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;
 }

--- a/tstypes/type/schema.d.ts
+++ b/tstypes/type/schema.d.ts
@@ -1,17 +1,18 @@
 import Maybe from '../tsutils/Maybe';
-import { GraphQLObjectType } from './definition';
+import { SchemaDefinitionNode, SchemaExtensionNode } from '../language/ast';
+import { GraphQLDirective } from './directives';
 import {
   GraphQLType,
   GraphQLNamedType,
   GraphQLAbstractType,
+  GraphQLObjectType,
 } from './definition';
-import { SchemaDefinitionNode, SchemaExtensionNode } from '../language/ast';
-import { GraphQLDirective } from './directives';
 
 /**
  * Test if the given value is a GraphQL schema.
  */
 export function isSchema(schema: any): schema is GraphQLSchema;
+export function assertSchema(schema: any): GraphQLSchema;
 
 /**
  * Schema Definition
@@ -40,6 +41,7 @@ export function isSchema(schema: any): schema is GraphQLSchema;
  *
  */
 export class GraphQLSchema {
+  extensions: Maybe<Record<string, any>>;
   astNode: Maybe<SchemaDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<SchemaExtensionNode>>;
 
@@ -65,7 +67,10 @@ export class GraphQLSchema {
   toConfig(): GraphQLSchemaConfig & {
     types: GraphQLNamedType[];
     directives: GraphQLDirective[];
+    extensions: Maybe<Record<string, any>>;
     extensionASTNodes: ReadonlyArray<SchemaExtensionNode>;
+    assumeValid: boolean;
+    allowedLegacyNames: ReadonlyArray<string>;
   };
 }
 
@@ -97,6 +102,7 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
   subscription?: Maybe<GraphQLObjectType>;
   types?: Maybe<GraphQLNamedType[]>;
   directives?: Maybe<GraphQLDirective[]>;
+  extensions?: Maybe<Record<string, any>>;
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;
 }

--- a/tstypes/type/validate.d.ts
+++ b/tstypes/type/validate.d.ts
@@ -1,5 +1,5 @@
-import { GraphQLSchema } from './schema';
 import { GraphQLError } from '../error/GraphQLError';
+import { GraphQLSchema } from './schema';
 
 /**
  * Implements the "Type Validation" sub-sections of the specification's


### PR DESCRIPTION
Specifically:
Add `extensions` field in lots of places
Reorder fields

Both this and #2106 add Path.d.ts, but they're the same. If theres a merge conflict, just pick one.