### PR TITLE
add exports field to support Node.js ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,45 @@
   },
   "sideEffects": false,
   "homepage": "https://github.com/graphql/graphql-js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs"
+    },
+    "./package.json": "./package.json",
+    "./error": {
+      "require": "./error/index.js",
+      "import": "./error/index.mjs"
+    },
+    "./execution": {
+      "require": "./execution/index.js",
+      "import": "./execution/index.mjs"
+    },
+    "./language": {
+      "require": "./language/index.js",
+      "import": "./language/index.mjs"
+    },
+    "./subscription": {
+      "require": "./subscription/index.js",
+      "import": "./subscription/index.mjs"
+    },
+    "./type": {
+      "require": "./type/index.js",
+      "import": "./type/index.mjs"
+    },
+    "./utilities": {
+      "require": "./utilities/index.js",
+      "import": "./utilities/index.mjs"
+    },
+    "./validation": {
+      "require": "./validation/index.js",
+      "import": "./validation/index.mjs"
+    },
+    "./*": {
+      "require": "./*.js",
+      "import": "./*.mjs"
+    }
+  },
   "bugs": {
     "url": "https://github.com/graphql/graphql-js/issues"
   },


### PR DESCRIPTION
Recently I've authored a blog post that works as a guide for enabling ESM Support for Node.js libraries: [What does it take to support Node.js ESM?](https://the-guild.dev/blog/support-nodejs-esm) that might help in giving some context, fortunately, this package has most of the work already done 🎉 , but there is an import missing piece.

The exports field adds support for Node.js ESM through [Conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports), which is required to be able to use the already existing ".mjs" files.


Since Node.js v12.20.0 (2020-11-24) and v14.13.0 (2020-09-29) the latest and finally stable version of package.exports is available, and since support for Node.js v10.x is already dropped, everything should be fine.


This change can already be tested with a simple package that installs "graphql", and adding the "exports" field manually in the "package.json" of the graphql package.


~~Adding this field for the major version "v16" is the perfect moment to do it~~, since, for people that are currently using ESM with the "graphql" package, all the imports were using the ".js" `CommonJS` version. With this change, if another library that uses graphql as peer dependency doesn't support ESM, it will use the CommonJS version, and the Node.js application is going to have a duplicated "graphql" instance, and the current state of this library doesn't support a duplicated instance of itself. 

You might think that the previously mentioned issue is a bad thing, but I think it's a good thing since it will push the Node.js ESM Ecosystem forward, something that is very needed currently.

## Nothing changes for people only using CommonJS

There is nothing to fear for people using only CommonJS, this change doesn't affect anything in that regard, and this change just enables compatibility for both "environments", which is one of the main reasons for the existence of Node.js `Conditional exports` in the first place