### PR TITLE
toConfig: allows 'extensionASTNodes' to be undefined

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -586,7 +586,7 @@ export class GraphQLScalarType {
     parseValue: GraphQLScalarValueParser<*>,
     parseLiteral: GraphQLScalarLiteralParser<*>,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<ScalarTypeExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<ScalarTypeExtensionNode>,
   |} {
     return {
       name: this.name,
@@ -596,7 +596,7 @@ export class GraphQLScalarType {
       parseLiteral: this.parseLiteral,
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
     };
   }
 
@@ -715,7 +715,7 @@ export class GraphQLObjectType {
     interfaces: Array<GraphQLInterfaceType>,
     fields: GraphQLFieldConfigMap<*, *>,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<ObjectTypeExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<ObjectTypeExtensionNode>,
   |} {
     return {
       name: this.name,
@@ -725,7 +725,7 @@ export class GraphQLObjectType {
       isTypeOf: this.isTypeOf,
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
     };
   }
 
@@ -1005,7 +1005,7 @@ export class GraphQLInterfaceType {
     ...GraphQLInterfaceTypeConfig<*, *>,
     fields: GraphQLFieldConfigMap<*, *>,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<InterfaceTypeExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<InterfaceTypeExtensionNode>,
   |} {
     return {
       name: this.name,
@@ -1014,7 +1014,7 @@ export class GraphQLInterfaceType {
       resolveType: this.resolveType,
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
     };
   }
 
@@ -1103,7 +1103,7 @@ export class GraphQLUnionType {
     ...GraphQLUnionTypeConfig<*, *>,
     types: Array<GraphQLObjectType>,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<UnionTypeExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<UnionTypeExtensionNode>,
   |} {
     return {
       name: this.name,
@@ -1112,7 +1112,7 @@ export class GraphQLUnionType {
       resolveType: this.resolveType,
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
     };
   }
 
@@ -1236,7 +1236,7 @@ export class GraphQLEnumType /* <T> */ {
   toConfig(): {|
     ...GraphQLEnumTypeConfig,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<EnumTypeExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<EnumTypeExtensionNode>,
   |} {
     const values = keyValMap(
       this.getValues(),
@@ -1256,7 +1256,7 @@ export class GraphQLEnumType /* <T> */ {
       values,
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
     };
   }
 
@@ -1379,7 +1379,7 @@ export class GraphQLInputObjectType {
     ...GraphQLInputObjectTypeConfig,
     fields: GraphQLInputFieldConfigMap,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<InputObjectTypeExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<InputObjectTypeExtensionNode>,
   |} {
     const fields = mapValue(this.getFields(), field => ({
       description: field.description,
@@ -1395,7 +1395,7 @@ export class GraphQLInputObjectType {
       fields,
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
     };
   }
 

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -263,7 +263,7 @@ export class GraphQLSchema {
     types: Array<GraphQLNamedType>,
     directives: Array<GraphQLDirective>,
     extensions: ?ReadOnlyObjMap<mixed>,
-    extensionASTNodes: $ReadOnlyArray<SchemaExtensionNode>,
+    extensionASTNodes: ?$ReadOnlyArray<SchemaExtensionNode>,
     assumeValid: boolean,
   |} {
     return {
@@ -274,7 +274,7 @@ export class GraphQLSchema {
       directives: this.getDirectives().slice(),
       extensions: this.extensions,
       astNode: this.astNode,
-      extensionASTNodes: this.extensionASTNodes || [],
+      extensionASTNodes: this.extensionASTNodes,
       assumeValid: this.__validationErrors !== undefined,
     };
   }

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -202,7 +202,10 @@ export function extendSchema(
     types: objectValues(typeMap),
     directives: getMergedDirectives(),
     astNode: schemaDef || schemaConfig.astNode,
-    extensionASTNodes: schemaConfig.extensionASTNodes.concat(schemaExts),
+    extensionASTNodes: concatMaybeArrays(
+      schemaConfig.extensionASTNodes,
+      schemaExts,
+    ),
   });
 
   // Below are functions used for producing this schema that have closed over
@@ -285,7 +288,10 @@ export function extendSchema(
           field => astBuilder.buildInputField(field),
         ),
       }),
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
+      extensionASTNodes: concatMaybeArrays(
+        config.extensionASTNodes,
+        extensions,
+      ),
     });
   }
 
@@ -304,7 +310,10 @@ export function extendSchema(
           value => astBuilder.buildEnumValue(value),
         ),
       },
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
+      extensionASTNodes: concatMaybeArrays(
+        config.extensionASTNodes,
+        extensions,
+      ),
     });
   }
 
@@ -314,7 +323,10 @@ export function extendSchema(
 
     return new GraphQLScalarType({
       ...config,
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
+      extensionASTNodes: concatMaybeArrays(
+        config.extensionASTNodes,
+        extensions,
+      ),
     });
   }
 
@@ -341,7 +353,10 @@ export function extendSchema(
           node => astBuilder.buildField(node),
         ),
       }),
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
+      extensionASTNodes: concatMaybeArrays(
+        config.extensionASTNodes,
+        extensions,
+      ),
     });
   }
 
@@ -362,7 +377,10 @@ export function extendSchema(
           node => astBuilder.buildField(node),
         ),
       }),
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
+      extensionASTNodes: concatMaybeArrays(
+        config.extensionASTNodes,
+        extensions,
+      ),
     });
   }
 
@@ -380,7 +398,10 @@ export function extendSchema(
         // validation with validateSchema() will produce more actionable results.
         ...typeNodes.map(node => (astBuilder.getNamedType(node): any)),
       ],
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
+      extensionASTNodes: concatMaybeArrays(
+        config.extensionASTNodes,
+        extensions,
+      ),
     });
   }
 
@@ -398,4 +419,17 @@ export function extendSchema(
       type: replaceType(arg.type),
     };
   }
+}
+
+function concatMaybeArrays<X>(
+  ...arrays: $ReadOnlyArray<?$ReadOnlyArray<X>>
+): ?$ReadOnlyArray<X> {
+  // eslint-disable-next-line no-undef-init
+  let result = undefined;
+  for (const maybeArray of arrays) {
+    if (maybeArray) {
+      result = result === undefined ? maybeArray : result.concat(maybeArray);
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
We should have consistent behaviour for all properties returned by
`toConfig` and since `extensions` is optional that mean
`extensionASTNodes` should also be optional