### PR TITLE
Export internal Executor class for experimentation

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -138,6 +138,16 @@ export interface ExecutionArgs {
 }
 
 /**
+ * Executor class responsible for implementing the Execution section of the GraphQL spec.
+ *
+ * This class is exported only to assist people in implementing their own executors
+ * without duplicating too much code and should be used only as last resort for cases
+ * such as experimental syntax or if certain features could not be contributed upstream.
+ *
+ * It is still part of the internal API and is versioned, so any changes to it are never
+ * considered breaking changes. If you still need to support multiple versions of the
+ * library, please use the `versionInfo` variable for version detection.
+ *
  * @internal
  */
 export class Executor {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -8,6 +8,8 @@ export type {
   FormattedExecutionResult,
 } from './executor';
 
+export { Executor } from './executor';
+
 export { execute, executeSync } from './execute';
 
 export { subscribe, createSourceEventStream } from './subscribe';

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,6 +306,7 @@ export type {
 
 /** Execute GraphQL queries. */
 export {
+  Executor,
   execute,
   executeSync,
   defaultFieldResolver,


### PR DESCRIPTION
This class, similar to the Parser class, is exported only to assist people in implementing their own executors without duplicating too much code and should be used only as last resort for cases such as experimental syntax or if certain features could not be contributed upstream.

It is still part of the internal API and is versioned, so any changes to it are never considered breaking changes. If you still need to support multiple versions of the library, please use the `versionInfo` variable for version detection.

Depends on #3301