### PR TITLE
fix: Permit `isDeprecated` field in presence of `deprecationReason`

### DIFF
--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -399,6 +399,22 @@ describe('Type System: Objects', () => {
     );
   });
 
+  it('allows an Object type with an isDeprecated field if a deprecationReason field is present', () => {
+    const OldObject = new GraphQLObjectType({
+      name: 'OldObject',
+      // $DisableFlowOnNegativeTest
+      fields: {
+        field: {
+          type: ScalarType,
+          isDeprecated: false,
+          deprecationReason: undefined,
+        },
+      },
+    });
+
+    expect(() => OldObject.getFields()).not.to.throw();
+  });
+
   it('rejects an Object type with incorrectly typed interfaces', () => {
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
@@ -755,6 +771,19 @@ describe('Type System: Enums', () => {
     ).to.throw(
       'SomeEnum.FOO should provide "deprecationReason" instead of "isDeprecated".',
     );
+  });
+
+  it('allows an Enum type with an isDeprecated field if a deprecationReason field is present', () => {
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          // $DisableFlowOnNegativeTest
+          values: {
+            FOO: { isDeprecated: true, deprecationReason: 'deprecated' },
+          },
+        }),
+    ).not.to.throw();
   });
 });
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -836,7 +836,7 @@ function defineFieldMap<TSource, TContext>(
       `${config.name}.${fieldName} field config must be an object.`,
     );
     devAssert(
-      !('isDeprecated' in fieldConfig),
+      !('isDeprecated' in fieldConfig) || 'deprecationReason' in fieldConfig,
       `${config.name}.${fieldName} should provide "deprecationReason" instead of "isDeprecated".`,
     );
     devAssert(
@@ -1428,8 +1428,9 @@ function defineEnumValues(
       `${typeName}.${valueName} must refer to an object with a "value" key ` +
         `representing an internal value but got: ${inspect(valueConfig)}.`,
     );
+
     devAssert(
-      !('isDeprecated' in valueConfig),
+      !('isDeprecated' in valueConfig) || 'deprecationReason' in valueConfig,
       `${typeName}.${valueName} should provide "deprecationReason" instead of "isDeprecated".`,
     );
     return {


### PR DESCRIPTION
Currently, the typings for a `GraphQLField` and `GraphQLEnumValue` are at odds with their runtime expectations.

The typings require the existence of `isDeprecated`.
https://github.com/graphql/graphql-js/blob/13ab792895c7056186fddee552d0db9776c735a3/src/type/definition.js#L1002
https://github.com/graphql/graphql-js/blob/13ab792895c7056186fddee552d0db9776c735a3/src/type/definition.js#L1470

However, at runtime, we throw an error if `isDeprecated` exists.
https://github.com/graphql/graphql-js/blob/13ab792895c7056186fddee552d0db9776c735a3/src/type/definition.js#L838-L841
https://github.com/graphql/graphql-js/blob/13ab792895c7056186fddee552d0db9776c735a3/src/type/definition.js#L1431-L1434

This PR proposes that we _permit_ the presence of that field as long as `deprecationReason` is also provided. Alternatively, we could update the types and make `isDeprecated` optional.

I'm currently running into this error in a PR to the `apollo-tooling` repo to migrate to v15:
https://github.com/apollographql/apollo-tooling/pull/1743