### PR TITLE
Flow: add more typings for function arguments and return values

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -31,6 +31,7 @@
     "subcommand",
     "transpilation",
     "instanceof",
+    "flowtype",
 
     // Different names used inside tests
     "Skywalker",

--- a/src/execution/__tests__/directives-test.js
+++ b/src/execution/__tests__/directives-test.js
@@ -7,7 +7,6 @@ import { GraphQLSchema } from '../../type/schema';
 import { GraphQLString } from '../../type/scalars';
 import { GraphQLObjectType } from '../../type/definition';
 
-import type { ExecutionResult } from '../execute';
 import { executeSync } from '../execute';
 
 const schema = new GraphQLSchema({
@@ -29,7 +28,7 @@ const rootValue = {
   },
 };
 
-function executeTestQuery(query: string): ExecutionResult {
+function executeTestQuery(query: string) {
   const document = parse(query);
   return executeSync({ schema, document, rootValue });
 }

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -65,7 +65,8 @@ describe('Execute: Accepts any iterable as list value', () => {
 });
 
 describe('Execute: Handles list nullability', () => {
-  async function complete({ listField, as }) {
+  async function complete(args: {| listField: mixed, as: string |}) {
+    const { listField, as } = args;
     const schema = buildSchema(`type Query { listField: ${as} }`);
     const document = parse('{ listField }');
 
@@ -84,7 +85,7 @@ describe('Execute: Handles list nullability', () => {
     }
     return result;
 
-    function executeQuery(listValue) {
+    function executeQuery(listValue: mixed) {
       return execute({ schema, document, rootValue: { listField: listValue } });
     }
 

--- a/src/execution/__tests__/resolve-test.js
+++ b/src/execution/__tests__/resolve-test.js
@@ -8,7 +8,6 @@ import { GraphQLSchema } from '../../type/schema';
 import { GraphQLInt, GraphQLString } from '../../type/scalars';
 import { GraphQLObjectType } from '../../type/definition';
 
-import type { ExecutionResult } from '../execute';
 import { executeSync } from '../execute';
 
 describe('Execute: resolve function', () => {
@@ -96,7 +95,7 @@ describe('Execute: resolve function', () => {
       resolve: (source, args) => JSON.stringify([source, args]),
     });
 
-    function executeQuery(query: string, rootValue?: mixed): ExecutionResult {
+    function executeQuery(query: string, rootValue?: mixed) {
       const document = parse(query);
       return executeSync({ schema, document, rootValue });
     }

--- a/src/execution/__tests__/variables-test.js
+++ b/src/execution/__tests__/variables-test.js
@@ -7,6 +7,7 @@ import invariant from '../../jsutils/invariant';
 import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
 
+import type { GraphQLArgumentConfig } from '../../type/definition';
 import { GraphQLSchema } from '../../type/schema';
 import { GraphQLString } from '../../type/scalars';
 import {
@@ -63,7 +64,7 @@ const TestEnum = new GraphQLEnumType({
   },
 });
 
-function fieldWithInputArg(inputArg) {
+function fieldWithInputArg(inputArg: GraphQLArgumentConfig) {
   return {
     type: GraphQLString,
     args: { input: inputArg },
@@ -116,7 +117,10 @@ const TestType = new GraphQLObjectType({
 
 const schema = new GraphQLSchema({ query: TestType });
 
-function executeQuery(query, variableValues) {
+function executeQuery(
+  query: string,
+  variableValues?: { [variable: string]: mixed, ... },
+) {
   const document = parse(query);
   return executeSync({ schema, document, variableValues });
 }
@@ -1010,7 +1014,7 @@ describe('Execute: Handles inputs', () => {
 
     const inputValue = { input: [0, 1, 2] };
 
-    function invalidValueError(value, index) {
+    function invalidValueError(value: number, index: number) {
       return {
         message: `Variable "$input" got invalid value ${value} at "input[${index}]"; String cannot represent a non string value: ${value}`,
         locations: [{ line: 2, column: 14 }],

--- a/src/jsutils/__tests__/suggestionList-test.js
+++ b/src/jsutils/__tests__/suggestionList-test.js
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 
 import suggestionList from '../suggestionList';
 
-function expectSuggestions(input, options) {
+function expectSuggestions(input: string, options: Array<string>) {
   return expect(suggestionList(input, options));
 }
 

--- a/src/jsutils/inspect.js
+++ b/src/jsutils/inspect.js
@@ -1,3 +1,4 @@
+/* eslint-disable flowtype/no-weak-types */
 import nodejsCustomInspectSymbol from './nodejsCustomInspectSymbol';
 
 const MAX_ARRAY_LENGTH = 10;
@@ -10,7 +11,7 @@ export default function inspect(value: mixed): string {
   return formatValue(value, []);
 }
 
-function formatValue(value, seenValues) {
+function formatValue(value: mixed, seenValues: Array<mixed>): string {
   switch (typeof value) {
     case 'string':
       return JSON.stringify(value);
@@ -26,7 +27,10 @@ function formatValue(value, seenValues) {
   }
 }
 
-function formatObjectValue(value, previouslySeenValues) {
+function formatObjectValue(
+  value: Object,
+  previouslySeenValues: Array<mixed>,
+): string {
   if (previouslySeenValues.indexOf(value) !== -1) {
     return '[Circular]';
   }
@@ -35,7 +39,6 @@ function formatObjectValue(value, previouslySeenValues) {
   const customInspectFn = getCustomFn(value);
 
   if (customInspectFn !== undefined) {
-    // $FlowFixMe[incompatible-use]
     const customValue = customInspectFn.call(value);
 
     // check for infinite recursion
@@ -51,7 +54,7 @@ function formatObjectValue(value, previouslySeenValues) {
   return formatObject(value, seenValues);
 }
 
-function formatObject(object, seenValues) {
+function formatObject(object: Object, seenValues: Array<mixed>): string {
   const keys = Object.keys(object);
   if (keys.length === 0) {
     return '{}';
@@ -69,7 +72,7 @@ function formatObject(object, seenValues) {
   return '{ ' + properties.join(', ') + ' }';
 }
 
-function formatArray(array, seenValues) {
+function formatArray(array: Array<mixed>, seenValues: Array<mixed>): string {
   if (array.length === 0) {
     return '[]';
   }
@@ -95,7 +98,7 @@ function formatArray(array, seenValues) {
   return '[' + items.join(', ') + ']';
 }
 
-function getCustomFn(object) {
+function getCustomFn(object: Object) {
   const customInspectFn = object[String(nodejsCustomInspectSymbol)];
 
   if (typeof customInspectFn === 'function') {
@@ -107,7 +110,7 @@ function getCustomFn(object) {
   }
 }
 
-function getObjectTag(object) {
+function getObjectTag(object: Object): string {
   const tag = Object.prototype.toString
     .call(object)
     .replace(/^\[object /, '')

--- a/src/jsutils/instanceOf.js
+++ b/src/jsutils/instanceOf.js
@@ -12,11 +12,11 @@ declare function instanceOf(
 export default process.env.NODE_ENV === 'production'
   ? // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
     // eslint-disable-next-line no-shadow
-    function instanceOf(value: mixed, constructor: mixed) {
+    function instanceOf(value: mixed, constructor: mixed): boolean {
       return value instanceof constructor;
     }
   : // eslint-disable-next-line no-shadow
-    function instanceOf(value: any, constructor: any) {
+    function instanceOf(value: any, constructor: any): boolean {
       if (value instanceof constructor) {
         return true;
       }

--- a/src/jsutils/memoize3.js
+++ b/src/jsutils/memoize3.js
@@ -9,7 +9,7 @@ export default function memoize3<
 >(fn: (A1, A2, A3) => R): (A1, A2, A3) => R {
   let cache0;
 
-  function memoized(a1, a2, a3) {
+  return function memoized(a1, a2, a3) {
     if (!cache0) {
       cache0 = new WeakMap();
     }
@@ -34,7 +34,5 @@ export default function memoize3<
     const newValue = fn(a1, a2, a3);
     cache2.set(a3, newValue);
     return newValue;
-  }
-
-  return memoized;
+  };
 }

--- a/src/jsutils/suggestionList.js
+++ b/src/jsutils/suggestionList.js
@@ -125,7 +125,7 @@ class LexicalDistance {
   }
 }
 
-function stringToArray(str) {
+function stringToArray(str: string): Array<number> {
   const strLength = str.length;
   const array = new Array(strLength);
   for (let i = 0; i < strLength; ++i) {

--- a/src/language/__tests__/blockString-fuzz.js
+++ b/src/language/__tests__/blockString-fuzz.js
@@ -10,7 +10,7 @@ import { Lexer } from '../lexer';
 import { Source } from '../source';
 import { printBlockString } from '../blockString';
 
-function lexValue(str) {
+function lexValue(str: string) {
   const lexer = new Lexer(new Source(str));
   const value = lexer.advance().value;
 

--- a/src/language/__tests__/blockString-test.js
+++ b/src/language/__tests__/blockString-test.js
@@ -7,7 +7,7 @@ import {
   printBlockString,
 } from '../blockString';
 
-function joinLines(...args) {
+function joinLines(...args: Array<string>) {
   return args.join('\n');
 }
 

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -13,18 +13,18 @@ import { Source } from '../source';
 import { TokenKind } from '../tokenKind';
 import { Lexer, isPunctuatorTokenKind } from '../lexer';
 
-function lexOne(str) {
+function lexOne(str: string) {
   const lexer = new Lexer(new Source(str));
   return lexer.advance();
 }
 
-function lexSecond(str) {
+function lexSecond(str: string) {
   const lexer = new Lexer(new Source(str));
   lexer.advance();
   return lexer.advance();
 }
 
-function expectSyntaxError(text) {
+function expectSyntaxError(text: string) {
   return expect(() => lexSecond(text)).to.throw();
 }
 
@@ -905,7 +905,7 @@ describe('Lexer', () => {
 });
 
 describe('isPunctuatorTokenKind', () => {
-  function isPunctuatorToken(text) {
+  function isPunctuatorToken(text: string) {
     return isPunctuatorTokenKind(lexOne(text).kind);
   }
 

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -16,7 +16,7 @@ import { kitchenSinkQuery } from '../../__fixtures__/index';
 
 import toJSONDeep from './toJSONDeep';
 
-function expectSyntaxError(text) {
+function expectSyntaxError(text: string) {
   return expect(() => parse(text)).to.throw();
 }
 

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -9,11 +9,11 @@ import { parse } from '../parser';
 
 import toJSONDeep from './toJSONDeep';
 
-function expectSyntaxError(text) {
+function expectSyntaxError(text: string) {
   return expect(() => parse(text)).to.throw();
 }
 
-function typeNode(name, loc) {
+function typeNode(name: mixed, loc: mixed) {
   return {
     kind: 'NamedType',
     name: nameNode(name, loc),
@@ -21,7 +21,7 @@ function typeNode(name, loc) {
   };
 }
 
-function nameNode(name, loc) {
+function nameNode(name: mixed, loc: mixed) {
   return {
     kind: 'Name',
     value: name,
@@ -29,11 +29,11 @@ function nameNode(name, loc) {
   };
 }
 
-function fieldNode(name, type, loc) {
+function fieldNode(name: mixed, type: mixed, loc: mixed) {
   return fieldNodeWithArgs(name, type, [], loc);
 }
 
-function fieldNodeWithArgs(name, type, args, loc) {
+function fieldNodeWithArgs(name: mixed, type: mixed, args: mixed, loc: mixed) {
   return {
     kind: 'FieldDefinition',
     description: undefined,
@@ -45,7 +45,7 @@ function fieldNodeWithArgs(name, type, args, loc) {
   };
 }
 
-function enumValueNode(name, loc) {
+function enumValueNode(name: mixed, loc: mixed) {
   return {
     kind: 'EnumValueDefinition',
     name: nameNode(name, loc),
@@ -55,7 +55,12 @@ function enumValueNode(name, loc) {
   };
 }
 
-function inputValueNode(name, type, defaultValue, loc) {
+function inputValueNode(
+  name: mixed,
+  type: mixed,
+  defaultValue: mixed,
+  loc: mixed,
+) {
   return {
     kind: 'InputValueDefinition',
     name,

--- a/src/language/__tests__/source-test.js
+++ b/src/language/__tests__/source-test.js
@@ -11,7 +11,7 @@ describe('Source', () => {
   });
 
   it('rejects invalid locationOffset', () => {
-    function createSource(locationOffset) {
+    function createSource(locationOffset: {| line: number, column: number |}) {
       return new Source('', '', locationOffset);
     }
 

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -3,13 +3,14 @@ import { describe, it } from 'mocha';
 
 import invariant from '../../jsutils/invariant';
 
+import type { ASTNode } from '../ast';
 import { Kind } from '../kinds';
 import { parse } from '../parser';
 import { visit, visitInParallel, BREAK, QueryDocumentKeys } from '../visitor';
 
 import { kitchenSinkQuery } from '../../__fixtures__/index';
 
-function checkVisitorFnArgs(ast, args, isEdited) {
+function checkVisitorFnArgs(ast: any, args: any, isEdited: boolean = false) {
   const [node, key, parent, path, ancestors] = args;
 
   expect(node).to.be.an.instanceof(Object);
@@ -50,7 +51,7 @@ function checkVisitorFnArgs(ast, args, isEdited) {
   }
 }
 
-function getValue(node) {
+function getValue(node: ASTNode) {
   return node.value != null ? node.value : undefined;
 }
 

--- a/src/language/blockString.js
+++ b/src/language/blockString.js
@@ -34,7 +34,7 @@ export function dedentBlockStringValue(rawString: string): string {
   return lines.slice(startLine, endLine).join('\n');
 }
 
-function isBlank(str) {
+function isBlank(str: string): boolean {
   for (let i = 0; i < str.length; ++i) {
     if (str[i] !== ' ' && str[i] !== '\t') {
       return false;

--- a/src/language/lexer.js
+++ b/src/language/lexer.js
@@ -94,7 +94,7 @@ export function isPunctuatorTokenKind(kind: TokenKindEnum): boolean %checks {
   );
 }
 
-function printCharCode(code) {
+function printCharCode(code: number): string {
   return (
     // NaN/undefined represents access beyond the end of the file.
     isNaN(code)
@@ -271,7 +271,7 @@ function readToken(lexer: Lexer, prev: Token): Token {
 /**
  * Report a message that an unexpected character was encountered.
  */
-function unexpectedCharacterMessage(code) {
+function unexpectedCharacterMessage(code: number): string {
   if (code < 0x0020 && code !== 0x0009 && code !== 0x000a && code !== 0x000d) {
     return `Cannot contain the invalid character ${printCharCode(code)}.`;
   }
@@ -289,7 +289,13 @@ function unexpectedCharacterMessage(code) {
  *
  * #[\u0009\u0020-\uFFFF]*
  */
-function readComment(source, start, line, col, prev): Token {
+function readComment(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token | null,
+): Token {
   const body = source.body;
   let code;
   let position = start;
@@ -320,7 +326,14 @@ function readComment(source, start, line, col, prev): Token {
  * Int:   -?(0|[1-9][0-9]*)
  * Float: -?(0|[1-9][0-9]*)(\.[0-9]+)?((E|e)(+|-)?[0-9]+)?
  */
-function readNumber(source, start, firstCode, line, col, prev): Token {
+function readNumber(
+  source: Source,
+  start: number,
+  firstCode: number,
+  line: number,
+  col: number,
+  prev: Token | null,
+): Token {
   const body = source.body;
   let code = firstCode;
   let position = start;
@@ -391,7 +404,7 @@ function readNumber(source, start, firstCode, line, col, prev): Token {
 /**
  * Returns the new position in the source after reading digits.
  */
-function readDigits(source, start, firstCode) {
+function readDigits(source: Source, start: number, firstCode: number): number {
   const body = source.body;
   let position = start;
   let code = firstCode;
@@ -414,7 +427,13 @@ function readDigits(source, start, firstCode) {
  *
  * "([^"\\\u000A\u000D]|(\\(u[0-9a-fA-F]{4}|["\\/bfnrt])))*"
  */
-function readString(source, start, line, col, prev): Token {
+function readString(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token | null,
+): Token {
   const body = source.body;
   let position = start + 1;
   let chunkStart = position;
@@ -523,7 +542,14 @@ function readString(source, start, line, col, prev): Token {
  *
  * """("?"?(\\"""|\\(?!=""")|[^"\\]))*"""
  */
-function readBlockString(source, start, line, col, prev, lexer): Token {
+function readBlockString(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token | null,
+  lexer: Lexer,
+): Token {
   const body = source.body;
   let position = start + 3;
   let chunkStart = position;
@@ -605,7 +631,7 @@ function readBlockString(source, start, line, col, prev, lexer): Token {
  * This is implemented by noting that char2hex() returns -1 on error,
  * which means the result of ORing the char2hex() will also be negative.
  */
-function uniCharCode(a, b, c, d) {
+function uniCharCode(a: number, b: number, c: number, d: number): number {
   return (
     (char2hex(a) << 12) | (char2hex(b) << 8) | (char2hex(c) << 4) | char2hex(d)
   );
@@ -619,7 +645,7 @@ function uniCharCode(a, b, c, d) {
  *
  * Returns -1 on error.
  */
-function char2hex(a) {
+function char2hex(a: number): number {
   return a >= 48 && a <= 57
     ? a - 48 // 0-9
     : a >= 65 && a <= 70
@@ -634,7 +660,13 @@ function char2hex(a) {
  *
  * [_A-Za-z][_0-9A-Za-z]*
  */
-function readName(source, start, line, col, prev): Token {
+function readName(
+  source: Source,
+  start: number,
+  line: number,
+  col: number,
+  prev: Token | null,
+): Token {
   const body = source.body;
   const bodyLength = body.length;
   let position = start + 1;
@@ -661,7 +693,7 @@ function readName(source, start, line, col, prev): Token {
 }
 
 // _ A-Z a-z
-function isNameStart(code): boolean {
+function isNameStart(code: number): boolean {
   return (
     code === 95 || (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
   );

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -254,7 +254,7 @@ function addDescription(cb) {
  * Given maybeArray, print an empty string if it is null or empty, otherwise
  * print all items together separated by separator if provided
  */
-function join(maybeArray: ?Array<string>, separator = '') {
+function join(maybeArray: ?Array<string>, separator = ''): string {
   return maybeArray?.filter((x) => x).join(separator) ?? '';
 }
 
@@ -262,28 +262,29 @@ function join(maybeArray: ?Array<string>, separator = '') {
  * Given array, print each item on its own line, wrapped in an
  * indented "{ }" block.
  */
-function block(array) {
+function block(array: ?Array<string>): string {
   return array && array.length !== 0
     ? '{\n' + indent(join(array, '\n')) + '\n}'
     : '';
 }
 
 /**
- * If maybeString is not null or empty, then wrap with start and end, otherwise
- * print an empty string.
+ * If maybeString is not null or empty, then wrap with start and end, otherwise print an empty string.
  */
-function wrap(start, maybeString, end = '') {
-  return maybeString ? start + maybeString + end : '';
+function wrap(start: string, maybeString: ?string, end: string = ''): string {
+  return maybeString != null && maybeString !== ''
+    ? start + maybeString + end
+    : '';
 }
 
-function indent(maybeString) {
-  return maybeString && '  ' + maybeString.replace(/\n/g, '\n  ');
+function indent(str: string): string {
+  return str !== '' ? '  ' + str.replace(/\n/g, '\n  ') : '';
 }
 
-function isMultiline(string) {
-  return string.indexOf('\n') !== -1;
+function isMultiline(str: string): boolean {
+  return str.indexOf('\n') !== -1;
 }
 
-function hasMultilineItems(maybeArray) {
-  return maybeArray && maybeArray.some(isMultiline);
+function hasMultilineItems(maybeArray: ?Array<string>): boolean {
+  return maybeArray != null && maybeArray.some(isMultiline);
 }

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -13,7 +13,7 @@ export default function eventEmitterAsyncIterator(
   let listening = true;
   eventEmitter.addListener(eventName, pushValue);
 
-  function pushValue(event) {
+  function pushValue(event: mixed) {
     if (pullQueue.length !== 0) {
       pullQueue.shift()({ value: event, done: false });
     } else {
@@ -53,7 +53,7 @@ export default function eventEmitterAsyncIterator(
       emptyQueue();
       return Promise.resolve({ value: undefined, done: true });
     },
-    throw(error) {
+    throw(error: mixed) {
       emptyQueue();
       return Promise.reject(error);
     },

--- a/src/subscription/__tests__/mapAsyncIterator-test.js
+++ b/src/subscription/__tests__/mapAsyncIterator-test.js
@@ -301,7 +301,7 @@ describe('mapAsyncIterator', () => {
     });
   });
 
-  async function testClosesSourceWithMapper(mapper) {
+  async function testClosesSourceWithMapper<T>(mapper: (number) => T) {
     let didVisitFinally = false;
 
     async function* source() {
@@ -357,7 +357,7 @@ describe('mapAsyncIterator', () => {
     );
   });
 
-  async function testClosesSourceWithRejectMapper(mapper) {
+  async function testClosesSourceWithRejectMapper<T>(mapper: (Error) => T) {
     async function* source() {
       yield 1;
       throw new Error(2);

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import type { DocumentNode } from '../../language/ast';
 import { parse } from '../../language/parser';
 
 import { GraphQLError } from '../../error/GraphQLError';
@@ -57,7 +58,10 @@ const EmailEventType = new GraphQLObjectType({
 
 const emailSchema = emailSchemaWithResolvers();
 
-function emailSchemaWithResolvers(subscribeFn, resolveFn) {
+function emailSchemaWithResolvers<T: mixed>(
+  subscribeFn?: (T) => mixed,
+  resolveFn?: (T) => mixed,
+) {
   return new GraphQLSchema({
     query: QueryType,
     subscription: new GraphQLObjectType({
@@ -92,9 +96,9 @@ const defaultSubscriptionAST = parse(`
 `);
 
 async function createSubscription(
-  pubsub,
-  schema = emailSchema,
-  document = defaultSubscriptionAST,
+  pubsub: EventEmitter,
+  schema: GraphQLSchema = emailSchema,
+  document: DocumentNode = defaultSubscriptionAST,
 ) {
   const data = {
     inbox: {
@@ -112,7 +116,7 @@ async function createSubscription(
     },
   };
 
-  function sendImportantEmail(newEmail) {
+  function sendImportantEmail(newEmail: mixed) {
     data.inbox.emails.push(newEmail);
     // Returns true if the event was consumed by a subscriber.
     return pubsub.emit('importantEmail', {
@@ -131,7 +135,10 @@ async function createSubscription(
   };
 }
 
-async function expectPromiseToThrow(promise, message) {
+async function expectPromiseToThrow(
+  promise: () => Promise<mixed>,
+  message: string,
+) {
   try {
     await promise();
     // istanbul ignore next (Shouldn't be reached)
@@ -425,7 +432,7 @@ describe('Subscription Initialization Phase', () => {
     );
     await testReportsError(subscriptionRejectingErrorSchema);
 
-    async function testReportsError(schema) {
+    async function testReportsError(schema: GraphQLSchema) {
       // Promise<AsyncIterable<ExecutionResult> | ExecutionResult>
       const result = await subscribe({
         schema,
@@ -473,7 +480,7 @@ describe('Subscription Initialization Phase', () => {
     );
     await testReportsError(subscriptionRejectingErrorSchema);
 
-    async function testReportsError(schema) {
+    async function testReportsError(schema: GraphQLSchema) {
       // Promise<AsyncIterable<ExecutionResult> | ExecutionResult>
       const result = await createSourceEventStream(
         schema,

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -18,13 +18,13 @@ export default function mapAsyncIterator<T, U>(
   let abruptClose;
   if (typeof iterator.return === 'function') {
     $return = iterator.return;
-    abruptClose = (error) => {
+    abruptClose = (error: mixed) => {
       const rethrow = () => Promise.reject(error);
       return $return.call(iterator).then(rethrow, rethrow);
     };
   }
 
-  function mapResult(result) {
+  function mapResult(result: IteratorResult<T, void>) {
     return result.done
       ? result
       : asyncMapValue(result.value, callback).then(iteratorResult, abruptClose);
@@ -34,14 +34,14 @@ export default function mapAsyncIterator<T, U>(
   if (rejectCallback) {
     // Capture rejectCallback to ensure it cannot be null.
     const reject = rejectCallback;
-    mapReject = (error) =>
+    mapReject = (error: mixed) =>
       asyncMapValue(error, reject).then(iteratorResult, abruptClose);
   }
 
   /* TODO: Flow doesn't support symbols as keys:
      https://github.com/facebook/flow/issues/3258 */
   return ({
-    next() {
+    next(): Promise<IteratorResult<U, void>> {
       return iterator.next().then(mapResult, mapReject);
     },
     return() {
@@ -49,7 +49,7 @@ export default function mapAsyncIterator<T, U>(
         ? $return.call(iterator).then(mapResult, mapReject)
         : Promise.resolve({ value: undefined, done: true });
     },
-    throw(error) {
+    throw(error?: mixed): Promise<IteratorResult<U, void>> {
       if (typeof iterator.throw === 'function') {
         return iterator.throw(error).then(mapResult, mapReject);
       }

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -104,7 +104,7 @@ export function subscribe(
  * an ExecutionResult, containing only errors and no data. Otherwise treat the
  * error as a system-class error and re-throw it.
  */
-function reportGraphQLError(error) {
+function reportGraphQLError(error: mixed): ExecutionResult {
   if (error instanceof GraphQLError) {
     return { errors: [error] };
   }

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -364,9 +364,7 @@ describe('Type System: Objects', () => {
         return [{ field: ScalarType }];
       },
     });
-    expect(() => objType.getFields()).to.throw(
-      'SomeObject fields must be an object with field names as keys or a function which returns such an object.',
-    );
+    expect(() => objType.getFields()).to.throw();
   });
 
   it('rejects an Object type with incorrectly typed field args', () => {
@@ -959,7 +957,7 @@ describe('Type System: test utility methods', () => {
   });
 
   it('Object.toStringifies types', () => {
-    function toString(obj) {
+    function toString(obj: mixed): string {
       return Object.prototype.toString.call(obj);
     }
 

--- a/src/type/__tests__/enumType-test.js
+++ b/src/type/__tests__/enumType-test.js
@@ -112,7 +112,10 @@ const schema = new GraphQLSchema({
   subscription: SubscriptionType,
 });
 
-function executeQuery(source, variableValues) {
+function executeQuery(
+  source: string,
+  variableValues?: { +[variable: string]: mixed, ... },
+) {
   return graphqlSync({ schema, source, variableValues });
 }
 

--- a/src/type/__tests__/extensions-test.js
+++ b/src/type/__tests__/extensions-test.js
@@ -16,7 +16,7 @@ import {
 
 const dummyType = new GraphQLScalarType({ name: 'DummyScalar' });
 
-function expectObjMap(value) {
+function expectObjMap(value: mixed) {
   invariant(value != null && typeof value === 'object');
   expect(Object.getPrototypeOf(value)).to.equal(null);
   return expect(value);

--- a/src/type/__tests__/predicate-test.js
+++ b/src/type/__tests__/predicate-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import type { GraphQLArgument, GraphQLInputField } from '../definition';
 import {
   GraphQLDirective,
   GraphQLSkipDirective,
@@ -295,7 +296,7 @@ describe('Type predicates', () => {
   });
 
   describe('isInputType', () => {
-    function expectInputType(type) {
+    function expectInputType(type: mixed) {
       expect(isInputType(type)).to.equal(true);
       expect(() => assertInputType(type)).to.not.throw();
     }
@@ -316,7 +317,7 @@ describe('Type predicates', () => {
       expectInputType(new GraphQLNonNull(InputObjectType));
     });
 
-    function expectNonInputType(type) {
+    function expectNonInputType(type: mixed) {
       expect(isInputType(type)).to.equal(false);
       expect(() => assertInputType(type)).to.throw();
     }
@@ -339,7 +340,7 @@ describe('Type predicates', () => {
   });
 
   describe('isOutputType', () => {
-    function expectOutputType(type) {
+    function expectOutputType(type: mixed) {
       expect(isOutputType(type)).to.equal(true);
       expect(() => assertOutputType(type)).to.not.throw();
     }
@@ -366,7 +367,7 @@ describe('Type predicates', () => {
       expectOutputType(new GraphQLNonNull(EnumType));
     });
 
-    function expectNonOutputType(type) {
+    function expectNonOutputType(type: mixed) {
       expect(isOutputType(type)).to.equal(false);
       expect(() => assertOutputType(type)).to.throw();
     }
@@ -558,7 +559,7 @@ describe('Type predicates', () => {
   });
 
   describe('isRequiredArgument', () => {
-    function buildArg(config) {
+    function buildArg(config: $Shape<GraphQLArgument>) {
       return {
         name: 'someArg',
         description: undefined,
@@ -602,7 +603,7 @@ describe('Type predicates', () => {
   });
 
   describe('isRequiredInputField', () => {
-    function buildInputField(config) {
+    function buildInputField(config: $Shape<GraphQLInputField>) {
       return {
         name: 'someInputField',
         description: undefined,

--- a/src/type/__tests__/scalars-test.js
+++ b/src/type/__tests__/scalars-test.js
@@ -14,7 +14,7 @@ import {
 describe('Type System: Specified scalar types', () => {
   describe('GraphQLInt', () => {
     it('parseValue', () => {
-      function parseValue(value) {
+      function parseValue(value: mixed) {
         return GraphQLInt.parseValue(value);
       }
 
@@ -65,7 +65,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('parseLiteral', () => {
-      function parseLiteral(str) {
+      function parseLiteral(str: string) {
         return GraphQLInt.parseLiteral(parseValueToAST(str));
       }
 
@@ -110,7 +110,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('serialize', () => {
-      function serialize(value) {
+      function serialize(value: mixed) {
         return GraphQLInt.serialize(value);
       }
 
@@ -183,7 +183,7 @@ describe('Type System: Specified scalar types', () => {
 
   describe('GraphQLFloat', () => {
     it('parseValue', () => {
-      function parseValue(value) {
+      function parseValue(value: mixed) {
         return GraphQLFloat.parseValue(value);
       }
 
@@ -230,7 +230,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('parseLiteral', () => {
-      function parseLiteral(str) {
+      function parseLiteral(str: string) {
         return GraphQLFloat.parseLiteral(parseValueToAST(str));
       }
 
@@ -270,7 +270,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('serialize', () => {
-      function serialize(value) {
+      function serialize(value: mixed) {
         return GraphQLFloat.serialize(value);
       }
 
@@ -313,7 +313,7 @@ describe('Type System: Specified scalar types', () => {
 
   describe('GraphQLString', () => {
     it('parseValue', () => {
-      function parseValue(value) {
+      function parseValue(value: mixed) {
         return GraphQLString.parseValue(value);
       }
 
@@ -343,7 +343,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('parseLiteral', () => {
-      function parseLiteral(str) {
+      function parseLiteral(str: string) {
         return GraphQLString.parseLiteral(parseValueToAST(str));
       }
 
@@ -377,7 +377,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('serialize', () => {
-      function serialize(value) {
+      function serialize(value: mixed) {
         return GraphQLString.serialize(value);
       }
 
@@ -418,7 +418,7 @@ describe('Type System: Specified scalar types', () => {
 
   describe('GraphQLBoolean', () => {
     it('parseValue', () => {
-      function parseValue(value) {
+      function parseValue(value: mixed) {
         return GraphQLBoolean.parseValue(value);
       }
 
@@ -455,7 +455,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('parseLiteral', () => {
-      function parseLiteral(str) {
+      function parseLiteral(str: string) {
         return GraphQLBoolean.parseLiteral(parseValueToAST(str));
       }
 
@@ -495,7 +495,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('serialize', () => {
-      function serialize(value) {
+      function serialize(value: mixed) {
         return GraphQLBoolean.serialize(value);
       }
 
@@ -532,7 +532,7 @@ describe('Type System: Specified scalar types', () => {
 
   describe('GraphQLID', () => {
     it('parseValue', () => {
-      function parseValue(value) {
+      function parseValue(value: mixed) {
         return GraphQLID.parseValue(value);
       }
 
@@ -570,7 +570,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('parseLiteral', () => {
-      function parseLiteral(str) {
+      function parseLiteral(str: string) {
         return GraphQLID.parseLiteral(parseValueToAST(str));
       }
 
@@ -610,7 +610,7 @@ describe('Type System: Specified scalar types', () => {
     });
 
     it('serialize', () => {
-      function serialize(value) {
+      function serialize(value: mixed) {
         return GraphQLID.serialize(value);
       }
 

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -873,11 +873,13 @@ function defineFieldMap<TSource, TContext>(
   });
 }
 
-function isPlainObj(obj) {
+function isPlainObj(obj: mixed): boolean {
   return isObjectLike(obj) && !Array.isArray(obj);
 }
 
-function fieldsToFieldsConfig(fields) {
+function fieldsToFieldsConfig(
+  fields: GraphQLFieldMap<mixed, mixed>,
+): GraphQLFieldConfigMap<mixed, mixed> {
   return mapValue(fields, (field) => ({
     description: field.description,
     type: field.type,

--- a/src/type/validate.js
+++ b/src/type/validate.js
@@ -108,7 +108,7 @@ class SchemaValidationContext {
   }
 }
 
-function validateRootTypes(context) {
+function validateRootTypes(context: SchemaValidationContext): void {
   const schema = context.schema;
   const queryType = schema.getQueryType();
   if (!queryType) {
@@ -528,7 +528,7 @@ function validateInputFields(
 
 function createInputObjectCircularRefsValidator(
   context: SchemaValidationContext,
-) {
+): (GraphQLInputObjectType) => void {
   // Modified copy of algorithm from 'src/validation/rules/NoFragmentCycles.js'.
   // Tracks already visited types to maintain O(N) and to ensure that cycles
   // are not redundantly reported.
@@ -545,7 +545,7 @@ function createInputObjectCircularRefsValidator(
   // This does a straight-forward DFS to find cycles.
   // It does not terminate when a cycle was found but continues to explore
   // the graph to find all possible cycles.
-  function detectCycleRecursive(inputObj: GraphQLInputObjectType) {
+  function detectCycleRecursive(inputObj: GraphQLInputObjectType): void {
     if (visitedTypes[inputObj.name]) {
       return;
     }

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -5,10 +5,12 @@ import dedent from '../../__testUtils__/dedent';
 
 import invariant from '../../jsutils/invariant';
 
+import type { ASTNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
 import { print } from '../../language/printer';
 
+import type { GraphQLNamedType } from '../../type/definition';
 import { GraphQLSchema } from '../../type/schema';
 import { validateSchema } from '../../type/validate';
 import { __Schema, __EnumValue } from '../../type/introspection';
@@ -45,7 +47,7 @@ import { buildASTSchema, buildSchema } from '../buildASTSchema';
  * the SDL, parsed in a schema AST, materializing that schema AST into an
  * in-memory GraphQLSchema, and then finally printing that object into the SDL
  */
-function cycleSDL(sdl, options) {
+function cycleSDL(sdl: string, options): string {
   const ast = parse(sdl);
   const schema = buildASTSchema(ast, options);
 
@@ -53,12 +55,12 @@ function cycleSDL(sdl, options) {
   return printSchema(schema, { commentDescriptions });
 }
 
-function printASTNode(obj) {
+function printASTNode(obj: ?{ +astNode: ?ASTNode, ... }): string {
   invariant(obj?.astNode != null);
   return print(obj.astNode);
 }
 
-function printAllASTNodes(obj) {
+function printAllASTNodes(obj: GraphQLNamedType): string {
   invariant(obj.astNode != null && obj.extensionASTNodes != null);
   return print({
     kind: Kind.DOCUMENT,

--- a/src/utilities/__tests__/buildClientSchema-benchmark.js
+++ b/src/utilities/__tests__/buildClientSchema-benchmark.js
@@ -4,6 +4,6 @@ import { bigSchemaIntrospectionResult } from '../../__fixtures__/index';
 
 export const name = 'Build Schema from Introspection';
 export const count = 10;
-export function measure() {
+export function measure(): void {
   buildClientSchema(bigSchemaIntrospectionResult.data, { assumeValid: true });
 }

--- a/src/utilities/__tests__/coerceInputValue-test.js
+++ b/src/utilities/__tests__/coerceInputValue-test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import invariant from '../../jsutils/invariant';
 
+import type { GraphQLInputType } from '../../type/definition';
 import { GraphQLInt } from '../../type/scalars';
 import {
   GraphQLList,
@@ -14,25 +15,27 @@ import {
 
 import { coerceInputValue } from '../coerceInputValue';
 
-function expectValue(result) {
+function expectValue(result: any) {
   expect(result.errors).to.deep.equal([]);
   return expect(result.value);
 }
 
-function expectErrors(result) {
+function expectErrors(result: any) {
   return expect(result.errors);
 }
 
 describe('coerceInputValue', () => {
-  function coerceValue(inputValue, type) {
+  function coerceValue(inputValue: mixed, type: GraphQLInputType) {
     const errors = [];
+    const value = coerceInputValue(
+      inputValue,
+      type,
+      (path, invalidValue, error) => {
+        errors.push({ path, value: invalidValue, error: error.message });
+      },
+    );
 
-    const value = coerceInputValue(inputValue, type, onError);
     return { errors, value };
-
-    function onError(path, invalidValue, error) {
-      errors.push({ path, value: invalidValue, error: error.message });
-    }
   }
 
   describe('for GraphQLNonNull', () => {

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -5,12 +5,14 @@ import dedent from '../../__testUtils__/dedent';
 
 import invariant from '../../jsutils/invariant';
 
+import type { ASTNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
 import { print } from '../../language/printer';
 
 import { graphqlSync } from '../../graphql';
 
+import type { GraphQLNamedType } from '../../type/definition';
 import { GraphQLSchema } from '../../type/schema';
 import { validateSchema } from '../../type/validate';
 import { assertDirective } from '../../type/directives';
@@ -35,7 +37,7 @@ import { printSchema } from '../printSchema';
 import { extendSchema } from '../extendSchema';
 import { buildSchema } from '../buildASTSchema';
 
-function printExtensionNodes(obj) {
+function printExtensionNodes(obj: ?GraphQLNamedType | GraphQLSchema): string {
   invariant(obj?.extensionASTNodes != null);
   return print({
     kind: Kind.DOCUMENT,
@@ -43,7 +45,10 @@ function printExtensionNodes(obj) {
   });
 }
 
-function printSchemaChanges(schema, extendedSchema) {
+function printSchemaChanges(
+  schema: GraphQLSchema,
+  extendedSchema: GraphQLSchema,
+): string {
   const schemaDefinitions = parse(printSchema(schema)).definitions.map(print);
   const ast = parse(printSchema(extendedSchema));
   return print({
@@ -54,7 +59,7 @@ function printSchemaChanges(schema, extendedSchema) {
   });
 }
 
-function printASTNode(obj) {
+function printASTNode(obj: ?{ +astNode: ?ASTNode, ... }): string {
   invariant(obj?.astNode != null);
   return print(obj.astNode);
 }

--- a/src/utilities/__tests__/getOperationRootType-test.js
+++ b/src/utilities/__tests__/getOperationRootType-test.js
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import invariant from '../../jsutils/invariant';
 
+import type { DocumentNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
 
@@ -33,7 +34,7 @@ const subscriptionType = new GraphQLObjectType({
   }),
 });
 
-function getOperationNode(doc) {
+function getOperationNode(doc: DocumentNode) {
   const operationNode = doc.definitions[0];
   invariant(operationNode && operationNode.kind === Kind.OPERATION_DEFINITION);
   return operationNode;

--- a/src/utilities/__tests__/introspectionFromSchema-test.js
+++ b/src/utilities/__tests__/introspectionFromSchema-test.js
@@ -7,11 +7,12 @@ import { GraphQLSchema } from '../../type/schema';
 import { GraphQLString } from '../../type/scalars';
 import { GraphQLObjectType } from '../../type/definition';
 
+import type { IntrospectionQuery } from '../getIntrospectionQuery';
 import { printSchema } from '../printSchema';
 import { buildClientSchema } from '../buildClientSchema';
 import { introspectionFromSchema } from '../introspectionFromSchema';
 
-function introspectionToSDL(introspection) {
+function introspectionToSDL(introspection: IntrospectionQuery): string {
   return printSchema(buildClientSchema(introspection));
 }
 

--- a/src/utilities/__tests__/lexicographicSortSchema-test.js
+++ b/src/utilities/__tests__/lexicographicSortSchema-test.js
@@ -7,7 +7,7 @@ import { printSchema } from '../printSchema';
 import { buildSchema } from '../buildASTSchema';
 import { lexicographicSortSchema } from '../lexicographicSortSchema';
 
-function sortSDL(sdl) {
+function sortSDL(sdl: string): string {
   const schema = buildSchema(sdl);
   return printSchema(lexicographicSortSchema(schema));
 }

--- a/src/utilities/__tests__/printSchema-test.js
+++ b/src/utilities/__tests__/printSchema-test.js
@@ -5,6 +5,7 @@ import dedent from '../../__testUtils__/dedent';
 
 import { DirectiveLocation } from '../../language/directiveLocation';
 
+import type { GraphQLFieldConfig } from '../../type/definition';
 import { GraphQLSchema } from '../../type/schema';
 import { GraphQLDirective } from '../../type/directives';
 import { GraphQLInt, GraphQLString, GraphQLBoolean } from '../../type/scalars';
@@ -22,14 +23,14 @@ import {
 import { buildSchema } from '../buildASTSchema';
 import { printSchema, printIntrospectionSchema } from '../printSchema';
 
-function expectPrintedSchema(schema) {
+function expectPrintedSchema(schema: GraphQLSchema) {
   const schemaText = printSchema(schema);
   // keep printSchema and buildSchema in sync
   expect(printSchema(buildSchema(schemaText))).to.equal(schemaText);
   return expect(schemaText);
 }
 
-function buildSingleFieldSchema(fieldConfig) {
+function buildSingleFieldSchema(fieldConfig: GraphQLFieldConfig<mixed, mixed>) {
   const Query = new GraphQLObjectType({
     name: 'Query',
     fields: { singleField: fieldConfig },

--- a/src/utilities/__tests__/stripIgnoredCharacters-fuzz.js
+++ b/src/utilities/__tests__/stripIgnoredCharacters-fuzz.js
@@ -11,7 +11,7 @@ import { Source } from '../../language/source';
 
 import { stripIgnoredCharacters } from '../stripIgnoredCharacters';
 
-function lexValue(str) {
+function lexValue(str: string) {
   const lexer = new Lexer(new Source(str));
   const value = lexer.advance().value;
 

--- a/src/utilities/__tests__/stripIgnoredCharacters-test.js
+++ b/src/utilities/__tests__/stripIgnoredCharacters-test.js
@@ -58,7 +58,7 @@ const nonPunctuatorTokens = [
   '"""block\nstring\nvalue"""', // StringValue(BlockString)
 ];
 
-function lexValue(str) {
+function lexValue(str: string): ?string {
   const lexer = new Lexer(new Source(str));
   const value = lexer.advance().value;
 
@@ -66,9 +66,9 @@ function lexValue(str) {
   return value;
 }
 
-function expectStripped(docString) {
+function expectStripped(docString: string) {
   return {
-    toEqual(expected) {
+    toEqual(expected: string): void {
       const stripped = stripIgnoredCharacters(docString);
 
       invariant(
@@ -91,7 +91,7 @@ function expectStripped(docString) {
         `,
       );
     },
-    toStayTheSame() {
+    toStayTheSame(): void {
       this.toEqual(docString);
     },
   };
@@ -398,7 +398,7 @@ describe('stripIgnoredCharacters', () => {
   });
 
   it('strips ignored characters inside block strings', () => {
-    function expectStrippedString(blockStr) {
+    function expectStrippedString(blockStr: string) {
       const originalValue = lexValue(blockStr);
       const strippedValue = lexValue(stripIgnoredCharacters(blockStr));
 

--- a/src/utilities/__tests__/typeComparators-test.js
+++ b/src/utilities/__tests__/typeComparators-test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import type { GraphQLFieldConfigMap } from '../../type/definition';
 import { GraphQLSchema } from '../../type/schema';
 import { GraphQLString, GraphQLInt, GraphQLFloat } from '../../type/scalars';
 import {
@@ -52,7 +53,7 @@ describe('typeComparators', () => {
   });
 
   describe('isTypeSubTypeOf', () => {
-    function testSchema(fields) {
+    function testSchema(fields: GraphQLFieldConfigMap<mixed, mixed>) {
       return new GraphQLSchema({
         query: new GraphQLObjectType({
           name: 'Query',

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -8,7 +8,12 @@ import isObjectLike from '../jsutils/isObjectLike';
 import { parseValue } from '../language/parser';
 
 import type { GraphQLSchemaValidationOptions } from '../type/schema';
-import type { GraphQLType, GraphQLNamedType } from '../type/definition';
+import type {
+  GraphQLType,
+  GraphQLNamedType,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigMap,
+} from '../type/definition';
 import { GraphQLSchema } from '../type/schema';
 import { GraphQLDirective } from '../type/directives';
 import { specifiedScalarTypes } from '../type/scalars';
@@ -31,6 +36,9 @@ import {
 
 import type {
   IntrospectionQuery,
+  IntrospectionDirective,
+  IntrospectionField,
+  IntrospectionInputValue,
   IntrospectionType,
   IntrospectionScalarType,
   IntrospectionObjectType,
@@ -203,7 +211,7 @@ export function buildClientSchema(
     implementingIntrospection:
       | IntrospectionObjectType
       | IntrospectionInterfaceType,
-  ) {
+  ): Array<GraphQLInterfaceType> {
     // TODO: Temporary workaround until GraphQL ecosystem will fully support
     // 'interfaces' on interface types.
     if (
@@ -300,7 +308,9 @@ export function buildClientSchema(
     });
   }
 
-  function buildFieldDefMap(typeIntrospection) {
+  function buildFieldDefMap(
+    typeIntrospection: IntrospectionObjectType | IntrospectionInterfaceType,
+  ): GraphQLFieldConfigMap<mixed, mixed> {
     if (!typeIntrospection.fields) {
       throw new Error(
         `Introspection result missing fields: ${inspect(typeIntrospection)}.`,
@@ -314,7 +324,9 @@ export function buildClientSchema(
     );
   }
 
-  function buildField(fieldIntrospection) {
+  function buildField(
+    fieldIntrospection: IntrospectionField,
+  ): GraphQLFieldConfig<mixed, mixed> {
     const type = getType(fieldIntrospection.type);
     if (!isOutputType(type)) {
       const typeStr = inspect(type);
@@ -338,7 +350,9 @@ export function buildClientSchema(
     };
   }
 
-  function buildInputValueDefMap(inputValueIntrospections) {
+  function buildInputValueDefMap(
+    inputValueIntrospections: $ReadOnlyArray<IntrospectionInputValue>,
+  ) {
     return keyValMap(
       inputValueIntrospections,
       (inputValue) => inputValue.name,
@@ -346,7 +360,7 @@ export function buildClientSchema(
     );
   }
 
-  function buildInputValue(inputValueIntrospection) {
+  function buildInputValue(inputValueIntrospection: IntrospectionInputValue) {
     const type = getType(inputValueIntrospection.type);
     if (!isInputType(type)) {
       const typeStr = inspect(type);
@@ -366,7 +380,9 @@ export function buildClientSchema(
     };
   }
 
-  function buildDirective(directiveIntrospection) {
+  function buildDirective(
+    directiveIntrospection: IntrospectionDirective,
+  ): GraphQLDirective {
     if (!directiveIntrospection.args) {
       const directiveIntrospectionStr = inspect(directiveIntrospection);
       throw new Error(

--- a/src/utilities/coerceInputValue.js
+++ b/src/utilities/coerceInputValue.js
@@ -42,7 +42,7 @@ function defaultOnError(
   path: $ReadOnlyArray<string | number>,
   invalidValue: mixed,
   error: GraphQLError,
-) {
+): void {
   let errorPrefix = 'Invalid value ' + inspect(invalidValue);
   if (path.length > 0) {
     errorPrefix += ` at "value${printPathArray(path)}"`;

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -52,10 +52,12 @@ import type {
 import type {
   GraphQLType,
   GraphQLNamedType,
+  GraphQLFieldConfig,
   GraphQLFieldConfigMap,
+  GraphQLArgumentConfig,
+  GraphQLFieldConfigArgumentMap,
   GraphQLEnumValueConfigMap,
   GraphQLInputFieldConfigMap,
-  GraphQLFieldConfigArgumentMap,
 } from '../type/definition';
 import { assertSchema, GraphQLSchema } from '../type/schema';
 import { specifiedScalarTypes, isSpecifiedScalarType } from '../type/scalars';
@@ -394,15 +396,18 @@ export function extendSchemaImpl(
     });
   }
 
-  function extendField(field) {
+  function extendField(
+    field: GraphQLFieldConfig<mixed, mixed>,
+  ): GraphQLFieldConfig<mixed, mixed> {
     return {
       ...field,
       type: replaceType(field.type),
+      // $FlowFixMe[incompatible-call]
       args: mapValue(field.args, extendArg),
     };
   }
 
-  function extendArg(arg) {
+  function extendArg(arg: GraphQLArgumentConfig) {
     return {
       ...arg,
       type: replaceType(arg.type),

--- a/src/utilities/lexicographicSortSchema.js
+++ b/src/utilities/lexicographicSortSchema.js
@@ -5,7 +5,13 @@ import inspect from '../jsutils/inspect';
 import invariant from '../jsutils/invariant';
 import keyValMap from '../jsutils/keyValMap';
 
-import type { GraphQLType, GraphQLNamedType } from '../type/definition';
+import type {
+  GraphQLType,
+  GraphQLNamedType,
+  GraphQLFieldConfigMap,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLInputFieldConfigMap,
+} from '../type/definition';
 import { GraphQLSchema } from '../type/schema';
 import { GraphQLDirective } from '../type/directives';
 import { isIntrospectionType } from '../type/introspection';
@@ -64,11 +70,11 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     return ((typeMap[type.name]: any): T);
   }
 
-  function replaceMaybeType(maybeType) {
+  function replaceMaybeType<T: ?GraphQLNamedType>(maybeType: T): T {
     return maybeType && replaceNamedType(maybeType);
   }
 
-  function sortDirective(directive) {
+  function sortDirective(directive: GraphQLDirective) {
     const config = directive.toConfig();
     return new GraphQLDirective({
       ...config,
@@ -77,14 +83,14 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     });
   }
 
-  function sortArgs(args) {
+  function sortArgs(args: GraphQLFieldConfigArgumentMap) {
     return sortObjMap(args, (arg) => ({
       ...arg,
       type: replaceType(arg.type),
     }));
   }
 
-  function sortFields(fieldsMap) {
+  function sortFields(fieldsMap: GraphQLFieldConfigMap<mixed, mixed>) {
     return sortObjMap(fieldsMap, (field) => ({
       ...field,
       type: replaceType(field.type),
@@ -92,7 +98,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     }));
   }
 
-  function sortInputFields(fieldsMap) {
+  function sortInputFields(fieldsMap: GraphQLInputFieldConfigMap) {
     return sortObjMap(fieldsMap, (field) => ({
       ...field,
       type: replaceType(field.type),
@@ -103,7 +109,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     return sortByName(arr).map(replaceNamedType);
   }
 
-  function sortNamedType(type) {
+  function sortNamedType<T: GraphQLNamedType>(type: T) {
     if (isScalarType(type) || isIntrospectionType(type)) {
       return type;
     }

--- a/src/utilities/printSchema.js
+++ b/src/utilities/printSchema.js
@@ -10,8 +10,12 @@ import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLDirective } from '../type/directives';
 import type {
   GraphQLNamedType,
+  GraphQLField,
+  GraphQLArgument,
+  GraphQLInputField,
   GraphQLScalarType,
   GraphQLEnumType,
+  GraphQLEnumValue,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
@@ -248,7 +252,10 @@ function printInputObject(type: GraphQLInputObjectType, options): string {
   );
 }
 
-function printFields(options, type) {
+function printFields(
+  options,
+  type: GraphQLObjectType | GraphQLInterfaceType,
+): string {
   const fields = objectValues(type.getFields()).map(
     (f, i) =>
       printDescription(options, f, '  ', !i) +
@@ -262,11 +269,15 @@ function printFields(options, type) {
   return printBlock(fields);
 }
 
-function printBlock(items) {
+function printBlock(items: $ReadOnlyArray<string>): string {
   return items.length !== 0 ? ' {\n' + items.join('\n') + '\n}' : '';
 }
 
-function printArgs(options, args, indentation = '') {
+function printArgs(
+  options,
+  args: Array<GraphQLArgument>,
+  indentation: string = '',
+): string {
   if (args.length === 0) {
     return '';
   }
@@ -293,7 +304,7 @@ function printArgs(options, args, indentation = '') {
   );
 }
 
-function printInputValue(arg) {
+function printInputValue(arg: GraphQLInputField): string {
   const defaultAST = astFromValue(arg.defaultValue, arg.type);
   let argDecl = arg.name + ': ' + String(arg.type);
   if (defaultAST) {
@@ -302,7 +313,7 @@ function printInputValue(arg) {
   return argDecl;
 }
 
-function printDirective(directive, options) {
+function printDirective(directive: GraphQLDirective, options): string {
   return (
     printDescription(options, directive) +
     'directive @' +
@@ -314,7 +325,9 @@ function printDirective(directive, options) {
   );
 }
 
-function printDeprecated(fieldOrEnumVal) {
+function printDeprecated(
+  fieldOrEnumVal: GraphQLEnumValue | GraphQLField<mixed, mixed>,
+): string {
   const { deprecationReason } = fieldOrEnumVal;
   if (deprecationReason == null) {
     return '';
@@ -326,7 +339,7 @@ function printDeprecated(fieldOrEnumVal) {
   return ' @deprecated';
 }
 
-function printSpecifiedByUrl(scalar: GraphQLScalarType) {
+function printSpecifiedByUrl(scalar: GraphQLScalarType): string {
   if (scalar.specifiedByUrl == null) {
     return '';
   }
@@ -341,9 +354,9 @@ function printSpecifiedByUrl(scalar: GraphQLScalarType) {
 
 function printDescription(
   options,
-  def,
-  indentation = '',
-  firstInBlock = true,
+  def: { +description: ?string, ... },
+  indentation: string = '',
+  firstInBlock: boolean = true,
 ): string {
   const { description } = def;
   if (description == null) {

--- a/src/utilities/stripIgnoredCharacters.js
+++ b/src/utilities/stripIgnoredCharacters.js
@@ -102,7 +102,7 @@ export function stripIgnoredCharacters(source: string | Source): string {
   return strippedBody;
 }
 
-function dedentBlockString(blockStr) {
+function dedentBlockString(blockStr: string): string {
   // skip leading and trailing triple quotations
   const rawStr = blockStr.slice(3, -3);
   let body = dedentBlockStringValue(rawStr);

--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -152,7 +152,10 @@ export function valueFromAST(
 
 // Returns true if the provided valueNode is a variable which is not defined
 // in the set of variables.
-function isMissingVariable(valueNode, variables) {
+function isMissingVariable(
+  valueNode: ValueNode,
+  variables: ?ObjMap<mixed>,
+): boolean {
   return (
     valueNode.kind === Kind.VARIABLE &&
     (variables == null || variables[valueNode.name.value] === undefined)

--- a/src/validation/__tests__/ExecutableDefinitionsRule-test.js
+++ b/src/validation/__tests__/ExecutableDefinitionsRule-test.js
@@ -4,11 +4,11 @@ import { ExecutableDefinitionsRule } from '../rules/ExecutableDefinitionsRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(ExecutableDefinitionsRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.js
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.js
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 
 import { parse } from '../../language/parser';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { validate } from '../validate';
@@ -10,11 +12,11 @@ import { FieldsOnCorrectTypeRule } from '../rules/FieldsOnCorrectTypeRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(FieldsOnCorrectTypeRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
@@ -255,7 +257,7 @@ describe('Validate: Fields on correct type', () => {
   });
 
   describe('Fields on correct type error message', () => {
-    function expectErrorMessage(schema, queryStr) {
+    function expectErrorMessage(schema: GraphQLSchema, queryStr: string) {
       const errors = validate(schema, parse(queryStr), [
         FieldsOnCorrectTypeRule,
       ]);

--- a/src/validation/__tests__/FragmentsOnCompositeTypesRule-test.js
+++ b/src/validation/__tests__/FragmentsOnCompositeTypesRule-test.js
@@ -4,11 +4,11 @@ import { FragmentsOnCompositeTypesRule } from '../rules/FragmentsOnCompositeType
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(FragmentsOnCompositeTypesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/KnownArgumentNamesRule-test.js
+++ b/src/validation/__tests__/KnownArgumentNamesRule-test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import {
@@ -9,15 +11,15 @@ import {
 
 import { expectValidationErrors, expectSDLValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(KnownArgumentNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(
     schema,
     KnownArgumentNamesOnDirectivesRule,
@@ -25,7 +27,7 @@ function expectSDLErrors(sdlStr, schema) {
   );
 }
 
-function expectValidSDL(sdlStr) {
+function expectValidSDL(sdlStr: string) {
   expectSDLErrors(sdlStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/KnownDirectivesRule-test.js
+++ b/src/validation/__tests__/KnownDirectivesRule-test.js
@@ -1,24 +1,26 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { KnownDirectivesRule } from '../rules/KnownDirectivesRule';
 
 import { expectValidationErrors, expectSDLValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(KnownDirectivesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, KnownDirectivesRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/KnownFragmentNamesRule-test.js
+++ b/src/validation/__tests__/KnownFragmentNamesRule-test.js
@@ -4,11 +4,11 @@ import { KnownFragmentNamesRule } from '../rules/KnownFragmentNamesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(KnownFragmentNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/KnownTypeNamesRule-test.js
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { KnownTypeNamesRule } from '../rules/KnownTypeNamesRule';
@@ -10,23 +12,23 @@ import {
   expectSDLValidationErrors,
 } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(KnownTypeNamesRule, queryStr);
 }
 
-function expectErrorsWithSchema(schema, queryStr) {
+function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
   return expectValidationErrorsWithSchema(schema, KnownTypeNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, KnownTypeNamesRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/LoneAnonymousOperationRule-test.js
+++ b/src/validation/__tests__/LoneAnonymousOperationRule-test.js
@@ -4,11 +4,11 @@ import { LoneAnonymousOperationRule } from '../rules/LoneAnonymousOperationRule'
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(LoneAnonymousOperationRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/LoneSchemaDefinitionRule-test.js
+++ b/src/validation/__tests__/LoneSchemaDefinitionRule-test.js
@@ -1,16 +1,18 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { LoneSchemaDefinitionRule } from '../rules/LoneSchemaDefinitionRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, LoneSchemaDefinitionRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/NoFragmentCyclesRule-test.js
+++ b/src/validation/__tests__/NoFragmentCyclesRule-test.js
@@ -4,11 +4,11 @@ import { NoFragmentCyclesRule } from '../rules/NoFragmentCyclesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(NoFragmentCyclesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/NoSchemaIntrospectionCustomRule-test.js
+++ b/src/validation/__tests__/NoSchemaIntrospectionCustomRule-test.js
@@ -6,7 +6,7 @@ import { NoSchemaIntrospectionCustomRule } from '../rules/custom/NoSchemaIntrosp
 
 import { expectValidationErrorsWithSchema } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrorsWithSchema(
     schema,
     NoSchemaIntrospectionCustomRule,
@@ -14,7 +14,7 @@ function expectErrors(queryStr) {
   );
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/NoUndefinedVariablesRule-test.js
+++ b/src/validation/__tests__/NoUndefinedVariablesRule-test.js
@@ -4,11 +4,11 @@ import { NoUndefinedVariablesRule } from '../rules/NoUndefinedVariablesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(NoUndefinedVariablesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/NoUnusedFragmentsRule-test.js
+++ b/src/validation/__tests__/NoUnusedFragmentsRule-test.js
@@ -4,11 +4,11 @@ import { NoUnusedFragmentsRule } from '../rules/NoUnusedFragmentsRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(NoUnusedFragmentsRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/NoUnusedVariablesRule-test.js
+++ b/src/validation/__tests__/NoUnusedVariablesRule-test.js
@@ -4,11 +4,11 @@ import { NoUnusedVariablesRule } from '../rules/NoUnusedVariablesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(NoUnusedVariablesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { OverlappingFieldsCanBeMergedRule } from '../rules/OverlappingFieldsCanBeMergedRule';
@@ -9,15 +11,15 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(OverlappingFieldsCanBeMergedRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectErrorsWithSchema(schema, queryStr) {
+function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
   return expectValidationErrorsWithSchema(
     schema,
     OverlappingFieldsCanBeMergedRule,
@@ -25,7 +27,7 @@ function expectErrorsWithSchema(schema, queryStr) {
   );
 }
 
-function expectValidWithSchema(schema, queryStr) {
+function expectValidWithSchema(schema: GraphQLSchema, queryStr: string) {
   expectErrorsWithSchema(schema, queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/PossibleFragmentSpreadsRule-test.js
+++ b/src/validation/__tests__/PossibleFragmentSpreadsRule-test.js
@@ -4,11 +4,11 @@ import { PossibleFragmentSpreadsRule } from '../rules/PossibleFragmentSpreadsRul
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(PossibleFragmentSpreadsRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/PossibleTypeExtensionsRule-test.js
+++ b/src/validation/__tests__/PossibleTypeExtensionsRule-test.js
@@ -1,16 +1,18 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { PossibleTypeExtensionsRule } from '../rules/PossibleTypeExtensionsRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, PossibleTypeExtensionsRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/ProvidedRequiredArgumentsRule-test.js
+++ b/src/validation/__tests__/ProvidedRequiredArgumentsRule-test.js
@@ -1,5 +1,7 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import {
@@ -9,15 +11,15 @@ import {
 
 import { expectValidationErrors, expectSDLValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(ProvidedRequiredArgumentsRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(
     schema,
     ProvidedRequiredArgumentsOnDirectivesRule,
@@ -25,7 +27,7 @@ function expectSDLErrors(sdlStr, schema) {
   );
 }
 
-function expectValidSDL(sdlStr) {
+function expectValidSDL(sdlStr: string) {
   expectSDLErrors(sdlStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/ScalarLeafsRule-test.js
+++ b/src/validation/__tests__/ScalarLeafsRule-test.js
@@ -4,11 +4,11 @@ import { ScalarLeafsRule } from '../rules/ScalarLeafsRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(ScalarLeafsRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/SingleFieldSubscriptionsRule-test.js
+++ b/src/validation/__tests__/SingleFieldSubscriptionsRule-test.js
@@ -4,11 +4,11 @@ import { SingleFieldSubscriptionsRule } from '../rules/SingleFieldSubscriptionsR
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(SingleFieldSubscriptionsRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueArgumentNamesRule-test.js
+++ b/src/validation/__tests__/UniqueArgumentNamesRule-test.js
@@ -4,11 +4,11 @@ import { UniqueArgumentNamesRule } from '../rules/UniqueArgumentNamesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(UniqueArgumentNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueDirectiveNamesRule-test.js
+++ b/src/validation/__tests__/UniqueDirectiveNamesRule-test.js
@@ -1,16 +1,18 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { UniqueDirectiveNamesRule } from '../rules/UniqueDirectiveNamesRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, UniqueDirectiveNamesRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.js
+++ b/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.js
@@ -1,6 +1,9 @@
 import { describe, it } from 'mocha';
 
 import { parse } from '../../language/parser';
+
+import type { GraphQLSchema } from '../../type/schema';
+
 import { extendSchema } from '../../utilities/extendSchema';
 
 import { UniqueDirectivesPerLocationRule } from '../rules/UniqueDirectivesPerLocationRule';
@@ -19,7 +22,7 @@ const extensionSDL = `
 `;
 const schemaWithDirectives = extendSchema(testSchema, parse(extensionSDL));
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrorsWithSchema(
     schemaWithDirectives,
     UniqueDirectivesPerLocationRule,
@@ -27,11 +30,11 @@ function expectErrors(queryStr) {
   );
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(
     schema,
     UniqueDirectivesPerLocationRule,

--- a/src/validation/__tests__/UniqueEnumValueNamesRule-test.js
+++ b/src/validation/__tests__/UniqueEnumValueNamesRule-test.js
@@ -1,16 +1,18 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { UniqueEnumValueNamesRule } from '../rules/UniqueEnumValueNamesRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, UniqueEnumValueNamesRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueFieldDefinitionNamesRule-test.js
+++ b/src/validation/__tests__/UniqueFieldDefinitionNamesRule-test.js
@@ -1,12 +1,14 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { UniqueFieldDefinitionNamesRule } from '../rules/UniqueFieldDefinitionNamesRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(
     schema,
     UniqueFieldDefinitionNamesRule,
@@ -14,7 +16,7 @@ function expectSDLErrors(sdlStr, schema) {
   );
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueFragmentNamesRule-test.js
+++ b/src/validation/__tests__/UniqueFragmentNamesRule-test.js
@@ -4,11 +4,11 @@ import { UniqueFragmentNamesRule } from '../rules/UniqueFragmentNamesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(UniqueFragmentNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueInputFieldNamesRule-test.js
+++ b/src/validation/__tests__/UniqueInputFieldNamesRule-test.js
@@ -4,11 +4,11 @@ import { UniqueInputFieldNamesRule } from '../rules/UniqueInputFieldNamesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(UniqueInputFieldNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueOperationNamesRule-test.js
+++ b/src/validation/__tests__/UniqueOperationNamesRule-test.js
@@ -4,11 +4,11 @@ import { UniqueOperationNamesRule } from '../rules/UniqueOperationNamesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(UniqueOperationNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueOperationTypesRule-test.js
+++ b/src/validation/__tests__/UniqueOperationTypesRule-test.js
@@ -1,16 +1,18 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { UniqueOperationTypesRule } from '../rules/UniqueOperationTypesRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, UniqueOperationTypesRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueTypeNamesRule-test.js
+++ b/src/validation/__tests__/UniqueTypeNamesRule-test.js
@@ -1,16 +1,18 @@
 import { describe, it } from 'mocha';
 
+import type { GraphQLSchema } from '../../type/schema';
+
 import { buildSchema } from '../../utilities/buildASTSchema';
 
 import { UniqueTypeNamesRule } from '../rules/UniqueTypeNamesRule';
 
 import { expectSDLValidationErrors } from './harness';
 
-function expectSDLErrors(sdlStr, schema) {
+function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
   return expectSDLValidationErrors(schema, UniqueTypeNamesRule, sdlStr);
 }
 
-function expectValidSDL(sdlStr, schema) {
+function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
   expectSDLErrors(sdlStr, schema).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/UniqueVariableNamesRule-test.js
+++ b/src/validation/__tests__/UniqueVariableNamesRule-test.js
@@ -4,11 +4,11 @@ import { UniqueVariableNamesRule } from '../rules/UniqueVariableNamesRule';
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(UniqueVariableNamesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.js
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.js
@@ -13,11 +13,11 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(ValuesOfCorrectTypeRule, queryStr);
 }
 
-function expectErrorsWithSchema(schema, queryStr) {
+function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
   return expectValidationErrorsWithSchema(
     schema,
     ValuesOfCorrectTypeRule,
@@ -25,11 +25,11 @@ function expectErrorsWithSchema(schema, queryStr) {
   );
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 
-function expectValidWithSchema(schema, queryStr) {
+function expectValidWithSchema(schema: GraphQLSchema, queryStr: string) {
   expectErrorsWithSchema(schema, queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/VariablesAreInputTypesRule-test.js
+++ b/src/validation/__tests__/VariablesAreInputTypesRule-test.js
@@ -4,11 +4,11 @@ import { VariablesAreInputTypesRule } from '../rules/VariablesAreInputTypesRule'
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(VariablesAreInputTypesRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/VariablesInAllowedPositionRule-test.js
+++ b/src/validation/__tests__/VariablesInAllowedPositionRule-test.js
@@ -4,11 +4,11 @@ import { VariablesInAllowedPositionRule } from '../rules/VariablesInAllowedPosit
 
 import { expectValidationErrors } from './harness';
 
-function expectErrors(queryStr) {
+function expectErrors(queryStr: string) {
   return expectValidationErrors(VariablesInAllowedPositionRule, queryStr);
 }
 
-function expectValid(queryStr) {
+function expectValid(queryStr: string) {
   expectErrors(queryStr).to.deep.equal([]);
 }
 

--- a/src/validation/__tests__/validateGQL-benchmark.js
+++ b/src/validation/__tests__/validateGQL-benchmark.js
@@ -11,6 +11,6 @@ const queryAST = parse(getIntrospectionQuery());
 
 export const name = 'Validate Introspection Query';
 export const count = 50;
-export function measure() {
+export function measure(): void {
   validate(schema, queryAST);
 }

--- a/src/validation/__tests__/validateInvalidGQL-benchmark.js
+++ b/src/validation/__tests__/validateInvalidGQL-benchmark.js
@@ -22,6 +22,6 @@ const queryAST = parse(`
 
 export const name = 'Validate Invalid Query';
 export const count = 50;
-export function measure() {
+export function measure(): void {
   validate(schema, queryAST);
 }

--- a/src/validation/__tests__/validateSDL-benchmark.js
+++ b/src/validation/__tests__/validateSDL-benchmark.js
@@ -8,6 +8,6 @@ const sdlAST = parse(bigSchemaSDL);
 
 export const name = 'Validate SDL Document';
 export const count = 10;
-export function measure() {
+export function measure(): void {
   validateSDL(sdlAST);
 }

--- a/src/validation/__tests__/validation-test.js
+++ b/src/validation/__tests__/validation-test.js
@@ -8,6 +8,7 @@ import { parse } from '../../language/parser';
 import { TypeInfo } from '../../utilities/TypeInfo';
 import { buildSchema } from '../../utilities/buildASTSchema';
 
+import type { ValidationContext } from '../ValidationContext';
 import { validate } from '../validate';
 
 import { testSchema } from './harness';
@@ -95,7 +96,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    function customRule(context) {
+    function customRule(context: ValidationContext) {
       return {
         Directive(node) {
           const directiveDef = context.getDirective();
@@ -128,11 +129,11 @@ describe('Validate: Limit maximum number of validation errors', () => {
   `;
   const doc = parse(query, { noLocation: true });
 
-  function validateDocument(options) {
+  function validateDocument(options: {| maxErrors?: number |}) {
     return validate(testSchema, doc, undefined, undefined, options);
   }
 
-  function invalidFieldError(fieldName) {
+  function invalidFieldError(fieldName: string) {
     return {
       message: `Cannot query field "${fieldName}" on type "QueryRoot".`,
       locations: [],

--- a/src/validation/rules/KnownDirectivesRule.js
+++ b/src/validation/rules/KnownDirectivesRule.js
@@ -4,7 +4,7 @@ import invariant from '../../jsutils/invariant';
 import { GraphQLError } from '../../error/GraphQLError';
 
 import type { ASTVisitor } from '../../language/visitor';
-import type { OperationTypeNode } from '../../language/ast';
+import type { ASTNode, OperationTypeNode } from '../../language/ast';
 import type { DirectiveLocationEnum } from '../../language/directiveLocation';
 import { Kind } from '../../language/kinds';
 import { DirectiveLocation } from '../../language/directiveLocation';
@@ -67,7 +67,9 @@ export function KnownDirectivesRule(
   };
 }
 
-function getDirectiveLocationForASTPath(ancestors) {
+function getDirectiveLocationForASTPath(
+  ancestors: $ReadOnlyArray<ASTNode | $ReadOnlyArray<ASTNode>>,
+): DirectiveLocationEnum | void {
   const appliedTo = ancestors[ancestors.length - 1];
   invariant(!Array.isArray(appliedTo));
 

--- a/src/validation/rules/KnownTypeNamesRule.js
+++ b/src/validation/rules/KnownTypeNamesRule.js
@@ -71,7 +71,7 @@ const standardTypeNames = [...specifiedScalarTypes, ...introspectionTypes].map(
   (type) => type.name,
 );
 
-function isStandardTypeName(typeName) {
+function isStandardTypeName(typeName: string): boolean {
   return standardTypeNames.indexOf(typeName) !== -1;
 }
 

--- a/src/validation/rules/NoFragmentCyclesRule.js
+++ b/src/validation/rules/NoFragmentCyclesRule.js
@@ -29,7 +29,7 @@ export function NoFragmentCyclesRule(
   // This does a straight-forward DFS to find cycles.
   // It does not terminate when a cycle was found but continues to explore
   // the graph to find all possible cycles.
-  function detectCycleRecursive(fragment: FragmentDefinitionNode) {
+  function detectCycleRecursive(fragment: FragmentDefinitionNode): void {
     if (visitedFrags[fragment.name.value]) {
       return;
     }

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.js
@@ -9,6 +9,7 @@ import { GraphQLError } from '../../error/GraphQLError';
 import type { ASTVisitor } from '../../language/visitor';
 import type {
   SelectionSetNode,
+  ValueNode,
   FieldNode,
   ArgumentNode,
   FragmentDefinitionNode,
@@ -641,7 +642,7 @@ function sameArguments(
   });
 }
 
-function sameValue(value1, value2) {
+function sameValue(value1: ValueNode, value2: ValueNode): boolean {
   return print(value1) === print(value2);
 }
 
@@ -796,11 +797,11 @@ function subfieldConflicts(
 class PairSet {
   _data: ObjMap<ObjMap<boolean>>;
 
-  constructor(): void {
+  constructor() {
     this._data = Object.create(null);
   }
 
-  has(a: string, b: string, areMutuallyExclusive: boolean) {
+  has(a: string, b: string, areMutuallyExclusive: boolean): boolean {
     const first = this._data[a];
     const result = first && first[b];
     if (result === undefined) {
@@ -815,17 +816,17 @@ class PairSet {
     return true;
   }
 
-  add(a: string, b: string, areMutuallyExclusive: boolean) {
-    _pairSetAdd(this._data, a, b, areMutuallyExclusive);
-    _pairSetAdd(this._data, b, a, areMutuallyExclusive);
+  add(a: string, b: string, areMutuallyExclusive: boolean): void {
+    this._pairSetAdd(a, b, areMutuallyExclusive);
+    this._pairSetAdd(b, a, areMutuallyExclusive);
   }
-}
 
-function _pairSetAdd(data, a, b, areMutuallyExclusive) {
-  let map = data[a];
-  if (!map) {
-    map = Object.create(null);
-    data[a] = map;
+  _pairSetAdd(a: string, b: string, areMutuallyExclusive: boolean): void {
+    let map = this._data[a];
+    if (!map) {
+      map = Object.create(null);
+      this._data[a] = map;
+    }
+    map[b] = areMutuallyExclusive;
   }
-  map[b] = areMutuallyExclusive;
 }

--- a/src/validation/rules/PossibleFragmentSpreadsRule.js
+++ b/src/validation/rules/PossibleFragmentSpreadsRule.js
@@ -4,6 +4,7 @@ import { GraphQLError } from '../../error/GraphQLError';
 
 import type { ASTVisitor } from '../../language/visitor';
 
+import type { GraphQLCompositeType } from '../../type/definition';
 import { isCompositeType } from '../../type/definition';
 
 import { typeFromAST } from '../../utilities/typeFromAST';
@@ -62,7 +63,10 @@ export function PossibleFragmentSpreadsRule(
   };
 }
 
-function getFragmentType(context, name) {
+function getFragmentType(
+  context: ValidationContext,
+  name: string,
+): ?GraphQLCompositeType {
   const frag = context.getFragment(name);
   if (frag) {
     const type = typeFromAST(context.getSchema(), frag.typeCondition);

--- a/src/validation/rules/PossibleTypeExtensionsRule.js
+++ b/src/validation/rules/PossibleTypeExtensionsRule.js
@@ -5,10 +5,13 @@ import suggestionList from '../../jsutils/suggestionList';
 
 import { GraphQLError } from '../../error/GraphQLError';
 
+import type { KindEnum } from '../../language/kinds';
 import type { ASTVisitor } from '../../language/visitor';
+import type { TypeExtensionNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { isTypeDefinitionNode } from '../../language/predicates';
 
+import type { GraphQLNamedType } from '../../type/definition';
 import {
   isScalarType,
   isObjectType,
@@ -46,7 +49,7 @@ export function PossibleTypeExtensionsRule(
     InputObjectTypeExtension: checkExtension,
   };
 
-  function checkExtension(node) {
+  function checkExtension(node: TypeExtensionNode): void {
     const typeName = node.name.value;
     const defNode = definedTypes[typeName];
     const existingType = schema?.getType(typeName);
@@ -95,7 +98,7 @@ const defKindToExtKind = {
   [Kind.INPUT_OBJECT_TYPE_DEFINITION]: Kind.INPUT_OBJECT_TYPE_EXTENSION,
 };
 
-function typeToExtKind(type) {
+function typeToExtKind(type: GraphQLNamedType): KindEnum {
   if (isScalarType(type)) {
     return Kind.SCALAR_TYPE_EXTENSION;
   }
@@ -120,7 +123,7 @@ function typeToExtKind(type) {
   invariant(false, 'Unexpected type: ' + inspect((type: empty)));
 }
 
-function extensionKindToTypeName(kind) {
+function extensionKindToTypeName(kind: KindEnum): string {
   switch (kind) {
     case Kind.SCALAR_TYPE_EXTENSION:
       return 'scalar';

--- a/src/validation/rules/ProvidedRequiredArgumentsRule.js
+++ b/src/validation/rules/ProvidedRequiredArgumentsRule.js
@@ -3,9 +3,10 @@ import keyMap from '../../jsutils/keyMap';
 
 import { GraphQLError } from '../../error/GraphQLError';
 
+import type { ASTVisitor } from '../../language/visitor';
+import type { InputValueDefinitionNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
-import type { ASTVisitor } from '../../language/visitor';
 
 import { specifiedDirectives } from '../../type/directives';
 import { isType, isRequiredArgument } from '../../type/definition';
@@ -118,6 +119,6 @@ export function ProvidedRequiredArgumentsOnDirectivesRule(
   };
 }
 
-function isRequiredArgumentNode(arg) {
+function isRequiredArgumentNode(arg: InputValueDefinitionNode): boolean {
   return arg.type.kind === Kind.NON_NULL_TYPE && arg.defaultValue == null;
 }

--- a/src/validation/rules/UniqueEnumValueNamesRule.js
+++ b/src/validation/rules/UniqueEnumValueNamesRule.js
@@ -1,6 +1,10 @@
 import { GraphQLError } from '../../error/GraphQLError';
 
 import type { ASTVisitor } from '../../language/visitor';
+import type {
+  EnumTypeDefinitionNode,
+  EnumTypeExtensionNode,
+} from '../../language/ast';
 
 import { isEnumType } from '../../type/definition';
 
@@ -23,7 +27,9 @@ export function UniqueEnumValueNamesRule(
     EnumTypeExtension: checkValueUniqueness,
   };
 
-  function checkValueUniqueness(node) {
+  function checkValueUniqueness(
+    node: EnumTypeDefinitionNode | EnumTypeExtensionNode,
+  ) {
     const typeName = node.name.value;
 
     if (!knownValueNames[typeName]) {

--- a/src/validation/rules/UniqueFieldDefinitionNamesRule.js
+++ b/src/validation/rules/UniqueFieldDefinitionNamesRule.js
@@ -1,7 +1,13 @@
 import { GraphQLError } from '../../error/GraphQLError';
 
 import type { ASTVisitor } from '../../language/visitor';
+import type {
+  NameNode,
+  FieldDefinitionNode,
+  InputValueDefinitionNode,
+} from '../../language/ast';
 
+import type { GraphQLNamedType } from '../../type/definition';
 import {
   isObjectType,
   isInterfaceType,
@@ -31,7 +37,11 @@ export function UniqueFieldDefinitionNamesRule(
     ObjectTypeExtension: checkFieldUniqueness,
   };
 
-  function checkFieldUniqueness(node) {
+  function checkFieldUniqueness(node: {
+    +name: NameNode,
+    +fields?: $ReadOnlyArray<InputValueDefinitionNode | FieldDefinitionNode>,
+    ...
+  }) {
     const typeName = node.name.value;
 
     if (!knownFieldNames[typeName]) {
@@ -68,9 +78,9 @@ export function UniqueFieldDefinitionNamesRule(
   }
 }
 
-function hasField(type, fieldName) {
+function hasField(type: GraphQLNamedType, fieldName: string): boolean {
   if (isObjectType(type) || isInterfaceType(type) || isInputObjectType(type)) {
-    return type.getFields()[fieldName];
+    return type.getFields()[fieldName] != null;
   }
   return false;
 }

--- a/src/validation/rules/UniqueOperationTypesRule.js
+++ b/src/validation/rules/UniqueOperationTypesRule.js
@@ -1,6 +1,10 @@
 import { GraphQLError } from '../../error/GraphQLError';
 
 import type { ASTVisitor } from '../../language/visitor';
+import type {
+  SchemaDefinitionNode,
+  SchemaExtensionNode,
+} from '../../language/ast';
 
 import type { SDLValidationContext } from '../ValidationContext';
 
@@ -27,7 +31,9 @@ export function UniqueOperationTypesRule(
     SchemaExtension: checkOperationTypes,
   };
 
-  function checkOperationTypes(node) {
+  function checkOperationTypes(
+    node: SchemaDefinitionNode | SchemaExtensionNode,
+  ) {
     // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2203')
     const operationTypesNodes = node.operationTypes ?? [];
 


### PR DESCRIPTION
In preparation for TS convertion since TS doesn't deduce types of local
functions from their calls.