### PR TITLE
Make variableDefinitions not nullable

### DIFF
--- a/src/language/ast.d.ts
+++ b/src/language/ast.d.ts
@@ -220,7 +220,7 @@ export interface OperationDefinitionNode {
   readonly loc?: Location;
   readonly operation: OperationTypeNode;
   readonly name?: NameNode;
-  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
+  readonly variableDefinitions: ReadonlyArray<VariableDefinitionNode>;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
 }
@@ -290,7 +290,7 @@ export interface FragmentDefinitionNode {
   readonly name: NameNode;
   // Note: fragment variable definitions are experimental and may be changed
   // or removed in the future.
-  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
+  readonly variableDefinitions: ReadonlyArray<VariableDefinitionNode>;
   readonly typeCondition: NamedTypeNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;


### PR DESCRIPTION
:sparkles: _**This is an old work account. Please reference @brandonchinn178 for all future communication**_ :sparkles:
<!-- updated by mention_personal_account_in_comments.py -->

---

It seems like `variableDefinitions` will always be a non-null array.

https://github.com/graphql/graphql-js/blob/f07ec241d51d7c3fb0263bb3ade1975dc87babc3/src/language/parser.js#L258-L285
https://github.com/graphql/graphql-js/blob/f07ec241d51d7c3fb0263bb3ade1975dc87babc3/src/language/parser.js#L307