### PR TITLE
Fix #2895 `inputValueDeprecation: true` getIntrospectionQuery error 

### DIFF
--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1603,8 +1603,10 @@ describe('Introspection', () => {
       source,
     });
 
-    assert.isUndefined(errors, `Introspection query was not successful ${JSON.stringify(errors)}`);
+    assert.isUndefined(
+      errors,
+      `Introspection query was not successful ${JSON.stringify(errors) || ''}`,
+    );
     assert.isOk(data);
   });
-
 });

--- a/src/type/__tests__/introspection-test.js
+++ b/src/type/__tests__/introspection-test.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import invariant from '../../jsutils/invariant';
@@ -1586,4 +1586,25 @@ describe('Introspection', () => {
       }),
     ).to.not.throw();
   });
+
+  it('can include deprecated input fields', () => {
+    const schema = buildSchema(`
+    type Query {
+      oldField(input: Boolean @deprecated(reason: "got over it")): String
+    }
+    `);
+
+    const source = getIntrospectionQuery({
+      inputValueDeprecation: true,
+    });
+
+    const { data, errors } = graphqlSync({
+      schema,
+      source,
+    });
+
+    assert.isUndefined(errors, `Introspection query was not successful ${JSON.stringify(errors)}`);
+    assert.isOk(data);
+  });
+
 });

--- a/src/utilities/__tests__/getIntrospectionQuery-test.js
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.js
@@ -108,7 +108,7 @@ describe('getIntrospectionQuery', () => {
 
     expectIntrospectionQuery({ inputValueDeprecation: true }).toMatch(
       'includeDeprecated: true',
-      5,
+      4,
     );
 
     expectIntrospectionQuery({ inputValueDeprecation: false }).toMatch(

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -62,7 +62,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
           ${descriptions}
           ${directiveIsRepeatable}
           locations
-          args${inputDeprecation('(includeDeprecated: true)')} {
+          args {
             ...InputValue
           }
         }


### PR DESCRIPTION
Issue #2895 

* Adds test to reproduce the issue
* Made a fix attempt: Not sure if removing `includeDeprecated` from directive is the right approach, but tests are passing