### PR TITLE
Adapt some comments after serialization of enums changed

### DIFF
--- a/src/utilities/coerceInputValue.js
+++ b/src/utilities/coerceInputValue.js
@@ -151,9 +151,9 @@ function coerceInputValueImpl(
   if (isLeafType(type)) {
     let parseResult;
 
-    // Scalars determine if a input value is valid via parseValue(), which can
-    // throw to indicate failure. If it throws, maintain a reference to
-    // the original error.
+    // Scalars and Enums determine if a input value is valid via parseValue(),
+    // which can throw to indicate failure. If it throws, maintain a reference
+    // to the original error.
     try {
       parseResult = type.parseValue(inputValue);
     } catch (error) {

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -132,7 +132,7 @@ export function valueFromAST(
   }
 
   if (isLeafType(type)) {
-    // Scalars fulfill parsing a literal value via parseLiteral().
+    // Scalars and Enums fulfill parsing a literal value via parseLiteral().
     // Invalid values represent a failure to parse correctly, in which case
     // no value is returned.
     let result;

--- a/src/validation/rules/ValuesOfCorrectTypeRule.js
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.js
@@ -125,8 +125,8 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
     return;
   }
 
-  // Scalars determine if a literal value is valid via parseLiteral() which
-  // may throw or return an invalid value to indicate failure.
+  // Scalars and Enums determine if a literal value is valid via parseLiteral(),
+  // which may throw or return an invalid value to indicate failure.
   try {
     const parseResult = type.parseLiteral(node, undefined /* variables */);
     if (parseResult === undefined) {


### PR DESCRIPTION
Adapt comments for code which is now also used for enums, not only scalars (change in 15.0.0-rc.1).