### PR TITLE
Use PromiseLike for `isPromise` type guard

### DIFF
--- a/src/jsutils/isPromise.ts
+++ b/src/jsutils/isPromise.ts
@@ -2,6 +2,6 @@
  * Returns true if the value acts like a Promise, i.e. has a "then" function,
  * otherwise returns false.
  */
-export function isPromise(value: any): value is Promise<unknown> {
+export function isPromise(value: any): value is PromiseLike<unknown> {
   return typeof value?.then === 'function';
 }


### PR DESCRIPTION
## Problem

The util function `isPromise` has a type guard to guarantee that return value is `Promise`, but it's just checking if it has`then`  function, so I think `PromiseLike` type is more suitable than `Promise` here.

It seems that you invoke only `then` method carefully on promise-like object ([example](https://github.com/graphql/graphql-js/blob/4bb273de4932ba81fc41bc6581415527df862205/src/execution/execute.ts#L505-L506)) , so using `PromiseLike` type might make it safer.

## Additional context

While I'm working on this [issue](https://github.com/dotansimha/graphql-code-generator/issues/6378), I'd like to clarify that the resolver functions can return PromiseLike value.