### PR TITLE
Validate variables are known types

### DIFF
--- a/src/validation/__tests__/VariablesAreInputTypesRule-test.ts
+++ b/src/validation/__tests__/VariablesAreInputTypesRule-test.ts
@@ -21,6 +21,23 @@ describe('Validate: Variables are input types', () => {
     `);
   });
 
+  it('unknown types are invalid', () => {
+    expectErrors(`
+      query Foo($a: Unknown, $b: [[Unknown!]]!) {
+        field(a: $a, b: $b)
+      }
+    `).to.deep.equal([
+      {
+        locations: [{ line: 2, column: 21 }],
+        message: 'Variable "$a" references unknown type "Unknown".',
+      },
+      {
+        locations: [{ line: 2, column: 34 }],
+        message: 'Variable "$b" references unknown type "[[Unknown!]]!".',
+      },
+    ]);
+  });
+
   it('output types are invalid', () => {
     expectErrors(`
       query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {

--- a/src/validation/rules/VariablesAreInputTypesRule.ts
+++ b/src/validation/rules/VariablesAreInputTypesRule.ts
@@ -22,27 +22,15 @@ export function VariablesAreInputTypesRule(
   return {
     VariableDefinition(node: VariableDefinitionNode) {
       const type = typeFromAST(context.getSchema(), node.type);
-
-      if (!type) {
-        const variableName = node.variable.name.value;
-        const typeReference = print(node.type);
-
-        context.reportError(
-          new GraphQLError(
-            `Variable "$${variableName}" references unknown type "${typeReference}".`,
-            node.type,
-          ),
-        );
-        return;
-      }
-
       if (!isInputType(type)) {
         const variableName = node.variable.name.value;
         const typeReference = print(node.type);
 
         context.reportError(
           new GraphQLError(
-            `Variable "$${variableName}" cannot be non-input type "${typeReference}".`,
+            type === undefined
+              ? `Variable "$${variableName}" references unknown type "${typeReference}".`
+              : `Variable "$${variableName}" cannot be non-input type "${typeReference}".`,
             node.type,
           ),
         );

--- a/src/validation/rules/VariablesAreInputTypesRule.ts
+++ b/src/validation/rules/VariablesAreInputTypesRule.ts
@@ -23,13 +23,26 @@ export function VariablesAreInputTypesRule(
     VariableDefinition(node: VariableDefinitionNode) {
       const type = typeFromAST(context.getSchema(), node.type);
 
-      if (type && !isInputType(type)) {
+      if (!type) {
         const variableName = node.variable.name.value;
-        const typeName = print(node.type);
+        const typeReference = print(node.type);
 
         context.reportError(
           new GraphQLError(
-            `Variable "$${variableName}" cannot be non-input type "${typeName}".`,
+            `Variable "$${variableName}" references unknown type "${typeReference}".`,
+            node.type,
+          ),
+        );
+        return;
+      }
+
+      if (!isInputType(type)) {
+        const variableName = node.variable.name.value;
+        const typeReference = print(node.type);
+
+        context.reportError(
+          new GraphQLError(
+            `Variable "$${variableName}" cannot be non-input type "${typeReference}".`,
             node.type,
           ),
         );


### PR DESCRIPTION
Adds a check to the validation rule VariablesAreInputTypes to ensure
that referenced types exist at all before checking they are input types.

This check is not explicitly described in the specification for validating
variables: http://spec.graphql.org/draft/#sec-Validation.Variables
I am assuming this is simply an oversight and the rule is implicit.
Still, it is valuable to check for it in order to provide a proper error to clients.