### PR TITLE
Added check for specific symbols in polyfills/symbols

### DIFF
--- a/src/polyfills/symbols.js
+++ b/src/polyfills/symbols.js
@@ -1,13 +1,19 @@
 // In ES2015 (or a polyfilled) environment, this will be Symbol.iterator
 // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
 export const SYMBOL_ITERATOR: string =
-  typeof Symbol === 'function' ? Symbol.iterator : '@@iterator';
+  typeof Symbol === 'function' && Boolean(Symbol.iterator)
+    ? Symbol.iterator
+    : '@@iterator';
 
 // In ES2017 (or a polyfilled) environment, this will be Symbol.asyncIterator
 // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
 export const SYMBOL_ASYNC_ITERATOR: string =
-  typeof Symbol === 'function' ? Symbol.asyncIterator : '@@asyncIterator';
+  typeof Symbol === 'function' && Boolean(Symbol.asyncIterator)
+    ? Symbol.asyncIterator
+    : '@@asyncIterator';
 
 // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
 export const SYMBOL_TO_STRING_TAG: string =
-  typeof Symbol === 'function' ? Symbol.toStringTag : '@@toStringTag';
+  typeof Symbol === 'function' && Boolean(Symbol.toStringTag)
+    ? Symbol.toStringTag
+    : '@@toStringTag';

--- a/src/polyfills/symbols.js
+++ b/src/polyfills/symbols.js
@@ -1,19 +1,19 @@
 // In ES2015 (or a polyfilled) environment, this will be Symbol.iterator
 // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
 export const SYMBOL_ITERATOR: string =
-  typeof Symbol === 'function' && Boolean(Symbol.iterator)
+  typeof Symbol === 'function' && Symbol.iterator != null
     ? Symbol.iterator
     : '@@iterator';
 
 // In ES2017 (or a polyfilled) environment, this will be Symbol.asyncIterator
 // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
 export const SYMBOL_ASYNC_ITERATOR: string =
-  typeof Symbol === 'function' && Boolean(Symbol.asyncIterator)
+  typeof Symbol === 'function' && Symbol.asyncIterator != null
     ? Symbol.asyncIterator
     : '@@asyncIterator';
 
 // istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
 export const SYMBOL_TO_STRING_TAG: string =
-  typeof Symbol === 'function' && Boolean(Symbol.toStringTag)
+  typeof Symbol === 'function' && Symbol.toStringTag != null
     ? Symbol.toStringTag
     : '@@toStringTag';


### PR DESCRIPTION
Added check for specific symbols in polyfills/symbols because in nodejs 8 Symbol exists, but Symbol.asyncIterator is not.
This cause an error 
`
message: "Subscription field must return Async Iterable. Received: { next: [function next], return: [function return], throw: [function throw], @@asyncIterator: [function] }."
`
just because `isAsyncIterable` returns false
Checking for specific symbols in Symbol will fix it