### PR TITLE
ESLint: move custom rule into CLI argument

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,8 +10,6 @@ plugins:
   - import
 
 rules:
-  no-dir-import: error
-
   ##############################################################################
   # `eslint-plugin-flowtype` rule list based on `v4.6.x`
   # https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ci": "yarn check --integrity && npm run prettier:check && npm run lint -- --no-cache && npm run check && npm run testonly:cover && npm run check:ts && npm run check:spelling && npm run build",
     "testonly": "mocha --full-trace src/**/__tests__/**/*-test.js",
     "testonly:cover": "nyc npm run testonly",
-    "lint": "eslint --rulesdir './resources/eslint-rules' --cache --ext .js,.ts src resources",
+    "lint": "eslint --rulesdir './resources/eslint-rules' --rule 'no-dir-import: error' --cache --ext .js,.ts src resources",
     "benchmark": "node --noconcurrent_sweeping --expose-gc --predictable ./resources/benchmark.js",
     "prettier": "prettier --ignore-path .gitignore --write --list-different \"**/*.{js,ts,md,json,yml}\"",
     "prettier:check": "prettier --ignore-path .gitignore --check \"**/*.{js,ts,md,json,yml}\"",


### PR DESCRIPTION
AFAIK, the are no way to specify `rulesdir` inside '.eslintrc' config
because of that IDE can't run ESLint with default CLI options