### PR TITLE
Remove outdated "Live Feedback" section from CONTRIBUTING.modified

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -61,11 +61,6 @@ Complete your CLA here: <https://code.facebook.com/cla>
    npm test
    ```
 
-### Live Feedback
-
-While actively developing, we recommend running `npm run watch` in a terminal.
-This will watch the file system run any relevant lint, tests, and type checks automatically whenever you save a `.js` file.
-
 ## Coding Style
 
 This project uses [Prettier](https://prettier.io/) for standard formatting. To


### PR DESCRIPTION
The `npm run watch` command was removed in commit c3dd670, making this section no longer valid.