### PR TITLE
add opportunity to set path to object fields value

### DIFF
--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -304,6 +304,20 @@ describe('Type System: Objects', () => {
     expect(() => objType.getFields()).to.not.throw();
   });
 
+  it('accepts a object with custom path to fields', () => {
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        f: {
+          type: ScalarType,
+          resolve: dummyFunc,
+        },
+      },
+      objectValueFieldsPath: 'data',
+    });
+    expect(() => objType.getFields()).to.not.throw();
+  });
+
   it('rejects an Object type without name', () => {
     // $DisableFlowOnNegativeTest
     expect(() => new GraphQLObjectType({})).to.throw('Must provide name.');

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -382,6 +382,7 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
   extensions: Maybe<Readonly<Record<string, any>>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
+  objectValueFieldsPath: Maybe<string>;
 
   constructor(config: Readonly<GraphQLObjectTypeConfig<TSource, TContext>>);
 
@@ -391,6 +392,7 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
   toConfig(): GraphQLObjectTypeConfig<any, any> & {
     interfaces: Array<GraphQLInterfaceType>;
     fields: GraphQLFieldConfigMap<any, any>;
+    objectValueFieldsPath: Maybe<string>;
     extensions: Maybe<Readonly<Record<string, any>>>;
     extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
   };
@@ -409,6 +411,7 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
   description?: Maybe<string>;
   interfaces?: Thunk<Maybe<Array<GraphQLInterfaceType>>>;
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>;
+  objectValueFieldsPath: Maybe<string>;
   isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
   extensions?: Maybe<Readonly<Record<string, any>>>;
   astNode?: Maybe<ObjectTypeDefinitionNode>;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -705,6 +705,7 @@ export class GraphQLObjectType {
   extensions: ?ReadOnlyObjMap<mixed>;
   astNode: ?ObjectTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ObjectTypeExtensionNode>;
+  objectValueFieldsPath: ?string;
 
   _fields: Thunk<GraphQLFieldMap<any, any>>;
   _interfaces: Thunk<Array<GraphQLInterfaceType>>;
@@ -716,6 +717,7 @@ export class GraphQLObjectType {
     this.extensions = config.extensions && toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);
+    this.objectValueFieldsPath = config.objectValueFieldsPath;
 
     this._fields = defineFieldMap.bind(undefined, config);
     this._interfaces = defineInterfaces.bind(undefined, config);
@@ -745,6 +747,7 @@ export class GraphQLObjectType {
     ...GraphQLObjectTypeConfig<any, any>,
     interfaces: Array<GraphQLInterfaceType>,
     fields: GraphQLFieldConfigMap<any, any>,
+    objectValueFieldsPath: ?string,
     extensions: ?ReadOnlyObjMap<mixed>,
     extensionASTNodes: $ReadOnlyArray<ObjectTypeExtensionNode>,
   |} {
@@ -753,6 +756,7 @@ export class GraphQLObjectType {
       description: this.description,
       interfaces: this.getInterfaces(),
       fields: fieldsToFieldsConfig(this.getFields()),
+      objectValueFieldsPath: this.objectValueFieldsPath,
       isTypeOf: this.isTypeOf,
       extensions: this.extensions,
       astNode: this.astNode,
@@ -884,6 +888,7 @@ export type GraphQLObjectTypeConfig<TSource, TContext> = {|
   description?: ?string,
   interfaces?: Thunk<?Array<GraphQLInterfaceType>>,
   fields: Thunk<GraphQLFieldConfigMap<TSource, TContext>>,
+  objectValueFieldsPath?: ?string,
   isTypeOf?: ?GraphQLIsTypeOfFn<TSource, TContext>,
   extensions?: ?ReadOnlyObjMapLike<mixed>,
   astNode?: ?ObjectTypeDefinitionNode,


### PR DESCRIPTION
Related issue: https://github.com/graphql/graphql-js/issues/2510

I've added simple string config fields which optionally can be passed to graphql object type.

It this field is provided - in process of object value competing  fields values will be taken not from provided to graphql value, but from internal object field.

P.S.
I wanted to add test for this behaviour, but I didn' found corresponding section in tests (If you want tests - give me advise, please)
