### PR TITLE
Fix typescript definition for getVariableValues

### DIFF
--- a/src/execution/values.d.ts
+++ b/src/execution/values.d.ts
@@ -29,7 +29,7 @@ type CoercedVariableValues =
  */
 export function getVariableValues(
   schema: GraphQLSchema,
-  varDefNodes: VariableDefinitionNode[],
+  varDefNodes: ReadonlyArray<VariableDefinitionNode>,
   inputs: { [key: string]: any },
   options?: { maxErrors?: number },
 ): CoercedVariableValues;


### PR DESCRIPTION
This fixes the typescript definition to match flow and prevent errors when passing a read-only array. 