### PR TITLE
GraphQLScalarType: default 'parseLiteral' should handle variables

### DIFF
--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -91,6 +91,9 @@ describe('Type System: Scalars', () => {
     expect(scalar.parseLiteral(parseValue('{ foo: "bar" }'))).to.equal(
       'parseValue: { foo: "bar" }',
     );
+    expect(
+      scalar.parseLiteral(parseValue('{ foo: { bar: $var } }'), { var: 'baz' }),
+    ).to.equal('parseValue: { foo: { bar: "baz" } }');
   });
 
   it('rejects a Scalar type without name', () => {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -591,7 +591,8 @@ export class GraphQLScalarType {
     this.serialize = config.serialize ?? identityFunc;
     this.parseValue = parseValue;
     this.parseLiteral =
-      config.parseLiteral ?? ((node) => parseValue(valueFromASTUntyped(node)));
+      config.parseLiteral ??
+      ((node, variables) => parseValue(valueFromASTUntyped(node, variables)));
     this.extensions = config.extensions && toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = undefineIfEmpty(config.extensionASTNodes);


### PR DESCRIPTION
Motivation #2657