### PR TITLE
Make ES modules compatible with Deno

### DIFF
--- a/src/jsutils/instanceOf.js
+++ b/src/jsutils/instanceOf.js
@@ -11,7 +11,8 @@ declare function instanceOf(
 
 // See: https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production
 // See: https://webpack.js.org/guides/production/
-export default process.env.NODE_ENV === 'production'
+export default typeof process !== 'undefined' &&
+process.env.NODE_ENV === 'production'
   ? // istanbul ignore next (See: https://github.com/graphql/graphql-js/issues/2317)
     // eslint-disable-next-line no-shadow
     function instanceOf(value: mixed, constructor: mixed) {


### PR DESCRIPTION
Small tweak that provides a workaround for #2566. This way, at least you can do something like
 
```
import {
  GraphQLSchema,
} from "https://cdn.jsdelivr.net/npm/graphql@15.0.0/index.mjs";
```

and at least use the library, albeit without any TS type definitions.