### PR TITLE
print/printSchema: remove trailing new line

### DIFF
--- a/src/__testUtils__/__tests__/dedent-test.js
+++ b/src/__testUtils__/__tests__/dedent-test.js
@@ -25,7 +25,6 @@ describe('dedent', () => {
         '  id: ID',
         '  name: String',
         '}',
-        '',
       ].join('\n'),
     );
   });
@@ -38,7 +37,7 @@ describe('dedent', () => {
                   fourth
     `;
     expect(output).to.equal(
-      ['first', '  second', '    third', '      fourth', ''].join('\n'),
+      ['first', '  second', '    third', '      fourth'].join('\n'),
     );
   });
 
@@ -53,7 +52,6 @@ describe('dedent', () => {
         'type Root {',
         '  field(arg: String = "wi\th de\fault"): String',
         '}',
-        '',
       ].join('\n'),
     );
   });
@@ -64,29 +62,20 @@ describe('dedent', () => {
         \t\t      me: User
         \t\t    }
     `;
-    expect(output).to.equal(['type Query {', '  me: User', '}', ''].join('\n'));
-  });
-
-  it('removes leading newlines', () => {
-    const output = dedent`
-
-
-      type Query {
-        me: User
-      }`;
     expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
   });
 
-  it('does not remove trailing newlines', () => {
+  it('removes leading and trailing newlines', () => {
     const output = dedent`
+
+
       type Query {
         me: User
       }
 
+
     `;
-    expect(output).to.equal(
-      ['type Query {', '  me: User', '}', '', ''].join('\n'),
-    );
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
   });
 
   it('removes all trailing spaces and tabs', () => {
@@ -95,13 +84,14 @@ describe('dedent', () => {
         me: User
       }
           \t\t  \t `;
-    expect(output).to.equal(['type Query {', '  me: User', '}', ''].join('\n'));
+    expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
   });
 
   it('works on text without leading newline', () => {
     const output = dedent`      type Query {
         me: User
-      }`;
+      }
+    `;
     expect(output).to.equal(['type Query {', '  me: User', '}'].join('\n'));
   });
 
@@ -124,7 +114,6 @@ describe('dedent', () => {
         '    "surname": "Doe"',
         '  }',
         '}',
-        '',
       ].join('\n'),
     );
   });

--- a/src/__testUtils__/dedent.js
+++ b/src/__testUtils__/dedent.js
@@ -1,6 +1,5 @@
 /**
- * An ES6 string tag that fixes indentation. Also removes leading newlines
- * and trailing spaces and tabs, but keeps trailing newlines.
+ * An ES6 string tag that fixes indentation and also trims string.
  *
  * Example usage:
  * const str = dedent`
@@ -8,7 +7,7 @@
  *     test
  *   }
  * `;
- * str === "{\n  test\n}\n";
+ * str === "{\n  test\n}";
  */
 export function dedent(
   strings: $ReadOnlyArray<string>,
@@ -28,7 +27,7 @@ export function dedent(
 
   const trimmedStr = str
     .replace(/^\n*/m, '') //  remove leading newline
-    .replace(/[ \t]*$/, ''); // remove trailing spaces and tabs
+    .replace(/[ \t\n]*$/, ''); // remove trailing spaces and tabs
 
   // fixes indentation by removing leading spaces and tabs from each line
   let indent = '';

--- a/src/error/__tests__/GraphQLError-test.js
+++ b/src/error/__tests__/GraphQLError-test.js
@@ -182,7 +182,7 @@ describe('printError', () => {
       fieldB.type,
     ]);
 
-    expect(printError(error) + '\n').to.equal(dedent`
+    expect(printError(error)).to.equal(dedent`
       Example error with two nodes
 
       SourceA:2:10

--- a/src/language/__tests__/lexer-test.js
+++ b/src/language/__tests__/lexer-test.js
@@ -165,7 +165,7 @@ describe('Lexer', () => {
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError) + '\n').to.equal(dedent`
+    expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Cannot parse the unexpected character "?".
 
       GraphQL request:3:5
@@ -185,7 +185,7 @@ describe('Lexer', () => {
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError) + '\n').to.equal(dedent`
+    expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Cannot parse the unexpected character "?".
 
       foo.js:13:6
@@ -204,7 +204,7 @@ describe('Lexer', () => {
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError) + '\n').to.equal(dedent`
+    expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Cannot parse the unexpected character "?".
 
       foo.js:1:5

--- a/src/language/__tests__/parser-test.js
+++ b/src/language/__tests__/parser-test.js
@@ -32,7 +32,7 @@ describe('Parser', () => {
       locations: [{ line: 1, column: 2 }],
     });
 
-    expect(String(caughtError) + '\n').to.equal(dedent`
+    expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Expected Name, found <EOF>.
 
       GraphQL request:1:2
@@ -76,7 +76,7 @@ describe('Parser', () => {
     } catch (error) {
       caughtError = error;
     }
-    expect(String(caughtError) + '\n').to.equal(dedent`
+    expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Expected "{", found <EOF>.
 
       MyQuery.graphql:1:6
@@ -217,7 +217,7 @@ describe('Parser', () => {
 
     expect(toJSONDeep(result)).to.deep.equal({
       kind: Kind.DOCUMENT,
-      loc: { start: 0, end: 41 },
+      loc: { start: 0, end: 40 },
       definitions: [
         {
           kind: Kind.OPERATION_DEFINITION,
@@ -307,7 +307,7 @@ describe('Parser', () => {
 
     expect(toJSONDeep(result)).to.deep.equal({
       kind: Kind.DOCUMENT,
-      loc: { start: 0, end: 30 },
+      loc: { start: 0, end: 29 },
       definitions: [
         {
           kind: Kind.OPERATION_DEFINITION,

--- a/src/language/__tests__/printLocation-test.js
+++ b/src/language/__tests__/printLocation-test.js
@@ -16,7 +16,7 @@ describe('printSourceLocation', () => {
       line: 1,
       column: minifiedSource.body.indexOf('FIRST_ERROR_HERE') + 1,
     });
-    expect(firstLocation + '\n').to.equal(dedent`
+    expect(firstLocation).to.equal(dedent`
       GraphQL request:1:53
       1 | query SomeMinifiedQueryWithErrorInside($foo:String!=FIRST_ERROR_HERE$bar:String)
         |                                                     ^
@@ -27,7 +27,7 @@ describe('printSourceLocation', () => {
       line: 1,
       column: minifiedSource.body.indexOf('SECOND_ERROR_HERE') + 1,
     });
-    expect(secondLocation + '\n').to.equal(dedent`
+    expect(secondLocation).to.equal(dedent`
       GraphQL request:1:114
       1 | query SomeMinifiedQueryWithErrorInside($foo:String!=FIRST_ERROR_HERE$bar:String)
         | {someField(foo:$foo bar:$bar baz:SECOND_ERROR_HERE){fieldA fieldB{fieldC fieldD.
@@ -39,7 +39,7 @@ describe('printSourceLocation', () => {
       line: 1,
       column: minifiedSource.body.indexOf('THIRD_ERROR_HERE') + 1,
     });
-    expect(thirdLocation + '\n').to.equal(dedent`
+    expect(thirdLocation).to.equal(dedent`
       GraphQL request:1:166
       1 | query SomeMinifiedQueryWithErrorInside($foo:String!=FIRST_ERROR_HERE$bar:String)
         | {someField(foo:$foo bar:$bar baz:SECOND_ERROR_HERE){fieldA fieldB{fieldC fieldD.
@@ -54,7 +54,7 @@ describe('printSourceLocation', () => {
       { line: 1, column: 1 },
     );
 
-    expect(result + '\n').to.equal(dedent`
+    expect(result).to.equal(dedent`
       Test:9:1
       9 | *
         | ^
@@ -67,7 +67,7 @@ describe('printSourceLocation', () => {
       { line: 1, column: 1 },
     );
 
-    expect(result + '\n').to.equal(dedent`
+    expect(result).to.equal(dedent`
       Test:9:1
        9 | *
          | ^

--- a/src/language/__tests__/schema-parser-test.js
+++ b/src/language/__tests__/schema-parser-test.js
@@ -98,7 +98,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 30 },
         },
       ],
-      loc: { start: 0, end: 31 },
+      loc: { start: 0, end: 30 },
     });
   });
 
@@ -194,7 +194,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 37 },
         },
       ],
-      loc: { start: 0, end: 38 },
+      loc: { start: 0, end: 37 },
     });
   });
 
@@ -465,7 +465,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 31 },
         },
       ],
-      loc: { start: 0, end: 32 },
+      loc: { start: 0, end: 31 },
     });
   });
 
@@ -703,7 +703,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 35 },
         },
       ],
-      loc: { start: 0, end: 36 },
+      loc: { start: 0, end: 35 },
     });
   });
 
@@ -741,7 +741,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 45 },
         },
       ],
-      loc: { start: 0, end: 46 },
+      loc: { start: 0, end: 45 },
     });
   });
 
@@ -783,7 +783,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 52 },
         },
       ],
-      loc: { start: 0, end: 53 },
+      loc: { start: 0, end: 52 },
     });
   });
 
@@ -825,7 +825,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 48 },
         },
       ],
-      loc: { start: 0, end: 49 },
+      loc: { start: 0, end: 48 },
     });
   });
 
@@ -869,7 +869,7 @@ describe('Schema Parser', () => {
           loc: { start: 0, end: 60 },
         },
       ],
-      loc: { start: 0, end: 61 },
+      loc: { start: 0, end: 60 },
     });
   });
 

--- a/src/language/printer.js
+++ b/src/language/printer.js
@@ -21,7 +21,7 @@ const printDocASTReducer: any = {
   // Document
 
   Document: {
-    leave: (node) => join(node.definitions, '\n\n') + '\n',
+    leave: (node) => join(node.definitions, '\n\n'),
   },
 
   OperationDefinition: {

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -728,7 +728,7 @@ describe('Schema Builder', () => {
     `);
 
     const someScalar = assertScalarType(schema.getType('SomeScalar'));
-    expect(printType(someScalar) + '\n').to.equal(dedent`
+    expect(printType(someScalar)).to.equal(dedent`
       scalar SomeScalar
     `);
 
@@ -757,7 +757,7 @@ describe('Schema Builder', () => {
     `);
 
     const someObject = assertObjectType(schema.getType('SomeObject'));
-    expect(printType(someObject) + '\n').to.equal(dedent`
+    expect(printType(someObject)).to.equal(dedent`
       type SomeObject implements Foo & Bar & Baz {
         first: String
         second: Int
@@ -785,7 +785,7 @@ describe('Schema Builder', () => {
     const schema = buildSchema(interfaceSDL);
 
     const someInterface = assertInterfaceType(schema.getType('SomeInterface'));
-    expect(printType(someInterface) + '\n').to.equal(dedent`
+    expect(printType(someInterface)).to.equal(dedent`
       interface SomeInterface {
         first: String
         second: Int
@@ -812,7 +812,7 @@ describe('Schema Builder', () => {
     `);
 
     const someUnion = assertUnionType(schema.getType('SomeUnion'));
-    expect(printType(someUnion) + '\n').to.equal(dedent`
+    expect(printType(someUnion)).to.equal(dedent`
       union SomeUnion = FirstType | SecondType | ThirdType
     `);
 
@@ -836,7 +836,7 @@ describe('Schema Builder', () => {
     const schema = buildSchema(enumSDL);
 
     const someEnum = assertEnumType(schema.getType('SomeEnum'));
-    expect(printType(someEnum) + '\n').to.equal(dedent`
+    expect(printType(someEnum)).to.equal(dedent`
       enum SomeEnum {
         FIRST
         SECOND
@@ -864,7 +864,7 @@ describe('Schema Builder', () => {
     const schema = buildSchema(inputSDL);
 
     const someInput = assertInputObjectType(schema.getType('SomeInput'));
-    expect(printType(someInput) + '\n').to.equal(dedent`
+    expect(printType(someInput)).to.equal(dedent`
       input SomeInput {
         first: String
         second: Int

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -826,10 +826,11 @@ describe('extendSchema', () => {
 
       interface AnotherNewInterface {
         anotherNewField: String
-      }`;
+      }
+    `;
     const schemaWithNewTypes = extendSchema(schema, parse(newTypesSDL));
     expect(printSchemaChanges(schema, schemaWithNewTypes)).to.equal(
-      newTypesSDL + '\n',
+      newTypesSDL,
     );
 
     const extendAST = parse(`
@@ -1219,7 +1220,7 @@ describe('extendSchema', () => {
 
       const queryType = extendedSchema.getQueryType();
       expect(queryType).to.include({ name: 'Foo' });
-      expect(printASTNode(extendedSchema) + '\n').to.equal(extensionSDL);
+      expect(printASTNode(extendedSchema)).to.equal(extensionSDL);
     });
 
     it('adds new root types via schema extension', () => {

--- a/src/utilities/__tests__/stripIgnoredCharacters-test.js
+++ b/src/utilities/__tests__/stripIgnoredCharacters-test.js
@@ -147,7 +147,7 @@ describe('stripIgnoredCharacters', () => {
       caughtError = e;
     }
 
-    expect(String(caughtError) + '\n').to.equal(dedent`
+    expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Unterminated string.
 
       GraphQL request:1:13

--- a/src/utilities/printSchema.js
+++ b/src/utilities/printSchema.js
@@ -58,15 +58,13 @@ function printFilteredSchema(
   const directives = schema.getDirectives().filter(directiveFilter);
   const types = Object.values(schema.getTypeMap()).filter(typeFilter);
 
-  return (
-    [printSchemaDefinition(schema)]
-      .concat(
-        directives.map((directive) => printDirective(directive)),
-        types.map((type) => printType(type)),
-      )
-      .filter(Boolean)
-      .join('\n\n') + '\n'
-  );
+  return [printSchemaDefinition(schema)]
+    .concat(
+      directives.map((directive) => printDirective(directive)),
+      types.map((type) => printType(type)),
+    )
+    .filter(Boolean)
+    .join('\n\n');
 }
 
 function printSchemaDefinition(schema: GraphQLSchema): ?string {


### PR DESCRIPTION
Remove special behaviour for printing `DocumentNode` that added trailing
new line.
This change allows to tools to add newline only if it required by code
convention or OS convention.

Scripts and CLI tool can return previous behaviour by adding `\n`.