### PR TITLE
backport: Preserve `deprecationReason` on `GraphQLInputField`s

### DIFF
--- a/src/type/__tests__/definition-test.js
+++ b/src/type/__tests__/definition-test.js
@@ -856,6 +856,22 @@ describe('Type System: Input Objects', () => {
       );
     });
   });
+
+  it('Deprecation reason is preserved on fields', () => {
+    const inputObjType = new GraphQLInputObjectType({
+      name: 'SomeInputObject',
+      fields: {
+        deprecatedField: {
+          type: ScalarType,
+          deprecationReason: 'not used anymore',
+        },
+      },
+    });
+    expect(inputObjType.toConfig()).to.have.nested.property(
+      'fields.deprecatedField.deprecationReason',
+      'not used anymore',
+    );
+  });
 });
 
 describe('Type System: List', () => {

--- a/src/type/definition.js
+++ b/src/type/definition.js
@@ -1546,6 +1546,7 @@ export class GraphQLInputObjectType {
       description: field.description,
       type: field.type,
       defaultValue: field.defaultValue,
+      deprecationReason: field.deprecationReason,
       extensions: field.extensions,
       astNode: field.astNode,
     }));


### PR DESCRIPTION
Backported from #3257

Co-authored-by: Ivan Goncharov <ivan.goncharov.ua@gmail.com>