### PR TITLE
collectFields: use ES6 collections instead of Object.create(null)

### DIFF
--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -333,8 +333,8 @@ function executeOperation(
     exeContext,
     type,
     operation.selectionSet,
-    Object.create(null),
-    Object.create(null),
+    new Map(),
+    new Set(),
   );
 
   const path = undefined;
@@ -369,12 +369,11 @@ function executeFieldsSerially(
   parentType: GraphQLObjectType,
   sourceValue: mixed,
   path: Path | void,
-  fields: ObjMap<Array<FieldNode>>,
+  fields: Map<string, Array<FieldNode>>,
 ): PromiseOrValue<ObjMap<mixed>> {
   return promiseReduce(
-    Object.keys(fields),
-    (results, responseName) => {
-      const fieldNodes = fields[responseName];
+    fields.entries(),
+    (results, [responseName, fieldNodes]) => {
       const fieldPath = addPath(path, responseName, parentType.name);
       const result = resolveField(
         exeContext,
@@ -408,13 +407,12 @@ function executeFields(
   parentType: GraphQLObjectType,
   sourceValue: mixed,
   path: Path | void,
-  fields: ObjMap<Array<FieldNode>>,
+  fields: Map<string, Array<FieldNode>>,
 ): PromiseOrValue<ObjMap<mixed>> {
   const results = Object.create(null);
   let containsPromise = false;
 
-  for (const responseName of Object.keys(fields)) {
-    const fieldNodes = fields[responseName];
+  for (const [responseName, fieldNodes] of fields.entries()) {
     const fieldPath = addPath(path, responseName, parentType.name);
     const result = resolveField(
       exeContext,
@@ -457,9 +455,9 @@ export function collectFields(
   exeContext: ExecutionContext,
   runtimeType: GraphQLObjectType,
   selectionSet: SelectionSetNode,
-  fields: ObjMap<Array<FieldNode>>,
-  visitedFragmentNames: ObjMap<boolean>,
-): ObjMap<Array<FieldNode>> {
+  fields: Map<string, Array<FieldNode>>,
+  visitedFragmentNames: Set<string>,
+): Map<string, Array<FieldNode>> {
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {
       case Kind.FIELD: {
@@ -467,10 +465,12 @@ export function collectFields(
           continue;
         }
         const name = getFieldEntryKey(selection);
-        if (!fields[name]) {
-          fields[name] = [];
+        const fieldList = fields.get(name);
+        if (fieldList !== undefined) {
+          fieldList.push(selection);
+        } else {
+          fields.set(name, [selection]);
         }
-        fields[name].push(selection);
         break;
       }
       case Kind.INLINE_FRAGMENT: {
@@ -492,12 +492,12 @@ export function collectFields(
       case Kind.FRAGMENT_SPREAD: {
         const fragName = selection.name.value;
         if (
-          visitedFragmentNames[fragName] ||
+          visitedFragmentNames.has(fragName) ||
           !shouldIncludeNode(exeContext, selection)
         ) {
           continue;
         }
-        visitedFragmentNames[fragName] = true;
+        visitedFragmentNames.add(fragName);
         const fragment = exeContext.fragments[fragName];
         if (
           !fragment ||
@@ -1085,9 +1085,9 @@ function _collectSubfields(
   exeContext: ExecutionContext,
   returnType: GraphQLObjectType,
   fieldNodes: $ReadOnlyArray<FieldNode>,
-): ObjMap<Array<FieldNode>> {
-  let subFieldNodes = Object.create(null);
-  const visitedFragmentNames = Object.create(null);
+): Map<string, Array<FieldNode>> {
+  let subFieldNodes = new Map();
+  const visitedFragmentNames = new Set();
   for (const node of fieldNodes) {
     if (node.selectionSet) {
       subFieldNodes = collectFields(

--- a/src/jsutils/promiseReduce.js
+++ b/src/jsutils/promiseReduce.js
@@ -10,15 +10,15 @@ import { isPromise } from './isPromise';
  * return a Promise.
  */
 export function promiseReduce<T, U>(
-  values: $ReadOnlyArray<T>,
-  callback: (accumulator: U, currentValue: T) => PromiseOrValue<U>,
+  values: Iterable<T>,
+  callbackFn: (accumulator: U, currentValue: T) => PromiseOrValue<U>,
   initialValue: PromiseOrValue<U>,
 ): PromiseOrValue<U> {
-  return values.reduce(
-    (previous, value) =>
-      isPromise(previous)
-        ? previous.then((resolved) => callback(resolved, value))
-        : callback(previous, value),
-    initialValue,
-  );
+  let accumulator = initialValue;
+  for (const value of values) {
+    accumulator = isPromise(accumulator)
+      ? accumulator.then((resolved) => callbackFn(resolved, value))
+      : callbackFn(accumulator, value);
+  }
+  return accumulator;
 }

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -195,10 +195,10 @@ async function executeSubscription(
     exeContext,
     type,
     operation.selectionSet,
-    Object.create(null),
-    Object.create(null),
+    new Map(),
+    new Set(),
   );
-  const [responseName, fieldNodes] = Object.entries(fields)[0];
+  const [responseName, fieldNodes] = [...fields.entries()][0];
   const fieldName = fieldNodes[0].name.value;
   const fieldDef = getFieldDef(schema, type, fieldName);
 


### PR DESCRIPTION
Also resulted in ~10% perfomance increase for `execute` at least on my machine:
![image](https://user-images.githubusercontent.com/8336157/118013154-7cf82d80-b35a-11eb-8262-c86bd1a0e472.png)
