### PR TITLE
Fix typescript-4.3 version in the integration tests

### DIFF
--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -10,6 +10,6 @@
     "typescript-4.0": "npm:typescript@4.0.x",
     "typescript-4.1": "npm:typescript@4.1.x",
     "typescript-4.2": "npm:typescript@4.2.x",
-    "typescript-4.3": "npm:typescript@4.2.x"
+    "typescript-4.3": "npm:typescript@4.3.x"
   }
 }


### PR DESCRIPTION
Make the `typescript-4.3` dependency be actually `4.3.x` and not `4.2.x`.