### PR TITLE
Update outdated documentation

### DIFF
--- a/docs/APIReference-Utilities.md
+++ b/docs/APIReference-Utilities.md
@@ -186,8 +186,8 @@ function buildASTSchema(
 ): GraphQLSchema
 ```
 
-This takes the ast of a schema document produced by `parseSchemaIntoAST` in
-`graphql/language/schema` and constructs a GraphQLSchema instance which can be
+This takes the ast of a schema document produced by `parse` in
+`graphql/language` and constructs a GraphQLSchema instance which can be
 then used with all GraphQL.js tools, but cannot be used to execute a query, as
 introspection does not represent the "resolver", "parse" or "serialize"
 functions or any other server-internal mechanisms.


### PR DESCRIPTION
This method is not named `parseSchemaIntoAST` anymore, but is instead called `parse`.

I'm not sure how the process is, but the error can also be found here https://github.com/graphql/graphql.github.io/blob/9a6e78630448d9235664209a0026c7a19912ce5e/site/graphql-js/APIReference-Utilities.md