### PR TITLE
lexer: Remove superfluous statement in `readDigits`

### DIFF
--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -490,11 +490,10 @@ function readDigits(lexer: Lexer, start: number, firstCode: number): number {
 
   const body = lexer.source.body;
   let position = start;
-  let code = firstCode;
 
   do {
-    code = body.charCodeAt(++position);
-  } while (isDigit(code));
+    // empty
+  } while (isDigit(body.charCodeAt(++position)));
 
   return position;
 }

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -489,11 +489,11 @@ function readDigits(lexer: Lexer, start: number, firstCode: number): number {
   }
 
   const body = lexer.source.body;
-  let position = start;
+  let position = start + 1; // +1 to skip first firstCode
 
-  do {
-    // empty
-  } while (isDigit(body.charCodeAt(++position)));
+  while (isDigit(body.charCodeAt(position))) {
+    ++position;
+  }
 
   return position;
 }


### PR DESCRIPTION
Setting `code = firstCode` does not make sense here, since it is immediately overwritten. Either just `let code;` or use an empty loop as I have done here.