### PR TITLE
`*.d.ts`: Switch comments to comment to TSDoc

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -22,13 +22,13 @@
  *     import { parse } from 'graphql';
  *     import { parse } from 'graphql/language';
  */
-// The GraphQL.js version info.
+/** The GraphQL.js version info. */
 export { version, versionInfo } from './version';
-// The primary entry point into fulfilling a GraphQL request.
+/** The primary entry point into fulfilling a GraphQL request. */
 export { GraphQLArgs, graphql, graphqlSync } from './graphql';
-// Create and operate on GraphQL type definitions and schema.
+/** Create and operate on GraphQL type definitions and schema. */
 export {
-  // Definitions
+  /** Definitions */
   GraphQLSchema,
   GraphQLDirective,
   GraphQLScalarType,
@@ -39,24 +39,24 @@ export {
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
-  // Standard GraphQL Scalars
+  /** Standard GraphQL Scalars */
   specifiedScalarTypes,
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
-  // Built-in Directives defined by the Spec
+  /** Built-in Directives defined by the Spec */
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
-  // "Enum" of Type Kinds
+  /** "Enum" of Type Kinds */
   TypeKind,
-  // Constant Deprecation Reason
+  /** Constant Deprecation Reason */
   DEFAULT_DEPRECATION_REASON,
-  // GraphQL Types for introspection.
+  /** GraphQL Types for introspection. */
   introspectionTypes,
   __Schema,
   __Directive,
@@ -66,11 +66,11 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-  // Meta-field definitions.
+  /** Meta-field definitions. */
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
-  // Predicates
+  /** Predicates */
   isSchema,
   isDirective,
   isType,
@@ -95,7 +95,7 @@ export {
   isSpecifiedScalarType,
   isIntrospectionType,
   isSpecifiedDirective,
-  // Assertions
+  /** Assertions */
   assertSchema,
   assertDirective,
   assertType,
@@ -115,10 +115,10 @@ export {
   assertWrappingType,
   assertNullableType,
   assertNamedType,
-  // Un-modifiers
+  /** Un-modifiers */
   getNullableType,
   getNamedType,
-  // Validate GraphQL schema.
+  /** Validate GraphQL schema. */
   validateSchema,
   assertValidSchema,
 } from './type/index';
@@ -179,33 +179,33 @@ export {
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
 } from './type/index';
-// Parse and operate on GraphQL language source files.
+/** Parse and operate on GraphQL language source files. */
 export {
   Token,
   Source,
   Location,
   getLocation,
-  // Print source location
+  /** Print source location */
   printLocation,
   printSourceLocation,
-  // Lex
+  /** Lex */
   Lexer,
   TokenKind,
-  // Parse
+  /** Parse */
   parse,
   parseValue,
   parseConstValue,
   parseType,
-  // Print
+  /** Print */
   print,
-  // Visit
+  /** Visit */
   visit,
   visitInParallel,
   getVisitFn,
   BREAK,
   Kind,
   DirectiveLocation,
-  // Predicates
+  /** Predicates */
   isDefinitionNode,
   isExecutableDefinitionNode,
   isSelectionNode,
@@ -223,13 +223,13 @@ export {
   TokenKindEnum,
   KindEnum,
   DirectiveLocationEnum,
-  // Visitor utilities
+  /** Visitor utilities */
   ASTVisitor,
   ASTVisitFn,
-  // AST nodes
+  /** AST nodes */
   ASTNode,
   ASTKindToNode,
-  // Each kind of AST node
+  /** Each kind of AST node */
   NameNode,
   DocumentNode,
   DefinitionNode,
@@ -290,7 +290,7 @@ export {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
 } from './language/index';
-// Execute GraphQL queries.
+/** Execute GraphQL queries. */
 export {
   execute,
   executeSync,
@@ -307,13 +307,13 @@ export {
   createSourceEventStream,
   SubscriptionArgs,
 } from './subscription/index';
-// Validate GraphQL documents.
+/** Validate GraphQL documents. */
 export {
   validate,
   ValidationContext,
-  // All validation rules in the GraphQL Specification.
+  /** All validation rules in the GraphQL Specification. */
   specifiedRules,
-  // Individual validation rules.
+  /** Individual validation rules. */
   ExecutableDefinitionsRule,
   FieldsOnCorrectTypeRule,
   FragmentsOnCompositeTypesRule,
@@ -340,7 +340,7 @@ export {
   ValuesOfCorrectTypeRule,
   VariablesAreInputTypesRule,
   VariablesInAllowedPositionRule,
-  // SDL-specific validation rules
+  /** SDL-specific validation rules */
   LoneSchemaDefinitionRule,
   UniqueOperationTypesRule,
   UniqueTypeNamesRule,
@@ -348,12 +348,12 @@ export {
   UniqueFieldDefinitionNamesRule,
   UniqueDirectiveNamesRule,
   PossibleTypeExtensionsRule,
-  // Custom validation rules
+  /** Custom validation rules */
   NoDeprecatedCustomRule,
   NoSchemaIntrospectionCustomRule,
   ValidationRule,
 } from './validation/index';
-// Create, format, and print GraphQL errors.
+/** Create, format, and print GraphQL errors. */
 export {
   GraphQLError,
   syntaxError,
@@ -362,65 +362,63 @@ export {
   formatError,
   GraphQLFormattedError,
 } from './error/index';
-// Utilities for operating on GraphQL type schema and parsed sources.
+/** Utilities for operating on GraphQL type schema and parsed sources. */
 export {
-  // Produce the GraphQL query recommended for a full schema introspection.
-  // Accepts optional IntrospectionOptions.
+  /**
+   * Produce the GraphQL query recommended for a full schema introspection.
+   * Accepts optional IntrospectionOptions.
+   */
   getIntrospectionQuery,
-  // Gets the target Operation from a Document.
+  /** Gets the target Operation from a Document. */
   getOperationAST,
-  // Gets the Type for the target Operation AST.
+  /** Gets the Type for the target Operation AST. */
   getOperationRootType,
-  // Convert a GraphQLSchema to an IntrospectionQuery.
+  /** Convert a GraphQLSchema to an IntrospectionQuery. */
   introspectionFromSchema,
-  // Build a GraphQLSchema from an introspection result.
+  /** Build a GraphQLSchema from an introspection result. */
   buildClientSchema,
-  // Build a GraphQLSchema from a parsed GraphQL Schema language AST.
+  /** Build a GraphQLSchema from a parsed GraphQL Schema language AST. */
   buildASTSchema,
-  // Build a GraphQLSchema from a GraphQL schema language document.
+  /** Build a GraphQLSchema from a GraphQL schema language document. */
   buildSchema,
-  // Extends an existing GraphQLSchema from a parsed GraphQL Schema
-  // language AST.
+  /** Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST. */
   extendSchema,
-  // Sort a GraphQLSchema.
+  /** Sort a GraphQLSchema. */
   lexicographicSortSchema,
-  // Print a GraphQLSchema to GraphQL Schema language.
+  /** Print a GraphQLSchema to GraphQL Schema language. */
   printSchema,
-  // Print a GraphQLType to GraphQL Schema language.
+  /** Print a GraphQLType to GraphQL Schema language. */
   printType,
-  // Prints the built-in introspection schema in the Schema Language
-  // format.
+  /** Prints the built-in introspection schema in the Schema Language format. */
   printIntrospectionSchema,
-  // Create a GraphQLType from a GraphQL language AST.
+  /** Create a GraphQLType from a GraphQL language AST. */
   typeFromAST,
-  // Create a JavaScript value from a GraphQL language AST with a Type.
+  /** Create a JavaScript value from a GraphQL language AST with a Type. */
   valueFromAST,
-  // Create a JavaScript value from a GraphQL language AST without a Type.
+  /** Create a JavaScript value from a GraphQL language AST without a Type. */
   valueFromASTUntyped,
-  // Create a GraphQL language AST from a JavaScript value.
+  /** Create a GraphQL language AST from a JavaScript value. */
   astFromValue,
-  // A helper to use within recursive-descent visitors which need to be aware of
-  // the GraphQL type system.
+  /** A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system. */
   TypeInfo,
   visitWithTypeInfo,
-  // Coerces a JavaScript value to a GraphQL type, or produces errors.
+  /** Coerces a JavaScript value to a GraphQL type, or produces errors. */
   coerceInputValue,
-  // Concatenates multiple AST together.
+  /** Concatenates multiple AST together. */
   concatAST,
-  // Separates an AST into an AST per Operation.
+  /** Separates an AST into an AST per Operation. */
   separateOperations,
-  // Strips characters that are not significant to the validity or execution
-  // of a GraphQL document.
+  /** Strips characters that are not significant to the validity or execution of a GraphQL document. */
   stripIgnoredCharacters,
-  // Comparators for types
+  /** Comparators for types */
   isEqualType,
   isTypeSubTypeOf,
   doTypesOverlap,
-  // Asserts a string is a valid GraphQL name.
+  /** Asserts a string is a valid GraphQL name. */
   assertValidName,
-  // Determine if a string is a valid GraphQL name.
+  /** Determine if a string is a valid GraphQL name. */
   isValidNameError,
-  // Compares two GraphQLSchemas and detects breaking changes.
+  /** Compares two GraphQLSchemas and detects breaking changes. */
   BreakingChangeType,
   DangerousChangeType,
   findBreakingChanges,

--- a/src/index.js
+++ b/src/index.js
@@ -22,16 +22,16 @@
  *     import { parse } from 'graphql/language';
  */
 
-// The GraphQL.js version info.
+/** The GraphQL.js version info. */
 export { version, versionInfo } from './version';
 
-// The primary entry point into fulfilling a GraphQL request.
+/** The primary entry point into fulfilling a GraphQL request. */
 export type { GraphQLArgs } from './graphql';
 export { graphql, graphqlSync } from './graphql';
 
-// Create and operate on GraphQL type definitions and schema.
+/** Create and operate on GraphQL type definitions and schema. */
 export {
-  // Definitions
+  /** Definitions */
   GraphQLSchema,
   GraphQLDirective,
   GraphQLScalarType,
@@ -42,24 +42,24 @@ export {
   GraphQLInputObjectType,
   GraphQLList,
   GraphQLNonNull,
-  // Standard GraphQL Scalars
+  /** Standard GraphQL Scalars */
   specifiedScalarTypes,
   GraphQLInt,
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
-  // Built-in Directives defined by the Spec
+  /** Built-in Directives defined by the Spec */
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
-  // "Enum" of Type Kinds
+  /** "Enum" of Type Kinds */
   TypeKind,
-  // Constant Deprecation Reason
+  /** Constant Deprecation Reason */
   DEFAULT_DEPRECATION_REASON,
-  // GraphQL Types for introspection.
+  /** GraphQL Types for introspection. */
   introspectionTypes,
   __Schema,
   __Directive,
@@ -69,11 +69,11 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-  // Meta-field definitions.
+  /** Meta-field definitions. */
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
-  // Predicates
+  /** Predicates */
   isSchema,
   isDirective,
   isType,
@@ -98,7 +98,7 @@ export {
   isSpecifiedScalarType,
   isIntrospectionType,
   isSpecifiedDirective,
-  // Assertions
+  /** Assertions */
   assertSchema,
   assertDirective,
   assertType,
@@ -118,10 +118,10 @@ export {
   assertWrappingType,
   assertNullableType,
   assertNamedType,
-  // Un-modifiers
+  /** Un-modifiers */
   getNullableType,
   getNamedType,
-  // Validate GraphQL schema.
+  /** Validate GraphQL schema. */
   validateSchema,
   assertValidSchema,
 } from './type/index';
@@ -172,33 +172,33 @@ export type {
   GraphQLScalarLiteralParser,
 } from './type/index';
 
-// Parse and operate on GraphQL language source files.
+/** Parse and operate on GraphQL language source files. */
 export {
   Token,
   Source,
   Location,
   getLocation,
-  // Print source location
+  /** Print source location */
   printLocation,
   printSourceLocation,
-  // Lex
+  /** Lex */
   Lexer,
   TokenKind,
-  // Parse
+  /** Parse */
   parse,
   parseValue,
   parseConstValue,
   parseType,
-  // Print
+  /** Print */
   print,
-  // Visit
+  /** Visit */
   visit,
   visitInParallel,
   getVisitFn,
   BREAK,
   Kind,
   DirectiveLocation,
-  // Predicates
+  /** Predicates */
   isDefinitionNode,
   isExecutableDefinitionNode,
   isSelectionNode,
@@ -217,13 +217,13 @@ export type {
   TokenKindEnum,
   KindEnum,
   DirectiveLocationEnum,
-  // Visitor utilities
+  /** Visitor utilities */
   ASTVisitor,
   ASTVisitFn,
-  // AST nodes
+  /** AST nodes */
   ASTNode,
   ASTKindToNode,
-  // Each kind of AST node
+  /** Each kind of AST node */
   NameNode,
   DocumentNode,
   DefinitionNode,
@@ -285,7 +285,7 @@ export type {
   InputObjectTypeExtensionNode,
 } from './language/index';
 
-// Execute GraphQL queries.
+/** Execute GraphQL queries. */
 export {
   execute,
   executeSync,
@@ -304,13 +304,13 @@ export type {
 export { subscribe, createSourceEventStream } from './subscription/index';
 export type { SubscriptionArgs } from './subscription/index';
 
-// Validate GraphQL documents.
+/** Validate GraphQL documents. */
 export {
   validate,
   ValidationContext,
-  // All validation rules in the GraphQL Specification.
+  /** All validation rules in the GraphQL Specification. */
   specifiedRules,
-  // Individual validation rules.
+  /** Individual validation rules. */
   ExecutableDefinitionsRule,
   FieldsOnCorrectTypeRule,
   FragmentsOnCompositeTypesRule,
@@ -337,7 +337,7 @@ export {
   ValuesOfCorrectTypeRule,
   VariablesAreInputTypesRule,
   VariablesInAllowedPositionRule,
-  // SDL-specific validation rules
+  /** SDL-specific validation rules */
   LoneSchemaDefinitionRule,
   UniqueOperationTypesRule,
   UniqueTypeNamesRule,
@@ -345,14 +345,14 @@ export {
   UniqueFieldDefinitionNamesRule,
   UniqueDirectiveNamesRule,
   PossibleTypeExtensionsRule,
-  // Custom validation rules
+  /** Custom validation rules */
   NoDeprecatedCustomRule,
   NoSchemaIntrospectionCustomRule,
 } from './validation/index';
 
 export type { ValidationRule } from './validation/index';
 
-// Create, format, and print GraphQL errors.
+/** Create, format, and print GraphQL errors. */
 export {
   GraphQLError,
   syntaxError,
@@ -363,65 +363,63 @@ export {
 
 export type { GraphQLFormattedError } from './error/index';
 
-// Utilities for operating on GraphQL type schema and parsed sources.
+/** Utilities for operating on GraphQL type schema and parsed sources. */
 export {
-  // Produce the GraphQL query recommended for a full schema introspection.
-  // Accepts optional IntrospectionOptions.
+  /**
+   * Produce the GraphQL query recommended for a full schema introspection.
+   * Accepts optional IntrospectionOptions.
+   */
   getIntrospectionQuery,
-  // Gets the target Operation from a Document.
+  /** Gets the target Operation from a Document. */
   getOperationAST,
-  // Gets the Type for the target Operation AST.
+  /** Gets the Type for the target Operation AST. */
   getOperationRootType,
-  // Convert a GraphQLSchema to an IntrospectionQuery.
+  /** Convert a GraphQLSchema to an IntrospectionQuery. */
   introspectionFromSchema,
-  // Build a GraphQLSchema from an introspection result.
+  /** Build a GraphQLSchema from an introspection result. */
   buildClientSchema,
-  // Build a GraphQLSchema from a parsed GraphQL Schema language AST.
+  /** Build a GraphQLSchema from a parsed GraphQL Schema language AST. */
   buildASTSchema,
-  // Build a GraphQLSchema from a GraphQL schema language document.
+  /** Build a GraphQLSchema from a GraphQL schema language document. */
   buildSchema,
-  // Extends an existing GraphQLSchema from a parsed GraphQL Schema
-  // language AST.
+  /** Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST. */
   extendSchema,
-  // Sort a GraphQLSchema.
+  /** Sort a GraphQLSchema. */
   lexicographicSortSchema,
-  // Print a GraphQLSchema to GraphQL Schema language.
+  /** Print a GraphQLSchema to GraphQL Schema language. */
   printSchema,
-  // Print a GraphQLType to GraphQL Schema language.
+  /** Print a GraphQLType to GraphQL Schema language. */
   printType,
-  // Prints the built-in introspection schema in the Schema Language
-  // format.
+  /** Prints the built-in introspection schema in the Schema Language format. */
   printIntrospectionSchema,
-  // Create a GraphQLType from a GraphQL language AST.
+  /** Create a GraphQLType from a GraphQL language AST. */
   typeFromAST,
-  // Create a JavaScript value from a GraphQL language AST with a Type.
+  /** Create a JavaScript value from a GraphQL language AST with a Type. */
   valueFromAST,
-  // Create a JavaScript value from a GraphQL language AST without a Type.
+  /** Create a JavaScript value from a GraphQL language AST without a Type. */
   valueFromASTUntyped,
-  // Create a GraphQL language AST from a JavaScript value.
+  /** Create a GraphQL language AST from a JavaScript value. */
   astFromValue,
-  // A helper to use within recursive-descent visitors which need to be aware of
-  // the GraphQL type system.
+  /** A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system. */
   TypeInfo,
   visitWithTypeInfo,
-  // Coerces a JavaScript value to a GraphQL type, or produces errors.
+  /** Coerces a JavaScript value to a GraphQL type, or produces errors. */
   coerceInputValue,
-  // Concatenates multiple AST together.
+  /** Concatenates multiple AST together. */
   concatAST,
-  // Separates an AST into an AST per Operation.
+  /** Separates an AST into an AST per Operation. */
   separateOperations,
-  // Strips characters that are not significant to the validity or execution
-  // of a GraphQL document.
+  /** Strips characters that are not significant to the validity or execution of a GraphQL document. */
   stripIgnoredCharacters,
-  // Comparators for types
+  /** Comparators for types */
   isEqualType,
   isTypeSubTypeOf,
   doTypesOverlap,
-  // Asserts a string is a valid GraphQL name.
+  /** Asserts a string is a valid GraphQL name. */
   assertValidName,
-  // Determine if a string is a valid GraphQL name.
+  /** Determine if a string is a valid GraphQL name. */
   isValidNameError,
-  // Compares two GraphQLSchemas and detects breaking changes.
+  /** Compares two GraphQLSchemas and detects breaking changes. */
   BreakingChangeType,
   DangerousChangeType,
   findBreakingChanges,

--- a/src/jsutils/Maybe.d.ts
+++ b/src/jsutils/Maybe.d.ts
@@ -1,2 +1,2 @@
-// Conveniently represents flow's "Maybe" type https://flow.org/en/docs/types/maybe/
+/** Conveniently represents flow's "Maybe" type https://flow.org/en/docs/types/maybe/ */
 export type Maybe<T> = null | undefined | T;

--- a/src/language/ast.d.ts
+++ b/src/language/ast.d.ts
@@ -179,13 +179,13 @@ export interface ASTKindToNode {
   EnumTypeExtension: EnumTypeExtensionNode;
   InputObjectTypeExtension: InputObjectTypeExtensionNode;
 }
-// Name
+/** Name */
 export interface NameNode {
   readonly kind: 'Name';
   readonly loc?: Location;
   readonly value: string;
 }
-// Document
+/** Document */
 export interface DocumentNode {
   readonly kind: 'Document';
   readonly loc?: Location;
@@ -248,7 +248,7 @@ export interface ConstArgumentNode {
   readonly name: NameNode;
   readonly value: ConstValueNode;
 }
-// Fragments
+/** Fragments */
 export interface FragmentSpreadNode {
   readonly kind: 'FragmentSpread';
   readonly loc?: Location;
@@ -266,13 +266,13 @@ export interface FragmentDefinitionNode {
   readonly kind: 'FragmentDefinition';
   readonly loc?: Location;
   readonly name: NameNode;
-  // Note: fragment variable definitions are deprecated and will removed in v17.0.0
+  /** @deprecated variableDefinitions will be removed in v17.0.0 */
   readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
   readonly typeCondition: NamedTypeNode;
   readonly directives?: ReadonlyArray<DirectiveNode>;
   readonly selectionSet: SelectionSetNode;
 }
-// Values
+/** Values */
 export type ValueNode =
   | VariableNode
   | IntValueNode
@@ -354,7 +354,7 @@ export interface ConstObjectFieldNode {
   readonly name: NameNode;
   readonly value: ConstValueNode;
 }
-// Directives
+/** Directives */
 export interface DirectiveNode {
   readonly kind: 'Directive';
   readonly loc?: Location;
@@ -367,7 +367,7 @@ export interface ConstDirectiveNode {
   readonly name: NameNode;
   readonly arguments?: ReadonlyArray<ConstArgumentNode>;
 }
-// Type Reference
+/** Type Reference */
 export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
 export interface NamedTypeNode {
   readonly kind: 'NamedType';
@@ -384,7 +384,7 @@ export interface NonNullTypeNode {
   readonly loc?: Location;
   readonly type: NamedTypeNode | ListTypeNode;
 }
-// Type System Definition
+/** Type System Definition */
 export type TypeSystemDefinitionNode =
   | SchemaDefinitionNode
   | TypeDefinitionNode
@@ -402,7 +402,7 @@ export interface OperationTypeDefinitionNode {
   readonly operation: OperationTypeNode;
   readonly type: NamedTypeNode;
 }
-// Type Definition
+/** Type Definition */
 export type TypeDefinitionNode =
   | ScalarTypeDefinitionNode
   | ObjectTypeDefinitionNode
@@ -484,7 +484,7 @@ export interface InputObjectTypeDefinitionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
 }
-// Directive Definitions
+/** Directive Definitions */
 export interface DirectiveDefinitionNode {
   readonly kind: 'DirectiveDefinition';
   readonly loc?: Location;
@@ -494,7 +494,7 @@ export interface DirectiveDefinitionNode {
   readonly repeatable: boolean;
   readonly locations: ReadonlyArray<NameNode>;
 }
-// Type System Extensions
+/** Type System Extensions */
 export type TypeSystemExtensionNode = SchemaExtensionNode | TypeExtensionNode;
 export interface SchemaExtensionNode {
   readonly kind: 'SchemaExtension';
@@ -502,7 +502,7 @@ export interface SchemaExtensionNode {
   readonly directives?: ReadonlyArray<ConstDirectiveNode>;
   readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
 }
-// Type Extensions
+/** Type Extensions */
 export type TypeExtensionNode =
   | ScalarTypeExtensionNode
   | ObjectTypeExtensionNode

--- a/src/language/ast.js
+++ b/src/language/ast.js
@@ -225,7 +225,7 @@ export type ASTKindToNode = {
   InputObjectTypeExtension: InputObjectTypeExtensionNode,
 };
 
-// Name
+/** Name */
 
 export type NameNode = {
   +kind: 'Name',
@@ -233,7 +233,7 @@ export type NameNode = {
   +value: string,
 };
 
-// Document
+/** Document */
 
 export type DocumentNode = {
   +kind: 'Document',
@@ -309,7 +309,7 @@ export type ConstArgumentNode = {
   +value: ConstValueNode,
 };
 
-// Fragments
+/** Fragments */
 
 export type FragmentSpreadNode = {
   +kind: 'FragmentSpread',
@@ -330,14 +330,14 @@ export type FragmentDefinitionNode = {
   +kind: 'FragmentDefinition',
   +loc?: Location,
   +name: NameNode,
-  // Note: fragment variable definitions are deprecated and will removed in v17.0.0
+  /** @deprecated variableDefinitions will be removed in v17.0.0 */
   +variableDefinitions?: $ReadOnlyArray<VariableDefinitionNode>,
   +typeCondition: NamedTypeNode,
   +directives?: $ReadOnlyArray<DirectiveNode>,
   +selectionSet: SelectionSetNode,
 };
 
-// Values
+/** Values */
 
 export type ValueNode =
   | VariableNode
@@ -434,7 +434,7 @@ export type ConstObjectFieldNode = {
   +value: ConstValueNode,
 };
 
-// Directives
+/** Directives */
 
 export type DirectiveNode = {
   +kind: 'Directive',
@@ -450,7 +450,7 @@ export type ConstDirectiveNode = {
   +arguments?: $ReadOnlyArray<ConstArgumentNode>,
 };
 
-// Type Reference
+/** Type Reference */
 
 export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
 
@@ -472,7 +472,7 @@ export type NonNullTypeNode = {
   +type: NamedTypeNode | ListTypeNode,
 };
 
-// Type System Definition
+/** Type System Definition */
 
 export type TypeSystemDefinitionNode =
   | SchemaDefinitionNode
@@ -494,7 +494,7 @@ export type OperationTypeDefinitionNode = {
   +type: NamedTypeNode,
 };
 
-// Type Definition
+/** Type Definition */
 
 export type TypeDefinitionNode =
   | ScalarTypeDefinitionNode
@@ -587,7 +587,7 @@ export type InputObjectTypeDefinitionNode = {
   +fields?: $ReadOnlyArray<InputValueDefinitionNode>,
 };
 
-// Directive Definitions
+/** Directive Definitions */
 
 export type DirectiveDefinitionNode = {
   +kind: 'DirectiveDefinition',
@@ -599,7 +599,7 @@ export type DirectiveDefinitionNode = {
   +locations: $ReadOnlyArray<NameNode>,
 };
 
-// Type System Extensions
+/** Type System Extensions */
 
 export type TypeSystemExtensionNode = SchemaExtensionNode | TypeExtensionNode;
 
@@ -610,7 +610,7 @@ export type SchemaExtensionNode = {
   +operationTypes?: $ReadOnlyArray<OperationTypeDefinitionNode>,
 };
 
-// Type Extensions
+/** Type Extensions */
 
 export type TypeExtensionNode =
   | ScalarTypeExtensionNode

--- a/src/language/directiveLocation.d.ts
+++ b/src/language/directiveLocation.d.ts
@@ -2,7 +2,7 @@
  * The set of allowed directive location values.
  */
 export const DirectiveLocation: Readonly<{
-  // Request Definitions
+  /** Request Definitions */
   QUERY: 'QUERY';
   MUTATION: 'MUTATION';
   SUBSCRIPTION: 'SUBSCRIPTION';
@@ -11,7 +11,7 @@ export const DirectiveLocation: Readonly<{
   FRAGMENT_SPREAD: 'FRAGMENT_SPREAD';
   INLINE_FRAGMENT: 'INLINE_FRAGMENT';
   VARIABLE_DEFINITION: 'VARIABLE_DEFINITION';
-  // Type System Definitions
+  /** Type System Definitions */
   SCHEMA: 'SCHEMA';
   SCALAR: 'SCALAR';
   OBJECT: 'OBJECT';

--- a/src/language/directiveLocation.js
+++ b/src/language/directiveLocation.js
@@ -2,7 +2,7 @@
  * The set of allowed directive location values.
  */
 export const DirectiveLocation = Object.freeze({
-  // Request Definitions
+  /** Request Definitions */
   QUERY: 'QUERY',
   MUTATION: 'MUTATION',
   SUBSCRIPTION: 'SUBSCRIPTION',
@@ -11,7 +11,7 @@ export const DirectiveLocation = Object.freeze({
   FRAGMENT_SPREAD: 'FRAGMENT_SPREAD',
   INLINE_FRAGMENT: 'INLINE_FRAGMENT',
   VARIABLE_DEFINITION: 'VARIABLE_DEFINITION',
-  // Type System Definitions
+  /** Type System Definitions */
   SCHEMA: 'SCHEMA',
   SCALAR: 'SCALAR',
   OBJECT: 'OBJECT',

--- a/src/language/index.d.ts
+++ b/src/language/index.d.ts
@@ -25,7 +25,7 @@ export {
   Token,
   ASTNode,
   ASTKindToNode,
-  // Each kind of AST node
+  /** Each kind of AST node */
   NameNode,
   DocumentNode,
   DefinitionNode,

--- a/src/language/index.js
+++ b/src/language/index.js
@@ -25,7 +25,7 @@ export { Location, Token } from './ast';
 export type {
   ASTNode,
   ASTKindToNode,
-  // Each kind of AST node
+  /** Each kind of AST node */
   NameNode,
   DocumentNode,
   DefinitionNode,

--- a/src/language/kinds.d.ts
+++ b/src/language/kinds.d.ts
@@ -2,20 +2,20 @@
  * The set of allowed kind values for AST nodes.
  */
 export const Kind: Readonly<{
-  // Name
+  /** Name */
   NAME: 'Name';
-  // Document
+  /** Document */
   DOCUMENT: 'Document';
   OPERATION_DEFINITION: 'OperationDefinition';
   VARIABLE_DEFINITION: 'VariableDefinition';
   SELECTION_SET: 'SelectionSet';
   FIELD: 'Field';
   ARGUMENT: 'Argument';
-  // Fragments
+  /** Fragments */
   FRAGMENT_SPREAD: 'FragmentSpread';
   INLINE_FRAGMENT: 'InlineFragment';
   FRAGMENT_DEFINITION: 'FragmentDefinition';
-  // Values
+  /** Values */
   VARIABLE: 'Variable';
   INT: 'IntValue';
   FLOAT: 'FloatValue';
@@ -26,16 +26,16 @@ export const Kind: Readonly<{
   LIST: 'ListValue';
   OBJECT: 'ObjectValue';
   OBJECT_FIELD: 'ObjectField';
-  // Directives
+  /** Directives */
   DIRECTIVE: 'Directive';
-  // Types
+  /** Types */
   NAMED_TYPE: 'NamedType';
   LIST_TYPE: 'ListType';
   NON_NULL_TYPE: 'NonNullType';
-  // Type System Definitions
+  /** Type System Definitions */
   SCHEMA_DEFINITION: 'SchemaDefinition';
   OPERATION_TYPE_DEFINITION: 'OperationTypeDefinition';
-  // Type Definitions
+  /** Type Definitions */
   SCALAR_TYPE_DEFINITION: 'ScalarTypeDefinition';
   OBJECT_TYPE_DEFINITION: 'ObjectTypeDefinition';
   FIELD_DEFINITION: 'FieldDefinition';
@@ -45,11 +45,11 @@ export const Kind: Readonly<{
   ENUM_TYPE_DEFINITION: 'EnumTypeDefinition';
   ENUM_VALUE_DEFINITION: 'EnumValueDefinition';
   INPUT_OBJECT_TYPE_DEFINITION: 'InputObjectTypeDefinition';
-  // Directive Definitions
+  /** Directive Definitions */
   DIRECTIVE_DEFINITION: 'DirectiveDefinition';
-  // Type System Extensions
+  /** Type System Extensions */
   SCHEMA_EXTENSION: 'SchemaExtension';
-  // Type Extensions
+  /** Type Extensions */
   SCALAR_TYPE_EXTENSION: 'ScalarTypeExtension';
   OBJECT_TYPE_EXTENSION: 'ObjectTypeExtension';
   INTERFACE_TYPE_EXTENSION: 'InterfaceTypeExtension';

--- a/src/language/kinds.js
+++ b/src/language/kinds.js
@@ -2,10 +2,10 @@
  * The set of allowed kind values for AST nodes.
  */
 export const Kind = Object.freeze({
-  // Name
+  /** Name */
   NAME: 'Name',
 
-  // Document
+  /** Document */
   DOCUMENT: 'Document',
   OPERATION_DEFINITION: 'OperationDefinition',
   VARIABLE_DEFINITION: 'VariableDefinition',
@@ -13,12 +13,12 @@ export const Kind = Object.freeze({
   FIELD: 'Field',
   ARGUMENT: 'Argument',
 
-  // Fragments
+  /** Fragments */
   FRAGMENT_SPREAD: 'FragmentSpread',
   INLINE_FRAGMENT: 'InlineFragment',
   FRAGMENT_DEFINITION: 'FragmentDefinition',
 
-  // Values
+  /** Values */
   VARIABLE: 'Variable',
   INT: 'IntValue',
   FLOAT: 'FloatValue',
@@ -30,19 +30,19 @@ export const Kind = Object.freeze({
   OBJECT: 'ObjectValue',
   OBJECT_FIELD: 'ObjectField',
 
-  // Directives
+  /** Directives */
   DIRECTIVE: 'Directive',
 
-  // Types
+  /** Types */
   NAMED_TYPE: 'NamedType',
   LIST_TYPE: 'ListType',
   NON_NULL_TYPE: 'NonNullType',
 
-  // Type System Definitions
+  /** Type System Definitions */
   SCHEMA_DEFINITION: 'SchemaDefinition',
   OPERATION_TYPE_DEFINITION: 'OperationTypeDefinition',
 
-  // Type Definitions
+  /** Type Definitions */
   SCALAR_TYPE_DEFINITION: 'ScalarTypeDefinition',
   OBJECT_TYPE_DEFINITION: 'ObjectTypeDefinition',
   FIELD_DEFINITION: 'FieldDefinition',
@@ -53,13 +53,13 @@ export const Kind = Object.freeze({
   ENUM_VALUE_DEFINITION: 'EnumValueDefinition',
   INPUT_OBJECT_TYPE_DEFINITION: 'InputObjectTypeDefinition',
 
-  // Directive Definitions
+  /** Directive Definitions */
   DIRECTIVE_DEFINITION: 'DirectiveDefinition',
 
-  // Type System Extensions
+  /** Type System Extensions */
   SCHEMA_EXTENSION: 'SchemaExtension',
 
-  // Type Extensions
+  /** Type Extensions */
   SCALAR_TYPE_EXTENSION: 'ScalarTypeExtension',
   OBJECT_TYPE_EXTENSION: 'ObjectTypeExtension',
   INTERFACE_TYPE_EXTENSION: 'InterfaceTypeExtension',

--- a/src/type/definition.d.ts
+++ b/src/type/definition.d.ts
@@ -284,11 +284,11 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   name: string;
   description?: Maybe<string>;
   specifiedBy?: Maybe<string>;
-  // Serializes an internal value to include in a response.
+  /** Serializes an internal value to include in a response. */
   serialize?: GraphQLScalarSerializer<TExternal>;
-  // Parses an externally provided value to use as an input.
+  /** Parses an externally provided value to use as an input. */
   parseValue?: GraphQLScalarValueParser<TInternal>;
-  // Parses an externally provided literal value to use as an input.
+  /** Parses an externally provided literal value to use as an input. */
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>;
   extensions?: Maybe<Readonly<GraphQLScalarTypeExtensions>>;
   astNode?: Maybe<ScalarTypeDefinitionNode>;

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -647,11 +647,11 @@ export type GraphQLScalarTypeConfig<TInternal, TExternal> = {
   name: string,
   description?: ?string,
   specifiedByURL?: ?string,
-  // Serializes an internal value to include in a response.
+  /** Serializes an internal value to include in a response. */
   serialize?: GraphQLScalarSerializer<TExternal>,
-  // Parses an externally provided value to use as an input.
+  /** Parses an externally provided value to use as an input. */
   parseValue?: GraphQLScalarValueParser<TInternal>,
-  // Parses an externally provided literal value to use as an input.
+  /** Parses an externally provided literal value to use as an input. */
   parseLiteral?: GraphQLScalarLiteralParser<TInternal>,
   extensions?: ?ReadOnlyObjMapLike<mixed>,
   astNode?: ?ScalarTypeDefinitionNode,

--- a/src/type/index.d.ts
+++ b/src/type/index.d.ts
@@ -1,16 +1,16 @@
 export { Path as ResponsePath } from '../jsutils/Path';
 export {
-  // Predicate
+  /** Predicate */
   isSchema,
-  // Assertion
+  /** Assertion */
   assertSchema,
-  // GraphQL Schema definition
+  /** GraphQL Schema definition */
   GraphQLSchema,
   GraphQLSchemaConfig,
   GraphQLSchemaExtensions,
 } from './schema';
 export {
-  // Predicates
+  /** Predicates */
   isType,
   isScalarType,
   isObjectType,
@@ -30,7 +30,7 @@ export {
   isNamedType,
   isRequiredArgument,
   isRequiredInputField,
-  // Assertions
+  /** Assertions */
   assertType,
   assertScalarType,
   assertObjectType,
@@ -48,20 +48,20 @@ export {
   assertWrappingType,
   assertNullableType,
   assertNamedType,
-  // Un-modifiers
+  /** Un-modifiers */
   getNullableType,
   getNamedType,
-  // Definitions
+  /** Definitions */
   GraphQLScalarType,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  // Type Wrappers
+  /** Type Wrappers */
   GraphQLList,
   GraphQLNonNull,
-  // type
+  /** type */
   GraphQLType,
   GraphQLInputType,
   GraphQLOutputType,
@@ -114,26 +114,26 @@ export {
   GraphQLScalarLiteralParser,
 } from './definition';
 export {
-  // Predicate
+  /** Predicate */
   isDirective,
-  // Assertion
+  /** Assertion */
   assertDirective,
-  // Directives Definition
+  /** Directives Definition */
   GraphQLDirective,
-  // Built-in Directives defined by the Spec
+  /** Built-in Directives defined by the Spec */
   isSpecifiedDirective,
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
-  // Constant Deprecation Reason
+  /** Constant Deprecation Reason */
   DEFAULT_DEPRECATION_REASON,
-  // type
+  /** type */
   GraphQLDirectiveConfig,
   GraphQLDirectiveExtensions,
 } from './directives';
-// Common built-in scalar instances.
+/** Common built-in scalar instances. */
 export {
   isSpecifiedScalarType,
   specifiedScalarTypes,
@@ -144,9 +144,9 @@ export {
   GraphQLID,
 } from './scalars';
 export {
-  // "Enum" of Type Kinds
+  /** "Enum" of Type Kinds */
   TypeKind,
-  // GraphQL Types for introspection.
+  /** GraphQL Types for introspection. */
   isIntrospectionType,
   introspectionTypes,
   __Schema,
@@ -157,7 +157,7 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-  // Meta-field definitions.
+  /** Meta-field definitions. */
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,

--- a/src/type/index.js
+++ b/src/type/index.js
@@ -1,17 +1,17 @@
 export type { Path as ResponsePath } from '../jsutils/Path';
 
 export {
-  // Predicate
+  /** Predicate */
   isSchema,
-  // Assertion
+  /** Assertion */
   assertSchema,
-  // GraphQL Schema definition
+  /** GraphQL Schema definition */
   GraphQLSchema,
 } from './schema';
 export type { GraphQLSchemaConfig } from './schema';
 
 export {
-  // Predicates
+  /** Predicates */
   isType,
   isScalarType,
   isObjectType,
@@ -31,7 +31,7 @@ export {
   isNamedType,
   isRequiredArgument,
   isRequiredInputField,
-  // Assertions
+  /** Assertions */
   assertType,
   assertScalarType,
   assertObjectType,
@@ -49,46 +49,46 @@ export {
   assertWrappingType,
   assertNullableType,
   assertNamedType,
-  // Un-modifiers
+  /** Un-modifiers */
   getNullableType,
   getNamedType,
-  // Definitions
+  /** Definitions */
   GraphQLScalarType,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
-  // Type Wrappers
+  /** Type Wrappers */
   GraphQLList,
   GraphQLNonNull,
 } from './definition';
 
 export {
-  // Predicate
+  /** Predicate */
   isDirective,
-  // Assertion
+  /** Assertion */
   assertDirective,
-  // Directives Definition
+  /** Directives Definition */
   GraphQLDirective,
-  // Built-in Directives defined by the Spec
+  /** Built-in Directives defined by the Spec */
   isSpecifiedDirective,
   specifiedDirectives,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
-  // Constant Deprecation Reason
+  /** Constant Deprecation Reason */
   DEFAULT_DEPRECATION_REASON,
 } from './directives';
 
 export type { GraphQLDirectiveConfig } from './directives';
 
-// Common built-in scalar instances.
+/** Common built-in scalar instances. */
 export {
-  // Predicate
+  /** Predicate */
   isSpecifiedScalarType,
-  // Standard GraphQL Scalars
+  /** Standard GraphQL Scalars */
   specifiedScalarTypes,
   GraphQLInt,
   GraphQLFloat,
@@ -98,9 +98,9 @@ export {
 } from './scalars';
 
 export {
-  // Predicate
+  /** Predicate */
   isIntrospectionType,
-  // GraphQL Types for introspection.
+  /** GraphQL Types for introspection. */
   introspectionTypes,
   __Schema,
   __Directive,
@@ -110,9 +110,9 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-  // "Enum" of Type Kinds
+  /** "Enum" of Type Kinds */
   TypeKind,
-  // Meta-field definitions.
+  /** Meta-field definitions. */
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
@@ -161,5 +161,5 @@ export type {
   GraphQLScalarLiteralParser,
 } from './definition';
 
-// Validate GraphQL schema.
+/** Validate GraphQL schema. */
 export { validateSchema, assertValidSchema } from './validate';

--- a/src/utilities/TypeInfo.d.ts
+++ b/src/utilities/TypeInfo.d.ts
@@ -20,10 +20,12 @@ import type {
 export class TypeInfo {
   constructor(
     schema: GraphQLSchema,
-    // Initial type may be provided in rare cases to facilitate traversals
-    // beginning somewhere other than documents.
+    /**
+     * Initial type may be provided in rare cases to facilitate traversals
+     *  beginning somewhere other than documents.
+     */
     initialType?: GraphQLType,
-    // @deprecated will be removed in 17.0.0
+    /** @deprecated will be removed in 17.0.0 */
     getFieldDefFn?: getFieldDef,
   );
   getType(): Maybe<GraphQLOutputType>;

--- a/src/utilities/TypeInfo.js
+++ b/src/utilities/TypeInfo.js
@@ -55,11 +55,13 @@ export class TypeInfo {
 
   constructor(
     schema: GraphQLSchema,
-    // Initial type may be provided in rare cases to facilitate traversals
-    // beginning somewhere other than documents.
+    /**
+     * Initial type may be provided in rare cases to facilitate traversals
+     *  beginning somewhere other than documents.
+     */
     initialType?: ?GraphQLType,
 
-    // @deprecated will be removed in 17.0.0
+    /** @deprecated will be removed in 17.0.0 */
     getFieldDefFn?: typeof getFieldDef,
   ) {
     this._schema = schema;

--- a/src/utilities/getIntrospectionQuery.d.ts
+++ b/src/utilities/getIntrospectionQuery.d.ts
@@ -1,20 +1,30 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { DirectiveLocationEnum } from '../language/directiveLocation';
 export interface IntrospectionOptions {
-  // Whether to include descriptions in the introspection result.
-  // Default: true
+  /**
+   * Whether to include descriptions in the introspection result.
+   * Default: true
+   */
   descriptions?: boolean;
-  // Whether to include `specifiedByURL` in the introspection result.
-  // Default: false
+  /**
+   * Whether to include `specifiedByURL` in the introspection result.
+   * Default: false
+   */
   specifiedByUrl?: boolean;
-  // Whether to include `isRepeatable` flag on directives.
-  // Default: false
+  /**
+   * Whether to include `isRepeatable` flag on directives.
+   * Default: false
+   */
   directiveIsRepeatable?: boolean;
-  // Whether to include `description` field on schema.
-  // Default: false
+  /**
+   * Whether to include `description` field on schema.
+   * Default: false
+   */
   schemaDescription?: boolean;
-  // Whether target GraphQL server support deprecation of input values.
-  // Default: false
+  /**
+   * Whether target GraphQL server support deprecation of input values.
+   * Default: false
+   */
   inputValueDeprecation?: boolean;
 }
 export function getIntrospectionQuery(options?: IntrospectionOptions): string;

--- a/src/utilities/getIntrospectionQuery.js
+++ b/src/utilities/getIntrospectionQuery.js
@@ -1,24 +1,34 @@
 import type { DirectiveLocationEnum } from '../language/directiveLocation';
 
 export type IntrospectionOptions = {
-  // Whether to include descriptions in the introspection result.
-  // Default: true
+  /**
+   * Whether to include descriptions in the introspection result.
+   * Default: true
+   */
   descriptions?: boolean,
 
-  // Whether to include `specifiedByUrl` in the introspection result.
-  // Default: false
+  /**
+   * Whether to include `specifiedByURL` in the introspection result.
+   * Default: false
+   */
   specifiedByUrl?: boolean,
 
-  // Whether to include `isRepeatable` field on directives.
-  // Default: false
+  /**
+   * Whether to include `isRepeatable` flag on directives.
+   * Default: false
+   */
   directiveIsRepeatable?: boolean,
 
-  // Whether to include `description` field on schema.
-  // Default: false
+  /**
+   * Whether to include `description` field on schema.
+   * Default: false
+   */
   schemaDescription?: boolean,
 
-  // Whether target GraphQL server support deprecation of input values.
-  // Default: false
+  /**
+   * Whether target GraphQL server support deprecation of input values.
+   * Default: false
+   */
   inputValueDeprecation?: boolean,
 };
 

--- a/src/utilities/index.d.ts
+++ b/src/utilities/index.d.ts
@@ -1,6 +1,8 @@
 export {
-  // Produce the GraphQL query recommended for a full schema introspection.
-  // Accepts optional IntrospectionOptions.
+  /**
+   * Produce the GraphQL query recommended for a full schema introspection.
+   * Accepts optional IntrospectionOptions.
+   */
   getIntrospectionQuery,
   IntrospectionOptions,
   IntrospectionQuery,
@@ -25,59 +27,58 @@ export {
   IntrospectionEnumValue,
   IntrospectionDirective,
 } from './getIntrospectionQuery';
-// Gets the target Operation from a Document
+/** Gets the target Operation from a Document */
 export { getOperationAST } from './getOperationAST';
-// Gets the Type for the target Operation AST.
+/** Gets the Type for the target Operation AST. */
 export { getOperationRootType } from './getOperationRootType';
-// Convert a GraphQLSchema to an IntrospectionQuery
+/** Convert a GraphQLSchema to an IntrospectionQuery */
 export { introspectionFromSchema } from './introspectionFromSchema';
-// Build a GraphQLSchema from an introspection result.
+/** Build a GraphQLSchema from an introspection result. */
 export { buildClientSchema } from './buildClientSchema';
-// Build a GraphQLSchema from GraphQL Schema language.
+/** Build a GraphQLSchema from GraphQL Schema language. */
 export {
   buildASTSchema,
   buildSchema,
   BuildSchemaOptions,
 } from './buildASTSchema';
-// Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
+/** Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST. */
 export { extendSchema } from './extendSchema';
-// Sort a GraphQLSchema.
+/** Sort a GraphQLSchema. */
 export { lexicographicSortSchema } from './lexicographicSortSchema';
-// Print a GraphQLSchema to GraphQL Schema language.
+/** Print a GraphQLSchema to GraphQL Schema language. */
 export {
   printSchema,
   printType,
   printIntrospectionSchema,
 } from './printSchema';
-// Create a GraphQLType from a GraphQL language AST.
+/** Create a GraphQLType from a GraphQL language AST. */
 export { typeFromAST } from './typeFromAST';
-// Create a JavaScript value from a GraphQL language AST with a type.
+/** Create a JavaScript value from a GraphQL language AST with a type. */
 export { valueFromAST } from './valueFromAST';
-// Create a JavaScript value from a GraphQL language AST without a type.
+/** Create a JavaScript value from a GraphQL language AST without a type. */
 export { valueFromASTUntyped } from './valueFromASTUntyped';
-// Create a GraphQL language AST from a JavaScript value.
+/** Create a GraphQL language AST from a JavaScript value. */
 export { astFromValue } from './astFromValue';
-// A helper to use within recursive-descent visitors which need to be aware of
-// the GraphQL type system.
+/** A helper to use within recursive-descent visitors which need to be aware of */
+/** the GraphQL type system. */
 export { TypeInfo, visitWithTypeInfo } from './TypeInfo';
-// Coerces a JavaScript value to a GraphQL type, or produces errors.
+/** Coerces a JavaScript value to a GraphQL type, or produces errors. */
 export { coerceInputValue } from './coerceInputValue';
-// Concatenates multiple AST together.
+/** Concatenates multiple AST together. */
 export { concatAST } from './concatAST';
-// Separates an AST into an AST per Operation.
+/** Separates an AST into an AST per Operation. */
 export { separateOperations } from './separateOperations';
-// Strips characters that are not significant to the validity or execution
-// of a GraphQL document.
+/** Strips characters that are not significant to the validity or execution of a GraphQL document. */
 export { stripIgnoredCharacters } from './stripIgnoredCharacters';
-// Comparators for types
+/** Comparators for types */
 export {
   isEqualType,
   isTypeSubTypeOf,
   doTypesOverlap,
 } from './typeComparators';
-// Asserts that a string is a valid GraphQL name
+/** Asserts that a string is a valid GraphQL name */
 export { assertValidName, isValidNameError } from './assertValidName';
-// Compares two GraphQLSchemas and detects breaking changes.
+/** Compares two GraphQLSchemas and detects breaking changes. */
 export {
   BreakingChangeType,
   DangerousChangeType,
@@ -86,5 +87,5 @@ export {
   BreakingChange,
   DangerousChange,
 } from './findBreakingChanges';
-// Wrapper type that contains DocumentNode and types that can be deduced from it.
+/** Wrapper type that contains DocumentNode and types that can be deduced from it. */
 export { TypedQueryDocumentNode } from './typedQueryDocumentNode';

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -1,5 +1,7 @@
-// Produce the GraphQL query recommended for a full schema introspection.
-// Accepts optional IntrospectionOptions.
+/**
+ * Produce the GraphQL query recommended for a full schema introspection.
+ * Accepts optional IntrospectionOptions.
+ */
 export { getIntrospectionQuery } from './getIntrospectionQuery';
 
 export type {
@@ -27,75 +29,73 @@ export type {
   IntrospectionDirective,
 } from './getIntrospectionQuery';
 
-// Gets the target Operation from a Document.
+/** Gets the target Operation from a Document. */
 export { getOperationAST } from './getOperationAST';
 
-// Gets the Type for the target Operation AST.
+/** Gets the Type for the target Operation AST. */
 export { getOperationRootType } from './getOperationRootType';
 
-// Convert a GraphQLSchema to an IntrospectionQuery.
+/** Convert a GraphQLSchema to an IntrospectionQuery. */
 export { introspectionFromSchema } from './introspectionFromSchema';
 
-// Build a GraphQLSchema from an introspection result.
+/** Build a GraphQLSchema from an introspection result. */
 export { buildClientSchema } from './buildClientSchema';
 
-// Build a GraphQLSchema from GraphQL Schema language.
+/** Build a GraphQLSchema from GraphQL Schema language. */
 export { buildASTSchema, buildSchema } from './buildASTSchema';
 export type { BuildSchemaOptions } from './buildASTSchema';
 
-// Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST.
+/** Extends an existing GraphQLSchema from a parsed GraphQL Schema language AST. */
 export { extendSchema } from './extendSchema';
 
-// Sort a GraphQLSchema.
+/** Sort a GraphQLSchema. */
 export { lexicographicSortSchema } from './lexicographicSortSchema';
 
-// Print a GraphQLSchema to GraphQL Schema language.
+/** Print a GraphQLSchema to GraphQL Schema language. */
 export {
   printSchema,
   printType,
   printIntrospectionSchema,
 } from './printSchema';
 
-// Create a GraphQLType from a GraphQL language AST.
+/** Create a GraphQLType from a GraphQL language AST. */
 export { typeFromAST } from './typeFromAST';
 
-// Create a JavaScript value from a GraphQL language AST with a type.
+/** Create a JavaScript value from a GraphQL language AST with a type. */
 export { valueFromAST } from './valueFromAST';
 
-// Create a JavaScript value from a GraphQL language AST without a type.
+/** Create a JavaScript value from a GraphQL language AST without a type. */
 export { valueFromASTUntyped } from './valueFromASTUntyped';
 
-// Create a GraphQL language AST from a JavaScript value.
+/** Create a GraphQL language AST from a JavaScript value. */
 export { astFromValue } from './astFromValue';
 
-// A helper to use within recursive-descent visitors which need to be aware of
-// the GraphQL type system.
+/** A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system. */
 export { TypeInfo, visitWithTypeInfo } from './TypeInfo';
 
-// Coerces a JavaScript value to a GraphQL type, or produces errors.
+/** Coerces a JavaScript value to a GraphQL type, or produces errors. */
 export { coerceInputValue } from './coerceInputValue';
 
-// Concatenates multiple AST together.
+/** Concatenates multiple AST together. */
 export { concatAST } from './concatAST';
 
-// Separates an AST into an AST per Operation.
+/** Separates an AST into an AST per Operation. */
 export { separateOperations } from './separateOperations';
 
-// Strips characters that are not significant to the validity or execution
-// of a GraphQL document.
+/** Strips characters that are not significant to the validity or execution of a GraphQL document. */
 export { stripIgnoredCharacters } from './stripIgnoredCharacters';
 
-// Comparators for types
+/** Comparators for types */
 export {
   isEqualType,
   isTypeSubTypeOf,
   doTypesOverlap,
 } from './typeComparators';
 
-// Asserts that a string is a valid GraphQL name
+/** Asserts that a string is a valid GraphQL name */
 export { assertValidName, isValidNameError } from './assertValidName';
 
-// Compares two GraphQLSchemas and detects breaking changes.
+/** Compares two GraphQLSchemas and detects breaking changes. */
 export {
   BreakingChangeType,
   DangerousChangeType,

--- a/src/validation/index.d.ts
+++ b/src/validation/index.d.ts
@@ -1,59 +1,59 @@
 export { validate } from './validate';
 export { ValidationContext, ValidationRule } from './ValidationContext';
 export { specifiedRules } from './specifiedRules';
-// Spec Section: "Executable Definitions"
+/** Spec Section: "Executable Definitions" */
 export { ExecutableDefinitionsRule } from './rules/ExecutableDefinitionsRule';
-// Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"
+/** Spec Section: "Field Selections on Objects, Interfaces, and Unions Types" */
 export { FieldsOnCorrectTypeRule } from './rules/FieldsOnCorrectTypeRule';
-// Spec Section: "Fragments on Composite Types"
+/** Spec Section: "Fragments on Composite Types" */
 export { FragmentsOnCompositeTypesRule } from './rules/FragmentsOnCompositeTypesRule';
-// Spec Section: "Argument Names"
+/** Spec Section: "Argument Names" */
 export { KnownArgumentNamesRule } from './rules/KnownArgumentNamesRule';
-// Spec Section: "Directives Are Defined"
+/** Spec Section: "Directives Are Defined" */
 export { KnownDirectivesRule } from './rules/KnownDirectivesRule';
-// Spec Section: "Fragment spread target defined"
+/** Spec Section: "Fragment spread target defined" */
 export { KnownFragmentNamesRule } from './rules/KnownFragmentNamesRule';
-// Spec Section: "Fragment Spread Type Existence"
+/** Spec Section: "Fragment Spread Type Existence" */
 export { KnownTypeNamesRule } from './rules/KnownTypeNamesRule';
-// Spec Section: "Lone Anonymous Operation"
+/** Spec Section: "Lone Anonymous Operation" */
 export { LoneAnonymousOperationRule } from './rules/LoneAnonymousOperationRule';
-// Spec Section: "Fragments must not form cycles"
+/** Spec Section: "Fragments must not form cycles" */
 export { NoFragmentCyclesRule } from './rules/NoFragmentCyclesRule';
-// Spec Section: "All Variable Used Defined"
+/** Spec Section: "All Variable Used Defined" */
 export { NoUndefinedVariablesRule } from './rules/NoUndefinedVariablesRule';
-// Spec Section: "Fragments must be used"
+/** Spec Section: "Fragments must be used" */
 export { NoUnusedFragmentsRule } from './rules/NoUnusedFragmentsRule';
-// Spec Section: "All Variables Used"
+/** Spec Section: "All Variables Used" */
 export { NoUnusedVariablesRule } from './rules/NoUnusedVariablesRule';
-// Spec Section: "Field Selection Merging"
+/** Spec Section: "Field Selection Merging" */
 export { OverlappingFieldsCanBeMergedRule } from './rules/OverlappingFieldsCanBeMergedRule';
-// Spec Section: "Fragment spread is possible"
+/** Spec Section: "Fragment spread is possible" */
 export { PossibleFragmentSpreadsRule } from './rules/PossibleFragmentSpreadsRule';
-// Spec Section: "Argument Optionality"
+/** Spec Section: "Argument Optionality" */
 export { ProvidedRequiredArgumentsRule } from './rules/ProvidedRequiredArgumentsRule';
-// Spec Section: "Leaf Field Selections"
+/** Spec Section: "Leaf Field Selections" */
 export { ScalarLeafsRule } from './rules/ScalarLeafsRule';
-// Spec Section: "Subscriptions with Single Root Field"
+/** Spec Section: "Subscriptions with Single Root Field" */
 export { SingleFieldSubscriptionsRule } from './rules/SingleFieldSubscriptionsRule';
-// Spec Section: "Argument Uniqueness"
+/** Spec Section: "Argument Uniqueness" */
 export { UniqueArgumentNamesRule } from './rules/UniqueArgumentNamesRule';
-// Spec Section: "Directives Are Unique Per Location"
+/** Spec Section: "Directives Are Unique Per Location" */
 export { UniqueDirectivesPerLocationRule } from './rules/UniqueDirectivesPerLocationRule';
-// Spec Section: "Fragment Name Uniqueness"
+/** Spec Section: "Fragment Name Uniqueness" */
 export { UniqueFragmentNamesRule } from './rules/UniqueFragmentNamesRule';
-// Spec Section: "Input Object Field Uniqueness"
+/** Spec Section: "Input Object Field Uniqueness" */
 export { UniqueInputFieldNamesRule } from './rules/UniqueInputFieldNamesRule';
-// Spec Section: "Operation Name Uniqueness"
+/** Spec Section: "Operation Name Uniqueness" */
 export { UniqueOperationNamesRule } from './rules/UniqueOperationNamesRule';
-// Spec Section: "Variable Uniqueness"
+/** Spec Section: "Variable Uniqueness" */
 export { UniqueVariableNamesRule } from './rules/UniqueVariableNamesRule';
-// Spec Section: "Values Type Correctness"
+/** Spec Section: "Values Type Correctness" */
 export { ValuesOfCorrectTypeRule } from './rules/ValuesOfCorrectTypeRule';
-// Spec Section: "Variables are Input Types"
+/** Spec Section: "Variables are Input Types" */
 export { VariablesAreInputTypesRule } from './rules/VariablesAreInputTypesRule';
-// Spec Section: "All Variable Usages Are Allowed"
+/** Spec Section: "All Variable Usages Are Allowed" */
 export { VariablesInAllowedPositionRule } from './rules/VariablesInAllowedPositionRule';
-// SDL-specific validation rules
+/** SDL-specific validation rules */
 export { LoneSchemaDefinitionRule } from './rules/LoneSchemaDefinitionRule';
 export { UniqueOperationTypesRule } from './rules/UniqueOperationTypesRule';
 export { UniqueTypeNamesRule } from './rules/UniqueTypeNamesRule';
@@ -61,6 +61,6 @@ export { UniqueEnumValueNamesRule } from './rules/UniqueEnumValueNamesRule';
 export { UniqueFieldDefinitionNamesRule } from './rules/UniqueFieldDefinitionNamesRule';
 export { UniqueDirectiveNamesRule } from './rules/UniqueDirectiveNamesRule';
 export { PossibleTypeExtensionsRule } from './rules/PossibleTypeExtensionsRule';
-// Optional rules not defined by the GraphQL Specification
+/** Optional rules not defined by the GraphQL Specification */
 export { NoDeprecatedCustomRule } from './rules/custom/NoDeprecatedCustomRule';
 export { NoSchemaIntrospectionCustomRule } from './rules/custom/NoSchemaIntrospectionCustomRule';

--- a/src/validation/index.js
+++ b/src/validation/index.js
@@ -3,88 +3,88 @@ export { validate } from './validate';
 export { ValidationContext } from './ValidationContext';
 export type { ValidationRule } from './ValidationContext';
 
-// All validation rules in the GraphQL Specification.
+/** All validation rules in the GraphQL Specification. */
 export { specifiedRules } from './specifiedRules';
 
-// Spec Section: "Executable Definitions"
+/** Spec Section: "Executable Definitions" */
 export { ExecutableDefinitionsRule } from './rules/ExecutableDefinitionsRule';
 
-// Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"
+/** Spec Section: "Field Selections on Objects, Interfaces, and Unions Types" */
 export { FieldsOnCorrectTypeRule } from './rules/FieldsOnCorrectTypeRule';
 
-// Spec Section: "Fragments on Composite Types"
+/** Spec Section: "Fragments on Composite Types" */
 export { FragmentsOnCompositeTypesRule } from './rules/FragmentsOnCompositeTypesRule';
 
-// Spec Section: "Argument Names"
+/** Spec Section: "Argument Names" */
 export { KnownArgumentNamesRule } from './rules/KnownArgumentNamesRule';
 
-// Spec Section: "Directives Are Defined"
+/** Spec Section: "Directives Are Defined" */
 export { KnownDirectivesRule } from './rules/KnownDirectivesRule';
 
-// Spec Section: "Fragment spread target defined"
+/** Spec Section: "Fragment spread target defined" */
 export { KnownFragmentNamesRule } from './rules/KnownFragmentNamesRule';
 
-// Spec Section: "Fragment Spread Type Existence"
+/** Spec Section: "Fragment Spread Type Existence" */
 export { KnownTypeNamesRule } from './rules/KnownTypeNamesRule';
 
-// Spec Section: "Lone Anonymous Operation"
+/** Spec Section: "Lone Anonymous Operation" */
 export { LoneAnonymousOperationRule } from './rules/LoneAnonymousOperationRule';
 
-// Spec Section: "Fragments must not form cycles"
+/** Spec Section: "Fragments must not form cycles" */
 export { NoFragmentCyclesRule } from './rules/NoFragmentCyclesRule';
 
-// Spec Section: "All Variable Used Defined"
+/** Spec Section: "All Variable Used Defined" */
 export { NoUndefinedVariablesRule } from './rules/NoUndefinedVariablesRule';
 
-// Spec Section: "Fragments must be used"
+/** Spec Section: "Fragments must be used" */
 export { NoUnusedFragmentsRule } from './rules/NoUnusedFragmentsRule';
 
-// Spec Section: "All Variables Used"
+/** Spec Section: "All Variables Used" */
 export { NoUnusedVariablesRule } from './rules/NoUnusedVariablesRule';
 
-// Spec Section: "Field Selection Merging"
+/** Spec Section: "Field Selection Merging" */
 export { OverlappingFieldsCanBeMergedRule } from './rules/OverlappingFieldsCanBeMergedRule';
 
-// Spec Section: "Fragment spread is possible"
+/** Spec Section: "Fragment spread is possible" */
 export { PossibleFragmentSpreadsRule } from './rules/PossibleFragmentSpreadsRule';
 
-// Spec Section: "Argument Optionality"
+/** Spec Section: "Argument Optionality" */
 export { ProvidedRequiredArgumentsRule } from './rules/ProvidedRequiredArgumentsRule';
 
-// Spec Section: "Leaf Field Selections"
+/** Spec Section: "Leaf Field Selections" */
 export { ScalarLeafsRule } from './rules/ScalarLeafsRule';
 
-// Spec Section: "Subscriptions with Single Root Field"
+/** Spec Section: "Subscriptions with Single Root Field" */
 export { SingleFieldSubscriptionsRule } from './rules/SingleFieldSubscriptionsRule';
 
-// Spec Section: "Argument Uniqueness"
+/** Spec Section: "Argument Uniqueness" */
 export { UniqueArgumentNamesRule } from './rules/UniqueArgumentNamesRule';
 
-// Spec Section: "Directives Are Unique Per Location"
+/** Spec Section: "Directives Are Unique Per Location" */
 export { UniqueDirectivesPerLocationRule } from './rules/UniqueDirectivesPerLocationRule';
 
-// Spec Section: "Fragment Name Uniqueness"
+/** Spec Section: "Fragment Name Uniqueness" */
 export { UniqueFragmentNamesRule } from './rules/UniqueFragmentNamesRule';
 
-// Spec Section: "Input Object Field Uniqueness"
+/** Spec Section: "Input Object Field Uniqueness" */
 export { UniqueInputFieldNamesRule } from './rules/UniqueInputFieldNamesRule';
 
-// Spec Section: "Operation Name Uniqueness"
+/** Spec Section: "Operation Name Uniqueness" */
 export { UniqueOperationNamesRule } from './rules/UniqueOperationNamesRule';
 
-// Spec Section: "Variable Uniqueness"
+/** Spec Section: "Variable Uniqueness" */
 export { UniqueVariableNamesRule } from './rules/UniqueVariableNamesRule';
 
-// Spec Section: "Values Type Correctness"
+/** Spec Section: "Values Type Correctness" */
 export { ValuesOfCorrectTypeRule } from './rules/ValuesOfCorrectTypeRule';
 
-// Spec Section: "Variables are Input Types"
+/** Spec Section: "Variables are Input Types" */
 export { VariablesAreInputTypesRule } from './rules/VariablesAreInputTypesRule';
 
-// Spec Section: "All Variable Usages Are Allowed"
+/** Spec Section: "All Variable Usages Are Allowed" */
 export { VariablesInAllowedPositionRule } from './rules/VariablesInAllowedPositionRule';
 
-// SDL-specific validation rules
+/** SDL-specific validation rules */
 export { LoneSchemaDefinitionRule } from './rules/LoneSchemaDefinitionRule';
 export { UniqueOperationTypesRule } from './rules/UniqueOperationTypesRule';
 export { UniqueTypeNamesRule } from './rules/UniqueTypeNamesRule';
@@ -93,6 +93,6 @@ export { UniqueFieldDefinitionNamesRule } from './rules/UniqueFieldDefinitionNam
 export { UniqueDirectiveNamesRule } from './rules/UniqueDirectiveNamesRule';
 export { PossibleTypeExtensionsRule } from './rules/PossibleTypeExtensionsRule';
 
-// Optional rules not defined by the GraphQL Specification
+/** Optional rules not defined by the GraphQL Specification */
 export { NoDeprecatedCustomRule } from './rules/custom/NoDeprecatedCustomRule';
 export { NoSchemaIntrospectionCustomRule } from './rules/custom/NoSchemaIntrospectionCustomRule';

--- a/src/validation/validate.d.ts
+++ b/src/validation/validate.d.ts
@@ -25,7 +25,7 @@ export function validate(
   documentAST: DocumentNode,
   rules?: ReadonlyArray<ValidationRule>,
   options?: { maxErrors?: number },
-  // @deprecate will be removed in 17.0.0
+  /** @deprecate will be removed in 17.0.0 */
   typeInfo?: TypeInfo,
 ): ReadonlyArray<GraphQLError>;
 /**

--- a/src/validation/validate.js
+++ b/src/validation/validate.js
@@ -36,7 +36,7 @@ export function validate(
   rules: $ReadOnlyArray<ValidationRule> = specifiedRules,
   options: { maxErrors?: number } = { maxErrors: undefined },
 
-  // @deprecate will be removed in 17.0.0
+  /** @deprecate will be removed in 17.0.0 */
   typeInfo: TypeInfo = new TypeInfo(schema),
 ): $ReadOnlyArray<GraphQLError> {
   devAssert(documentAST, 'Must provide document.');


### PR DESCRIPTION
Typescript strips all non-TSDoc documents in generated definitions