### PR TITLE
fix: use babel-plugin-transform-require-extensions

### DIFF
--- a/.babelrc.json
+++ b/.babelrc.json
@@ -2,7 +2,8 @@
   "presets": [["@babel/preset-env", { "targets": { "node": "current" } }]],
   "plugins": [
     "./resources/inline-invariant",
-    "@babel/plugin-transform-flow-strip-types"
+    "@babel/plugin-transform-flow-strip-types",
+    "transform-require-extensions"
   ],
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "@babel/core": "7.8.4",
     "@babel/plugin-transform-flow-strip-types": "7.8.3",
+    "babel-plugin-transform-require-extensions": "^2.0.0",
     "@babel/preset-env": "7.8.4",
     "@babel/register": "7.8.3",
     "@typescript-eslint/eslint-plugin": "2.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,6 +1001,11 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-transform-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-require-extensions/-/babel-plugin-transform-require-extensions-2.0.0.tgz#29334575890d4a597726de2879f350834a945b9a"
+  integrity sha512-9Iqalv5LGLCV9D9UhoW3vLveb21ex6NL/gHpluAbJoQcSuSZax29D01DUKWByoC2PZhIrfS9M0U21eJPMg7SKA==
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"


### PR DESCRIPTION
use _babel-plugin-transform-require-extensions_ to generate fully qualified (with file name extension) imports