### PR TITLE
Correct isSpecifiedScalarType refinement, fix #2153

### DIFF
--- a/tstypes/type/scalars.d.ts
+++ b/tstypes/type/scalars.d.ts
@@ -13,6 +13,6 @@ export type SpecifiedScalarType =
   | typeof GraphQLBoolean
   | typeof GraphQLID;
 
-export const specifiedScalarTypes: ReadonlyArray<GraphQLScalarType>;
+export const specifiedScalarTypes: ReadonlyArray<SpecifiedScalarType>;
 
 export function isSpecifiedScalarType(type: any): type is SpecifiedScalarType;

--- a/tstypes/type/scalars.d.ts
+++ b/tstypes/type/scalars.d.ts
@@ -1,11 +1,18 @@
 import { GraphQLScalarType } from './definition';
 
-export const GraphQLInt: GraphQLScalarType;
-export const GraphQLFloat: GraphQLScalarType;
-export const GraphQLString: GraphQLScalarType;
-export const GraphQLBoolean: GraphQLScalarType;
-export const GraphQLID: GraphQLScalarType;
+export const GraphQLInt: GraphQLScalarType & { name: 'Int' };
+export const GraphQLFloat: GraphQLScalarType & { name: 'Float' };
+export const GraphQLString: GraphQLScalarType & { name: 'String' };
+export const GraphQLBoolean: GraphQLScalarType & { name: 'Boolean' };
+export const GraphQLID: GraphQLScalarType & { name: 'ID' };
+
+export type SpecifiedScalarType =
+  | typeof GraphQLInt
+  | typeof GraphQLFloat
+  | typeof GraphQLString
+  | typeof GraphQLBoolean
+  | typeof GraphQLID;
 
 export const specifiedScalarTypes: ReadonlyArray<GraphQLScalarType>;
 
-export function isSpecifiedScalarType(type: any): type is GraphQLScalarType;
+export function isSpecifiedScalarType(type: any): type is SpecifiedScalarType;


### PR DESCRIPTION
Fixes #2153

Ran into this when looking to upgrade to the latest in [graphql-nexus](https://github.com/prisma/nexus). To reproduce:

```ts
if (isScalarType(type)) {
  if (isSpecifiedScalarType(type)) {
    rootTypeMap[type.name] = SpecifiedScalars[type.name]
  } else {
    rootTypeMap[type.name] = "any"
  }
}
```

Before the changes in this PR, `type` in the `else` block is inferred to be `never`, because `isSpecifiedScalarType` is currently narrows to all scalars rather than just the "specified" ones, and as such `type.name` is invalid:

<img width="705" alt="Screen Shot 2019-09-22 at 11 21 55 PM" src="https://user-images.githubusercontent.com/154748/65400376-cc59a680-dd8f-11e9-9102-456dccf7b495.png">


By adding the `& { name: '...' }` for each of the specified scalars, we give enough context to know that the `else` block is a valid codepath for all "non-specified" scalars.