### PR TITLE
[workflow] Fixing double run when creating a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 env:
   NODE_VERSION_USED_FOR_DEVELOPMENT: 14
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
-on: [push, pull_request]
+on: [push]
 env:
   NODE_VERSION_USED_FOR_DEVELOPMENT: 14
 jobs:
   lint:
-    name: Lint source files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ env:
   NODE_VERSION_USED_FOR_DEVELOPMENT: 14
 jobs:
   lint:
+    name: Lint source files
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Currently, the workflow runs twice every PR. This is caused by `push` and on `pull_request` events.
Sadly [the documentation says that it will be an or](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#example-using-a-list-of-events). 

But in practice, this triggers twice. 

Alternatively, we could just leave push
```yaml
on:  push
```

this is visible when inspecting some of the PR's 

![image](https://user-images.githubusercontent.com/226559/100417471-daf7b980-3035-11eb-9ba0-d50c28b03d81.png)

every step produces 2 runs (one for push the other for pull_request) 
[example for pull request](https://github.com/graphql/graphql-js/pull/2861/checks?check_run_id=1454997986) 
[example for push](https://github.com/graphql/graphql-js/pull/2861/checks?check_run_id=1454997986)

this is also visible in #2757 
![image](https://user-images.githubusercontent.com/226559/100417639-3aee6000-3036-11eb-8b7f-f477958d63b5.png)