### PR TITLE
schema: Always validate basic config structure

### DIFF
--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -333,24 +333,6 @@ describe('Type System: Schema', () => {
           }).__validationErrors,
         ).to.deep.equal([]);
       });
-
-      it('does not check the configuration for mistakes', () => {
-        const config = [];
-        // $DisableFlowOnNegativeTest
-        config.assumeValid = true;
-        // $DisableFlowOnNegativeTest
-        expect(() => new GraphQLSchema(config)).to.not.throw();
-
-        expect(
-          () =>
-            // $DisableFlowOnNegativeTest
-            new GraphQLSchema({
-              assumeValid: true,
-              types: {},
-              directives: { reduce: () => [] },
-            }),
-        ).to.not.throw();
-      });
     });
   });
 });

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -138,24 +138,19 @@ export class GraphQLSchema {
   constructor(config: $ReadOnly<GraphQLSchemaConfig>): void {
     // If this schema was built from a source known to be valid, then it may be
     // marked with assumeValid to avoid an additional type system validation.
-    if (config.assumeValid === true) {
-      this.__validationErrors = [];
-    } else {
-      this.__validationErrors = undefined;
+    this.__validationErrors = config.assumeValid === true ? [] : undefined;
 
-      // Otherwise check for common mistakes during construction to produce
-      // clear and early error messages.
-      devAssert(isObjectLike(config), 'Must provide configuration object.');
-      devAssert(
-        !config.types || Array.isArray(config.types),
-        `"types" must be Array if provided but got: ${inspect(config.types)}.`,
-      );
-      devAssert(
-        !config.directives || Array.isArray(config.directives),
-        '"directives" must be Array if provided but got: ' +
-          `${inspect(config.directives)}.`,
-      );
-    }
+    // Check for common mistakes during construction to produce early errors.
+    devAssert(isObjectLike(config), 'Must provide configuration object.');
+    devAssert(
+      !config.types || Array.isArray(config.types),
+      `"types" must be Array if provided but got: ${inspect(config.types)}.`,
+    );
+    devAssert(
+      !config.directives || Array.isArray(config.directives),
+      '"directives" must be Array if provided but got: ' +
+        `${inspect(config.directives)}.`,
+    );
 
     this.extensions = config.extensions && toObjMap(config.extensions);
     this.astNode = config.astNode;


### PR DESCRIPTION
It introduces small perfomance penalty but simplify writing code around
GraphQLSchema a lot. Also good long term solution would be to have
separate dev and production (without `devAssert` checks) builds.