### PR TITLE
Use {} instead of Object.create(null)

### DIFF
--- a/src/utilities/valueFromAST.js
+++ b/src/utilities/valueFromAST.js
@@ -106,7 +106,7 @@ export function valueFromAST(
     if (valueNode.kind !== Kind.OBJECT) {
       return; // Invalid: intentionally return no value.
     }
-    const coercedObj = Object.create(null);
+    const coercedObj = {};
     const fieldNodes = keyMap(valueNode.fields, (field) => field.name.value);
     for (const field of Object.values(type.getFields())) {
       const fieldNode = fieldNodes[field.name];


### PR DESCRIPTION
## Reason for the pull request

I noticed an odd behavior with an app I was working on that uses Apollo. When calling a mutation that takes an object, if I used the variable syntax to send the object, everything worked fine. However, if I passed the object directly as a parameter, I would get this error message: `TypeError: Cannot convert object to primitive value`, which was thrown deep in request body creation logic of `node-fetch`.

### This works:
```graphql
mutation CreateThing($thing: ThingInput!) {
  createThing(thing: $thing) {
    success
    message
  }
}
```

### This does not:
```graphql
mutation CreateThing {
  createThing(thing: {
    thingId: "abc123"
    description: "this is a thing"
  }) {
    success
    message
  }
}
```

## What does this have to do with `graphql-js`?

As I debugged the two scenarios above, the one difference I discovered is that the `thing` object passed into my resolver using the object value syntax didn't have a prototype, whereas the `thing` object sent as a variable did. 🤔 "That's odd," I thought. So I dug further to see how that object was being created. This led me to this project, and `valueFromAST()`. If the object was passed as a variable, it returned a normal object. If, however, the object was an ObjectValue, a new object was created using `Object.create(null)`, and then the properties were copied to this object.

Sure enough `Object.create(null)` creates an object without a prototype, which can lead to some interesting behavior, [as documented here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#custom_and_null_objects).

This PR changes this use of `Object.create(null)` to `{}`, giving the coerced object a full object prototype, and good behavior as it's being used elsewhere in my application.