### PR TITLE
fix(flatMap): suppress flow error from second reference to flatMap

### DIFF
--- a/src/polyfills/flatMap.js
+++ b/src/polyfills/flatMap.js
@@ -9,6 +9,7 @@ declare function flatMap<T, U>(
 // $FlowFixMe
 const flatMap = Array.prototype.flatMap
   ? function(list, fn) {
+      // $FlowFixMe
       return Array.prototype.flatMap.call(list, fn);
     }
   : function(list, fn) {


### PR DESCRIPTION
Gives me an error on Flow 0.84.0 at least