### PR TITLE
Checks for existence of process before process.env for esm build

### DIFF
--- a/src/jsutils/instanceOf.js
+++ b/src/jsutils/instanceOf.js
@@ -11,7 +11,8 @@ declare function instanceOf(
 
 // See: https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production
 // See: https://webpack.js.org/guides/production/
-export default process.env.NODE_ENV === 'production'
+export default typeof process === 'undefined' ||
+process.env.NODE_ENV === 'production'
   ? /* istanbul ignore next (See: https://github.com/graphql/graphql-js/issues/2317) */
     // eslint-disable-next-line no-shadow
     function instanceOf(value: mixed, constructor: mixed) {


### PR DESCRIPTION
Related to #2277 specifically https://github.com/graphql/graphql-js/commit/8e7cc02775e77c3603049c58115540da2e350d1f. The last thing required to make this package run in the browser without bundling.

This change will make `instanceOf` choose production mode if:

1. The script is being executed in a browser (the global `process` doesn't exist)
2. The script is being executed in node where `NODE_ENV === 'production'`

I do not know if there is a more webpack specific check required. That is:

3. Is there be a case where it would be expected to choose production mode of `instanceOf` but where  `NODE_ENV  !== 'production'`.