### PR TITLE
execute: Forbid to return `null` from `serialize` function

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -1123,7 +1123,7 @@ describe('Execute: Handles basic execution tasks', () => {
       errors: [
         {
           message:
-            'Expected a value of type "CustomScalar" but received: "CUSTOM_VALUE"',
+            'Expected `CustomScalar.serialize("CUSTOM_VALUE")` to return non-nullable value, returned: undefined',
           locations: [{ line: 1, column: 3 }],
           path: ['customScalar'],
         },

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -750,10 +750,10 @@ function completeLeafValue(
   result: unknown,
 ): unknown {
   const serializedResult = returnType.serialize(result);
-  if (serializedResult === undefined) {
+  if (serializedResult == null) {
     throw new Error(
-      `Expected a value of type "${inspect(returnType)}" but ` +
-        `received: ${inspect(result)}`,
+      `Expected \`${inspect(returnType)}.serialize(${inspect(result)})\` to ` +
+        `return non-nullable value, returned: ${inspect(serializedResult)}`,
     );
   }
   return serializedResult;


### PR DESCRIPTION
Fixes #1579