### PR TITLE
Make specifiedByUrl in IntrospectionScalarType's flow type optional

### DIFF
--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -173,7 +173,7 @@ export type IntrospectionScalarType = {|
   +kind: 'SCALAR',
   +name: string,
   +description?: ?string,
-  +specifiedByUrl: ?string,
+  +specifiedByUrl?: ?string,
 |};
 
 export type IntrospectionObjectType = {|


### PR DESCRIPTION
This makes the flow definition of `specifiedByUrl` identical to the TS definition in https://github.com/graphql/graphql-js/blob/master/src/utilities/getIntrospectionQuery.d.ts#L65

This also will make the next `graphql-js` release no longer have a breaking flow change compared to v15.0.0: I discovered this flow issue as I was upgrading from v15.0 to v15.3.