### PR TITLE
schema: fix error message when provided type has no name

### DIFF
--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -357,6 +357,19 @@ describe('Type System: Schema', () => {
         );
       });
 
+      it('rejects a Schema when a provided type has no name', () => {
+        const query = new GraphQLObjectType({
+          name: 'Query',
+          fields: { foo: { type: GraphQLString } },
+        });
+        const types = [{}, query, {}];
+
+        // $DisableFlowOnNegativeTest
+        expect(() => new GraphQLSchema({ query, types })).to.throw(
+          'One of the provided types for building the Schema is missing a name.',
+        );
+      });
+
       it('rejects a Schema which defines an object type twice', () => {
         const types = [
           new GraphQLObjectType({ name: 'SameName', fields: {} }),

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -213,6 +213,11 @@ export class GraphQLSchema {
       }
 
       const typeName = namedType.name;
+      if (!typeName) {
+        throw new Error(
+          'One of the provided types for building the Schema is missing a name.',
+        );
+      }
       if (this._typeMap[typeName] !== undefined) {
         throw new Error(
           `Schema must contain uniquely named types but contains multiple types named "${typeName}".`,

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -213,11 +213,10 @@ export class GraphQLSchema {
       }
 
       const typeName = namedType.name;
-      if (!typeName) {
-        throw new Error(
-          'One of the provided types for building the Schema is missing a name.',
-        );
-      }
+      devAssert(
+        typeName,
+        'One of the provided types for building the Schema is missing a name.',
+      );
       if (this._typeMap[typeName] !== undefined) {
         throw new Error(
           `Schema must contain uniquely named types but contains multiple types named "${typeName}".`,


### PR DESCRIPTION
Small fix to show an error message when one provided type has no name and to avoid error messages like "multiple types named undefined" when multiple provided types have no name.