### PR TITLE
scalars: ID and String support for serializing BigInt

### DIFF
--- a/src/type/__tests__/scalars-test.js
+++ b/src/type/__tests__/scalars-test.js
@@ -620,6 +620,8 @@ describe('Type System: Specified scalar types', () => {
       expect(serialize(123)).to.equal('123');
       expect(serialize(0)).to.equal('0');
       expect(serialize(-1)).to.equal('-1');
+      // $FlowFixMe[bigint-unsupported];
+      expect(serialize(1n)).to.equal('1');
 
       const valueOf = () => 'valueOf ID';
       const toJSON = () => 'toJSON ID';

--- a/src/type/scalars.js
+++ b/src/type/scalars.js
@@ -143,6 +143,12 @@ function serializeObject(outputValue: mixed): mixed {
       return outputValue.toJSON();
     }
   }
+  // $FlowFixMe[illegal-typeof]
+  if (typeof outputValue === 'bigint') {
+    // $FlowFixMe[incompatible-use]
+    return outputValue.toString();
+  }
+
   return outputValue;
 }
 


### PR DESCRIPTION
Add support to serialize BigInt for String and ID scalar.