### PR TITLE
Add better error message for extension with descriptions

### DIFF
--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -333,7 +333,8 @@ describe('Schema Parser', () => {
         world: String
       }
     `).to.deep.equal({
-      message: 'Syntax Error: Unexpected Name "extend".',
+      message:
+        'Syntax Error: Unexpected Name "extend". Extension do not include descriptions.',
       locations: [{ line: 3, column: 7 }],
     });
 
@@ -354,7 +355,8 @@ describe('Schema Parser', () => {
         world: String
       }
     `).to.deep.equal({
-      message: 'Syntax Error: Unexpected Name "extend".',
+      message:
+        'Syntax Error: Unexpected Name "extend". Extension do not include descriptions.',
       locations: [{ line: 3, column: 7 }],
     });
 

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -725,7 +725,8 @@ class Parser {
    */
   parseTypeSystemDefinition(): TypeSystemDefinitionNode {
     // Many definitions begin with a description and require a lookahead.
-    const keywordToken = this.peekDescription()
+    const hasDescription = this.peekDescription();
+    const keywordToken = hasDescription
       ? this._lexer.lookahead()
       : this._lexer.token;
 
@@ -748,6 +749,14 @@ class Parser {
         case 'directive':
           return this.parseDirectiveDefinition();
       }
+    }
+
+    if (hasDescription && keywordToken.value === 'extend') {
+      throw syntaxError(
+        this._lexer.source,
+        keywordToken.start,
+        'Unexpected Name "extend". Extension do not include descriptions.',
+      );
     }
 
     throw this.unexpected(keywordToken);


### PR DESCRIPTION
fixes #2385 

This PR adds a detailed error message for when description is used with extensions, it being not allowed. Please suggested better error message if required.