### PR TITLE
Make it work with Node ESModules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "module": "index.mjs",
   "types": "index.d.ts",
   "sideEffects": false,
+  "exports": {
+    "require": "index.js",
+    "default": "index.mjs"
+  },
   "homepage": "https://github.com/graphql/graphql-js",
   "bugs": {
     "url": "https://github.com/graphql/graphql-js/issues"


### PR DESCRIPTION
A missing piece to run `graphql` with Node's experimental ecmascript modules.