### PR TITLE
Bring `visitorKeys` back

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ export type {
   /** Visitor utilities */
   ASTVisitor,
   ASTVisitFn,
-  VisitorKeyMap,
+  ASTVisitorKeyMap,
   /** AST nodes */
   ASTNode,
   ASTKindToNode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,7 @@ export type {
   /** Visitor utilities */
   ASTVisitor,
   ASTVisitFn,
+  VisitorKeyMap,
   /** AST nodes */
   ASTNode,
   ASTKindToNode,

--- a/src/language/__tests__/visitor-test.ts
+++ b/src/language/__tests__/visitor-test.ts
@@ -896,7 +896,7 @@ describe('Visitor', () => {
 
   it('visits only the specified `Kind` in visitorKeyMap', () => {
     const visited: Array<[string, string, ReturnType<typeof getValue>]> = [];
-    
+
     const visitorKeyMap: VisitorKeyMap<ASTKindToNode> = {
       Document: ['definitions'],
       OperationDefinition: ['name'],
@@ -910,10 +910,10 @@ describe('Visitor', () => {
         visited.push(['leave', node.kind, getValue(node)]);
       },
     };
-    
+
     const exampleDocumentAST = parse(/* GraphQL */ `
-      query ExampleOperation { 
-        someField 
+      query ExampleOperation {
+        someField
       }
     `);
 

--- a/src/language/__tests__/visitor-test.ts
+++ b/src/language/__tests__/visitor-test.ts
@@ -3,11 +3,11 @@ import { describe, it } from 'mocha';
 
 import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery';
 
-import type { ASTKindToNode, ASTNode, SelectionSetNode } from '../ast';
+import type { ASTNode, SelectionSetNode } from '../ast';
+import type { ASTVisitorKeyMap, ASTVisitor } from '../visitor';
 import { isNode } from '../ast';
 import { Kind } from '../kinds';
 import { parse } from '../parser';
-import type { VisitorKeyMap, ASTVisitor } from '../visitor';
 import { visit, visitInParallel, BREAK } from '../visitor';
 
 function checkVisitorFnArgs(ast: any, args: any, isEdited: boolean = false) {
@@ -463,6 +463,41 @@ describe('Visitor', () => {
     ]);
   });
 
+  it('visits only the specified `Kind` in visitorKeyMap', () => {
+    const visited: Array<any> = [];
+
+    const visitorKeyMap: ASTVisitorKeyMap = {
+      Document: ['definitions'],
+      OperationDefinition: ['name'],
+    };
+
+    const visitor: ASTVisitor = {
+      enter(node) {
+        visited.push(['enter', node.kind, getValue(node)]);
+      },
+      leave(node) {
+        visited.push(['leave', node.kind, getValue(node)]);
+      },
+    };
+
+    const exampleDocumentAST = parse(`
+      query ExampleOperation {
+        someField
+      }
+    `);
+
+    visit(exampleDocumentAST, visitor, visitorKeyMap);
+
+    expect(visited).to.deep.equal([
+      ['enter', 'Document', undefined],
+      ['enter', 'OperationDefinition', undefined],
+      ['enter', 'Name', 'ExampleOperation'],
+      ['leave', 'Name', 'ExampleOperation'],
+      ['leave', 'OperationDefinition', undefined],
+      ['leave', 'Document', undefined],
+    ]);
+  });
+
   it('Legacy: visits variables defined in fragments', () => {
     const ast = parse('fragment a($v: Boolean = false) on t { f }', {
       noLocation: true,
@@ -891,41 +926,6 @@ describe('Visitor', () => {
       ['leave', 'SelectionSet', 'selectionSet', 'OperationDefinition'],
       ['leave', 'OperationDefinition', 5, undefined],
       ['leave', 'Document', undefined, undefined],
-    ]);
-  });
-
-  it('visits only the specified `Kind` in visitorKeyMap', () => {
-    const visited: Array<[string, string, ReturnType<typeof getValue>]> = [];
-
-    const visitorKeyMap: VisitorKeyMap<ASTKindToNode> = {
-      Document: ['definitions'],
-      OperationDefinition: ['name'],
-    };
-
-    const visitor: ASTVisitor = {
-      enter(node) {
-        visited.push(['enter', node.kind, getValue(node)]);
-      },
-      leave(node) {
-        visited.push(['leave', node.kind, getValue(node)]);
-      },
-    };
-
-    const exampleDocumentAST = parse(/* GraphQL */ `
-      query ExampleOperation {
-        someField
-      }
-    `);
-
-    visit(exampleDocumentAST, visitor, visitorKeyMap);
-
-    expect(visited).to.deep.equal([
-      ['enter', Kind.DOCUMENT, undefined],
-      ['enter', Kind.OPERATION_DEFINITION, undefined],
-      ['enter', Kind.NAME, 'ExampleOperation'],
-      ['leave', Kind.NAME, 'ExampleOperation'],
-      ['leave', Kind.OPERATION_DEFINITION, undefined],
-      ['leave', Kind.DOCUMENT, undefined],
     ]);
   });
 

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -19,7 +19,7 @@ export type { ParseOptions } from './parser';
 export { print } from './printer';
 
 export { visit, visitInParallel, getVisitFn, BREAK } from './visitor';
-export type { ASTVisitor, ASTVisitFn, VisitorKeyMap } from './visitor';
+export type { ASTVisitor, ASTVisitFn, ASTVisitorKeyMap } from './visitor';
 
 export { Location, Token } from './ast';
 export type {

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -19,7 +19,7 @@ export type { ParseOptions } from './parser';
 export { print } from './printer';
 
 export { visit, visitInParallel, getVisitFn, BREAK } from './visitor';
-export type { ASTVisitor, ASTVisitFn } from './visitor';
+export type { ASTVisitor, ASTVisitFn, VisitorKeyMap } from './visitor';
 
 export { Location, Token } from './ast';
 export type {

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -79,11 +79,11 @@ type ReducedField<T, R> = T extends null | undefined
 /**
  * A KeyMap describes each the traversable properties of each kind of node.
  */
-export type VisitorKeyMap<KindToNode> = {
-  [P in keyof KindToNode]?: ReadonlyArray<keyof KindToNode[P]>;
+export type ASTVisitorKeyMap = {
+  [P in keyof ASTKindToNode]?: ReadonlyArray<keyof ASTKindToNode[P]>;
 };
 
-export const QueryDocumentKeys: VisitorKeyMap<ASTKindToNode> = {
+export const QueryDocumentKeys: ASTVisitorKeyMap = {
   Document: ['definitions'],
   OperationDefinition: [
     'name',
@@ -244,17 +244,17 @@ export const BREAK: unknown = Object.freeze({});
 export function visit<N extends ASTNode>(
   root: N,
   visitor: ASTVisitor,
-  visitorKeys?: VisitorKeyMap<ASTKindToNode>,
+  visitorKeys?: ASTVisitorKeyMap,
 ): N;
 export function visit<R>(
   root: ASTNode,
   visitor: ASTReducer<R>,
-  visitorKeys?: VisitorKeyMap<ASTKindToNode>,
+  visitorKeys?: ASTVisitorKeyMap,
 ): R;
 export function visit(
   root: ASTNode,
   visitor: ASTVisitor | ASTReducer<any>,
-  visitorKeys: VisitorKeyMap<ASTKindToNode> = QueryDocumentKeys,
+  visitorKeys: ASTVisitorKeyMap = QueryDocumentKeys,
 ): any {
   /* eslint-disable no-undef-init */
   let stack: any = undefined;

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -77,9 +77,11 @@ type ReducedField<T, R> = T extends null | undefined
   : R;
 
 /**
-* A KeyMap describes each the traversable properties of each kind of node.
-*/
-export type VisitorKeyMap<KindToNode> = { [P in keyof KindToNode]?: ReadonlyArray<keyof KindToNode[P]> };
+ * A KeyMap describes each the traversable properties of each kind of node.
+ */
+export type VisitorKeyMap<KindToNode> = {
+  [P in keyof KindToNode]?: ReadonlyArray<keyof KindToNode[P]>;
+};
 
 export const QueryDocumentKeys: VisitorKeyMap<ASTKindToNode> = {
   Document: ['definitions'],
@@ -239,12 +241,20 @@ export const BREAK: unknown = Object.freeze({});
  * })
  * ```
  */
-export function visit<N extends ASTNode>(root: N, visitor: ASTVisitor, visitorKeys?: VisitorKeyMap<ASTKindToNode>): N;
-export function visit<R>(root: ASTNode, visitor: ASTReducer<R>, visitorKeys?: VisitorKeyMap<ASTKindToNode>): R;
+export function visit<N extends ASTNode>(
+  root: N,
+  visitor: ASTVisitor,
+  visitorKeys?: VisitorKeyMap<ASTKindToNode>,
+): N;
+export function visit<R>(
+  root: ASTNode,
+  visitor: ASTReducer<R>,
+  visitorKeys?: VisitorKeyMap<ASTKindToNode>,
+): R;
 export function visit(
   root: ASTNode,
   visitor: ASTVisitor | ASTReducer<any>,
-  visitorKeys: VisitorKeyMap<ASTKindToNode> = QueryDocumentKeys
+  visitorKeys: VisitorKeyMap<ASTKindToNode> = QueryDocumentKeys,
 ): any {
   /* eslint-disable no-undef-init */
   let stack: any = undefined;


### PR DESCRIPTION
See https://github.com/graphql/graphql-js/issues/3245#issuecomment-907177003

I checked `Allow edits by maintainers`. So you can make changes on this PR instead of creating a new one by checking out this branch using GitHub CLI. Also you can leave comments here then I can also do the changes you want :)



