### PR TITLE
NaN values should be checked inside scalar's `serialize` method

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -6,8 +6,6 @@ import inspect from '../jsutils/inspect';
 import memoize3 from '../jsutils/memoize3';
 import invariant from '../jsutils/invariant';
 import devAssert from '../jsutils/devAssert';
-import isInvalid from '../jsutils/isInvalid';
-import isNullish from '../jsutils/isNullish';
 import isPromise from '../jsutils/isPromise';
 import { type ObjMap } from '../jsutils/ObjMap';
 import isObjectLike from '../jsutils/isObjectLike';
@@ -833,8 +831,8 @@ function completeValue(
     return completed;
   }
 
-  // If result value is null-ish (null, undefined, or NaN) then return null.
-  if (isNullish(result)) {
+  // If result value is null or undefined then return null.
+  if (result == null) {
     return null;
   }
 
@@ -940,7 +938,7 @@ function completeListValue(
  */
 function completeLeafValue(returnType: GraphQLLeafType, result: mixed): mixed {
   const serializedResult = returnType.serialize(result);
-  if (isInvalid(serializedResult)) {
+  if (serializedResult === undefined) {
     throw new Error(
       `Expected a value of type "${inspect(returnType)}" but ` +
         `received: ${inspect(result)}`,

--- a/src/jsutils/isInvalid.js
+++ b/src/jsutils/isInvalid.js
@@ -1,8 +1,0 @@
-// @flow strict
-
-/**
- * Returns true if a value is undefined, or NaN.
- */
-export default function isInvalid(value: mixed): boolean %checks {
-  return value === undefined || value !== value;
-}

--- a/src/jsutils/isNullish.js
+++ b/src/jsutils/isNullish.js
@@ -1,8 +1,0 @@
-// @flow strict
-
-/**
- * Returns true if a value is null, undefined, or NaN.
- */
-export default function isNullish(value: mixed): boolean %checks {
-  return value === null || value === undefined || value !== value;
-}

--- a/src/utilities/__tests__/astFromValue-test.js
+++ b/src/utilities/__tests__/astFromValue-test.js
@@ -34,8 +34,6 @@ describe('astFromValue', () => {
 
     expect(astFromValue(undefined, GraphQLBoolean)).to.deep.equal(null);
 
-    expect(astFromValue(NaN, GraphQLInt)).to.deep.equal(null);
-
     expect(astFromValue(null, GraphQLBoolean)).to.deep.equal({
       kind: 'NullValue',
     });
@@ -82,6 +80,10 @@ describe('astFromValue', () => {
     // Note: outside the bounds of 32bit signed int.
     expect(() => astFromValue(1e40, GraphQLInt)).to.throw(
       'Int cannot represent non 32-bit signed integer value: 1e+40',
+    );
+
+    expect(() => astFromValue(NaN, GraphQLInt)).to.throw(
+      'Int cannot represent non-integer value: NaN',
     );
   });
 
@@ -205,7 +207,9 @@ describe('astFromValue', () => {
       value: 'value',
     });
 
-    expect(astFromValue(NaN, passthroughScalar)).to.equal(null);
+    expect(() => astFromValue(NaN, passthroughScalar)).to.throw(
+      'Cannot convert value to AST: NaN.',
+    );
     expect(() => astFromValue(Infinity, passthroughScalar)).to.throw(
       'Cannot convert value to AST: Infinity.',
     );

--- a/src/utilities/__tests__/valueFromASTUntyped-test.js
+++ b/src/utilities/__tests__/valueFromASTUntyped-test.js
@@ -53,6 +53,8 @@ describe('valueFromASTUntyped', () => {
       { a: ['foo'] },
     );
     testCaseWithVars('$testVariable', { testVariable: null }, null);
+    testCaseWithVars('$testVariable', { testVariable: NaN }, NaN);
     testCaseWithVars('$testVariable', {}, undefined);
+    testCaseWithVars('$testVariable', null, undefined);
   });
 });

--- a/src/utilities/astFromValue.js
+++ b/src/utilities/astFromValue.js
@@ -6,8 +6,6 @@ import objectValues from '../polyfills/objectValues';
 
 import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
-import isNullish from '../jsutils/isNullish';
-import isInvalid from '../jsutils/isInvalid';
 import isObjectLike from '../jsutils/isObjectLike';
 import isCollection from '../jsutils/isCollection';
 
@@ -59,8 +57,8 @@ export function astFromValue(value: mixed, type: GraphQLInputType): ?ValueNode {
     return { kind: Kind.NULL };
   }
 
-  // undefined, NaN
-  if (isInvalid(value)) {
+  // undefined
+  if (value === undefined) {
     return null;
   }
 
@@ -107,7 +105,7 @@ export function astFromValue(value: mixed, type: GraphQLInputType): ?ValueNode {
     // Since value is an internally represented value, it must be serialized
     // to an externally represented value before converting into an AST.
     const serialized = type.serialize(value);
-    if (isNullish(serialized)) {
+    if (serialized == null) {
       return null;
     }
 

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -5,7 +5,6 @@ import objectValues from '../polyfills/objectValues';
 import keyMap from '../jsutils/keyMap';
 import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
-import isInvalid from '../jsutils/isInvalid';
 import { type ObjMap } from '../jsutils/ObjMap';
 
 import { Kind } from '../language/kinds';
@@ -52,7 +51,7 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    if (!variables || isInvalid(variables[variableName])) {
+    if (variables == null || variables[variableName] === undefined) {
       // No valid return value.
       return;
     }
@@ -92,7 +91,7 @@ export function valueFromAST(
           coercedValues.push(null);
         } else {
           const itemValue = valueFromAST(itemNode, itemType, variables);
-          if (isInvalid(itemValue)) {
+          if (itemValue === undefined) {
             return; // Invalid: intentionally return no value.
           }
           coercedValues.push(itemValue);
@@ -101,7 +100,7 @@ export function valueFromAST(
       return coercedValues;
     }
     const coercedValue = valueFromAST(valueNode, itemType, variables);
-    if (isInvalid(coercedValue)) {
+    if (coercedValue === undefined) {
       return; // Invalid: intentionally return no value.
     }
     return [coercedValue];
@@ -124,7 +123,7 @@ export function valueFromAST(
         continue;
       }
       const fieldValue = valueFromAST(fieldNode.value, field.type, variables);
-      if (isInvalid(fieldValue)) {
+      if (fieldValue === undefined) {
         return; // Invalid: intentionally return no value.
       }
       coercedObj[field.name] = fieldValue;
@@ -157,6 +156,6 @@ export function valueFromAST(
 function isMissingVariable(valueNode, variables) {
   return (
     valueNode.kind === Kind.VARIABLE &&
-    (!variables || isInvalid(variables[valueNode.name.value]))
+    (variables == null || variables[valueNode.name.value] === undefined)
   );
 }

--- a/src/utilities/valueFromASTUntyped.js
+++ b/src/utilities/valueFromASTUntyped.js
@@ -3,7 +3,6 @@
 import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
-import isInvalid from '../jsutils/isInvalid';
 import { type ObjMap } from '../jsutils/ObjMap';
 
 import { Kind } from '../language/kinds';
@@ -48,12 +47,8 @@ export function valueFromASTUntyped(
         field => field.name.value,
         field => valueFromASTUntyped(field.value, variables),
       );
-    case Kind.VARIABLE: {
-      const variableName = valueNode.name.value;
-      return variables && !isInvalid(variables[variableName])
-        ? variables[variableName]
-        : undefined;
-    }
+    case Kind.VARIABLE:
+      return variables?.[valueNode.name.value];
   }
 
   // Not reachable. All possible value nodes have been considered.

--- a/src/validation/rules/ValuesOfCorrectTypeRule.js
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.js
@@ -4,7 +4,6 @@ import objectValues from '../../polyfills/objectValues';
 
 import keyMap from '../../jsutils/keyMap';
 import inspect from '../../jsutils/inspect';
-import isInvalid from '../../jsutils/isInvalid';
 import didYouMean from '../../jsutils/didYouMean';
 import suggestionList from '../../jsutils/suggestionList';
 
@@ -130,7 +129,7 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // may throw or return an invalid value to indicate failure.
   try {
     const parseResult = type.parseLiteral(node, undefined /* variables */);
-    if (isInvalid(parseResult)) {
+    if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(
         new GraphQLError(


### PR DESCRIPTION
We shouldn't have special casing for NaN since it masks programmer mistakes.
Also it makes it imposible to implement custom scalar that can encode NaN.