### PR TITLE
Pass down context info to serialize method of leaf nodes

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -850,7 +850,7 @@ function completeValue(
   // If field type is a leaf type, Scalar or Enum, serialize to a valid value,
   // returning null if serialization is not possible.
   if (isLeafType(returnType)) {
-    return completeLeafValue(returnType, result);
+    return completeLeafValue(returnType, result, fieldNodes, info);
   }
 
   // If field type is an abstract type, Interface or Union, determine the
@@ -935,8 +935,8 @@ function completeListValue(
  * Complete a Scalar or Enum by serializing to a valid value, returning
  * null if serialization is not possible.
  */
-function completeLeafValue(returnType: GraphQLLeafType, result: mixed): mixed {
-  const serializedResult = returnType.serialize(result);
+function completeLeafValue(returnType: GraphQLLeafType, result: mixed, fieldNodes: $ReadOnlyArray<FieldNode>, info: GraphQLResolveInfo): mixed {
+  const serializedResult = returnType.serialize(result, fieldNodes, info);
   if (isInvalid(serializedResult)) {
     throw new Error(
       `Expected a value of type "${inspect(returnType)}" but ` +


### PR DESCRIPTION
This came from a requirement to change the serialization behaviour based on what arguments were supplied to the field in the query. Specifically, a custom scalar was developed to convert values to the units requested in a "unit" field argument, e.g. request length values in meters instead of feet.

With this change this now possible by inspecting the `fieldNodes` and its arguments. Having the `info` passed down too is required to find the default value of the field arguments.