### PR TITLE
feat(subscribe): allow providing custom execute function for subscribe

### DIFF
--- a/src/subscription/subscribe.d.ts
+++ b/src/subscription/subscribe.d.ts
@@ -1,7 +1,7 @@
 import { Maybe } from '../jsutils/Maybe';
 
 import { DocumentNode } from '../language/ast';
-import { ExecutionResult } from '../execution/execute';
+import { execute, ExecutionResult } from '../execution/execute';
 import { GraphQLSchema } from '../type/schema';
 import { GraphQLFieldResolver } from '../type/definition';
 
@@ -14,6 +14,7 @@ export interface SubscriptionArgs {
   operationName?: Maybe<string>;
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  execute?: Maybe<typeof execute>
 }
 
 /**

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -14,7 +14,7 @@ import {
   buildExecutionContext,
   buildResolveInfo,
   collectFields,
-  execute,
+  execute as defaultExecute,
   getFieldDef,
 } from '../execution/execute';
 
@@ -34,6 +34,7 @@ export type SubscriptionArgs = {|
   operationName?: ?string,
   fieldResolver?: ?GraphQLFieldResolver<any, any>,
   subscribeFieldResolver?: ?GraphQLFieldResolver<any, any>,
+  execute?: ?typeof execute
 |};
 
 /**
@@ -69,6 +70,7 @@ export async function subscribe(
     operationName,
     fieldResolver,
     subscribeFieldResolver,
+    execute = defaultExecute
   } = args;
 
   // $FlowFixMe[incompatible-call]


### PR DESCRIPTION
This allows solving https://github.com/graphql/graphql-js/issues/894 and https://github.com/enisdenjo/graphql-ws/pull/180 in user-land by providing a custom execute function for `subscribe`, that creates the `contextValue` per published value (for each `execute` invocation), instead of once for the whole subscription.