### PR TITLE
Type: Improve grapqhl scalar type functions

### DIFF
--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -313,11 +313,11 @@ export class GraphQLScalarType {
   inspect(): string;
 }
 
-export type GraphQLScalarSerializer<TExternal> = (
-  value: any,
+export type GraphQLScalarSerializer<TExternal, TInternal = any> = (
+  value: TInternal,
 ) => Maybe<TExternal>;
-export type GraphQLScalarValueParser<TInternal> = (
-  value: any,
+export type GraphQLScalarValueParser<TInternal, TExternal = any> = (
+  value: TExternal,
 ) => Maybe<TInternal>;
 export type GraphQLScalarLiteralParser<TInternal> = (
   valueNode: ValueNode,
@@ -328,9 +328,9 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   name: string;
   description?: Maybe<string>;
   // Serializes an internal value to include in a response.
-  serialize: GraphQLScalarSerializer<TExternal>;
+  serialize: GraphQLScalarSerializer<TExternal, TInternal>;
   // Parses an externally provided value to use as an input.
-  parseValue?: GraphQLScalarValueParser<TInternal>;
+  parseValue?: GraphQLScalarValueParser<TInternal, TExternal>;
   // Parses an externally provided literal value to use as an input.
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>;
   extensions?: Maybe<Readonly<Record<string, any>>>;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -634,12 +634,12 @@ export class GraphQLScalarType {
 
 defineToJSON(GraphQLScalarType);
 
-export type GraphQLScalarSerializer<TExternal> = (
-  outputValue: mixed,
+export type GraphQLScalarSerializer<TExternal, TInternal = mixed> = (
+  outputValue: TInternal,
 ) => ?TExternal;
 
-export type GraphQLScalarValueParser<TInternal> = (
-  inputValue: mixed,
+export type GraphQLScalarValueParser<TInternal, TExternal = mixed> = (
+  inputValue: TExternal,
 ) => ?TInternal;
 
 export type GraphQLScalarLiteralParser<TInternal> = (
@@ -651,9 +651,9 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   name: string,
   description?: ?string,
   // Serializes an internal value to include in a response.
-  serialize?: GraphQLScalarSerializer<TExternal>,
+  serialize?: GraphQLScalarSerializer<TExternal, TInternal>,
   // Parses an externally provided value to use as an input.
-  parseValue?: GraphQLScalarValueParser<TInternal>,
+  parseValue?: GraphQLScalarValueParser<TInternal, TExternal>,
   // Parses an externally provided literal value to use as an input.
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>,
   extensions?: ?ReadOnlyObjMapLike<mixed>,


### PR DESCRIPTION
This PR improves the type definition of `GraphQLScalarSerializer` and `GraphQLScalarValueParser`.
 For backward compatibility, those second generic parameter have default type.