### PR TITLE
Refine getNamedType() for Input and Output types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -137,6 +137,8 @@ export {
   GraphQLWrappingType,
   GraphQLNullableType,
   GraphQLNamedType,
+  GraphQLNamedInputType,
+  GraphQLNamedOutputType,
   ThunkArray,
   ThunkObjMap,
   GraphQLSchemaConfig,

--- a/src/index.js
+++ b/src/index.js
@@ -136,6 +136,8 @@ export type {
   GraphQLWrappingType,
   GraphQLNullableType,
   GraphQLNamedType,
+  GraphQLNamedInputType,
+  GraphQLNamedOutputType,
   ThunkArray,
   ThunkObjMap,
   GraphQLSchemaConfig,

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -249,19 +249,27 @@ export function getNullableType<T extends GraphQLNullableType>(
 /**
  * These named types do not include modifiers like List or NonNull.
  */
-export type GraphQLNamedType =
+export type GraphQLNamedType = GraphQLNamedInputType | GraphQLNamedOutputType;
+
+export type GraphQLNamedInputType =
+  | GraphQLScalarType
+  | GraphQLEnumType
+  | GraphQLInputObjectType;
+
+export type GraphQLNamedOutputType =
   | GraphQLScalarType
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
-  | GraphQLEnumType
-  | GraphQLInputObjectType;
+  | GraphQLEnumType;
 
 export function isNamedType(type: unknown): type is GraphQLNamedType;
 
 export function assertNamedType(type: unknown): GraphQLNamedType;
 
 export function getNamedType(type: undefined): undefined;
+export function getNamedType(type: GraphQLInputType): GraphQLNamedInputType;
+export function getNamedType(type: GraphQLOutputType): GraphQLNamedOutputType;
 export function getNamedType(type: GraphQLType): GraphQLNamedType;
 
 /**

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -467,13 +467,19 @@ export function getNullableType(type) {
 /**
  * These named types do not include modifiers like List or NonNull.
  */
-export type GraphQLNamedType =
+export type GraphQLNamedType = GraphQLNamedInputType | GraphQLNamedOutputType;
+
+export type GraphQLNamedInputType =
+  | GraphQLScalarType
+  | GraphQLEnumType
+  | GraphQLInputObjectType;
+
+export type GraphQLNamedOutputType =
   | GraphQLScalarType
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
-  | GraphQLEnumType
-  | GraphQLInputObjectType;
+  | GraphQLEnumType;
 
 export function isNamedType(type: mixed): boolean %checks {
   return (
@@ -495,6 +501,8 @@ export function assertNamedType(type: mixed): GraphQLNamedType {
 
 /* eslint-disable no-redeclare */
 declare function getNamedType(type: void | null): void;
+declare function getNamedType(type: GraphQLInputType): GraphQLNamedInputType;
+declare function getNamedType(type: GraphQLOutputType): GraphQLNamedOutputType;
 declare function getNamedType(type: GraphQLType): GraphQLNamedType;
 export function getNamedType(type) {
   /* eslint-enable no-redeclare */

--- a/src/type/index.d.ts
+++ b/src/type/index.d.ts
@@ -73,6 +73,8 @@ export {
   GraphQLWrappingType,
   GraphQLNullableType,
   GraphQLNamedType,
+  GraphQLNamedInputType,
+  GraphQLNamedOutputType,
   ThunkArray,
   ThunkObjMap,
   GraphQLArgument,

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -128,6 +128,8 @@ export type {
   GraphQLWrappingType,
   GraphQLNullableType,
   GraphQLNamedType,
+  GraphQLNamedInputType,
+  GraphQLNamedOutputType,
   ThunkArray,
   ThunkObjMap,
   GraphQLArgument,


### PR DESCRIPTION
This introduces type definitions `GraphQLNamedInputType` and `GraphQLNamedOutputType` as the subsets of `GraphQLNamedType`, and adds function overrides for `getNamedType()` such that if an input or output type is provided, one of these refined subset types is returned.