### PR TITLE
fix: add default export for mapAsyncIterator

### DIFF
--- a/src/subscription/mapAsyncIterator.ts
+++ b/src/subscription/mapAsyncIterator.ts
@@ -52,3 +52,7 @@ export function mapAsyncIterator<T, U, R = undefined>(
     },
   };
 }
+
+// mapAsyncIterator is exported for easier backwards-compat for libraries that support GraphQL.js 15 and 16
+// eslint-disable-next-line import/no-default-export
+export default mapAsyncIterator;


### PR DESCRIPTION
Previously the `mapAsyncIterator` function could be imported via 

`import mapAsyncIterator  from 'graphql/subscription/mapAsyncIterator.js';`

but the export was changed to `import { mapAsyncIterator } from 'graphql/subscription/mapAsyncIterator.js';`

Could we still have a default export for having easy backward compatibility without having to inline the function into our libraries?