### PR TITLE
export function printFilteredSchema

### DIFF
--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -79,7 +79,7 @@ function isDefinedType(type: GraphQLNamedType): boolean {
   return !isSpecifiedScalarType(type) && !isIntrospectionType(type);
 }
 
-function printFilteredSchema(
+export function printFilteredSchema(
   schema: GraphQLSchema,
   directiveFilter: (type: GraphQLDirective) => boolean,
   typeFilter: (type: GraphQLNamedType) => boolean,

--- a/src/utilities/schemaPrinter.js
+++ b/src/utilities/schemaPrinter.js
@@ -83,7 +83,7 @@ export function printFilteredSchema(
   schema: GraphQLSchema,
   directiveFilter: (type: GraphQLDirective) => boolean,
   typeFilter: (type: GraphQLNamedType) => boolean,
-  options,
+  options?: Options,
 ): string {
   const directives = schema.getDirectives().filter(directiveFilter);
   const typeMap = schema.getTypeMap();


### PR DESCRIPTION
It is useful to be able to print directives that are part of graphql's representation of the schema. Previous discussions on this have [noted](https://github.com/graphql/graphql-js/issues/869#issuecomment-309899380) that printing directives as part of a schema doesn't make sense for a publicly accessible schema as they're not true parts of the 'graph' graphql represents.

However, I'm currently working with code generation tools, and not being able to print the full in-memory schema into canonical form is a deal breaker. `printFilteredSchema` already exposes the ability to adjust the way the schema is printed so this PR simply exposes it.