### PR TITLE
Export utilities for working with execution context

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -204,7 +204,7 @@ export function executeSync(args: ExecutionArgs): ExecutionResult {
  * Given a completed execution context and data, build the `{ errors, data }`
  * response defined by the "Response" section of the GraphQL specification.
  */
-function buildResponse(
+export function buildResponse(
   exeContext: ExecutionContext,
   data: PromiseOrValue<ObjMap<unknown> | null>,
 ): PromiseOrValue<ExecutionResult> {
@@ -318,7 +318,7 @@ export function buildExecutionContext(
 /**
  * Implements the "Executing operations" section of the spec.
  */
-function executeOperation(
+export function executeOperation(
   exeContext: ExecutionContext,
   operation: OperationDefinitionNode,
   rootValue: unknown,


### PR DESCRIPTION
# About

While the `buildExecutionContext` function is exported, the utility functions which can consume the resulting response aren't.

