### PR TITLE
Remove duplicate colon in coercion error message

### DIFF
--- a/src/utilities/__tests__/coerceInputValue-test.js
+++ b/src/utilities/__tests__/coerceInputValue-test.js
@@ -380,7 +380,7 @@ describe('coerceInputValue', () => {
       expect(() =>
         coerceInputValue([null], GraphQLList(GraphQLNonNull(GraphQLInt))),
       ).to.throw(
-        'Invalid value null at "value[0]": : Expected non-nullable type "Int!" not to be null.',
+        'Invalid value null at "value[0]": Expected non-nullable type "Int!" not to be null.',
       );
     });
   });

--- a/src/utilities/coerceInputValue.js
+++ b/src/utilities/coerceInputValue.js
@@ -46,7 +46,7 @@ function defaultOnError(
 ) {
   let errorPrefix = 'Invalid value ' + inspect(invalidValue);
   if (path.length > 0) {
-    errorPrefix += ` at "value${printPathArray(path)}": `;
+    errorPrefix += ` at "value${printPathArray(path)}"`;
   }
   error.message = errorPrefix + ': ' + error.message;
   throw error;


### PR DESCRIPTION
Remove a duplicate colon in coercion error messages with path.