### PR TITLE
Make documentation for 'getFieldDef' more accurate

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -1222,12 +1222,12 @@ export const defaultFieldResolver: GraphQLFieldResolver<
 
 /**
  * This method looks up the field on the given type definition.
- * It has special casing for the two introspection fields, __schema
- * and __typename. __typename is special because it can always be
- * queried as a field, even in situations where no other fields
- * are allowed, like on a Union. __schema could get automatically
- * added to the query type, but that would require mutating type
- * definitions, which would cause issues.
+ * It has special casing for the three introspection fields,
+ * __schema, __type and __typename. __typename is special because
+ * it can always be queried as a field, even in situations where no
+ * other fields are allowed, like on a Union. __schema and __type
+ * could get automatically added to the query type, but that would
+ * require mutating type definitions, which would cause issues.
  *
  * @internal
  */


### PR DESCRIPTION
The `__type`  field should also be mentioned in the jsdoc comment.