### PR TITLE
refactor: use regexp-exec

### DIFF
--- a/src/language/experimentalOnlineParser/onlineParser.js
+++ b/src/language/experimentalOnlineParser/onlineParser.js
@@ -234,7 +234,7 @@ export class OnlineParser {
   }
 
   indentation(): number {
-    const match = this._lexer.source.body.match(/\s*/);
+    const match = /\s*/.exec(this._lexer.source.body);
     let indent = 0;
 
     if (match && match.length === 0) {


### PR DESCRIPTION
This typescript eslint rule﻿[`prefer-regexp-exec`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/prefer-regexp-exec.md) is enabled so we should use `exec` over `match`. Cherry-picked from #2828
