### PR TITLE
Remove "uninitialized-instance-property" flowlint rule from GraphQLError.js

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -1,6 +1,3 @@
-// FIXME:
-// flowlint uninitialized-instance-property:off
-
 import isObjectLike from '../jsutils/isObjectLike';
 import { SYMBOL_TO_STRING_TAG } from '../polyfills/symbols';
 


### PR DESCRIPTION
Hey Folks!

I ran into the same issue as described [in this comment here](https://github.com/graphql/graphql-js/issues/2110#issuecomment-608111262). Basically, `flow check` throws an error in the `GraphQLError.js.flow` file:

```sh
 $ flow check
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ node_modules/graphql/error/GraphQLError.js.flow:3:13

Redundant argument. This argument doesn't change any lint settings. [lint-setting]

     1│ // @flow strict
     2│ // FIXME:
     3│ // flowlint uninitialized-instance-property:off
     4│
     5│ import isObjectLike from '../jsutils/isObjectLike';
     6│ import { SYMBOL_TO_STRING_TAG } from '../polyfills/symbols';
```

As suggested in [another comment](https://github.com/graphql/graphql-js/issues/2110#issuecomment-644205632), I tried adding the file to both the `[untyped]`/`[ignore]` sections of our `.flowconfig` but it still seems to throw an error in our project.

My best guess is that this rule (`uninitialized-instance-property`) [does not exist in flowlint anymore](https://flow.org/en/docs/linting/rule-reference/) (?) and hence doesn't allow for overriding either.

Going by the above assumption we removed the following two lines from the file manually & this seems to make `flow check` pass for our project:
```js
// FIXME:	
// flowlint uninitialized-instance-property:off
```

Is this lint rule safe to remove from `graphql-js`? 

Thanks :)