### PR TITLE
Docs: fix spelling error in src/README.md

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -17,7 +17,7 @@ Each sub directory within is a sub-module of graphql-js:
   fulfilling a GraphQL result.
 - [`graphql/execution`](execution/README.md): The Execution phase of fulfilling
   a GraphQL request.
-- [`graphql/error`](error/README.md): Creating and formating GraphQL errors.
+- [`graphql/error`](error/README.md): Creating and formatting GraphQL errors.
 - [`graphql/utilities`](utilities/README.md): Common useful computations upon
   the GraphQL language and type objects.
 - [`graphql/subscription`](subscription/README.md): Subscribe to data updates.


### PR DESCRIPTION
The tests failed locally because of a mistype :)