### PR TITLE
Exported `Token` and `Location` as ES6 classes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -172,7 +172,9 @@ export {
 
 // Parse and operate on GraphQL language source files.
 export {
+  Token,
   Source,
+  Location,
   getLocation,
   // Print source location
   printLocation,
@@ -208,8 +210,6 @@ export {
 export {
   ParseOptions,
   SourceLocation,
-  Location,
-  Token,
   TokenKindEnum,
   KindEnum,
   DirectiveLocationEnum,

--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,9 @@ export type {
 
 // Parse and operate on GraphQL language source files.
 export {
+  Token,
   Source,
+  Location,
   getLocation,
   // Print source location
   printLocation,
@@ -209,8 +211,6 @@ export {
 export type {
   ParseOptions,
   SourceLocation,
-  Location,
-  Token,
   TokenKindEnum,
   KindEnum,
   DirectiveLocationEnum,

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -23,9 +23,8 @@ export { print } from './printer';
 export { visit, visitInParallel, getVisitFn, BREAK } from './visitor';
 export type { ASTVisitor, Visitor, VisitFn, VisitorKeyMap } from './visitor';
 
+export { Location, Token } from './ast';
 export type {
-  Location,
-  Token,
   ASTNode,
   ASTKindToNode,
   // Each kind of AST node


### PR DESCRIPTION
Reported here: https://github.com/graphql/graphql-js/pull/2233#issuecomment-621312122