### PR TITLE
buildASTSchema ignores schema extensions

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -691,6 +691,32 @@ describe('Schema Builder', () => {
     expect(cycleSDL(sdl)).to.equal(sdl);
   });
 
+  it('Extension adds new fields and interfaces', () => {
+    const sdl = dedent`
+      interface Bar {
+        bravo: String
+      }
+
+      type Foo {
+        alpha: String
+      }
+
+      extend type Foo implements Bar {
+        bravo: String
+      }
+    `;
+    expect(cycleSDL(sdl)).to.equal(dedent`
+      interface Bar {
+        bravo: String
+      }
+
+      type Foo implements Bar {
+        alpha: String
+        bravo: String
+      }
+    `);
+  });
+
   it('Supports @deprecated', () => {
     const sdl = dedent`
       enum MyEnum {


### PR DESCRIPTION
While using graphql-js to check a sample schema for a blog post, I discovered that `buildASTSchema` completely ignores extension logic. I haven't had a chance to fix this yet, but just added failing test to show the current behavior.

I'll create a fix for this when I have time.