### PR TITLE
Replace resolved types in lexicographic schema sort

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -1006,7 +1006,9 @@ function ensureValidRuntimeType(
   const runtimeType =
     typeof runtimeTypeOrName === 'string'
       ? exeContext.schema.getType(runtimeTypeOrName)
-      : runtimeTypeOrName;
+      : (runtimeTypeOrName &&
+          exeContext.schema.getType(runtimeTypeOrName.name)) ||
+        runtimeTypeOrName;
 
   if (!isObjectType(runtimeType)) {
     throw new GraphQLError(

--- a/src/utilities/lexicographicSortSchema.js
+++ b/src/utilities/lexicographicSortSchema.js
@@ -11,7 +11,6 @@ import type {
   GraphQLFieldConfigMap,
   GraphQLFieldConfigArgumentMap,
   GraphQLInputFieldConfigMap,
-  GraphQLTypeResolver,
 } from '../type/definition';
 import { GraphQLSchema } from '../type/schema';
 import { GraphQLDirective } from '../type/directives';
@@ -75,20 +74,6 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     return maybeType && replaceNamedType(maybeType);
   }
 
-  function replaceResolvedType(
-    maybeTypeResolver: ?GraphQLTypeResolver<mixed, mixed>,
-  ) {
-    return (
-      maybeTypeResolver &&
-      ((...args) =>
-        Promise.resolve(maybeTypeResolver(...args)).then((resolvedType) =>
-          isObjectType(resolvedType)
-            ? replaceNamedType(resolvedType)
-            : resolvedType,
-        ))
-    );
-  }
-
   function sortDirective(directive: GraphQLDirective) {
     const config = directive.toConfig();
     return new GraphQLDirective({
@@ -142,7 +127,6 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
         ...config,
         interfaces: () => sortTypes(config.interfaces),
         fields: () => sortFields(config.fields),
-        resolveType: replaceResolvedType(config.resolveType),
       });
     }
     if (isUnionType(type)) {
@@ -150,7 +134,6 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
       return new GraphQLUnionType({
         ...config,
         types: () => sortTypes(config.types),
-        resolveType: replaceResolvedType(config.resolveType),
       });
     }
     if (isEnumType(type)) {


### PR DESCRIPTION
When using `lexicographicSortSchema()` with a schema containing `resolveType` for either interfaces or unions the resolved type wasn't being replaced with the new `GraphQLObjectType` created during sorting. This PR wraps any `resolveType` functions provided and substitutes the sorted named type for the type returned from the `resolveType` function.

Downstream issue: https://github.com/nestjs/graphql/issues/1107