### PR TITLE
fix(stream): continue on iterator error values

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -346,9 +346,9 @@ function sampleModule(modulePath) {
 
     clock(7, module.measure); // warm up
     global.gc();
-    process.nextTick(() => {
+    process.nextTick(async () => {
       const memBaseline = process.memoryUsage().heapUsed;
-      const clocked = clock(module.count, module.measure);
+      const clocked = await clock(module.count, module.measure);
       process.send({
         name: module.name,
         clocked: clocked / module.count,
@@ -357,10 +357,10 @@ function sampleModule(modulePath) {
     });
 
     // Clocks the time taken to execute a test per cycle (secs).
-    function clock(count, fn) {
+    async function clock(count, fn) {
       const start = process.hrtime.bigint();
       for (let i = 0; i < count; ++i) {
-        fn();
+        await fn();
       }
       return Number(process.hrtime.bigint() - start);
     }

--- a/benchmark/list-async-benchmark.js
+++ b/benchmark/list-async-benchmark.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { execute } = require('graphql/execution/execute.js');
+const { buildSchema } = require('graphql/utilities/buildASTSchema.js');
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+function listField() {
+  const results = [];
+  for (let index = 0; index < 100000; index++) {
+    results.push(Promise.resolve(index));
+  }
+  return results;
+}
+
+module.exports = {
+  name: 'Execute Asynchronous List Field',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { listField },
+    });
+  },
+};

--- a/benchmark/list-asyncIterable-benchmark.js
+++ b/benchmark/list-asyncIterable-benchmark.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { execute } = require('graphql/execution/execute.js');
+const { buildSchema } = require('graphql/utilities/buildASTSchema.js');
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+async function* listField() {
+  for (let index = 0; index < 100000; index++) {
+    yield index;
+  }
+}
+
+module.exports = {
+  name: 'Execute Async Iterable List Field',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { listField },
+    });
+  },
+};

--- a/benchmark/list-sync-benchmark.js
+++ b/benchmark/list-sync-benchmark.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { execute } = require('graphql/execution/execute.js');
+const { buildSchema } = require('graphql/utilities/buildASTSchema.js');
+
+const schema = buildSchema('type Query { listField: [String] }');
+const document = parse('{ listField }');
+
+function listField() {
+  const results = [];
+  for (let index = 0; index < 100000; index++) {
+    results.push(index);
+  }
+  return results;
+}
+
+module.exports = {
+  name: 'Execute Synchronous List Field',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { listField },
+    });
+  },
+};

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -103,6 +103,24 @@ describe('Execute: Accepts async iterables as list value', () => {
       ],
     });
   });
+
+  it('Handles errors from `completeValue` in AsyncIterables', async () => {
+    async function* listField() {
+      yield await 'two';
+      yield await {};
+    }
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', null] },
+      errors: [
+        {
+          message: 'String cannot represent value: {}',
+          locations: [{ line: 1, column: 3 }],
+          path: ['listField', 1],
+        },
+      ],
+    });
+  });
 });
 
 describe('Execute: Handles list nullability', () => {

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -139,6 +139,25 @@ describe('Execute: Accepts async iterables as list value', () => {
     });
   });
 
+  it('Handles an AsyncGenerator function where an intermediate value triggers an error', async () => {
+    async function* listField() {
+      yield await 'two';
+      yield await {};
+      yield await 4;
+    }
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', null, '4'] },
+      errors: [
+        {
+          message: 'String cannot represent value: {}',
+          locations: [{ line: 1, column: 3 }],
+          path: ['listField', 1],
+        },
+      ],
+    });
+  });
+
   it('Handles errors from `completeValue` in AsyncIterables', async () => {
     async function* listField() {
       yield await 'two';

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -64,6 +64,47 @@ describe('Execute: Accepts any iterable as list value', () => {
   });
 });
 
+describe('Execute: Accepts async iterables as list value', () => {
+  function complete(rootValue: mixed) {
+    return execute({
+      schema: buildSchema('type Query { listField: [String] }'),
+      document: parse('{ listField }'),
+      rootValue,
+    });
+  }
+
+  it('Accepts an AsyncGenerator function as a List value', async () => {
+    async function* listField() {
+      yield await 'two';
+      yield await 4;
+      yield await false;
+    }
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', '4', 'false'] },
+    });
+  });
+
+  it('Handles an AsyncGenerator function that throws', async () => {
+    async function* listField() {
+      yield await 'two';
+      yield await 4;
+      throw new Error('bad');
+    }
+
+    expect(await complete({ listField })).to.deep.equal({
+      data: { listField: ['two', '4', null] },
+      errors: [
+        {
+          message: 'bad',
+          locations: [{ line: 1, column: 3 }],
+          path: ['listField', 2],
+        },
+      ],
+    });
+  });
+});
+
 describe('Execute: Handles list nullability', () => {
   async function complete(args: {| listField: mixed, as: string |}) {
     const { listField, as } = args;

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -2,6 +2,9 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { parse } from '../../language/parser';
+import { GraphQLList, GraphQLObjectType } from '../../type/definition';
+import { GraphQLString } from '../../type/scalars';
+import { GraphQLSchema } from '../../type/schema';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
 
@@ -73,6 +76,38 @@ describe('Execute: Accepts async iterables as list value', () => {
     });
   }
 
+  function completeObjectList(resolve) {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          listField: {
+            resolve: async function* listField() {
+              yield await { index: 0 };
+              yield await { index: 1 };
+              yield await { index: 2 };
+            },
+            type: new GraphQLList(
+              new GraphQLObjectType({
+                name: 'ObjectWrapper',
+                fields: {
+                  index: {
+                    type: GraphQLString,
+                    resolve,
+                  },
+                },
+              }),
+            ),
+          },
+        },
+      }),
+    });
+    return execute({
+      schema,
+      document: parse('{ listField { index } }'),
+    });
+  }
+
   it('Accepts an AsyncGenerator function as a List value', async () => {
     async function* listField() {
       yield await 'two';
@@ -117,6 +152,34 @@ describe('Execute: Accepts async iterables as list value', () => {
           message: 'String cannot represent value: {}',
           locations: [{ line: 1, column: 3 }],
           path: ['listField', 1],
+        },
+      ],
+    });
+  });
+
+  it('Handles promises from `completeValue` in AsyncIterables', async () => {
+    expect(
+      await completeObjectList(({ index }) => Promise.resolve(index)),
+    ).to.deep.equal({
+      data: { listField: [{ index: '0' }, { index: '1' }, { index: '2' }] },
+    });
+  });
+
+  it('Handles rejected promises from `completeValue` in AsyncIterables', async () => {
+    expect(
+      await completeObjectList(({ index }) => {
+        if (index === 2) {
+          return Promise.reject(new Error('bad'));
+        }
+        return Promise.resolve(index);
+      }),
+    ).to.deep.equal({
+      data: { listField: [{ index: '0' }, { index: '1' }, { index: null }] },
+      errors: [
+        {
+          message: 'bad',
+          locations: [{ line: 1, column: 15 }],
+          path: ['listField', 2, 'index'],
         },
       ],
     });

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -1,4 +1,5 @@
 import arrayFrom from '../polyfills/arrayFrom';
+import { SYMBOL_ASYNC_ITERATOR } from '../polyfills/symbols';
 
 import type { Path } from '../jsutils/Path';
 import type { ObjMap } from '../jsutils/ObjMap';
@@ -8,6 +9,7 @@ import memoize3 from '../jsutils/memoize3';
 import invariant from '../jsutils/invariant';
 import devAssert from '../jsutils/devAssert';
 import isPromise from '../jsutils/isPromise';
+import isAsyncIterable from '../jsutils/isAsyncIterable';
 import isObjectLike from '../jsutils/isObjectLike';
 import isCollection from '../jsutils/isCollection';
 import promiseReduce from '../jsutils/promiseReduce';
@@ -856,6 +858,49 @@ function completeValue(
 }
 
 /**
+ * Complete a async iterator value by completing the result and calling
+ * recursively until all the results are completed.
+ */
+function completeAsyncIteratorValue(
+  exeContext: ExecutionContext,
+  itemType: GraphQLOutputType,
+  fieldNodes: $ReadOnlyArray<FieldNode>,
+  info: GraphQLResolveInfo,
+  path: Path,
+  index: number,
+  completedResults: Array<mixed>,
+  iterator: AsyncIterator<mixed>,
+): Promise<$ReadOnlyArray<mixed>> {
+  const fieldPath = addPath(path, index, undefined);
+  return iterator.next().then(
+    ({ value, done }) => {
+      if (done) {
+        return completedResults;
+      }
+      completedResults.push(
+        completeValue(exeContext, itemType, fieldNodes, info, fieldPath, value),
+      );
+      return completeAsyncIteratorValue(
+        exeContext,
+        itemType,
+        fieldNodes,
+        info,
+        path,
+        index + 1,
+        completedResults,
+        iterator,
+      );
+    },
+    (rawError) => {
+      completedResults.push(null);
+      const error = locatedError(rawError, fieldNodes, pathToArray(fieldPath));
+      handleFieldError(error, itemType, exeContext);
+      return completedResults;
+    },
+  );
+}
+
+/**
  * Complete a list value by completing each item in the list with the
  * inner type
  */
@@ -867,6 +912,23 @@ function completeListValue(
   path: Path,
   result: mixed,
 ): PromiseOrValue<$ReadOnlyArray<mixed>> {
+  const itemType = returnType.ofType;
+
+  if (isAsyncIterable(result)) {
+    const iterator = result[SYMBOL_ASYNC_ITERATOR]();
+
+    return completeAsyncIteratorValue(
+      exeContext,
+      itemType,
+      fieldNodes,
+      info,
+      path,
+      0,
+      [],
+      iterator,
+    );
+  }
+
   if (!isCollection(result)) {
     throw new GraphQLError(
       `Expected Iterable, but did not find one for field "${info.parentType.name}.${info.fieldName}".`,
@@ -875,7 +937,6 @@ function completeListValue(
 
   // This is specified as a simple map, however we're optimizing the path
   // where the list contains no Promises by avoiding creating another Promise.
-  const itemType = returnType.ofType;
   let containsPromise = false;
   const completedResults = arrayFrom(result, (item, index) => {
     // No need to modify the info object containing the path,

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -869,6 +869,7 @@ function completeAsyncIteratorValue(
   path: Path,
   iterator: AsyncIterator<mixed>,
 ): Promise<$ReadOnlyArray<mixed>> {
+  let containsPromise = false;
   return new Promise((resolve) => {
     function next(index, completedResults) {
       const fieldPath = addPath(path, index, undefined);
@@ -880,16 +881,18 @@ function completeAsyncIteratorValue(
           }
           // TODO can the error checking logic be consolidated with completeListValue?
           try {
-            completedResults.push(
-              completeValue(
-                exeContext,
-                itemType,
-                fieldNodes,
-                info,
-                fieldPath,
-                value,
-              ),
+            const completedItem = completeValue(
+              exeContext,
+              itemType,
+              fieldNodes,
+              info,
+              fieldPath,
+              value,
             );
+            if (isPromise(completedItem)) {
+              containsPromise = true;
+            }
+            completedResults.push(completedItem);
           } catch (rawError) {
             completedResults.push(null);
             const error = locatedError(
@@ -917,7 +920,9 @@ function completeAsyncIteratorValue(
       );
     }
     next(0, []);
-  });
+  }).then((completedResults) =>
+    containsPromise ? Promise.all(completedResults) : completedResults,
+  );
 }
 
 /**

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -901,8 +901,6 @@ function completeAsyncIteratorValue(
               pathToArray(fieldPath),
             );
             handleFieldError(error, itemType, exeContext);
-            resolve(completedResults);
-            return;
           }
 
           next(index + 1, completedResults);


### PR DESCRIPTION
if the iterator errors when attempting to get the next value, we can assume subsequent calls to next will also error, and abort, but if we successfully get the next value, but it ends up triggering an error, we can continue, optimistic that the next value will not do so.