### PR TITLE
docs: Changed how to import graphqlHTTP in graphql-express modules

### DIFF
--- a/docs/APIReference-ExpressGraphQL.md
+++ b/docs/APIReference-ExpressGraphQL.md
@@ -10,8 +10,8 @@ next: /graphql-js/graphql/
 The `express-graphql` module provides a simple way to create an [Express](https://expressjs.com/) server that runs a GraphQL API.
 
 ```js
-import graphqlHTTP from 'express-graphql'; // ES6
-var graphqlHTTP = require('express-graphql'); // CommonJS
+import { graphqlHTTP } from 'express-graphql'; // ES6
+var { graphqlHTTP } = require('express-graphql'); // CommonJS
 ```
 
 ### graphqlHTTP

--- a/docs/Guides-ConstructingTypes.md
+++ b/docs/Guides-ConstructingTypes.md
@@ -14,7 +14,7 @@ For example, let's say we are building a simple API that lets you fetch user dat
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 var schema = buildSchema(`
@@ -64,7 +64,7 @@ We can implement this same API without using GraphQL schema language:
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var graphql = require('graphql');
 
 // Maps id to User object

--- a/docs/Tutorial-Authentication.md
+++ b/docs/Tutorial-Authentication.md
@@ -15,7 +15,7 @@ For example, let's say we wanted our server to log the IP address of every reque
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 var schema = buildSchema(`

--- a/docs/Tutorial-BasicTypes.md
+++ b/docs/Tutorial-BasicTypes.md
@@ -18,7 +18,7 @@ Each of these types maps straightforwardly to JavaScript, so you can just return
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language

--- a/docs/Tutorial-ExpressGraphQL.md
+++ b/docs/Tutorial-ExpressGraphQL.md
@@ -17,7 +17,7 @@ Let's modify our “hello world” example so that it's an API server rather tha
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language

--- a/docs/Tutorial-Mutations.md
+++ b/docs/Tutorial-Mutations.md
@@ -73,7 +73,7 @@ Here's some runnable code that implements this schema, keeping the data in memor
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language

--- a/docs/Tutorial-ObjectTypes.md
+++ b/docs/Tutorial-ObjectTypes.md
@@ -74,7 +74,7 @@ Putting this all together, here is some sample code that runs a server with this
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language

--- a/docs/Tutorial-PassingArguments.md
+++ b/docs/Tutorial-PassingArguments.md
@@ -58,7 +58,7 @@ The entire code for a server that hosts this `rollDice` API is:
 
 ```js
 var express = require('express');
-var graphqlHTTP = require('express-graphql');
+var { graphqlHTTP } = require('express-graphql');
 var { buildSchema } = require('graphql');
 
 // Construct a schema, using GraphQL schema language


### PR DESCRIPTION
## overview
- graphql-js tutorial has an error in [running-an-express-graphql-server](https://graphql.org/graphql-js/running-an-express-graphql-server/graphql-express) try to import modules.

I just followed the document at graphql-js tutorials.

But there is problem when I import graphqlHTTP from 'express-grapqhl'.
![image](https://user-images.githubusercontent.com/33471826/86720330-dff4a600-c05f-11ea-951d-a9750d1045be.png)
(The squared black blank is my user name.)

Because they updated express-grapqhl modules and updated official `README.md` 27 days ago. [express-graphql history](https://github.com/graphql/express-graphql/commit/0f74f05cc2d09d20aa3822472132f9f4701df8c7) (see below image)
![image](https://user-images.githubusercontent.com/33471826/86719670-3e6d5480-c05f-11ea-8d5b-40640225f41f.png)

So I changed require statement in graphql-js tutorials.
`var graphqlHTTP = require('express-graphql')`
to
`var { graphqlHTTP } = require('express-graphql')`

And it works!
![image](https://user-images.githubusercontent.com/33471826/86720934-7759f900-c060-11ea-9f47-71c558a65e43.png)
