### PR TITLE
Add two more tests to KnownArgumentNames validation rule

### DIFF
--- a/src/validation/__tests__/KnownArgumentNames-test.js
+++ b/src/validation/__tests__/KnownArgumentNames-test.js
@@ -110,6 +110,27 @@ describe('Validate: Known argument names', () => {
     ]);
   });
 
+  it('directive without args is valid', () => {
+    expectValid(`
+      {
+        dog @onField
+      }
+    `);
+  });
+
+  it('arg passed to directive without arg is reported', () => {
+    expectErrors(`
+      {
+        dog @onField(if: true)
+      }
+    `).to.deep.equal([
+      {
+        message: 'Unknown argument "if" on directive "@onField".',
+        locations: [{ line: 3, column: 22 }],
+      },
+    ]);
+  });
+
   it('misspelled directive args are reported', () => {
     expectErrors(`
       {


### PR DESCRIPTION
Tests that arguments passed to an argument-less directive are properly reported as an error.

The test suite did not catch that this did not work properly in the Python port, so I added these tests.