### PR TITLE
Add TResult to GraphQLFieldResolver signature

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -965,12 +965,13 @@ export type GraphQLFieldResolver<
   TSource,
   TContext,
   TArgs = { [argument: string]: any },
+  TResult = unknown,
 > = (
   source: TSource,
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo,
-) => unknown;
+) => TResult;
 
 export interface GraphQLResolveInfo {
   readonly fieldName: string;


### PR DESCRIPTION
Tried out the 16.0.0-rc and noticed the change from return type of `GraphQLFieldResolver` from [any in 15.x](https://github.com/graphql/graphql-js/blob/acc468bb550222d6ac0893d0655720d540e24566/src/type/definition.d.ts#L467-L476) to `unknown`. While this type change is correct, it'd be better if the generic could be specified by a consumer library, for instance if maintaining the previous behavior of `any` is desired in a library usage.