### PR TITLE
remove unneeded flow disable

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -1,8 +1,5 @@
 // @flow strict
 
-// FIXME:
-// flowlint uninitialized-instance-property:off
-
 import isObjectLike from '../jsutils/isObjectLike';
 import { SYMBOL_TO_STRING_TAG } from '../polyfills/symbols';
 


### PR DESCRIPTION
This `flowlint` disable is not doing anything, causing problems in downstream libraries with stricter flow settings.