### PR TITLE
Avoid relying on constructor.name for instanceOf error check.

### DIFF
--- a/src/jsutils/__tests__/instanceOf-test.js
+++ b/src/jsutils/__tests__/instanceOf-test.js
@@ -2,6 +2,15 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { instanceOf } from '../instanceOf';
+import { SYMBOL_TO_STRING_TAG } from '../../polyfills/symbols';
+import {
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+} from '../../type/definition';
 
 describe('instanceOf', () => {
   it('fails with descriptive error message', () => {
@@ -18,5 +27,107 @@ describe('instanceOf', () => {
     expect(() => instanceOf(new Foo2(), Foo1)).to.throw(
       /^Cannot use Foo "\[object Object\]" from another module or realm./m,
     );
+  });
+
+  describe('Symbol.toStringTag', () => {
+    function checkSameNameClasses(getClass) {
+      const Class1 = getClass('FirstClass');
+      const Class2 = getClass('SecondClass');
+
+      expect(Class1.name).to.equal('Foo');
+      expect(Class2.name).to.equal('Foo');
+
+      expect(instanceOf(null, Class1)).to.equal(false);
+      expect(instanceOf(null, Class2)).to.equal(false);
+
+      const c1 = new Class1();
+      const c2 = new Class2();
+
+      expect(getTag(c1)).to.equal('FirstClass');
+      expect(getTag(c2)).to.equal('SecondClass');
+
+      // In these Symbol.toStringTag tests, instanceOf returns the
+      // expected boolean value without throwing an error, because even
+      // though Class1.name === Class2.name, the Symbol.toStringTag
+      // strings of the two classes are different.
+      expect(instanceOf(c1, Class1)).to.equal(true);
+      expect(instanceOf(c1, Class2)).to.equal(false);
+      expect(instanceOf(c2, Class1)).to.equal(false);
+      expect(instanceOf(c2, Class2)).to.equal(true);
+    }
+
+    function getTag(from: any): string {
+      return from[SYMBOL_TO_STRING_TAG];
+    }
+
+    it('does not fail if dynamically-defined tags differ', () => {
+      checkSameNameClasses((tag) => {
+        class Foo {}
+        Object.defineProperty(Foo.prototype, SYMBOL_TO_STRING_TAG, {
+          value: tag,
+        });
+        return Foo;
+      });
+    });
+
+    it('does not fail if dynamically-defined tag getters differ', () => {
+      checkSameNameClasses((tag) => {
+        class Foo {}
+        Object.defineProperty(Foo.prototype, SYMBOL_TO_STRING_TAG, {
+          get() {
+            return tag;
+          },
+        });
+        return Foo;
+      });
+    });
+
+    it('does not fail for anonymous classes', () => {
+      checkSameNameClasses((tag) => {
+        const Foo = class {};
+        Object.defineProperty(Foo.prototype, SYMBOL_TO_STRING_TAG, {
+          get() {
+            return tag;
+          },
+        });
+        return Foo;
+      });
+    });
+
+    it('does not fail if prototype property tags differ', () => {
+      checkSameNameClasses((tag) => {
+        class Foo {}
+        (Foo.prototype: any)[SYMBOL_TO_STRING_TAG] = tag;
+        return Foo;
+      });
+    });
+
+    it('does not fail if computed getter tags differ', () => {
+      checkSameNameClasses((tag) => {
+        class Foo {
+          // $FlowFixMe[unsupported-syntax] Flow doesn't support computed properties yet
+          get [SYMBOL_TO_STRING_TAG]() {
+            return tag;
+          }
+        }
+        return Foo;
+      });
+    });
+
+    it('is defined for various GraphQL*Type classes', () => {
+      function checkGraphQLType(constructor, expectedName) {
+        expect(getTag(constructor.prototype)).to.equal(expectedName);
+        const instance = Object.create(constructor.prototype);
+        expect(getTag(instance)).to.equal(expectedName);
+        expect(instanceOf(instance, constructor)).to.equal(true);
+      }
+
+      checkGraphQLType(GraphQLScalarType, 'GraphQLScalarType');
+      checkGraphQLType(GraphQLObjectType, 'GraphQLObjectType');
+      checkGraphQLType(GraphQLInterfaceType, 'GraphQLInterfaceType');
+      checkGraphQLType(GraphQLUnionType, 'GraphQLUnionType');
+      checkGraphQLType(GraphQLEnumType, 'GraphQLEnumType');
+      checkGraphQLType(GraphQLInputObjectType, 'GraphQLInputObjectType');
+    });
   });
 });

--- a/src/jsutils/__tests__/instanceOf-test.js
+++ b/src/jsutils/__tests__/instanceOf-test.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { instanceOf } from '../instanceOf';
-import { SYMBOL_TO_STRING_TAG } from '../../polyfills/symbols';
 import {
   GraphQLScalarType,
   GraphQLObjectType,
@@ -57,13 +56,13 @@ describe('instanceOf', () => {
     }
 
     function getTag(from: any): string {
-      return from[SYMBOL_TO_STRING_TAG];
+      return from[Symbol.toStringTag];
     }
 
     it('does not fail if dynamically-defined tags differ', () => {
       checkSameNameClasses((tag) => {
         class Foo {}
-        Object.defineProperty(Foo.prototype, SYMBOL_TO_STRING_TAG, {
+        Object.defineProperty(Foo.prototype, Symbol.toStringTag, {
           value: tag,
         });
         return Foo;
@@ -73,7 +72,7 @@ describe('instanceOf', () => {
     it('does not fail if dynamically-defined tag getters differ', () => {
       checkSameNameClasses((tag) => {
         class Foo {}
-        Object.defineProperty(Foo.prototype, SYMBOL_TO_STRING_TAG, {
+        Object.defineProperty(Foo.prototype, Symbol.toStringTag, {
           get() {
             return tag;
           },
@@ -85,7 +84,7 @@ describe('instanceOf', () => {
     it('does not fail for anonymous classes', () => {
       checkSameNameClasses((tag) => {
         const Foo = class {};
-        Object.defineProperty(Foo.prototype, SYMBOL_TO_STRING_TAG, {
+        Object.defineProperty(Foo.prototype, Symbol.toStringTag, {
           get() {
             return tag;
           },
@@ -97,7 +96,7 @@ describe('instanceOf', () => {
     it('does not fail if prototype property tags differ', () => {
       checkSameNameClasses((tag) => {
         class Foo {}
-        (Foo.prototype: any)[SYMBOL_TO_STRING_TAG] = tag;
+        (Foo.prototype: any)[Symbol.toStringTag] = tag;
         return Foo;
       });
     });
@@ -106,7 +105,7 @@ describe('instanceOf', () => {
       checkSameNameClasses((tag) => {
         class Foo {
           // $FlowFixMe[unsupported-syntax] Flow doesn't support computed properties yet
-          get [SYMBOL_TO_STRING_TAG]() {
+          get [Symbol.toStringTag]() {
             return tag;
           }
         }

--- a/src/jsutils/instanceOf.js
+++ b/src/jsutils/instanceOf.js
@@ -1,5 +1,3 @@
-import { SYMBOL_TO_STRING_TAG } from '../polyfills/symbols';
-
 /**
  * A replacement for instanceof which includes an error warning when multi-realm
  * constructors are detected.
@@ -18,7 +16,7 @@ export const instanceOf: (mixed, mixed) => boolean =
         }
         if (value) {
           const proto = constructor && constructor.prototype;
-          const classTag = proto && proto[SYMBOL_TO_STRING_TAG];
+          const classTag = proto && proto[Symbol.toStringTag];
           const className = classTag || constructor.name;
           // When the constructor class defines a Symbol.toStringTag
           // property, as most classes exported by graphql-js do, use it
@@ -32,8 +30,8 @@ export const instanceOf: (mixed, mixed) => boolean =
           // they could be minified to the same short string, even though
           // value is legitimately _not_ instanceof constructor.
           const valueName = classTag
-                ? value[SYMBOL_TO_STRING_TAG]
-                : value.constructor && value.constructor.name;
+            ? value[Symbol.toStringTag]
+            : value.constructor && value.constructor.name;
           if (typeof className === 'string' && valueName === className) {
             throw new Error(
               `Cannot use ${className} "${value}" from another module or realm.


### PR DESCRIPTION
PR #1174 disabled [`instanceOf`](https://github.com/graphql/graphql-js/blob/master/src/jsutils/instanceOf.js) error checking when `process.env.NODE_ENV === 'production'`, which eliminated some false positives due to collisions of minified class names in production. This PR aims to eliminate the same kind of false positive errors in non-production environments that enable minification, such as `NODE_ENV='staging'`. Please see https://github.com/apollographql/apollo-client/issues/7446#issuecomment-767660631 for motivating use cases and background explanation.

Fortunately, the `graphql` package goes to the trouble of providing a [`Symbol.toStringTag`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag) property for most of the classes it exports ([one of many examples](https://github.com/graphql/graphql-js/blob/3bce13f652e4043d940df8eec29f79eef24b6215/src/type/definition.js#L793-L795)), and that string is immune to minification (unlike `constructor.name`). This PR proposes using that tag string for error checking in `instanceOf(value, constructor)` whenever the `constructor` provides a `Symbol.toStringTag` property, falling back to `constructor.name` and `value.constructor.name` for constructors that do not define `Symbol.toStringTag` (as before).

If this is controversial in any way, I would be happy to discuss alternative solutions, but I believe this change will resolve many of the remaining issues linked at the bottom of the #1174 issue thread.

Remaining to-dos:
- [x] Add more [`instanceOf` tests](https://github.com/graphql/graphql-js/blob/master/src/jsutils/__tests__/instanceOf-test.js) to restore full coverage.