### PR TITLE
execute/subscribe: simplify to improve debugging experience

### DIFF
--- a/src/error/locatedError.d.ts
+++ b/src/error/locatedError.d.ts
@@ -5,12 +5,12 @@ import { ASTNode } from '../language/ast';
 import { GraphQLError } from './GraphQLError';
 
 /**
- * Given an arbitrary Error, presumably thrown while attempting to execute a
+ * Given an arbitrary value, presumably thrown while attempting to execute a
  * GraphQL operation, produce a new GraphQLError aware of the location in the
  * document responsible for the original Error.
  */
 export function locatedError(
-  originalError: Error | GraphQLError,
+  rawOriginalError: any,
   nodes: ASTNode | ReadonlyArray<ASTNode> | undefined,
   path?: Maybe<ReadonlyArray<string | number>>,
 ): GraphQLError;

--- a/src/error/locatedError.js
+++ b/src/error/locatedError.js
@@ -1,19 +1,26 @@
+import inspect from '../jsutils/inspect';
+
 import type { ASTNode } from '../language/ast';
 
 import { GraphQLError } from './GraphQLError';
 
 /**
- * Given an arbitrary Error, presumably thrown while attempting to execute a
+ * Given an arbitrary value, presumably thrown while attempting to execute a
  * GraphQL operation, produce a new GraphQLError aware of the location in the
  * document responsible for the original Error.
  */
 export function locatedError(
-  originalError: Error | GraphQLError,
+  rawOriginalError: mixed,
   nodes: ASTNode | $ReadOnlyArray<ASTNode> | void | null,
   path?: ?$ReadOnlyArray<string | number>,
 ): GraphQLError {
-  // Note: this uses a brand-check to support GraphQL errors originating from
-  // other contexts.
+  // Sometimes a non-error is thrown, wrap it as an Error instance to ensure a consistent Error interface.
+  const originalError: Error | GraphQLError =
+    rawOriginalError instanceof Error
+      ? rawOriginalError
+      : new Error('Unexpected error value: ' + inspect(rawOriginalError));
+
+  // Note: this uses a brand-check to support GraphQL errors originating from other contexts.
   if (Array.isArray(originalError.path)) {
     return (originalError: any);
   }

--- a/src/execution/execute.d.ts
+++ b/src/execution/execute.d.ts
@@ -160,21 +160,6 @@ export function buildResolveInfo(
 ): GraphQLResolveInfo;
 
 /**
- * Isolates the "ReturnOrAbrupt" behavior to not de-opt the `resolveField`
- * function. Returns the result of resolveFn or the abrupt-return Error object.
- *
- * @internal
- */
-export function resolveFieldValueOrError(
-  exeContext: ExecutionContext,
-  fieldDef: GraphQLField<any, any>,
-  fieldNodes: ReadonlyArray<FieldNode>,
-  resolveFn: GraphQLFieldResolver<any, any>,
-  source: any,
-  info: GraphQLResolveInfo,
-): any;
-
-/**
  * If a resolveType function is not given, then a default resolve behavior is
  * used which attempts two strategies:
  *

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -8,7 +8,8 @@ import { locatedError } from '../error/locatedError';
 
 import type { DocumentNode } from '../language/ast';
 
-import type { ExecutionResult } from '../execution/execute';
+import type { ExecutionResult, ExecutionContext } from '../execution/execute';
+import { getArgumentValues } from '../execution/values';
 import {
   assertValidExecutionArguments,
   buildExecutionContext,
@@ -16,7 +17,6 @@ import {
   collectFields,
   execute,
   getFieldDef,
-  resolveFieldValueOrError,
 } from '../execution/execute';
 
 import type { GraphQLSchema } from '../type/schema';
@@ -207,7 +207,7 @@ export function createSourceEventStream(
   // developer mistake which should throw an early error.
   assertValidExecutionArguments(schema, document, variableValues);
 
-  try {
+  return new Promise((resolve) => {
     // If a valid context cannot be created due to incorrect arguments,
     // this will throw an error.
     const exeContext = buildExecutionContext(
@@ -220,81 +220,83 @@ export function createSourceEventStream(
       fieldResolver,
     );
 
-    // Return early errors if execution context failed.
-    if (Array.isArray(exeContext)) {
-      return Promise.resolve({ errors: exeContext });
-    }
-
-    const type = getOperationRootType(schema, exeContext.operation);
-    const fields = collectFields(
-      exeContext,
-      type,
-      exeContext.operation.selectionSet,
-      Object.create(null),
-      Object.create(null),
+    resolve(
+      // Return early errors if execution context failed.
+      Array.isArray(exeContext)
+        ? { errors: exeContext }
+        : executeSubscription(exeContext),
     );
-    const responseNames = Object.keys(fields);
-    const responseName = responseNames[0];
-    const fieldNodes = fields[responseName];
-    const fieldNode = fieldNodes[0];
-    const fieldName = fieldNode.name.value;
-    const fieldDef = getFieldDef(schema, type, fieldName);
+  }).catch(reportGraphQLError);
+}
 
-    if (!fieldDef) {
-      throw new GraphQLError(
-        `The subscription field "${fieldName}" is not defined.`,
-        fieldNodes,
-      );
-    }
+function executeSubscription(
+  exeContext: ExecutionContext,
+): Promise<AsyncIterable<mixed>> {
+  const { schema, operation, variableValues, rootValue } = exeContext;
+  const type = getOperationRootType(schema, operation);
+  const fields = collectFields(
+    exeContext,
+    type,
+    operation.selectionSet,
+    Object.create(null),
+    Object.create(null),
+  );
+  const responseNames = Object.keys(fields);
+  const responseName = responseNames[0];
+  const fieldNodes = fields[responseName];
+  const fieldNode = fieldNodes[0];
+  const fieldName = fieldNode.name.value;
+  const fieldDef = getFieldDef(schema, type, fieldName);
+
+  if (!fieldDef) {
+    throw new GraphQLError(
+      `The subscription field "${fieldName}" is not defined.`,
+      fieldNodes,
+    );
+  }
+
+  const path = addPath(undefined, responseName, type.name);
+  const info = buildResolveInfo(exeContext, fieldDef, fieldNodes, type, path);
+
+  // Coerce to Promise for easier error handling and consistent return type.
+  return new Promise((resolveResult) => {
+    // Implements the "ResolveFieldEventStream" algorithm from GraphQL specification.
+    // It differs from "ResolveFieldValue" due to providing a different `resolveFn`.
+
+    // Build a JS object of arguments from the field.arguments AST, using the
+    // variables scope to fulfill any variable references.
+    const args = getArgumentValues(fieldDef, fieldNodes[0], variableValues);
+
+    // The resolve function's optional third argument is a context value that
+    // is provided to every resolve function within an execution. It is commonly
+    // used to represent an authenticated user, or request-specific caches.
+    const contextValue = exeContext.contextValue;
 
     // Call the `subscribe()` resolver or the default resolver to produce an
     // AsyncIterable yielding raw payloads.
     const resolveFn = fieldDef.subscribe ?? exeContext.fieldResolver;
-
-    const path = addPath(undefined, responseName, type.name);
-
-    const info = buildResolveInfo(exeContext, fieldDef, fieldNodes, type, path);
-
-    // resolveFieldValueOrError implements the "ResolveFieldEventStream"
-    // algorithm from GraphQL specification. It differs from
-    // "ResolveFieldValue" due to providing a different `resolveFn`.
-    const result = resolveFieldValueOrError(
-      exeContext,
-      fieldDef,
-      fieldNodes,
-      resolveFn,
-      rootValue,
-      info,
-    );
-
-    // Coerce to Promise for easier error handling and consistent return type.
-    return Promise.resolve(result).then((eventStream) => {
-      // If eventStream is an Error, rethrow a located error.
+    resolveResult(resolveFn(rootValue, args, contextValue, info));
+  }).then(
+    (eventStream) => {
       if (eventStream instanceof Error) {
-        return {
-          errors: [locatedError(eventStream, fieldNodes, pathToArray(path))],
-        };
+        throw locatedError(eventStream, fieldNodes, pathToArray(path));
       }
 
       // Assert field returned an event stream, otherwise yield an error.
-      if (isAsyncIterable(eventStream)) {
-        // Note: isAsyncIterable above ensures this will be correct.
-        return ((eventStream: any): AsyncIterable<mixed>);
+      if (!isAsyncIterable(eventStream)) {
+        throw new Error(
+          'Subscription field must return Async Iterable. ' +
+            `Received: ${inspect(eventStream)}.`,
+        );
       }
 
-      throw new Error(
-        'Subscription field must return Async Iterable. ' +
-          `Received: ${inspect(eventStream)}.`,
-      );
-    });
-  } catch (error) {
-    // As with reportGraphQLError above, if the error is a GraphQLError, report
-    // it as an ExecutionResult; otherwise treat it as a system-class error and
-    // re-throw it.
-    return error instanceof GraphQLError
-      ? Promise.resolve({ errors: [error] })
-      : Promise.reject(error);
-  }
+      // Note: isAsyncIterable above ensures this will be correct.
+      return ((eventStream: any): AsyncIterable<mixed>);
+    },
+    (error) => {
+      throw locatedError(error, fieldNodes, pathToArray(path));
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
Also move handling for error that not inherit from Error to `locatedError`