### PR TITLE
Fix stream directive error on all directive declarations

### DIFF
--- a/src/validation/rules/StreamDirectiveOnListFieldRule.ts
+++ b/src/validation/rules/StreamDirectiveOnListFieldRule.ts
@@ -24,6 +24,7 @@ export function StreamDirectiveOnListFieldRule(
         fieldDef &&
         parentType &&
         isDirective(GraphQLStreamDirective) &&
+        node.name.value === "stream" &&
         !isListType(fieldDef.type)
       ) {
         context.reportError(


### PR DESCRIPTION
# About

Minor bugfix - looks like the `@stream` directive validation wasn't being constrained exclusively to that directive.

I was seeing the following error 

```
// Query
{ articles { id ...ArticleFragment @anydirectivename(label: \"thing\") } } fragment ArticleFragment on Article { title }

// Error
"Stream directive cannot be used on non-list field \"articles\" on type \"Article\"."
```