### PR TITLE
Align calls of buildExecutionContext

### DIFF
--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -147,23 +147,24 @@ export async function createSourceEventStream(
   // developer mistake which should throw an early error.
   assertValidExecutionArguments(schema, document, variableValues);
 
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const exeContext = buildExecutionContext(
+    schema,
+    document,
+    rootValue,
+    contextValue,
+    variableValues,
+    operationName,
+    fieldResolver,
+  );
+
+  // Return early errors if execution context failed.
+  if (!('schema' in exeContext)) {
+    return { errors: exeContext };
+  }
+
   try {
-    // If a valid context cannot be created due to incorrect arguments, this will throw an error.
-    const exeContext = buildExecutionContext(
-      schema,
-      document,
-      rootValue,
-      contextValue,
-      variableValues,
-      operationName,
-      fieldResolver,
-    );
-
-    // Return early errors if execution context failed.
-    if (!('schema' in exeContext)) {
-      return { errors: exeContext };
-    }
-
     const eventStream = await executeSubscription(exeContext);
 
     // Assert field returned an event stream, otherwise yield an error.


### PR DESCRIPTION
`buildExecutionContext` used to throw an error on failure, but was changed
to return an array of errors (enabling the function to return multiple
errors encountered during variable coercion).

As the function is no longer designed to throw, it no longer needs to be
wrapped in a try block when used within the `subscribe` function. This
change aligns the use of `buildExecutionContext between the `subscribe`
and `execute` functions.