### PR TITLE
Don't Expose Mabye<T> in typescript def

### DIFF
--- a/src/error/GraphQLError.d.ts
+++ b/src/error/GraphQLError.d.ts
@@ -72,7 +72,7 @@ export class GraphQLError extends Error {
   /**
    * The original error thrown from a field resolver during execution.
    */
-  readonly originalError: Maybe<Error>;
+  readonly originalError?: Error;
 
   /**
    * Extension fields to add to the formatted error.


### PR DESCRIPTION
[Pull 2621](https://github.com/graphql/graphql-js/pull/2621#issuecomment-641927660) Removed Maybe<T> from tsutils export, however it still remains in the def for GraphQLError.originalError.

This broke our use case where we have leverage [customFormatErrorFn](https://github.com/graphql/express-graphql/blob/master/src/index.ts#L103) in express, in which we : 

``` Typescript
export function errorHandler(error?: Error) {
	//
}

errorHandler(error.originalError); 
```

Results in:
``` 
Argument of type 'Maybe<Error>' is not assignable to parameter of type 'Error | undefined'.
  Type 'null' is not assignable to type 'Error | undefined'.ts(2345)
```

We could go the route of the [Apollo Fix](https://github.com/apollographql/apollo-server/pull/4230) and re-define maybe in our own package, but if this is doable, would like to simply not expose it in `GraphQLError.d.ts`