### PR TITLE
fix: discrepancies between Flow and TS types

### DIFF
--- a/src/language/blockString.d.ts
+++ b/src/language/blockString.d.ts
@@ -3,6 +3,8 @@
  * CoffeeScript's block string, Python's docstring trim or Ruby's strip_heredoc.
  *
  * This implements the GraphQL spec's BlockStringValue() static algorithm.
+ *
+ * @internal
  */
 export function dedentBlockStringValue(rawString: string): string;
 
@@ -15,6 +17,8 @@ export function getBlockStringIndentation(body: string): number;
  * Print a block string in the indented block form by adding a leading and
  * trailing blank line. However, if a block string starts with whitespace and is
  * a single-line, adding a leading blank line would strip that whitespace.
+ *
+ * @internal
  */
 export function printBlockString(
   value: string,

--- a/src/language/directiveLocation.d.ts
+++ b/src/language/directiveLocation.d.ts
@@ -1,7 +1,7 @@
 /**
  * The set of allowed directive location values.
  */
-export const DirectiveLocation: {
+export const DirectiveLocation: Readonly<{
   // Request Definitions
   QUERY: 'QUERY';
   MUTATION: 'MUTATION';
@@ -24,7 +24,7 @@ export const DirectiveLocation: {
   ENUM_VALUE: 'ENUM_VALUE';
   INPUT_OBJECT: 'INPUT_OBJECT';
   INPUT_FIELD_DEFINITION: 'INPUT_FIELD_DEFINITION';
-};
+}>;
 
 /**
  * The enum type representing the directive location values.

--- a/src/language/kinds.d.ts
+++ b/src/language/kinds.d.ts
@@ -1,7 +1,7 @@
 /**
  * The set of allowed kind values for AST nodes.
  */
-export const Kind: {
+export const Kind: Readonly<{
   // Name
   NAME: 'Name';
 
@@ -66,7 +66,7 @@ export const Kind: {
   UNION_TYPE_EXTENSION: 'UnionTypeExtension';
   ENUM_TYPE_EXTENSION: 'EnumTypeExtension';
   INPUT_OBJECT_TYPE_EXTENSION: 'InputObjectTypeExtension';
-};
+}>;
 
 /**
  * The enum type representing the possible kind values of AST nodes.

--- a/src/language/lexer.d.ts
+++ b/src/language/lexer.d.ts
@@ -50,9 +50,4 @@ export class Lexer {
 /**
  * @internal
  */
-export function isPunctuatorToken(token: Token): boolean;
-
-/**
- * @internal
- */
 export function isPunctuatorTokenKind(kind: TokenKindEnum): boolean;

--- a/src/language/source.d.ts
+++ b/src/language/source.d.ts
@@ -15,6 +15,7 @@ export class Source {
   name: string;
   locationOffset: Location;
   constructor(body: string, name?: string, locationOffset?: Location);
+  get [Symbol.toStringTag](): string;
 }
 
 /**

--- a/src/language/tokenKind.d.ts
+++ b/src/language/tokenKind.d.ts
@@ -2,7 +2,7 @@
  * An exported enum describing the different kinds of tokens that the
  * lexer emits.
  */
-export const TokenKind: {
+export const TokenKind: Readonly<{
   SOF: '<SOF>';
   EOF: '<EOF>';
   BANG: '!';
@@ -25,7 +25,7 @@ export const TokenKind: {
   STRING: 'String';
   BLOCK_STRING: 'BlockString';
   COMMENT: 'Comment';
-};
+}>;
 
 /**
  * The enum type representing the token kinds values.

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -180,6 +180,7 @@ export class GraphQLList<T extends GraphQLType> {
   toString: () => string;
   toJSON: () => string;
   inspect: () => string;
+  get [Symbol.toStringTag](): string;
 }
 
 /**
@@ -210,6 +211,7 @@ export class GraphQLNonNull<T extends GraphQLNullableType> {
   toString: () => string;
   toJSON: () => string;
   inspect: () => string;
+  get [Symbol.toStringTag](): string;
 }
 
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
@@ -426,6 +428,7 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
   toString(): string;
   toJSON(): string;
   inspect(): string;
+  get [Symbol.toStringTag](): string;
 }
 
 export function argsToArgsConfig(
@@ -632,6 +635,7 @@ export class GraphQLInterfaceType {
   toString(): string;
   toJSON(): string;
   inspect(): string;
+  get [Symbol.toStringTag](): string;
 }
 
 export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
@@ -706,6 +710,7 @@ export class GraphQLUnionType {
   toString(): string;
   toJSON(): string;
   inspect(): string;
+  get [Symbol.toStringTag](): string;
 }
 
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
@@ -782,6 +787,7 @@ export class GraphQLEnumType {
   toString(): string;
   toJSON(): string;
   inspect(): string;
+  get [Symbol.toStringTag](): string;
 }
 
 export interface GraphQLEnumTypeConfig {
@@ -879,6 +885,7 @@ export class GraphQLInputObjectType {
   toString(): string;
   toJSON(): string;
   inspect(): string;
+  get [Symbol.toStringTag](): string;
 }
 
 export interface GraphQLInputObjectTypeConfig {

--- a/src/type/directives.d.ts
+++ b/src/type/directives.d.ts
@@ -51,6 +51,7 @@ export class GraphQLDirective {
   toString(): string;
   toJSON(): string;
   inspect(): string;
+  get [Symbol.toStringTag](): string;
 }
 
 export interface GraphQLDirectiveConfig {

--- a/src/type/introspection.d.ts
+++ b/src/type/introspection.d.ts
@@ -13,7 +13,7 @@ export const __Field: GraphQLObjectType;
 export const __InputValue: GraphQLObjectType;
 export const __EnumValue: GraphQLObjectType;
 
-export const TypeKind: {
+export const TypeKind: Readonly<{
   SCALAR: 'SCALAR';
   OBJECT: 'OBJECT';
   INTERFACE: 'INTERFACE';
@@ -22,7 +22,7 @@ export const TypeKind: {
   INPUT_OBJECT: 'INPUT_OBJECT';
   LIST: 'LIST';
   NON_NULL: 'NON_NULL';
-};
+}>;
 
 export const __TypeKind: GraphQLEnumType;
 

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -81,7 +81,7 @@ export class GraphQLSchema {
 
   isSubType(
     abstractType: GraphQLAbstractType,
-    maybeSubType: GraphQLNamedType,
+    maybeSubType: GraphQLObjectType | GraphQLInterfaceType,
   ): boolean;
 
   getDirectives(): ReadonlyArray<GraphQLDirective>;

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -94,6 +94,7 @@ export class GraphQLSchema {
     extensionASTNodes: ReadonlyArray<SchemaExtensionNode>;
     assumeValid: boolean;
   };
+  get [Symbol.toStringTag](): string;
 }
 
 interface TypeMap {

--- a/src/utilities/TypeInfo.d.ts
+++ b/src/utilities/TypeInfo.d.ts
@@ -34,7 +34,7 @@ export class TypeInfo {
   getParentType(): Maybe<GraphQLCompositeType>;
   getInputType(): Maybe<GraphQLInputType>;
   getParentInputType(): Maybe<GraphQLInputType>;
-  getFieldDef(): GraphQLField<any, Maybe<any>>;
+  getFieldDef(): Maybe<GraphQLField<any, any>>;
   getDefaultValue(): Maybe<any>;
   getDirective(): Maybe<GraphQLDirective>;
   getArgument(): Maybe<GraphQLArgument>;

--- a/src/validation/validate.d.ts
+++ b/src/validation/validate.d.ts
@@ -43,7 +43,7 @@ export function validateSDL(
   documentAST: DocumentNode,
   schemaToExtend?: Maybe<GraphQLSchema>,
   rules?: ReadonlyArray<SDLValidationRule>,
-): Array<GraphQLError>;
+): Readonly<GraphQLError>;
 
 /**
  * Utility function which asserts a SDL document is valid by throwing an error


### PR DESCRIPTION
Split PR #2985
- feat: remove unexported type
- feat: exported type should be readonly
- feat: add get Symbol.toStringTag
- feat: add internal annotations
- fix: match type as per flow def
-  feat: add type for [Symbol.toStringTag] getter
- fix: match input type with flow
- fix: match return return type with flow
