### PR TITLE
Make onError optional in SDLValidationContext

### DIFF
--- a/src/validation/ValidationContext.js
+++ b/src/validation/ValidationContext.js
@@ -149,7 +149,7 @@ export class SDLValidationContext extends ASTValidationContext {
   constructor(
     ast: DocumentNode,
     schema: ?GraphQLSchema,
-    onError: (err: GraphQLError) => void,
+    onError?: (err: GraphQLError) => void,
   ): void {
     super(ast, onError);
     this._schema = schema;


### PR DESCRIPTION
The onError argument was probably meant to be optional,
just like in ASTValidationContext and ValidationContext.