### PR TITLE
getIntrospectionQuery-test: use RegExp.exec

### DIFF
--- a/src/utilities/__tests__/getIntrospectionQuery-test.js
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.js
@@ -12,7 +12,7 @@ function expectIntrospectionQuery(options?: IntrospectionOptions) {
       const pattern = toRegExp(name);
 
       expect(query).to.match(pattern);
-      expect(query.match(pattern)).to.have.lengthOf(times);
+      expect(pattern.exec(query)).to.have.lengthOf(times);
     },
     toNotMatch(name: string): void {
       expect(query).to.not.match(toRegExp(name));


### PR DESCRIPTION
to enable `@typescript-eslint/prefer-regexp-exec`