### PR TITLE
fix: type annotation cannot appear on a constructor declaration

### DIFF
--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -83,7 +83,7 @@ export class GraphQLError extends Error {
     path?: ?$ReadOnlyArray<string | number>,
     originalError?: ?(Error & { +extensions?: mixed, ... }),
     extensions?: ?{ [key: string]: mixed, ... },
-  ): void {
+  ) {
     super(message);
 
     // Compute list of blame nodes.

--- a/src/language/source.js
+++ b/src/language/source.js
@@ -25,7 +25,7 @@ export class Source {
     body: string,
     name: string = 'GraphQL request',
     locationOffset: Location = { line: 1, column: 1 },
-  ): void {
+  ) {
     devAssert(
       typeof body === 'string',
       `Body must be a string. Received: ${inspect(body)}.`,

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -583,7 +583,7 @@ export class GraphQLScalarType {
   astNode: ?ScalarTypeDefinitionNode;
   extensionASTNodes: ?$ReadOnlyArray<ScalarTypeExtensionNode>;
 
-  constructor(config: $ReadOnly<GraphQLScalarTypeConfig<mixed, mixed>>): void {
+  constructor(config: $ReadOnly<GraphQLScalarTypeConfig<mixed, mixed>>) {
     const parseValue = config.parseValue ?? identityFunc;
     this.name = config.name;
     this.description = config.description;
@@ -736,7 +736,7 @@ export class GraphQLObjectType {
   _fields: Thunk<GraphQLFieldMap<any, any>>;
   _interfaces: Thunk<Array<GraphQLInterfaceType>>;
 
-  constructor(config: $ReadOnly<GraphQLObjectTypeConfig<any, any>>): void {
+  constructor(config: $ReadOnly<GraphQLObjectTypeConfig<any, any>>) {
     this.name = config.name;
     this.description = config.description;
     this.isTypeOf = config.isTypeOf;
@@ -1064,7 +1064,7 @@ export class GraphQLInterfaceType {
   _fields: Thunk<GraphQLFieldMap<any, any>>;
   _interfaces: Thunk<Array<GraphQLInterfaceType>>;
 
-  constructor(config: $ReadOnly<GraphQLInterfaceTypeConfig<any, any>>): void {
+  constructor(config: $ReadOnly<GraphQLInterfaceTypeConfig<any, any>>) {
     this.name = config.name;
     this.description = config.description;
     this.resolveType = config.resolveType;
@@ -1183,7 +1183,7 @@ export class GraphQLUnionType {
 
   _types: Thunk<Array<GraphQLObjectType>>;
 
-  constructor(config: $ReadOnly<GraphQLUnionTypeConfig<any, any>>): void {
+  constructor(config: $ReadOnly<GraphQLUnionTypeConfig<any, any>>) {
     this.name = config.name;
     this.description = config.description;
     this.resolveType = config.resolveType;
@@ -1301,7 +1301,7 @@ export class GraphQLEnumType /* <T> */ {
   _valueLookup: Map<any /* T */, GraphQLEnumValue>;
   _nameLookup: ObjMap<GraphQLEnumValue>;
 
-  constructor(config: $ReadOnly<GraphQLEnumTypeConfig /* <T> */>): void {
+  constructor(config: $ReadOnly<GraphQLEnumTypeConfig /* <T> */>) {
     this.name = config.name;
     this.description = config.description;
     this.extensions = config.extensions && toObjMap(config.extensions);
@@ -1523,7 +1523,7 @@ export class GraphQLInputObjectType {
 
   _fields: Thunk<GraphQLInputFieldMap>;
 
-  constructor(config: $ReadOnly<GraphQLInputObjectTypeConfig>): void {
+  constructor(config: $ReadOnly<GraphQLInputObjectTypeConfig>) {
     this.name = config.name;
     this.description = config.description;
     this.extensions = config.extensions && toObjMap(config.extensions);

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -53,7 +53,7 @@ export class GraphQLDirective {
   extensions: ?ReadOnlyObjMap<mixed>;
   astNode: ?DirectiveDefinitionNode;
 
-  constructor(config: $ReadOnly<GraphQLDirectiveConfig>): void {
+  constructor(config: $ReadOnly<GraphQLDirectiveConfig>) {
     this.name = config.name;
     this.description = config.description;
     this.locations = config.locations;

--- a/src/type/schema.js
+++ b/src/type/schema.js
@@ -142,7 +142,7 @@ export class GraphQLSchema {
   // Used as a cache for validateSchema().
   __validationErrors: ?$ReadOnlyArray<GraphQLError>;
 
-  constructor(config: $ReadOnly<GraphQLSchemaConfig>): void {
+  constructor(config: $ReadOnly<GraphQLSchemaConfig>) {
     // If this schema was built from a source known to be valid, then it may be
     // marked with assumeValid to avoid an additional type system validation.
     this.__validationErrors = config.assumeValid === true ? [] : undefined;

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -64,7 +64,7 @@ export class TypeInfo {
     // Initial type may be provided in rare cases to facilitate traversals
     // beginning somewhere other than documents.
     initialType?: GraphQLType,
-  ): void {
+  ) {
     this._schema = schema;
     this._typeStack = [];
     this._parentTypeStack = [];

--- a/src/validation/ValidationContext.js
+++ b/src/validation/ValidationContext.js
@@ -50,7 +50,7 @@ export class ASTValidationContext {
     $ReadOnlyArray<FragmentDefinitionNode>,
   >;
 
-  constructor(ast: DocumentNode, onError: (err: GraphQLError) => void): void {
+  constructor(ast: DocumentNode, onError: (err: GraphQLError) => void) {
     this._ast = ast;
     this._fragments = undefined;
     this._fragmentSpreads = new Map();
@@ -141,7 +141,7 @@ export class SDLValidationContext extends ASTValidationContext {
     ast: DocumentNode,
     schema: ?GraphQLSchema,
     onError: (err: GraphQLError) => void,
-  ): void {
+  ) {
     super(ast, onError);
     this._schema = schema;
   }
@@ -167,7 +167,7 @@ export class ValidationContext extends ASTValidationContext {
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (err: GraphQLError) => void,
-  ): void {
+  ) {
     super(ast, onError);
     this._schema = schema;
     this._typeInfo = typeInfo;


### PR DESCRIPTION
As mentioned by @IvanGoncharov in https://github.com/graphql/graphql-js/pull/2828#discussion_r554132661