### PR TITLE
tstypes: Use `any` as BREAK type.

### DIFF
--- a/tstypes/language/visitor.d.ts
+++ b/tstypes/language/visitor.d.ts
@@ -140,7 +140,7 @@ export const QueryDocumentKeys: {
   InputObjectTypeExtension: ['name', 'directives', 'fields'];
 };
 
-export const BREAK: {};
+export const BREAK: any;
 
 /**
  * visit() will walk through an AST using a depth first traversal, calling


### PR DESCRIPTION
Otherwise, TS will reposrt errors when a visit function only conditionally returns BREAK (not all paths return a value error)