### PR TITLE
Update TravisCi to run full CI suite on Node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - '8'
 
 script: |
-  if [[ "$(node -pe process.version)" == v10.* ]]; then # Is latest LTS?
+  if [[ "$(node -pe process.version)" == v12.* ]]; then # Is latest LTS?
     npm run test:ci &&
     bash <(curl -s https://codecov.io/bash) -f coverage/tests/coverage-final.json
   else
@@ -23,7 +23,7 @@ jobs:
       if: type = push AND branch = master
       script: npm run gitpublish
       skip_cleanup: true
-      node_js: '10'
+      node_js: '12'
 
 notifications:
   irc:


### PR DESCRIPTION
Update TravisCi to run the full `test:ci` commands on Node 12, which was promoted to LTS on 2019-10-21 ([source](https://nodejs.org/en/about/releases/)).