### PR TITLE
Remove forgotten internal error message functions (#2159)

### DIFF
--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -5,8 +5,6 @@ import { describe, it } from 'mocha';
 
 import invariant from '../../jsutils/invariant';
 
-import { missingFieldArgMessage } from '../../validation/rules/ProvidedRequiredArguments';
-
 import { graphqlSync } from '../../graphql';
 import { getIntrospectionQuery } from '../../utilities/getIntrospectionQuery';
 
@@ -1253,7 +1251,8 @@ describe('Introspection', () => {
     expect(graphqlSync(schema, request)).to.deep.equal({
       errors: [
         {
-          message: missingFieldArgMessage('__type', 'name', 'String!'),
+          message:
+            'Field "__type" argument "name" of type "String!" is required, but it was not provided.',
           locations: [{ line: 3, column: 9 }],
         },
       ],

--- a/src/validation/rules/ProvidedRequiredArguments.js
+++ b/src/validation/rules/ProvidedRequiredArguments.js
@@ -17,22 +17,6 @@ import {
   type SDLValidationContext,
 } from '../ValidationContext';
 
-export function missingFieldArgMessage(
-  fieldName: string,
-  argName: string,
-  type: string,
-): string {
-  return `Field "${fieldName}" argument "${argName}" of type "${type}" is required, but it was not provided.`;
-}
-
-export function missingDirectiveArgMessage(
-  directiveName: string,
-  argName: string,
-  type: string,
-): string {
-  return `Directive "@${directiveName}" argument "${argName}" of type "${type}" is required, but it was not provided.`;
-}
-
 /**
  * Provided required arguments
  *

--- a/src/validation/rules/ScalarLeafs.js
+++ b/src/validation/rules/ScalarLeafs.js
@@ -11,20 +11,6 @@ import { getNamedType, isLeafType } from '../../type/definition';
 
 import { type ValidationContext } from '../ValidationContext';
 
-export function noSubselectionAllowedMessage(
-  fieldName: string,
-  type: string,
-): string {
-  return `Field "${fieldName}" must not have a selection since type "${type}" has no subfields.`;
-}
-
-export function requiredSubselectionMessage(
-  fieldName: string,
-  type: string,
-): string {
-  return `Field "${fieldName}" of type "${type}" must have a selection of subfields. Did you mean "${fieldName} { ... }"?`;
-}
-
 /**
  * Scalar leafs
  *

--- a/src/validation/rules/UniqueArgumentNames.js
+++ b/src/validation/rules/UniqueArgumentNames.js
@@ -5,10 +5,6 @@ import { type ASTVisitor } from '../../language/visitor';
 
 import { type ASTValidationContext } from '../ValidationContext';
 
-export function duplicateArgMessage(argName: string): string {
-  return `There can be only one argument named "${argName}".`;
-}
-
 /**
  * Unique argument names
  *

--- a/src/validation/rules/UniqueDirectiveNames.js
+++ b/src/validation/rules/UniqueDirectiveNames.js
@@ -5,14 +5,6 @@ import { type ASTVisitor } from '../../language/visitor';
 
 import { type SDLValidationContext } from '../ValidationContext';
 
-export function duplicateDirectiveNameMessage(directiveName: string): string {
-  return `There can be only one directive named "${directiveName}".`;
-}
-
-export function existedDirectiveNameMessage(directiveName: string): string {
-  return `Directive "${directiveName}" already exists in the schema. It cannot be redefined.`;
-}
-
 /**
  * Unique directive names
  *


### PR DESCRIPTION
In #2519, the internal functions for validation error messages have been removed, but some have been forgotten.