### PR TITLE
Make print() break arguments over multiple lines

### DIFF
--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -196,7 +196,7 @@ describe('Printer: Query document', () => {
     );
   });
 
-  it('keeps arguments on one line if line is long (> 80 chars)', () => {
+  it('puts arguments on multiple lines if line is long (> 80 chars)', () => {
     const printed = print(
       parse(
         '{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}',

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -158,9 +158,13 @@ describe('Printer: Query document', () => {
       }
 
       fragment frag on Friend @onFragmentDefinition {
-        foo(size: $size, bar: $b, obj: {key: "value", block: """
-          block string uses \"""
-        """})
+        foo(
+          size: $size
+          bar: $b
+          obj: {key: "value", block: """
+            block string uses \"""
+          """}
+        )
       }
 
       {
@@ -198,9 +202,9 @@ describe('Printer: Query document', () => {
       dedent(String.raw`
       {
         trip(
-          wheelchair: false,
-          arriveBy: false,
-          includePlannedCancellations: true,
+          wheelchair: false
+          arriveBy: false
+          includePlannedCancellations: true
           transitDistanceReluctance: 2000
         ) {
           dateTime

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -174,4 +174,39 @@ describe('Printer: Query document', () => {
     `),
     );
   });
+
+  it('keeps arguments on one line if line is short (<= 80 chars)', () => {
+    const printed = print(parse('{trip(wheelchair:false arriveBy:false){dateTime}}'));
+
+    expect(printed).to.equal(
+      // $FlowFixMe[incompatible-call]
+      dedent(String.raw`
+      {
+        trip(wheelchair: false, arriveBy: false) {
+          dateTime
+        }
+      }
+    `),
+    );
+  });
+
+  it('keeps arguments on one line if line is long (> 80 chars)', () => {
+    const printed = print(parse('{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}'));
+
+    expect(printed).to.equal(
+      // $FlowFixMe[incompatible-call]
+      dedent(String.raw`
+      {
+        trip(
+          wheelchair: false,
+          arriveBy: false,
+          includePlannedCancellations: true,
+          transitDistanceReluctance: 2000
+        ) {
+          dateTime
+        }
+      }
+    `),
+    );
+  });
 });

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -79,6 +79,47 @@ describe('Printer: Query document', () => {
     `);
   });
 
+  it('keeps arguments on one line if line is short (<= 80 chars)', () => {
+    const printed = print(
+      parse('{trip(wheelchair:false arriveBy:false){dateTime}}'),
+    );
+
+    expect(printed).to.equal(
+      // $FlowFixMe[incompatible-call]
+      dedent(String.raw`
+      {
+        trip(wheelchair: false, arriveBy: false) {
+          dateTime
+        }
+      }
+    `),
+    );
+  });
+
+  it('puts arguments on multiple lines if line is long (> 80 chars)', () => {
+    const printed = print(
+      parse(
+        '{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}',
+      ),
+    );
+
+    expect(printed).to.equal(
+      // $FlowFixMe[incompatible-call]
+      dedent(String.raw`
+      {
+        trip(
+          wheelchair: false
+          arriveBy: false
+          includePlannedCancellations: true
+          transitDistanceReluctance: 2000
+        ) {
+          dateTime
+        }
+      }
+    `),
+    );
+  });
+
   it('Experimental: prints fragment with variable directives', () => {
     const queryASTWithVariableDirective = parse(
       'fragment Foo($foo: TestType @test) on TestType @testDirective { id }',
@@ -174,47 +215,6 @@ describe('Printer: Query document', () => {
 
       {
         __typename
-      }
-    `),
-    );
-  });
-
-  it('keeps arguments on one line if line is short (<= 80 chars)', () => {
-    const printed = print(
-      parse('{trip(wheelchair:false arriveBy:false){dateTime}}'),
-    );
-
-    expect(printed).to.equal(
-      // $FlowFixMe[incompatible-call]
-      dedent(String.raw`
-      {
-        trip(wheelchair: false, arriveBy: false) {
-          dateTime
-        }
-      }
-    `),
-    );
-  });
-
-  it('puts arguments on multiple lines if line is long (> 80 chars)', () => {
-    const printed = print(
-      parse(
-        '{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}',
-      ),
-    );
-
-    expect(printed).to.equal(
-      // $FlowFixMe[incompatible-call]
-      dedent(String.raw`
-      {
-        trip(
-          wheelchair: false
-          arriveBy: false
-          includePlannedCancellations: true
-          transitDistanceReluctance: 2000
-        ) {
-          dateTime
-        }
       }
     `),
     );

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -180,7 +180,9 @@ describe('Printer: Query document', () => {
   });
 
   it('keeps arguments on one line if line is short (<= 80 chars)', () => {
-    const printed = print(parse('{trip(wheelchair:false arriveBy:false){dateTime}}'));
+    const printed = print(
+      parse('{trip(wheelchair:false arriveBy:false){dateTime}}'),
+    );
 
     expect(printed).to.equal(
       // $FlowFixMe[incompatible-call]
@@ -195,7 +197,11 @@ describe('Printer: Query document', () => {
   });
 
   it('keeps arguments on one line if line is long (> 80 chars)', () => {
-    const printed = print(parse('{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}'));
+    const printed = print(
+      parse(
+        '{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}',
+      ),
+    );
 
     expect(printed).to.equal(
       // $FlowFixMe[incompatible-call]

--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -85,14 +85,13 @@ describe('Printer: Query document', () => {
     );
 
     expect(printed).to.equal(
-      // $FlowFixMe[incompatible-call]
-      dedent(String.raw`
+      dedent`
       {
         trip(wheelchair: false, arriveBy: false) {
           dateTime
         }
       }
-    `),
+    `,
     );
   });
 
@@ -104,8 +103,7 @@ describe('Printer: Query document', () => {
     );
 
     expect(printed).to.equal(
-      // $FlowFixMe[incompatible-call]
-      dedent(String.raw`
+      dedent`
       {
         trip(
           wheelchair: false
@@ -116,7 +114,7 @@ describe('Printer: Query document', () => {
           dateTime
         }
       }
-    `),
+    `,
     );
   });
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -91,7 +91,7 @@ const printDocASTReducer: any = {
   NullValue: () => 'null',
   EnumValue: ({ value }) => value,
   ListValue: ({ values }) => '[' + join(values, ', ') + ']',
-  ObjectValue: ({ fields }) => block(fields),
+  ObjectValue: ({ fields }) => '{' + join(fields, ', ') + '}',
   ObjectField: ({ name, value }) => name + ': ' + value,
 
   // Directive

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -44,7 +44,9 @@ const printDocASTReducer: any = {
   Field: ({ alias, name, arguments: args, directives, selectionSet }) =>
     join(
       [
-        wrap('', alias, ': ') + name + wrap('(', join(args, ', '), ')'),
+        wrap('', alias, ': ') +
+          name +
+          wrap('(\n', indent(join(args, ',\n')), '\n)'),
         join(directives, ' '),
         selectionSet,
       ],
@@ -89,7 +91,7 @@ const printDocASTReducer: any = {
   NullValue: () => 'null',
   EnumValue: ({ value }) => value,
   ListValue: ({ values }) => '[' + join(values, ', ') + ']',
-  ObjectValue: ({ fields }) => '{' + join(fields, ', ') + '}',
+  ObjectValue: ({ fields }) => block(fields),
   ObjectField: ({ name, value }) => name + ': ' + value,
 
   // Directive

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -11,7 +11,7 @@ export function print(ast: ASTNode): string {
   return visit(ast, { leave: printDocASTReducer });
 }
 
-const MAX_LINE_LENGTH = 80
+const MAX_LINE_LENGTH = 80;
 
 // TODO: provide better type coverage in future
 const printDocASTReducer: any = {
@@ -44,21 +44,14 @@ const printDocASTReducer: any = {
   SelectionSet: ({ selections }) => block(selections),
 
   Field: ({ alias, name, arguments: args, directives, selectionSet }) => {
-    const prefix = wrap('', alias, ': ') + name
-    let argsLine = prefix + wrap('(', join(args, ', '), ')')
+    const prefix = wrap('', alias, ': ') + name;
+    let argsLine = prefix + wrap('(', join(args, ', '), ')');
 
     if (argsLine.length > MAX_LINE_LENGTH) {
-      argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)')
+      argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)');
     }
 
-    return join(
-      [
-        argsLine,
-        join(directives, ' '),
-        selectionSet,
-      ],
-      ' ',
-    )
+    return join([argsLine, join(directives, ' '), selectionSet], ' ');
   },
 
   Argument: ({ name, value }) => name + ': ' + value,

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -11,6 +11,8 @@ export function print(ast: ASTNode): string {
   return visit(ast, { leave: printDocASTReducer });
 }
 
+const MAX_LINE_LENGTH = 80
+
 // TODO: provide better type coverage in future
 const printDocASTReducer: any = {
   Name: (node) => node.value,
@@ -41,17 +43,23 @@ const printDocASTReducer: any = {
     wrap(' ', join(directives, ' ')),
   SelectionSet: ({ selections }) => block(selections),
 
-  Field: ({ alias, name, arguments: args, directives, selectionSet }) =>
-    join(
+  Field: ({ alias, name, arguments: args, directives, selectionSet }) => {
+    const prefix = wrap('', alias, ': ') + name
+    let argsLine = prefix + wrap('(', join(args, ', '), ')')
+
+    if (argsLine.length > MAX_LINE_LENGTH) {
+      argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)')
+    }
+
+    return join(
       [
-        wrap('', alias, ': ') +
-          name +
-          wrap('(\n', indent(join(args, ',\n')), '\n)'),
+        argsLine,
         join(directives, ' '),
         selectionSet,
       ],
       ' ',
-    ),
+    )
+  },
 
   Argument: ({ name, value }) => name + ': ' + value,
 


### PR DESCRIPTION
Hi! We are using the `print` function to pretty-print our queries. It works quite well, but there is one thing that I think could be improved upon, and that's the rendering of arguments.

This first image illustrates our problem. The main query takes a lot of parameters, and when formatting the query, all of these are put on the same line.

<img width="1239" alt="image" src="https://user-images.githubusercontent.com/4339443/92813771-29e06c00-f3c2-11ea-9c1c-fab4e7e3ea71.png">

This next image illustrates the result of the changes made in this PR. All parameters are put on individual lines, and object values are also "prettified".

<img width="643" alt="image" src="https://user-images.githubusercontent.com/4339443/92813940-8d6a9980-f3c2-11ea-98f7-2aa22b5c97e0.png">

## Questions
1. Should a parameter be kept on one line if there is only the one?
<img width="202" alt="image" src="https://user-images.githubusercontent.com/4339443/92814565-a9bb0600-f3c3-11ea-8784-221019039ae3.png">

2. Should perhaps array values also be broken over multiple lines, or is the following okay? 
<img width="541" alt="image" src="https://user-images.githubusercontent.com/4339443/92814914-ff8fae00-f3c3-11ea-9e5a-e841d84253c8.png">
