### PR TITLE
DRY in subscribe-test

### DIFF
--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -505,24 +505,9 @@ describe('Subscription Initialization Phase', () => {
     // If we receive variables that cannot be coerced correctly, subscribe()
     // will resolve to an ExecutionResult that contains an informative error
     // description.
-    const ast = parse(`
-      subscription ($priority: Int) {
-        importantEmail(priority: $priority) {
-          email {
-            from
-            subject
-          }
-          inbox {
-            unread
-            total
-          }
-        }
-      }
-    `);
-
     const result = await subscribe({
       schema: emailSchema,
-      document: ast,
+      document: defaultSubscriptionAST,
       variableValues: { priority: 'meow' },
     });
 
@@ -531,7 +516,7 @@ describe('Subscription Initialization Phase', () => {
         {
           message:
             'Variable "$priority" got invalid value "meow"; Int cannot represent non-integer value: "meow"',
-          locations: [{ line: 2, column: 21 }],
+          locations: [{ line: 2, column: 17 }],
         },
       ],
     });


### PR DESCRIPTION
This removes a basically-redundant bespoke subscription request, and uses the "default" one instead because it is functionally identical to the bespoke one.

Also uses constant to suck out all the repetition in the data, which helps understanding by the poor limited people like me! (1110 lines -> 892 lines)