### PR TITLE
separateOperations: stop unused fragments from being included

### DIFF
--- a/src/utilities/__tests__/separateOperations-test.js
+++ b/src/utilities/__tests__/separateOperations-test.js
@@ -161,4 +161,53 @@ describe('separateOperations', () => {
       }
     `);
   });
+
+  it('only includes fragments that are used', () => {
+    const ast = parse(`
+      fragment One on T {
+        oneField
+        ...Three
+      }
+      
+      fragment Two on T {
+        twoField
+      }
+
+      fragment Three on T {
+        threeField
+      }
+
+      query One {
+        ...Two
+      }
+    
+      query Ones {
+        ...One
+      }
+
+      query Twos {
+        ...One
+        ...Two
+      }
+    `);
+
+    const separatedASTs = separateOperations(ast);
+
+    expect(separatedASTs).to.have.all.keys('One', 'Ones', 'Twos');
+
+    expect(print(separatedASTs.Ones)).to.equal(dedent`
+      fragment One on T {
+        oneField
+        ...Three
+      }
+
+      fragment Three on T {
+        threeField
+      }
+
+      query Ones {
+        ...One
+      }
+    `);
+  });
 });


### PR DESCRIPTION
The `separateOperations` method sometimes include unused fragments if you name an operation the same thing as a fragment:

```graphql
fragment One on T {
  oneField
}

fragment Two on T {
  twoField
}

query One {
  ...Two
}

query Ones {
  ...One
}
```

When running `separateOperations` on the above, and then looking at `.Ones` of the result, we get:

```graphql
fragment One on T {
  oneField
}

## NOT SUPPOSED TO BE HERE ##
fragment Two on T {
  twoField
}

query Ones {
  ...One
}
```

This happens because in the dependency graph, there's nothing differentiating an operation from a fragment. They are just added by name. So in the scenario above the _fragment_ `One` will add the _query_ `One` as a dependecy of `Ones`, and then the _query_ `One` has the _fragment_ `Two` as a dependency, so that will be added too.

I fixed this by adding a prefix to the names in the dependecy graph, so operations can't be added a dependencies anymore, only fragments.