### PR TITLE
chore(jsutils): improved didYouMean to handle more edge cases

### DIFF
--- a/src/jsutils/__tests__/didYouMean-test.js
+++ b/src/jsutils/__tests__/didYouMean-test.js
@@ -35,4 +35,27 @@ describe('didYouMean', () => {
       ' Did you mean the letter "A"?',
     );
   });
+  // Test for handling Duplications
+  it('Handle duplicates, resulting in single unique element', () => {
+    expect(didYouMean(['A', 'A'])).to.equal(' Did you mean "A"?');
+  });
+  it('Handle duplicates, resulting in two elements', () => {
+    expect(didYouMean(['A', 'B', 'A', 'B'])).to.equal(
+      ' Did you mean "A" or "B"?',
+    );
+  });
+  it('Handle duplicates, resulting in more thentwo elements', () => {
+    expect(didYouMean(['A', 'B', 'C', 'C', 'B', 'A'])).to.equal(
+      ' Did you mean "A", "B", or "C"?',
+    );
+  });
+  // Test for filtering null, undefined, NaN...
+  it('should filter the broken values', () => {
+    expect(didYouMean(['A', 'B', 'C', 'C', undefined, null])).to.equal(
+      ' Did you mean "A", "B", or "C"?',
+    );
+  });
+  it('Does accept an empty list', () => {
+    expect(didYouMean([null, undefined, NaN])).to.equal('');
+  });
 });

--- a/src/jsutils/didYouMean.js
+++ b/src/jsutils/didYouMean.js
@@ -19,12 +19,16 @@ export default function didYouMean(firstArg, secondArg) {
       ? [firstArg, secondArg]
       : [undefined, firstArg];
 
+  const suggestionsArgFromSet = Array.from(new Set(suggestionsArg)).filter(
+    x => x,
+  );
+  console.log({ suggestionsArgFromSet });
   let message = ' Did you mean ';
   if (subMessage) {
     message += subMessage + ' ';
   }
 
-  const suggestions = suggestionsArg.map(x => `"${x}"`);
+  const suggestions = suggestionsArgFromSet.map(x => `"${x}"`);
   switch (suggestions.length) {
     case 0:
       return '';


### PR DESCRIPTION
### Description
Better edge cases handling for the `jsutils/didYouMean`. 

- Handling duplication
- Handling broken values like (`undefined`, `null`, `NaN`)

### Current behaviour
As of now, the module is not able to handle any duplicated values in the `Array`.
Similarly, if it encounters `undefined`, `null` etc then it converts it to the string "undefined", "null".

### Approach
I tried creating a new `Set` from the given `Array`, then finally filtering it in order to eliminate the broken or garbage values.

- [x] Tests Added

