### PR TITLE
Allow consumers to specify a custom data type for execute

### DIFF
--- a/src/execution/execute.d.ts
+++ b/src/execution/execute.d.ts
@@ -89,8 +89,14 @@ export interface ExecutionArgs {
  *
  * Accepts either an object with named arguments, or individual arguments.
  */
-export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult>;
-export function execute(
+export function execute<
+  TData = { [key: string]: any },
+  TExtensions = { [key: string]: any }
+>(args: ExecutionArgs): PromiseOrValue<ExecutionResult<TData, TExtensions>>;
+export function execute<
+  TData = { [key: string]: any },
+  TExtensions = { [key: string]: any }
+>(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
@@ -99,14 +105,17 @@ export function execute(
   operationName?: Maybe<string>,
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>,
-): PromiseOrValue<ExecutionResult>;
+): PromiseOrValue<ExecutionResult<TData, TExtensions>>;
 
 /**
  * Also implements the "Evaluating requests" section of the GraphQL specification.
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
-export function executeSync(args: ExecutionArgs): ExecutionResult;
+export function executeSync<
+  TData = { [key: string]: any },
+  TExtensions = { [key: string]: any }
+>(args: ExecutionArgs): ExecutionResult<TData, TExtensions>;
 
 /**
  * Essential assertions before executing to provide developer feedback for


### PR DESCRIPTION
This change is a follow-on of https://github.com/graphql/graphql-js/pull/2490, which fixed an issue where consumers of `execute` were forced to specify the data type generic when calling `execute` or when using the `ExecutionResult` type. Currently, `ExecutionResult` allows the data type generic to be overridden, but `execute` does not. With this change, `execute` is still callable without specifying the data type, but will optionally accept an override to the default data type.

With this change:

A consumer can override the default data type by passing a generic to `execute`.
```ts
async function executeUserQuery(): ExecutionResult<User> {
  return await execute<User>(schema, userQuery, root, context, variableValues);
}
```

Or, by generically using graphql-typed-document-node's `TypedDocumentNode`, generated by graphql-code-generator.
```ts
async function executeQuery<T extends TypedDocumentNode>(queryDoc: T): ExecutionResult<ResultOf<T>> {
  return await execute<User>(schema, userQuery, root, context, variableValues);
}
```

But, `execute` can still be called without specifying a data type. The default `{ [key: string]: any }` is used.
```ts
await execute(schema, document, root, context, variableValues)
```
