### PR TITLE
Subscriptions should normalize request properties only once

### DIFF
--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -502,8 +502,7 @@ describe('Subscription Initialization Phase', () => {
 
     // If we receive variables that cannot be coerced correctly, subscribe() will
     // resolve to an ExecutionResult that contains an informative error description.
-    const result = await subscribe({ schema, document, variableValues });
-    expectJSON(result).to.deep.equal({
+    const expectedResult = {
       errors: [
         {
           message:
@@ -511,7 +510,21 @@ describe('Subscription Initialization Phase', () => {
           locations: [{ line: 2, column: 21 }],
         },
       ],
-    });
+    };
+
+    expectJSON(
+      await subscribe({ schema, document, variableValues }),
+    ).to.deep.equal(expectedResult);
+
+    expectJSON(
+      await createSourceEventStream(
+        schema,
+        document,
+        undefined,
+        undefined,
+        variableValues,
+      ),
+    ).to.deep.equal(expectedResult);
   });
 });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -180,7 +180,11 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
     return { errors: exeContext };
   }
 
-  // Return data or a  Promise that will eventually resolve to the data described
+  return executeQueryOrMutation(exeContext);
+}
+
+export function executeQueryOrMutation(exeContext: ExecutionContext) {
+  // Return data or a Promise that will eventually resolve to the data described
   // by the "Response" section of the GraphQL specification.
 
   // If errors are encountered while executing a GraphQL field, only that


### PR DESCRIPTION
The `subscribe` method calls `createSourceEventStream` and `execute`, each of which normalize the request properties separately.

By normalizing requests within the `subscribe` function, we can pass the normalized arguments to the implementation for `createSourceEventStream` (new function `createSourceEventStreamImpl`) and the implementation for `execute` (new function `executeQueryOrMutation`).

Depends on #3294