### PR TITLE
parser: Export `Parser` class as unstable API

### DIFF
--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -162,7 +162,18 @@ export function parseType(
   return type;
 }
 
-class Parser {
+/**
+ * This class is exported only to assist people in implementing their own parsers
+ * without duplicating too much code and should be used only as last resort for cases
+ * such as experimental syntax or if certain features could not be contributed upstream.
+ *
+ * It is still part of the internal API and is versioned, so any changes to it are never
+ * considered breaking changes. If you still need to support multiple versions of the
+ * library, please use the `versionInfo` variable for version detection.
+ *
+ * @internal
+ */
+export class Parser {
   _options: ?ParseOptions;
   _lexer: Lexer;
 


### PR DESCRIPTION
Fixes #2741