### PR TITLE
fix: Preserve `deprecationReason` on `GraphQLInputField`s

### DIFF
--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -818,6 +818,22 @@ describe('Type System: Input Objects', () => {
       );
     });
   });
+
+  describe('Deprecation reason is preserved on fields', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: {
+        deprecatedField: {
+          type: ScalarType,
+          deprecationReason: 'not used anymore',
+        },
+      },
+    });
+    const config = inputObjType.toConfig();
+    expect(config.fields.deprecatedField.deprecationReason).to.equal(
+      'not used anymore',
+    );
+  });
 });
 
 describe('Type System: List', () => {

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -819,7 +819,7 @@ describe('Type System: Input Objects', () => {
     });
   });
 
-  describe('Deprecation reason is preserved on fields', () => {
+  it('Deprecation reason is preserved on fields', () => {
     const inputObjType = new GraphQLInputObjectType({
       name: 'SomeInputObject',
       fields: {
@@ -829,8 +829,8 @@ describe('Type System: Input Objects', () => {
         },
       },
     });
-    const config = inputObjType.toConfig();
-    expect(config.fields.deprecatedField.deprecationReason).to.equal(
+    expect(inputObjType.toConfig()).to.have.nested.property(
+      'fields.deprecatedField.deprecationReason',
       'not used anymore',
     );
   });

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1648,9 +1648,9 @@ export class GraphQLInputObjectType {
       description: field.description,
       type: field.type,
       defaultValue: field.defaultValue,
+      deprecationReason: field.deprecationReason,
       extensions: field.extensions,
       astNode: field.astNode,
-      deprecationReason: field.deprecationReason,
     }));
 
     return {

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1650,6 +1650,7 @@ export class GraphQLInputObjectType {
       defaultValue: field.defaultValue,
       extensions: field.extensions,
       astNode: field.astNode,
+      deprecationReason: field.deprecationReason,
     }));
 
     return {


### PR DESCRIPTION
`GraphQLInputObjectType.toConfig()` currently doesn't preserve `deprecationReason`s on its fields. Anything internal depending on this function omits the `deprecationReason` from a `GraphQLInputObjectType`'s fields.

This was easy to remedy - we just needed to copy the field's `deprecationReason` property during the mapping of fields done in `toConfig()`.

I experienced this issue when using `extendSchema` on a `GraphQLSchema` object which had a `GraphQLInputObjectType` with fields marked `@deprecated`. The reason would be dropped from the extended schema.