### PR TITLE
Disallow "true", "false", and "null" as enum values

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -120,6 +120,26 @@ describe('Parser', () => {
     });
   });
 
+  it('does not allow "true", "false", or "null" as enum value', () => {
+    expectSyntaxError('enum Test { VALID, true }').to.deep.equal({
+      message:
+        'Syntax Error: Name "true" is reserved and cannot be used for an enum value.',
+      locations: [{ line: 1, column: 20 }],
+    });
+
+    expectSyntaxError('enum Test { VALID, false }').to.deep.equal({
+      message:
+        'Syntax Error: Name "false" is reserved and cannot be used for an enum value.',
+      locations: [{ line: 1, column: 20 }],
+    });
+
+    expectSyntaxError('enum Test { VALID, null }').to.deep.equal({
+      message:
+        'Syntax Error: Name "null" is reserved and cannot be used for an enum value.',
+      locations: [{ line: 1, column: 20 }],
+    });
+  });
+
   it('parses multi-byte characters', () => {
     // Note: \u0A0A could be naively interpreted as two line-feed chars.
     const ast = parse(`

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -1036,13 +1036,11 @@ export class Parser {
 
   /**
    * EnumValueDefinition : Description? EnumValue Directives[Const]?
-   *
-   * EnumValue : Name
    */
   parseEnumValueDefinition(): EnumValueDefinitionNode {
     const start = this._lexer.token;
     const description = this.parseDescription();
-    const name = this.parseName();
+    const name = this.parseEnumValueName();
     const directives = this.parseConstDirectives();
     return this.node<EnumValueDefinitionNode>(start, {
       kind: Kind.ENUM_VALUE_DEFINITION,
@@ -1050,6 +1048,26 @@ export class Parser {
       name,
       directives,
     });
+  }
+
+  /**
+   * EnumValue : Name but not `true`, `false` or `null`
+   */
+  parseEnumValueName(): NameNode {
+    if (
+      this._lexer.token.value === 'true' ||
+      this._lexer.token.value === 'false' ||
+      this._lexer.token.value === 'null'
+    ) {
+      throw syntaxError(
+        this._lexer.source,
+        this._lexer.token.start,
+        `${getTokenDesc(
+          this._lexer.token,
+        )} is reserved and cannot be used for an enum value.`,
+      );
+    }
+    return this.parseName();
   }
 
   /**


### PR DESCRIPTION
The specification disallows these in the SDL grammar definition, and using one of these enum values would result in a schema that would throw validation errors on creation.

Fixes #3221.

I also changed the type of `EnumValueDefinitionNode.name` from `NameNode` to `EnumValueNode`, so this is definitely breaking. We might even want to rename the `name` property to `value`, but that would be even more breaking.