### PR TITLE
Improve parser location API

### DIFF
--- a/src/language/parser.d.ts
+++ b/src/language/parser.d.ts
@@ -3,7 +3,6 @@ import { GraphQLError } from '../error/GraphQLError';
 
 import {
   Token,
-  Location,
   NameNode,
   VariableNode,
   DocumentNode,
@@ -501,9 +500,11 @@ export declare class Parser {
   parseDirectiveLocation(): NameNode;
 
   /**
-   * Returns a location object, used to identify the place in the source that created a given parsed object.
+   * Returns a node that, if configured to do so, sets a "loc" field as a
+   * location object, used to identify the place in the source that created a
+   * given parsed object.
    */
-  loc(startToken: Token): Location | undefined;
+  node<T>(startToken: Token, node: T): T;
 
   /**
    * Determines if the next token is of a given kind

--- a/src/language/visitor.js
+++ b/src/language/visitor.js
@@ -221,15 +221,9 @@ export function visit(root: ASTNode, visitor: ASTVisitor): any {
       node = parent;
       parent = ancestors.pop();
       if (isEdited) {
-        if (inArray) {
-          node = node.slice();
-        } else {
-          const clone = {};
-          for (const k of Object.keys(node)) {
-            clone[k] = node[k];
-          }
-          node = clone;
-        }
+        node = inArray
+          ? node.slice()
+          : Object.defineProperties({}, Object.getOwnPropertyDescriptors(node));
         let editOffset = 0;
         for (let ii = 0; ii < edits.length; ii++) {
           let editKey: any = edits[ii][0];
@@ -268,7 +262,6 @@ export function visit(root: ASTNode, visitor: ASTVisitor): any {
       }
       const visitFn = getVisitFn(visitor, node.kind, isLeaving);
       if (visitFn) {
-        // $FlowFixMe[incompatible-call]
         result = visitFn.call(visitor, node, key, parent, path, ancestors);
 
         if (result === BREAK) {


### PR DESCRIPTION
This replaces manual assignment of `loc` on each node in Parser with a `node()` function. This simplifies the parser and also ensures the `loc` field does not appear at all when `noLocation` is provided.