### PR TITLE
introspection: Allow interfaces to be undefined for interfaces

### DIFF
--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -213,7 +213,7 @@ export function buildClientSchema(
     // TODO: Temporary workaround until GraphQL ecosystem will fully support
     // 'interfaces' on interface types.
     if (
-      implementingIntrospection.interfaces === null &&
+      !implementingIntrospection.interfaces &&
       implementingIntrospection.kind === TypeKind.INTERFACE
     ) {
       return [];


### PR DESCRIPTION
The old code was using strict equality check for null to check if the introspected field `interfaces` was not defined, which means that it would fail in case `interfaces` was set to undefined. Older GraphQL implementations will not send the `interfaces` field when introspecting an interface, and thus would fail with `Introspection result missing interfaces`.