### PR TITLE
docs: follow express' best practice

### DIFF
--- a/docs/Guides-ConstructingTypes.md
+++ b/docs/Guides-ConstructingTypes.md
@@ -55,8 +55,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 We can implement this same API without using GraphQL schema language:
@@ -114,8 +115,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 When we use this method of creating the API, the root level resolvers are implemented on the `Query` and `Mutation` types rather than on a `root` object.

--- a/docs/Tutorial-Authentication.md
+++ b/docs/Tutorial-Authentication.md
@@ -45,8 +45,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 In a REST API, authentication is often handled with a header, that contains an auth token which proves what user is making this request. Express middleware processes these headers and puts authentication data on the Express `request` object. Some middleware modules that handle authentication like this are [Passport](http://passportjs.org/), [express-jwt](https://github.com/auth0/express-jwt), and [express-session](https://github.com/expressjs/session). Each of these modules works with `express-graphql`.

--- a/docs/Tutorial-BasicTypes.md
+++ b/docs/Tutorial-BasicTypes.md
@@ -52,8 +52,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 If you run this code with `node server.js` and browse to http://localhost:4000/graphql you can try out these APIs.

--- a/docs/Tutorial-ExpressGraphQL.md
+++ b/docs/Tutorial-ExpressGraphQL.md
@@ -43,8 +43,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 You can run this GraphQL server with:

--- a/docs/Tutorial-ObjectTypes.md
+++ b/docs/Tutorial-ObjectTypes.md
@@ -125,8 +125,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 When you issue a GraphQL query against an API that returns object types, you can call multiple methods on the object at once by nesting the GraphQL field names. For example, if you wanted to call both `rollOnce` to roll a die once, and `roll` to roll a die three times, you could do it with this query:

--- a/docs/Tutorial-PassingArguments.md
+++ b/docs/Tutorial-PassingArguments.md
@@ -88,8 +88,9 @@ app.use(
     graphiql: true,
   }),
 );
-app.listen(4000);
-console.log('Running a GraphQL API server at localhost:4000/graphql');
+app.listen(4000, () => {
+  console.log('Running a GraphQL API server at localhost:4000/graphql');
+});
 ```
 
 When you call this API, you have to pass each argument by name. So for the server above, you could issue this GraphQL query to roll three six-sided dice:


### PR DESCRIPTION
There were lots of `console.logs` that were coded like synchronous code, but express' `listen` function provides callback and is best practice to provide the callback for post-listen operations.

It was  already correct in this documentation: https://github.com/graphql/graphql-js/blob/master/docs/Tutorial-Mutations.md