### PR TITLE
Generalize defineArguments()

### DIFF
--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -809,21 +809,11 @@ function defineFieldMap<TSource, TContext>(
       `${config.name}.${fieldName} args must be an object with argument names as keys.`,
     );
 
-    const args = Object.entries(argsConfig).map(([argName, argConfig]) => ({
-      name: argName,
-      description: argConfig.description,
-      type: argConfig.type,
-      defaultValue: argConfig.defaultValue,
-      deprecationReason: argConfig.deprecationReason,
-      extensions: argConfig.extensions && toObjMap(argConfig.extensions),
-      astNode: argConfig.astNode,
-    }));
-
     return {
       name: fieldName,
       description: fieldConfig.description,
       type: fieldConfig.type,
-      args,
+      args: defineArguments(argsConfig),
       resolve: fieldConfig.resolve,
       subscribe: fieldConfig.subscribe,
       deprecationReason: fieldConfig.deprecationReason,
@@ -831,6 +821,20 @@ function defineFieldMap<TSource, TContext>(
       astNode: fieldConfig.astNode,
     };
   });
+}
+
+export function defineArguments(
+  config: GraphQLFieldConfigArgumentMap,
+): $ReadOnlyArray<GraphQLArgument> {
+  return Object.entries(config).map(([argName, argConfig]) => ({
+    name: argName,
+    description: argConfig.description,
+    type: argConfig.type,
+    defaultValue: argConfig.defaultValue,
+    deprecationReason: argConfig.deprecationReason,
+    extensions: argConfig.extensions && toObjMap(argConfig.extensions),
+    astNode: argConfig.astNode,
+  }));
 }
 
 function isPlainObj(obj: mixed): boolean {

--- a/src/type/directives.js
+++ b/src/type/directives.js
@@ -14,7 +14,11 @@ import type {
   GraphQLFieldConfigArgumentMap,
 } from './definition';
 import { GraphQLString, GraphQLBoolean } from './scalars';
-import { argsToArgsConfig, GraphQLNonNull } from './definition';
+import {
+  defineArguments,
+  argsToArgsConfig,
+  GraphQLNonNull,
+} from './definition';
 
 /**
  * Test if the given value is a GraphQL directive.
@@ -44,7 +48,7 @@ export class GraphQLDirective {
   name: string;
   description: ?string;
   locations: Array<DirectiveLocationEnum>;
-  args: Array<GraphQLArgument>;
+  args: $ReadOnlyArray<GraphQLArgument>;
   isRepeatable: boolean;
   extensions: ?ReadOnlyObjMap<mixed>;
   astNode: ?DirectiveDefinitionNode;
@@ -69,15 +73,7 @@ export class GraphQLDirective {
       `@${config.name} args must be an object with argument names as keys.`,
     );
 
-    this.args = Object.entries(args).map(([argName, argConfig]) => ({
-      name: argName,
-      description: argConfig.description,
-      type: argConfig.type,
-      defaultValue: argConfig.defaultValue,
-      deprecationReason: argConfig.deprecationReason,
-      extensions: argConfig.extensions && toObjMap(argConfig.extensions),
-      astNode: argConfig.astNode,
-    }));
+    this.args = defineArguments(args);
   }
 
   toConfig(): GraphQLDirectiveNormalizedConfig {

--- a/src/utilities/printSchema.js
+++ b/src/utilities/printSchema.js
@@ -228,7 +228,7 @@ function printBlock(items: $ReadOnlyArray<string>): string {
 }
 
 function printArgs(
-  args: Array<GraphQLArgument>,
+  args: $ReadOnlyArray<GraphQLArgument>,
   indentation: string = '',
 ): string {
   if (args.length === 0) {


### PR DESCRIPTION
Fields and Directives both define arguments according to identical logic. This generalizes that and shares the implementation across both constructions.