### PR TITLE
printLocation: Remove trailing whitespace from empty lines

### DIFF
--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -111,13 +111,7 @@ describe('Lexer', () => {
   it('errors respect whitespace', () => {
     let caughtError;
     try {
-      lexOne(dedent`
-      
-      
-          ?
-      
-      
-      `);
+      lexOne(['', '', '    ?', ''].join('\n'));
     } catch (error) {
       caughtError = error;
     }
@@ -125,10 +119,10 @@ describe('Lexer', () => {
       Syntax Error: Cannot parse the unexpected character "?".
 
       GraphQL request:3:5
-      2 | 
+      2 |
       3 |     ?
         |     ^
-      4 | 
+      4 |
     `);
   });
 
@@ -145,10 +139,10 @@ describe('Lexer', () => {
       Syntax Error: Cannot parse the unexpected character "?".
 
       foo.js:13:6
-      12 | 
+      12 |
       13 |      ?
          |      ^
-      14 | 
+      14 |
     `);
   });
 

--- a/src/language/__tests__/printLocation-test.js
+++ b/src/language/__tests__/printLocation-test.js
@@ -73,7 +73,7 @@ describe('printSourceLocation', () => {
       Test:9:1
        9 | *
          | ^
-      10 | 
+      10 |
     `);
   });
 });

--- a/src/language/printLocation.js
+++ b/src/language/printLocation.js
@@ -72,7 +72,9 @@ function printPrefixedLines(lines: $ReadOnlyArray<[string, string]>): string {
 
   const padLen = Math.max(...existingLines.map(([prefix]) => prefix.length));
   return existingLines
-    .map(([prefix, line]) => lpad(padLen, prefix) + ' | ' + line)
+    .map(
+      ([prefix, line]) => lpad(padLen, prefix) + (line ? ' | ' + line : ' |'),
+    )
     .join('\n');
 }
 


### PR DESCRIPTION
Simplifies tests and terminal output