### PR TITLE
TS: remove TS-specific TData from ExecutionResult

### DIFF
--- a/src/execution/execute.d.ts
+++ b/src/execution/execute.d.ts
@@ -37,20 +37,15 @@ export interface ExecutionContext {
   errors: Array<GraphQLError>;
 }
 
-export interface ExecutionResultDataDefault {
-  [key: string]: any;
-}
-
 /**
  * The result of GraphQL execution.
  *
  *   - `errors` is included when any errors occurred as a non-empty array.
  *   - `data` is the result of a successful execution of the query.
  */
-// TS_SPECIFIC: TData and ExecutionResultDataDefault
-export interface ExecutionResult<TData = ExecutionResultDataDefault> {
+export interface ExecutionResult {
   errors?: ReadonlyArray<GraphQLError>;
-  data?: TData | null;
+  data?: { [key: string]: any } | null;
 }
 
 export type ExecutionArgs = {
@@ -76,10 +71,8 @@ export type ExecutionArgs = {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function execute<TData = ExecutionResultDataDefault>(
-  args: ExecutionArgs,
-): PromiseOrValue<ExecutionResult<TData>>;
-export function execute<TData = ExecutionResultDataDefault>(
+export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult>;
+export function execute(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
@@ -88,7 +81,7 @@ export function execute<TData = ExecutionResultDataDefault>(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>,
-): PromiseOrValue<ExecutionResult<TData>>;
+): PromiseOrValue<ExecutionResult>;
 
 /**
  * Essential assertions before executing to provide developer feedback for

--- a/src/graphql.d.ts
+++ b/src/graphql.d.ts
@@ -2,10 +2,7 @@ import Maybe from './tsutils/Maybe';
 import { Source } from './language/source';
 import { GraphQLSchema } from './type/schema';
 import { GraphQLFieldResolver, GraphQLTypeResolver } from './type/definition';
-import {
-  ExecutionResult,
-  ExecutionResultDataDefault,
-} from './execution/execute';
+import { ExecutionResult } from './execution/execute';
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
@@ -53,10 +50,8 @@ export interface GraphQLArgs {
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
 }
 
-export function graphql<TData = ExecutionResultDataDefault>(
-  args: GraphQLArgs,
-): Promise<ExecutionResult<TData>>;
-export function graphql<TData = ExecutionResultDataDefault>(
+export function graphql(args: GraphQLArgs): Promise<ExecutionResult>;
+export function graphql(
   schema: GraphQLSchema,
   source: Source | string,
   rootValue?: any,
@@ -65,7 +60,7 @@ export function graphql<TData = ExecutionResultDataDefault>(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>,
-): Promise<ExecutionResult<TData>>;
+): Promise<ExecutionResult>;
 
 /**
  * The graphqlSync function also fulfills GraphQL operations by parsing,
@@ -73,10 +68,8 @@ export function graphql<TData = ExecutionResultDataDefault>(
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
-export function graphqlSync<TData = ExecutionResultDataDefault>(
-  args: GraphQLArgs,
-): ExecutionResult<TData>;
-export function graphqlSync<TData = ExecutionResultDataDefault>(
+export function graphqlSync(args: GraphQLArgs): ExecutionResult;
+export function graphqlSync(
   schema: GraphQLSchema,
   source: Source | string,
   rootValue?: any,
@@ -85,4 +78,4 @@ export function graphqlSync<TData = ExecutionResultDataDefault>(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>,
-): ExecutionResult<TData>;
+): ExecutionResult;

--- a/src/subscription/subscribe.d.ts
+++ b/src/subscription/subscribe.d.ts
@@ -1,9 +1,6 @@
 import Maybe from '../tsutils/Maybe';
 import { DocumentNode } from '../language/ast';
-import {
-  ExecutionResult,
-  ExecutionResultDataDefault,
-} from '../execution/execute';
+import { ExecutionResult } from '../execution/execute';
 import { GraphQLSchema } from '../type/schema';
 import { GraphQLFieldResolver } from '../type/definition';
 
@@ -38,13 +35,11 @@ export interface SubscriptionArgs {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function subscribe<TData = ExecutionResultDataDefault>(
+export function subscribe(
   args: SubscriptionArgs,
-): Promise<
-  AsyncIterableIterator<ExecutionResult<TData>> | ExecutionResult<TData>
->;
+): Promise<AsyncIterableIterator<ExecutionResult> | ExecutionResult>;
 
-export function subscribe<TData = ExecutionResultDataDefault>(
+export function subscribe(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
@@ -53,9 +48,7 @@ export function subscribe<TData = ExecutionResultDataDefault>(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
-): Promise<
-  AsyncIterableIterator<ExecutionResult<TData>> | ExecutionResult<TData>
->;
+): Promise<AsyncIterableIterator<ExecutionResult> | ExecutionResult>;
 
 /**
  * Implements the "CreateSourceEventStream" algorithm described in the
@@ -75,7 +68,7 @@ export function subscribe<TData = ExecutionResultDataDefault>(
  * or otherwise separating these two steps. For more on this, see the
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
  */
-export function createSourceEventStream<TData = ExecutionResultDataDefault>(
+export function createSourceEventStream(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
@@ -83,4 +76,4 @@ export function createSourceEventStream<TData = ExecutionResultDataDefault>(
   variableValues?: { [key: string]: any },
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
-): Promise<AsyncIterable<any> | ExecutionResult<TData>>;
+): Promise<AsyncIterable<any> | ExecutionResult>;


### PR DESCRIPTION
Reverts https://github.com/DefinitelyTyped/DefinitelyTyped/pull/26763
Since we can't gurantee that response match types it was basically
glorified type cast.