### PR TITLE
Use specifiedBy instead of specifiedByUrl

### DIFF
--- a/docs/APIReference-TypeSystem.md
+++ b/docs/APIReference-TypeSystem.md
@@ -206,7 +206,7 @@ class GraphQLScalarType<InternalType> {
 type GraphQLScalarTypeConfig<InternalType> = {
   name: string;
   description?: ?string;
-  specifiedBy?: string;
+  specifiedByURL?: string;
   serialize: (value: mixed) => ?InternalType;
   parseValue?: (value: mixed) => ?InternalType;
   parseLiteral?: (valueAST: Value) => ?InternalType;

--- a/docs/APIReference-TypeSystem.md
+++ b/docs/APIReference-TypeSystem.md
@@ -206,7 +206,7 @@ class GraphQLScalarType<InternalType> {
 type GraphQLScalarTypeConfig<InternalType> = {
   name: string;
   description?: ?string;
-  specifiedByUrl?: string;
+  specifiedBy?: string;
   serialize: (value: mixed) => ?InternalType;
   parseValue?: (value: mixed) => ?InternalType;
   parseLiteral?: (valueAST: Value) => ?InternalType;

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -46,12 +46,12 @@ describe('Type System: Scalars', () => {
     expect(() => new GraphQLScalarType({ name: 'SomeScalar' })).to.not.throw();
   });
 
-  it('accepts a Scalar type defining specifiedByUrl', () => {
+  it('accepts a Scalar type defining specifiedBy', () => {
     expect(
       () =>
         new GraphQLScalarType({
           name: 'SomeScalar',
-          specifiedByUrl: 'https://example.com/foo_spec',
+          specifiedBy: 'https://example.com/foo_spec',
         }),
     ).not.to.throw();
   });
@@ -139,16 +139,16 @@ describe('Type System: Scalars', () => {
     );
   });
 
-  it('rejects a Scalar type defining specifiedByUrl with an incorrect type', () => {
+  it('rejects a Scalar type defining specifiedBy with an incorrect type', () => {
     expect(
       () =>
         new GraphQLScalarType({
           name: 'SomeScalar',
           // $FlowExpectedError[incompatible-call]
-          specifiedByUrl: {},
+          specifiedBy: {},
         }),
     ).to.throw(
-      'SomeScalar must provide "specifiedByUrl" as a string, but got: {}.',
+      'SomeScalar must provide "specifiedBy" as a string, but got: {}.',
     );
   });
 });

--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -46,12 +46,12 @@ describe('Type System: Scalars', () => {
     expect(() => new GraphQLScalarType({ name: 'SomeScalar' })).to.not.throw();
   });
 
-  it('accepts a Scalar type defining specifiedBy', () => {
+  it('accepts a Scalar type defining specifiedByURL', () => {
     expect(
       () =>
         new GraphQLScalarType({
           name: 'SomeScalar',
-          specifiedBy: 'https://example.com/foo_spec',
+          specifiedByURL: 'https://example.com/foo_spec',
         }),
     ).not.to.throw();
   });
@@ -139,16 +139,16 @@ describe('Type System: Scalars', () => {
     );
   });
 
-  it('rejects a Scalar type defining specifiedBy with an incorrect type', () => {
+  it('rejects a Scalar type defining specifiedByURL with an incorrect type', () => {
     expect(
       () =>
         new GraphQLScalarType({
           name: 'SomeScalar',
           // $FlowExpectedError[incompatible-call]
-          specifiedBy: {},
+          specifiedByURL: {},
         }),
     ).to.throw(
-      'SomeScalar must provide "specifiedBy" as a string, but got: {}.',
+      'SomeScalar must provide "specifiedByURL" as a string, but got: {}.',
     );
   });
 });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -35,7 +35,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: 'SomeObject',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'someField',
@@ -57,7 +57,7 @@ describe('Introspection', () => {
             {
               kind: 'SCALAR',
               name: 'String',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -67,7 +67,7 @@ describe('Introspection', () => {
             {
               kind: 'SCALAR',
               name: 'Boolean',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -77,7 +77,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Schema',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'description',
@@ -182,7 +182,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Type',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'kind',
@@ -222,7 +222,7 @@ describe('Introspection', () => {
                   deprecationReason: null,
                 },
                 {
-                  name: 'specifiedBy',
+                  name: 'specifiedByURL',
                   args: [],
                   type: {
                     kind: 'SCALAR',
@@ -377,7 +377,7 @@ describe('Introspection', () => {
             {
               kind: 'ENUM',
               name: '__TypeKind',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -428,7 +428,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Field',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'name',
@@ -539,7 +539,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__InputValue',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'name',
@@ -628,7 +628,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__EnumValue',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'name',
@@ -691,7 +691,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Directive',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: [
                 {
                   name: 'name',
@@ -789,7 +789,7 @@ describe('Introspection', () => {
             {
               kind: 'ENUM',
               name: '__DirectiveLocation',
-              specifiedBy: null,
+              specifiedByURL: null,
               fields: null,
               inputFields: null,
               interfaces: null,

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1560,7 +1560,7 @@ describe('Introspection', () => {
     `);
 
     const source = getIntrospectionQuery({
-      specifiedBy: true,
+      specifiedByUrl: true,
       directiveIsRepeatable: true,
       schemaDescription: true,
     });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -35,7 +35,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: 'SomeObject',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'someField',
@@ -57,7 +57,7 @@ describe('Introspection', () => {
             {
               kind: 'SCALAR',
               name: 'String',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -67,7 +67,7 @@ describe('Introspection', () => {
             {
               kind: 'SCALAR',
               name: 'Boolean',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -77,7 +77,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Schema',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'description',
@@ -182,7 +182,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Type',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'kind',
@@ -222,7 +222,7 @@ describe('Introspection', () => {
                   deprecationReason: null,
                 },
                 {
-                  name: 'specifiedByUrl',
+                  name: 'specifiedBy',
                   args: [],
                   type: {
                     kind: 'SCALAR',
@@ -377,7 +377,7 @@ describe('Introspection', () => {
             {
               kind: 'ENUM',
               name: '__TypeKind',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -428,7 +428,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Field',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'name',
@@ -539,7 +539,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__InputValue',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'name',
@@ -628,7 +628,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__EnumValue',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'name',
@@ -691,7 +691,7 @@ describe('Introspection', () => {
             {
               kind: 'OBJECT',
               name: '__Directive',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: [
                 {
                   name: 'name',
@@ -789,7 +789,7 @@ describe('Introspection', () => {
             {
               kind: 'ENUM',
               name: '__DirectiveLocation',
-              specifiedByUrl: null,
+              specifiedBy: null,
               fields: null,
               inputFields: null,
               interfaces: null,
@@ -1560,7 +1560,7 @@ describe('Introspection', () => {
     `);
 
     const source = getIntrospectionQuery({
-      specifiedByUrl: true,
+      specifiedBy: true,
       directiveIsRepeatable: true,
       schemaDescription: true,
     });

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -304,7 +304,7 @@ export interface GraphQLScalarTypeExtensions {
 export class GraphQLScalarType {
   name: string;
   description: Maybe<string>;
-  specifiedByUrl: Maybe<string>;
+  specifiedBy: Maybe<string>;
   serialize: GraphQLScalarSerializer<unknown>;
   parseValue: GraphQLScalarValueParser<unknown>;
   parseLiteral: GraphQLScalarLiteralParser<unknown>;
@@ -315,7 +315,7 @@ export class GraphQLScalarType {
   constructor(config: Readonly<GraphQLScalarTypeConfig<unknown, unknown>>);
 
   toConfig(): GraphQLScalarTypeConfig<unknown, unknown> & {
-    specifiedByUrl: Maybe<string>;
+    specifiedBy: Maybe<string>;
     serialize: GraphQLScalarSerializer<unknown>;
     parseValue: GraphQLScalarValueParser<unknown>;
     parseLiteral: GraphQLScalarLiteralParser<unknown>;
@@ -342,7 +342,7 @@ export type GraphQLScalarLiteralParser<TInternal> = (
 export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   name: string;
   description?: Maybe<string>;
-  specifiedByUrl?: Maybe<string>;
+  specifiedBy?: Maybe<string>;
   // Serializes an internal value to include in a response.
   serialize?: GraphQLScalarSerializer<TExternal>;
   // Parses an externally provided value to use as an input.

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -304,7 +304,7 @@ export interface GraphQLScalarTypeExtensions {
 export class GraphQLScalarType {
   name: string;
   description: Maybe<string>;
-  specifiedBy: Maybe<string>;
+  specifiedByURL: Maybe<string>;
   serialize: GraphQLScalarSerializer<unknown>;
   parseValue: GraphQLScalarValueParser<unknown>;
   parseLiteral: GraphQLScalarLiteralParser<unknown>;
@@ -315,7 +315,7 @@ export class GraphQLScalarType {
   constructor(config: Readonly<GraphQLScalarTypeConfig<unknown, unknown>>);
 
   toConfig(): GraphQLScalarTypeConfig<unknown, unknown> & {
-    specifiedBy: Maybe<string>;
+    specifiedByURL: Maybe<string>;
     serialize: GraphQLScalarSerializer<unknown>;
     parseValue: GraphQLScalarValueParser<unknown>;
     parseLiteral: GraphQLScalarLiteralParser<unknown>;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -549,7 +549,7 @@ function resolveObjMapThunk<T>(thunk: ThunkObjMap<T>): ObjMap<T> {
 export class GraphQLScalarType {
   name: string;
   description: ?string;
-  specifiedBy: ?string;
+  specifiedByURL: ?string;
   serialize: GraphQLScalarSerializer<mixed>;
   parseValue: GraphQLScalarValueParser<mixed>;
   parseLiteral: GraphQLScalarLiteralParser<mixed>;
@@ -561,7 +561,7 @@ export class GraphQLScalarType {
     const parseValue = config.parseValue ?? identityFunc;
     this.name = config.name;
     this.description = config.description;
-    this.specifiedBy = config.specifiedBy;
+    this.specifiedByURL = config.specifiedByURL;
     this.serialize = config.serialize ?? identityFunc;
     this.parseValue = parseValue;
     this.parseLiteral =
@@ -574,9 +574,10 @@ export class GraphQLScalarType {
     devAssert(typeof config.name === 'string', 'Must provide name.');
 
     devAssert(
-      config.specifiedBy == null || typeof config.specifiedBy === 'string',
-      `${this.name} must provide "specifiedBy" as a string, ` +
-        `but got: ${inspect(config.specifiedBy)}.`,
+      config.specifiedByURL == null ||
+        typeof config.specifiedByURL === 'string',
+      `${this.name} must provide "specifiedByURL" as a string, ` +
+        `but got: ${inspect(config.specifiedByURL)}.`,
     );
 
     devAssert(
@@ -597,7 +598,7 @@ export class GraphQLScalarType {
     return {
       name: this.name,
       description: this.description,
-      specifiedBy: this.specifiedBy,
+      specifiedByURL: this.specifiedByURL,
       serialize: this.serialize,
       parseValue: this.parseValue,
       parseLiteral: this.parseLiteral,
@@ -637,7 +638,7 @@ export type GraphQLScalarLiteralParser<TInternal> = (
 export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   name: string,
   description?: ?string,
-  specifiedBy?: ?string,
+  specifiedByURL?: ?string,
   // Serializes an internal value to include in a response.
   serialize?: GraphQLScalarSerializer<TExternal>,
   // Parses an externally provided value to use as an input.

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -549,7 +549,7 @@ function resolveObjMapThunk<T>(thunk: ThunkObjMap<T>): ObjMap<T> {
 export class GraphQLScalarType {
   name: string;
   description: ?string;
-  specifiedByUrl: ?string;
+  specifiedBy: ?string;
   serialize: GraphQLScalarSerializer<mixed>;
   parseValue: GraphQLScalarValueParser<mixed>;
   parseLiteral: GraphQLScalarLiteralParser<mixed>;
@@ -561,7 +561,7 @@ export class GraphQLScalarType {
     const parseValue = config.parseValue ?? identityFunc;
     this.name = config.name;
     this.description = config.description;
-    this.specifiedByUrl = config.specifiedByUrl;
+    this.specifiedBy = config.specifiedBy;
     this.serialize = config.serialize ?? identityFunc;
     this.parseValue = parseValue;
     this.parseLiteral =
@@ -574,10 +574,9 @@ export class GraphQLScalarType {
     devAssert(typeof config.name === 'string', 'Must provide name.');
 
     devAssert(
-      config.specifiedByUrl == null ||
-        typeof config.specifiedByUrl === 'string',
-      `${this.name} must provide "specifiedByUrl" as a string, ` +
-        `but got: ${inspect(config.specifiedByUrl)}.`,
+      config.specifiedBy == null || typeof config.specifiedBy === 'string',
+      `${this.name} must provide "specifiedBy" as a string, ` +
+        `but got: ${inspect(config.specifiedBy)}.`,
     );
 
     devAssert(
@@ -598,7 +597,7 @@ export class GraphQLScalarType {
     return {
       name: this.name,
       description: this.description,
-      specifiedByUrl: this.specifiedByUrl,
+      specifiedBy: this.specifiedBy,
       serialize: this.serialize,
       parseValue: this.parseValue,
       parseLiteral: this.parseLiteral,
@@ -638,7 +637,7 @@ export type GraphQLScalarLiteralParser<TInternal> = (
 export type GraphQLScalarTypeConfig<TInternal, TExternal> = {|
   name: string,
   description?: ?string,
-  specifiedByUrl?: ?string,
+  specifiedBy?: ?string,
   // Serializes an internal value to include in a response.
   serialize?: GraphQLScalarSerializer<TExternal>,
   // Parses an externally provided value to use as an input.

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -196,7 +196,7 @@ export const __DirectiveLocation: GraphQLEnumType = new GraphQLEnumType({
 export const __Type: GraphQLObjectType = new GraphQLObjectType({
   name: '__Type',
   description:
-    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByUrl`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
+    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedBy`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
   fields: () =>
     ({
       kind: {
@@ -241,10 +241,10 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         resolve: (type) =>
           type.description !== undefined ? type.description : undefined,
       },
-      specifiedByUrl: {
+      specifiedBy: {
         type: GraphQLString,
         resolve: (obj) =>
-          obj.specifiedByUrl !== undefined ? obj.specifiedByUrl : undefined,
+          obj.specifiedBy !== undefined ? obj.specifiedBy : undefined,
       },
       fields: {
         type: new GraphQLList(new GraphQLNonNull(__Field)),

--- a/src/type/introspection.js
+++ b/src/type/introspection.js
@@ -196,7 +196,7 @@ export const __DirectiveLocation: GraphQLEnumType = new GraphQLEnumType({
 export const __Type: GraphQLObjectType = new GraphQLObjectType({
   name: '__Type',
   description:
-    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedBy`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
+    'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
   fields: () =>
     ({
       kind: {
@@ -241,10 +241,10 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         resolve: (type) =>
           type.description !== undefined ? type.description : undefined,
       },
-      specifiedBy: {
+      specifiedByURL: {
         type: GraphQLString,
         resolve: (obj) =>
-          obj.specifiedBy !== undefined ? obj.specifiedBy : undefined,
+          obj.specifiedByURL !== undefined ? obj.specifiedByURL : undefined,
       },
       fields: {
         type: new GraphQLList(new GraphQLNonNull(__Field)),

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -707,7 +707,7 @@ describe('Schema Builder', () => {
     const schema = buildSchema(sdl);
 
     expect(schema.getType('Foo')).to.include({
-      specifiedByUrl: 'https://example.com/foo_spec',
+      specifiedBy: 'https://example.com/foo_spec',
     });
   });
 

--- a/src/utilities/__tests__/buildASTSchema-test.js
+++ b/src/utilities/__tests__/buildASTSchema-test.js
@@ -707,7 +707,7 @@ describe('Schema Builder', () => {
     const schema = buildSchema(sdl);
 
     expect(schema.getType('Foo')).to.include({
-      specifiedBy: 'https://example.com/foo_spec',
+      specifiedByURL: 'https://example.com/foo_spec',
     });
   });
 

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -315,7 +315,7 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(schema, parse(extensionSDL));
     const foo = assertScalarType(extendedSchema.getType('Foo'));
 
-    expect(foo.specifiedBy).to.equal('https://example.com/foo_spec');
+    expect(foo.specifiedByURL).to.equal('https://example.com/foo_spec');
 
     expect(validateSchema(extendedSchema)).to.deep.equal([]);
     expectExtensionASTNodes(foo).to.equal(extensionSDL);

--- a/src/utilities/__tests__/extendSchema-test.js
+++ b/src/utilities/__tests__/extendSchema-test.js
@@ -315,7 +315,7 @@ describe('extendSchema', () => {
     const extendedSchema = extendSchema(schema, parse(extensionSDL));
     const foo = assertScalarType(extendedSchema.getType('Foo'));
 
-    expect(foo.specifiedByUrl).to.equal('https://example.com/foo_spec');
+    expect(foo.specifiedBy).to.equal('https://example.com/foo_spec');
 
     expect(validateSchema(extendedSchema)).to.deep.equal([]);
     expectExtensionASTNodes(foo).to.equal(extensionSDL);

--- a/src/utilities/__tests__/getIntrospectionQuery-test.js
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.js
@@ -63,15 +63,13 @@ describe('getIntrospectionQuery', () => {
     }).toNotMatch('description');
   });
 
-  it('include "specifiedByUrl" field', () => {
-    expectIntrospectionQuery().toNotMatch('specifiedByUrl');
+  it('include "specifiedBy" field', () => {
+    expectIntrospectionQuery().toNotMatch('specifiedBy');
 
-    expectIntrospectionQuery({ specifiedByUrl: true }).toMatch(
-      'specifiedByUrl',
-    );
+    expectIntrospectionQuery({ specifiedByUrl: true }).toMatch('specifiedBy');
 
     expectIntrospectionQuery({ specifiedByUrl: false }).toNotMatch(
-      'specifiedByUrl',
+      'specifiedBy',
     );
   });
 

--- a/src/utilities/__tests__/getIntrospectionQuery-test.js
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.js
@@ -64,12 +64,14 @@ describe('getIntrospectionQuery', () => {
   });
 
   it('include "specifiedBy" field', () => {
-    expectIntrospectionQuery().toNotMatch('specifiedBy');
+    expectIntrospectionQuery().toNotMatch('specifiedByURL');
 
-    expectIntrospectionQuery({ specifiedByUrl: true }).toMatch('specifiedBy');
+    expectIntrospectionQuery({ specifiedByUrl: true }).toMatch(
+      'specifiedByURL',
+    );
 
     expectIntrospectionQuery({ specifiedByUrl: false }).toNotMatch(
-      'specifiedBy',
+      'specifiedByURL',
     );
   });
 

--- a/src/utilities/__tests__/printSchema-test.js
+++ b/src/utilities/__tests__/printSchema-test.js
@@ -495,10 +495,10 @@ describe('Type System Printer', () => {
     `);
   });
 
-  it('Custom Scalar with specifiedBy', () => {
+  it('Custom Scalar with specifiedByURL', () => {
     const FooType = new GraphQLScalarType({
       name: 'Foo',
-      specifiedBy: 'https://example.com/foo_spec',
+      specifiedByURL: 'https://example.com/foo_spec',
     });
 
     const schema = new GraphQLSchema({ types: [FooType] });
@@ -670,13 +670,13 @@ describe('Type System Printer', () => {
       """
       The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \`__TypeKind\` enum.
 
-      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional \`specifiedBy\`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional \`specifiedByURL\`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
       """
       type __Type {
         kind: __TypeKind!
         name: String
         description: String
-        specifiedBy: String
+        specifiedByURL: String
         fields(includeDeprecated: Boolean = false): [__Field!]
         interfaces: [__Type!]
         possibleTypes: [__Type!]

--- a/src/utilities/__tests__/printSchema-test.js
+++ b/src/utilities/__tests__/printSchema-test.js
@@ -495,10 +495,10 @@ describe('Type System Printer', () => {
     `);
   });
 
-  it('Custom Scalar with specifiedByUrl', () => {
+  it('Custom Scalar with specifiedBy', () => {
     const FooType = new GraphQLScalarType({
       name: 'Foo',
-      specifiedByUrl: 'https://example.com/foo_spec',
+      specifiedBy: 'https://example.com/foo_spec',
     });
 
     const schema = new GraphQLSchema({ types: [FooType] });
@@ -670,13 +670,13 @@ describe('Type System Printer', () => {
       """
       The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the \`__TypeKind\` enum.
 
-      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional \`specifiedByUrl\`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
+      Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional \`specifiedBy\`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.
       """
       type __Type {
         kind: __TypeKind!
         name: String
         description: String
-        specifiedByUrl: String
+        specifiedBy: String
         fields(includeDeprecated: Boolean = false): [__Field!]
         interfaces: [__Type!]
         possibleTypes: [__Type!]

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -201,7 +201,7 @@ export function buildClientSchema(
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
-      specifiedBy: scalarIntrospection.specifiedBy,
+      specifiedByURL: scalarIntrospection.specifiedByURL,
     });
   }
 

--- a/src/utilities/buildClientSchema.js
+++ b/src/utilities/buildClientSchema.js
@@ -201,7 +201,7 @@ export function buildClientSchema(
     return new GraphQLScalarType({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
-      specifiedByUrl: scalarIntrospection.specifiedByUrl,
+      specifiedBy: scalarIntrospection.specifiedBy,
     });
   }
 

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -310,14 +310,14 @@ export function extendSchemaImpl(
     const config = type.toConfig();
     const extensions = typeExtensionsMap[config.name] ?? [];
 
-    let specifiedBy = config.specifiedBy;
+    let specifiedByURL = config.specifiedByURL;
     for (const extensionNode of extensions) {
-      specifiedBy = getSpecifiedBy(extensionNode) ?? specifiedBy;
+      specifiedByURL = getSpecifiedByURL(extensionNode) ?? specifiedByURL;
     }
 
     return new GraphQLScalarType({
       ...config,
-      specifiedBy,
+      specifiedByURL,
       extensionASTNodes: config.extensionASTNodes.concat(extensions),
     });
   }
@@ -655,7 +655,7 @@ export function extendSchemaImpl(
         return new GraphQLScalarType({
           name,
           description: astNode.description?.value,
-          specifiedBy: getSpecifiedBy(astNode),
+          specifiedByURL: getSpecifiedByURL(astNode),
           astNode,
           extensionASTNodes,
         });
@@ -702,9 +702,9 @@ function getDeprecationReason(
 }
 
 /**
- * Given a scalar node, returns the string value for the specifiedBy.
+ * Given a scalar node, returns the string value for the specifiedByURL.
  */
-function getSpecifiedBy(
+function getSpecifiedByURL(
   node: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
 ): ?string {
   const specifiedBy = getDirectiveValues(GraphQLSpecifiedByDirective, node);

--- a/src/utilities/extendSchema.js
+++ b/src/utilities/extendSchema.js
@@ -310,14 +310,14 @@ export function extendSchemaImpl(
     const config = type.toConfig();
     const extensions = typeExtensionsMap[config.name] ?? [];
 
-    let specifiedByUrl = config.specifiedByUrl;
+    let specifiedBy = config.specifiedBy;
     for (const extensionNode of extensions) {
-      specifiedByUrl = getSpecifiedByUrl(extensionNode) ?? specifiedByUrl;
+      specifiedBy = getSpecifiedBy(extensionNode) ?? specifiedBy;
     }
 
     return new GraphQLScalarType({
       ...config,
-      specifiedByUrl,
+      specifiedBy,
       extensionASTNodes: config.extensionASTNodes.concat(extensions),
     });
   }
@@ -655,7 +655,7 @@ export function extendSchemaImpl(
         return new GraphQLScalarType({
           name,
           description: astNode.description?.value,
-          specifiedByUrl: getSpecifiedByUrl(astNode),
+          specifiedBy: getSpecifiedBy(astNode),
           astNode,
           extensionASTNodes,
         });
@@ -702,9 +702,9 @@ function getDeprecationReason(
 }
 
 /**
- * Given a scalar node, returns the string value for the specifiedByUrl.
+ * Given a scalar node, returns the string value for the specifiedBy.
  */
-function getSpecifiedByUrl(
+function getSpecifiedBy(
   node: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
 ): ?string {
   const specifiedBy = getDirectiveValues(GraphQLSpecifiedByDirective, node);

--- a/src/utilities/getIntrospectionQuery.d.ts
+++ b/src/utilities/getIntrospectionQuery.d.ts
@@ -7,7 +7,7 @@ export interface IntrospectionOptions {
   // Default: true
   descriptions?: boolean;
 
-  // Whether to include `specifiedBy` in the introspection result.
+  // Whether to include `specifiedByURL` in the introspection result.
   // Default: false
   specifiedByUrl?: boolean;
 
@@ -67,7 +67,7 @@ export interface IntrospectionScalarType {
   readonly kind: 'SCALAR';
   readonly name: string;
   readonly description?: Maybe<string>;
-  readonly specifiedBy?: Maybe<string>;
+  readonly specifiedByURL?: Maybe<string>;
 }
 
 export interface IntrospectionObjectType {

--- a/src/utilities/getIntrospectionQuery.d.ts
+++ b/src/utilities/getIntrospectionQuery.d.ts
@@ -7,7 +7,7 @@ export interface IntrospectionOptions {
   // Default: true
   descriptions?: boolean;
 
-  // Whether to include `specifiedByUrl` in the introspection result.
+  // Whether to include `specifiedBy` in the introspection result.
   // Default: false
   specifiedByUrl?: boolean;
 
@@ -67,7 +67,7 @@ export interface IntrospectionScalarType {
   readonly kind: 'SCALAR';
   readonly name: string;
   readonly description?: Maybe<string>;
-  readonly specifiedByUrl?: Maybe<string>;
+  readonly specifiedBy?: Maybe<string>;
 }
 
 export interface IntrospectionObjectType {

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -33,9 +33,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   };
 
   const descriptions = optionsWithDefault.descriptions ? 'description' : '';
-  const specifiedByUrl = optionsWithDefault.specifiedByUrl
-    ? 'specifiedByUrl'
-    : '';
+  const specifiedByUrl = optionsWithDefault.specifiedByUrl ? 'specifiedBy' : '';
   const directiveIsRepeatable = optionsWithDefault.directiveIsRepeatable
     ? 'isRepeatable'
     : '';
@@ -184,7 +182,7 @@ export type IntrospectionScalarType = {|
   +kind: 'SCALAR',
   +name: string,
   +description?: ?string,
-  +specifiedByUrl?: ?string,
+  +specifiedBy?: ?string,
 |};
 
 export type IntrospectionObjectType = {|

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -33,7 +33,9 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   };
 
   const descriptions = optionsWithDefault.descriptions ? 'description' : '';
-  const specifiedByUrl = optionsWithDefault.specifiedByUrl ? 'specifiedBy' : '';
+  const specifiedByUrl = optionsWithDefault.specifiedByUrl
+    ? 'specifiedByURL'
+    : '';
   const directiveIsRepeatable = optionsWithDefault.directiveIsRepeatable
     ? 'isRepeatable'
     : '';
@@ -182,7 +184,7 @@ export type IntrospectionScalarType = {|
   +kind: 'SCALAR',
   +name: string,
   +description?: ?string,
-  +specifiedBy?: ?string,
+  +specifiedByURL?: ?string,
 |};
 
 export type IntrospectionObjectType = {|

--- a/src/utilities/printSchema.js
+++ b/src/utilities/printSchema.js
@@ -150,7 +150,7 @@ export function printType(type: GraphQLNamedType): string {
 
 function printScalar(type: GraphQLScalarType): string {
   return (
-    printDescription(type) + `scalar ${type.name}` + printSpecifiedBy(type)
+    printDescription(type) + `scalar ${type.name}` + printSpecifiedByURL(type)
   );
 }
 
@@ -288,15 +288,15 @@ function printDeprecated(reason: ?string): string {
   return ' @deprecated';
 }
 
-function printSpecifiedBy(scalar: GraphQLScalarType): string {
-  if (scalar.specifiedBy == null) {
+function printSpecifiedByURL(scalar: GraphQLScalarType): string {
+  if (scalar.specifiedByURL == null) {
     return '';
   }
-  const url = scalar.specifiedBy;
+  const url = scalar.specifiedByURL;
   const urlAST = astFromValue(url, GraphQLString);
   invariant(
     urlAST,
-    'Unexpected null value returned from `astFromValue` for specifiedByUrl',
+    'Unexpected null value returned from `astFromValue` for specifiedByURL',
   );
   return ' @specifiedBy(url: ' + print(urlAST) + ')';
 }

--- a/src/utilities/printSchema.js
+++ b/src/utilities/printSchema.js
@@ -150,7 +150,7 @@ export function printType(type: GraphQLNamedType): string {
 
 function printScalar(type: GraphQLScalarType): string {
   return (
-    printDescription(type) + `scalar ${type.name}` + printSpecifiedByUrl(type)
+    printDescription(type) + `scalar ${type.name}` + printSpecifiedBy(type)
   );
 }
 
@@ -288,11 +288,11 @@ function printDeprecated(reason: ?string): string {
   return ' @deprecated';
 }
 
-function printSpecifiedByUrl(scalar: GraphQLScalarType): string {
-  if (scalar.specifiedByUrl == null) {
+function printSpecifiedBy(scalar: GraphQLScalarType): string {
+  if (scalar.specifiedBy == null) {
     return '';
   }
-  const url = scalar.specifiedByUrl;
+  const url = scalar.specifiedBy;
   const urlAST = astFromValue(url, GraphQLString);
   invariant(
     urlAST,


### PR DESCRIPTION
- I followed as "[[RFC] Custom Scalar Specification URLs](https://github.com/graphql/graphql-spec/pull/649)".
- `@specifiedBy` directive uses "specifiedBy" field on `__Type`. ref: [schema-introspection](https://github.com/graphql/graphql-spec/blob/main/spec/Section%204%20--%20Introspection.md#schema-introspection)

```gql
type __Type {
  kind: __TypeKind!
  name: String
  description: String
  ...
  # should be non-null for custom SCALAR only, must be null for the others
  specifiedBy: String
}
```
- But I didn't fix `IntrospectionOptions` fields because keeping backward compatible.