### PR TITLE
Add failing test in findBreakingChanges-test.js

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -562,6 +562,24 @@ describe('findBreakingChanges', () => {
     expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([]);
   });
 
+  it('should not flag args changing from String or Int to ID as breaking', () => {
+    const oldSchema = buildSchema(`
+      type Type1 {
+        field1(arg1: String): Int
+        field2(arg1: Int): Int
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      type Type1 {
+        field1(arg1: ID): Int
+        field2(arg1: ID): Int
+      }
+    `);
+
+    expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([]);
+  });
+
   it('should consider args that move away from NonNull as non-breaking', () => {
     const oldSchema = buildSchema(`
       type Type1 {


### PR DESCRIPTION
Not sure if I'm overlooking some cases, so I'm starting with a failing test to help demonstrate the proposed change.

The output of the test in this PR is:

```sh
1) findBreakingChanges
    should not flag args changing from String or Int to ID as breaking:

    AssertionError: expected [ Array(2) ] to deeply equal []
    + expected - actual

    -[
    -  {
    -    "description": "Type1.field1 arg arg1 has changed type from String to ID."
    -    "type": "ARG_CHANGED_KIND"
    -  }
    -  {
    -    "description": "Type1.field2 arg arg1 has changed type from Int to ID."
    -    "type": "ARG_CHANGED_KIND"
    -  }
    -]
    +[]
```

Looking through the commit history of `findBreakingChanges`, it seems like the feature was designed to follow the spirit of "breaking changes" as mentioned in the spec:

> As GraphQL type system schema evolve over time by adding new types and new fields, it is possible that a request which was previously valid could later become invalid. Any change that can cause a previously valid request to become invalid is considered a breaking change

If an argument's type is changed from either a `String` or `Int` to `ID`, a query providing either of those input types should still pass validation, and be capable of executing successfully (assuming the field resolve functions adjusts for input coercion).