### PR TITLE
Preserve defaultValue literals

### DIFF
--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -23,6 +23,7 @@ import { typeFromAST } from '../utilities/typeFromAST';
 import {
   coerceInputValue,
   coerceInputLiteral,
+  coerceDefaultValue,
 } from '../utilities/coerceInputValue';
 
 type CoercedVariableValues =
@@ -177,8 +178,11 @@ export function getArgumentValues(
     const argumentNode = argNodeMap[name];
 
     if (!argumentNode) {
-      if (argDef.defaultValue !== undefined) {
-        coercedValues[name] = argDef.defaultValue;
+      if (argDef.defaultValue) {
+        coercedValues[name] = coerceDefaultValue(
+          argDef.defaultValue,
+          argDef.type,
+        );
       } else if (isNonNullType(argType)) {
         throw new GraphQLError(
           `Argument ${argDef} of required type ${argType} was not provided.`,
@@ -197,8 +201,11 @@ export function getArgumentValues(
         variableValues == null ||
         !hasOwnProperty(variableValues, variableName)
       ) {
-        if (argDef.defaultValue !== undefined) {
-          coercedValues[name] = argDef.defaultValue;
+        if (argDef.defaultValue) {
+          coercedValues[name] = coerceDefaultValue(
+            argDef.defaultValue,
+            argDef.type,
+          );
         } else if (isNonNullType(argType)) {
           throw new GraphQLError(
             `Argument ${argDef} of required type ${argType} ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,6 +181,7 @@ export type {
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
+  GraphQLDefaultValueUsage,
 } from './type/index';
 
 /** Parse and operate on GraphQL language source files. */

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -826,6 +826,69 @@ describe('Type System: Input Objects', () => {
       );
     });
   });
+
+  describe('Input Object fields may have default values', () => {
+    it('accepts an Input Object type with a default value', () => {
+      const inputObjType = new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: { type: ScalarType, defaultValue: 3 },
+        },
+      });
+      expect(inputObjType.getFields()).to.deep.equal({
+        f: {
+          coordinate: 'SomeInputObject.f',
+          name: 'f',
+          description: undefined,
+          type: ScalarType,
+          defaultValue: { value: 3 },
+          deprecationReason: undefined,
+          extensions: undefined,
+          astNode: undefined,
+        },
+      });
+    });
+
+    it('accepts an Input Object type with a default value literal', () => {
+      const inputObjType = new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: ScalarType,
+            defaultValueLiteral: { kind: 'IntValue', value: '3' },
+          },
+        },
+      });
+      expect(inputObjType.getFields()).to.deep.equal({
+        f: {
+          coordinate: 'SomeInputObject.f',
+          name: 'f',
+          description: undefined,
+          type: ScalarType,
+          defaultValue: { literal: { kind: 'IntValue', value: '3' } },
+          deprecationReason: undefined,
+          extensions: undefined,
+          astNode: undefined,
+        },
+      });
+    });
+
+    it('rejects an Input Object type with potentially conflicting default values', () => {
+      const inputObjType = new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          f: {
+            type: ScalarType,
+            defaultValue: 3,
+            defaultValueLiteral: { kind: 'IntValue', value: '3' },
+          },
+        },
+      });
+      expect(() => inputObjType.getFields()).to.throw(
+        'f has both a defaultValue and a defaultValueLiteral property, but only one must be provided.',
+      );
+    });
+  });
 });
 
 describe('Type System: List', () => {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -116,6 +116,7 @@ export type {
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
+  GraphQLDefaultValueUsage,
 } from './definition';
 
 export {

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -384,8 +384,13 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
           'A GraphQL-formatted string representing the default value for this input value.',
         resolve(inputValue) {
           const { type, defaultValue } = inputValue;
-          const valueAST = astFromValue(defaultValue, type);
-          return valueAST ? print(valueAST) : null;
+          if (!defaultValue) {
+            return null;
+          }
+          const literal =
+            defaultValue.literal ?? astFromValue(defaultValue.value, type);
+          invariant(literal, 'Invalid default value');
+          return print(literal);
         },
       },
       isDeprecated: {

--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -17,6 +17,7 @@ import type {
   GraphQLArgument,
   GraphQLInputField,
   GraphQLEnumValue,
+  GraphQLDefaultValueUsage,
 } from '../type/definition';
 import {
   isObjectType,
@@ -49,7 +50,7 @@ export class TypeInfo {
   private _parentTypeStack: Array<Maybe<GraphQLCompositeType>>;
   private _inputTypeStack: Array<Maybe<GraphQLInputType>>;
   private _fieldDefStack: Array<Maybe<GraphQLField<unknown, unknown>>>;
-  private _defaultValueStack: Array<Maybe<unknown>>;
+  private _defaultValueStack: Array<GraphQLDefaultValueUsage | undefined>;
   private _directive: Maybe<GraphQLDirective>;
   private _argument: Maybe<GraphQLArgument>;
   private _enumValue: Maybe<GraphQLEnumValue>;
@@ -119,7 +120,7 @@ export class TypeInfo {
     }
   }
 
-  getDefaultValue(): Maybe<unknown> {
+  getDefaultValue(): GraphQLDefaultValueUsage | undefined {
     if (this._defaultValueStack.length > 0) {
       return this._defaultValueStack[this._defaultValueStack.length - 1];
     }

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -4,7 +4,7 @@ import { isObjectLike } from '../jsutils/isObjectLike';
 import { isIterableObject } from '../jsutils/isIterableObject';
 import type { Maybe } from '../jsutils/Maybe';
 
-import type { ValueNode } from '../language/ast';
+import type { ConstValueNode } from '../language/ast';
 import { Kind } from '../language/kinds';
 
 import type { GraphQLInputType } from '../type/definition';
@@ -41,7 +41,7 @@ import {
 export function astFromValue(
   value: unknown,
   type: GraphQLInputType,
-): Maybe<ValueNode> {
+): Maybe<ConstValueNode> {
   if (isNonNullType(type)) {
     const astValue = astFromValue(value, type.ofType);
     if (astValue?.kind === Kind.NULL) {

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -47,7 +47,6 @@ import type {
   IntrospectionTypeRef,
   IntrospectionNamedTypeRef,
 } from './getIntrospectionQuery';
-import { coerceInputLiteral } from './coerceInputValue';
 
 /**
  * Build a GraphQLSchema for use by client tools.
@@ -366,17 +365,13 @@ export function buildClientSchema(
       );
     }
 
-    const defaultValue =
-      inputValueIntrospection.defaultValue != null
-        ? coerceInputLiteral(
-            parseConstValue(inputValueIntrospection.defaultValue),
-            type,
-          )
-        : undefined;
     return {
       description: inputValueIntrospection.description,
       type,
-      defaultValue,
+      defaultValueLiteral:
+        inputValueIntrospection.defaultValue != null
+          ? parseConstValue(inputValueIntrospection.defaultValue)
+          : undefined,
       deprecationReason: inputValueIntrospection.deprecationReason,
     };
   }

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -80,8 +80,6 @@ import {
   GraphQLInputObjectType,
 } from '../type/definition';
 
-import { coerceInputLiteral } from './coerceInputValue';
-
 interface Options extends GraphQLSchemaValidationOptions {
   /**
    * Set to true to assume the SDL is valid.
@@ -491,9 +489,7 @@ export function extendSchemaImpl(
       argConfigMap[arg.name.value] = {
         type,
         description: arg.description?.value,
-        defaultValue: arg.defaultValue
-          ? coerceInputLiteral(arg.defaultValue, type)
-          : undefined,
+        defaultValueLiteral: arg.defaultValue,
         deprecationReason: getDeprecationReason(arg),
         astNode: arg,
       };
@@ -520,9 +516,7 @@ export function extendSchemaImpl(
         inputFieldMap[field.name.value] = {
           type,
           description: field.description?.value,
-          defaultValue: field.defaultValue
-            ? coerceInputLiteral(field.defaultValue, type)
-            : undefined,
+          defaultValueLiteral: field.defaultValue,
           deprecationReason: getDeprecationReason(field),
           astNode: field,
         };

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -17,6 +17,7 @@ import type {
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLInputObjectType,
+  GraphQLDefaultValueUsage,
 } from '../type/definition';
 import { isSpecifiedScalarType } from '../type/scalars';
 import {
@@ -527,10 +528,12 @@ function typeKindName(type: GraphQLNamedType): string {
   invariant(false, 'Unexpected type: ' + inspect(type));
 }
 
-function stringifyValue(value: unknown, type: GraphQLInputType): string {
-  const ast = astFromValue(value, type);
-  invariant(ast != null);
-
+function stringifyValue(
+  defaultValue: GraphQLDefaultValueUsage,
+  type: GraphQLInputType,
+): string {
+  const ast = defaultValue.literal ?? astFromValue(defaultValue.value, type);
+  invariant(ast);
   const sortedAST = visit(ast, {
     ObjectValue(objectNode) {
       // Make a copy since sort mutates array

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -259,10 +259,13 @@ function printArgs(
 }
 
 function printInputValue(arg: GraphQLInputField): string {
-  const defaultAST = astFromValue(arg.defaultValue, arg.type);
   let argDecl = arg.name + ': ' + String(arg.type);
-  if (defaultAST) {
-    argDecl += ` = ${print(defaultAST)}`;
+  if (arg.defaultValue) {
+    const literal =
+      arg.defaultValue.literal ??
+      astFromValue(arg.defaultValue.value, arg.type);
+    invariant(literal, 'Invalid default value');
+    argDecl += ` = ${print(literal)}`;
   }
   return argDecl + printDeprecated(arg.deprecationReason);
 }

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -25,6 +25,7 @@ import type {
   GraphQLField,
   GraphQLArgument,
   GraphQLEnumValue,
+  GraphQLDefaultValueUsage,
 } from '../type/definition';
 
 import { TypeInfo, visitWithTypeInfo } from '../utilities/TypeInfo';
@@ -33,7 +34,7 @@ type NodeWithSelectionSet = OperationDefinitionNode | FragmentDefinitionNode;
 interface VariableUsage {
   readonly node: VariableNode;
   readonly type: Maybe<GraphQLInputType>;
-  readonly defaultValue: Maybe<unknown>;
+  readonly defaultValue: GraphQLDefaultValueUsage | undefined;
 }
 
 /**

--- a/src/validation/rules/VariablesInAllowedPositionRule.ts
+++ b/src/validation/rules/VariablesInAllowedPositionRule.ts
@@ -7,7 +7,10 @@ import type { ValueNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { GraphQLSchema } from '../../type/schema';
-import type { GraphQLType } from '../../type/definition';
+import type {
+  GraphQLType,
+  GraphQLDefaultValueUsage,
+} from '../../type/definition';
 import { isNonNullType } from '../../type/definition';
 
 import { typeFromAST } from '../../utilities/typeFromAST';
@@ -79,7 +82,7 @@ function allowedVariableUsage(
   varType: GraphQLType,
   varDefaultValue: Maybe<ValueNode>,
   locationType: GraphQLType,
-  locationDefaultValue: Maybe<unknown>,
+  locationDefaultValue: GraphQLDefaultValueUsage | undefined,
 ): boolean {
   if (isNonNullType(locationType) && !isNonNullType(varType)) {
     const hasNonNullVariableDefaultValue =


### PR DESCRIPTION
Depends on #3092
Fixes #3051

This change solves the problem of default values defined via SDL not always resolving correctly through introspection by preserving the original GraphQL literal in the schema definition. This changes argument and input field definitions `defaultValue` field from just the "value" to a new `GraphQLDefaultValueUsage` type which contains either or both "value" and "literal" fields.

Since either of these fields may be set, new functions for resolving a value or literal from either have been added - `getLiteralDefaultValue` and `getCoercedDefaultValue` - these replace uses that either assumed a set value or were manually converting a value back to a literal.

Here is the flow for how a default value defined in an SDL would be converted into a functional schema and back to an SDL:

**Before this change:**

```
(SDL) --parse-> (AST) --coerceInputLiteral--> (defaultValue config) --valueToAST--> (AST) --print --> (SDL)
```

`coerceInputLiteral` performs coercion which is a one-way function, and `valueToAST` is unsafe and set to be deprecated in #3049.

**After this change:**

```
(SDL) --parse-> (defaultValue literal config) --print --> (SDL)
```
