### PR TITLE
Add per-field thunk support

### DIFF
--- a/docs/APIReference-TypeSystem.md
+++ b/docs/APIReference-TypeSystem.md
@@ -294,8 +294,10 @@ type GraphQLArgumentConfig = {
 }
 
 type GraphQLFieldConfigMap = {
-  [fieldName: string]: GraphQLFieldConfig;
+  [fieldName: string]: GraphQLFieldConfigThunk | GraphQLFieldConfig;
 };
+
+type GraphQLFieldConfigThunk = () => GraphQLFieldConfig;
 ```
 
 Almost all of the GraphQL types you define will be object types. Object types

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -213,12 +213,35 @@ describe('Type System: Objects', () => {
     });
   });
 
-  it('accepts an Object type with a field function', () => {
+  it('accepts an Object type with a fields function', () => {
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
       fields: () => ({
         f: { type: ScalarType },
       }),
+    });
+    expect(objType.getFields()).to.deep.equal({
+      f: {
+        name: 'f',
+        description: undefined,
+        type: ScalarType,
+        args: [],
+        resolve: undefined,
+        subscribe: undefined,
+        isDeprecated: false,
+        deprecationReason: undefined,
+        extensions: undefined,
+        astNode: undefined,
+      },
+    });
+  });
+
+  it('accepts an Object type with a field function', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        f: () => ({ type: ScalarType }),
+      },
     });
     expect(objType.getFields()).to.deep.equal({
       f: {

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -496,7 +496,7 @@ export type GraphQLFieldConfigMap<
   TContext,
   TArgs = { [key: string]: any }
 > = {
-  [key: string]: GraphQLFieldConfig<TSource, TContext, TArgs>;
+  [key: string]: Thunk<GraphQLFieldConfig<TSource, TContext, TArgs>>;
 };
 
 export interface GraphQLField<

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -775,7 +775,8 @@ function defineFieldMap<TSource, TContext>(
     `${config.name} fields must be an object with field names as keys or a function which returns such an object.`,
   );
 
-  return mapValue(fieldMap, (fieldConfig, fieldName) => {
+  return mapValue(fieldMap, (fieldConfigThunk, fieldName) => {
+    const fieldConfig = resolveThunk(fieldConfigThunk);
     devAssert(
       isPlainObj(fieldConfig),
       `${config.name}.${fieldName} field config must be an object.`,
@@ -930,7 +931,7 @@ export type GraphQLArgumentConfig = {|
 |};
 
 export type GraphQLFieldConfigMap<TSource, TContext> = ObjMap<
-  GraphQLFieldConfig<TSource, TContext>,
+  Thunk<GraphQLFieldConfig<TSource, TContext>>,
 >;
 
 export type GraphQLField<


### PR DESCRIPTION
Closes #277

It'd be nice to not have to use helper functions around all `fields` definitions that resolve per-field thunks that are imported from other files. That's currently the only way to avoid cyclic import issues when a field is defined in a separate file from the object type.

Tests were failing locally because of a seemingly unrelated `Identifier 'xxx' has already been declared` issue, so hoping CI tests will work...