### PR TITLE
isValidNameError: Remove node argument

### DIFF
--- a/src/error/locatedError.d.ts
+++ b/src/error/locatedError.d.ts
@@ -1,3 +1,5 @@
+import Maybe from '../tsutils/Maybe';
+
 import { ASTNode } from '../language/ast';
 
 import { GraphQLError } from './GraphQLError';
@@ -9,6 +11,6 @@ import { GraphQLError } from './GraphQLError';
  */
 export function locatedError(
   originalError: Error | GraphQLError,
-  nodes: ReadonlyArray<ASTNode>,
-  path: ReadonlyArray<string | number>,
+  nodes: ASTNode | ReadonlyArray<ASTNode> | undefined,
+  path?: Maybe<ReadonlyArray<string | number>>,
 ): GraphQLError;

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -11,8 +11,8 @@ import { GraphQLError } from './GraphQLError';
  */
 export function locatedError(
   originalError: Error | GraphQLError,
-  nodes: $ReadOnlyArray<ASTNode>,
-  path: $ReadOnlyArray<string | number>,
+  nodes: ASTNode | $ReadOnlyArray<ASTNode> | void | null,
+  path?: ?$ReadOnlyArray<string | number>,
 ): GraphQLError {
   // Note: this uses a brand-check to support GraphQL errors originating from
   // other contexts.

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -7,6 +7,7 @@ import objectValues from '../polyfills/objectValues';
 import inspect from '../jsutils/inspect';
 
 import { GraphQLError } from '../error/GraphQLError';
+import { locatedError } from '../error/locatedError';
 
 import { type ASTNode, type NamedTypeNode } from '../language/ast';
 
@@ -188,9 +189,9 @@ function validateName(
   node: { +name: string, +astNode: ?ASTNode, ... },
 ): void {
   // Ensure names are valid, however introspection types opt out.
-  const error = isValidNameError(node.name, node.astNode ?? undefined);
+  const error = isValidNameError(node.name);
   if (error) {
-    context.addError(error);
+    context.addError(locatedError(error, node.astNode));
   }
 }
 

--- a/src/utilities/assertValidName.d.ts
+++ b/src/utilities/assertValidName.d.ts
@@ -1,5 +1,4 @@
 import { GraphQLError } from '../error/GraphQLError';
-import { ASTNode } from '../language/ast';
 
 /**
  * Upholds the spec rules about naming.
@@ -9,7 +8,4 @@ export function assertValidName(name: string): string;
 /**
  * Returns an Error if a name is invalid.
  */
-export function isValidNameError(
-  name: string,
-  node?: ASTNode | undefined,
-): GraphQLError | undefined;
+export function isValidNameError(name: string): GraphQLError | undefined;

--- a/src/utilities/assertValidName.js
+++ b/src/utilities/assertValidName.js
@@ -3,7 +3,6 @@
 import devAssert from '../jsutils/devAssert';
 
 import { GraphQLError } from '../error/GraphQLError';
-import { type ASTNode } from '../language/ast';
 
 const NAME_RX = /^[_a-zA-Z][_a-zA-Z0-9]*$/;
 
@@ -21,21 +20,16 @@ export function assertValidName(name: string): string {
 /**
  * Returns an Error if a name is invalid.
  */
-export function isValidNameError(
-  name: string,
-  node?: ASTNode | void,
-): GraphQLError | void {
+export function isValidNameError(name: string): GraphQLError | void {
   devAssert(typeof name === 'string', 'Expected name to be a string.');
   if (name.length > 1 && name[0] === '_' && name[1] === '_') {
     return new GraphQLError(
       `Name "${name}" must not begin with "__", which is reserved by GraphQL introspection.`,
-      node,
     );
   }
   if (!NAME_RX.test(name)) {
     return new GraphQLError(
       `Names must match /^[_a-zA-Z][_a-zA-Z0-9]*$/ but "${name}" does not.`,
-      node,
     );
   }
 }


### PR DESCRIPTION
If you want to bind error to node please use `locatedError`:
```
const error = isValidNameError(name);
if (error) {
  someFunction(locatedError(error, node));
}
```