### PR TITLE
Fix #2504 access field astNode's type by optional chaining

### DIFF
--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -355,7 +355,7 @@ function validateTypeImplementsInterface(
         `Interface field ${iface.name}.${fieldName} expects type ` +
           `${inspect(ifaceField.type)} but ${type.name}.${fieldName} ` +
           `is type ${inspect(typeField.type)}.`,
-        [ifaceField.astNode.type, typeField.astNode.type],
+        [ifaceField.astNode?.type, typeField.astNode?.type],
       );
     }
 
@@ -382,7 +382,7 @@ function validateTypeImplementsInterface(
             `expects type ${inspect(ifaceArg.type)} but ` +
             `${type.name}.${fieldName}(${argName}:) is type ` +
             `${inspect(typeArg.type)}.`,
-          [ifaceArg.astNode.type, typeArg.astNode.type],
+          [ifaceArg.astNode?.type, typeArg.astNode?.type],
         );
       }
 


### PR DESCRIPTION
This is to fix #2504 regression that throws `TypeError` not normal `GraphQLError` when running `validateTypeImplementsInterface` if `astNode` is not provided to `GraphQLType`