### PR TITLE
ESM build for the browser

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -15,5 +15,27 @@ module.exports = {
     mjs: {
       presets: [['@babel/preset-env', { modules: false }]],
     },
+    esm: {
+      presets: [['@babel/preset-env', { modules: false }]],
+      plugins: [
+        function({ types }) {
+          return {
+            visitor: {
+              ImportDeclaration: function(path, state) {
+                var source = path.node.source.value;
+                if (source.match(/^\.{0,2}\//) && !source.endsWith('.es.js')) {
+                  path.replaceWith(
+                    types.importDeclaration(
+                      path.node.specifiers,
+                      types.stringLiteral(source + '.es.js'),
+                    ),
+                  );
+                }
+              },
+            },
+          };
+        },
+      ],
+    },
   },
 };

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -22,10 +22,24 @@ module.exports = {
           return {
             visitor: {
               ImportDeclaration: function(path, state) {
+                if (!path.node.source) return;
                 var source = path.node.source.value;
                 if (source.match(/^\.{0,2}\//) && !source.endsWith('.es.js')) {
                   path.replaceWith(
                     types.importDeclaration(
+                      path.node.specifiers,
+                      types.stringLiteral(source + '.es.js'),
+                    ),
+                  );
+                }
+              },
+              ExportNamedDeclaration: function(path, state) {
+                if (!path.node.source) return;
+                const source = path.node.source.value;
+                if (source.match(/^\.{0,2}\//) && !source.endsWith('.es.js')) {
+                  path.replaceWith(
+                    types.exportNamedDeclaration(
+                      path.node.declaration,
                       path.node.specifiers,
                       types.stringLiteral(source + '.es.js'),
                     ),

--- a/resources/build.js
+++ b/resources/build.js
@@ -101,6 +101,7 @@ function buildJSFile(filepath) {
   copyFile(srcPath, destPath + '.flow');
   writeFile(destPath, babelBuild(srcPath, 'cjs'));
   writeFile(destPath.replace(/\.js$/, '.mjs'), babelBuild(srcPath, 'mjs'));
+  writeFile(destPath.replace(/\.js$/, '.es.js'), babelBuild(srcPath, 'esm'));
 }
 
 function buildPackageJSON() {

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { forEach, isCollection } from 'iterall';
+import { forEach, isCollection } from '../jsutils/iterall';
 
 import inspect from '../jsutils/inspect';
 import memoize3 from '../jsutils/memoize3';

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ export {
   // Validate GraphQL schema.
   validateSchema,
   assertValidSchema,
-} from './type';
+} from './type/index';
 
 export type {
   GraphQLType,
@@ -168,7 +168,7 @@ export type {
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
-} from './type';
+} from './type/index';
 
 // Parse and operate on GraphQL language source files.
 export {
@@ -204,7 +204,7 @@ export {
   isTypeDefinitionNode,
   isTypeSystemExtensionNode,
   isTypeExtensionNode,
-} from './language';
+} from './language/index';
 
 export type {
   ParseOptions,
@@ -276,7 +276,7 @@ export type {
   UnionTypeExtensionNode,
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
-} from './language';
+} from './language/index';
 
 // Execute GraphQL queries.
 export {
@@ -285,12 +285,12 @@ export {
   defaultTypeResolver,
   responsePathAsArray,
   getDirectiveValues,
-} from './execution';
+} from './execution/index';
 
-export type { ExecutionArgs, ExecutionResult } from './execution';
+export type { ExecutionArgs, ExecutionResult } from './execution/index';
 
-export { subscribe, createSourceEventStream } from './subscription';
-export type { SubscriptionArgs } from './subscription';
+export { subscribe, createSourceEventStream } from './subscription/index';
+export type { SubscriptionArgs } from './subscription/index';
 
 // Validate GraphQL documents.
 export {
@@ -324,9 +324,9 @@ export {
   ValuesOfCorrectTypeRule,
   VariablesAreInputTypesRule,
   VariablesInAllowedPositionRule,
-} from './validation';
+} from './validation/index';
 
-export type { ValidationRule } from './validation';
+export type { ValidationRule } from './validation/index';
 
 // Create, format, and print GraphQL errors.
 export {
@@ -335,9 +335,9 @@ export {
   locatedError,
   printError,
   formatError,
-} from './error';
+} from './error/index';
 
-export type { GraphQLFormattedError } from './error';
+export type { GraphQLFormattedError } from './error/index';
 
 // Utilities for operating on GraphQL type schema and parsed sources.
 export {
@@ -406,7 +406,7 @@ export {
   findDangerousChanges,
   // Report all deprecated usage within a GraphQL document.
   findDeprecatedUsages,
-} from './utilities';
+} from './utilities/index';
 
 export type {
   IntrospectionOptions,
@@ -434,4 +434,4 @@ export type {
   BuildSchemaOptions,
   BreakingChange,
   DangerousChange,
-} from './utilities';
+} from './utilities/index';

--- a/src/jsutils/instanceOf.js
+++ b/src/jsutils/instanceOf.js
@@ -11,7 +11,8 @@ declare function instanceOf(
 
 // See: https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production
 // See: https://webpack.js.org/guides/production/
-export default process.env.NODE_ENV === 'production'
+export default typeof process !== 'undefined' &&
+process.env.NODE_ENV === 'production'
   ? // eslint-disable-next-line no-shadow
     function instanceOf(value: mixed, constructor: mixed) {
       return value instanceof constructor;

--- a/src/jsutils/iterall.js
+++ b/src/jsutils/iterall.js
@@ -1,0 +1,168 @@
+// @flow strict
+
+const SYMBOL = typeof Symbol === 'function' ? Symbol : undefined;
+const SYMBOL_ITERATOR = SYMBOL && SYMBOL.iterator;
+const SYMBOL_ASYNC_ITERATOR = SYMBOL && SYMBOL.asyncIterator;
+
+function AsyncFromSyncIterator(iterator) {
+  this._i = iterator;
+}
+
+AsyncFromSyncIterator.prototype[$$asyncIterator] = function() {
+  return this;
+};
+
+AsyncFromSyncIterator.prototype.next = function() {
+  const step = this._i.next();
+  return Promise.resolve(step.value).then(value => ({
+    value,
+    done: step.done,
+  }));
+};
+
+function ArrayLikeIterator(obj) {
+  this._o = obj;
+  this._i = 0;
+}
+
+ArrayLikeIterator.prototype[$$iterator] = function() {
+  return this;
+};
+
+ArrayLikeIterator.prototype.next = function() {
+  if (this._o === undefined || this._i >= this._o.length) {
+    this._o = undefined;
+    return { value: undefined, done: true };
+  }
+  return { value: this._o[this._i++], done: false };
+};
+
+export const $$iterator = SYMBOL_ITERATOR || '@@iterator';
+
+export function isIterable(obj) {
+  return Boolean(getIteratorMethod(obj));
+}
+
+export function isArrayLike(obj) {
+  const length = obj != null && obj.length;
+  return typeof length === 'number' && length >= 0 && length % 1 === 0;
+}
+
+export function isCollection(obj) {
+  return Object(obj) === obj && (isArrayLike(obj) || isIterable(obj));
+}
+
+export function getIterator(iterable) {
+  const method = getIteratorMethod(iterable);
+  if (method) {
+    return method.call(iterable);
+  }
+}
+
+export function getIteratorMethod(iterable) {
+  if (iterable != null) {
+    const method =
+      (SYMBOL_ITERATOR && iterable[SYMBOL_ITERATOR]) || iterable['@@iterator'];
+    if (typeof method === 'function') {
+      return method;
+    }
+  }
+}
+
+export function createIterator(collection) {
+  if (collection != null) {
+    const iterator = getIterator(collection);
+    if (iterator) {
+      return iterator;
+    }
+    if (isArrayLike(collection)) {
+      return new ArrayLikeIterator(collection);
+    }
+  }
+}
+
+export function forEach(collection, callback, thisArg) {
+  if (collection != null) {
+    if (typeof collection.forEach === 'function') {
+      return collection.forEach(callback, thisArg);
+    }
+    let i = 0;
+    const iterator = getIterator(collection);
+    if (iterator) {
+      let step;
+      while (!(step = iterator.next()).done) {
+        callback.call(thisArg, step.value, i++, collection);
+        if (i > 9999999) {
+          throw new TypeError('Near-infinite iteration.');
+        }
+      }
+    } else if (isArrayLike(collection)) {
+      for (; i < collection.length; i++) {
+        if (Object.prototype.hasOwnProperty.call(collection, i)) {
+          callback.call(thisArg, collection[i], i, collection);
+        }
+      }
+    }
+  }
+}
+
+export const $$asyncIterator = SYMBOL_ASYNC_ITERATOR || '@@asyncIterator';
+
+export const isAsyncIterable = obj => Boolean(getAsyncIteratorMethod(obj));
+
+export const getAsyncIterator = asyncIterable => {
+  const method = getAsyncIteratorMethod(asyncIterable);
+  if (method) {
+    return method.call(asyncIterable);
+  }
+};
+
+export const getAsyncIteratorMethod = asyncIterable => {
+  if (asyncIterable != null) {
+    const method =
+      (SYMBOL_ASYNC_ITERATOR && asyncIterable[SYMBOL_ASYNC_ITERATOR]) ||
+      asyncIterable['@@asyncIterator'];
+    if (typeof method === 'function') {
+      return method;
+    }
+  }
+};
+
+export const createAsyncIterator = source => {
+  if (source != null) {
+    const asyncIterator = getAsyncIterator(source);
+    if (asyncIterator) {
+      return asyncIterator;
+    }
+    const iterator = createIterator(source);
+    if (iterator) {
+      return new AsyncFromSyncIterator(iterator);
+    }
+  }
+};
+
+export const forAwaitEach = (source, callback, thisArg) => {
+  const asyncIterator = createAsyncIterator(source);
+  if (asyncIterator) {
+    let i = 0;
+    return new Promise((resolve, reject) => {
+      function next() {
+        asyncIterator
+          .next()
+          .then(step => {
+            if (!step.done) {
+              Promise.resolve(callback.call(thisArg, step.value, i++, source))
+                .then(next)
+                .catch(reject);
+            } else {
+              resolve();
+            }
+            return null;
+          })
+          .catch(reject);
+        return null;
+      }
+      next();
+    });
+  }
+};

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -1,7 +1,7 @@
 // @flow strict
 
 import type EventEmitter from 'events';
-import { $$asyncIterator } from 'iterall';
+import { $$asyncIterator } from '../../jsutils/iterall';
 
 /**
  * Create an AsyncIterator from an EventEmitter. Useful for mocking a

--- a/src/subscription/asyncIteratorReject.js
+++ b/src/subscription/asyncIteratorReject.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { $$asyncIterator } from 'iterall';
+import { $$asyncIterator } from '../jsutils/iterall';
 
 /**
  * Given an error, returns an AsyncIterable which will fail with that error.

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { $$asyncIterator, getAsyncIterator } from 'iterall';
+import { $$asyncIterator, getAsyncIterator } from '../jsutils/iterall';
 
 import { type PromiseOrValue } from '../jsutils/PromiseOrValue';
 

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { isAsyncIterable } from 'iterall';
+import { isAsyncIterable } from '../jsutils/iterall';
 
 import inspect from '../jsutils/inspect';
 import { addPath, pathToArray } from '../jsutils/Path';

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { forEach, isCollection } from 'iterall';
+import { forEach, isCollection } from '../jsutils/iterall';
 
 import objectValues from '../polyfills/objectValues';
 

--- a/src/utilities/coerceInputValue.js
+++ b/src/utilities/coerceInputValue.js
@@ -1,6 +1,6 @@
 // @flow strict
 
-import { forEach, isCollection } from 'iterall';
+import { forEach, isCollection } from '../jsutils/iterall';
 
 import objectValues from '../polyfills/objectValues';
 


### PR DESCRIPTION
Hey 👋 I'm a big advocate of buildstep-less architectures on the web, taking advantage of ES modules to eschew the need for bundling ([es-react](https://github.com/lukejacksonn/es-react) for example). This PR addresses https://github.com/graphql/graphql-js/issues/1819.

### 💭 Rationale

Recently I wanted to use [urql](https://github.com/formidablelabs/urql) in one of my projects that falls into this build free category. So I set about picking apart the dependencies of the package to see how far it was from being ESM ready. Probably unsurprisingly this package is the biggest dependency of urql so I started with fixing it up and this is what I ended up working with.

### 👨‍🔧 Changes

- https://github.com/graphql/graphql-js/pull/2277/commits/316a69e39d3da3e441b80ec068b0ec07f85616ec Created a new build `esm` with a custom babel extension that appends `.es.js` to import/export statement sources. The differences between this and `mjs` build are subtle but this decision was made as not to disturb any existing builds. Explicit extensions are required according to the browser es module spec (also the most recent node es module spec).
- https://github.com/graphql/graphql-js/pull/2277/commits/8e7cc02775e77c3603049c58115540da2e350d1f Checks `typeof process` in `instanceOf.js` to prevent `Cannot find property .env of undefined` error when running the browser; without altering the node behaviour.
- https://github.com/graphql/graphql-js/pull/2277/commits/d27e528c8912df80c941f7744f30225d65634b9f Vendor'd the `iterall` package to eradicate the only bare specifier import and making the whole codebase dependency free!
- https://github.com/graphql/graphql-js/pull/2277/commits/d7210ecc5cbb361b233f30aeabbc5233242fdcc8 Makes paths in `/index.js` resolvable by extension only (due to `/depencendy.js` and `/dependency/index.js` inconsistency usually handled by nodes resolution algorithm)

### 📦 Output

This PR itself is a POC that I made for myself, I'm not precious about the implementation details but I am quite optimistic about the results.

Here is a published version of this PR: https://www.runpkg.com/?es-graphql@1.0.3/dist/index.es.js
Here is a demo of this build working with urql: https://es-urql.lukejacksonn.now.sh

Running `yarn build && yarn testonly` currently succeeds with no errors but type checking fails due to no definitions for the functions within `iterall.js`. If anyone has suggestions of how to achieve the same result with a different approach to any of the steps outlined by specific commits here, then I am all ears (I am no babel aficionado)!

### 🤔 Conclusion

This library required very few changes in order to make it _just work_ in the browser. I'm almost certain that this would trivialise and encourage gql client library authors to generate es module builds themselves which will lower the barrier to entry for people getting started with GraphQL in general (example projects could now just be an index.html with no install or build process to explain).