### PR TITLE
Add `@specifiedBy` directive

### DIFF
--- a/docs/APIReference-TypeSystem.md
+++ b/docs/APIReference-TypeSystem.md
@@ -206,10 +206,10 @@ class GraphQLScalarType<InternalType> {
 type GraphQLScalarTypeConfig<InternalType> = {
   name: string;
   description?: ?string;
+  specifiedByUrl?: string;
   serialize: (value: mixed) => ?InternalType;
   parseValue?: (value: mixed) => ?InternalType;
   parseLiteral?: (valueAST: Value) => ?InternalType;
-  specifiedByUrl?: string;
 }
 ```
 

--- a/docs/APIReference-TypeSystem.md
+++ b/docs/APIReference-TypeSystem.md
@@ -209,6 +209,7 @@ type GraphQLScalarTypeConfig<InternalType> = {
   serialize: (value: mixed) => ?InternalType;
   parseValue?: (value: mixed) => ?InternalType;
   parseLiteral?: (valueAST: Value) => ?InternalType;
+  specifiedByUrl?: string;
 }
 ```
 

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -49,6 +49,16 @@ describe('Type System: Scalars', () => {
     expect(() => new GraphQLScalarType({ name: 'SomeScalar' })).to.not.throw();
   });
 
+  it('accepts a Scalar type defining specifiedByUrl', () => {
+    expect(
+      () =>
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          specifiedByUrl: 'https://example.com/foo_spec',
+        }),
+    ).not.to.throw();
+  });
+
   it('accepts a Scalar type defining parseValue and parseLiteral', () => {
     expect(
       () =>
@@ -126,6 +136,19 @@ describe('Type System: Scalars', () => {
         }),
     ).to.throw(
       'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
+    );
+  });
+
+  it('rejects a Scalar type defining specifiedByUrl with an incorrect type', () => {
+    expect(
+      () =>
+        new GraphQLScalarType({
+          name: 'SomeScalar',
+          // $DisableFlowOnNegativeTest
+          specifiedByUrl: {},
+        }),
+    ).to.throw(
+      'SomeScalar must provide "specifiedByUrl" as a string, but got: {}.',
     );
   });
 });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -63,6 +63,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'SCALAR',
@@ -72,6 +73,7 @@ describe('Introspection', () => {
               interfaces: null,
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'SCALAR',
@@ -81,6 +83,7 @@ describe('Introspection', () => {
               interfaces: null,
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -185,6 +188,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -218,6 +222,17 @@ describe('Introspection', () => {
                 },
                 {
                   name: 'description',
+                  args: [],
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'specifiedByUrl',
                   args: [],
                   type: {
                     kind: 'SCALAR',
@@ -358,6 +373,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'ENUM',
@@ -408,6 +424,7 @@ describe('Introspection', () => {
                 },
               ],
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -508,6 +525,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -570,6 +588,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -632,6 +651,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -729,6 +749,7 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
+              specifiedByUrl: null,
             },
             {
               kind: 'ENUM',
@@ -834,6 +855,7 @@ describe('Introspection', () => {
                 },
               ],
               possibleTypes: null,
+              specifiedByUrl: null,
             },
           ],
           directives: [
@@ -871,6 +893,26 @@ describe('Introspection', () => {
                     ofType: {
                       kind: 'SCALAR',
                       name: 'Boolean',
+                      ofType: null,
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: 'specifiedBy',
+              isRepeatable: false,
+              locations: ['SCALAR'],
+              args: [
+                {
+                  defaultValue: null,
+                  name: 'url',
+                  type: {
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'String',
                       ofType: null,
                     },
                   },

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -30,8 +30,8 @@ describe('Introspection', () => {
     });
     const source = getIntrospectionQuery({
       descriptions: false,
-      directiveIsRepeatable: true,
       specifiedByUrl: true,
+      directiveIsRepeatable: true,
     });
 
     const result = graphqlSync({ schema, source });
@@ -657,6 +657,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Directive',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'name',
@@ -750,7 +751,6 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'ENUM',
@@ -901,6 +901,22 @@ describe('Introspection', () => {
               ],
             },
             {
+              name: 'deprecated',
+              isRepeatable: false,
+              locations: ['FIELD_DEFINITION', 'ENUM_VALUE'],
+              args: [
+                {
+                  defaultValue: '"No longer supported"',
+                  name: 'reason',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                },
+              ],
+            },
+            {
               name: 'specifiedBy',
               isRepeatable: false,
               locations: ['SCALAR'],
@@ -916,22 +932,6 @@ describe('Introspection', () => {
                       name: 'String',
                       ofType: null,
                     },
-                  },
-                },
-              ],
-            },
-            {
-              name: 'deprecated',
-              isRepeatable: false,
-              locations: ['FIELD_DEFINITION', 'ENUM_VALUE'],
-              args: [
-                {
-                  defaultValue: '"No longer supported"',
-                  name: 'reason',
-                  type: {
-                    kind: 'SCALAR',
-                    name: 'String',
-                    ofType: null,
                   },
                 },
               ],

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -31,6 +31,7 @@ describe('Introspection', () => {
     const source = getIntrospectionQuery({
       descriptions: false,
       directiveIsRepeatable: true,
+      specifiedByUrl: true,
     });
 
     const result = graphqlSync({ schema, source });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -46,6 +46,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: 'QueryRoot',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'onlyField',
@@ -63,31 +64,31 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'SCALAR',
               name: 'String',
+              specifiedByUrl: null,
               fields: null,
               inputFields: null,
               interfaces: null,
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'SCALAR',
               name: 'Boolean',
+              specifiedByUrl: null,
               fields: null,
               inputFields: null,
               interfaces: null,
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
               name: '__Schema',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'description',
@@ -188,11 +189,11 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
               name: '__Type',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'kind',
@@ -373,11 +374,11 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'ENUM',
               name: '__TypeKind',
+              specifiedByUrl: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -424,11 +425,11 @@ describe('Introspection', () => {
                 },
               ],
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
               name: '__Field',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'name',
@@ -525,11 +526,11 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
               name: '__InputValue',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'name',
@@ -588,11 +589,11 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
               name: '__EnumValue',
+              specifiedByUrl: null,
               fields: [
                 {
                   name: 'name',
@@ -651,7 +652,6 @@ describe('Introspection', () => {
               interfaces: [],
               enumValues: null,
               possibleTypes: null,
-              specifiedByUrl: null,
             },
             {
               kind: 'OBJECT',
@@ -754,6 +754,7 @@ describe('Introspection', () => {
             {
               kind: 'ENUM',
               name: '__DirectiveLocation',
+              specifiedByUrl: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -855,7 +856,6 @@ describe('Introspection', () => {
                 },
               ],
               possibleTypes: null,
-              specifiedByUrl: null,
             },
           ],
           directives: [

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -291,7 +291,7 @@ export type Thunk<T> = (() => T) | T;
 export class GraphQLScalarType {
   name: string;
   description: Maybe<string>;
-  specifiedByUrl?: Maybe<string>;
+  specifiedByUrl: Maybe<string>;
   serialize: GraphQLScalarSerializer<any>;
   parseValue: GraphQLScalarValueParser<any>;
   parseLiteral: GraphQLScalarLiteralParser<any>;

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -297,6 +297,7 @@ export class GraphQLScalarType {
   extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
+  specifiedByUrl?: Maybe<string>;
 
   constructor(config: Readonly<GraphQLScalarTypeConfig<any, any>>);
 
@@ -306,6 +307,7 @@ export class GraphQLScalarType {
     parseLiteral: GraphQLScalarLiteralParser<any>;
     extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
+    specifiedByUrl: Maybe<string>;
   };
 
   toString(): string;
@@ -336,6 +338,7 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
+  specifiedByUrl?: Maybe<string>;
 }
 
 /**

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -291,23 +291,23 @@ export type Thunk<T> = (() => T) | T;
 export class GraphQLScalarType {
   name: string;
   description: Maybe<string>;
+  specifiedByUrl?: Maybe<string>;
   serialize: GraphQLScalarSerializer<any>;
   parseValue: GraphQLScalarValueParser<any>;
   parseLiteral: GraphQLScalarLiteralParser<any>;
   extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
-  specifiedByUrl?: Maybe<string>;
 
   constructor(config: Readonly<GraphQLScalarTypeConfig<any, any>>);
 
   toConfig(): GraphQLScalarTypeConfig<any, any> & {
+    specifiedByUrl: Maybe<string>;
     serialize: GraphQLScalarSerializer<any>;
     parseValue: GraphQLScalarValueParser<any>;
     parseLiteral: GraphQLScalarLiteralParser<any>;
     extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
-    specifiedByUrl: Maybe<string>;
   };
 
   toString(): string;
@@ -329,6 +329,7 @@ export type GraphQLScalarLiteralParser<TInternal> = (
 export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   name: string;
   description?: Maybe<string>;
+  specifiedByUrl?: Maybe<string>;
   // Serializes an internal value to include in a response.
   serialize: GraphQLScalarSerializer<TExternal>;
   // Parses an externally provided value to use as an input.
@@ -338,7 +339,6 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
-  specifiedByUrl?: Maybe<string>;
 }
 
 /**

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -590,6 +590,14 @@ export class GraphQLScalarType {
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);
 
     devAssert(typeof config.name === 'string', 'Must provide name.');
+
+    devAssert(
+      config.specifiedByUrl == null ||
+        typeof config.specifiedByUrl === 'string',
+      `${this.name} must provide "specifiedByUrl" as a string, ` +
+        `but got: ${inspect(config.specifiedByUrl)}.`,
+    );
+
     devAssert(
       config.serialize == null || typeof config.serialize === 'function',
       `${this.name} must provide "serialize" function. If this custom Scalar is also used as an input type, ensure "parseValue" and "parseLiteral" functions are also provided.`,
@@ -600,14 +608,6 @@ export class GraphQLScalarType {
         typeof config.parseValue === 'function' &&
           typeof config.parseLiteral === 'function',
         `${this.name} must provide both "parseValue" and "parseLiteral" functions.`,
-      );
-    }
-
-    if (config.specifiedByUrl != null) {
-      devAssert(
-        typeof config.specifiedByUrl === 'string',
-        `${this.name} must provide "specifiedByUrl" as a string, ` +
-          `but got: ${inspect(config.specifiedByUrl)}.`,
       );
     }
   }

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -568,18 +568,19 @@ function undefineIfEmpty<T>(arr: ?$ReadOnlyArray<T>): ?$ReadOnlyArray<T> {
 export class GraphQLScalarType {
   name: string;
   description: ?string;
+  specifiedByUrl: ?string;
   serialize: GraphQLScalarSerializer<mixed>;
   parseValue: GraphQLScalarValueParser<mixed>;
   parseLiteral: GraphQLScalarLiteralParser<mixed>;
   extensions: ?ReadOnlyObjMap<mixed>;
   astNode: ?ScalarTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ScalarTypeExtensionNode>;
-  specifiedByUrl: ?string;
 
   constructor(config: $ReadOnly<GraphQLScalarTypeConfig<mixed, mixed>>): void {
     const parseValue = config.parseValue ?? identityFunc;
     this.name = config.name;
     this.description = config.description;
+    this.specifiedByUrl = config.specifiedByUrl;
     this.serialize = config.serialize ?? identityFunc;
     this.parseValue = parseValue;
     this.parseLiteral =
@@ -587,7 +588,6 @@ export class GraphQLScalarType {
     this.extensions = config.extensions && toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);
-    this.specifiedByUrl = config.specifiedByUrl;
 
     devAssert(typeof config.name === 'string', 'Must provide name.');
     devAssert(
@@ -614,23 +614,23 @@ export class GraphQLScalarType {
 
   toConfig(): {|
     ...GraphQLScalarTypeConfig<mixed, mixed>,
+    specifiedByUrl: ?string,
     serialize: GraphQLScalarSerializer<mixed>,
     parseValue: GraphQLScalarValueParser<mixed>,
     parseLiteral: GraphQLScalarLiteralParser<mixed>,
     extensions: ?ReadOnlyObjMap<mixed>,
     extensionASTNodes: $ReadOnlyArray<ScalarTypeExtensionNode>,
-    specifiedByUrl: ?string,
   |} {
     return {
       name: this.name,
       description: this.description,
+      specifiedByUrl: this.specifiedByUrl,
       serialize: this.serialize,
       parseValue: this.parseValue,
       parseLiteral: this.parseLiteral,
       extensions: this.extensions,
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes ?? [],
-      specifiedByUrl: this.specifiedByUrl,
     };
   }
 
@@ -662,6 +662,7 @@ export type GraphQLScalarLiteralParser<TInternal> = (
 export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   name: string,
   description?: ?string,
+  specifiedByUrl?: ?string,
   // Serializes an internal value to include in a response.
   serialize?: GraphQLScalarSerializer<TExternal>,
   // Parses an externally provided value to use as an input.
@@ -671,7 +672,6 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   extensions?: ?ReadOnlyObjMapLike<mixed>,
   astNode?: ?ScalarTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<ScalarTypeExtensionNode>,
-  specifiedByUrl?: ?string,
 |};
 
 /**

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -574,6 +574,7 @@ export class GraphQLScalarType {
   extensions: ?ReadOnlyObjMap<mixed>;
   astNode: ?ScalarTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ScalarTypeExtensionNode>;
+  specifiedByUrl: ?string;
 
   constructor(config: $ReadOnly<GraphQLScalarTypeConfig<mixed, mixed>>): void {
     const parseValue = config.parseValue ?? identityFunc;
@@ -586,6 +587,7 @@ export class GraphQLScalarType {
     this.extensions = config.extensions && toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);
+    this.specifiedByUrl = config.specifiedByUrl;
 
     devAssert(typeof config.name === 'string', 'Must provide name.');
     devAssert(
@@ -600,6 +602,14 @@ export class GraphQLScalarType {
         `${this.name} must provide both "parseValue" and "parseLiteral" functions.`,
       );
     }
+
+    if (config.specifiedByUrl != null) {
+      devAssert(
+        typeof config.specifiedByUrl === 'string',
+        `${this.name} must provide "specifiedByUrl" as a string, ` +
+          `but got: ${inspect(config.specifiedByUrl)}.`,
+      );
+    }
   }
 
   toConfig(): {|
@@ -609,6 +619,7 @@ export class GraphQLScalarType {
     parseLiteral: GraphQLScalarLiteralParser<mixed>,
     extensions: ?ReadOnlyObjMap<mixed>,
     extensionASTNodes: $ReadOnlyArray<ScalarTypeExtensionNode>,
+    specifiedByUrl: ?string,
   |} {
     return {
       name: this.name,
@@ -619,6 +630,7 @@ export class GraphQLScalarType {
       extensions: this.extensions,
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes ?? [],
+      specifiedByUrl: this.specifiedByUrl,
     };
   }
 
@@ -659,6 +671,7 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   extensions?: ?ReadOnlyObjMapLike<mixed>,
   astNode?: ?ScalarTypeDefinitionNode,
   extensionASTNodes?: ?$ReadOnlyArray<ScalarTypeExtensionNode>,
+  specifiedByUrl?: ?string,
 |};
 
 /**

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -614,7 +614,6 @@ export class GraphQLScalarType {
 
   toConfig(): {|
     ...GraphQLScalarTypeConfig<mixed, mixed>,
-    specifiedByUrl: ?string,
     serialize: GraphQLScalarSerializer<mixed>,
     parseValue: GraphQLScalarValueParser<mixed>,
     parseLiteral: GraphQLScalarLiteralParser<mixed>,

--- a/src/type/directives.d.ts
+++ b/src/type/directives.d.ts
@@ -60,6 +60,11 @@ export const GraphQLIncludeDirective: GraphQLDirective;
 export const GraphQLSkipDirective: GraphQLDirective;
 
 /**
+ * Used to provide a URL for specifying the behavior of custom scalar definitions.
+ */
+export const GraphQLSpecifiedByDirective: GraphQLDirective;
+
+/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON: 'No longer supported';

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -171,21 +171,6 @@ export const GraphQLSkipDirective = new GraphQLDirective({
 });
 
 /**
- * Used to provide a URL for specifying the behaviour of custom scalar definitions.
- */
-export const GraphQLSpecifiedByDirective = new GraphQLDirective({
-  name: 'specifiedBy',
-  description: 'Exposes a URL that specifies the behaviour of this scalar.',
-  locations: [DirectiveLocation.SCALAR],
-  args: {
-    url: {
-      type: GraphQLNonNull(GraphQLString),
-      description: 'The URL that specifies the behaviour of this scalar.',
-    },
-  },
-});
-
-/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
@@ -208,13 +193,28 @@ export const GraphQLDeprecatedDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to provide a URL for specifying the behaviour of custom scalar definitions.
+ */
+export const GraphQLSpecifiedByDirective = new GraphQLDirective({
+  name: 'specifiedBy',
+  description: 'Exposes a URL that specifies the behaviour of this scalar.',
+  locations: [DirectiveLocation.SCALAR],
+  args: {
+    url: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'The URL that specifies the behaviour of this scalar.',
+    },
+  },
+});
+
+/**
  * The full list of specified directives.
  */
 export const specifiedDirectives = Object.freeze([
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
-  GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
+  GraphQLSpecifiedByDirective,
 ]);
 
 export function isSpecifiedDirective(

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -171,6 +171,21 @@ export const GraphQLSkipDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to provide a URL for specifying the behaviour of custom scalar definitions.
+ */
+export const GraphQLSpecifiedByDirective = new GraphQLDirective({
+  name: 'specifiedBy',
+  description: 'Exposes a URL that specifies the behaviour of this scalar.',
+  locations: [DirectiveLocation.SCALAR],
+  args: {
+    url: {
+      type: GraphQLNonNull(GraphQLString),
+      description: 'The URL that specifies the behaviour of this scalar.',
+    },
+  },
+});
+
+/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
@@ -198,6 +213,7 @@ export const GraphQLDeprecatedDirective = new GraphQLDirective({
 export const specifiedDirectives = Object.freeze([
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
 ]);
 

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -241,7 +241,7 @@ export const __Type = new GraphQLObjectType({
       },
       specifiedByUrl: {
         type: GraphQLString,
-        resolve: obj =>
+        resolve: (obj) =>
           obj.specifiedByUrl !== undefined ? obj.specifiedByUrl : undefined,
       },
       fields: {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -195,7 +195,7 @@ export const __DirectiveLocation = new GraphQLEnumType({
 export const __Type = new GraphQLObjectType({
   name: '__Type',
   description:
-    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional specifiedByUrl, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
+    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByUrl`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
   fields: () =>
     ({
       kind: {

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -195,7 +195,7 @@ export const __DirectiveLocation = new GraphQLEnumType({
 export const __Type = new GraphQLObjectType({
   name: '__Type',
   description:
-    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
+    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional specifiedByUrl, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
   fields: () =>
     ({
       kind: {
@@ -238,6 +238,11 @@ export const __Type = new GraphQLObjectType({
         type: GraphQLString,
         resolve: (type) =>
           type.description !== undefined ? type.description : undefined,
+      },
+      specifiedByUrl: {
+        type: GraphQLString,
+        resolve: obj =>
+          obj.specifiedByUrl !== undefined ? obj.specifiedByUrl : undefined,
       },
       fields: {
         type: GraphQLList(GraphQLNonNull(__Field)),

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -16,8 +16,8 @@ import {
   assertDirective,
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
-  GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
+  GraphQLSpecifiedByDirective,
 } from '../../type/directives';
 import {
   GraphQLID,
@@ -222,11 +222,11 @@ describe('Schema Builder', () => {
     expect(schema.getDirectives()).to.have.lengthOf(4);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
-    expect(schema.getDirective('specifiedBy')).to.equal(
-      GraphQLSpecifiedByDirective,
-    );
     expect(schema.getDirective('deprecated')).to.equal(
       GraphQLDeprecatedDirective,
+    );
+    expect(schema.getDirective('specifiedBy')).to.equal(
+      GraphQLSpecifiedByDirective,
     );
   });
 
@@ -234,8 +234,8 @@ describe('Schema Builder', () => {
     const schema = buildSchema(`
       directive @skip on FIELD
       directive @include on FIELD
-      directive @specifiedBy on FIELD_DEFINITION
       directive @deprecated on FIELD_DEFINITION
+      directive @specifiedBy on FIELD_DEFINITION
     `);
 
     expect(schema.getDirectives()).to.have.lengthOf(4);
@@ -243,11 +243,11 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
     );
-    expect(schema.getDirective('specifiedBy')).to.not.equal(
-      GraphQLSpecifiedByDirective,
-    );
     expect(schema.getDirective('deprecated')).to.not.equal(
       GraphQLDeprecatedDirective,
+    );
+    expect(schema.getDirective('specifiedBy')).to.not.equal(
+      GraphQLSpecifiedByDirective,
     );
   });
 
@@ -259,8 +259,8 @@ describe('Schema Builder', () => {
     expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
-    expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
+    expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
   });
 
   it('Type modifiers', () => {

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -791,9 +791,7 @@ describe('Schema Builder', () => {
 
     const schema = buildSchema(sdl);
 
-    const foo = assertScalarType(schema.getType('Foo'));
-
-    expect(foo).to.include({
+    expect(schema.getType('Foo')).to.include({
       specifiedByUrl: 'https://example.com/foo_spec',
     });
   });

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -33,7 +33,10 @@ import { introspectionFromSchema } from '../introspectionFromSchema';
  * returns that schema printed as SDL.
  */
 function cycleIntrospection(sdlString: string): string {
-  const options = { directiveIsRepeatable: true };
+  const options = {
+    directiveIsRepeatable: true,
+    specifiedByUrl: true,
+  };
 
   const serverSchema = buildSchema(sdlString);
   const initialIntrospection = introspectionFromSchema(serverSchema, options);

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -533,6 +533,18 @@ describe('Type System: build schema from introspection', () => {
     expect(cycleIntrospection(sdl)).to.equal(sdl);
   });
 
+  it('builds a schema with specifiedBy url', () => {
+    const sdl = dedent`
+      scalar Foo @specifiedBy(url: "https://example.com/foo_spec")
+
+      type Query {
+        foo: Foo
+      }
+    `;
+
+    expect(cycleIntrospection(sdl)).to.equal(sdl);
+  });
+
   it('can use client schema for limited execution', () => {
     const schema = buildSchema(`
       scalar CustomScalar

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -34,8 +34,8 @@ import { introspectionFromSchema } from '../introspectionFromSchema';
  */
 function cycleIntrospection(sdlString: string): string {
   const options = {
-    directiveIsRepeatable: true,
     specifiedByUrl: true,
+    directiveIsRepeatable: true,
   };
 
   const serverSchema = buildSchema(sdlString);

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -378,9 +378,7 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(schema, parse(extensionSDL));
     const foo = assertScalarType(extendedSchema.getType('Foo'));
 
-    expect(foo.toConfig().specifiedByUrl).to.equal(
-      'https://example.com/foo_spec',
-    );
+    expect(foo.specifiedByUrl).to.equal('https://example.com/foo_spec');
 
     expect(validateSchema(extendedSchema)).to.deep.equal([]);
     expect(printExtensionNodes(foo)).to.deep.equal(extensionSDL);

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -7,6 +7,7 @@ import { GraphQLSchema } from '../../type/schema';
 import {
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
+  GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
 } from '../../type/directives';
 
@@ -799,7 +800,11 @@ describe('findBreakingChanges', () => {
     const oldSchema = new GraphQLSchema({});
 
     const newSchema = new GraphQLSchema({
-      directives: [GraphQLSkipDirective, GraphQLIncludeDirective],
+      directives: [
+        GraphQLSkipDirective,
+        GraphQLIncludeDirective,
+        GraphQLSpecifiedByDirective,
+      ],
     });
 
     expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([

--- a/src/utilities/__tests__/getIntrospectionQuery-test.js
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.js
@@ -51,4 +51,16 @@ describe('getIntrospectionQuery', () => {
       getIntrospectionQuery({ descriptions: false, schemaDescription: true }),
     ).to.not.match(/\bdescription\b/);
   });
+
+  it('include "specifiedByUrl" field', () => {
+    expect(getIntrospectionQuery()).to.not.match(/\bspecifiedByUrl\b/);
+
+    expect(getIntrospectionQuery({ specifiedByUrl: true })).to.match(
+      /\bspecifiedByUrl\b/,
+    );
+
+    expect(getIntrospectionQuery({ specifiedByUrl: false })).to.not.match(
+      /\bspecifiedByUrl\b/,
+    );
+  });
 });

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -687,7 +687,7 @@ describe('Type System Printer', () => {
       """
       The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \`__TypeKind\` enum.
 
-      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional specifiedByUrl, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional \`specifiedByUrl\`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
       """
       type __Type {
         kind: __TypeKind!
@@ -901,7 +901,7 @@ describe('Type System Printer', () => {
 
       # The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \`__TypeKind\` enum.
       #
-      # Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional specifiedByUrl, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+      # Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional \`specifiedByUrl\`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
       type __Type {
         kind: __TypeKind!
         name: String

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -505,6 +505,19 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('Custom Scalar with specifiedByUrl', () => {
+    const FooType = new GraphQLScalarType({
+      name: 'Foo',
+      specifiedByUrl: 'https://example.com/foo_spec',
+    });
+
+    const Schema = new GraphQLSchema({ types: [FooType] });
+    const output = printForTest(Schema);
+    expect(output).to.equal(dedent`
+      scalar Foo @specifiedBy(url: "https://example.com/foo_spec")
+    `);
+  });
+
   it('Enum', () => {
     const RGBType = new GraphQLEnumType({
       name: 'RGB',
@@ -631,6 +644,12 @@ describe('Type System Printer', () => {
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+      """Exposes a URL that specifies the behaviour of this scalar."""
+      directive @specifiedBy(
+        """The URL that specifies the behaviour of this scalar."""
+        url: String!
+      ) on SCALAR
+
       """Marks an element of a GraphQL schema as no longer supported."""
       directive @deprecated(
         """
@@ -668,12 +687,13 @@ describe('Type System Printer', () => {
       """
       The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \`__TypeKind\` enum.
 
-      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional specifiedByUrl, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
       """
       type __Type {
         kind: __TypeKind!
         name: String
         description: String
+        specifiedByUrl: String
         fields(includeDeprecated: Boolean = false): [__Field!]
         interfaces: [__Type!]
         possibleTypes: [__Type!]
@@ -847,6 +867,12 @@ describe('Type System Printer', () => {
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+      # Exposes a URL that specifies the behaviour of this scalar.
+      directive @specifiedBy(
+        # The URL that specifies the behaviour of this scalar.
+        url: String!
+      ) on SCALAR
+
       # Marks an element of a GraphQL schema as no longer supported.
       directive @deprecated(
         # Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).
@@ -875,11 +901,12 @@ describe('Type System Printer', () => {
 
       # The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \`__TypeKind\` enum.
       #
-      # Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+      # Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional specifiedByUrl, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
       type __Type {
         kind: __TypeKind!
         name: String
         description: String
+        specifiedByUrl: String
         fields(includeDeprecated: Boolean = false): [__Field!]
         interfaces: [__Type!]
         possibleTypes: [__Type!]

--- a/src/utilities/__tests__/schemaPrinter-test.js
+++ b/src/utilities/__tests__/schemaPrinter-test.js
@@ -644,12 +644,6 @@ describe('Type System Printer', () => {
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-      """Exposes a URL that specifies the behaviour of this scalar."""
-      directive @specifiedBy(
-        """The URL that specifies the behaviour of this scalar."""
-        url: String!
-      ) on SCALAR
-
       """Marks an element of a GraphQL schema as no longer supported."""
       directive @deprecated(
         """
@@ -657,6 +651,12 @@ describe('Type System Printer', () => {
         """
         reason: String = "No longer supported"
       ) on FIELD_DEFINITION | ENUM_VALUE
+
+      """Exposes a URL that specifies the behaviour of this scalar."""
+      directive @specifiedBy(
+        """The URL that specifies the behaviour of this scalar."""
+        url: String!
+      ) on SCALAR
 
       """
       A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
@@ -867,17 +867,17 @@ describe('Type System Printer', () => {
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-      # Exposes a URL that specifies the behaviour of this scalar.
-      directive @specifiedBy(
-        # The URL that specifies the behaviour of this scalar.
-        url: String!
-      ) on SCALAR
-
       # Marks an element of a GraphQL schema as no longer supported.
       directive @deprecated(
         # Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).
         reason: String = "No longer supported"
       ) on FIELD_DEFINITION | ENUM_VALUE
+
+      # Exposes a URL that specifies the behaviour of this scalar.
+      directive @specifiedBy(
+        # The URL that specifies the behaviour of this scalar.
+        url: String!
+      ) on SCALAR
 
       # A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
       type __Schema {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -17,6 +17,7 @@ import {
   GraphQLSkipDirective,
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
+  GraphQLSpecifiedByDirective,
 } from '../type/directives';
 
 import { extendSchemaImpl } from './extendSchema';
@@ -100,6 +101,10 @@ export function buildASTSchema(
 
   if (!directives.some((directive) => directive.name === 'include')) {
     directives.push(GraphQLIncludeDirective);
+  }
+
+  if (!directives.some((directive) => directive.name === 'specifiedBy')) {
+    directives.push(GraphQLSpecifiedByDirective);
   }
 
   if (!directives.some((directive) => directive.name === 'deprecated')) {

--- a/src/utilities/buildASTSchema.js
+++ b/src/utilities/buildASTSchema.js
@@ -103,12 +103,12 @@ export function buildASTSchema(
     directives.push(GraphQLIncludeDirective);
   }
 
-  if (!directives.some((directive) => directive.name === 'specifiedBy')) {
-    directives.push(GraphQLSpecifiedByDirective);
-  }
-
   if (!directives.some((directive) => directive.name === 'deprecated')) {
     directives.push(GraphQLDeprecatedDirective);
+  }
+
+  if (!directives.some((directive) => directive.name === 'specifiedBy')) {
+    directives.push(GraphQLSpecifiedByDirective);
   }
 
   return new GraphQLSchema(config);

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -200,6 +200,7 @@ export function buildClientSchema(
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
+      specifiedByUrl: scalarIntrospection.specifiedByUrl,
     });
   }
 

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -334,8 +334,8 @@ export function extendSchemaImpl(
 
     return new GraphQLScalarType({
       ...config,
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
       specifiedByUrl,
+      extensionASTNodes: config.extensionASTNodes.concat(extensions),
     });
   }
 
@@ -667,9 +667,9 @@ export function extendSchemaImpl(
         return new GraphQLScalarType({
           name,
           description,
+          specifiedByUrl: getSpecifiedByUrl(astNode),
           astNode,
           extensionASTNodes,
-          specifiedByUrl: getSpecifiedByUrl(astNode),
         });
       }
       case Kind.INPUT_OBJECT_TYPE_DEFINITION: {

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -327,10 +327,10 @@ export function extendSchemaImpl(
     const config = type.toConfig();
     const extensions = typeExtensionsMap[config.name] ?? [];
 
-    const specifiedByUrl = [
-      config.specifiedByUrl,
-      ...extensions.map(getSpecifiedByUrl),
-    ].filter(Boolean)[0];
+    let specifiedByUrl = config.specifiedByUrl;
+    for (const extensionNode of extensions) {
+      specifiedByUrl = getSpecifiedByUrl(extensionNode) ?? specifiedByUrl;
+    }
 
     return new GraphQLScalarType({
       ...config,

--- a/src/utilities/getIntrospectionQuery.d.ts
+++ b/src/utilities/getIntrospectionQuery.d.ts
@@ -6,6 +6,10 @@ export interface IntrospectionOptions {
   // Default: true
   descriptions: boolean;
 
+  // Whether to include `specifiedByUrl` in the introspection result.
+  // Default: false
+  specifiedByUrl?: boolean;
+
   // Whether to include `isRepeatable` flag on directives.
   // Default: false
   directiveIsRepeatable?: boolean;

--- a/src/utilities/getIntrospectionQuery.d.ts
+++ b/src/utilities/getIntrospectionQuery.d.ts
@@ -53,6 +53,7 @@ export interface IntrospectionScalarType {
   readonly kind: 'SCALAR';
   readonly name: string;
   readonly description?: Maybe<string>;
+  readonly specifiedByUrl?: Maybe<string>;
 }
 
 export interface IntrospectionObjectType {

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -7,6 +7,10 @@ export type IntrospectionOptions = {|
   // Default: true
   descriptions?: boolean,
 
+  // Whether to include `specifiedByUrl` in the introspection result.
+  // Default: false
+  specifiedByUrl?: boolean,
+
   // Whether to include `isRepeatable` field on directives.
   // Default: false
   directiveIsRepeatable?: boolean,
@@ -19,12 +23,16 @@ export type IntrospectionOptions = {|
 export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   const optionsWithDefault = {
     descriptions: true,
+    specifiedByUrl: false,
     directiveIsRepeatable: false,
     schemaDescription: false,
     ...options,
   };
 
   const descriptions = optionsWithDefault.descriptions ? 'description' : '';
+  const specifiedByUrl = optionsWithDefault.specifiedByUrl
+    ? 'specifiedByUrl'
+    : '';
   const directiveIsRepeatable = optionsWithDefault.directiveIsRepeatable
     ? 'isRepeatable'
     : '';
@@ -58,7 +66,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
       kind
       name
       ${descriptions}
-      specifiedByUrl
+      ${specifiedByUrl}
       fields(includeDeprecated: true) {
         name
         ${descriptions}

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -58,6 +58,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
       kind
       name
       ${descriptions}
+      specifiedByUrl
       fields(includeDeprecated: true) {
         name
         ${descriptions}
@@ -166,6 +167,7 @@ export type IntrospectionScalarType = {|
   +kind: 'SCALAR',
   +name: string,
   +description?: ?string,
+  +specifiedByUrl: ?string,
 |};
 
 export type IntrospectionObjectType = {|

--- a/src/utilities/printSchema.js
+++ b/src/utilities/printSchema.js
@@ -181,7 +181,11 @@ export function printType(type: GraphQLNamedType, options?: Options): string {
 }
 
 function printScalar(type: GraphQLScalarType, options): string {
-  return printDescription(options, type) + `scalar ${type.name}`;
+  return (
+    printDescription(options, type) +
+    `scalar ${type.name}` +
+    printSpecifiedByUrl(type)
+  );
 }
 
 function printImplementedInterfaces(
@@ -319,6 +323,19 @@ function printDeprecated(fieldOrEnumVal) {
     return ' @deprecated(reason: ' + print(reasonAST) + ')';
   }
   return ' @deprecated';
+}
+
+function printSpecifiedByUrl(scalar: GraphQLScalarType) {
+  if (scalar.specifiedByUrl == null) {
+    return '';
+  }
+  const url = scalar.specifiedByUrl;
+  const urlAST = astFromValue(url, GraphQLString);
+  invariant(
+    urlAST,
+    'Unexpected null value returned from `astFromValue` for specifiedByUrl',
+  );
+  return ' @specifiedBy(url: ' + print(urlAST) + ')';
 }
 
 function printDescription(


### PR DESCRIPTION
### Description

This in an implementation for a spec proposal:

* Spec proposal: [[RFC] Custom Scalar Specification URIs](https://github.com/graphql/graphql-spec/pull/649)
* Original issue: [[RFC] Custom Scalar Specification URIs](https://github.com/graphql/graphql-spec/issues/635)

### Example usage
#### Source
```javascript
const { graphql, buildSchema } = require("graphql");

const schema = buildSchema(`
  """
  A UUID
  """
  scalar UUID @specified(by: "https://tools.ietf.org/html/rfc4122")
  
  type Query {
    someUUID: UUID
  }
`);

const root = {
  someUUID: () => {
    return "750fce86-fc2f-4b25-a7df-fd0941d3fa08";
  }
};

const query = `
{
  __type(name: "UUID") {
    kind
    name
    description
    specifiedBy
  }
}`;

graphql(schema, query, root).then(response => {
  console.log(JSON.stringify(response, null, 4));
});
```

#### Output
```
{
    "data": {
        "__type": {
            "kind": "SCALAR",
            "name": "UUID",
            "description": "A UUID",
            "specifiedBy": "https://tools.ietf.org/html/rfc4122"
        }
    }
}
```

### Notes
Please let me know if I forgot something.