### PR TITLE
Fix relative imports

### DIFF
--- a/tstypes/utilities/coerceInputValue.d.ts
+++ b/tstypes/utilities/coerceInputValue.d.ts
@@ -1,5 +1,5 @@
 import { GraphQLInputType } from '../type/definition';
-import { GraphQLError } from 'tstypes/error';
+import { GraphQLError } from '../error';
 
 type OnErrorCB = (
   path: ReadonlyArray<string | number>,

--- a/tstypes/validation/validate.d.ts
+++ b/tstypes/validation/validate.d.ts
@@ -3,7 +3,7 @@ import { DocumentNode } from '../language/ast';
 import { GraphQLSchema } from '../type/schema';
 import { TypeInfo } from '../utilities/TypeInfo';
 import { ValidationRule, SDLValidationRule } from './ValidationContext';
-import Maybe from 'tstypes/tsutils/Maybe';
+import Maybe from '../tsutils/Maybe';
 
 /**
  * Implements the "Validation" section of the spec.


### PR DESCRIPTION
Mistakenly imported some items using incorrect relative imports in the pervious TS merger. This fixes that.