### PR TITLE
ci: migrate master to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
     if: |
       github.event_name == 'push' &&
       github.repository == 'graphql/graphql-js' &&
-      github.ref == 'refs/heads/master'
+      github.ref == 'refs/heads/main'
     needs: [test, fuzz, lint, checkForCommonlyIgnoredFiles, integrationTests]
     steps:
       - name: Checkout repo
@@ -239,7 +239,7 @@ jobs:
     if: |
       github.event_name == 'push' &&
       github.repository == 'graphql/graphql-js' &&
-      github.ref == 'refs/heads/master'
+      github.ref == 'refs/heads/main'
     needs: [test, fuzz, lint, checkForCommonlyIgnoredFiles, integrationTests]
     steps:
       - name: Checkout repo

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 The JavaScript reference implementation for GraphQL, a query language for APIs created by Facebook.
 
 [![npm version](https://badge.fury.io/js/graphql.svg)](https://badge.fury.io/js/graphql)
-[![Build Status](https://github.com/graphql/graphql-js/workflows/CI/badge.svg?branch=master)](https://github.com/graphql/graphql-js/actions?query=branch%3Amaster)
-[![Coverage Status](https://codecov.io/gh/graphql/graphql-js/branch/master/graph/badge.svg)](https://codecov.io/gh/graphql/graphql-js)
+[![Build Status](https://github.com/graphql/graphql-js/workflows/CI/badge.svg?branch=main)](https://github.com/graphql/graphql-js/actions?query=branch%3Amain)
+[![Coverage Status](https://codecov.io/gh/graphql/graphql-js/branch/main/graph/badge.svg)](https://codecov.io/gh/graphql/graphql-js)
 
 See more complete documentation at https://graphql.org/ and
 https://graphql.org/graphql-js/.
@@ -14,7 +14,7 @@ Looking for help? Find resources [from the community](https://graphql.org/commun
 ## Getting Started
 
 A general overview of GraphQL is available in the
-[README](https://github.com/graphql/graphql-spec/blob/master/README.md) for the
+[README](https://github.com/graphql/graphql-spec/blob/main/README.md) for the
 [Specification for GraphQL](https://github.com/graphql/graphql-spec). That overview
 describes a simple set of GraphQL examples that exist as [tests](src/__tests__)
 in this repository. A good way to get started with this repository is to walk
@@ -106,7 +106,7 @@ graphql(schema, query).then((result) => {
 ### Want to ride the bleeding edge?
 
 The `npm` branch in this repository is automatically maintained to be the last
-commit to `master` to pass all tests, in the same form found on npm. It is
+commit to `main` to pass all tests, in the same form found on npm. It is
 recommended to use builds deployed to npm for many reasons, but if you want to use
 the latest not-yet-released version of graphql-js, you can do so by depending
 directly on this branch:

--- a/resources/checkgit.sh
+++ b/resources/checkgit.sh
@@ -2,10 +2,10 @@
 trap "exit 1" ERR
 
 #
-# This script determines if current git state is the up to date master. If so
+# This script determines if current git state is the up to date main. If so
 # it exits normally. If not it prompts for an explicit continue. This script
 # intends to protect from versioning for NPM without first pushing changes
-# and including any changes on master.
+# and including any changes on main.
 #
 
 # First fetch to ensure git is up to date. Fail-fast if this fails.
@@ -17,9 +17,9 @@ GIT_BRANCH=$(git branch -v 2> /dev/null | sed '/^[^*]/d');
 GIT_BRANCH_NAME=$(echo "$GIT_BRANCH" | sed 's/* \([A-Za-z0-9_\-]*\).*/\1/');
 GIT_BRANCH_SYNC=$(echo "$GIT_BRANCH" | sed 's/* [^[]*.\([^]]*\).*/\1/');
 
-# Check if master is checked out
-if [ "$GIT_BRANCH_NAME" != "master" ]; then
-  read -p "Git not on master but $GIT_BRANCH_NAME. Continue? (y|N) " yn;
+# Check if main is checked out
+if [ "$GIT_BRANCH_NAME" != "main" ]; then
+  read -p "Git not on main but $GIT_BRANCH_NAME. Continue? (y|N) " yn;
   if [ "$yn" != "y" ]; then exit 1; fi;
 fi;
 

--- a/resources/gitpublish.sh
+++ b/resources/gitpublish.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#  This script maintains a git branch which mirrors master but in a form that
+#  This script maintains a git branch which mirrors main but in a form that
 #  what will eventually be deployed to npm, allowing npm dependencies to use:
 #
 #      "graphql": "git://github.com/graphql/graphql-js.git#npm"


### PR DESCRIPTION
### Summary

Updates the CI, scripts and Readme badges to switch branches from `master` to `main`


**Reviewer:** @IvanGoncharov 

Related #2860 
