### PR TITLE
Add parentType to path to avoid path ambiguity

### DIFF
--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -329,7 +329,7 @@ describe('Execute: Handles basic execution tasks', () => {
       name: 'TestUnion',
       types: [a],
       resolveType() {
-        return a;
+        return 'A';
       },
     });
     const testType = new GraphQLObjectType({

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -306,7 +306,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const field = operation.selectionSet.selections[0];
     expect(resolvedInfo).to.deep.include({
       fieldNodes: [field],
-      path: { prev: undefined, key: 'result' },
+      path: { prev: undefined, key: 'result', parentType: 'Test' },
       variableValues: { var: 'abc' },
     });
   });

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -307,7 +307,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const field = operation.selectionSet.selections[0];
     expect(resolvedInfo).to.deep.include({
       fieldNodes: [field],
-      path: { prev: undefined, key: 'result', parentType: 'Test' },
+      path: { prev: undefined, key: 'result', typename: 'Test' },
       variableValues: { var: 'abc' },
     });
   });
@@ -358,13 +358,13 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expect(path).to.deep.equal({
       key: 'l2',
-      parentType: 'SomeObject',
+      typename: 'SomeObject',
       prev: {
         key: 0,
-        parentType: undefined,
+        typename: undefined,
         prev: {
           key: 'l1',
-          parentType: 'SomeQuery',
+          typename: 'SomeQuery',
           prev: undefined,
         },
       },

--- a/src/execution/__tests__/executor-test.js
+++ b/src/execution/__tests__/executor-test.js
@@ -354,7 +354,7 @@ describe('Execute: Handles basic execution tasks', () => {
       }
     `);
 
-    execute({ schema, document, rootValue });
+    executeSync({ schema, document, rootValue });
 
     expect(path).to.deep.equal({
       key: 'l2',

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -400,7 +400,7 @@ function executeFieldsSerially(
     Object.keys(fields),
     (results, responseName) => {
       const fieldNodes = fields[responseName];
-      const fieldPath = addPath(path, responseName);
+      const fieldPath = addPath(path, responseName, parentType.name);
       const result = resolveField(
         exeContext,
         parentType,
@@ -440,7 +440,7 @@ function executeFields(
 
   for (const responseName of Object.keys(fields)) {
     const fieldNodes = fields[responseName];
-    const fieldPath = addPath(path, responseName);
+    const fieldPath = addPath(path, responseName, parentType.name);
     const result = resolveField(
       exeContext,
       parentType,
@@ -918,7 +918,7 @@ function completeListValue(
   const completedResults = arrayFrom(result, (item, index) => {
     // No need to modify the info object containing the path,
     // since from here on it is not ever accessed by resolver functions.
-    const fieldPath = addPath(path, index);
+    const fieldPath = addPath(path, index, undefined);
     const completedItem = completeValueCatchingError(
       exeContext,
       itemType,

--- a/src/jsutils/Path.d.ts
+++ b/src/jsutils/Path.d.ts
@@ -1,12 +1,17 @@
 export interface Path {
   prev: Path | undefined;
   key: string | number;
+  parentType: string | undefined;
 }
 
 /**
  * Given a Path and a key, return a new Path containing the new key.
  */
-export function addPath(prev: Path | undefined, key: string | number): Path;
+export function addPath(
+  prev: Path | undefined,
+  key: string | number,
+  parentType: string | undefined,
+): Path;
 
 /**
  * Given a Path, return an Array of the path keys.

--- a/src/jsutils/Path.d.ts
+++ b/src/jsutils/Path.d.ts
@@ -1,7 +1,7 @@
 export interface Path {
   prev: Path | undefined;
   key: string | number;
-  parentType: string | undefined;
+  typename: string | undefined;
 }
 
 /**
@@ -10,7 +10,7 @@ export interface Path {
 export function addPath(
   prev: Path | undefined,
   key: string | number,
-  parentType: string | undefined,
+  typename: string | undefined,
 ): Path;
 
 /**

--- a/src/jsutils/Path.js
+++ b/src/jsutils/Path.js
@@ -3,7 +3,7 @@
 export type Path = {|
   +prev: Path | void,
   +key: string | number,
-  +parentType: string | void,
+  +typename: string | void,
 |};
 
 /**
@@ -12,9 +12,9 @@ export type Path = {|
 export function addPath(
   prev: $ReadOnly<Path> | void,
   key: string | number,
-  parentType: string | void,
+  typename: string | void,
 ): Path {
-  return { prev, key, parentType };
+  return { prev, key, typename };
 }
 
 /**

--- a/src/jsutils/Path.js
+++ b/src/jsutils/Path.js
@@ -3,6 +3,7 @@
 export type Path = {|
   +prev: Path | void,
   +key: string | number,
+  +parentType: string | void,
 |};
 
 /**
@@ -11,8 +12,9 @@ export type Path = {|
 export function addPath(
   prev: $ReadOnly<Path> | void,
   key: string | number,
+  parentType: string | void,
 ): Path {
-  return { prev, key };
+  return { prev, key, parentType };
 }
 
 /**

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -253,7 +253,7 @@ export function createSourceEventStream(
     // AsyncIterable yielding raw payloads.
     const resolveFn = fieldDef.subscribe ?? exeContext.fieldResolver;
 
-    const path = addPath(undefined, responseName);
+    const path = addPath(undefined, responseName, type.name);
 
     const info = buildResolveInfo(exeContext, fieldDef, fieldNodes, type, path);
 

--- a/src/utilities/coerceInputValue.js
+++ b/src/utilities/coerceInputValue.js
@@ -82,7 +82,7 @@ function coerceInputValueImpl(
     const itemType = type.ofType;
     if (isCollection(inputValue)) {
       return arrayFrom(inputValue, (itemValue, index) => {
-        const itemPath = addPath(path, index);
+        const itemPath = addPath(path, index, undefined);
         return coerceInputValueImpl(itemValue, itemType, onError, itemPath);
       });
     }
@@ -126,7 +126,7 @@ function coerceInputValueImpl(
         fieldValue,
         field.type,
         onError,
-        addPath(path, field.name),
+        addPath(path, field.name, undefined),
       );
     }
 

--- a/src/utilities/coerceInputValue.js
+++ b/src/utilities/coerceInputValue.js
@@ -126,7 +126,7 @@ function coerceInputValueImpl(
         fieldValue,
         field.type,
         onError,
-        addPath(path, field.name, undefined),
+        addPath(path, field.name, type.name),
       );
     }
 


### PR DESCRIPTION
Imagine you have the schema:

```graphql
type A {
  int: Int
  union: C
}
type B {
  int: Int
  union: C
}
union C = A | B
type Query {
  root: C
}
```

You could write the query:

```graphql
{
  root {
    ... on A {
      union {
        ... on A {
          alias1: union { # EXAMPLE1
            int
          }
          alias2: union {
            int
          }
        }
        ... on B {
          alias1: union {
            int
          }
          alias2: union {
            int
          }
        }
      }
    }
    ... on B {
      union {
        ... on A {
          alias1: union { # EXAMPLE2
            int
          }
          alias2: union {
            int
          }
        }
        ... on B {
          alias1: union {
            int
          }
          alias2: union {
            int
          }
        }
      }
    }
  }
}
```

In the resolver for `A.union`, in `resolveInfo` (the fourth argument to resolve) you would not be able to tell if you are in position `EXAMPLE1` or `EXAMPLE2` without looking into the `loc` data in `fieldNodes`. This makes it challenging to write certain classes of lookahead engine.

Namely in both EXAMPLE1 and EXAMPLE2, you have:

- `parentType: 'A'`
- `path: {key: 'alias1', prev: { key: 'union', prev: { key: 'root' } } }`

So the `path` is ambiguous. This PR adds `parentType` to the `Path` type, so these paths would become:

- EXAMPLE1: `path: {key: 'alias1', parentTypeName: 'A', prev: { key: 'union', parentTypeName: 'A', prev: { key: 'root', parentTypeName: 'Query' } } }`
- EXAMPLE2: `path: {key: 'alias1', parentTypeName: 'A', prev: { key: 'union', parentTypeName: 'B', prev: { key: 'root', parentTypeName: 'Query' } } }`

Note the subtle difference between the A/B parentTypeName in the middle of the path.