### PR TITLE
Support returning async iterables from resolver functions

### DIFF
--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -62,6 +62,39 @@ describe('Execute: Accepts any iterable as list value', () => {
       ],
     });
   });
+
+  it('Accepts an AsyncGenerator function as a List value', async () => {
+    async function* yieldAsyncItems() {
+      yield await 'two';
+      yield await 4;
+      yield await false;
+    }
+    const listField = yieldAsyncItems();
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', '4', 'false'] },
+    });
+  });
+
+  it('Handles an AsyncGenerator function that throws', async () => {
+    async function* yieldAsyncItemsError() {
+      yield await 'two';
+      yield await 4;
+      throw new Error('bad');
+    }
+    const listField = yieldAsyncItemsError();
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', '4', null] },
+      errors: [
+        {
+          message: 'bad',
+          locations: [{ line: 1, column: 3 }],
+          path: ['listField', 2],
+        },
+      ],
+    });
+  });
 });
 
 describe('Execute: Handles list nullability', () => {

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -62,14 +62,23 @@ describe('Execute: Accepts any iterable as list value', () => {
       ],
     });
   });
+});
+
+describe('Execute: Accepts async iterables as list value', () => {
+  function complete(rootValue: mixed) {
+    return execute({
+      schema: buildSchema('type Query { listField: [String] }'),
+      document: parse('{ listField }'),
+      rootValue,
+    });
+  }
 
   it('Accepts an AsyncGenerator function as a List value', async () => {
-    async function* yieldAsyncItems() {
+    async function* listField() {
       yield await 'two';
       yield await 4;
       yield await false;
     }
-    const listField = yieldAsyncItems();
 
     expect(await complete({ listField })).to.deep.equal({
       data: { listField: ['two', '4', 'false'] },
@@ -77,12 +86,11 @@ describe('Execute: Accepts any iterable as list value', () => {
   });
 
   it('Handles an AsyncGenerator function that throws', async () => {
-    async function* yieldAsyncItemsError() {
+    async function* listField() {
       yield await 'two';
       yield await 4;
       throw new Error('bad');
     }
-    const listField = yieldAsyncItemsError();
 
     expect(await complete({ listField })).to.deep.equal({
       data: { listField: ['two', '4', null] },

--- a/src/jsutils/isAsyncIterable.js
+++ b/src/jsutils/isAsyncIterable.js
@@ -1,0 +1,17 @@
+import { SYMBOL_ASYNC_ITERATOR } from '../polyfills/symbols';
+
+/**
+ * Returns true if the provided object implements the AsyncIterator protocol via
+ * either implementing a `Symbol.asyncIterator` or `"@@asyncIterator"` method.
+ */
+declare function isAsyncIterable(value: mixed): boolean %checks(value instanceof
+  AsyncIterable);
+
+// eslint-disable-next-line no-redeclare
+export default function isAsyncIterable(maybeAsyncIterable) {
+  if (maybeAsyncIterable == null || typeof maybeAsyncIterable !== 'object') {
+    return false;
+  }
+
+  return typeof maybeAsyncIterable[SYMBOL_ASYNC_ITERATOR] === 'function';
+}

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -1,6 +1,5 @@
-import { SYMBOL_ASYNC_ITERATOR } from '../polyfills/symbols';
-
 import inspect from '../jsutils/inspect';
+import isAsyncIterable from '../jsutils/isAsyncIterable';
 import { addPath, pathToArray } from '../jsutils/Path';
 
 import { GraphQLError } from '../error/GraphQLError';
@@ -158,7 +157,7 @@ function subscribeImpl(
     // Note: Flow can't refine isAsyncIterable, so explicit casts are used.
     isAsyncIterable(resultOrStream)
       ? mapAsyncIterator(
-          ((resultOrStream: any): AsyncIterable<mixed>),
+          resultOrStream,
           mapSourceToResponse,
           reportGraphQLError,
         )
@@ -289,24 +288,10 @@ function executeSubscription(
             `Received: ${inspect(eventStream)}.`,
         );
       }
-
-      // Note: isAsyncIterable above ensures this will be correct.
-      return ((eventStream: any): AsyncIterable<mixed>);
+      return eventStream;
     },
     (error) => {
       throw locatedError(error, fieldNodes, pathToArray(path));
     },
   );
-}
-
-/**
- * Returns true if the provided object implements the AsyncIterator protocol via
- * either implementing a `Symbol.asyncIterator` or `"@@asyncIterator"` method.
- */
-function isAsyncIterable(maybeAsyncIterable: mixed): boolean {
-  if (maybeAsyncIterable == null || typeof maybeAsyncIterable !== 'object') {
-    return false;
-  }
-
-  return typeof maybeAsyncIterable[SYMBOL_ASYNC_ITERATOR] === 'function';
 }


### PR DESCRIPTION
Returning AsyncIterables in resolver methods is useful when `@stream` is supported and can be added without any breaking changes. This is split out from https://github.com/graphql/graphql-js/pull/2319

