### PR TITLE
fix: added FlowFixMe on Array.prototype.flatMap

### DIFF
--- a/src/polyfills/flatMap.js
+++ b/src/polyfills/flatMap.js
@@ -9,6 +9,7 @@ declare function flatMap<T, U>(
 // $FlowFixMe
 const flatMap = Array.prototype.flatMap
   ? function(list, fn) {
+      // $FlowFixMe
       return Array.prototype.flatMap.call(list, fn);
     }
   : function(list, fn) {


### PR DESCRIPTION
- Fix for flow-bin 0.96, which complains about flatMap not existing.


When on flow-bin 0.96, we get flow complaints with the flatMap polyfill:
```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/graphql/polyfills/flatMap.js.flow:12:30

Cannot get Array.prototype.flatMap because property flatMap is missing in Array [1].

     node_modules/graphql/polyfills/flatMap.js.flow
       9│ // $FlowFixMe
      10│ const flatMap = Array.prototype.flatMap
      11│   ? function(list, fn) {
      12│       return Array.prototype.flatMap.call(list, fn);
      13│     }
      14│   : function(list, fn) {
      15│       let result = [];

     /private/tmp/flow/flowlib_3d33be40/core.js
 [1] 242│ declare class Array<T> extends $ReadOnlyArray<T> {
```

I believe line 10, the first $FlowFixMe there does the exact same thing as well. It's worth noting that the latest version of flow-bin does not have this problem. 