### PR TITLE
Makes explicit imports that rely on index file inference

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ export {
   // Validate GraphQL schema.
   validateSchema,
   assertValidSchema,
-} from './type';
+} from './type/index';
 
 export type {
   GraphQLType,
@@ -168,7 +168,7 @@ export type {
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
-} from './type';
+} from './type/index';
 
 // Parse and operate on GraphQL language source files.
 export {
@@ -203,7 +203,7 @@ export {
   isTypeDefinitionNode,
   isTypeSystemExtensionNode,
   isTypeExtensionNode,
-} from './language';
+} from './language/index';
 
 export type {
   ParseOptions,
@@ -275,7 +275,7 @@ export type {
   UnionTypeExtensionNode,
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
-} from './language';
+} from './language/index';
 
 // Execute GraphQL queries.
 export {
@@ -284,12 +284,12 @@ export {
   defaultTypeResolver,
   responsePathAsArray,
   getDirectiveValues,
-} from './execution';
+} from './execution/index';
 
-export type { ExecutionArgs, ExecutionResult } from './execution';
+export type { ExecutionArgs, ExecutionResult } from './execution/index';
 
-export { subscribe, createSourceEventStream } from './subscription';
-export type { SubscriptionArgs } from './subscription';
+export { subscribe, createSourceEventStream } from './subscription/index';
+export type { SubscriptionArgs } from './subscription/index';
 
 // Validate GraphQL documents.
 export {
@@ -323,9 +323,9 @@ export {
   ValuesOfCorrectTypeRule,
   VariablesAreInputTypesRule,
   VariablesInAllowedPositionRule,
-} from './validation';
+} from './validation/index';
 
-export type { ValidationRule } from './validation';
+export type { ValidationRule } from './validation/index';
 
 // Create, format, and print GraphQL errors.
 export {
@@ -334,9 +334,9 @@ export {
   locatedError,
   printError,
   formatError,
-} from './error';
+} from './error/index';
 
-export type { GraphQLFormattedError } from './error';
+export type { GraphQLFormattedError } from './error/index';
 
 // Utilities for operating on GraphQL type schema and parsed sources.
 export {
@@ -406,7 +406,7 @@ export {
   findDangerousChanges,
   // Report all deprecated usage within a GraphQL document.
   findDeprecatedUsages,
-} from './utilities';
+} from './utilities/index';
 
 export type {
   IntrospectionOptions,
@@ -434,4 +434,4 @@ export type {
   BuildSchemaOptions,
   BreakingChange,
   DangerousChange,
-} from './utilities';
+} from './utilities/index';


### PR DESCRIPTION
Partially resolves https://github.com/graphql/graphql-js/pull/2277 in combination with https://github.com/graphql/graphql-js/pull/2364

There are some import paths that rely on the bundler to resolve `./somefolder` to `./somefolder/index.js` at build time. This doesn't play well with the es module spec which demands import paths be complete.

Adding `/index` to these import statements (which only exist in the root `index.js` file) is minimally invasive and has no adverse effects on any of the existing builds but opens the door to a trivial transformation which adds `.es.js` extensions to import paths in order to generate a fully esm compatible build from source.

Since the project became dependency free the only manual edit to the source after this PR (in order to unlock browser esm compatibility) is to remove the [unprotected use of `process.env`](https://github.com/graphql/graphql-js/pull/2277/files#diff-8ae9c199e45f5279dddc0db0fe063462). I could pull in the changes from that commit to this PR or make a separate PR.

After that.. the babel transform ([which exists here](https://github.com/graphql/graphql-js/pull/2277/files#diff-8363ab4678bef8ef4d374bd410e88532)) would be all that is required.