### PR TITLE
Add support for defer and stream directives (Feedback is welcomed)

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -346,9 +346,9 @@ function sampleModule(modulePath) {
 
     clock(7, module.measure); // warm up
     global.gc();
-    process.nextTick(() => {
+    process.nextTick(async () => {
       const memBaseline = process.memoryUsage().heapUsed;
-      const clocked = clock(module.count, module.measure);
+      const clocked = await clock(module.count, module.measure);
       process.send({
         name: module.name,
         clocked: clocked / module.count,
@@ -357,10 +357,10 @@ function sampleModule(modulePath) {
     });
 
     // Clocks the time taken to execute a test per cycle (secs).
-    function clock(count, fn) {
+    async function clock(count, fn) {
       const start = process.hrtime.bigint();
       for (let i = 0; i < count; ++i) {
-        fn();
+        await fn();
       }
       return Number(process.hrtime.bigint() - start);
     }

--- a/benchmark/list-async-benchmark.js
+++ b/benchmark/list-async-benchmark.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { execute } = require('graphql/execution/execute.js');
+const { buildSchema } = require('graphql/utilities/buildASTSchema.js');
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+function listField() {
+  const results = [];
+  for (let index = 0; index < 100000; index++) {
+    results.push(Promise.resolve(index));
+  }
+  return results;
+}
+
+module.exports = {
+  name: 'Execute Asynchronous List Field',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { listField },
+    });
+  },
+};

--- a/benchmark/list-asyncIterable-benchmark.js
+++ b/benchmark/list-asyncIterable-benchmark.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { execute } = require('graphql/execution/execute.js');
+const { buildSchema } = require('graphql/utilities/buildASTSchema.js');
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+async function* listField() {
+  for (let index = 0; index < 100000; index++) {
+    yield index;
+  }
+}
+
+module.exports = {
+  name: 'Execute Async Iterable List Field',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { listField },
+    });
+  },
+};

--- a/benchmark/list-sync-benchmark.js
+++ b/benchmark/list-sync-benchmark.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { execute } = require('graphql/execution/execute.js');
+const { buildSchema } = require('graphql/utilities/buildASTSchema.js');
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+function listField() {
+  const results = [];
+  for (let index = 0; index < 100000; index++) {
+    results.push(index);
+  }
+  return results;
+}
+
+module.exports = {
+  name: 'Execute Synchronous List Field',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { listField },
+    });
+  },
+};

--- a/src/__tests__/starWarsIntrospection-test.js
+++ b/src/__tests__/starWarsIntrospection-test.js
@@ -37,6 +37,7 @@ describe('Star Wars Introspection Tests', () => {
             { name: 'Droid' },
             { name: 'Query' },
             { name: 'Boolean' },
+            { name: 'Int' },
             { name: '__Schema' },
             { name: '__Type' },
             { name: '__TypeKind' },

--- a/src/execution/__tests__/defer-test.js
+++ b/src/execution/__tests__/defer-test.js
@@ -1,0 +1,270 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import isAsyncIterable from '../../jsutils/isAsyncIterable';
+import { parse } from '../../language/parser';
+
+import { GraphQLID, GraphQLString } from '../../type/scalars';
+import { GraphQLSchema } from '../../type/schema';
+import { GraphQLObjectType, GraphQLList } from '../../type/definition';
+
+import { execute } from '../execute';
+
+const friendType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+  },
+  name: 'Friend',
+});
+
+const friends = [
+  { name: 'Han', id: 2 },
+  { name: 'Leia', id: 3 },
+  { name: 'C-3PO', id: 4 },
+];
+
+const heroType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    errorField: {
+      type: GraphQLString,
+      resolve: () => {
+        throw new Error('bad');
+      },
+    },
+    friends: {
+      type: new GraphQLList(friendType),
+      resolve: () => friends,
+    },
+  },
+  name: 'Hero',
+});
+
+const hero = { name: 'Luke', id: 1 };
+
+const query = new GraphQLObjectType({
+  fields: {
+    hero: {
+      type: heroType,
+      resolve: () => hero,
+    },
+  },
+  name: 'Query',
+});
+
+async function complete(document) {
+  const schema = new GraphQLSchema({ query });
+
+  const result = await execute({
+    schema,
+    document,
+    rootValue: {},
+  });
+
+  if (isAsyncIterable(result)) {
+    const results = [];
+    for await (const patch of result) {
+      results.push(patch);
+    }
+    return results;
+  }
+  return result;
+}
+
+describe('Execute: defer directive', () => {
+  it('Can defer fragments containing scalar types', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer
+        }
+      }
+      fragment NameFragment on Hero {
+        id
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '1',
+          name: 'Luke',
+        },
+        path: ['hero'],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can disable defer using if argument', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer(if: false)
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal({
+      data: {
+        hero: {
+          id: '1',
+          name: 'Luke',
+        },
+      },
+    });
+  });
+  it('Can defer fragments containing on the top level Query field', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        ...QueryFragment @defer(label: "DeferQuery")
+      }
+      fragment QueryFragment on Query {
+        hero {
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {},
+        hasNext: true,
+      },
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        path: [],
+        label: 'DeferQuery',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can defer a fragment within an already deferred fragment', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...TopFragment @defer(label: "DeferTop")
+        }
+      }
+      fragment TopFragment on Hero {
+        name
+        ...NestedFragment @defer(label: "DeferNested")
+      }
+      fragment NestedFragment on Hero {
+        friends {
+          name
+        }
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
+        },
+        path: ['hero'],
+        label: 'DeferNested',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Luke',
+        },
+        path: ['hero'],
+        label: 'DeferTop',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can defer an inline fragment', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ... on Hero @defer(label: "InlineDeferred") {
+            name
+          }
+        }
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: { hero: { id: '1' } },
+        hasNext: true,
+      },
+      {
+        data: { name: 'Luke' },
+        path: ['hero'],
+        label: 'InlineDeferred',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles errors thrown in deferred fragments', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer
+        }
+      }
+      fragment NameFragment on Hero {
+        errorField
+      }
+    `);
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: { hero: { id: '1' } },
+        hasNext: true,
+      },
+      {
+        data: { errorField: null },
+        path: ['hero'],
+        errors: [
+          {
+            message: 'bad',
+            locations: [{ line: 9, column: 9 }],
+            path: ['hero', 'errorField'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+});

--- a/src/execution/__tests__/mutations-test.js
+++ b/src/execution/__tests__/mutations-test.js
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 
 import resolveOnNextTick from '../../__testUtils__/resolveOnNextTick';
 
+import invariant from '../../jsutils/invariant';
+import isAsyncIterable from '../../jsutils/isAsyncIterable';
 import { parse } from '../../language/parser';
 
 import { GraphQLInt } from '../../type/scalars';
@@ -49,6 +51,15 @@ class Root {
 const numberHolderType = new GraphQLObjectType({
   fields: {
     theNumber: { type: GraphQLInt },
+    promiseToGetTheNumber: {
+      type: GraphQLInt,
+      resolve: (root) =>
+        new Promise((resolve) => {
+          process.nextTick(() => {
+            resolve(root.theNumber);
+          });
+        }),
+    },
   },
   name: 'NumberHolder',
 });
@@ -189,5 +200,123 @@ describe('Execute: Handles mutation execution ordering', () => {
         },
       ],
     });
+  });
+  it('Mutation fields with @defer do not block next mutation', async () => {
+    const document = parse(`
+      mutation M {
+        first: promiseToChangeTheNumber(newNumber: 1) {
+          ...DeferFragment @defer(label: "defer-label")
+        },
+        second: immediatelyChangeTheNumber(newNumber: 2) {
+          theNumber
+        }
+      }
+      fragment DeferFragment on NumberHolder {
+        promiseToGetTheNumber
+      }
+    `);
+
+    const rootValue = new Root(6);
+    const mutationResult = await execute({
+      schema,
+      document,
+      rootValue,
+    });
+    const patches = [];
+
+    invariant(isAsyncIterable(mutationResult));
+    for await (const patch of mutationResult) {
+      patches.push(patch);
+    }
+
+    expect(patches).to.deep.equal([
+      {
+        data: {
+          first: {},
+          second: { theNumber: 2 },
+        },
+        hasNext: true,
+      },
+      {
+        label: 'defer-label',
+        path: ['first'],
+        data: {
+          promiseToGetTheNumber: 2,
+        },
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Mutation inside of a fragment', async () => {
+    const document = parse(`
+      mutation M {
+        ...MutationFragment
+        second: immediatelyChangeTheNumber(newNumber: 2) {
+          theNumber
+        }
+      }
+      fragment MutationFragment on Mutation {
+        first: promiseToChangeTheNumber(newNumber: 1) {
+          theNumber
+        },
+      }
+    `);
+
+    const rootValue = new Root(6);
+    const mutationResult = await execute({ schema, document, rootValue });
+
+    expect(mutationResult).to.deep.equal({
+      data: {
+        first: { theNumber: 1 },
+        second: { theNumber: 2 },
+      },
+    });
+  });
+  it('Mutation with @defer is not executed serially', async () => {
+    const document = parse(`
+      mutation M {
+        ...MutationFragment @defer(label: "defer-label")
+        second: immediatelyChangeTheNumber(newNumber: 2) {
+          theNumber
+        }
+      }
+      fragment MutationFragment on Mutation {
+        first: promiseToChangeTheNumber(newNumber: 1) {
+          theNumber
+        },
+      }
+    `);
+
+    const rootValue = new Root(6);
+    const mutationResult = await execute({
+      schema,
+      document,
+      rootValue,
+    });
+    const patches = [];
+
+    invariant(isAsyncIterable(mutationResult));
+    for await (const patch of mutationResult) {
+      patches.push(patch);
+    }
+
+    expect(patches).to.deep.equal([
+      {
+        data: {
+          second: { theNumber: 2 },
+        },
+        hasNext: true,
+      },
+      {
+        label: 'defer-label',
+        path: [],
+        data: {
+          first: {
+            theNumber: 1,
+          },
+        },
+        hasNext: false,
+      },
+    ]);
   });
 });

--- a/src/execution/__tests__/stream-test.js
+++ b/src/execution/__tests__/stream-test.js
@@ -1,0 +1,629 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import isAsyncIterable from '../../jsutils/isAsyncIterable';
+import { parse } from '../../language/parser';
+
+import { GraphQLID, GraphQLString } from '../../type/scalars';
+import { GraphQLSchema } from '../../type/schema';
+import { GraphQLObjectType, GraphQLList } from '../../type/definition';
+
+import { execute } from '../execute';
+
+const friendType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    asyncName: {
+      type: GraphQLString,
+      resolve(rootValue) {
+        return Promise.resolve(rootValue.name);
+      },
+    },
+  },
+  name: 'Friend',
+});
+
+const friends = [
+  { name: 'Luke', id: 1 },
+  { name: 'Han', id: 2 },
+  { name: 'Leia', id: 3 },
+];
+
+const query = new GraphQLObjectType({
+  fields: {
+    scalarList: {
+      type: new GraphQLList(GraphQLString),
+      resolve: () => ['apple', 'banana', 'coconut'],
+    },
+    asyncList: {
+      type: new GraphQLList(friendType),
+      resolve: () => friends.map((f) => Promise.resolve(f)),
+    },
+    asyncListError: {
+      type: new GraphQLList(friendType),
+      resolve: () =>
+        friends.map((f, i) => {
+          if (i === 1) {
+            return Promise.reject(new Error('bad'));
+          }
+          return Promise.resolve(f);
+        }),
+    },
+    asyncIterableList: {
+      type: new GraphQLList(friendType),
+      async *resolve() {
+        for (const friend of friends) {
+          yield friend;
+        }
+      },
+    },
+    asyncIterableError: {
+      type: new GraphQLList(friendType),
+      async *resolve() {
+        yield friends[0];
+        throw new Error('bad');
+      },
+    },
+    asyncIterableInvalid: {
+      type: new GraphQLList(GraphQLString),
+      async *resolve() {
+        yield friends[0].name;
+        yield {};
+      },
+    },
+    asyncIterableListDelayedClose: {
+      type: new GraphQLList(friendType),
+      async *resolve() {
+        for (const friend of friends) {
+          yield friend;
+        }
+        await new Promise((r) => setTimeout(r, 1));
+      },
+    },
+  },
+  name: 'Query',
+});
+
+async function complete(document) {
+  const schema = new GraphQLSchema({ query });
+
+  const result = await execute(schema, document, {});
+
+  if (isAsyncIterable(result)) {
+    const results = [];
+    for await (const patch of result) {
+      results.push(patch);
+    }
+    return results;
+  }
+  return result;
+}
+
+describe('Execute: stream directive', () => {
+  it('Can stream a list field', async () => {
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          scalarList: [],
+        },
+        hasNext: true,
+      },
+      {
+        data: 'apple',
+        path: ['scalarList', 0],
+        hasNext: true,
+      },
+      {
+        data: 'banana',
+        path: ['scalarList', 1],
+        hasNext: true,
+      },
+      {
+        data: 'coconut',
+        path: ['scalarList', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Returns label from stream directive', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 1, label: "scalar-stream") }',
+    );
+    const result = await complete(document);
+
+    expect(result).to.deep.equal([
+      {
+        data: {
+          scalarList: ['apple'],
+        },
+        hasNext: true,
+      },
+      {
+        data: 'banana',
+        path: ['scalarList', 1],
+        label: 'scalar-stream',
+        hasNext: true,
+      },
+      {
+        data: 'coconut',
+        path: ['scalarList', 2],
+        label: 'scalar-stream',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can disable @stream using if argument', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 0, if: false) }',
+    );
+    const result = await complete(document);
+
+    expect(result).to.deep.equal({
+      data: { scalarList: ['apple', 'banana', 'coconut'] },
+    });
+  });
+  it('Can stream a field that returns a list of promises', async () => {
+    const document = parse(`
+      query { 
+        asyncList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncList: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            {
+              name: 'Han',
+              id: '2',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncList', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles rejections in a field that returns a list of promises before initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncListError @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        errors: [
+          {
+            message: 'bad',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncListError', 1],
+          },
+        ],
+        data: {
+          asyncListError: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            null,
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncListError', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles rejections in a field that returns a list of promises after initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncListError @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncListError: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: null,
+        path: ['asyncListError', 1],
+        errors: [
+          {
+            message: 'bad',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncListError', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncListError', 2],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream a field that returns an async iterable', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableList: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            {
+              name: 'Han',
+              id: '2',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          id: '3',
+        },
+        path: ['asyncIterableList', 2],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles error thrown in async iterable before initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableError @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal({
+      errors: [
+        {
+          message: 'bad',
+          locations: [
+            {
+              line: 3,
+              column: 9,
+            },
+          ],
+          path: ['asyncIterableError', 1],
+        },
+      ],
+      data: {
+        asyncIterableError: [
+          {
+            name: 'Luke',
+            id: '1',
+          },
+          null,
+        ],
+      },
+    });
+  });
+  it('Handles error thrown in async iterable after initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableError @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableError: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: null,
+        path: ['asyncIterableError', 1],
+        errors: [
+          {
+            message: 'bad',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncIterableError', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles errors thrown by completeValue after initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableInvalid @stream(initialCount: 1)
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableInvalid: ['Luke'],
+        },
+        hasNext: true,
+      },
+      {
+        data: null,
+        path: ['asyncIterableInvalid', 1],
+        errors: [
+          {
+            message: 'String cannot represent value: {}',
+            locations: [
+              {
+                line: 3,
+                column: 9,
+              },
+            ],
+            path: ['asyncIterableInvalid', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+      },
+    ]);
+  });
+
+  it('Handles promises returned by completeValue after initialCount is reached', async () => {
+    const document = parse(`
+      query { 
+        asyncIterableList @stream(initialCount: 1) {
+          name
+          asyncName
+        }
+      }
+    `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableList: [
+            {
+              name: 'Luke',
+              asyncName: 'Luke',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+          asyncName: 'Han',
+        },
+        path: ['asyncIterableList', 1],
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+          asyncName: 'Leia',
+        },
+        path: ['asyncIterableList', 2],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+      },
+    ]);
+  });
+
+  it('Can @defer fields that are resolved after async iterable is complete', async () => {
+    const document = parse(`
+    query { 
+      asyncIterableList @stream(initialCount: 1, label:"stream-label") {
+        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+        id
+      }
+    }
+    fragment NameFragment on Friend {
+      name
+    }
+  `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableList: [
+            {
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Luke',
+        },
+        path: ['asyncIterableList', 0],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '2',
+        },
+        path: ['asyncIterableList', 1],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '3',
+        },
+        path: ['asyncIterableList', 2],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+        },
+        path: ['asyncIterableList', 1],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+        },
+        path: ['asyncIterableList', 2],
+        label: 'DeferName',
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can @defer fields that are resolved before async iterable is complete', async () => {
+    const document = parse(`
+    query { 
+      asyncIterableListDelayedClose @stream(initialCount: 1, label:"stream-label") {
+        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+        id
+      }
+    }
+    fragment NameFragment on Friend {
+      name
+    }
+  `);
+    const result = await complete(document);
+    expect(result).to.deep.equal([
+      {
+        data: {
+          asyncIterableListDelayedClose: [
+            {
+              id: '1',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Luke',
+        },
+        path: ['asyncIterableListDelayedClose', 0],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '2',
+        },
+        path: ['asyncIterableListDelayedClose', 1],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          id: '3',
+        },
+        path: ['asyncIterableListDelayedClose', 2],
+        label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+        },
+        path: ['asyncIterableListDelayedClose', 1],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Leia',
+        },
+        path: ['asyncIterableListDelayedClose', 2],
+        label: 'DeferName',
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+      },
+    ]);
+  });
+});

--- a/src/execution/__tests__/sync-test.js
+++ b/src/execution/__tests__/sync-test.js
@@ -111,6 +111,24 @@ describe('Execute: synchronously when possible', () => {
         });
       }).to.throw('GraphQL execution failed to complete synchronously.');
     });
+
+    it('throws if encountering async iterable execution', () => {
+      const doc = `
+        query Example {
+          ...deferFrag @defer(label: "deferLabel")
+        }
+        fragment deferFrag on Query {
+          syncField
+        }
+      `;
+      expect(() => {
+        executeSync({
+          schema,
+          document: parse(doc),
+          rootValue: 'rootValue',
+        });
+      }).to.throw('GraphQL execution failed to complete synchronously.');
+    });
   });
 
   describe('graphqlSync', () => {

--- a/src/execution/execute.d.ts
+++ b/src/execution/execute.d.ts
@@ -44,6 +44,7 @@ export interface ExecutionContext {
  *
  *   - `errors` is included when any errors occurred as a non-empty array.
  *   - `data` is the result of a successful execution of the query.
+ *   - `hasNext` is true if a future payload is expected.
  *   - `extensions` is reserved for adding non-standard properties.
  */
 export interface ExecutionResult<
@@ -53,6 +54,7 @@ export interface ExecutionResult<
   errors?: ReadonlyArray<GraphQLError>;
   // TS_SPECIFIC: TData. Motivation: https://github.com/graphql/graphql-js/pull/2490#issuecomment-639154229
   data?: TData | null;
+  hasNext?: boolean;
   extensions?: TExtensions;
 }
 
@@ -65,6 +67,42 @@ export interface FormattedExecutionResult<
   data?: TData | null;
   extensions?: TExtensions;
 }
+
+/**
+ * The result of an asynchronous GraphQL patch.
+ *
+ *   - `errors` is included when any errors occurred as a non-empty array.
+ *   - `data` is the result of the additional asynchronous data.
+ *   - `path` is the location of data.
+ *   - `hasNext` is true if a future payload is expected.
+ *   - `label` is the label provided to @defer or @stream.
+ *   - `extensions` is reserved for adding non-standard properties.
+ */
+export interface ExecutionPatchResult<
+  TData = { [key: string]: any },
+  TExtensions = { [key: string]: any }
+> {
+  errors?: ReadonlyArray<GraphQLError>;
+  data?: TData | null;
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+  hasNext: boolean;
+  extensions?: TExtensions;
+}
+
+export interface FormattedExecutionPatchResult<
+  TData = { [key: string]: any },
+  TExtensions = { [key: string]: any }
+> {
+  errors?: ReadonlyArray<GraphQLFormattedError>;
+  data?: TData | null;
+  path?: ReadonlyArray<string | number>;
+  label?: string;
+  hasNext: boolean;
+  extensions?: TExtensions;
+}
+
+export type AsyncExecutionResult = ExecutionResult | ExecutionPatchResult;
 
 export interface ExecutionArgs {
   schema: GraphQLSchema;
@@ -89,7 +127,11 @@ export interface ExecutionArgs {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult>;
+export function execute(
+  args: ExecutionArgs,
+): PromiseOrValue<
+  ExecutionResult | AsyncIterableIterator<AsyncExecutionResult>
+>;
 export function execute(
   schema: GraphQLSchema,
   document: DocumentNode,
@@ -99,7 +141,9 @@ export function execute(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>,
-): PromiseOrValue<ExecutionResult>;
+): PromiseOrValue<
+  ExecutionResult | AsyncIterableIterator<AsyncExecutionResult>
+>;
 
 /**
  * Also implements the "Evaluating requests" section of the GraphQL specification.

--- a/src/execution/index.d.ts
+++ b/src/execution/index.d.ts
@@ -8,6 +8,9 @@ export {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  FormattedExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execute';
 
 export { getDirectiveValues } from './values';

--- a/src/execution/index.js
+++ b/src/execution/index.js
@@ -11,6 +11,9 @@ export type {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  FormattedExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execute';
 
 export { getDirectiveValues } from './values';

--- a/src/graphql.d.ts
+++ b/src/graphql.d.ts
@@ -3,7 +3,7 @@ import { Maybe } from './jsutils/Maybe';
 import { Source } from './language/source';
 import { GraphQLSchema } from './type/schema';
 import { GraphQLFieldResolver, GraphQLTypeResolver } from './type/definition';
-import { ExecutionResult } from './execution/execute';
+import { ExecutionResult, AsyncExecutionResult } from './execution/execute';
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
@@ -51,7 +51,9 @@ export interface GraphQLArgs {
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
 }
 
-export function graphql(args: GraphQLArgs): Promise<ExecutionResult>;
+export function graphql(
+  args: GraphQLArgs,
+): Promise<ExecutionResult | AsyncIterableIterator<AsyncExecutionResult>>;
 export function graphql(
   schema: GraphQLSchema,
   source: Source | string,
@@ -61,7 +63,7 @@ export function graphql(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>,
-): Promise<ExecutionResult>;
+): Promise<ExecutionResult | AsyncIterableIterator<AsyncExecutionResult>>;
 
 /**
  * The graphqlSync function also fulfills GraphQL operations by parsing,

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -13,7 +13,10 @@ import type {
 import type { GraphQLSchema } from './type/schema';
 import { validateSchema } from './type/validate';
 
-import type { ExecutionResult } from './execution/execute';
+import type {
+  ExecutionResult,
+  AsyncExecutionResult,
+} from './execution/execute';
 import { execute } from './execution/execute';
 
 /**
@@ -65,7 +68,10 @@ export type GraphQLArgs = {|
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   typeResolver?: ?GraphQLTypeResolver<any, any>,
 |};
-declare function graphql(GraphQLArgs, ..._: []): Promise<ExecutionResult>;
+declare function graphql(
+  GraphQLArgs,
+  ..._: []
+): PromiseOrValue<ExecutionResult | AsyncIterable<AsyncExecutionResult>>;
 /* eslint-disable no-redeclare */
 declare function graphql(
   schema: GraphQLSchema,
@@ -76,7 +82,7 @@ declare function graphql(
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   typeResolver?: ?GraphQLTypeResolver<any, any>,
-): Promise<ExecutionResult>;
+): PromiseOrValue<ExecutionResult | AsyncIterable<AsyncExecutionResult>>;
 export function graphql(
   argsOrSchema,
   source,
@@ -160,7 +166,9 @@ export function graphqlSync(
   return result;
 }
 
-function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
+function graphqlImpl(
+  args: GraphQLArgs,
+): PromiseOrValue<ExecutionResult | AsyncIterable<AsyncExecutionResult>> {
   const {
     schema,
     source,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -300,6 +300,9 @@ export {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  FormattedExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execution/index';
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // "Enum" of Type Kinds

--- a/src/index.js
+++ b/src/index.js
@@ -291,6 +291,9 @@ export type {
   ExecutionArgs,
   ExecutionResult,
   FormattedExecutionResult,
+  ExecutionPatchResult,
+  FormattedExecutionPatchResult,
+  AsyncExecutionResult,
 } from './execution/index';
 
 export { subscribe, createSourceEventStream } from './subscription/index';

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ export {
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // "Enum" of Type Kinds

--- a/src/subscription/__tests__/flattenAsyncIterator-test.js
+++ b/src/subscription/__tests__/flattenAsyncIterator-test.js
@@ -1,0 +1,135 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import flattenAsyncIterator from '../flattenAsyncIterator';
+
+describe('flattenAsyncIterator', () => {
+  it('does not modify an already flat async generator', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    const result = flattenAsyncIterator(source());
+
+    expect(await result.next()).to.deep.equal({ value: 1, done: false });
+    expect(await result.next()).to.deep.equal({ value: 2, done: false });
+    expect(await result.next()).to.deep.equal({ value: 3, done: false });
+    expect(await result.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+  });
+
+  it('does not modify an already flat async iterator', async () => {
+    const items = [1, 2, 3];
+
+    const iterator: any = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        return Promise.resolve({
+          done: items.length === 0,
+          value: items.shift(),
+        });
+      },
+    };
+
+    const result = flattenAsyncIterator(iterator);
+
+    expect(await result.next()).to.deep.equal({ value: 1, done: false });
+    expect(await result.next()).to.deep.equal({ value: 2, done: false });
+    expect(await result.next()).to.deep.equal({ value: 3, done: false });
+    expect(await result.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+  });
+
+  it('flatten nested async generators', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield (async function* (): AsyncGenerator<number, void, void> {
+        yield 2.1;
+        yield 2.2;
+      })();
+      yield 3;
+    }
+
+    const doubles = flattenAsyncIterator(source());
+
+    const result = [];
+    for await (const x of doubles) {
+      result.push(x);
+    }
+    expect(result).to.deep.equal([1, 2, 2.1, 2.2, 3]);
+  });
+
+  it('allows returning early from a nested async generator', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield (async function* (): AsyncGenerator<number, void, void> {
+        yield 2.1;
+        // istanbul ignore next (Shouldn't be reached)
+        yield 2.2;
+      })();
+      // istanbul ignore next (Shouldn't be reached)
+      yield 3;
+    }
+
+    const doubles = flattenAsyncIterator(source());
+
+    expect(await doubles.next()).to.deep.equal({ value: 1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2.1, done: false });
+
+    // Early return
+    expect(await doubles.return()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+
+    // Subsequent next calls
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+  });
+
+  it('allows throwing errors from a nested async generator', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield (async function* (): AsyncGenerator<number, void, void> {
+        yield 2.1;
+        // istanbul ignore next (Shouldn't be reached)
+        yield 2.2;
+      })();
+      // istanbul ignore next (Shouldn't be reached)
+      yield 3;
+    }
+
+    const doubles = flattenAsyncIterator(source());
+
+    expect(await doubles.next()).to.deep.equal({ value: 1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2.1, done: false });
+
+    // Throw error
+    let caughtError;
+    try {
+      await doubles.throw('ouch');
+    } catch (e) {
+      caughtError = e;
+    }
+    expect(caughtError).to.equal('ouch');
+  });
+});

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -668,6 +668,153 @@ describe('Subscription Publish Phase', () => {
     });
   });
 
+  it('produces additional payloads for subscriptions with @defer', async () => {
+    const pubsub = new SimplePubSub();
+    const subscription = await createSubscription(
+      pubsub,
+      emailSchema,
+      parse(`
+        subscription ($priority: Int = 0) {
+          importantEmail(priority: $priority) {
+            email {
+              from
+              subject
+            }
+            ... @defer {
+              inbox {
+                unread
+                total
+              }
+            }
+          }
+        }
+      `),
+    );
+    invariant(isAsyncIterable(subscription));
+    // Wait for the next subscription payload.
+    const payload = subscription.next();
+
+    // A new email arrives!
+    expect(
+      pubsub.emit({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright',
+        message: 'Tests are good',
+        unread: true,
+      }),
+    ).to.equal(true);
+
+    // The previously waited on payload now has a value.
+    expect(await payload).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          importantEmail: {
+            email: {
+              from: 'yuzhi@graphql.org',
+              subject: 'Alright',
+            },
+          },
+        },
+        hasNext: true,
+      },
+    });
+
+    // Wait for the next payload from @defer
+    expect(await subscription.next()).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          inbox: {
+            unread: 1,
+            total: 2,
+          },
+        },
+        path: ['importantEmail'],
+        hasNext: false,
+      },
+    });
+
+    // Another new email arrives, after all incrementally delivered payloads are received.
+    expect(
+      pubsub.emit({
+        from: 'hyo@graphql.org',
+        subject: 'Tools',
+        message: 'I <3 making things',
+        unread: true,
+      }),
+    ).to.equal(true);
+
+    // The next waited on payload will have a value.
+    expect(await subscription.next()).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          importantEmail: {
+            email: {
+              from: 'hyo@graphql.org',
+              subject: 'Tools',
+            },
+          },
+        },
+        hasNext: true,
+      },
+    });
+
+    // Another new email arrives, before the incrementally delivered payloads from the last email was received.
+    expect(
+      pubsub.emit({
+        from: 'adam@graphql.org',
+        subject: 'Important',
+        message: 'Read me please',
+        unread: true,
+      }),
+    ).to.equal(true);
+
+    // Deferred payload from previous event is received.
+    expect(await subscription.next()).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          inbox: {
+            unread: 2,
+            total: 3,
+          },
+        },
+        path: ['importantEmail'],
+        hasNext: false,
+      },
+    });
+
+    // Next payload from last event
+    expect(await subscription.next()).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          importantEmail: {
+            email: {
+              from: 'adam@graphql.org',
+              subject: 'Important',
+            },
+          },
+        },
+        hasNext: true,
+      },
+    });
+
+    // The client disconnects before the deferred payload is consumed.
+    expect(await subscription.return()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+
+    // Awaiting a subscription after closing it results in completed results.
+    expect(await subscription.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
   it('produces a payload when there are multiple events', async () => {
     const pubsub = new SimplePubSub();
     const subscription = await createSubscription(pubsub);

--- a/src/subscription/flattenAsyncIterator.js
+++ b/src/subscription/flattenAsyncIterator.js
@@ -1,0 +1,49 @@
+import { SYMBOL_ASYNC_ITERATOR } from '../polyfills/symbols';
+
+import isAsyncIterable from '../jsutils/isAsyncIterable';
+
+/**
+ * Given an AsyncIterable that could potentially yield other async iterators,
+ * flatten all yielded results into a single AsyncIterable
+ */
+export default function flattenAsyncIterator<T>(
+  iterable: AsyncGenerator<AsyncGenerator<T, void, void> | T, void, void>,
+): AsyncGenerator<T, void, void> {
+  // $FlowFixMe[prop-missing]
+  const iteratorMethod = iterable[SYMBOL_ASYNC_ITERATOR];
+  const iterator: any = iteratorMethod.call(iterable);
+  let iteratorStack: Array<AsyncGenerator<T, void, void>> = [iterator];
+
+  function next(): Promise<IteratorResult<T, void>> {
+    const currentIterator = iteratorStack[0];
+    if (!currentIterator) {
+      return Promise.resolve({ value: undefined, done: true });
+    }
+    return currentIterator.next().then((result) => {
+      if (result.done) {
+        iteratorStack.shift();
+        return next();
+      } else if (isAsyncIterable(result.value)) {
+        const childIteratorMethod = result.value[SYMBOL_ASYNC_ITERATOR];
+        const childIterator: any = childIteratorMethod.call(result.value);
+        iteratorStack.unshift(childIterator);
+        return next();
+      }
+      return result;
+    });
+  }
+  return ({
+    next,
+    return() {
+      iteratorStack = [];
+      return iterator.return();
+    },
+    throw(error?: mixed): Promise<IteratorResult<T, void>> {
+      iteratorStack = [];
+      return iterator.throw(error);
+    },
+    [SYMBOL_ASYNC_ITERATOR]() {
+      return this;
+    },
+  }: $FlowFixMe);
+}

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -24,6 +24,7 @@ import type { GraphQLFieldResolver } from '../type/definition';
 import { getOperationRootType } from '../utilities/getOperationRootType';
 
 import mapAsyncIterator from './mapAsyncIterator';
+import flattenAsyncIterator from './flattenAsyncIterator';
 
 export type SubscriptionArgs = {|
   schema: GraphQLSchema,
@@ -140,8 +141,8 @@ function subscribeImpl(
   // the GraphQL specification. The `execute` function provides the
   // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
   // "ExecuteQuery" algorithm, for which `execute` is also used.
-  const mapSourceToResponse = (payload) => {
-    const executionResult = execute({
+  const mapSourceToResponse = (payload) =>
+    execute({
       schema,
       document,
       rootValue: payload,
@@ -150,24 +151,18 @@ function subscribeImpl(
       operationName,
       fieldResolver,
     });
-    /* istanbul ignore if - TODO: implement support for defer/stream in subscriptions */
-    if (isAsyncIterable(executionResult)) {
-      throw new Error(
-        'TODO: implement support for defer/stream in subscriptions',
-      );
-    }
-    return executionResult;
-  };
 
   // Resolve the Source Stream, then map every source value to a
   // ExecutionResult value as described above.
   return sourcePromise.then((resultOrStream) =>
     // Note: Flow can't refine isAsyncIterable, so explicit casts are used.
     isAsyncIterable(resultOrStream)
-      ? mapAsyncIterator(
-          resultOrStream,
-          mapSourceToResponse,
-          reportGraphQLError,
+      ? flattenAsyncIterator(
+          mapAsyncIterator(
+            resultOrStream,
+            mapSourceToResponse,
+            reportGraphQLError,
+          ),
         )
       : ((resultOrStream: any): ExecutionResult),
   );

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -937,6 +937,31 @@ describe('Introspection', () => {
               ],
             },
             {
+              name: 'defer',
+              isRepeatable: false,
+              locations: ['FRAGMENT_SPREAD', 'INLINE_FRAGMENT'],
+              args: [
+                {
+                  defaultValue: null,
+                  name: 'if',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'Boolean',
+                    ofType: null,
+                  },
+                },
+                {
+                  defaultValue: null,
+                  name: 'label',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                },
+              ],
+            },
+            {
               name: 'deprecated',
               isRepeatable: false,
               locations: [

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -77,6 +77,16 @@ describe('Introspection', () => {
               possibleTypes: null,
             },
             {
+              kind: 'SCALAR',
+              name: 'Int',
+              specifiedByUrl: null,
+              fields: null,
+              inputFields: null,
+              interfaces: null,
+              enumValues: null,
+              possibleTypes: null,
+            },
+            {
               kind: 'OBJECT',
               name: '__Schema',
               specifiedByUrl: null,
@@ -957,6 +967,44 @@ describe('Introspection', () => {
                     kind: 'SCALAR',
                     name: 'String',
                     ofType: null,
+                  },
+                },
+              ],
+            },
+            {
+              name: 'stream',
+              isRepeatable: false,
+              locations: ['FIELD'],
+              args: [
+                {
+                  defaultValue: null,
+                  name: 'if',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'Boolean',
+                    ofType: null,
+                  },
+                },
+                {
+                  defaultValue: null,
+                  name: 'label',
+                  type: {
+                    kind: 'SCALAR',
+                    name: 'String',
+                    ofType: null,
+                  },
+                },
+                {
+                  defaultValue: null,
+                  name: 'initialCount',
+                  type: {
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'SCALAR',
+                      name: 'Int',
+                      ofType: null,
+                    },
                   },
                 },
               ],

--- a/src/type/__tests__/schema-test.js
+++ b/src/type/__tests__/schema-test.js
@@ -295,6 +295,7 @@ describe('Type System: Schema', () => {
       'ASub',
       'Boolean',
       'String',
+      'Int',
       '__Schema',
       '__Type',
       '__TypeKind',

--- a/src/type/directives.d.ts
+++ b/src/type/directives.d.ts
@@ -79,6 +79,11 @@ export const GraphQLSkipDirective: GraphQLDirective;
 export const GraphQLDeferDirective: GraphQLDirective;
 
 /**
+ * Used to conditionally stream list fields.
+ */
+export const GraphQLStreamDirective: GraphQLDirective;
+
+/**
  * Used to provide a URL for specifying the behavior of custom scalar definitions.
  */
 export const GraphQLSpecifiedByDirective: GraphQLDirective;

--- a/src/type/directives.d.ts
+++ b/src/type/directives.d.ts
@@ -74,6 +74,11 @@ export const GraphQLIncludeDirective: GraphQLDirective;
 export const GraphQLSkipDirective: GraphQLDirective;
 
 /**
+ * Used to conditionally defer fragments.
+ */
+export const GraphQLDeferDirective: GraphQLDirective;
+
+/**
  * Used to provide a URL for specifying the behavior of custom scalar definitions.
  */
 export const GraphQLSpecifiedByDirective: GraphQLDirective;

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -17,7 +17,7 @@ import type {
   GraphQLArgument,
   GraphQLFieldConfigArgumentMap,
 } from './definition';
-import { GraphQLString, GraphQLBoolean } from './scalars';
+import { GraphQLString, GraphQLBoolean, GraphQLInt } from './scalars';
 import { argsToArgsConfig, GraphQLNonNull } from './definition';
 
 /**
@@ -192,6 +192,30 @@ export const GraphQLDeferDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to conditionally stream list fields.
+ */
+export const GraphQLStreamDirective = new GraphQLDirective({
+  name: 'stream',
+  description:
+    'Directs the executor to stream plural fields when the `if` argument is true or undefined.',
+  locations: [DirectiveLocation.FIELD],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: 'Stream when true or undefined.',
+    },
+    label: {
+      type: GraphQLString,
+      description: 'Unique name',
+    },
+    initialCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: 'Number of items to return immediately',
+    },
+  },
+});
+
+/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
@@ -240,6 +264,7 @@ export const specifiedDirectives = Object.freeze([
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
 ]);

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -169,6 +169,29 @@ export const GraphQLSkipDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to conditionally defer fragments.
+ */
+export const GraphQLDeferDirective = new GraphQLDirective({
+  name: 'defer',
+  description:
+    'Directs the executor to defer this fragment when the `if` argument is true or undefined.',
+  locations: [
+    DirectiveLocation.FRAGMENT_SPREAD,
+    DirectiveLocation.INLINE_FRAGMENT,
+  ],
+  args: {
+    if: {
+      type: GraphQLBoolean,
+      description: 'Deferred when true or undefined.',
+    },
+    label: {
+      type: GraphQLString,
+      description: 'Unique name',
+    },
+  },
+});
+
+/**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON = 'No longer supported';
@@ -216,6 +239,7 @@ export const GraphQLSpecifiedByDirective = new GraphQLDirective({
 export const specifiedDirectives = Object.freeze([
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
 ]);

--- a/src/type/index.d.ts
+++ b/src/type/index.d.ts
@@ -126,6 +126,7 @@ export {
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // Constant Deprecation Reason

--- a/src/type/index.d.ts
+++ b/src/type/index.d.ts
@@ -125,6 +125,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // Constant Deprecation Reason

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -77,6 +77,7 @@ export {
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // Constant Deprecation Reason

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -76,6 +76,7 @@ export {
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   // Constant Deprecation Reason

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -20,6 +20,7 @@ import {
   GraphQLIncludeDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
+  GraphQLDeferDirective,
 } from '../../type/directives';
 import {
   GraphQLID,
@@ -251,12 +252,13 @@ describe('Schema Builder', () => {
     expect(cycleSDL(sdl, { commentDescriptions: true })).to.equal(sdl);
   });
 
-  it('Maintains @include, @skip & @specifiedBy', () => {
+  it('Maintains specified directives', () => {
     const schema = buildSchema('type Query');
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
+    expect(schema.getDirective('defer')).to.equal(GraphQLDeferDirective);
     expect(schema.getDirective('deprecated')).to.equal(
       GraphQLDeprecatedDirective,
     );
@@ -271,9 +273,10 @@ describe('Schema Builder', () => {
       directive @include on FIELD
       directive @deprecated on FIELD_DEFINITION
       directive @specifiedBy on FIELD_DEFINITION
+      directive @defer on FRAGMENT_SPREAD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
@@ -284,16 +287,18 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.not.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('defer')).to.not.equal(GraphQLDeferDirective);
   });
 
-  it('Adding directives maintains @include, @skip & @specifiedBy', () => {
+  it('Adding directives maintains specified directives', () => {
     const schema = buildSchema(`
       directive @foo(arg: Int) on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
+    expect(schema.getDirective('defer')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
     expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
   });

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -21,6 +21,7 @@ import {
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
 } from '../../type/directives';
 import {
   GraphQLID,
@@ -162,8 +163,7 @@ describe('Schema Builder', () => {
   it('include standard type only if it is used', () => {
     const schema = buildSchema('type Query');
 
-    // String and Boolean are always included through introspection types
-    expect(schema.getType('Int')).to.equal(undefined);
+    // String, Boolean, and Int are always included through introspection types
     expect(schema.getType('Float')).to.equal(undefined);
     expect(schema.getType('ID')).to.equal(undefined);
   });
@@ -255,10 +255,11 @@ describe('Schema Builder', () => {
   it('Maintains specified directives', () => {
     const schema = buildSchema('type Query');
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
     expect(schema.getDirective('defer')).to.equal(GraphQLDeferDirective);
+    expect(schema.getDirective('stream')).to.equal(GraphQLStreamDirective);
     expect(schema.getDirective('deprecated')).to.equal(
       GraphQLDeprecatedDirective,
     );
@@ -274,9 +275,10 @@ describe('Schema Builder', () => {
       directive @deprecated on FIELD_DEFINITION
       directive @specifiedBy on FIELD_DEFINITION
       directive @defer on FRAGMENT_SPREAD
+      directive @stream on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
@@ -288,6 +290,7 @@ describe('Schema Builder', () => {
       GraphQLSpecifiedByDirective,
     );
     expect(schema.getDirective('defer')).to.not.equal(GraphQLDeferDirective);
+    expect(schema.getDirective('stream')).to.not.equal(GraphQLStreamDirective);
   });
 
   it('Adding directives maintains specified directives', () => {
@@ -295,10 +298,11 @@ describe('Schema Builder', () => {
       directive @foo(arg: Int) on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(6);
+    expect(schema.getDirectives()).to.have.lengthOf(7);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
     expect(schema.getDirective('defer')).to.not.equal(undefined);
+    expect(schema.getDirective('stream')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
     expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
   });

--- a/src/utilities/__tests__/buildClientSchema-test.js
+++ b/src/utilities/__tests__/buildClientSchema-test.js
@@ -155,7 +155,6 @@ describe('Type System: build schema from introspection', () => {
     const introspection = introspectionFromSchema(schema);
     const clientSchema = buildClientSchema(introspection);
 
-    expect(clientSchema.getType('Int')).to.equal(undefined);
     expect(clientSchema.getType('Float')).to.equal(undefined);
     expect(clientSchema.getType('ID')).to.equal(undefined);
   });

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -199,8 +199,7 @@ describe('extendSchema', () => {
   it('extends objects with standard type fields', () => {
     const schema = buildSchema('type Query');
 
-    // String and Boolean are always included through introspection types
-    expect(schema.getType('Int')).to.equal(undefined);
+    // String, Boolean, and Int are always included through introspection types
     expect(schema.getType('Float')).to.equal(undefined);
     expect(schema.getType('String')).to.equal(GraphQLString);
     expect(schema.getType('Boolean')).to.equal(GraphQLBoolean);
@@ -214,7 +213,6 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(schema, extendAST);
 
     expect(validateSchema(extendedSchema)).to.deep.equal([]);
-    expect(extendedSchema.getType('Int')).to.equal(undefined);
     expect(extendedSchema.getType('Float')).to.equal(undefined);
     expect(extendedSchema.getType('String')).to.equal(GraphQLString);
     expect(extendedSchema.getType('Boolean')).to.equal(GraphQLBoolean);

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { GraphQLSchema } from '../../type/schema';
 import {
   GraphQLSkipDirective,
+  GraphQLDeferDirective,
   GraphQLIncludeDirective,
   GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
@@ -802,6 +803,7 @@ describe('findBreakingChanges', () => {
         GraphQLSkipDirective,
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
+        GraphQLDeferDirective,
       ],
     });
 

--- a/src/utilities/__tests__/findBreakingChanges-test.js
+++ b/src/utilities/__tests__/findBreakingChanges-test.js
@@ -5,6 +5,7 @@ import { GraphQLSchema } from '../../type/schema';
 import {
   GraphQLSkipDirective,
   GraphQLDeferDirective,
+  GraphQLStreamDirective,
   GraphQLIncludeDirective,
   GraphQLSpecifiedByDirective,
   GraphQLDeprecatedDirective,
@@ -804,6 +805,7 @@ describe('findBreakingChanges', () => {
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
         GraphQLDeferDirective,
+        GraphQLStreamDirective,
       ],
     });
 

--- a/src/utilities/__tests__/printSchema-test.js
+++ b/src/utilities/__tests__/printSchema-test.js
@@ -627,6 +627,17 @@ describe('Type System Printer', () => {
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+      """
+      Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
+      """
+      directive @defer(
+        """Deferred when true or undefined."""
+        if: Boolean
+      
+        """Unique name"""
+        label: String
+      ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
       """Marks an element of a GraphQL schema as no longer supported."""
       directive @deprecated(
         """
@@ -851,6 +862,15 @@ describe('Type System Printer', () => {
         # Skipped when true.
         if: Boolean!
       ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      # Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
+      directive @defer(
+        # Deferred when true or undefined.
+        if: Boolean
+      
+        # Unique name
+        label: String
+      ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
       # Marks an element of a GraphQL schema as no longer supported.
       directive @deprecated(

--- a/src/utilities/__tests__/printSchema-test.js
+++ b/src/utilities/__tests__/printSchema-test.js
@@ -638,6 +638,20 @@ describe('Type System Printer', () => {
         label: String
       ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
+      """
+      Directs the executor to stream plural fields when the \`if\` argument is true or undefined.
+      """
+      directive @stream(
+        """Stream when true or undefined."""
+        if: Boolean
+
+        """Unique name"""
+        label: String
+
+        """Number of items to return immediately"""
+        initialCount: Int!
+      ) on FIELD
+
       """Marks an element of a GraphQL schema as no longer supported."""
       directive @deprecated(
         """
@@ -871,6 +885,18 @@ describe('Type System Printer', () => {
         # Unique name
         label: String
       ) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+      # Directs the executor to stream plural fields when the \`if\` argument is true or undefined.
+      directive @stream(
+        # Stream when true or undefined.
+        if: Boolean
+
+        # Unique name
+        label: String
+
+        # Number of items to return immediately
+        initialCount: Int!
+      ) on FIELD
 
       # Marks an element of a GraphQL schema as no longer supported.
       directive @deprecated(

--- a/src/validation/__tests__/KnownTypeNamesRule-test.js
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.js
@@ -81,7 +81,7 @@ describe('Validate: Known type names', () => {
   it('references to standard scalars that are missing in schema', () => {
     const schema = buildSchema('type Query { foo: String }');
     const query = `
-      query ($id: ID, $float: Float, $int: Int) {
+      query ($id: ID, $float: Float) {
         __typename
       }
     `;
@@ -93,10 +93,6 @@ describe('Validate: Known type names', () => {
       {
         message: 'Unknown type "Float".',
         locations: [{ line: 2, column: 31 }],
-      },
-      {
-        message: 'Unknown type "Int".',
-        locations: [{ line: 2, column: 44 }],
       },
     ]);
   });

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.js
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.js
@@ -98,6 +98,123 @@ describe('Validate: Overlapping fields can be merged', () => {
     `);
   });
 
+  it('Same stream directives supported', () => {
+    expectValid(`
+      fragment differentDirectivesWithDifferentAliases on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "streamLabel", initialCount: 1)
+      }
+    `);
+  });
+
+  it('different stream directive label', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "anotherLabel", initialCount: 1)
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive initialCount', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "streamLabel", initialCount: 2)
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive first missing args', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream
+        name @stream(label: "streamLabel", initialCount: 1)
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive second missing args', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('mix of stream and no stream', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream
+        name
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
+  it('different stream directive both missing args', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream
+        name @stream
+      }
+    `).to.deep.equal([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
   it('Same aliases with different field targets', () => {
     expectErrors(`
       fragment sameAliasesWithDifferentFieldTargets on Dog {


### PR DESCRIPTION
> The implementation in this pull request is a reference implementation of the specification proposal outlined in graphql/graphql-spec#742. It is no longer compatible with with the @defer and @stream implementation in Relay.

> This branch is published to npm as version graphql@15.4.0-experimental-stream-defer.1 under the tag graphql@experimental-stream-defer. We encourage anyone interested in this feature to try out this version and report any feedback, issues, or potential improvements to the API. This feedback will help the working group gain confidence to move forward with standardization.

Developed and maintained by @lilianammmatos @robrichard