### PR TITLE
Add Fragment Spread Arguments

### DIFF
--- a/src/language/__tests__/printer-test.js
+++ b/src/language/__tests__/printer-test.js
@@ -145,6 +145,49 @@ describe('Printer: Query document', () => {
     `);
   });
 
+  it('Legacy: correctly prints fragment spread arguments', () => {
+    const parsed = parse('{ ...Foo(bar: $bar) }', {
+      allowLegacyFragmentVariables: true,
+    });
+
+    expect(print(parsed)).to.equal(dedent`
+      {
+        ...Foo(bar: $bar)
+      }
+    `);
+  });
+
+  it('Legacy: correctly prints fragment spread arguments that exceed the max line length', () => {
+    const parsed = parse(
+      '{ ...Dogs(breads: ["Boston Terrier", "Poodle", "Beagle"], likesPets: true, likesToys: true) }',
+      {
+        allowLegacyFragmentVariables: true,
+      },
+    );
+
+    expect(print(parsed)).to.equal(dedent`
+      {
+        ...Dogs(
+          breads: ["Boston Terrier", "Poodle", "Beagle"]
+          likesPets: true
+          likesToys: true
+        )
+      }
+    `);
+  });
+
+  it('Legacy: correctly prints fragment spread arguments with directives', () => {
+    const parsed = parse('{ ...Foo(bar: $bar) @skip(if: $isBaz) }', {
+      allowLegacyFragmentVariables: true,
+    });
+
+    expect(print(parsed)).to.equal(dedent`
+      {
+        ...Foo(bar: $bar) @skip(if: $isBaz)
+      }
+    `);
+  });
+
   it('prints kitchen sink', () => {
     const printed = print(parse(kitchenSinkQuery));
 

--- a/src/language/__tests__/visitor-test.js
+++ b/src/language/__tests__/visitor-test.js
@@ -470,6 +470,53 @@ describe('Visitor', () => {
     ]);
   });
 
+  it('Legacy: visits fragment spread arguments', () => {
+    const ast = parse('{ ...Foo(v: $v) }', {
+      noLocation: true,
+      allowLegacyFragmentVariables: true,
+    });
+
+    const visited = [];
+
+    visit(ast, {
+      enter(node) {
+        checkVisitorFnArgs(ast, arguments);
+        visited.push(['enter', node.kind, getValue(node)]);
+      },
+      leave(node) {
+        checkVisitorFnArgs(ast, arguments);
+        visited.push(['leave', node.kind, getValue(node)]);
+      },
+    });
+
+    const argumentNode = {
+      kind: Kind.VARIABLE,
+      name: { kind: Kind.NAME, loc: undefined, value: 'v' },
+      loc: undefined,
+    };
+
+    expect(visited).to.deep.equal([
+      ['enter', Kind.DOCUMENT, undefined],
+      ['enter', Kind.OPERATION_DEFINITION, undefined],
+      ['enter', Kind.SELECTION_SET, undefined],
+      ['enter', Kind.FRAGMENT_SPREAD, undefined],
+      ['enter', Kind.NAME, 'Foo'],
+      ['leave', Kind.NAME, 'Foo'],
+      ['enter', Kind.ARGUMENT, argumentNode],
+      ['enter', Kind.NAME, 'v'],
+      ['leave', Kind.NAME, 'v'],
+      ['enter', Kind.VARIABLE, undefined],
+      ['enter', Kind.NAME, 'v'],
+      ['leave', Kind.NAME, 'v'],
+      ['leave', Kind.VARIABLE, undefined],
+      ['leave', Kind.ARGUMENT, argumentNode],
+      ['leave', Kind.FRAGMENT_SPREAD, undefined],
+      ['leave', Kind.SELECTION_SET, undefined],
+      ['leave', Kind.OPERATION_DEFINITION, undefined],
+      ['leave', Kind.DOCUMENT, undefined],
+    ]);
+  });
+
   it('visits kitchen sink', () => {
     const ast = parse(kitchenSinkQuery);
     const visited = [];

--- a/src/language/ast.d.ts
+++ b/src/language/ast.d.ts
@@ -282,6 +282,8 @@ export interface FragmentSpreadNode {
   readonly kind: 'FragmentSpread';
   readonly loc?: Location;
   readonly name: NameNode;
+  // Note: fragment variable definitions are deprecated and will removed in v17.0.0
+  readonly arguments?: ReadonlyArray<ArgumentNode>;
   readonly directives?: ReadonlyArray<DirectiveNode>;
 }
 

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -308,6 +308,8 @@ export type FragmentSpreadNode = {|
   +kind: 'FragmentSpread',
   +loc?: Location,
   +name: NameNode,
+  // Note: fragment variable definitions are deprecated and will removed in v17.0.0
+  +arguments?: $ReadOnlyArray<ArgumentNode>,
   +directives?: $ReadOnlyArray<DirectiveNode>,
 |};
 

--- a/src/language/parser.js
+++ b/src/language/parser.js
@@ -434,6 +434,12 @@ export class Parser {
       return {
         kind: Kind.FRAGMENT_SPREAD,
         name: this.parseFragmentName(),
+        // Legacy support for fragment variables changes the grammar of a
+        // FragmentSpreadNode.
+        arguments:
+          this._options?.allowLegacyFragmentVariables ?? false
+            ? this.parseArguments(false)
+            : undefined,
         directives: this.parseDirectives(false),
         loc: this.loc(start),
       };

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -69,9 +69,18 @@ const printDocASTReducer: any = {
 
   // Fragments
 
+  // Note: fragment variable definitions are deprecated and will removed in v17.0.0
   FragmentSpread: {
-    leave: ({ name, directives }) =>
-      '...' + name + wrap(' ', join(directives, ' ')),
+    leave: ({ name, arguments: args, directives }) => {
+      const prefix = '...' + name;
+      let argsLine = prefix + wrap('(', join(args, ', '), ')');
+
+      if (argsLine.length > MAX_LINE_LENGTH) {
+        argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)');
+      }
+
+      return argsLine + wrap(' ', join(directives, ' '));
+    },
   },
 
   InlineFragment: {

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -54,7 +54,12 @@ const QueryDocumentKeys = {
   Field: ['alias', 'name', 'arguments', 'directives', 'selectionSet'],
   Argument: ['name', 'value'],
 
-  FragmentSpread: ['name', 'directives'],
+  FragmentSpread: [
+    'name',
+    // Note: fragment variable definitions are deprecated and will removed in v17.0.0
+    'arguments',
+    'directives',
+  ],
   InlineFragment: ['typeCondition', 'directives', 'selectionSet'],
   FragmentDefinition: [
     'name',


### PR DESCRIPTION
This is a continuation of the work done by @sam-swarr in #1141 to support [parameterized fragments](https://github.com/graphql/graphql-spec/issues/204). This PR adds the ability to pass arguments to fragment spreads. For example,

```gql
query GetEmployee($id: ID!, $employeeScheduleFilters: ScheduleFilters) {
  employee(id: $id) {
    ...EmployeeFragment(scheduleFilters: $employeeScheduleFilters)
  }
}

fragment EmployeeFragment($scheduleFilters: ScheduleFilters) on Employee {
  id
  name
  schedule(filters: $scheduleFilters) {
    # selection set
  }
}
```

Parameterized fragments are a prerequisite for encapsulation. Without encapsulation fragments are context dependent. This makes them difficult to compose into larger selection sets or to reuse in more than one operation.

In my opinion each fragment spread (not inline fragment) should create a new isolated scope. However, this would be a breaking change. I think a good compromise is to allow opting-in to isolated scopes by adding variables to a fragment. Each parameterized fragment would create a new isolated scope and fields within that fragment cannot use variables outside that fragment's scope.

The following is an example of transforming a document that contains parameterized fragments into a spec compliant document that can be parsed by GraphQL servers.

```typescript
import {
  ArgumentNode,
  ASTNode,
  FragmentDefinitionNode,
  Kind,
  VariableDefinitionNode,
  ValueNode,
  VariableNode,
  visit,
} from './npmDist/language';

type NonEmptyArray<T> = [T, ...T[]];

interface VariableArgumentNode extends ArgumentNode {
  value: VariableNode;
}

interface VariableFragmentDefinitionNode extends FragmentDefinitionNode {
  variableDefinitions: Readonly<NonEmptyArray<VariableDefinitionNode>>;
}

type VariableScope = {
  [key: string]: ValueNode;
};

type Context = {
  parameterizedFragments?: VariableFragmentDefinitionNode[];
  variables?: VariableScope;
};

type Predicate<T, U extends T> = (item: T) => item is U;

const isVariableArgument = (arg: ArgumentNode): arg is VariableArgumentNode =>
  arg.value.kind === Kind.VARIABLE;

const isVariableFragmentDefinition = (
  node: ASTNode,
): node is VariableFragmentDefinitionNode =>
  node.kind === Kind.FRAGMENT_DEFINITION &&
  Boolean(node.variableDefinitions?.length);

const splitBy = <T, U extends T>(
  items: readonly T[],
  predicate: Predicate<T, U> | ((item: T) => boolean),
): typeof predicate extends Predicate<T, U>
  ? [Exclude<T, U>[], U[]]
  : [T[], U[]] =>
  items.reduce<[T[], U[]]>(
    ([left, right], item) =>
      predicate(item) ? [left, [...right, item]] : [[...left, item], right],
    [[], []],
  );

/**
 * Transform a graphql document that contains parameterized fragments into
 * a spec compliant document that graphql servers can parse.
 *
 * Directives on fragment variables are not supported. Hoisting variable
 * directives would allow one fragment to produce side effects outside its scope.
 *
 * Each parameterized fragment will create a new isolated scope. Field arguments
 * within a parameterized fragment cannot use variables outside of the fragment's
 * scope.
 *
 * Fragment spreads will be replaced with inline fragments to allow using the
 * same fragment more than once, in a single operation, with different arguments.
 *
 * Parameterized fragments may contain more parameterized fragments and each
 * nested parameterized fragment will create a new isolated scope.
 */
const visitWithContext = (
  root: ASTNode,
  visited: WeakSet<ASTNode> = new WeakSet(),
  context?: Context,
) => {
  const newRoot = visit(root, {
    enter(node) {
      if (visited.has(node)) {
        return false;
      }
    },
    Document(node) {
      const [definitions, parameterizedFragments] = splitBy(
        node.definitions,
        isVariableFragmentDefinition,
      );

      const warnAboutDirectives = parameterizedFragments.some(
        ({ variableDefinitions }) =>
          variableDefinitions.some(({ directives }) => directives?.length),
      );

      if (warnAboutDirectives) {
        console.warn('Directives on fragment variables are not supported.');
      }

      return {
        ...node,
        definitions: [
          ...definitions.map((definition) =>
            visitWithContext(definition, visited, { parameterizedFragments }),
          ),
        ],
      };
    },
    Field(node) {
      if (!node.arguments?.length || !context?.variables) {
        return node;
      }

      const [args, variableArgs] = splitBy(node.arguments, isVariableArgument);

      return {
        ...node,
        arguments: [
          ...args,
          ...variableArgs.map((arg) => ({
            ...arg,
            value: context.variables?.[arg.value.name.value],
          })),
        ],
      };
    },
    FragmentSpread({ arguments: args, ...node }) {
      const fragment = context?.parameterizedFragments?.find(
        (fragment) => fragment.name.value === node.name.value,
      );

      if (!fragment) {
        return node;
      }

      // Replace the fragment with an inline fragment. This is necessary to
      // allow the same fragment to be used more than once with different
      // variables in the same operation.
      return {
        directives: [
          ...(node.directives ?? []),
          ...(fragment.directives ?? []),
        ],
        kind: Kind.INLINE_FRAGMENT,
        loc: undefined,
        selectionSet: visitWithContext(fragment.selectionSet, visited, {
          ...context,
          variables: fragment.variableDefinitions.reduce(
            (variables, node) => ({
              ...variables,
              [node.variable.name.value]:
                args?.find((arg) => arg.name.value === node.variable.name.value)
                  ?.value ?? node.defaultValue,
            }),
            {},
          ),
        }),
        typeCondition: fragment.typeCondition,
      };
    },
  });

  visited.add(newRoot);
  return newRoot;
};
```

If the queries are statically analyzable then this transformation can be applied at compile time. If this transformation was applied to the above example the result would be,

```gql
query GetEmployee($id: ID!, $employeeScheduleFilters: ScheduleFilters) {
  employee(id: $id) {
    ... on Employee {
      id
      name
      schedule(filters: $employeeScheduleFilters) {
        # selection set
      }
    }
  }
}
```