### PR TITLE
Remove empty lines from '*.d.ts' files

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -665,6 +665,10 @@ overrides:
       '@typescript-eslint/space-before-function-paren': off
       '@typescript-eslint/space-infix-ops': off
       '@typescript-eslint/type-annotation-spacing': off
+  - files: 'src/**/*.d.ts'
+    rules:
+      import/order: off
+      import/newline-after-import: off
   - files: 'src/**/__*__/**'
     rules:
       node/no-unpublished-import: [error, { allowModules: ['chai', 'mocha'] }]

--- a/src/error/GraphQLError.d.ts
+++ b/src/error/GraphQLError.d.ts
@@ -1,9 +1,7 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { ASTNode } from '../language/ast';
 import type { Source } from '../language/source';
 import type { SourceLocation } from '../language/location';
-
 /**
  * A GraphQLError describes an Error found during the parse, validate, or
  * execute phases of performing a GraphQL operation. In addition to a message
@@ -20,7 +18,6 @@ export class GraphQLError extends Error {
     originalError?: Maybe<Error>,
     extensions?: Maybe<{ [key: string]: unknown }>,
   );
-
   /**
    * A message describing the Error for debugging purposes.
    *
@@ -29,7 +26,6 @@ export class GraphQLError extends Error {
    * Note: should be treated as readonly, despite invariant usage.
    */
   message: string;
-
   /**
    * An array of { line, column } locations within the source GraphQL document
    * which correspond to this error.
@@ -41,7 +37,6 @@ export class GraphQLError extends Error {
    * Enumerable, and appears in the result of JSON.stringify().
    */
   readonly locations: ReadonlyArray<SourceLocation> | undefined;
-
   /**
    * An array describing the JSON-path into the execution response which
    * corresponds to this error. Only included for errors during execution.
@@ -49,12 +44,10 @@ export class GraphQLError extends Error {
    * Enumerable, and appears in the result of JSON.stringify().
    */
   readonly path: ReadonlyArray<string | number> | undefined;
-
   /**
    * An array of GraphQL AST Nodes corresponding to this error.
    */
   readonly nodes: ReadonlyArray<ASTNode> | undefined;
-
   /**
    * The source GraphQL document corresponding to this error.
    *
@@ -62,24 +55,20 @@ export class GraphQLError extends Error {
    * represent nodes after the first node.
    */
   readonly source: Source | undefined;
-
   /**
    * An array of character offsets within the source GraphQL document
    * which correspond to this error.
    */
   readonly positions: ReadonlyArray<number> | undefined;
-
   /**
    * The original error thrown from a field resolver during execution.
    */
   readonly originalError: Maybe<Error>;
-
   /**
    * Extension fields to add to the formatted error.
    */
   readonly extensions: { [key: string]: unknown } | undefined;
 }
-
 /**
  * Prints a GraphQLError to a string, representing useful location information
  * about the error's position in the source.

--- a/src/error/formatError.d.ts
+++ b/src/error/formatError.d.ts
@@ -1,13 +1,10 @@
 import type { SourceLocation } from '../language/location';
-
 import type { GraphQLError } from './GraphQLError';
-
 /**
  * Given a GraphQLError, format it according to the rules described by the
  * Response Format, Errors section of the GraphQL Specification.
  */
 export function formatError(error: GraphQLError): GraphQLFormattedError;
-
 /**
  * @see https://github.com/graphql/graphql-spec/blob/master/spec/Section%207%20--%20Response.md#errors
  */

--- a/src/error/locatedError.d.ts
+++ b/src/error/locatedError.d.ts
@@ -1,9 +1,6 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { ASTNode } from '../language/ast';
-
 import type { GraphQLError } from './GraphQLError';
-
 /**
  * Given an arbitrary value, presumably thrown while attempting to execute a
  * GraphQL operation, produce a new GraphQLError aware of the location in the

--- a/src/error/syntaxError.d.ts
+++ b/src/error/syntaxError.d.ts
@@ -1,7 +1,5 @@
 import type { Source } from '../language/source';
-
 import type { GraphQLError } from './GraphQLError';
-
 /**
  * Produces a GraphQLError representing a syntax error, containing useful
  * descriptive information about the syntax error's position in the source.

--- a/src/execution/execute.d.ts
+++ b/src/execution/execute.d.ts
@@ -1,12 +1,9 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
-
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import type { Path } from '../jsutils/Path';
-
 import type { GraphQLError } from '../error/GraphQLError';
 import type { GraphQLFormattedError } from '../error/formatError';
-
 import type {
   DocumentNode,
   OperationDefinitionNode,
@@ -22,7 +19,6 @@ import type {
   GraphQLTypeResolver,
   GraphQLObjectType,
 } from '../type/definition';
-
 /**
  * Terminology
  *
@@ -42,7 +38,6 @@ import type {
  * 2) fragment "spreads" e.g. "...c"
  * 3) inline fragment "spreads" e.g. "...on Type { a }"
  */
-
 /**
  * Data that must be available at all points during query execution.
  *
@@ -60,7 +55,6 @@ export interface ExecutionContext {
   typeResolver: GraphQLTypeResolver<any, any>;
   errors: Array<GraphQLError>;
 }
-
 /**
  * The result of GraphQL execution.
  *
@@ -77,7 +71,6 @@ export interface ExecutionResult<
   data?: TData | null;
   extensions?: TExtensions;
 }
-
 export interface FormattedExecutionResult<
   TData = { [key: string]: any },
   TExtensions = { [key: string]: any },
@@ -87,7 +80,6 @@ export interface FormattedExecutionResult<
   data?: TData | null;
   extensions?: TExtensions;
 }
-
 export interface ExecutionArgs {
   schema: GraphQLSchema;
   document: DocumentNode;
@@ -98,7 +90,6 @@ export interface ExecutionArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
 }
-
 /**
  * Implements the "Evaluating requests" section of the GraphQL specification.
  *
@@ -110,14 +101,12 @@ export interface ExecutionArgs {
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult>;
-
 /**
  * Also implements the "Evaluating requests" section of the GraphQL specification.
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
 export function executeSync(args: ExecutionArgs): ExecutionResult;
-
 /**
  * Essential assertions before executing to provide developer feedback for
  * improper use of the GraphQL library.
@@ -129,7 +118,6 @@ export function assertValidExecutionArguments(
   document: DocumentNode,
   rawVariableValues: Maybe<{ [key: string]: unknown }>,
 ): void;
-
 /**
  * Constructs a ExecutionContext object from the arguments passed to
  * execute, which we will pass throughout the other execution methods.
@@ -148,7 +136,6 @@ export function buildExecutionContext(
   fieldResolver: Maybe<GraphQLFieldResolver<unknown, unknown>>,
   typeResolver?: Maybe<GraphQLTypeResolver<unknown, unknown>>,
 ): ReadonlyArray<GraphQLError> | ExecutionContext;
-
 /**
  * Given a selectionSet, adds all of the fields in that selection to
  * the passed in map of fields, and returns it at the end.
@@ -166,7 +153,6 @@ export function collectFields(
   fields: ObjMap<Array<FieldNode>>,
   visitedFragmentNames: ObjMap<boolean>,
 ): ObjMap<Array<FieldNode>>;
-
 /**
  * @internal
  */
@@ -177,7 +163,6 @@ export function buildResolveInfo(
   parentType: GraphQLObjectType,
   path: Path,
 ): GraphQLResolveInfo;
-
 /**
  * If a resolveType function is not given, then a default resolve behavior is
  * used which attempts two strategies:
@@ -189,7 +174,6 @@ export function buildResolveInfo(
  * isTypeOf for the object being coerced, returning the first type that matches.
  */
 export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown>;
-
 /**
  * If a resolve function is not given, then a default resolve behavior is used
  * which takes the property of the source object of the same name as the field
@@ -197,7 +181,6 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown>;
  * of calling that function while passing along args and context value.
  */
 export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown>;
-
 /**
  * This method looks up the field on the given type definition.
  * It has special casing for the three introspection fields,

--- a/src/execution/index.d.ts
+++ b/src/execution/index.d.ts
@@ -1,5 +1,4 @@
 export { pathToArray as responsePathAsArray } from '../jsutils/Path';
-
 export {
   execute,
   executeSync,
@@ -9,5 +8,4 @@ export {
   ExecutionResult,
   FormattedExecutionResult,
 } from './execute';
-
 export { getDirectiveValues } from './values';

--- a/src/execution/values.d.ts
+++ b/src/execution/values.d.ts
@@ -1,21 +1,17 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
-
 import type { GraphQLError } from '../error/GraphQLError';
 import type {
   FieldNode,
   DirectiveNode,
   VariableDefinitionNode,
 } from '../language/ast';
-
 import type { GraphQLDirective } from '../type/directives';
 import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLField } from '../type/definition';
-
 type CoercedVariableValues =
   | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
   | { errors?: never; coerced: { [key: string]: unknown } };
-
 /**
  * Prepares an object map of variableValues of the correct type based on the
  * provided variable definitions and arbitrary input. If the input cannot be
@@ -31,7 +27,6 @@ export function getVariableValues(
   inputs: { [key: string]: unknown },
   options?: { maxErrors?: number },
 ): CoercedVariableValues;
-
 /**
  * Prepares an object map of argument values given a list of argument
  * definitions and list of argument AST nodes.
@@ -45,7 +40,6 @@ export function getArgumentValues(
   node: FieldNode | DirectiveNode,
   variableValues?: Maybe<ObjMap<unknown>>,
 ): { [key: string]: unknown };
-
 /**
  * Prepares an object map of argument values given a directive definition
  * and a AST node which may contain directives. Optionally also accepts a map

--- a/src/graphql.d.ts
+++ b/src/graphql.d.ts
@@ -1,5 +1,4 @@
 import type { Maybe } from './jsutils/Maybe';
-
 import type { Source } from './language/source';
 import type { GraphQLSchema } from './type/schema';
 import type {
@@ -7,7 +6,6 @@ import type {
   GraphQLTypeResolver,
 } from './type/definition';
 import type { ExecutionResult } from './execution/execute';
-
 /**
  * This is the primary entry point function for fulfilling GraphQL operations
  * by parsing, validating, and executing a GraphQL document along side a
@@ -57,9 +55,7 @@ export interface GraphQLArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
 }
-
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult>;
-
 /**
  * The graphqlSync function also fulfills GraphQL operations by parsing,
  * validating, and executing a GraphQL document along side a GraphQL schema.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,4 @@
 // Minimum TypeScript Version: 3.7
-
 /**
  * GraphQL.js provides a reference implementation for the GraphQL specification
  * but is also a useful utility for operating on GraphQL files and building
@@ -23,13 +22,10 @@
  *     import { parse } from 'graphql';
  *     import { parse } from 'graphql/language';
  */
-
 // The GraphQL.js version info.
 export { version, versionInfo } from './version';
-
 // The primary entry point into fulfilling a GraphQL request.
 export { GraphQLArgs, graphql, graphqlSync } from './graphql';
-
 // Create and operate on GraphQL type definitions and schema.
 export {
   // Definitions
@@ -126,7 +122,6 @@ export {
   validateSchema,
   assertValidSchema,
 } from './type/index';
-
 export {
   GraphQLType,
   GraphQLInputType,
@@ -184,7 +179,6 @@ export {
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
 } from './type/index';
-
 // Parse and operate on GraphQL language source files.
 export {
   Token,
@@ -223,7 +217,6 @@ export {
   isTypeSystemExtensionNode,
   isTypeExtensionNode,
 } from './language/index';
-
 export {
   ParseOptions,
   SourceLocation,
@@ -297,7 +290,6 @@ export {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
 } from './language/index';
-
 // Execute GraphQL queries.
 export {
   execute,
@@ -310,13 +302,11 @@ export {
   ExecutionResult,
   FormattedExecutionResult,
 } from './execution/index';
-
 export {
   subscribe,
   createSourceEventStream,
   SubscriptionArgs,
 } from './subscription/index';
-
 // Validate GraphQL documents.
 export {
   validate,
@@ -363,7 +353,6 @@ export {
   NoSchemaIntrospectionCustomRule,
   ValidationRule,
 } from './validation/index';
-
 // Create, format, and print GraphQL errors.
 export {
   GraphQLError,
@@ -373,7 +362,6 @@ export {
   formatError,
   GraphQLFormattedError,
 } from './error/index';
-
 // Utilities for operating on GraphQL type schema and parsed sources.
 export {
   // Produce the GraphQL query recommended for a full schema introspection.
@@ -438,7 +426,6 @@ export {
   findBreakingChanges,
   findDangerousChanges,
 } from './utilities/index';
-
 export {
   IntrospectionOptions,
   IntrospectionQuery,

--- a/src/jsutils/ObjMap.d.ts
+++ b/src/jsutils/ObjMap.d.ts
@@ -1,6 +1,5 @@
 export type ObjMap<T> = Record<string, T>;
 export type ObjMapLike<T> = ObjMap<T> | Record<string, T>;
-
 export type ReadOnlyObjMap<T> = Readonly<Record<string, T>>;
 export type ReadOnlyObjMapLike<T> =
   | Readonly<Record<string, T>>

--- a/src/jsutils/Path.d.ts
+++ b/src/jsutils/Path.d.ts
@@ -3,7 +3,6 @@ export interface Path {
   key: string | number;
   typename: string | undefined;
 }
-
 /**
  * Given a Path and a key, return a new Path containing the new key.
  */
@@ -12,7 +11,6 @@ export function addPath(
   key: string | number,
   typename: string | undefined,
 ): Path;
-
 /**
  * Given a Path, return an Array of the path keys.
  */

--- a/src/jsutils/toObjMap.d.ts
+++ b/src/jsutils/toObjMap.d.ts
@@ -4,6 +4,5 @@ import type {
   ReadOnlyObjMap,
   ReadOnlyObjMapLike,
 } from './ObjMap';
-
 export function toObjMap<T>(obj: ObjMapLike<T>): ObjMap<T>;
 export function toObjMap<T>(obj: ReadOnlyObjMapLike<T>): ReadOnlyObjMap<T>;

--- a/src/language/ast.d.ts
+++ b/src/language/ast.d.ts
@@ -1,6 +1,5 @@
 import type { Source } from './source';
 import type { TokenKindEnum } from './tokenKind';
-
 /**
  * Contains a range of UTF-8 character offsets and token references that
  * identify the region of the source from which the AST derived.
@@ -10,32 +9,25 @@ export class Location {
    * The character offset at which this Node begins.
    */
   readonly start: number;
-
   /**
    * The character offset at which this Node ends.
    */
   readonly end: number;
-
   /**
    * The Token at which this Node begins.
    */
   readonly startToken: Token;
-
   /**
    * The Token at which this Node ends.
    */
   readonly endToken: Token;
-
   /**
    * The Source document the AST represents.
    */
   readonly source: Source;
-
   constructor(startToken: Token, endToken: Token, source: Source);
-
   toJSON(): { start: number; end: number };
 }
-
 /**
  * Represents a range of characters represented by a lexical token
  * within a Source.
@@ -45,32 +37,26 @@ export class Token {
    * The kind of Token.
    */
   readonly kind: TokenKindEnum;
-
   /**
    * The character offset at which this Node begins.
    */
   readonly start: number;
-
   /**
    * The character offset at which this Node ends.
    */
   readonly end: number;
-
   /**
    * The 1-indexed line number on which this Token appears.
    */
   readonly line: number;
-
   /**
    * The 1-indexed column number at which this Token begins.
    */
   readonly column: number;
-
   /**
    * For non-punctuation tokens, represents the interpreted value of the token.
    */
   readonly value: string | undefined;
-
   /**
    * Tokens exist as nodes in a double-linked-list amongst all tokens
    * including ignored tokens. <SOF> is always the first node and <EOF>
@@ -78,7 +64,6 @@ export class Token {
    */
   readonly prev: Token | null;
   readonly next: Token | null;
-
   constructor(
     kind: TokenKindEnum,
     start: number,
@@ -88,7 +73,6 @@ export class Token {
     prev: Token | null,
     value?: string,
   );
-
   toJSON(): {
     kind: TokenKindEnum;
     value: string | undefined;
@@ -96,12 +80,10 @@ export class Token {
     column: number;
   };
 }
-
 /**
  * @internal
  */
 export function isNode(maybeNode: unknown): maybeNode is ASTNode;
-
 /**
  * The list of all possible AST node types.
  */
@@ -149,7 +131,6 @@ export type ASTNode =
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode;
-
 /**
  * Utility type listing all nodes indexed by their kind.
  */
@@ -198,32 +179,25 @@ export interface ASTKindToNode {
   EnumTypeExtension: EnumTypeExtensionNode;
   InputObjectTypeExtension: InputObjectTypeExtensionNode;
 }
-
 // Name
-
 export interface NameNode {
   readonly kind: 'Name';
   readonly loc?: Location;
   readonly value: string;
 }
-
 // Document
-
 export interface DocumentNode {
   readonly kind: 'Document';
   readonly loc?: Location;
   readonly definitions: ReadonlyArray<DefinitionNode>;
 }
-
 export type DefinitionNode =
   | ExecutableDefinitionNode
   | TypeSystemDefinitionNode
   | TypeSystemExtensionNode;
-
 export type ExecutableDefinitionNode =
   | OperationDefinitionNode
   | FragmentDefinitionNode;
-
 export interface OperationDefinitionNode {
   readonly kind: 'OperationDefinition';
   readonly loc?: Location;
@@ -233,9 +207,7 @@ export interface OperationDefinitionNode {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
 }
-
 export type OperationTypeNode = 'query' | 'mutation' | 'subscription';
-
 export interface VariableDefinitionNode {
   readonly kind: 'VariableDefinition';
   readonly loc?: Location;
@@ -244,21 +216,17 @@ export interface VariableDefinitionNode {
   readonly defaultValue?: ConstValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
 }
-
 export interface VariableNode {
   readonly kind: 'Variable';
   readonly loc?: Location;
   readonly name: NameNode;
 }
-
 export interface SelectionSetNode {
   kind: 'SelectionSet';
   loc?: Location;
   selections: ReadonlyArray<SelectionNode>;
 }
-
 export type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
-
 export interface FieldNode {
   readonly kind: 'Field';
   readonly loc?: Location;
@@ -268,30 +236,25 @@ export interface FieldNode {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet?: SelectionSetNode;
 }
-
 export interface ArgumentNode {
   readonly kind: 'Argument';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly value: ValueNode;
 }
-
 export interface ConstArgumentNode {
   readonly kind: 'Argument';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly value: ConstValueNode;
 }
-
 // Fragments
-
 export interface FragmentSpreadNode {
   readonly kind: 'FragmentSpread';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
 }
-
 export interface InlineFragmentNode {
   readonly kind: 'InlineFragment';
   readonly loc?: Location;
@@ -299,7 +262,6 @@ export interface InlineFragmentNode {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
 }
-
 export interface FragmentDefinitionNode {
   readonly kind: 'FragmentDefinition';
   readonly loc?: Location;
@@ -310,9 +272,7 @@ export interface FragmentDefinitionNode {
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
 }
-
 // Values
-
 export type ValueNode =
   | VariableNode
   | IntValueNode
@@ -323,7 +283,6 @@ export type ValueNode =
   | EnumValueNode
   | ListValueNode
   | ObjectValueNode;
-
 export type ConstValueNode =
   | IntValueNode
   | FloatValueNode
@@ -333,126 +292,103 @@ export type ConstValueNode =
   | EnumValueNode
   | ConstListValueNode
   | ConstObjectValueNode;
-
 export interface IntValueNode {
   readonly kind: 'IntValue';
   readonly loc?: Location;
   readonly value: string;
 }
-
 export interface FloatValueNode {
   readonly kind: 'FloatValue';
   readonly loc?: Location;
   readonly value: string;
 }
-
 export interface StringValueNode {
   readonly kind: 'StringValue';
   readonly loc?: Location;
   readonly value: string;
   readonly block?: boolean;
 }
-
 export interface BooleanValueNode {
   readonly kind: 'BooleanValue';
   readonly loc?: Location;
   readonly value: boolean;
 }
-
 export interface NullValueNode {
   readonly kind: 'NullValue';
   readonly loc?: Location;
 }
-
 export interface EnumValueNode {
   readonly kind: 'EnumValue';
   readonly loc?: Location;
   readonly value: string;
 }
-
 export interface ListValueNode {
   readonly kind: 'ListValue';
   readonly loc?: Location;
   readonly values: ReadonlyArray<ValueNode>;
 }
-
 export interface ConstListValueNode {
   readonly kind: 'ListValue';
   readonly loc?: Location;
   readonly values: ReadonlyArray<ConstValueNode>;
 }
-
 export interface ObjectValueNode {
   readonly kind: 'ObjectValue';
   readonly loc?: Location;
   readonly fields: ReadonlyArray<ObjectFieldNode>;
 }
-
 export interface ConstObjectValueNode {
   readonly kind: 'ObjectValue';
   readonly loc?: Location;
   readonly fields: ReadonlyArray<ConstObjectFieldNode>;
 }
-
 export interface ObjectFieldNode {
   readonly kind: 'ObjectField';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly value: ValueNode;
 }
-
 export interface ConstObjectFieldNode {
   readonly kind: 'ObjectField';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly value: ConstValueNode;
 }
-
 // Directives
-
 export interface DirectiveNode {
   readonly kind: 'Directive';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ArgumentNode>;
 }
-
 export interface ConstDirectiveNode {
   readonly kind: 'Directive';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ConstArgumentNode>;
 }
-
 // Type Reference
-
 export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
-
 export interface NamedTypeNode {
   readonly kind: 'NamedType';
   readonly loc?: Location;
   readonly name: NameNode;
 }
-
 export interface ListTypeNode {
   readonly kind: 'ListType';
   readonly loc?: Location;
   readonly type: TypeNode;
 }
-
 export interface NonNullTypeNode {
   readonly kind: 'NonNullType';
   readonly loc?: Location;
   readonly type: NamedTypeNode | ListTypeNode;
 }
-
 // Type System Definition
-
 export type TypeSystemDefinitionNode =
   | SchemaDefinitionNode
   | TypeDefinitionNode
   | DirectiveDefinitionNode;
-
 export interface SchemaDefinitionNode {
   readonly kind: 'SchemaDefinition';
   readonly loc?: Location;
@@ -460,16 +396,13 @@ export interface SchemaDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes: ReadonlyArray<OperationTypeDefinitionNode>;
 }
-
 export interface OperationTypeDefinitionNode {
   readonly kind: 'OperationTypeDefinition';
   readonly loc?: Location;
   readonly operation: OperationTypeNode;
   readonly type: NamedTypeNode;
 }
-
 // Type Definition
-
 export type TypeDefinitionNode =
   | ScalarTypeDefinitionNode
   | ObjectTypeDefinitionNode
@@ -477,7 +410,6 @@ export type TypeDefinitionNode =
   | UnionTypeDefinitionNode
   | EnumTypeDefinitionNode
   | InputObjectTypeDefinitionNode;
-
 export interface ScalarTypeDefinitionNode {
   readonly kind: 'ScalarTypeDefinition';
   readonly loc?: Location;
@@ -485,7 +417,6 @@ export interface ScalarTypeDefinitionNode {
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
 }
-
 export interface ObjectTypeDefinitionNode {
   readonly kind: 'ObjectTypeDefinition';
   readonly loc?: Location;
@@ -495,7 +426,6 @@ export interface ObjectTypeDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
 }
-
 export interface FieldDefinitionNode {
   readonly kind: 'FieldDefinition';
   readonly loc?: Location;
@@ -505,7 +435,6 @@ export interface FieldDefinitionNode {
   readonly type: TypeNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
 }
-
 export interface InputValueDefinitionNode {
   readonly kind: 'InputValueDefinition';
   readonly loc?: Location;
@@ -515,7 +444,6 @@ export interface InputValueDefinitionNode {
   readonly defaultValue?: ConstValueNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
 }
-
 export interface InterfaceTypeDefinitionNode {
   readonly kind: 'InterfaceTypeDefinition';
   readonly loc?: Location;
@@ -525,7 +453,6 @@ export interface InterfaceTypeDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
 }
-
 export interface UnionTypeDefinitionNode {
   readonly kind: 'UnionTypeDefinition';
   readonly loc?: Location;
@@ -534,7 +461,6 @@ export interface UnionTypeDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly types?: ReadonlyArray<NamedTypeNode>;
 }
-
 export interface EnumTypeDefinitionNode {
   readonly kind: 'EnumTypeDefinition';
   readonly loc?: Location;
@@ -543,7 +469,6 @@ export interface EnumTypeDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
 }
-
 export interface EnumValueDefinitionNode {
   readonly kind: 'EnumValueDefinition';
   readonly loc?: Location;
@@ -551,7 +476,6 @@ export interface EnumValueDefinitionNode {
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
 }
-
 export interface InputObjectTypeDefinitionNode {
   readonly kind: 'InputObjectTypeDefinition';
   readonly loc?: Location;
@@ -560,9 +484,7 @@ export interface InputObjectTypeDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
 }
-
 // Directive Definitions
-
 export interface DirectiveDefinitionNode {
   readonly kind: 'DirectiveDefinition';
   readonly loc?: Location;
@@ -572,20 +494,15 @@ export interface DirectiveDefinitionNode {
   readonly repeatable: boolean;
   readonly locations: ReadonlyArray<NameNode>;
 }
-
 // Type System Extensions
-
 export type TypeSystemExtensionNode = SchemaExtensionNode | TypeExtensionNode;
-
 export interface SchemaExtensionNode {
   readonly kind: 'SchemaExtension';
   readonly loc?: Location;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
 }
-
 // Type Extensions
-
 export type TypeExtensionNode =
   | ScalarTypeExtensionNode
   | ObjectTypeExtensionNode
@@ -593,14 +510,12 @@ export type TypeExtensionNode =
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode;
-
 export interface ScalarTypeExtensionNode {
   readonly kind: 'ScalarTypeExtension';
   readonly loc?: Location;
   readonly name: NameNode;
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
 }
-
 export interface ObjectTypeExtensionNode {
   readonly kind: 'ObjectTypeExtension';
   readonly loc?: Location;
@@ -609,7 +524,6 @@ export interface ObjectTypeExtensionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
 }
-
 export interface InterfaceTypeExtensionNode {
   readonly kind: 'InterfaceTypeExtension';
   readonly loc?: Location;
@@ -618,7 +532,6 @@ export interface InterfaceTypeExtensionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<FieldDefinitionNode>;
 }
-
 export interface UnionTypeExtensionNode {
   readonly kind: 'UnionTypeExtension';
   readonly loc?: Location;
@@ -626,7 +539,6 @@ export interface UnionTypeExtensionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly types?: ReadonlyArray<NamedTypeNode>;
 }
-
 export interface EnumTypeExtensionNode {
   readonly kind: 'EnumTypeExtension';
   readonly loc?: Location;
@@ -634,7 +546,6 @@ export interface EnumTypeExtensionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
 }
-
 export interface InputObjectTypeExtensionNode {
   readonly kind: 'InputObjectTypeExtension';
   readonly loc?: Location;

--- a/src/language/blockString.d.ts
+++ b/src/language/blockString.d.ts
@@ -7,12 +7,10 @@
  * @internal
  */
 export function dedentBlockStringValue(rawString: string): string;
-
 /**
  * @internal
  */
 export function getBlockStringIndentation(body: string): number;
-
 /**
  * Print a block string in the indented block form by adding a leading and
  * trailing blank line. However, if a block string starts with whitespace and is

--- a/src/language/directiveLocation.d.ts
+++ b/src/language/directiveLocation.d.ts
@@ -11,7 +11,6 @@ export const DirectiveLocation: Readonly<{
   FRAGMENT_SPREAD: 'FRAGMENT_SPREAD';
   INLINE_FRAGMENT: 'INLINE_FRAGMENT';
   VARIABLE_DEFINITION: 'VARIABLE_DEFINITION';
-
   // Type System Definitions
   SCHEMA: 'SCHEMA';
   SCALAR: 'SCALAR';
@@ -25,7 +24,6 @@ export const DirectiveLocation: Readonly<{
   INPUT_OBJECT: 'INPUT_OBJECT';
   INPUT_FIELD_DEFINITION: 'INPUT_FIELD_DEFINITION';
 }>;
-
 /**
  * The enum type representing the directive location values.
  */

--- a/src/language/index.d.ts
+++ b/src/language/index.d.ts
@@ -1,8 +1,6 @@
 export { Source } from './source';
 export { getLocation, SourceLocation } from './location';
-
 export { printLocation, printSourceLocation } from './printLocation';
-
 export { Kind, KindEnum } from './kinds';
 export { TokenKind, TokenKindEnum } from './tokenKind';
 export { Lexer } from './lexer';
@@ -22,7 +20,6 @@ export {
   ASTVisitor,
   ASTVisitFn,
 } from './visitor';
-
 export {
   Location,
   Token,
@@ -89,7 +86,6 @@ export {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
 } from './ast';
-
 export {
   isDefinitionNode,
   isExecutableDefinitionNode,
@@ -102,5 +98,4 @@ export {
   isTypeSystemExtensionNode,
   isTypeExtensionNode,
 } from './predicates';
-
 export { DirectiveLocation, DirectiveLocationEnum } from './directiveLocation';

--- a/src/language/kinds.d.ts
+++ b/src/language/kinds.d.ts
@@ -4,7 +4,6 @@
 export const Kind: Readonly<{
   // Name
   NAME: 'Name';
-
   // Document
   DOCUMENT: 'Document';
   OPERATION_DEFINITION: 'OperationDefinition';
@@ -12,12 +11,10 @@ export const Kind: Readonly<{
   SELECTION_SET: 'SelectionSet';
   FIELD: 'Field';
   ARGUMENT: 'Argument';
-
   // Fragments
   FRAGMENT_SPREAD: 'FragmentSpread';
   INLINE_FRAGMENT: 'InlineFragment';
   FRAGMENT_DEFINITION: 'FragmentDefinition';
-
   // Values
   VARIABLE: 'Variable';
   INT: 'IntValue';
@@ -29,19 +26,15 @@ export const Kind: Readonly<{
   LIST: 'ListValue';
   OBJECT: 'ObjectValue';
   OBJECT_FIELD: 'ObjectField';
-
   // Directives
   DIRECTIVE: 'Directive';
-
   // Types
   NAMED_TYPE: 'NamedType';
   LIST_TYPE: 'ListType';
   NON_NULL_TYPE: 'NonNullType';
-
   // Type System Definitions
   SCHEMA_DEFINITION: 'SchemaDefinition';
   OPERATION_TYPE_DEFINITION: 'OperationTypeDefinition';
-
   // Type Definitions
   SCALAR_TYPE_DEFINITION: 'ScalarTypeDefinition';
   OBJECT_TYPE_DEFINITION: 'ObjectTypeDefinition';
@@ -52,13 +45,10 @@ export const Kind: Readonly<{
   ENUM_TYPE_DEFINITION: 'EnumTypeDefinition';
   ENUM_VALUE_DEFINITION: 'EnumValueDefinition';
   INPUT_OBJECT_TYPE_DEFINITION: 'InputObjectTypeDefinition';
-
   // Directive Definitions
   DIRECTIVE_DEFINITION: 'DirectiveDefinition';
-
   // Type System Extensions
   SCHEMA_EXTENSION: 'SchemaExtension';
-
   // Type Extensions
   SCALAR_TYPE_EXTENSION: 'ScalarTypeExtension';
   OBJECT_TYPE_EXTENSION: 'ObjectTypeExtension';
@@ -67,7 +57,6 @@ export const Kind: Readonly<{
   ENUM_TYPE_EXTENSION: 'EnumTypeExtension';
   INPUT_OBJECT_TYPE_EXTENSION: 'InputObjectTypeExtension';
 }>;
-
 /**
  * The enum type representing the possible kind values of AST nodes.
  */

--- a/src/language/lexer.d.ts
+++ b/src/language/lexer.d.ts
@@ -1,7 +1,6 @@
 import type { Token } from './ast';
 import type { Source } from './source';
 import type { TokenKindEnum } from './tokenKind';
-
 /**
  * Given a Source object, this returns a Lexer for that source.
  * A Lexer is a stateful stream generator in that every time
@@ -12,41 +11,33 @@ import type { TokenKindEnum } from './tokenKind';
  */
 export class Lexer {
   source: Source;
-
   /**
    * The previously focused non-ignored token.
    */
   lastToken: Token;
-
   /**
    * The currently focused non-ignored token.
    */
   token: Token;
-
   /**
    * The (1-indexed) line containing the current token.
    */
   line: number;
-
   /**
    * The character offset at which the current line begins.
    */
   lineStart: number;
-
   constructor(source: Source);
-
   /**
    * Advances the token stream to the next non-ignored token.
    */
   advance(): Token;
-
   /**
    * Looks ahead and returns the next non-ignored token, but does not change
    * the state of Lexer.
    */
   lookahead(): Token;
 }
-
 /**
  * @internal
  */

--- a/src/language/location.d.ts
+++ b/src/language/location.d.ts
@@ -1,5 +1,4 @@
 import type { Source } from './source';
-
 /**
  * Represents a location in a Source.
  */
@@ -7,7 +6,6 @@ export interface SourceLocation {
   readonly line: number;
   readonly column: number;
 }
-
 /**
  * Takes a Source and a UTF-8 character offset, and returns the corresponding
  * line and column as a SourceLocation.

--- a/src/language/parser.d.ts
+++ b/src/language/parser.d.ts
@@ -1,6 +1,5 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { GraphQLError } from '../error/GraphQLError';
-
 import type {
   Token,
   NameNode,
@@ -66,7 +65,6 @@ export interface ParseOptions {
    * disables that behavior for performance or testing.
    */
   noLocation?: boolean;
-
   /**
    * @deprecated will be removed in the v17.0.0
    *
@@ -83,7 +81,6 @@ export interface ParseOptions {
    */
   allowLegacyFragmentVariables?: boolean;
 }
-
 /**
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
@@ -92,7 +89,6 @@ export function parse(
   source: string | Source,
   options?: ParseOptions,
 ): DocumentNode;
-
 /**
  * Given a string containing a GraphQL value, parse the AST for that value.
  * Throws GraphQLError if a syntax error is encountered.
@@ -104,7 +100,6 @@ export function parseValue(
   source: string | Source,
   options?: ParseOptions,
 ): ValueNode;
-
 /**
  * Similar to parseValue(), but raises a parse error if it encounters a
  * variable. The return type will be a constant value.
@@ -113,7 +108,6 @@ export function parseConstValue(
   source: string | Source,
   options?: ParseOptions,
 ): ConstValueNode;
-
 /**
  * Given a string containing a GraphQL Type (ex. `[Int!]`), parse the AST for
  * that type.
@@ -128,7 +122,6 @@ export function parseType(
   source: string | Source,
   options?: ParseOptions,
 ): TypeNode;
-
 /**
  * This class is exported only to assist people in implementing their own parsers
  * without duplicating too much code and should be used only as last resort for cases
@@ -143,19 +136,15 @@ export function parseType(
 export declare class Parser {
   _options: Maybe<ParseOptions>;
   _lexer: Lexer;
-
   constructor(source: string | Source, options?: ParseOptions);
-
   /**
    * Converts a name lex token into a name parse node.
    */
   parseName(): NameNode;
-
   /**
    * Document : Definition+
    */
   parseDocument(): DocumentNode;
-
   /**
    * Definition :
    *   - ExecutableDefinition
@@ -167,39 +156,32 @@ export declare class Parser {
    *   - FragmentDefinition
    */
   parseDefinition(): DefinitionNode;
-
   /**
    * OperationDefinition :
    *  - SelectionSet
    *  - OperationType Name? VariableDefinitions? Directives? SelectionSet
    */
   parseOperationDefinition(): OperationDefinitionNode;
-
   /**
    * OperationType : one of query mutation subscription
    */
   parseOperationType(): OperationTypeNode;
-
   /**
    * VariableDefinitions : ( VariableDefinition+ )
    */
   parseVariableDefinitions(): Array<VariableDefinitionNode>;
-
   /**
    * VariableDefinition : Variable : Type DefaultValue? Directives[Const]?
    */
   parseVariableDefinition(): VariableDefinitionNode;
-
   /**
    * Variable : $ Name
    */
   parseVariable(): VariableNode;
-
   /**
    * SelectionSet : { Selection+ }
    */
   parseSelectionSet(): SelectionSetNode;
-
   /**
    * Selection :
    *   - Field
@@ -207,28 +189,23 @@ export declare class Parser {
    *   - InlineFragment
    */
   parseSelection(): SelectionNode;
-
   /**
    * Field : Alias? Name Arguments? Directives? SelectionSet?
    *
    * Alias : Name :
    */
   parseField(): FieldNode;
-
   /**
    * Arguments[Const] : ( Argument[?Const]+ )
    */
   parseArguments(isConst: true): Array<ConstArgumentNode>;
   parseArguments(isConst: boolean): Array<ArgumentNode>;
-
   /**
    * Argument[Const] : Name : Value[?Const]
    */
   parseArgument(isConst: true): ConstArgumentNode;
   parseArgument(isConst: boolean): ArgumentNode;
-
   parseConstArgument(): ConstArgumentNode;
-
   /**
    * Corresponds to both FragmentSpread and InlineFragment in the spec.
    *
@@ -237,7 +214,6 @@ export declare class Parser {
    * InlineFragment : ... TypeCondition? Directives? SelectionSet
    */
   parseFragment(): FragmentSpreadNode | InlineFragmentNode;
-
   /**
    * FragmentDefinition :
    *   - fragment FragmentName on TypeCondition Directives? SelectionSet
@@ -245,12 +221,10 @@ export declare class Parser {
    * TypeCondition : NamedType
    */
   parseFragmentDefinition(): FragmentDefinitionNode;
-
   /**
    * FragmentName : Name but not `on`
    */
   parseFragmentName(): NameNode;
-
   /**
    * Value[Const] :
    *   - [~Const] Variable
@@ -271,9 +245,7 @@ export declare class Parser {
    */
   parseValueLiteral(isConst: true): ConstValueNode;
   parseValueLiteral(isConst: boolean): ValueNode;
-
   parseStringLiteral(): StringValueNode;
-
   /**
    * ListValue[Const] :
    *   - [ ]
@@ -281,7 +253,6 @@ export declare class Parser {
    */
   parseList(isConst: true): ConstListValueNode;
   parseList(isConst: boolean): ListValueNode;
-
   /**
    * ObjectValue[Const] :
    *   - { }
@@ -289,25 +260,21 @@ export declare class Parser {
    */
   parseObject(isConst: true): ConstObjectValueNode;
   parseObject(isConst: boolean): ObjectValueNode;
-
   /**
    * ObjectField[Const] : Name : Value[?Const]
    */
   parseObjectField(isConst: true): ConstObjectFieldNode;
   parseObjectField(isConst: boolean): ObjectFieldNode;
-
   /**
    * Directives[Const] : Directive[?Const]+
    */
   parseDirectives(isConst: true): Array<ConstDirectiveNode>;
   parseDirectives(isConst: boolean): Array<DirectiveNode>;
-
   /**
    * Directive[Const] : @ Name Arguments[?Const]?
    */
   parseDirective(isConst: true): ConstDirectiveNode;
   parseDirective(isConst: boolean): DirectiveNode;
-
   /**
    * Type :
    *   - NamedType
@@ -315,12 +282,10 @@ export declare class Parser {
    *   - NonNullType
    */
   parseTypeReference(): TypeNode;
-
   /**
    * NamedType : Name
    */
   parseNamedType(): NamedTypeNode;
-
   /**
    * TypeSystemDefinition :
    *   - SchemaDefinition
@@ -336,113 +301,93 @@ export declare class Parser {
    *   - InputObjectTypeDefinition
    */
   parseTypeSystemDefinition(): TypeSystemDefinitionNode;
-
   peekDescription(): boolean;
-
   /**
    * Description : StringValue
    */
   parseDescription(): undefined | StringValueNode;
-
   /**
    * SchemaDefinition : Description? schema Directives[Const]? { OperationTypeDefinition+ }
    */
   parseSchemaDefinition(): SchemaDefinitionNode;
-
   /**
    * OperationTypeDefinition : OperationType : NamedType
    */
   parseOperationTypeDefinition(): OperationTypeDefinitionNode;
-
   /**
    * ScalarTypeDefinition : Description? scalar Name Directives[Const]?
    */
   parseScalarTypeDefinition(): ScalarTypeDefinitionNode;
-
   /**
    * ObjectTypeDefinition :
    *   Description?
    *   type Name ImplementsInterfaces? Directives[Const]? FieldsDefinition?
    */
   parseObjectTypeDefinition(): ObjectTypeDefinitionNode;
-
   /**
    * ImplementsInterfaces :
    *   - implements `&`? NamedType
    *   - ImplementsInterfaces & NamedType
    */
   parseImplementsInterfaces(): Array<NamedTypeNode>;
-
   /**
    * FieldsDefinition : { FieldDefinition+ }
    */
   parseFieldsDefinition(): Array<FieldDefinitionNode>;
-
   /**
    * FieldDefinition :
    *   - Description? Name ArgumentsDefinition? : Type Directives[Const]?
    */
   parseFieldDefinition(): FieldDefinitionNode;
-
   /**
    * ArgumentsDefinition : ( InputValueDefinition+ )
    */
   parseArgumentDefs(): Array<InputValueDefinitionNode>;
-
   /**
    * InputValueDefinition :
    *   - Description? Name : Type DefaultValue? Directives[Const]?
    */
   parseInputValueDef(): InputValueDefinitionNode;
-
   /**
    * InterfaceTypeDefinition :
    *   - Description? interface Name Directives[Const]? FieldsDefinition?
    */
   parseInterfaceTypeDefinition(): InterfaceTypeDefinitionNode;
-
   /**
    * UnionTypeDefinition :
    *   - Description? union Name Directives[Const]? UnionMemberTypes?
    */
   parseUnionTypeDefinition(): UnionTypeDefinitionNode;
-
   /**
    * UnionMemberTypes :
    *   - = `|`? NamedType
    *   - UnionMemberTypes | NamedType
    */
   parseUnionMemberTypes(): Array<NamedTypeNode>;
-
   /**
    * EnumTypeDefinition :
    *   - Description? enum Name Directives[Const]? EnumValuesDefinition?
    */
   parseEnumTypeDefinition(): EnumTypeDefinitionNode;
-
   /**
    * EnumValuesDefinition : { EnumValueDefinition+ }
    */
   parseEnumValuesDefinition(): Array<EnumValueDefinitionNode>;
-
   /**
    * EnumValueDefinition : Description? EnumValue Directives[Const]?
    *
    * EnumValue : Name
    */
   parseEnumValueDefinition(): EnumValueDefinitionNode;
-
   /**
    * InputObjectTypeDefinition :
    *   - Description? input Name Directives[Const]? InputFieldsDefinition?
    */
   parseInputObjectTypeDefinition(): InputObjectTypeDefinitionNode;
-
   /**
    * InputFieldsDefinition : { InputValueDefinition+ }
    */
   parseInputFieldsDefinition(): Array<InputValueDefinitionNode>;
-
   /**
    * TypeSystemExtension :
    *   - SchemaExtension
@@ -457,20 +402,17 @@ export declare class Parser {
    *   - InputObjectTypeDefinition
    */
   parseTypeSystemExtension(): TypeSystemExtensionNode;
-
   /**
    * SchemaExtension :
    *  - extend schema Directives[Const]? { OperationTypeDefinition+ }
    *  - extend schema Directives[Const]
    */
   parseSchemaExtension(): SchemaExtensionNode;
-
   /**
    * ScalarTypeExtension :
    *   - extend scalar Name Directives[Const]
    */
   parseScalarTypeExtension(): ScalarTypeExtensionNode;
-
   /**
    * ObjectTypeExtension :
    *  - extend type Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
@@ -478,7 +420,6 @@ export declare class Parser {
    *  - extend type Name ImplementsInterfaces
    */
   parseObjectTypeExtension(): ObjectTypeExtensionNode;
-
   /**
    * InterfaceTypeExtension :
    *  - extend interface Name ImplementsInterfaces? Directives[Const]? FieldsDefinition
@@ -486,34 +427,29 @@ export declare class Parser {
    *  - extend interface Name ImplementsInterfaces
    */
   parseInterfaceTypeExtension(): InterfaceTypeExtensionNode;
-
   /**
    * UnionTypeExtension :
    *   - extend union Name Directives[Const]? UnionMemberTypes
    *   - extend union Name Directives[Const]
    */
   parseUnionTypeExtension(): UnionTypeExtensionNode;
-
   /**
    * EnumTypeExtension :
    *   - extend enum Name Directives[Const]? EnumValuesDefinition
    *   - extend enum Name Directives[Const]
    */
   parseEnumTypeExtension(): EnumTypeExtensionNode;
-
   /**
    * InputObjectTypeExtension :
    *   - extend input Name Directives[Const]? InputFieldsDefinition
    *   - extend input Name Directives[Const]
    */
   parseInputObjectTypeExtension(): InputObjectTypeExtensionNode;
-
   /**
    * DirectiveDefinition :
    *   - Description? directive @ Name ArgumentsDefinition? `repeatable`? on DirectiveLocations
    */
   parseDirectiveDefinition(): DirectiveDefinitionNode;
-
   /**
    * DirectiveLocations :
    *   - `|`? DirectiveLocation
@@ -521,48 +457,40 @@ export declare class Parser {
    */
   parseDirectiveLocations(): Array<NameNode>;
   parseDirectiveLocation(): NameNode;
-
   /**
    * Returns a node that, if configured to do so, sets a "loc" field as a
    * location object, used to identify the place in the source that created a
    * given parsed object.
    */
   node<T>(startToken: Token, node: T): T;
-
   /**
    * Determines if the next token is of a given kind
    */
   peek(kind: TokenKindEnum): boolean;
-
   /**
    * If the next token is of the given kind, return that token after advancing the lexer.
    * Otherwise, do not change the parser state and throw an error.
    */
   expectToken(kind: TokenKindEnum): Token;
-
   /**
    * If the next token is of the given kind, return that token after advancing the lexer.
    * Otherwise, do not change the parser state and return undefined.
    */
   expectOptionalToken(kind: TokenKindEnum): Maybe<Token>;
-
   /**
    * If the next token is a given keyword, advance the lexer.
    * Otherwise, do not change the parser state and throw an error.
    */
   expectKeyword(value: string): void;
-
   /**
    * If the next token is a given keyword, return "true" after advancing the lexer.
    * Otherwise, do not change the parser state and return "false".
    */
   expectOptionalKeyword(value: string): boolean;
-
   /**
    * Helper function for creating an error when an unexpected lexed token is encountered.
    */
   unexpected(atToken?: Maybe<Token>): GraphQLError;
-
   /**
    * Returns a possibly empty list of parse nodes, determined by the parseFn.
    * This list begins with a lex token of openKind and ends with a lex token of closeKind.
@@ -573,7 +501,6 @@ export declare class Parser {
     parseFn: () => T,
     closeKind: TokenKindEnum,
   ): Array<T>;
-
   /**
    * Returns a list of parse nodes, determined by the parseFn.
    * It can be empty only if open token is missing otherwise it will always return non-empty list
@@ -585,7 +512,6 @@ export declare class Parser {
     parseFn: () => T,
     closeKind: TokenKindEnum,
   ): Array<T>;
-
   /**
    * Returns a non-empty list of parse nodes, determined by the parseFn.
    * This list begins with a lex token of openKind and ends with a lex token of closeKind.
@@ -596,7 +522,6 @@ export declare class Parser {
     parseFn: () => T,
     closeKind: TokenKindEnum,
   ): Array<T>;
-
   /**
    * Returns a non-empty list of parse nodes, determined by the parseFn.
    * This list may begin with a lex token of delimiterKind followed by items separated by lex tokens of tokenKind.

--- a/src/language/predicates.d.ts
+++ b/src/language/predicates.d.ts
@@ -11,29 +11,19 @@ import type {
   TypeSystemExtensionNode,
   TypeExtensionNode,
 } from './ast';
-
 export function isDefinitionNode(node: ASTNode): node is DefinitionNode;
-
 export function isExecutableDefinitionNode(
   node: ASTNode,
 ): node is ExecutableDefinitionNode;
-
 export function isSelectionNode(node: ASTNode): node is SelectionNode;
-
 export function isValueNode(node: ASTNode): node is ValueNode;
-
 export function isConstValueNode(node: ASTNode): node is ConstValueNode;
-
 export function isTypeNode(node: ASTNode): node is TypeNode;
-
 export function isTypeSystemDefinitionNode(
   node: ASTNode,
 ): node is TypeSystemDefinitionNode;
-
 export function isTypeDefinitionNode(node: ASTNode): node is TypeDefinitionNode;
-
 export function isTypeSystemExtensionNode(
   node: ASTNode,
 ): node is TypeSystemExtensionNode;
-
 export function isTypeExtensionNode(node: ASTNode): node is TypeExtensionNode;

--- a/src/language/printLocation.d.ts
+++ b/src/language/printLocation.d.ts
@@ -1,12 +1,10 @@
 import type { Location } from './ast';
 import type { Source } from './source';
 import type { SourceLocation } from './location';
-
 /**
  * Render a helpful description of the location in the GraphQL Source document.
  */
 export function printLocation(location: Location): string;
-
 /**
  * Render a helpful description of the location in the GraphQL Source document.
  */

--- a/src/language/printer.d.ts
+++ b/src/language/printer.d.ts
@@ -1,5 +1,4 @@
 import type { ASTNode } from './ast';
-
 /**
  * Converts an AST into a string, using one set of reasonable
  * formatting rules.

--- a/src/language/source.d.ts
+++ b/src/language/source.d.ts
@@ -2,7 +2,6 @@ interface Location {
   line: number;
   column: number;
 }
-
 /**
  * A representation of source input to GraphQL. The `name` and `locationOffset` parameters are
  * optional, but they are useful for clients who store GraphQL documents in source files.
@@ -17,7 +16,6 @@ export class Source {
   constructor(body: string, name?: string, locationOffset?: Location);
   get [Symbol.toStringTag](): string;
 }
-
 /**
  * Test if the given value is a Source object.
  *

--- a/src/language/tokenKind.d.ts
+++ b/src/language/tokenKind.d.ts
@@ -26,7 +26,6 @@ export const TokenKind: Readonly<{
   BLOCK_STRING: 'BlockString';
   COMMENT: 'Comment';
 }>;
-
 /**
  * The enum type representing the token kinds values.
  */

--- a/src/language/visitor.d.ts
+++ b/src/language/visitor.d.ts
@@ -1,24 +1,19 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { ASTNode, ASTKindToNode } from './ast';
-
 /**
  * A visitor is provided to visit, it contains the collection of
  * relevant functions to be called during the visitor's traversal.
  */
 export type ASTVisitor = EnterLeaveVisitor<ASTNode> & KindVisitor;
-
 type KindVisitor = {
   readonly [K in keyof ASTKindToNode]?:
     | ASTVisitFn<ASTKindToNode[K]>
     | EnterLeaveVisitor<ASTKindToNode[K]>;
 };
-
 type EnterLeaveVisitor<TVisitedNode extends ASTNode> = {
   readonly enter?: ASTVisitFn<TVisitedNode>;
   readonly leave?: ASTVisitFn<TVisitedNode>;
 };
-
 /**
  * A visitor is comprised of visit functions, which are called on each node
  * during the visitor's traversal.
@@ -39,9 +34,7 @@ export type ASTVisitFn<TVisitedNode extends ASTNode> = (
    */
   ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
 ) => any;
-
 export const BREAK: any;
-
 /**
  * visit() will walk through an AST using a depth-first traversal, calling
  * the visitor's enter function at each node in the traversal, and calling the
@@ -114,7 +107,6 @@ export const BREAK: any;
  *     })
  */
 export function visit(root: ASTNode, visitor: ASTVisitor): any;
-
 /**
  * Creates a new visitor instance which delegates to many visitors to run in
  * parallel. Each visitor will be visited for each node before moving on.
@@ -124,7 +116,6 @@ export function visit(root: ASTNode, visitor: ASTVisitor): any;
 export function visitInParallel(
   visitors: ReadonlyArray<ASTVisitor>,
 ): ASTVisitor;
-
 /**
  * Given a visitor instance, if it is leaving or not, and a node kind, return
  * the function the visitor runtime should call.

--- a/src/subscription/mapAsyncIterator.d.ts
+++ b/src/subscription/mapAsyncIterator.d.ts
@@ -1,5 +1,4 @@
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
-
 /**
  * Given an AsyncIterable and a callback function, return an AsyncIterator
  * which produces values mapped via calling the callback function.

--- a/src/subscription/subscribe.d.ts
+++ b/src/subscription/subscribe.d.ts
@@ -1,10 +1,8 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { DocumentNode } from '../language/ast';
 import type { ExecutionResult } from '../execution/execute';
 import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLFieldResolver } from '../type/definition';
-
 export interface SubscriptionArgs {
   schema: GraphQLSchema;
   document: DocumentNode;
@@ -15,7 +13,6 @@ export interface SubscriptionArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
-
 /**
  * Implements the "Subscribe" algorithm described in the GraphQL specification.
  *
@@ -40,7 +37,6 @@ export interface SubscriptionArgs {
 export function subscribe(
   args: SubscriptionArgs,
 ): Promise<AsyncGenerator<ExecutionResult, void, void> | ExecutionResult>;
-
 /**
  * Implements the "CreateSourceEventStream" algorithm described in the
  * GraphQL specification, resolving the subscription source event stream.

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -1,9 +1,7 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import type { Path } from '../jsutils/Path';
 import type { ObjMap } from '../jsutils/ObjMap';
-
 import type {
   ScalarTypeDefinitionNode,
   ObjectTypeDefinitionNode,
@@ -25,9 +23,7 @@ import type {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
 } from '../language/ast';
-
 import type { GraphQLSchema } from './schema';
-
 /**
  * These are all of the possible kinds of types.
  */
@@ -40,45 +36,26 @@ export type GraphQLType =
   | GraphQLInputObjectType
   | GraphQLList<any>
   | GraphQLNonNull<any>;
-
 export function isType(type: unknown): type is GraphQLType;
-
 export function assertType(type: unknown): GraphQLType;
-
 export function isScalarType(type: unknown): type is GraphQLScalarType;
-
 export function assertScalarType(type: unknown): GraphQLScalarType;
-
 export function isObjectType(type: unknown): type is GraphQLObjectType;
-
 export function assertObjectType(type: unknown): GraphQLObjectType;
-
 export function isInterfaceType(type: unknown): type is GraphQLInterfaceType;
-
 export function assertInterfaceType(type: unknown): GraphQLInterfaceType;
-
 export function isUnionType(type: unknown): type is GraphQLUnionType;
-
 export function assertUnionType(type: unknown): GraphQLUnionType;
-
 export function isEnumType(type: unknown): type is GraphQLEnumType;
-
 export function assertEnumType(type: unknown): GraphQLEnumType;
-
 export function isInputObjectType(
   type: unknown,
 ): type is GraphQLInputObjectType;
-
 export function assertInputObjectType(type: unknown): GraphQLInputObjectType;
-
 export function isListType(type: unknown): type is GraphQLList<any>;
-
 export function assertListType(type: unknown): GraphQLList<any>;
-
 export function isNonNullType(type: unknown): type is GraphQLNonNull<any>;
-
 export function assertNonNullType(type: unknown): GraphQLNonNull<any>;
-
 /**
  * These types may be used as input types for arguments and directives.
  */
@@ -94,11 +71,8 @@ export type GraphQLInputType =
       | GraphQLInputObjectType
       | GraphQLList<any>
     >;
-
 export function isInputType(type: unknown): type is GraphQLInputType;
-
 export function assertInputType(type: unknown): GraphQLInputType;
-
 /**
  * These types may be used as output types as the result of fields.
  */
@@ -118,20 +92,14 @@ export type GraphQLOutputType =
       | GraphQLEnumType
       | GraphQLList<any>
     >;
-
 export function isOutputType(type: any): type is GraphQLOutputType;
-
 export function assertOutputType(type: any): GraphQLOutputType;
-
 /**
  * These types may describe types which may be leaf values.
  */
 export type GraphQLLeafType = GraphQLScalarType | GraphQLEnumType;
-
 export function isLeafType(type: unknown): type is GraphQLLeafType;
-
 export function assertLeafType(type: unknown): GraphQLLeafType;
-
 /**
  * These types may describe the parent context of a selection set.
  */
@@ -139,20 +107,14 @@ export type GraphQLCompositeType =
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType;
-
 export function isCompositeType(type: unknown): type is GraphQLCompositeType;
-
 export function assertCompositeType(type: unknown): GraphQLCompositeType;
-
 /**
  * These types may describe the parent context of a selection set.
  */
 export type GraphQLAbstractType = GraphQLInterfaceType | GraphQLUnionType;
-
 export function isAbstractType(type: unknown): type is GraphQLAbstractType;
-
 export function assertAbstractType(type: unknown): GraphQLAbstractType;
-
 /**
  * List Modifier
  *
@@ -173,15 +135,12 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType;
  */
 export class GraphQLList<T extends GraphQLType> {
   readonly ofType: T;
-
   constructor(type: T);
-
   toString: () => string;
   toJSON: () => string;
   inspect: () => string;
   get [Symbol.toStringTag](): string;
 }
-
 /**
  * Non-Null Modifier
  *
@@ -204,21 +163,15 @@ export class GraphQLList<T extends GraphQLType> {
  */
 export class GraphQLNonNull<T extends GraphQLNullableType> {
   readonly ofType: T;
-
   constructor(type: T);
-
   toString: () => string;
   toJSON: () => string;
   inspect: () => string;
   get [Symbol.toStringTag](): string;
 }
-
 export type GraphQLWrappingType = GraphQLList<any> | GraphQLNonNull<any>;
-
 export function isWrappingType(type: unknown): type is GraphQLWrappingType;
-
 export function assertWrappingType(type: unknown): GraphQLWrappingType;
-
 /**
  * These types can all accept null as a value.
  */
@@ -230,11 +183,8 @@ export type GraphQLNullableType =
   | GraphQLEnumType
   | GraphQLInputObjectType
   | GraphQLList<any>;
-
 export function isNullableType(type: unknown): type is GraphQLNullableType;
-
 export function assertNullableType(type: unknown): GraphQLNullableType;
-
 export function getNullableType(type: undefined): undefined;
 export function getNullableType<T extends GraphQLNullableType>(type: T): T;
 export function getNullableType<T extends GraphQLNullableType>(
@@ -242,40 +192,32 @@ export function getNullableType<T extends GraphQLNullableType>(
   // eslint-disable-next-line @typescript-eslint/unified-signatures
   type: GraphQLNonNull<T>,
 ): T;
-
 /**
  * These named types do not include modifiers like List or NonNull.
  */
 export type GraphQLNamedType = GraphQLNamedInputType | GraphQLNamedOutputType;
-
 export type GraphQLNamedInputType =
   | GraphQLScalarType
   | GraphQLEnumType
   | GraphQLInputObjectType;
-
 export type GraphQLNamedOutputType =
   | GraphQLScalarType
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
   | GraphQLEnumType;
-
 export function isNamedType(type: unknown): type is GraphQLNamedType;
-
 export function assertNamedType(type: unknown): GraphQLNamedType;
-
 export function getNamedType(type: undefined): undefined;
 export function getNamedType(type: GraphQLInputType): GraphQLNamedInputType;
 export function getNamedType(type: GraphQLOutputType): GraphQLNamedOutputType;
 export function getNamedType(type: GraphQLType): GraphQLNamedType;
-
 /**
  * Used while defining GraphQL types to allow for circular references in
  * otherwise immutable type definitions.
  */
 export type ThunkArray<T> = Array<T> | (() => Array<T>);
 export type ThunkObjMap<T> = ObjMap<T> | (() => ObjMap<T>);
-
 /**
  * Custom extensions
  *
@@ -288,7 +230,6 @@ export type ThunkObjMap<T> = ObjMap<T> | (() => ObjMap<T>);
 export interface GraphQLScalarTypeExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Scalar Type Definition
  *
@@ -316,9 +257,7 @@ export class GraphQLScalarType {
   extensions: Maybe<Readonly<GraphQLScalarTypeExtensions>>;
   astNode: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
-
   constructor(config: Readonly<GraphQLScalarTypeConfig<unknown, unknown>>);
-
   toConfig(): GraphQLScalarTypeConfig<unknown, unknown> & {
     specifiedByURL: Maybe<string>;
     serialize: GraphQLScalarSerializer<unknown>;
@@ -327,12 +266,10 @@ export class GraphQLScalarType {
     extensions: Maybe<Readonly<GraphQLScalarTypeExtensions>>;
     extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
 }
-
 export type GraphQLScalarSerializer<TExternal> = (
   value: unknown,
 ) => Maybe<TExternal>;
@@ -343,7 +280,6 @@ export type GraphQLScalarLiteralParser<TInternal> = (
   valueNode: ValueNode,
   variables: Maybe<ObjMap<unknown>>,
 ) => Maybe<TInternal>;
-
 export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   name: string;
   description?: Maybe<string>;
@@ -358,7 +294,6 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   astNode?: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
 }
-
 /**
  * Custom extensions
  *
@@ -374,7 +309,6 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
 export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
   [attributeName: string]: unknown;
 }
-
 /**
  * Object Type Definition
  *
@@ -419,29 +353,23 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
   extensions: Maybe<Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
-
   constructor(config: Readonly<GraphQLObjectTypeConfig<TSource, TContext>>);
-
   getFields(): GraphQLFieldMap<any, TContext>;
   getInterfaces(): Array<GraphQLInterfaceType>;
-
   toConfig(): GraphQLObjectTypeConfig<any, any> & {
     interfaces: Array<GraphQLInterfaceType>;
     fields: GraphQLFieldConfigMap<any, any>;
     extensions: Maybe<Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>>;
     extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
   get [Symbol.toStringTag](): string;
 }
-
 export function argsToArgsConfig(
   args: ReadonlyArray<GraphQLArgument>,
 ): GraphQLFieldConfigArgumentMap;
-
 export interface GraphQLObjectTypeConfig<TSource, TContext> {
   name: string;
   description?: Maybe<string>;
@@ -452,20 +380,17 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
   astNode?: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
-
 export type GraphQLTypeResolver<TSource, TContext> = (
   value: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
   abstractType: GraphQLAbstractType,
 ) => PromiseOrValue<string | undefined>;
-
 export type GraphQLIsTypeOfFn<TSource, TContext> = (
   source: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
 ) => PromiseOrValue<boolean>;
-
 export type GraphQLFieldResolver<
   TSource,
   TContext,
@@ -476,7 +401,6 @@ export type GraphQLFieldResolver<
   context: TContext,
   info: GraphQLResolveInfo,
 ) => unknown;
-
 export interface GraphQLResolveInfo {
   readonly fieldName: string;
   readonly fieldNodes: ReadonlyArray<FieldNode>;
@@ -489,7 +413,6 @@ export interface GraphQLResolveInfo {
   readonly operation: OperationDefinitionNode;
   readonly variableValues: { [variableName: string]: unknown };
 }
-
 /**
  * Custom extensions
  *
@@ -509,7 +432,6 @@ export interface GraphQLFieldExtensions<
 > {
   [attributeName: string]: unknown;
 }
-
 export interface GraphQLFieldConfig<
   TSource,
   TContext,
@@ -526,9 +448,7 @@ export interface GraphQLFieldConfig<
   >;
   astNode?: Maybe<FieldDefinitionNode>;
 }
-
 export type GraphQLFieldConfigArgumentMap = ObjMap<GraphQLArgumentConfig>;
-
 /**
  * Custom extensions
  *
@@ -541,7 +461,6 @@ export type GraphQLFieldConfigArgumentMap = ObjMap<GraphQLArgumentConfig>;
 export interface GraphQLArgumentExtensions {
   [attributeName: string]: unknown;
 }
-
 export interface GraphQLArgumentConfig {
   description?: Maybe<string>;
   type: GraphQLInputType;
@@ -550,11 +469,9 @@ export interface GraphQLArgumentConfig {
   extensions?: Maybe<Readonly<GraphQLArgumentExtensions>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
-
 export type GraphQLFieldConfigMap<TSource, TContext> = ObjMap<
   GraphQLFieldConfig<TSource, TContext>
 >;
-
 export interface GraphQLField<
   TSource,
   TContext,
@@ -570,7 +487,6 @@ export interface GraphQLField<
   extensions: Maybe<Readonly<GraphQLFieldExtensions<TSource, TContext, TArgs>>>;
   astNode?: Maybe<FieldDefinitionNode>;
 }
-
 export interface GraphQLArgument {
   name: string;
   description: Maybe<string>;
@@ -580,13 +496,10 @@ export interface GraphQLArgument {
   extensions: Maybe<Readonly<GraphQLArgumentExtensions>>;
   astNode: Maybe<InputValueDefinitionNode>;
 }
-
 export function isRequiredArgument(arg: GraphQLArgument): boolean;
-
 export type GraphQLFieldMap<TSource, TContext> = ObjMap<
   GraphQLField<TSource, TContext>
 >;
-
 /**
  * Custom extensions
  *
@@ -599,7 +512,6 @@ export type GraphQLFieldMap<TSource, TContext> = ObjMap<
 export interface GraphQLInterfaceTypeExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Interface Type Definition
  *
@@ -625,24 +537,20 @@ export class GraphQLInterfaceType {
   extensions: Maybe<Readonly<GraphQLInterfaceTypeExtensions>>;
   astNode?: Maybe<InterfaceTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode>;
-
   constructor(config: Readonly<GraphQLInterfaceTypeConfig<any, any>>);
   getFields(): GraphQLFieldMap<any, any>;
   getInterfaces(): Array<GraphQLInterfaceType>;
-
   toConfig(): GraphQLInterfaceTypeConfig<any, any> & {
     interfaces: Array<GraphQLInterfaceType>;
     fields: GraphQLFieldConfigMap<any, any>;
     extensions: Maybe<Readonly<GraphQLInterfaceTypeExtensions>>;
     extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
   get [Symbol.toStringTag](): string;
 }
-
 export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
   name: string;
   description?: Maybe<string>;
@@ -658,7 +566,6 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
   astNode?: Maybe<InterfaceTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 }
-
 /**
  * Custom extensions
  *
@@ -671,7 +578,6 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
 export interface GraphQLUnionTypeExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Union Type Definition
  *
@@ -702,22 +608,18 @@ export class GraphQLUnionType {
   extensions: Maybe<Readonly<GraphQLUnionTypeExtensions>>;
   astNode: Maybe<UnionTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<UnionTypeExtensionNode>;
-
   constructor(config: Readonly<GraphQLUnionTypeConfig<any, any>>);
   getTypes(): Array<GraphQLObjectType>;
-
   toConfig(): GraphQLUnionTypeConfig<any, any> & {
     types: Array<GraphQLObjectType>;
     extensions: Maybe<Readonly<GraphQLUnionTypeExtensions>>;
     extensionASTNodes: ReadonlyArray<UnionTypeExtensionNode>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
   get [Symbol.toStringTag](): string;
 }
-
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
   name: string;
   description?: Maybe<string>;
@@ -732,7 +634,6 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
   astNode?: Maybe<UnionTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<UnionTypeExtensionNode>>;
 }
-
 /**
  * Custom extensions
  *
@@ -745,7 +646,6 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
 export interface GraphQLEnumTypeExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Enum Type Definition
  *
@@ -773,7 +673,6 @@ export class GraphQLEnumType {
   extensions: Maybe<Readonly<GraphQLEnumTypeExtensions>>;
   astNode: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<EnumTypeExtensionNode>;
-
   constructor(config: Readonly<GraphQLEnumTypeConfig>);
   getValues(): Array<GraphQLEnumValue>;
   getValue(name: string): Maybe<GraphQLEnumValue>;
@@ -783,18 +682,15 @@ export class GraphQLEnumType {
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
   ): Maybe<any>;
-
   toConfig(): GraphQLEnumTypeConfig & {
     extensions: Maybe<Readonly<GraphQLEnumTypeExtensions>>;
     extensionASTNodes: ReadonlyArray<EnumTypeExtensionNode>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
   get [Symbol.toStringTag](): string;
 }
-
 export interface GraphQLEnumTypeConfig {
   name: string;
   description?: Maybe<string>;
@@ -803,9 +699,7 @@ export interface GraphQLEnumTypeConfig {
   astNode?: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 }
-
 export type GraphQLEnumValueConfigMap = ObjMap<GraphQLEnumValueConfig>;
-
 /**
  * Custom extensions
  *
@@ -818,7 +712,6 @@ export type GraphQLEnumValueConfigMap = ObjMap<GraphQLEnumValueConfig>;
 export interface GraphQLEnumValueExtensions {
   [attributeName: string]: unknown;
 }
-
 export interface GraphQLEnumValueConfig {
   description?: Maybe<string>;
   value?: any;
@@ -826,7 +719,6 @@ export interface GraphQLEnumValueConfig {
   extensions?: Maybe<Readonly<GraphQLEnumValueExtensions>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
 }
-
 export interface GraphQLEnumValue {
   name: string;
   description: Maybe<string>;
@@ -835,7 +727,6 @@ export interface GraphQLEnumValue {
   extensions: Maybe<Readonly<GraphQLEnumValueExtensions>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
 }
-
 /**
  * Custom extensions
  *
@@ -848,7 +739,6 @@ export interface GraphQLEnumValue {
 export interface GraphQLInputObjectTypeExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Input Object Type Definition
  *
@@ -875,22 +765,18 @@ export class GraphQLInputObjectType {
   extensions: Maybe<Readonly<GraphQLInputObjectTypeExtensions>>;
   astNode: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
-
   constructor(config: Readonly<GraphQLInputObjectTypeConfig>);
   getFields(): GraphQLInputFieldMap;
-
   toConfig(): GraphQLInputObjectTypeConfig & {
     fields: GraphQLInputFieldConfigMap;
     extensions: Maybe<Readonly<GraphQLInputObjectTypeExtensions>>;
     extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
   get [Symbol.toStringTag](): string;
 }
-
 export interface GraphQLInputObjectTypeConfig {
   name: string;
   description?: Maybe<string>;
@@ -899,7 +785,6 @@ export interface GraphQLInputObjectTypeConfig {
   astNode?: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
 }
-
 /**
  * Custom extensions
  *
@@ -912,7 +797,6 @@ export interface GraphQLInputObjectTypeConfig {
 export interface GraphQLInputFieldExtensions {
   [attributeName: string]: any;
 }
-
 export interface GraphQLInputFieldConfig {
   description?: Maybe<string>;
   type: GraphQLInputType;
@@ -921,9 +805,7 @@ export interface GraphQLInputFieldConfig {
   extensions?: Maybe<Readonly<GraphQLInputFieldExtensions>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
-
 export type GraphQLInputFieldConfigMap = ObjMap<GraphQLInputFieldConfig>;
-
 export interface GraphQLInputField {
   name: string;
   description?: Maybe<string>;
@@ -933,7 +815,5 @@ export interface GraphQLInputField {
   extensions: Maybe<Readonly<GraphQLInputFieldExtensions>>;
   astNode?: Maybe<InputValueDefinitionNode>;
 }
-
 export function isRequiredInputField(field: GraphQLInputField): boolean;
-
 export type GraphQLInputFieldMap = ObjMap<GraphQLInputField>;

--- a/src/type/directives.d.ts
+++ b/src/type/directives.d.ts
@@ -1,19 +1,15 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { DirectiveDefinitionNode } from '../language/ast';
 import type { DirectiveLocationEnum } from '../language/directiveLocation';
-
 import type {
   GraphQLFieldConfigArgumentMap,
   GraphQLArgument,
 } from './definition';
-
 /**
  * Test if the given value is a GraphQL directive.
  */
 export function isDirective(directive: unknown): directive is GraphQLDirective;
 export function assertDirective(directive: unknown): GraphQLDirective;
-
 /**
  * Custom extensions
  *
@@ -26,7 +22,6 @@ export function assertDirective(directive: unknown): GraphQLDirective;
 export interface GraphQLDirectiveExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Directives are used by the GraphQL runtime as a way of modifying execution
  * behavior. Type system creators will usually not create these directly.
@@ -39,21 +34,17 @@ export class GraphQLDirective {
   args: Array<GraphQLArgument>;
   extensions: Maybe<Readonly<GraphQLDirectiveExtensions>>;
   astNode: Maybe<DirectiveDefinitionNode>;
-
   constructor(config: Readonly<GraphQLDirectiveConfig>);
-
   toConfig(): GraphQLDirectiveConfig & {
     args: GraphQLFieldConfigArgumentMap;
     isRepeatable: boolean;
     extensions: Maybe<Readonly<GraphQLDirectiveExtensions>>;
   };
-
   toString(): string;
   toJSON(): string;
   inspect(): string;
   get [Symbol.toStringTag](): string;
 }
-
 export interface GraphQLDirectiveConfig {
   name: string;
   description?: Maybe<string>;
@@ -63,35 +54,28 @@ export interface GraphQLDirectiveConfig {
   extensions?: Maybe<Readonly<GraphQLDirectiveExtensions>>;
   astNode?: Maybe<DirectiveDefinitionNode>;
 }
-
 /**
  * Used to conditionally include fields or fragments.
  */
 export const GraphQLIncludeDirective: GraphQLDirective;
-
 /**
  * Used to conditionally skip (exclude) fields or fragments.
  */
 export const GraphQLSkipDirective: GraphQLDirective;
-
 /**
  * Used to provide a URL for specifying the behavior of custom scalar definitions.
  */
 export const GraphQLSpecifiedByDirective: GraphQLDirective;
-
 /**
  * Constant string used for default reason for a deprecation.
  */
 export const DEFAULT_DEPRECATION_REASON: 'No longer supported';
-
 /**
  * Used to declare element of a GraphQL schema as deprecated.
  */
 export const GraphQLDeprecatedDirective: GraphQLDirective;
-
 /**
  * The full list of specified directives.
  */
 export const specifiedDirectives: ReadonlyArray<GraphQLDirective>;
-
 export function isSpecifiedDirective(directive: GraphQLDirective): boolean;

--- a/src/type/index.d.ts
+++ b/src/type/index.d.ts
@@ -1,5 +1,4 @@
 export { Path as ResponsePath } from '../jsutils/Path';
-
 export {
   // Predicate
   isSchema,
@@ -10,7 +9,6 @@ export {
   GraphQLSchemaConfig,
   GraphQLSchemaExtensions,
 } from './schema';
-
 export {
   // Predicates
   isType,
@@ -115,7 +113,6 @@ export {
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
 } from './definition';
-
 export {
   // Predicate
   isDirective,
@@ -136,7 +133,6 @@ export {
   GraphQLDirectiveConfig,
   GraphQLDirectiveExtensions,
 } from './directives';
-
 // Common built-in scalar instances.
 export {
   isSpecifiedScalarType,
@@ -147,7 +143,6 @@ export {
   GraphQLBoolean,
   GraphQLID,
 } from './scalars';
-
 export {
   // "Enum" of Type Kinds
   TypeKind,
@@ -167,5 +162,4 @@ export {
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
 } from './introspection';
-
 export { validateSchema, assertValidSchema } from './validate';

--- a/src/type/introspection.d.ts
+++ b/src/type/introspection.d.ts
@@ -4,7 +4,6 @@ import type {
   GraphQLEnumType,
   GraphQLNamedType,
 } from './definition';
-
 export const __Schema: GraphQLObjectType;
 export const __Directive: GraphQLObjectType;
 export const __DirectiveLocation: GraphQLEnumType;
@@ -12,7 +11,6 @@ export const __Type: GraphQLObjectType;
 export const __Field: GraphQLObjectType;
 export const __InputValue: GraphQLObjectType;
 export const __EnumValue: GraphQLObjectType;
-
 export const TypeKind: Readonly<{
   SCALAR: 'SCALAR';
   OBJECT: 'OBJECT';
@@ -23,18 +21,13 @@ export const TypeKind: Readonly<{
   LIST: 'LIST';
   NON_NULL: 'NON_NULL';
 }>;
-
 export const __TypeKind: GraphQLEnumType;
-
 /**
  * Note that these are GraphQLField and not GraphQLFieldConfig,
  * so the format for args is different.
  */
-
 export const SchemaMetaFieldDef: GraphQLField<unknown, unknown>;
 export const TypeMetaFieldDef: GraphQLField<unknown, unknown>;
 export const TypeNameMetaFieldDef: GraphQLField<unknown, unknown>;
-
 export const introspectionTypes: ReadonlyArray<GraphQLNamedType>;
-
 export function isIntrospectionType(type: GraphQLNamedType): boolean;

--- a/src/type/scalars.d.ts
+++ b/src/type/scalars.d.ts
@@ -1,11 +1,8 @@
 import type { GraphQLScalarType, GraphQLNamedType } from './definition';
-
 export const GraphQLInt: GraphQLScalarType;
 export const GraphQLFloat: GraphQLScalarType;
 export const GraphQLString: GraphQLScalarType;
 export const GraphQLBoolean: GraphQLScalarType;
 export const GraphQLID: GraphQLScalarType;
-
 export const specifiedScalarTypes: ReadonlyArray<GraphQLScalarType>;
-
 export function isSpecifiedScalarType(type: GraphQLNamedType): boolean;

--- a/src/type/schema.d.ts
+++ b/src/type/schema.d.ts
@@ -1,11 +1,9 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
-
 import type {
   SchemaDefinitionNode,
   SchemaExtensionNode,
 } from '../language/ast';
-
 import type { GraphQLDirective } from './directives';
 import type {
   GraphQLNamedType,
@@ -13,13 +11,11 @@ import type {
   GraphQLObjectType,
   GraphQLInterfaceType,
 } from './definition';
-
 /**
  * Test if the given value is a GraphQL schema.
  */
 export function isSchema(schema: unknown): schema is GraphQLSchema;
 export function assertSchema(schema: unknown): GraphQLSchema;
-
 /**
  * Custom extensions
  *
@@ -32,7 +28,6 @@ export function assertSchema(schema: unknown): GraphQLSchema;
 export interface GraphQLSchemaExtensions {
   [attributeName: string]: unknown;
 }
-
 /**
  * Schema Definition
  *
@@ -64,30 +59,24 @@ export class GraphQLSchema {
   extensions: Maybe<Readonly<GraphQLSchemaExtensions>>;
   astNode: Maybe<SchemaDefinitionNode>;
   extensionASTNodes: ReadonlyArray<SchemaExtensionNode>;
-
   constructor(config: Readonly<GraphQLSchemaConfig>);
   getQueryType(): Maybe<GraphQLObjectType>;
   getMutationType(): Maybe<GraphQLObjectType>;
   getSubscriptionType(): Maybe<GraphQLObjectType>;
   getTypeMap(): TypeMap;
   getType(name: string): Maybe<GraphQLNamedType>;
-
   getPossibleTypes(
     abstractType: GraphQLAbstractType,
   ): ReadonlyArray<GraphQLObjectType>;
-
   getImplementations(
     interfaceType: GraphQLInterfaceType,
   ): InterfaceImplementations;
-
   isSubType(
     abstractType: GraphQLAbstractType,
     maybeSubType: GraphQLObjectType | GraphQLInterfaceType,
   ): boolean;
-
   getDirectives(): ReadonlyArray<GraphQLDirective>;
   getDirective(name: string): Maybe<GraphQLDirective>;
-
   toConfig(): GraphQLSchemaConfig & {
     types: Array<GraphQLNamedType>;
     directives: Array<GraphQLDirective>;
@@ -97,14 +86,11 @@ export class GraphQLSchema {
   };
   get [Symbol.toStringTag](): string;
 }
-
 type TypeMap = ObjMap<GraphQLNamedType>;
-
 interface InterfaceImplementations {
   objects: ReadonlyArray<GraphQLObjectType>;
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
 }
-
 export interface GraphQLSchemaValidationOptions {
   /**
    * When building a schema from a GraphQL service's introspection result, it
@@ -115,7 +101,6 @@ export interface GraphQLSchemaValidationOptions {
    */
   assumeValid?: boolean;
 }
-
 export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
   description?: Maybe<string>;
   query?: Maybe<GraphQLObjectType>;
@@ -127,7 +112,6 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;
 }
-
 /**
  * @internal
  */

--- a/src/type/validate.d.ts
+++ b/src/type/validate.d.ts
@@ -1,7 +1,5 @@
 import type { GraphQLError } from '../error/GraphQLError';
-
 import type { GraphQLSchema } from './schema';
-
 /**
  * Implements the "Type Validation" sub-sections of the specification's
  * "Type System" section.
@@ -12,7 +10,6 @@ import type { GraphQLSchema } from './schema';
 export function validateSchema(
   schema: GraphQLSchema,
 ): ReadonlyArray<GraphQLError>;
-
 /**
  * Utility function which asserts a schema is valid by throwing an error if
  * it is invalid.

--- a/src/utilities/TypeInfo.d.ts
+++ b/src/utilities/TypeInfo.d.ts
@@ -1,5 +1,4 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { ASTVisitor } from '../language/visitor';
 import type { ASTNode, FieldNode } from '../language/ast';
 import type { GraphQLSchema } from '../type/schema';
@@ -13,7 +12,6 @@ import type {
   GraphQLArgument,
   GraphQLEnumValue,
 } from '../type/definition';
-
 /**
  * TypeInfo is a utility class which, given a GraphQL schema, can keep track
  * of the current field and type definitions at any point in a GraphQL document
@@ -25,11 +23,9 @@ export class TypeInfo {
     // Initial type may be provided in rare cases to facilitate traversals
     // beginning somewhere other than documents.
     initialType?: GraphQLType,
-
     // @deprecated will be removed in 17.0.0
     getFieldDefFn?: getFieldDef,
   );
-
   getType(): Maybe<GraphQLOutputType>;
   getParentType(): Maybe<GraphQLCompositeType>;
   getInputType(): Maybe<GraphQLInputType>;
@@ -42,13 +38,11 @@ export class TypeInfo {
   enter(node: ASTNode): any;
   leave(node: ASTNode): any;
 }
-
 type getFieldDef = (
   schema: GraphQLSchema,
   parentType: GraphQLType,
   fieldNode: FieldNode,
 ) => Maybe<GraphQLField<unknown, unknown>>;
-
 /**
  * Creates a new visitor instance which maintains a provided TypeInfo instance
  * along with visiting visitor.

--- a/src/utilities/assertValidName.d.ts
+++ b/src/utilities/assertValidName.d.ts
@@ -1,10 +1,8 @@
 import type { GraphQLError } from '../error/GraphQLError';
-
 /**
  * Upholds the spec rules about naming.
  */
 export function assertValidName(name: string): string;
-
 /**
  * Returns an Error if a name is invalid.
  */

--- a/src/utilities/astFromValue.d.ts
+++ b/src/utilities/astFromValue.d.ts
@@ -1,8 +1,6 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { ValueNode } from '../language/ast';
 import type { GraphQLInputType } from '../type/definition';
-
 /**
  * Produces a GraphQL Value AST given a JavaScript value.
  *

--- a/src/utilities/buildASTSchema.d.ts
+++ b/src/utilities/buildASTSchema.d.ts
@@ -5,7 +5,6 @@ import type {
   GraphQLSchemaValidationOptions,
 } from '../type/schema';
 import type { ParseOptions } from '../language/parser';
-
 export interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
   /**
    * Set to true to assume the SDL is valid.
@@ -14,7 +13,6 @@ export interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
    */
   assumeValidSDL?: boolean;
 }
-
 /**
  * This takes the ast of a schema document produced by the parse function in
  * src/language/parser.js.
@@ -29,7 +27,6 @@ export function buildASTSchema(
   documentAST: DocumentNode,
   options?: BuildSchemaOptions,
 ): GraphQLSchema;
-
 /**
  * A helper function to build a GraphQLSchema directly from a source
  * document.

--- a/src/utilities/buildClientSchema.d.ts
+++ b/src/utilities/buildClientSchema.d.ts
@@ -2,9 +2,7 @@ import type {
   GraphQLSchema,
   GraphQLSchemaValidationOptions,
 } from '../type/schema';
-
 import type { IntrospectionQuery } from './getIntrospectionQuery';
-
 /**
  * Build a GraphQLSchema for use by client tools.
  *

--- a/src/utilities/coerceInputValue.d.ts
+++ b/src/utilities/coerceInputValue.d.ts
@@ -1,12 +1,10 @@
 import type { GraphQLInputType } from '../type/definition';
 import type { GraphQLError } from '../error/GraphQLError';
-
 type OnErrorCB = (
   path: ReadonlyArray<string | number>,
   invalidValue: unknown,
   error: GraphQLError,
 ) => void;
-
 /**
  * Coerces a JavaScript value given a GraphQL Input Type.
  */

--- a/src/utilities/concatAST.d.ts
+++ b/src/utilities/concatAST.d.ts
@@ -1,5 +1,4 @@
 import type { DocumentNode } from '../language/ast';
-
 /**
  * Provided a collection of ASTs, presumably each from different files,
  * concatenate the ASTs together into batched AST, useful for validating many

--- a/src/utilities/extendSchema.d.ts
+++ b/src/utilities/extendSchema.d.ts
@@ -4,7 +4,6 @@ import type {
   GraphQLSchema,
   GraphQLSchemaNormalizedConfig,
 } from '../type/schema';
-
 interface Options extends GraphQLSchemaValidationOptions {
   /**
    * Set to true to assume the SDL is valid.
@@ -13,7 +12,6 @@ interface Options extends GraphQLSchemaValidationOptions {
    */
   assumeValidSDL?: boolean;
 }
-
 /**
  * Produces a new schema given an existing schema and a document which may
  * contain GraphQL type extensions and definitions. The original schema will
@@ -31,7 +29,6 @@ export function extendSchema(
   documentAST: DocumentNode,
   options?: Options,
 ): GraphQLSchema;
-
 /**
  * @internal
  */

--- a/src/utilities/findBreakingChanges.d.ts
+++ b/src/utilities/findBreakingChanges.d.ts
@@ -1,5 +1,4 @@
 import type { GraphQLSchema } from '../type/schema';
-
 export const BreakingChangeType: {
   TYPE_REMOVED: 'TYPE_REMOVED';
   TYPE_CHANGED_KIND: 'TYPE_CHANGED_KIND';
@@ -18,7 +17,6 @@ export const BreakingChangeType: {
   DIRECTIVE_REPEATABLE_REMOVED: 'DIRECTIVE_REPEATABLE_REMOVED';
   DIRECTIVE_LOCATION_REMOVED: 'DIRECTIVE_LOCATION_REMOVED';
 };
-
 export const DangerousChangeType: {
   VALUE_ADDED_TO_ENUM: 'VALUE_ADDED_TO_ENUM';
   TYPE_ADDED_TO_UNION: 'TYPE_ADDED_TO_UNION';
@@ -27,17 +25,14 @@ export const DangerousChangeType: {
   IMPLEMENTED_INTERFACE_ADDED: 'IMPLEMENTED_INTERFACE_ADDED';
   ARG_DEFAULT_VALUE_CHANGE: 'ARG_DEFAULT_VALUE_CHANGE';
 };
-
 export interface BreakingChange {
   type: keyof typeof BreakingChangeType;
   description: string;
 }
-
 export interface DangerousChange {
   type: keyof typeof DangerousChangeType;
   description: string;
 }
-
 /**
  * Given two schemas, returns an Array containing descriptions of all the types
  * of breaking changes covered by the other functions down below.
@@ -46,7 +41,6 @@ export function findBreakingChanges(
   oldSchema: GraphQLSchema,
   newSchema: GraphQLSchema,
 ): Array<BreakingChange>;
-
 /**
  * Given two schemas, returns an Array containing descriptions of all the types
  * of potentially dangerous changes covered by the other functions down below.

--- a/src/utilities/getIntrospectionQuery.d.ts
+++ b/src/utilities/getIntrospectionQuery.d.ts
@@ -1,35 +1,26 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { DirectiveLocationEnum } from '../language/directiveLocation';
-
 export interface IntrospectionOptions {
   // Whether to include descriptions in the introspection result.
   // Default: true
   descriptions?: boolean;
-
   // Whether to include `specifiedByURL` in the introspection result.
   // Default: false
   specifiedByUrl?: boolean;
-
   // Whether to include `isRepeatable` flag on directives.
   // Default: false
   directiveIsRepeatable?: boolean;
-
   // Whether to include `description` field on schema.
   // Default: false
   schemaDescription?: boolean;
-
   // Whether target GraphQL server support deprecation of input values.
   // Default: false
   inputValueDeprecation?: boolean;
 }
-
 export function getIntrospectionQuery(options?: IntrospectionOptions): string;
-
 export interface IntrospectionQuery {
   readonly __schema: IntrospectionSchema;
 }
-
 export interface IntrospectionSchema {
   readonly description?: Maybe<string>;
   readonly queryType: IntrospectionNamedTypeRef<IntrospectionObjectType>;
@@ -42,7 +33,6 @@ export interface IntrospectionSchema {
   readonly types: ReadonlyArray<IntrospectionType>;
   readonly directives: ReadonlyArray<IntrospectionDirective>;
 }
-
 export type IntrospectionType =
   | IntrospectionScalarType
   | IntrospectionObjectType
@@ -50,26 +40,22 @@ export type IntrospectionType =
   | IntrospectionUnionType
   | IntrospectionEnumType
   | IntrospectionInputObjectType;
-
 export type IntrospectionOutputType =
   | IntrospectionScalarType
   | IntrospectionObjectType
   | IntrospectionInterfaceType
   | IntrospectionUnionType
   | IntrospectionEnumType;
-
 export type IntrospectionInputType =
   | IntrospectionScalarType
   | IntrospectionEnumType
   | IntrospectionInputObjectType;
-
 export interface IntrospectionScalarType {
   readonly kind: 'SCALAR';
   readonly name: string;
   readonly description?: Maybe<string>;
   readonly specifiedByURL?: Maybe<string>;
 }
-
 export interface IntrospectionObjectType {
   readonly kind: 'OBJECT';
   readonly name: string;
@@ -79,7 +65,6 @@ export interface IntrospectionObjectType {
     IntrospectionNamedTypeRef<IntrospectionInterfaceType>
   >;
 }
-
 export interface IntrospectionInterfaceType {
   readonly kind: 'INTERFACE';
   readonly name: string;
@@ -92,7 +77,6 @@ export interface IntrospectionInterfaceType {
     IntrospectionNamedTypeRef<IntrospectionObjectType>
   >;
 }
-
 export interface IntrospectionUnionType {
   readonly kind: 'UNION';
   readonly name: string;
@@ -101,42 +85,36 @@ export interface IntrospectionUnionType {
     IntrospectionNamedTypeRef<IntrospectionObjectType>
   >;
 }
-
 export interface IntrospectionEnumType {
   readonly kind: 'ENUM';
   readonly name: string;
   readonly description?: Maybe<string>;
   readonly enumValues: ReadonlyArray<IntrospectionEnumValue>;
 }
-
 export interface IntrospectionInputObjectType {
   readonly kind: 'INPUT_OBJECT';
   readonly name: string;
   readonly description?: Maybe<string>;
   readonly inputFields: ReadonlyArray<IntrospectionInputValue>;
 }
-
 export interface IntrospectionListTypeRef<
   T extends IntrospectionTypeRef = IntrospectionTypeRef,
 > {
   readonly kind: 'LIST';
   readonly ofType: T;
 }
-
 export interface IntrospectionNonNullTypeRef<
   T extends IntrospectionTypeRef = IntrospectionTypeRef,
 > {
   readonly kind: 'NON_NULL';
   readonly ofType: T;
 }
-
 export type IntrospectionTypeRef =
   | IntrospectionNamedTypeRef
   | IntrospectionListTypeRef
   | IntrospectionNonNullTypeRef<
       IntrospectionNamedTypeRef | IntrospectionListTypeRef
     >;
-
 export type IntrospectionOutputTypeRef =
   | IntrospectionNamedTypeRef<IntrospectionOutputType>
   | IntrospectionListTypeRef<IntrospectionOutputTypeRef>
@@ -144,7 +122,6 @@ export type IntrospectionOutputTypeRef =
       | IntrospectionNamedTypeRef<IntrospectionOutputType>
       | IntrospectionListTypeRef<IntrospectionOutputTypeRef>
     >;
-
 export type IntrospectionInputTypeRef =
   | IntrospectionNamedTypeRef<IntrospectionInputType>
   | IntrospectionListTypeRef<IntrospectionInputTypeRef>
@@ -152,14 +129,12 @@ export type IntrospectionInputTypeRef =
       | IntrospectionNamedTypeRef<IntrospectionInputType>
       | IntrospectionListTypeRef<IntrospectionInputTypeRef>
     >;
-
 export interface IntrospectionNamedTypeRef<
   T extends IntrospectionType = IntrospectionType,
 > {
   readonly kind: T['kind'];
   readonly name: string;
 }
-
 export interface IntrospectionField {
   readonly name: string;
   readonly description?: Maybe<string>;
@@ -168,7 +143,6 @@ export interface IntrospectionField {
   readonly isDeprecated: boolean;
   readonly deprecationReason: Maybe<string>;
 }
-
 export interface IntrospectionInputValue {
   readonly name: string;
   readonly description?: Maybe<string>;
@@ -177,14 +151,12 @@ export interface IntrospectionInputValue {
   readonly isDeprecated?: boolean;
   readonly deprecationReason?: Maybe<string>;
 }
-
 export interface IntrospectionEnumValue {
   readonly name: string;
   readonly description?: Maybe<string>;
   readonly isDeprecated: boolean;
   readonly deprecationReason: Maybe<string>;
 }
-
 export interface IntrospectionDirective {
   readonly name: string;
   readonly description?: Maybe<string>;

--- a/src/utilities/getOperationAST.d.ts
+++ b/src/utilities/getOperationAST.d.ts
@@ -1,7 +1,5 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { DocumentNode, OperationDefinitionNode } from '../language/ast';
-
 /**
  * Returns an operation AST given a document AST and optionally an operation
  * name. If a name is not provided, an operation is only returned if only one is

--- a/src/utilities/getOperationRootType.d.ts
+++ b/src/utilities/getOperationRootType.d.ts
@@ -4,7 +4,6 @@ import type {
 } from '../language/ast';
 import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLObjectType } from '../type/definition';
-
 /**
  * Extracts the root type of the operation from the schema.
  */

--- a/src/utilities/index.d.ts
+++ b/src/utilities/index.d.ts
@@ -25,78 +25,58 @@ export {
   IntrospectionEnumValue,
   IntrospectionDirective,
 } from './getIntrospectionQuery';
-
 // Gets the target Operation from a Document
 export { getOperationAST } from './getOperationAST';
-
 // Gets the Type for the target Operation AST.
 export { getOperationRootType } from './getOperationRootType';
-
 // Convert a GraphQLSchema to an IntrospectionQuery
 export { introspectionFromSchema } from './introspectionFromSchema';
-
 // Build a GraphQLSchema from an introspection result.
 export { buildClientSchema } from './buildClientSchema';
-
 // Build a GraphQLSchema from GraphQL Schema language.
 export {
   buildASTSchema,
   buildSchema,
   BuildSchemaOptions,
 } from './buildASTSchema';
-
 // Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
 export { extendSchema } from './extendSchema';
-
 // Sort a GraphQLSchema.
 export { lexicographicSortSchema } from './lexicographicSortSchema';
-
 // Print a GraphQLSchema to GraphQL Schema language.
 export {
   printSchema,
   printType,
   printIntrospectionSchema,
 } from './printSchema';
-
 // Create a GraphQLType from a GraphQL language AST.
 export { typeFromAST } from './typeFromAST';
-
 // Create a JavaScript value from a GraphQL language AST with a type.
 export { valueFromAST } from './valueFromAST';
-
 // Create a JavaScript value from a GraphQL language AST without a type.
 export { valueFromASTUntyped } from './valueFromASTUntyped';
-
 // Create a GraphQL language AST from a JavaScript value.
 export { astFromValue } from './astFromValue';
-
 // A helper to use within recursive-descent visitors which need to be aware of
 // the GraphQL type system.
 export { TypeInfo, visitWithTypeInfo } from './TypeInfo';
-
 // Coerces a JavaScript value to a GraphQL type, or produces errors.
 export { coerceInputValue } from './coerceInputValue';
-
 // Concatenates multiple AST together.
 export { concatAST } from './concatAST';
-
 // Separates an AST into an AST per Operation.
 export { separateOperations } from './separateOperations';
-
 // Strips characters that are not significant to the validity or execution
 // of a GraphQL document.
 export { stripIgnoredCharacters } from './stripIgnoredCharacters';
-
 // Comparators for types
 export {
   isEqualType,
   isTypeSubTypeOf,
   doTypesOverlap,
 } from './typeComparators';
-
 // Asserts that a string is a valid GraphQL name
 export { assertValidName, isValidNameError } from './assertValidName';
-
 // Compares two GraphQLSchemas and detects breaking changes.
 export {
   BreakingChangeType,
@@ -106,6 +86,5 @@ export {
   BreakingChange,
   DangerousChange,
 } from './findBreakingChanges';
-
 // Wrapper type that contains DocumentNode and types that can be deduced from it.
 export { TypedQueryDocumentNode } from './typedQueryDocumentNode';

--- a/src/utilities/introspectionFromSchema.d.ts
+++ b/src/utilities/introspectionFromSchema.d.ts
@@ -1,10 +1,8 @@
 import type { GraphQLSchema } from '../type/schema';
-
 import type {
   IntrospectionQuery,
   IntrospectionOptions,
 } from './getIntrospectionQuery';
-
 /**
  * Build an IntrospectionQuery from a GraphQLSchema
  *

--- a/src/utilities/lexicographicSortSchema.d.ts
+++ b/src/utilities/lexicographicSortSchema.d.ts
@@ -1,5 +1,4 @@
 import type { GraphQLSchema } from '../type/schema';
-
 /**
  * Sort GraphQLSchema.
  *

--- a/src/utilities/printSchema.d.ts
+++ b/src/utilities/printSchema.d.ts
@@ -1,8 +1,5 @@
 import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLNamedType } from '../type/definition';
-
 export function printSchema(schema: GraphQLSchema): string;
-
 export function printIntrospectionSchema(schema: GraphQLSchema): string;
-
 export function printType(type: GraphQLNamedType): string;

--- a/src/utilities/separateOperations.d.ts
+++ b/src/utilities/separateOperations.d.ts
@@ -1,6 +1,5 @@
 import type { ObjMap } from '../jsutils/ObjMap';
 import type { DocumentNode } from '../language/ast';
-
 /**
  * separateOperations accepts a single AST document which may contain many
  * operations and fragments and returns a collection of AST documents each of

--- a/src/utilities/stripIgnoredCharacters.d.ts
+++ b/src/utilities/stripIgnoredCharacters.d.ts
@@ -1,5 +1,4 @@
 import type { Source } from '../language/source';
-
 /**
  * Strips characters that are not significant to the validity or execution
  * of a GraphQL document:

--- a/src/utilities/typeComparators.d.ts
+++ b/src/utilities/typeComparators.d.ts
@@ -1,11 +1,9 @@
 import type { GraphQLSchema } from '../type/schema';
 import type { GraphQLType, GraphQLCompositeType } from '../type/definition';
-
 /**
  * Provided two types, return true if the types are equal (invariant).
  */
 export function isEqualType(typeA: GraphQLType, typeB: GraphQLType): boolean;
-
 /**
  * Provided a type and a super type, return true if the first type is either
  * equal or a subset of the second super type (covariant).
@@ -15,7 +13,6 @@ export function isTypeSubTypeOf(
   maybeSubType: GraphQLType,
   superType: GraphQLType,
 ): boolean;
-
 /**
  * Provided two composite types, determine if they "overlap". Two composite
  * types overlap when the Sets of possible concrete types for each intersect.

--- a/src/utilities/typeFromAST.d.ts
+++ b/src/utilities/typeFromAST.d.ts
@@ -9,7 +9,6 @@ import type {
   GraphQLList,
   GraphQLNonNull,
 } from '../type/definition';
-
 /**
  * Given a Schema and an AST node describing a type, return a GraphQLType
  * definition which applies to that type. For example, if provided the parsed
@@ -21,12 +20,10 @@ export function typeFromAST(
   schema: GraphQLSchema,
   typeNode: NamedTypeNode,
 ): GraphQLNamedType | undefined;
-
 export function typeFromAST(
   schema: GraphQLSchema,
   typeNode: ListTypeNode,
 ): GraphQLList<any> | undefined;
-
 export function typeFromAST(
   schema: GraphQLSchema,
   typeNode: NonNullTypeNode,

--- a/src/utilities/typedQueryDocumentNode.d.ts
+++ b/src/utilities/typedQueryDocumentNode.d.ts
@@ -1,5 +1,4 @@
 import type { DocumentNode, ExecutableDefinitionNode } from '../language/ast';
-
 /**
  * Wrapper type that contains DocumentNode and types that can be deduced from it.
  */

--- a/src/utilities/valueFromAST.d.ts
+++ b/src/utilities/valueFromAST.d.ts
@@ -1,9 +1,7 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
-
 import type { ValueNode } from '../language/ast';
 import type { GraphQLInputType } from '../type/definition';
-
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
  *

--- a/src/utilities/valueFromASTUntyped.d.ts
+++ b/src/utilities/valueFromASTUntyped.d.ts
@@ -1,8 +1,6 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
-
 import type { ValueNode } from '../language/ast';
-
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
  *

--- a/src/validation/ValidationContext.d.ts
+++ b/src/validation/ValidationContext.d.ts
@@ -1,5 +1,4 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { GraphQLError } from '../error/GraphQLError';
 import type { ASTVisitor } from '../language/visitor';
 import type {
@@ -21,14 +20,12 @@ import type {
   GraphQLEnumValue,
 } from '../type/definition';
 import type { TypeInfo } from '../utilities/TypeInfo';
-
 type NodeWithSelectionSet = OperationDefinitionNode | FragmentDefinitionNode;
 interface VariableUsage {
   readonly node: VariableNode;
   readonly type: Maybe<GraphQLInputType>;
   readonly defaultValue: Maybe<unknown>;
 }
-
 /**
  * An instance of this class is passed as the "this" context to all validators,
  * allowing access to commonly useful contextual information from within a
@@ -36,32 +33,23 @@ interface VariableUsage {
  */
 export class ASTValidationContext {
   constructor(ast: DocumentNode, onError: (error: GraphQLError) => void);
-
   reportError(error: GraphQLError): undefined;
-
   getDocument(): DocumentNode;
-
   getFragment(name: string): Maybe<FragmentDefinitionNode>;
-
   getFragmentSpreads(node: SelectionSetNode): ReadonlyArray<FragmentSpreadNode>;
-
   getRecursivelyReferencedFragments(
     operation: OperationDefinitionNode,
   ): ReadonlyArray<FragmentDefinitionNode>;
 }
-
 export class SDLValidationContext extends ASTValidationContext {
   constructor(
     ast: DocumentNode,
     schema: Maybe<GraphQLSchema>,
     onError: (error: GraphQLError) => void,
   );
-
   getSchema(): Maybe<GraphQLSchema>;
 }
-
 export type SDLValidationRule = (context: SDLValidationContext) => ASTVisitor;
-
 export class ValidationContext extends ASTValidationContext {
   constructor(
     schema: GraphQLSchema,
@@ -69,30 +57,18 @@ export class ValidationContext extends ASTValidationContext {
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
   );
-
   getSchema(): GraphQLSchema;
-
   getVariableUsages(node: NodeWithSelectionSet): ReadonlyArray<VariableUsage>;
-
   getRecursivelyReferencedFragments(
     operation: OperationDefinitionNode,
   ): ReadonlyArray<FragmentDefinitionNode>;
-
   getType(): Maybe<GraphQLOutputType>;
-
   getParentType(): Maybe<GraphQLCompositeType>;
-
   getInputType(): Maybe<GraphQLInputType>;
-
   getParentInputType(): Maybe<GraphQLInputType>;
-
   getFieldDef(): Maybe<GraphQLField<unknown, unknown>>;
-
   getDirective(): Maybe<GraphQLDirective>;
-
   getArgument(): Maybe<GraphQLArgument>;
-
   getEnumValue(): Maybe<GraphQLEnumValue>;
 }
-
 export type ValidationRule = (context: ValidationContext) => ASTVisitor;

--- a/src/validation/index.d.ts
+++ b/src/validation/index.d.ts
@@ -1,87 +1,58 @@
 export { validate } from './validate';
-
 export { ValidationContext, ValidationRule } from './ValidationContext';
-
 export { specifiedRules } from './specifiedRules';
-
 // Spec Section: "Executable Definitions"
 export { ExecutableDefinitionsRule } from './rules/ExecutableDefinitionsRule';
-
 // Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"
 export { FieldsOnCorrectTypeRule } from './rules/FieldsOnCorrectTypeRule';
-
 // Spec Section: "Fragments on Composite Types"
 export { FragmentsOnCompositeTypesRule } from './rules/FragmentsOnCompositeTypesRule';
-
 // Spec Section: "Argument Names"
 export { KnownArgumentNamesRule } from './rules/KnownArgumentNamesRule';
-
 // Spec Section: "Directives Are Defined"
 export { KnownDirectivesRule } from './rules/KnownDirectivesRule';
-
 // Spec Section: "Fragment spread target defined"
 export { KnownFragmentNamesRule } from './rules/KnownFragmentNamesRule';
-
 // Spec Section: "Fragment Spread Type Existence"
 export { KnownTypeNamesRule } from './rules/KnownTypeNamesRule';
-
 // Spec Section: "Lone Anonymous Operation"
 export { LoneAnonymousOperationRule } from './rules/LoneAnonymousOperationRule';
-
 // Spec Section: "Fragments must not form cycles"
 export { NoFragmentCyclesRule } from './rules/NoFragmentCyclesRule';
-
 // Spec Section: "All Variable Used Defined"
 export { NoUndefinedVariablesRule } from './rules/NoUndefinedVariablesRule';
-
 // Spec Section: "Fragments must be used"
 export { NoUnusedFragmentsRule } from './rules/NoUnusedFragmentsRule';
-
 // Spec Section: "All Variables Used"
 export { NoUnusedVariablesRule } from './rules/NoUnusedVariablesRule';
-
 // Spec Section: "Field Selection Merging"
 export { OverlappingFieldsCanBeMergedRule } from './rules/OverlappingFieldsCanBeMergedRule';
-
 // Spec Section: "Fragment spread is possible"
 export { PossibleFragmentSpreadsRule } from './rules/PossibleFragmentSpreadsRule';
-
 // Spec Section: "Argument Optionality"
 export { ProvidedRequiredArgumentsRule } from './rules/ProvidedRequiredArgumentsRule';
-
 // Spec Section: "Leaf Field Selections"
 export { ScalarLeafsRule } from './rules/ScalarLeafsRule';
-
 // Spec Section: "Subscriptions with Single Root Field"
 export { SingleFieldSubscriptionsRule } from './rules/SingleFieldSubscriptionsRule';
-
 // Spec Section: "Argument Uniqueness"
 export { UniqueArgumentNamesRule } from './rules/UniqueArgumentNamesRule';
-
 // Spec Section: "Directives Are Unique Per Location"
 export { UniqueDirectivesPerLocationRule } from './rules/UniqueDirectivesPerLocationRule';
-
 // Spec Section: "Fragment Name Uniqueness"
 export { UniqueFragmentNamesRule } from './rules/UniqueFragmentNamesRule';
-
 // Spec Section: "Input Object Field Uniqueness"
 export { UniqueInputFieldNamesRule } from './rules/UniqueInputFieldNamesRule';
-
 // Spec Section: "Operation Name Uniqueness"
 export { UniqueOperationNamesRule } from './rules/UniqueOperationNamesRule';
-
 // Spec Section: "Variable Uniqueness"
 export { UniqueVariableNamesRule } from './rules/UniqueVariableNamesRule';
-
 // Spec Section: "Values Type Correctness"
 export { ValuesOfCorrectTypeRule } from './rules/ValuesOfCorrectTypeRule';
-
 // Spec Section: "Variables are Input Types"
 export { VariablesAreInputTypesRule } from './rules/VariablesAreInputTypesRule';
-
 // Spec Section: "All Variable Usages Are Allowed"
 export { VariablesInAllowedPositionRule } from './rules/VariablesInAllowedPositionRule';
-
 // SDL-specific validation rules
 export { LoneSchemaDefinitionRule } from './rules/LoneSchemaDefinitionRule';
 export { UniqueOperationTypesRule } from './rules/UniqueOperationTypesRule';
@@ -90,7 +61,6 @@ export { UniqueEnumValueNamesRule } from './rules/UniqueEnumValueNamesRule';
 export { UniqueFieldDefinitionNamesRule } from './rules/UniqueFieldDefinitionNamesRule';
 export { UniqueDirectiveNamesRule } from './rules/UniqueDirectiveNamesRule';
 export { PossibleTypeExtensionsRule } from './rules/PossibleTypeExtensionsRule';
-
 // Optional rules not defined by the GraphQL Specification
 export { NoDeprecatedCustomRule } from './rules/custom/NoDeprecatedCustomRule';
 export { NoSchemaIntrospectionCustomRule } from './rules/custom/NoSchemaIntrospectionCustomRule';

--- a/src/validation/rules/ExecutableDefinitionsRule.d.ts
+++ b/src/validation/rules/ExecutableDefinitionsRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Executable definitions
  *

--- a/src/validation/rules/FieldsOnCorrectTypeRule.d.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Fields on correct type
  *

--- a/src/validation/rules/FragmentsOnCompositeTypesRule.d.ts
+++ b/src/validation/rules/FragmentsOnCompositeTypesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Fragments on composite type
  *

--- a/src/validation/rules/KnownArgumentNamesRule.d.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.d.ts
@@ -3,7 +3,6 @@ import type {
   SDLValidationContext,
 } from '../ValidationContext';
 import type { ASTVisitor } from '../../language/visitor';
-
 /**
  * Known argument names
  *
@@ -11,7 +10,6 @@ import type { ASTVisitor } from '../../language/visitor';
  * that field.
  */
 export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor;
-
 /**
  * @internal
  */

--- a/src/validation/rules/KnownDirectivesRule.d.ts
+++ b/src/validation/rules/KnownDirectivesRule.d.ts
@@ -3,7 +3,6 @@ import type {
   ValidationContext,
   SDLValidationContext,
 } from '../ValidationContext';
-
 /**
  * Known directives
  *

--- a/src/validation/rules/KnownFragmentNamesRule.d.ts
+++ b/src/validation/rules/KnownFragmentNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Known fragment names
  *

--- a/src/validation/rules/KnownTypeNamesRule.d.ts
+++ b/src/validation/rules/KnownTypeNamesRule.d.ts
@@ -3,7 +3,6 @@ import type {
   ValidationContext,
   SDLValidationContext,
 } from '../ValidationContext';
-
 /**
  * Known type names
  *

--- a/src/validation/rules/LoneAnonymousOperationRule.d.ts
+++ b/src/validation/rules/LoneAnonymousOperationRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Lone anonymous operation
  *

--- a/src/validation/rules/LoneSchemaDefinitionRule.d.ts
+++ b/src/validation/rules/LoneSchemaDefinitionRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Lone Schema definition
  *

--- a/src/validation/rules/NoFragmentCyclesRule.d.ts
+++ b/src/validation/rules/NoFragmentCyclesRule.d.ts
@@ -1,4 +1,3 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 export function NoFragmentCyclesRule(context: ValidationContext): ASTVisitor;

--- a/src/validation/rules/NoUndefinedVariablesRule.d.ts
+++ b/src/validation/rules/NoUndefinedVariablesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * No undefined variables
  *

--- a/src/validation/rules/NoUnusedFragmentsRule.d.ts
+++ b/src/validation/rules/NoUnusedFragmentsRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * No unused fragments
  *

--- a/src/validation/rules/NoUnusedVariablesRule.d.ts
+++ b/src/validation/rules/NoUnusedVariablesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * No unused variables
  *

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.d.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Overlapping fields can be merged
  *

--- a/src/validation/rules/PossibleFragmentSpreadsRule.d.ts
+++ b/src/validation/rules/PossibleFragmentSpreadsRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Possible fragment spread
  *

--- a/src/validation/rules/PossibleTypeExtensionsRule.d.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Possible type extension
  *

--- a/src/validation/rules/ProvidedRequiredArgumentsRule.d.ts
+++ b/src/validation/rules/ProvidedRequiredArgumentsRule.d.ts
@@ -3,7 +3,6 @@ import type {
   ValidationContext,
   SDLValidationContext,
 } from '../ValidationContext';
-
 /**
  * Provided required arguments
  *
@@ -13,7 +12,6 @@ import type {
 export function ProvidedRequiredArgumentsRule(
   context: ValidationContext,
 ): ASTVisitor;
-
 /**
  * @internal
  */

--- a/src/validation/rules/ScalarLeafsRule.d.ts
+++ b/src/validation/rules/ScalarLeafsRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Scalar leafs
  *

--- a/src/validation/rules/SingleFieldSubscriptionsRule.d.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Subscriptions must only include one field.
  *

--- a/src/validation/rules/UniqueArgumentNamesRule.d.ts
+++ b/src/validation/rules/UniqueArgumentNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Unique argument names
  *

--- a/src/validation/rules/UniqueDirectiveNamesRule.d.ts
+++ b/src/validation/rules/UniqueDirectiveNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Unique directive names
  *

--- a/src/validation/rules/UniqueDirectivesPerLocationRule.d.ts
+++ b/src/validation/rules/UniqueDirectivesPerLocationRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Unique directive names per location
  *

--- a/src/validation/rules/UniqueEnumValueNamesRule.d.ts
+++ b/src/validation/rules/UniqueEnumValueNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Unique enum value names
  *

--- a/src/validation/rules/UniqueFieldDefinitionNamesRule.d.ts
+++ b/src/validation/rules/UniqueFieldDefinitionNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Unique field definition names
  *

--- a/src/validation/rules/UniqueFragmentNamesRule.d.ts
+++ b/src/validation/rules/UniqueFragmentNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Unique fragment names
  *

--- a/src/validation/rules/UniqueInputFieldNamesRule.d.ts
+++ b/src/validation/rules/UniqueInputFieldNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Unique input field names
  *

--- a/src/validation/rules/UniqueOperationNamesRule.d.ts
+++ b/src/validation/rules/UniqueOperationNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Unique operation names
  *

--- a/src/validation/rules/UniqueOperationTypesRule.d.ts
+++ b/src/validation/rules/UniqueOperationTypesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Unique operation types
  *

--- a/src/validation/rules/UniqueTypeNamesRule.d.ts
+++ b/src/validation/rules/UniqueTypeNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { SDLValidationContext } from '../ValidationContext';
-
 /**
  * Unique type names
  *

--- a/src/validation/rules/UniqueVariableNamesRule.d.ts
+++ b/src/validation/rules/UniqueVariableNamesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ASTValidationContext } from '../ValidationContext';
-
 /**
  * Unique variable names
  *

--- a/src/validation/rules/ValuesOfCorrectTypeRule.d.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Value literals of correct type
  *

--- a/src/validation/rules/VariablesAreInputTypesRule.d.ts
+++ b/src/validation/rules/VariablesAreInputTypesRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Variables are input types
  *

--- a/src/validation/rules/VariablesInAllowedPositionRule.d.ts
+++ b/src/validation/rules/VariablesInAllowedPositionRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../language/visitor';
 import type { ValidationContext } from '../ValidationContext';
-
 /**
  * Variables passed to field arguments conform to type
  */

--- a/src/validation/rules/custom/NoDeprecatedCustomRule.d.ts
+++ b/src/validation/rules/custom/NoDeprecatedCustomRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../../language/visitor';
 import type { ValidationContext } from '../../ValidationContext';
-
 /**
  * No deprecated
  *

--- a/src/validation/rules/custom/NoSchemaIntrospectionCustomRule.d.ts
+++ b/src/validation/rules/custom/NoSchemaIntrospectionCustomRule.d.ts
@@ -1,6 +1,5 @@
 import type { ASTVisitor } from '../../../language/visitor';
 import type { ValidationContext } from '../../ValidationContext';
-
 /**
  * Prohibit introspection queries
  *

--- a/src/validation/specifiedRules.d.ts
+++ b/src/validation/specifiedRules.d.ts
@@ -1,5 +1,4 @@
 import type { ValidationRule, SDLValidationRule } from './ValidationContext';
-
 /**
  * This set includes all validation rules defined by the GraphQL spec.
  *
@@ -7,7 +6,6 @@ import type { ValidationRule, SDLValidationRule } from './ValidationContext';
  * most clear output when encountering multiple validation errors.
  */
 export const specifiedRules: ReadonlyArray<ValidationRule>;
-
 /**
  * @internal
  */

--- a/src/validation/validate.d.ts
+++ b/src/validation/validate.d.ts
@@ -1,15 +1,9 @@
 import type { Maybe } from '../jsutils/Maybe';
-
 import type { GraphQLError } from '../error/GraphQLError';
-
 import type { DocumentNode } from '../language/ast';
-
 import type { GraphQLSchema } from '../type/schema';
-
 import type { TypeInfo } from '../utilities/TypeInfo';
-
 import type { ValidationRule, SDLValidationRule } from './ValidationContext';
-
 /**
  * Implements the "Validation" section of the spec.
  *
@@ -31,11 +25,9 @@ export function validate(
   documentAST: DocumentNode,
   rules?: ReadonlyArray<ValidationRule>,
   options?: { maxErrors?: number },
-
   // @deprecate will be removed in 17.0.0
   typeInfo?: TypeInfo,
 ): ReadonlyArray<GraphQLError>;
-
 /**
  * @internal
  */
@@ -44,7 +36,6 @@ export function validateSDL(
   schemaToExtend?: Maybe<GraphQLSchema>,
   rules?: ReadonlyArray<SDLValidationRule>,
 ): Readonly<GraphQLError>;
-
 /**
  * Utility function which asserts a SDL document is valid by throwing an error
  * if it is invalid.
@@ -52,7 +43,6 @@ export function validateSDL(
  * @internal
  */
 export function assertValidSDL(documentAST: DocumentNode): void;
-
 /**
  * Utility function which asserts a SDL document is valid by throwing an error
  * if it is invalid.

--- a/src/version.d.ts
+++ b/src/version.d.ts
@@ -2,7 +2,6 @@
  * A string containing the version of the GraphQL.js library
  */
 export const version: string;
-
 /**
  * An object containing the components of the GraphQL.js version string
  */


### PR DESCRIPTION
We will remove those files anyway after TS migration
but it makes easier to diff generated and handwritten files