### PR TITLE
RFC: Lexing is Greedy

### DIFF
--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -444,6 +444,16 @@ function readNumber(source, start, firstCode, line, col, prev): Token {
       code = body.charCodeAt(++position);
     }
     position = readDigits(source, position, code);
+    code = body.charCodeAt(position);
+  }
+
+  // Numbers cannot be followed by . or e
+  if (code === 46 || code === 69 || code === 101) {
+    throw syntaxError(
+      source,
+      position,
+      `Invalid number, expected digit but got: ${printCharCode(code)}.`,
+    );
   }
 
   return new Tok(


### PR DESCRIPTION
Adds the test cases described in https://github.com/graphql/graphql-spec/pull/599

Makes the lookahead restriction change necessary for the new tests to pass for numbers, all other tests are already passing.