### PR TITLE
Replace 'find{Breaking,Dangerous}Changes' with generic 'findSchemaChanges'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -403,8 +403,7 @@ export {
   // Compares two GraphQLSchemas and detects breaking changes.
   BreakingChangeType,
   DangerousChangeType,
-  findBreakingChanges,
-  findDangerousChanges,
+  findSchemaChanges,
   // Report all deprecated usage within a GraphQL document.
   findDeprecatedUsages,
 } from './utilities';
@@ -433,6 +432,5 @@ export type {
   IntrospectionEnumValue,
   IntrospectionDirective,
   BuildSchemaOptions,
-  BreakingChange,
-  DangerousChange,
+  SchemaChange,
 } from './utilities';

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -62,54 +62,20 @@ export const DangerousChangeType = Object.freeze({
   ARG_DEFAULT_VALUE_CHANGE: 'ARG_DEFAULT_VALUE_CHANGE',
 });
 
-export type BreakingChange = {
-  type: $Keys<typeof BreakingChangeType>,
-  description: string,
-  ...
-};
-
-export type DangerousChange = {
-  type: $Keys<typeof DangerousChangeType>,
+export type SchemaChange = {
+  type: $Keys<typeof BreakingChangeType> | $Keys<typeof DangerousChangeType>,
   description: string,
   ...
 };
 
 /**
  * Given two schemas, returns an Array containing descriptions of all the types
- * of breaking changes covered by the other functions down below.
- */
-export function findBreakingChanges(
-  oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema,
-): Array<BreakingChange> {
-  const breakingChanges = findSchemaChanges(oldSchema, newSchema).filter(
-    change => change.type in BreakingChangeType,
-  );
-  return ((breakingChanges: any): Array<BreakingChange>);
-}
-
-/**
- * Given two schemas, returns an Array containing descriptions of all the types
- * of potentially dangerous changes covered by the other functions down below.
- */
-export function findDangerousChanges(
-  oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema,
-): Array<DangerousChange> {
-  const dangerousChanges = findSchemaChanges(oldSchema, newSchema).filter(
-    change => change.type in DangerousChangeType,
-  );
-  return ((dangerousChanges: any): Array<DangerousChange>);
-}
-
-/**
- * Given two schemas, returns an Array containing descriptions of all the types
- * of potentially breaking change and dangerous change
+ * of potentially breaking and dangerous changes.
  */
 export function findSchemaChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   return [
     ...findTypeChanges(oldSchema, newSchema),
     ...findDirectiveChanges(oldSchema, newSchema),
@@ -119,7 +85,7 @@ export function findSchemaChanges(
 function findDirectiveChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
 
   const directivesDiff = diff(
@@ -169,7 +135,7 @@ function findDirectiveChanges(
 function findTypeChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
 
   const typesDiff = diff(
@@ -211,7 +177,7 @@ function findTypeChanges(
 function findInputObjectTypeChanges(
   oldType: GraphQLInputObjectType,
   newType: GraphQLInputObjectType,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
   const fieldsDiff = diff(
     objectValues(oldType.getFields()),
@@ -260,7 +226,7 @@ function findInputObjectTypeChanges(
 function findUnionTypeChanges(
   oldType: GraphQLUnionType,
   newType: GraphQLUnionType,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
   const possibleTypesDiff = diff(oldType.getTypes(), newType.getTypes());
 
@@ -284,7 +250,7 @@ function findUnionTypeChanges(
 function findEnumTypeChanges(
   oldType: GraphQLEnumType,
   newType: GraphQLEnumType,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
   const valuesDiff = diff(oldType.getValues(), newType.getValues());
 
@@ -308,7 +274,7 @@ function findEnumTypeChanges(
 function findObjectTypeChanges(
   oldType: GraphQLObjectType,
   newType: GraphQLObjectType,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = findFieldChanges(oldType, newType);
   const interfacesDiff = diff(oldType.getInterfaces(), newType.getInterfaces());
 
@@ -332,7 +298,7 @@ function findObjectTypeChanges(
 function findFieldChanges(
   oldType: GraphQLObjectType | GraphQLInterfaceType,
   newType: GraphQLObjectType | GraphQLInterfaceType,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
   const fieldsDiff = diff(
     objectValues(oldType.getFields()),
@@ -370,7 +336,7 @@ function findArgChanges(
   oldType: GraphQLObjectType | GraphQLInterfaceType,
   oldField: GraphQLField<mixed, mixed>,
   newField: GraphQLField<mixed, mixed>,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
   const argsDiff = diff(oldField.args, newField.args);
 

--- a/src/utilities/findBreakingChanges.js
+++ b/src/utilities/findBreakingChanges.js
@@ -102,7 +102,11 @@ export function findDangerousChanges(
   return ((dangerousChanges: any): Array<DangerousChange>);
 }
 
-function findSchemaChanges(
+/**
+ * Given two schemas, returns an Array containing descriptions of all the types
+ * of potentially breaking change and dangerous change
+ */
+export function findSchemaChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
 ): Array<BreakingChange | DangerousChange> {

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -107,10 +107,9 @@ export { assertValidName, isValidNameError } from './assertValidName';
 export {
   BreakingChangeType,
   DangerousChangeType,
-  findBreakingChanges,
-  findDangerousChanges,
+  findSchemaChanges,
 } from './findBreakingChanges';
-export type { BreakingChange, DangerousChange } from './findBreakingChanges';
+export type { SchemaChange } from './findBreakingChanges';
 
 // Report all deprecated usage within a GraphQL document.
 export { findDeprecatedUsages } from './findDeprecatedUsages';

--- a/tstypes/index.d.ts
+++ b/tstypes/index.d.ts
@@ -403,8 +403,7 @@ export {
   // Compares two GraphQLSchemas and detects breaking changes.
   BreakingChangeType,
   DangerousChangeType,
-  findBreakingChanges,
-  findDangerousChanges,
+  findSchemaChanges,
   // Report all deprecated usage within a GraphQL document.
   findDeprecatedUsages,
 } from './utilities';
@@ -433,6 +432,5 @@ export {
   IntrospectionEnumValue,
   IntrospectionDirective,
   BuildSchemaOptions,
-  BreakingChange,
-  DangerousChange,
+  SchemaChange,
 } from './utilities';

--- a/tstypes/utilities/findBreakingChanges.d.ts
+++ b/tstypes/utilities/findBreakingChanges.d.ts
@@ -35,30 +35,16 @@ type _DangerousChangeType = {
   ARG_DEFAULT_VALUE_CHANGE: 'ARG_DEFAULT_VALUE_CHANGE';
 };
 
-export interface BreakingChange {
-  type: keyof _BreakingChangeType;
-  description: string;
-}
-
-export interface DangerousChange {
-  type: keyof _DangerousChangeType;
+export interface SchemaChange {
+  type: keyof _BreakingChangeType | keyof _DangerousChangeType;
   description: string;
 }
 
 /**
  * Given two schemas, returns an Array containing descriptions of all the types
- * of breaking changes covered by the other functions down below.
+ * of breaking and dangerous changes covered by the other functions down below.
  */
-export function findBreakingChanges(
+export function findSchemaChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
-): Array<BreakingChange>;
-
-/**
- * Given two schemas, returns an Array containing descriptions of all the types
- * of potentially dangerous changes covered by the other functions down below.
- */
-export function findDangerousChanges(
-  oldSchema: GraphQLSchema,
-  newSchema: GraphQLSchema,
-): Array<DangerousChange>;
+): Array<SchemaChange>;

--- a/tstypes/utilities/index.d.ts
+++ b/tstypes/utilities/index.d.ts
@@ -104,10 +104,8 @@ export { assertValidName, isValidNameError } from './assertValidName';
 export {
   BreakingChangeType,
   DangerousChangeType,
-  findBreakingChanges,
-  findDangerousChanges,
-  BreakingChange,
-  DangerousChange,
+  SchemaChange,
+  findSchemaChanges,
 } from './findBreakingChanges';
 
 // Report all deprecated usage within a GraphQL document.


### PR DESCRIPTION
# Motivation

Currently to find potentially Breaking and Dangerous changes developers need to call 2 separate methods and execute logic twice. This change simply exposes the underlying method that will give access to both with single execution logic. 