### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,4 +97,4 @@ git push --follow-tags
 ## License
 
 By contributing to graphql-js, you agree that your contributions will be
-licensed under its [MIT license](https://github.com/graphql/graphql-js/blob/master/LICENSE).
+licensed under its [MIT license](LICENSE).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,4 +97,4 @@ git push --follow-tags
 ## License
 
 By contributing to graphql-js, you agree that your contributions will be
-licensed under its [MIT license](LICENSE).
+licensed under its [MIT license](../LICENSE).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,4 +97,4 @@ git push --follow-tags
 ## License
 
 By contributing to graphql-js, you agree that your contributions will be
-licensed under its MIT license.
+licensed under its [MIT license](https://github.com/graphql/graphql-js/blob/master/LICENSE).


### PR DESCRIPTION
Added a link to the MIT licence text to direct to the licence of graphql-js.
Line No.100 :)
![image](https://user-images.githubusercontent.com/23498248/90315446-457a6300-df39-11ea-91e2-0ce44b43206e.png)
