### PR TITLE
Print only required BlockStrings

### DIFF
--- a/src/language/__tests__/blockString-fuzz.js
+++ b/src/language/__tests__/blockString-fuzz.js
@@ -10,7 +10,11 @@ import invariant from '../../jsutils/invariant';
 
 import { Lexer } from '../lexer';
 import { Source } from '../source';
-import { printBlockString } from '../blockString';
+import {
+  printBlockString,
+  isPrintableBlockString,
+  isBlank,
+} from '../blockString';
 
 function lexValue(str) {
   const lexer = new Lexer(new Source(str));
@@ -63,6 +67,80 @@ describe('printBlockString', () => {
             but got  ${inspectStr(printedMultilineString)}
         `,
       );
+    }
+  }).timeout(20000);
+});
+
+describe('isPrintableBlockString', () => {
+  it('correctly tells if random strings are printable block string', () => {
+    // Testing with length >7 is taking exponentially more time. However it is
+    // highly recommended to test with increased limit if you make any change.
+    for (const fuzzStr of genFuzzStrings({
+      allowedChars: ['\n', '\t', ' ', '"', 'a', '\\'],
+      maxLength: 7,
+    })) {
+      if (isPrintableBlockString(fuzzStr)) {
+        const testStr = '"""' + fuzzStr + '"""';
+
+        let testValue;
+        try {
+          testValue = lexValue(testStr);
+        } catch (e) {
+          continue; // skip invalid values
+        }
+        invariant(typeof testValue === 'string');
+
+        const printedValue = lexValue(printBlockString(testValue));
+
+        invariant(
+          testValue === printedValue,
+          dedent`
+          Expected lexValue(printBlockString(${inspectStr(testValue)}))
+            to equal ${inspectStr(testValue)}
+            but got  ${inspectStr(printedValue)}
+        `,
+        );
+
+        const printedMultilineString = lexValue(
+          printBlockString(testValue, ' ', true),
+        );
+
+        invariant(
+          testValue === printedMultilineString,
+          dedent`
+          Expected lexValue(printBlockString(${inspectStr(
+            testValue,
+          )}, ' ', true))
+            to equal ${inspectStr(testValue)}
+            but got  ${inspectStr(printedMultilineString)}
+        `,
+        );
+      } else {
+        if (isBlank(fuzzStr)) {
+          continue;
+        }
+        const printedValue = lexValue(printBlockString(fuzzStr));
+
+        invariant(
+          fuzzStr !== printedValue,
+          dedent`
+          Expected lexValue(printBlockString(${inspectStr(fuzzStr)}))
+            not to equal ${inspectStr(fuzzStr)}
+        `,
+        );
+
+        const printedMultilineString = lexValue(
+          printBlockString(fuzzStr, ' ', true),
+        );
+
+        invariant(
+          fuzzStr !== printedMultilineString,
+          dedent`
+          Expected lexValue(printBlockString(${inspectStr(fuzzStr)}, ' ', true))
+            not to equal ${inspectStr(fuzzStr)}
+        `,
+        );
+      }
     }
   }).timeout(20000);
 });

--- a/src/language/blockString.js
+++ b/src/language/blockString.js
@@ -66,8 +66,12 @@ function leadingWhitespace(str) {
   return i;
 }
 
-function isBlank(str) {
+export function isBlank(str: string): boolean {
   return leadingWhitespace(str) === str.length;
+}
+
+export function isPrintableBlockString(str: string): boolean {
+  return Boolean(dedentBlockStringValue(str));
 }
 
 /**

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -2,7 +2,7 @@
 
 import { visit } from './visitor';
 import { type ASTNode } from './ast';
-import { printBlockString } from './blockString';
+import { printBlockString, isPrintableBlockString } from './blockString';
 
 /**
  * Converts an AST into a string, using one set of reasonable
@@ -84,7 +84,9 @@ const printDocASTReducer: any = {
   FloatValue: ({ value }) => value,
   StringValue: ({ value, block: isBlockString }, key) =>
     isBlockString
-      ? printBlockString(value, key === 'description' ? '' : '  ')
+      ? isPrintableBlockString(value)
+        ? printBlockString(value, key === 'description' ? '' : '  ')
+        : ''
       : JSON.stringify(value),
   BooleanValue: ({ value }) => (value ? 'true' : 'false'),
   NullValue: () => 'null',


### PR DESCRIPTION
fixes: https://github.com/graphql/graphql-js/issues/2577

Currently `printSchema` uses block strings for all descriptions. This PR add a check if the given string is printable block string, otherwise don't print it.