### PR TITLE
execute: Rename resolveField function and update comments

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -368,7 +368,7 @@ function executeOperation(
 
 /**
  * Implements the "Executing selection sets" section of the spec
- * for "write" mode.
+ * for fields that must be executed serially.
  */
 function executeFieldsSerially(
   exeContext: ExecutionContext,
@@ -406,7 +406,7 @@ function executeFieldsSerially(
 
 /**
  * Implements the "Executing selection sets" section of the spec
- * for "read" mode.
+ * for fields that may be executed in parallel.
  */
 function executeFields(
   exeContext: ExecutionContext,

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -142,7 +142,7 @@ export interface ExecutionArgs {
 }
 
 /**
- * Implements the "Evaluating requests" section of the GraphQL specification.
+ * Implements the "Executing requests" section of the GraphQL specification.
  *
  * Returns either a synchronous ExecutionResult (if all encountered resolvers
  * are synchronous), or a Promise of an ExecutionResult that will eventually be
@@ -196,7 +196,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
 }
 
 /**
- * Also implements the "Evaluating requests" section of the GraphQL specification.
+ * Also implements the "Executing requests" section of the GraphQL specification.
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
@@ -327,7 +327,7 @@ export function buildExecutionContext(
 }
 
 /**
- * Implements the "Evaluating operations" section of the spec.
+ * Implements the "Executing operations" section of the spec.
  */
 function executeOperation(
   exeContext: ExecutionContext,
@@ -367,7 +367,7 @@ function executeOperation(
 }
 
 /**
- * Implements the "Evaluating selection sets" section of the spec
+ * Implements the "Executing selection sets" section of the spec
  * for "write" mode.
  */
 function executeFieldsSerially(
@@ -405,7 +405,7 @@ function executeFieldsSerially(
 }
 
 /**
- * Implements the "Evaluating selection sets" section of the spec
+ * Implements the "Executing selection sets" section of the spec
  * for "read" mode.
  */
 function executeFields(
@@ -722,7 +722,7 @@ function handleFieldError(
  * and then complete based on that type
  *
  * Otherwise, the field type expects a sub-selection set, and will complete the
- * value by evaluating all sub-selections.
+ * value by executing all sub-selections.
  */
 function completeValue(
   exeContext: ExecutionContext,

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -381,7 +381,7 @@ function executeFieldsSerially(
     fields.entries(),
     (results, [responseName, fieldNodes]) => {
       const fieldPath = addPath(path, responseName, parentType.name);
-      const result = resolveField(
+      const result = executeField(
         exeContext,
         parentType,
         sourceValue,
@@ -420,7 +420,7 @@ function executeFields(
 
   for (const [responseName, fieldNodes] of fields.entries()) {
     const fieldPath = addPath(path, responseName, parentType.name);
-    const result = resolveField(
+    const result = executeField(
       exeContext,
       parentType,
       sourceValue,
@@ -583,12 +583,12 @@ function getFieldEntryKey(node: FieldNode): string {
 }
 
 /**
- * Resolves the field on the given source object. In particular, this
- * figures out the value that the field returns by calling its resolve function,
- * then calls completeValue to complete promises, serialize scalars, or execute
- * the sub-selection-set for objects.
+ * Implements the "Executing field" section of the spec
+ * In particular, this function figures out the value that the field returns by
+ * calling its resolve function, then calls completeValue to complete promises,
+ * serialize scalars, or execute the sub-selection-set for objects.
  */
-function resolveField(
+function executeField(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   source: unknown,


### PR DESCRIPTION
The function implements the "Executing Field" section of the spec and should be called `executeField` rather than `resolveField` to reduce ambiguity.

Motivation: (1) correctness and (2) lays the groundwork for -- possibly -- providing a custom function for fields to optimize their execution, say, by not calling `getArgumentValues` if the arguments are passed unparsed to some external graphql service, or what have you.

Right now, if we would add a custom `execute` function, we would have to have a code block within a function called `resolveField` that calls the custom execute. Resolving is a part of executing, and so there is a semantic clash that could get pretty confusing (at least for me).