### PR TITLE
Export TypeKind as value

### DIFF
--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -166,15 +166,12 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
+  /** "Enum" of Type Kinds */
+  TypeKind,
   /** Meta-field definitions. */
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
-} from './introspection';
-
-export type {
-  /** "Enum" of Type Kinds */
-  TypeKind,
 } from './introspection';
 
 /** Validate GraphQL schema. */


### PR DESCRIPTION
`TypeKind` is currently exported as a type in `type/index.ts` but then re-exported as a value in `index.ts`. This causes the following error in webpack since type export are removed.

```
ERROR in ../../node_modules/graphql/index.mjs 32:0-128:26
export 'TypeKind' (reexported as 'TypeKind') was not found in './type/index.mjs'
```

`TypeKind` seems to be a value so I changed it to be exported as a value in `type/index.ts`.

Tested that this fixes the issue in an app.