### PR TITLE
validation: Export rules missing in <14.6.0 using legacy names

### DIFF
--- a/src/validation/rules/ExecutableDefinitions.d.ts
+++ b/src/validation/rules/ExecutableDefinitions.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { ExecutableDefinitionsRule } from 'graphql'
+ * or
+ *   import { ExecutableDefinitionsRule } from 'graphql/validation'
+ */
+export { ExecutableDefinitionsRule as ExecutableDefinitions } from './ExecutableDefinitionsRule';

--- a/src/validation/rules/ExecutableDefinitions.js
+++ b/src/validation/rules/ExecutableDefinitions.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { ExecutableDefinitionsRule } from 'graphql'
+ * or
+ *   import { ExecutableDefinitionsRule } from 'graphql/validation'
+ */
+export { ExecutableDefinitionsRule as ExecutableDefinitions } from './ExecutableDefinitionsRule';

--- a/src/validation/rules/LoneSchemaDefinition.d.ts
+++ b/src/validation/rules/LoneSchemaDefinition.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { LoneSchemaDefinitionRule } from 'graphql'
+ * or
+ *   import { LoneSchemaDefinitionRule } from 'graphql/validation'
+ */
+export { LoneSchemaDefinitionRule as LoneSchemaDefinition } from './LoneSchemaDefinitionRule';

--- a/src/validation/rules/LoneSchemaDefinition.js
+++ b/src/validation/rules/LoneSchemaDefinition.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { LoneSchemaDefinitionRule } from 'graphql'
+ * or
+ *   import { LoneSchemaDefinitionRule } from 'graphql/validation'
+ */
+export { LoneSchemaDefinitionRule as LoneSchemaDefinition } from './LoneSchemaDefinitionRule';

--- a/src/validation/rules/PossibleTypeExtensions.d.ts
+++ b/src/validation/rules/PossibleTypeExtensions.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { PossibleTypeExtensionsRule } from 'graphql'
+ * or
+ *   import { PossibleTypeExtensionsRule } from 'graphql/validation'
+ */
+export { PossibleTypeExtensionsRule as PossibleTypeExtensions } from './PossibleTypeExtensionsRule';

--- a/src/validation/rules/PossibleTypeExtensions.js
+++ b/src/validation/rules/PossibleTypeExtensions.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { PossibleTypeExtensionsRule } from 'graphql'
+ * or
+ *   import { PossibleTypeExtensionsRule } from 'graphql/validation'
+ */
+export { PossibleTypeExtensionsRule as PossibleTypeExtensions } from './PossibleTypeExtensionsRule';

--- a/src/validation/rules/UniqueDirectiveNames.d.ts
+++ b/src/validation/rules/UniqueDirectiveNames.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueDirectiveNamesRule } from 'graphql'
+ * or
+ *   import { UniqueDirectiveNamesRule } from 'graphql/validation'
+ */
+export { UniqueDirectiveNamesRule as UniqueDirectiveNames } from './UniqueDirectiveNamesRule';

--- a/src/validation/rules/UniqueDirectiveNames.js
+++ b/src/validation/rules/UniqueDirectiveNames.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueDirectiveNamesRule } from 'graphql'
+ * or
+ *   import { UniqueDirectiveNamesRule } from 'graphql/validation'
+ */
+export { UniqueDirectiveNamesRule as UniqueDirectiveNames } from './UniqueDirectiveNamesRule';

--- a/src/validation/rules/UniqueEnumValueNames.d.ts
+++ b/src/validation/rules/UniqueEnumValueNames.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueEnumValueNamesRule } from 'graphql'
+ * or
+ *   import { UniqueEnumValueNamesRule } from 'graphql/validation'
+ */
+export { UniqueEnumValueNamesRule as UniqueEnumValueNames } from './UniqueEnumValueNamesRule';

--- a/src/validation/rules/UniqueEnumValueNames.js
+++ b/src/validation/rules/UniqueEnumValueNames.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueEnumValueNamesRule } from 'graphql'
+ * or
+ *   import { UniqueEnumValueNamesRule } from 'graphql/validation'
+ */
+export { UniqueEnumValueNamesRule as UniqueEnumValueNames } from './UniqueEnumValueNamesRule';

--- a/src/validation/rules/UniqueFieldDefinitionNames.d.ts
+++ b/src/validation/rules/UniqueFieldDefinitionNames.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueFieldDefinitionNamesRule } from 'graphql'
+ * or
+ *   import { UniqueFieldDefinitionNamesRule } from 'graphql/validation'
+ */
+export { UniqueFieldDefinitionNamesRule as UniqueFieldDefinitionNames } from './UniqueFieldDefinitionNamesRule';

--- a/src/validation/rules/UniqueFieldDefinitionNames.js
+++ b/src/validation/rules/UniqueFieldDefinitionNames.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueFieldDefinitionNamesRule } from 'graphql'
+ * or
+ *   import { UniqueFieldDefinitionNamesRule } from 'graphql/validation'
+ */
+export { UniqueFieldDefinitionNamesRule as UniqueFieldDefinitionNames } from './UniqueFieldDefinitionNamesRule';

--- a/src/validation/rules/UniqueOperationTypes.d.ts
+++ b/src/validation/rules/UniqueOperationTypes.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueOperationTypesRule } from 'graphql'
+ * or
+ *   import { UniqueOperationTypesRule } from 'graphql/validation'
+ */
+export { UniqueOperationTypesRule as UniqueOperationTypes } from './UniqueOperationTypesRule';

--- a/src/validation/rules/UniqueOperationTypes.js
+++ b/src/validation/rules/UniqueOperationTypes.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueOperationTypesRule } from 'graphql'
+ * or
+ *   import { UniqueOperationTypesRule } from 'graphql/validation'
+ */
+export { UniqueOperationTypesRule as UniqueOperationTypes } from './UniqueOperationTypesRule';

--- a/src/validation/rules/UniqueTypeNames.d.ts
+++ b/src/validation/rules/UniqueTypeNames.d.ts
@@ -1,0 +1,8 @@
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueTypeNamesRule } from 'graphql'
+ * or
+ *   import { UniqueTypeNamesRule } from 'graphql/validation'
+ */
+export { UniqueTypeNamesRule as UniqueTypeNames } from './UniqueTypeNamesRule';

--- a/src/validation/rules/UniqueTypeNames.js
+++ b/src/validation/rules/UniqueTypeNames.js
@@ -1,0 +1,10 @@
+// @flow strict
+
+/**
+ * @deprecated and will be removed in v16
+ * Please use either:
+ *   import { UniqueTypeNamesRule } from 'graphql'
+ * or
+ *   import { UniqueTypeNamesRule } from 'graphql/validation'
+ */
+export { UniqueTypeNamesRule as UniqueTypeNames } from './UniqueTypeNamesRule';


### PR DESCRIPTION
It's recommended to update to 14.6.0 and start using correct exports
added in #2400 but if you stuck on the earlier version you could use these
exports as a temporary workaround.
Note: these exports are deprecated and will be removed in v16