### PR TITLE
fix(race): concurrent next calls with defer/stream

### DIFF
--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -133,16 +133,18 @@ async function complete(document: DocumentNode) {
   return result;
 }
 
-async function completeAsync(document, numCalls) {
+async function completeAsync(document: DocumentNode, numCalls: number) {
   const schema = new GraphQLSchema({ query });
 
   const result = await execute({ schema, document, rootValue: {} });
 
   invariant(isAsyncIterable(result));
 
+  const iterator = result[Symbol.asyncIterator]();
+
   const promises = [];
   for (let i = 0; i < numCalls; i++) {
-    promises.push(result.next());
+    promises.push(iterator.next());
   }
   return Promise.all(promises);
 }

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -138,14 +138,13 @@ async function completeAsync(document, numCalls) {
 
   const result = await execute({ schema, document, rootValue: {} });
 
-  if (isAsyncIterable(result)) {
-    const promises = [];
-    for (let i = 0; i < numCalls; i++) {
-      promises.push(result.next());
-    }
-    return Promise.all(promises);
+  invariant(isAsyncIterable(result));
+
+  const promises = [];
+  for (let i = 0; i < numCalls; i++) {
+    promises.push(result.next());
   }
-  return result;
+  return Promise.all(promises);
 }
 
 describe('Execute: stream directive', () => {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1784,47 +1784,61 @@ export class Dispatcher {
         done: false,
       });
     }
-    return new Promise<{
-      promise: Promise<IteratorResult<DispatcherResult, void>>;
-    }>((resolve) => {
+    return new Promise((resolve) => {
+      let resolved = false;
       this._subsequentPayloads.forEach((promise) => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        promise.then(() => {
-          // resolve with actual promise, not resolved value of promise so we can remove it from this._subsequentPayloads
-          resolve({ promise });
+        promise.then((payload) => {
+          if (resolved) {
+            return;
+          }
+
+          resolved = true;
+
+          if (this._subsequentPayloads.length === 0) {
+            // a different call to next has exhausted all payloads
+            resolve({ value: undefined, done: true });
+            return;
+          }
+
+          const index = this._subsequentPayloads.indexOf(promise);
+
+          if (index === -1) {
+            // a different call to next has consumed this payload
+            resolve(this._race());
+            return;
+          }
+
+          this._subsequentPayloads.splice(index, 1);
+
+          const { value, done } = payload;
+
+          if (done && this._subsequentPayloads.length === 0) {
+            // async iterable resolver just finished and no more pending payloads
+            resolve({
+              value: {
+                hasNext: false,
+              },
+              done: false,
+            });
+            return;
+          } else if (done) {
+            // async iterable resolver just finished but there are pending payloads
+            // return the next one
+            resolve(this._race());
+            return;
+          }
+
+          const returnValue: ExecutionPatchResult = {
+            ...value,
+            hasNext: this._subsequentPayloads.length > 0,
+          };
+          resolve({
+            value: returnValue,
+            done: false,
+          });
         });
       });
-    })
-      .then(({ promise }) => {
-        this._subsequentPayloads.splice(
-          this._subsequentPayloads.indexOf(promise),
-          1,
-        );
-        return promise;
-      })
-      .then(({ value, done }) => {
-        if (done && this._subsequentPayloads.length === 0) {
-          // async iterable resolver just finished and no more pending payloads
-          return {
-            value: {
-              hasNext: false,
-            },
-            done: false,
-          };
-        } else if (done) {
-          // async iterable resolver just finished but there are pending payloads
-          // return the next one
-          return this._race();
-        }
-        const returnValue: ExecutionPatchResult = {
-          ...value,
-          hasNext: this._subsequentPayloads.length > 0,
-        };
-        return {
-          value: returnValue,
-          done: false,
-        };
-      });
+    });
   }
 
   _next(): Promise<IteratorResult<AsyncExecutionResult, void>> {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1787,6 +1787,7 @@ export class Dispatcher {
     return new Promise((resolve) => {
       let resolved = false;
       this._subsequentPayloads.forEach((promise) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         promise.then((payload) => {
           if (resolved) {
             return;


### PR DESCRIPTION
This seems to work with me for my project.

not quite sure what to do about isDone which seems to be used just when return is  called (parenthetically, should that be renamed to isReturned for clarity/distinction between `isDone` and `done` attributes?)

namely, should the isDone check go up top prior to checking for the next resolved promise, within the next resolved promise check, or maybe both.

in general, not sure how we are really handling secure stopping issues, seems like -- for example -- there could be condition in which we await a promise which never resolves, but that is ok, because return has been called?

but still quite the novice with all of this async stuff

---From my opinionated perspective, I realize that graphql-js is a reference lib, and has a zero-dependency footprint, but seems like handling all these async issues (in JS in general and within `graphql-js`) would be easier with a Repeater-like construct (see https://repeater.js.org/, @brainkim) that could be even theoretically inlined in downsized version into `js-utils`.