### PR TITLE
grammar: 'falsey' => 'falsy'

### DIFF
--- a/src/__fixtures__/kitchen-sink.graphql
+++ b/src/__fixtures__/kitchen-sink.graphql
@@ -51,7 +51,7 @@ fragment frag on Friend @onFragmentDefinition {
 }
 
 {
-  unnamed(truthy: true, falsey: false, nullish: null),
+  unnamed(truthy: true, falsy: false, nullish: null),
   query
 }
 

--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -151,7 +151,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       writable: true,
     },
     locations: {
-      // Coercing falsey values to undefined ensures they will not be included
+      // Coercing falsy values to undefined ensures they will not be included
       // in JSON.stringify() when not provided.
       value: _locations || undefined,
       // By being enumerable, JSON.stringify will include `locations` in the
@@ -160,7 +160,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       enumerable: _locations != null,
     },
     path: {
-      // Coercing falsey values to undefined ensures they will not be included
+      // Coercing falsy values to undefined ensures they will not be included
       // in JSON.stringify() when not provided.
       value: path || undefined,
       // By being enumerable, JSON.stringify will include `path` in the
@@ -181,7 +181,7 @@ export function GraphQLError( // eslint-disable-line no-redeclare
       value: originalError,
     },
     extensions: {
-      // Coercing falsey values to undefined ensures they will not be included
+      // Coercing falsy values to undefined ensures they will not be included
       // in JSON.stringify() when not provided.
       value: _extensions || undefined,
       // By being enumerable, JSON.stringify will include `path` in the

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -165,7 +165,7 @@ describe('Printer: Query document', () => {
       }
 
       {
-        unnamed(truthy: true, falsey: false, nullish: null)
+        unnamed(truthy: true, falsy: false, nullish: null)
         query
       }
 

--- a/src/validation/__tests__/ValuesOfCorrectType-test.js
+++ b/src/validation/__tests__/ValuesOfCorrectType-test.js
@@ -796,7 +796,7 @@ describe('Validate: Values of correct type', () => {
       `);
     });
 
-    it('Partial object, required field can be falsey', () => {
+    it('Partial object, required field can be falsy', () => {
       expectValid(`
         {
           complicatedArgs {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Glossary/Falsy
> Sometimes written falsey, although in English usually turning
> a word into > an adjective with a -y, any final e is dropped
> (noise => noisy, ice => icy, shine => shiny)