### PR TITLE
Testing async iterables for memory leaks

### DIFF
--- a/src/execution/__tests__/list-async-benchmark.js
+++ b/src/execution/__tests__/list-async-benchmark.js
@@ -1,0 +1,26 @@
+import { parse } from '../../language/parser';
+
+import { buildSchema } from '../../utilities/buildASTSchema';
+
+import { execute } from '../execute';
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+function listField() {
+  const results = [];
+  for (let index = 0; index < 100000; index++) {
+    results.push(Promise.resolve(index));
+  }
+  return results;
+}
+
+export const name = 'Execute Asynchronous List Field';
+export const count = 10;
+export async function measure() {
+  await execute({
+    schema,
+    document,
+    rootValue: { listField },
+  });
+}

--- a/src/execution/__tests__/list-asyncIterable-benchmark.js
+++ b/src/execution/__tests__/list-asyncIterable-benchmark.js
@@ -1,0 +1,24 @@
+import { parse } from '../../language/parser';
+
+import { buildSchema } from '../../utilities/buildASTSchema';
+
+import { execute } from '../execute';
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+async function* listField() {
+  for (let index = 0; index < 100000; index++) {
+    yield index;
+  }
+}
+
+export const name = 'Execute Async Iterable List Field';
+export const count = 10;
+export async function measure() {
+  await execute({
+    schema,
+    document,
+    rootValue: { listField },
+  });
+}

--- a/src/execution/__tests__/list-sync-benchmark.js
+++ b/src/execution/__tests__/list-sync-benchmark.js
@@ -1,0 +1,26 @@
+import { parse } from '../../language/parser';
+
+import { buildSchema } from '../../utilities/buildASTSchema';
+
+import { execute } from '../execute';
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+function listField() {
+  const results = [];
+  for (let index = 0; index < 100000; index++) {
+    results.push(index);
+  }
+  return results;
+}
+
+export const name = 'Execute Synchronous List Field';
+export const count = 10;
+export async function measure() {
+  await execute({
+    schema,
+    document,
+    rootValue: { listField },
+  });
+}

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -103,6 +103,24 @@ describe('Execute: Accepts async iterables as list value', () => {
       ],
     });
   });
+
+  it('Handles errors from `completeValue` in AsyncIterables', async () => {
+    async function* listField() {
+      yield await 'two';
+      yield await {};
+    }
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', null] },
+      errors: [
+        {
+          message: 'String cannot represent value: {}',
+          locations: [{ line: 1, column: 3 }],
+          path: ['listField', 1],
+        },
+      ],
+    });
+  });
 });
 
 describe('Execute: Handles list nullability', () => {


### PR DESCRIPTION
Updated to follow the pattern used in https://github.com/leebyron/iterall/issues/24 to avoid a memory leak. This approach does significantly reduce the memory used.