### PR TITLE
fix: ensure variance of types matches how values are used

### DIFF
--- a/integrationTests/ts/index.ts
+++ b/integrationTests/ts/index.ts
@@ -95,3 +95,28 @@ const { data } = wrappedExecute(typedQueryDocument);
 if (data != null) {
   const typedData: ResponseData = data;
 }
+
+declare function runQueryA(q: TypedQueryDocumentNode<{ output: string }, { input: string | null }>): void;
+
+// valid
+declare const optionalInputRequiredOutput: TypedQueryDocumentNode<{ output: string }, { input: string | null }>;
+runQueryA(optionalInputRequiredOutput);
+
+declare function runQueryB(q: TypedQueryDocumentNode<{ output: string | null }, { input: string }>): void;
+
+// still valid: We still accept {output: string} as a valid result.
+// We're now passing in {input: string} which is still assignable to {input: string | null}
+runQueryB(optionalInputRequiredOutput);
+
+// valid: we now accept {output: null} as a valid Result
+declare const optionalInputOptionalOutput: TypedQueryDocumentNode<{ output: string | null }, { input: string | null }>;
+runQueryB(optionalInputOptionalOutput);
+
+// valid: we now only pass {input: string} to the query
+declare const requiredInputRequiredOutput: TypedQueryDocumentNode<{ output: string }, { input: string }>;
+runQueryB(requiredInputRequiredOutput);
+
+// valid: we now accept {output: null} as a valid Result AND
+//        we now only pass {input: string} to the query
+declare const requiredInputOptionalOutput: TypedQueryDocumentNode<{ output: null }, { input: string }>;
+runQueryB(requiredInputOptionalOutput);

--- a/integrationTests/ts/index.ts
+++ b/integrationTests/ts/index.ts
@@ -96,27 +96,43 @@ if (data != null) {
   const typedData: ResponseData = data;
 }
 
-declare function runQueryA(q: TypedQueryDocumentNode<{ output: string }, { input: string | null }>): void;
+declare function runQueryA(
+  q: TypedQueryDocumentNode<{ output: string }, { input: string | null }>,
+): void;
 
 // valid
-declare const optionalInputRequiredOutput: TypedQueryDocumentNode<{ output: string }, { input: string | null }>;
+declare const optionalInputRequiredOutput: TypedQueryDocumentNode<
+  { output: string },
+  { input: string | null }
+>;
 runQueryA(optionalInputRequiredOutput);
 
-declare function runQueryB(q: TypedQueryDocumentNode<{ output: string | null }, { input: string }>): void;
+declare function runQueryB(
+  q: TypedQueryDocumentNode<{ output: string | null }, { input: string }>,
+): void;
 
 // still valid: We still accept {output: string} as a valid result.
 // We're now passing in {input: string} which is still assignable to {input: string | null}
 runQueryB(optionalInputRequiredOutput);
 
 // valid: we now accept {output: null} as a valid Result
-declare const optionalInputOptionalOutput: TypedQueryDocumentNode<{ output: string | null }, { input: string | null }>;
+declare const optionalInputOptionalOutput: TypedQueryDocumentNode<
+  { output: string | null },
+  { input: string | null }
+>;
 runQueryB(optionalInputOptionalOutput);
 
 // valid: we now only pass {input: string} to the query
-declare const requiredInputRequiredOutput: TypedQueryDocumentNode<{ output: string }, { input: string }>;
+declare const requiredInputRequiredOutput: TypedQueryDocumentNode<
+  { output: string },
+  { input: string }
+>;
 runQueryB(requiredInputRequiredOutput);
 
 // valid: we now accept {output: null} as a valid Result AND
 //        we now only pass {input: string} to the query
-declare const requiredInputOptionalOutput: TypedQueryDocumentNode<{ output: null }, { input: string }>;
+declare const requiredInputOptionalOutput: TypedQueryDocumentNode<
+  { output: null },
+  { input: string }
+>;
 runQueryB(requiredInputOptionalOutput);

--- a/src/utilities/typedQueryDocumentNode.d.ts
+++ b/src/utilities/typedQueryDocumentNode.d.ts
@@ -14,5 +14,7 @@ export interface TypedQueryDocumentNode<
    * and that the Result is assignable to whatever you pass your result to. The method is never actually
    * implemented, but the type is valid because we list it as optional
    */
-  __ensureTypesOfVariablesAndResultMatching?: (variables: TRequestVariables) => TResponseData;
+  __ensureTypesOfVariablesAndResultMatching?: (
+    variables: TRequestVariables,
+  ) => TResponseData;
 }

--- a/src/utilities/typedQueryDocumentNode.d.ts
+++ b/src/utilities/typedQueryDocumentNode.d.ts
@@ -14,5 +14,5 @@ export interface TypedQueryDocumentNode<
    * and that the Result is assignable to whatever you pass your result to. The method is never actually
    * implemented, but the type is valid because we list it as optional
    */
-  __workaroundForTSToEnsureVariablesAndResultMatching?: (variables: TRequestVariables) => TResponseData;
+  __ensureTypesOfVariablesAndResultMatching?: (variables: TRequestVariables) => TResponseData;
 }

--- a/src/utilities/typedQueryDocumentNode.d.ts
+++ b/src/utilities/typedQueryDocumentNode.d.ts
@@ -14,5 +14,5 @@ export interface TypedQueryDocumentNode<
    * and that the Result is assignable to whatever you pass your result to. The method is never actually
    * implemented, but the type is valid because we list it as optional
    */
-  __apiType?: (variables: TRequestVariables) => TResponseData;
+  __workaroundForTSToEnsureVariablesAndResultMatching?: (variables: TRequestVariables) => TResponseData;
 }

--- a/src/utilities/typedQueryDocumentNode.d.ts
+++ b/src/utilities/typedQueryDocumentNode.d.ts
@@ -9,6 +9,10 @@ export interface TypedQueryDocumentNode<
 > extends DocumentNode {
   readonly definitions: ReadonlyArray<ExecutableDefinitionNode>;
   // FIXME: remove once TS implements proper way to enforce nominal typing
-  readonly __enforceStructuralTypingOnResponseDataType?: TResponseData;
-  readonly __enforceStructuralTypingOnRequestVariablesType?: TRequestVariables;
+  /**
+   * This type is used to ensure that the variables you pass in to the query are assignable to Variables
+   * and that the Result is assignable to whatever you pass your result to. The method is never actually
+   * implemented, but the type is valid because we list it as optional
+   */
+  __apiType?: (variables: Variables) => Result;
 }

--- a/src/utilities/typedQueryDocumentNode.d.ts
+++ b/src/utilities/typedQueryDocumentNode.d.ts
@@ -14,5 +14,5 @@ export interface TypedQueryDocumentNode<
    * and that the Result is assignable to whatever you pass your result to. The method is never actually
    * implemented, but the type is valid because we list it as optional
    */
-  __apiType?: (variables: Variables) => Result;
+  __apiType?: (variables: TRequestVariables) => TResponseData;
 }


### PR DESCRIPTION
I've written up detailed reasoning in https://github.com/dotansimha/graphql-typed-document-node/pull/38

I didn't remove the "FIXME" comment, as I'm not sure what you would prefer to do with it. Nominal typing wouldn't actually solve anything here, because the variables and responses are plain objects, not nominal types. What's needed is just accurate structural typing. I really don't view this as a hack because:

1. We're not lying about any of the types that exist at runtime
2. The `__apiType` property does accurately document/describe the API behavour
3. The type errors TypeScript would produce if you use these `TypedQueryDocumentNode`s incorrectly matches up with the issues you would see at runtime.