### PR TITLE
Do not fail when missing "interfaces" field on INTERFACE nodes

### DIFF
--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -695,6 +695,20 @@ describe('Type System: build schema from introspection', () => {
       expect(printSchema(clientSchema)).to.equal(printSchema(dummySchema));
     });
 
+    it('Legacy support for interfaces with missing interfaces field', () => {
+      const introspection = introspectionFromSchema(dummySchema);
+      const someInterfaceIntrospection = introspection.__schema.types.find(
+        ({ name }) => name === 'SomeInterface',
+      );
+
+      expect(someInterfaceIntrospection).to.have.property('interfaces');
+      delete (someInterfaceIntrospection: any).interfaces;
+      expect(someInterfaceIntrospection).to.not.have.property('interfaces');
+
+      const clientSchema = buildClientSchema(introspection);
+      expect(printSchema(clientSchema)).to.equal(printSchema(dummySchema));
+    });
+
     it('throws when missing fields', () => {
       const introspection = introspectionFromSchema(dummySchema);
       const queryTypeIntrospection = introspection.__schema.types.find(

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -207,7 +207,7 @@ export function buildClientSchema(
     // TODO: Temporary workaround until GraphQL ecosystem will fully support
     // 'interfaces' on interface types.
     if (
-      implementingIntrospection.interfaces === null &&
+      !implementingIntrospection.interfaces &&
       implementingIntrospection.kind === TypeKind.INTERFACE
     ) {
       return [];


### PR DESCRIPTION
Fixes github issue: Exception ["missing interfaces" thrown when processing introspection query result #2768".](https://github.com/graphql/graphql-js/issues/2768)

The following exception is thrown when processing introspection query result:
```
Error: Introspection result missing interfaces: { kind: "INTERFACE", name: "SomeInterface", description: null, fields: [[Object]], inputFields: null, enumValues: null, possibleTypes: [] }.
```

This error is thrown as the buildClientSchema.js rejects types with kind "INTERFACE" which do not have "interfaces" property. This property is required on "INTERFACE" types by the latest GraphQL spec draft http://spec.graphql.org/draft/, but is not consistent with latest official release of GraphQL spec: sections 4.5 & 4.5.2.4 Interface in http://spec.graphql.org/June2018/ - "interfaces" field
is OBJECTS only).

Consider this schema:
```graphql
  type Query {
    foo(bar: String): String
  }

  interface SomeInterface {
    foo: String
  }
```
The introspection query result (for the SomeInterface type) returned by backends following the June 2018 spec is:
```json
  {
    "kind": "INTERFACE",
    "name": "SomeInterface",
    "description": null,
    "fields": [
      {
        "name": "foo",
        "description": null,
        "args": [],
        "type": {
          "kind": "SCALAR",
          "name": "String",
          "ofType": null
        },
        "isDeprecated": false,
        "deprecationReason": null
      }
    ],
    "inputFields": null,
    "enumValues": null,
    "possibleTypes": []
  },
```
Note "interfaces" field is missing here. Such introspection query response causes the buildClientSchema.js to throw the exception.

Signifficance: recent versions of graphql UIs which are using graphql-js, such as GraphiQL, graphql-playground, fail to provide autocomplete functinality against backends which implement the GraphQL spec from June 2018.

Simple fix: line 210 of buildClientSchema.js should be "!implementingIntrospection.interfaces &&"rather than "implementingIntrospection.interfaces === null" in order to accept missing interfaces field on INTEFACES, which seems to be the intention of the code at present.