### PR TITLE
README: remove credits for `*.d.ts` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,30 +156,3 @@ Changes are tracked as [GitHub releases](https://github.com/graphql/graphql-js/r
 ### License
 
 GraphQL.js is [MIT-licensed](./LICENSE).
-
-### Credits
-
-The `*.d.ts` files in this project are based on [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/54712a7e28090c5b1253b746d1878003c954f3ff/types/graphql) definitions written by:
-
-<!--- spell-checker:disable -->
-
-- TonyYang https://github.com/TonyPythoneer
-- Caleb Meredith https://github.com/calebmer
-- Dominic Watson https://github.com/intellix
-- Firede https://github.com/firede
-- Kepennar https://github.com/kepennar
-- Mikhail Novikov https://github.com/freiksenet
-- Ivan Goncharov https://github.com/IvanGoncharov
-- Hagai Cohen https://github.com/DxCx
-- Ricardo Portugal https://github.com/rportugal
-- Tim Griesser https://github.com/tgriesser
-- Dylan Stewart https://github.com/dyst5422
-- Alessio Dionisi https://github.com/adnsio
-- Divyendu Singh https://github.com/divyenduz
-- Brad Zacher https://github.com/bradzacher
-- Curtis Layne https://github.com/clayne11
-- Jonathan Cardoso https://github.com/JCMais
-- Pavel Lang https://github.com/langpavel
-- Mark Caudill https://github.com/mc0
-- Martijn Walraven https://github.com/martijnwalraven
-- Jed Mao https://github.com/jedmao


### PR DESCRIPTION
We now switched to TS, so we generate our `*.d.ts` files.
Big thanks to everyone who maintained types `DefinitelyTyped` until we made this switch!

Closes #2857 