### PR TITLE
lexer: fix expression to decode surrogate pairs

### DIFF
--- a/src/language/__tests__/lexer-test.ts
+++ b/src/language/__tests__/lexer-test.ts
@@ -1040,6 +1040,21 @@ describe('Lexer', () => {
       locations: [{ line: 1, column: 1 }],
     });
 
+    expectSyntaxError('\uD83D\uDE00').to.deep.equal({
+      message: 'Syntax Error: Unexpected character: U+1F600.',
+      locations: [{ line: 1, column: 1 }],
+    });
+
+    expectSyntaxError('\uD800\uDC00').to.deep.equal({
+      message: 'Syntax Error: Unexpected character: U+10000.',
+      locations: [{ line: 1, column: 1 }],
+    });
+
+    expectSyntaxError('\uDBFF\uDFFF').to.deep.equal({
+      message: 'Syntax Error: Unexpected character: U+10FFFF.',
+      locations: [{ line: 1, column: 1 }],
+    });
+
     expectSyntaxError('\uDEAD').to.deep.equal({
       message: 'Syntax Error: Invalid character: U+DEAD.',
       locations: [{ line: 1, column: 1 }],

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -152,7 +152,7 @@ function encodeSurrogatePair(point: number): string {
 }
 
 function decodeSurrogatePair(leading: number, trailing: number): number {
-  return 0x10000 | ((leading & 0x03ff) << 10) | (trailing & 0x03ff);
+  return 0x10000 + (((leading & 0x03ff) << 10) | (trailing & 0x03ff));
 }
 
 /**


### PR DESCRIPTION
When calculating the code point for a surrogate pair, the base code point of 0x10000 must be added, not bitwise ORed. Added some tests for catching this problem.