### PR TITLE
expectJSON: return custom object instead of `expect`

### DIFF
--- a/src/__testUtils__/expectJSON.ts
+++ b/src/__testUtils__/expectJSON.ts
@@ -23,8 +23,18 @@ function toJSONDeep(value: unknown): unknown {
   return mapValue(value, toJSONDeep);
 }
 
-export function expectJSON(value: unknown) {
-  return expect(toJSONDeep(value));
+export function expectJSON(actual: unknown) {
+  return {
+    toDeepEqual(expected: unknown) {
+      expect(toJSONDeep(actual)).to.deep.equal(toJSONDeep(expected));
+    },
+    toDeepNestedProperty(path: string, expected: unknown) {
+      expect(toJSONDeep(actual)).to.deep.nested.property(
+        path,
+        toJSONDeep(expected),
+      );
+    },
+  };
 }
 
 export function expectToThrowJSON(fn: () => unknown) {

--- a/src/__tests__/starWarsQuery-test.ts
+++ b/src/__tests__/starWarsQuery-test.ts
@@ -395,7 +395,7 @@ describe('Star Wars Query Tests', () => {
       `;
 
       const result = await graphql({ schema, source });
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           hero: {
             name: 'R2-D2',
@@ -426,7 +426,7 @@ describe('Star Wars Query Tests', () => {
       `;
 
       const result = await graphql({ schema, source });
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           hero: {
             name: 'R2-D2',
@@ -477,7 +477,7 @@ describe('Star Wars Query Tests', () => {
       `;
 
       const result = await graphql({ schema, source });
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           mainHero: {
             name: 'R2-D2',

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -39,7 +39,7 @@ async function executeQuery(args: {
     contextValue: { async: true },
   });
 
-  expect(result).to.deep.equal(asyncResult);
+  expectJSON(result).toDeepEqual(asyncResult);
   return result;
 }
 
@@ -206,7 +206,7 @@ describe('Execute: Handles execution of abstract types', () => {
       }
     `;
 
-    expectJSON(await executeQuery({ schema, query })).to.deep.equal({
+    expectJSON(await executeQuery({ schema, query })).toDeepEqual({
       data: {
         pets: [null, null],
       },
@@ -360,7 +360,7 @@ describe('Execute: Handles execution of abstract types', () => {
       }
     `;
 
-    expectJSON(await executeQuery({ schema, query })).to.deep.equal({
+    expectJSON(await executeQuery({ schema, query })).toDeepEqual({
       data: {
         pets: [null, null],
       },
@@ -541,7 +541,7 @@ describe('Execute: Handles execution of abstract types', () => {
       const result = executeSync({ schema, document, rootValue });
       return {
         toEqual(message: string) {
-          expectJSON(result).to.deep.equal({
+          expectJSON(result).toDeepEqual({
             data: { pet: null },
             errors: [
               {

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -499,7 +499,7 @@ describe('Execute: Handles basic execution tasks', () => {
     };
 
     const result = await execute({ schema, document, rootValue });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: {
         sync: 'sync',
         syncError: null,
@@ -613,7 +613,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     const result = await execute({ schema, document });
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: { foods: null },
       errors: [
         {
@@ -672,7 +672,7 @@ describe('Execute: Handles basic execution tasks', () => {
     `);
 
     const result = executeSync({ schema, document });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: {
         nullableA: {
           aliasedA: null,
@@ -754,7 +754,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const rootValue = { a: 'b' };
 
     const result = executeSync({ schema, document, rootValue });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [{ message: 'Must provide an operation.' }],
     });
   });
@@ -774,7 +774,7 @@ describe('Execute: Handles basic execution tasks', () => {
     `);
 
     const result = executeSync({ schema, document });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -800,7 +800,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const operationName = 'UnknownExample';
 
     const result = executeSync({ schema, document, operationName });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [{ message: 'Unknown operation named "UnknownExample".' }],
     });
   });
@@ -818,7 +818,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const operationName = '';
 
     const result = executeSync({ schema, document, operationName });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [{ message: 'Unknown operation named "".' }],
     });
   });
@@ -919,7 +919,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expectJSON(
       executeSync({ schema, document, operationName: 'Q' }),
-    ).to.deep.equal({
+    ).toDeepEqual({
       data: null,
       errors: [
         {
@@ -931,7 +931,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expectJSON(
       executeSync({ schema, document, operationName: 'M' }),
-    ).to.deep.equal({
+    ).toDeepEqual({
       data: null,
       errors: [
         {
@@ -943,7 +943,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expectJSON(
       executeSync({ schema, document, operationName: 'S' }),
-    ).to.deep.equal({
+    ).toDeepEqual({
       data: null,
       errors: [
         {
@@ -1123,7 +1123,7 @@ describe('Execute: Handles basic execution tasks', () => {
     };
 
     const result = executeSync({ schema, document, rootValue });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: {
         specials: [{ value: 'foo' }, null],
       },
@@ -1167,7 +1167,7 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     const result = executeSync({ schema, document: parse('{ customScalar }') });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: { customScalar: null },
       errors: [
         {

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -52,7 +52,7 @@ describe('Execute: Accepts any iterable as list value', () => {
   it('Does not accept (Iterable) String-literal as a List value', () => {
     const listField = 'Singular';
 
-    expectJSON(complete({ listField })).to.deep.equal({
+    expectJSON(complete({ listField })).toDeepEqual({
       data: { listField: null },
       errors: [
         {
@@ -74,14 +74,14 @@ describe('Execute: Handles list nullability', () => {
 
     const result = await executeQuery(listField);
     // Promise<Array<T>> === Array<T>
-    expect(await executeQuery(promisify(listField))).to.deep.equal(result);
+    expectJSON(await executeQuery(promisify(listField))).toDeepEqual(result);
     if (Array.isArray(listField)) {
       const listOfPromises = listField.map(promisify);
 
       // Array<Promise<T>> === Array<T>
-      expect(await executeQuery(listOfPromises)).to.deep.equal(result);
+      expectJSON(await executeQuery(listOfPromises)).toDeepEqual(result);
       // Promise<Array<Promise<T>>> === Array<T>
-      expect(await executeQuery(promisify(listOfPromises))).to.deep.equal(
+      expectJSON(await executeQuery(promisify(listOfPromises))).toDeepEqual(
         result,
       );
     }
@@ -131,11 +131,11 @@ describe('Execute: Handles list nullability', () => {
     expect(await complete({ listField, as: '[Int]!' })).to.deep.equal({
       data: { listField: [1, null, 2] },
     });
-    expectJSON(await complete({ listField, as: '[Int!]' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]' })).toDeepEqual({
       data: { listField: null },
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int!]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]!' })).toDeepEqual({
       data: null,
       errors,
     });
@@ -154,14 +154,14 @@ describe('Execute: Handles list nullability', () => {
     expect(await complete({ listField, as: '[Int]' })).to.deep.equal({
       data: { listField: null },
     });
-    expectJSON(await complete({ listField, as: '[Int]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int]!' })).toDeepEqual({
       data: null,
       errors,
     });
     expect(await complete({ listField, as: '[Int!]' })).to.deep.equal({
       data: { listField: null },
     });
-    expectJSON(await complete({ listField, as: '[Int!]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]!' })).toDeepEqual({
       data: null,
       errors,
     });
@@ -177,19 +177,19 @@ describe('Execute: Handles list nullability', () => {
       },
     ];
 
-    expectJSON(await complete({ listField, as: '[Int]' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int]' })).toDeepEqual({
       data: { listField: [1, null, 2] },
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int]!' })).toDeepEqual({
       data: { listField: [1, null, 2] },
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int!]' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]' })).toDeepEqual({
       data: { listField: null },
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int!]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]!' })).toDeepEqual({
       data: null,
       errors,
     });
@@ -205,19 +205,19 @@ describe('Execute: Handles list nullability', () => {
       },
     ];
 
-    expectJSON(await complete({ listField, as: '[Int]' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int]' })).toDeepEqual({
       data: { listField: null },
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int]!' })).toDeepEqual({
       data: null,
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int!]' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]' })).toDeepEqual({
       data: { listField: null },
       errors,
     });
-    expectJSON(await complete({ listField, as: '[Int!]!' })).to.deep.equal({
+    expectJSON(await complete({ listField, as: '[Int!]!' })).toDeepEqual({
       data: null,
       errors,
     });

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -169,7 +169,7 @@ describe('Execute: Handles mutation execution ordering', () => {
     const rootValue = new Root(6);
     const result = await execute({ schema, document, rootValue });
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: {
         first: { theNumber: 1 },
         second: { theNumber: 2 },

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -132,7 +132,7 @@ async function executeSyncAndAsync(query: string, rootValue: unknown) {
     rootValue,
   });
 
-  expectJSON(asyncResult).to.deep.equal(patchData(syncResult));
+  expectJSON(asyncResult).toDeepEqual(patchData(syncResult));
   return syncResult;
 }
 
@@ -153,7 +153,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: { sync: null },
         errors: [
           {
@@ -177,7 +177,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeSyncAndAsync(query, nullingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: { syncNest: null },
         errors: [
           {
@@ -192,7 +192,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: { syncNest: null },
         errors: [
           {
@@ -244,7 +244,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeQuery(query, throwingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data,
         errors: [
           {
@@ -370,7 +370,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeQuery(query, nullingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data,
         errors: [
           {
@@ -431,7 +431,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeQuery(query, throwingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data,
         errors: [
           {
@@ -496,7 +496,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that returns null', async () => {
       const result = await executeSyncAndAsync(query, nullingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: null,
         errors: [
           {
@@ -511,7 +511,7 @@ describe('Execute: handles non-nullable types', () => {
 
     it('that throws', async () => {
       const result = await executeSyncAndAsync(query, throwingData);
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: null,
         errors: [
           {
@@ -611,7 +611,7 @@ describe('Execute: handles non-nullable types', () => {
         `),
       });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           withNonNullArg: null,
         },
@@ -638,7 +638,7 @@ describe('Execute: handles non-nullable types', () => {
         `),
       });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           withNonNullArg: null,
         },
@@ -668,7 +668,7 @@ describe('Execute: handles non-nullable types', () => {
         },
       });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           withNonNullArg: null,
         },
@@ -696,7 +696,7 @@ describe('Execute: handles non-nullable types', () => {
         },
       });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           withNonNullArg: null,
         },

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -372,7 +372,7 @@ describe('Subscription Initialization Phase', () => {
     const document = parse('subscription { unknownField }');
 
     const result = await subscribe({ schema, document });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -396,7 +396,7 @@ describe('Subscription Initialization Phase', () => {
     const document = parse('subscription { unknownField }');
 
     const result = await subscribe({ schema, document });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message: 'The subscription field "unknownField" is not defined.',
@@ -456,7 +456,7 @@ describe('Subscription Initialization Phase', () => {
       const document = parse('subscription { foo }');
       const result = await subscribe({ schema, document });
 
-      expect(await createSourceEventStream(schema, document)).to.deep.equal(
+      expectJSON(await createSourceEventStream(schema, document)).toDeepEqual(
         result,
       );
       return result;
@@ -475,24 +475,24 @@ describe('Subscription Initialization Phase', () => {
     expectJSON(
       // Returning an error
       await subscribeWithFn(() => new Error('test error')),
-    ).to.deep.equal(expectedResult);
+    ).toDeepEqual(expectedResult);
 
     expectJSON(
       // Throwing an error
       await subscribeWithFn(() => {
         throw new Error('test error');
       }),
-    ).to.deep.equal(expectedResult);
+    ).toDeepEqual(expectedResult);
 
     expectJSON(
       // Resolving to an error
       await subscribeWithFn(() => Promise.resolve(new Error('test error'))),
-    ).to.deep.equal(expectedResult);
+    ).toDeepEqual(expectedResult);
 
     expectJSON(
       // Rejecting with an error
       await subscribeWithFn(() => Promise.reject(new Error('test error'))),
-    ).to.deep.equal(expectedResult);
+    ).toDeepEqual(expectedResult);
   });
 
   it('resolves to an error if variables were wrong type', async () => {
@@ -519,7 +519,7 @@ describe('Subscription Initialization Phase', () => {
     // If we receive variables that cannot be coerced correctly, subscribe() will
     // resolve to an ExecutionResult that contains an informative error description.
     const result = await subscribe({ schema, document, variableValues });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -941,7 +941,7 @@ describe('Subscription Publish Phase', () => {
     });
 
     // An error in execution is presented as such.
-    expectJSON(await subscription.next()).to.deep.equal({
+    expectJSON(await subscription.next()).toDeepEqual({
       done: false,
       value: {
         data: { newMessage: null },
@@ -957,7 +957,7 @@ describe('Subscription Publish Phase', () => {
 
     // However that does not close the response event stream.
     // Subsequent events are still executed.
-    expectJSON(await subscription.next()).to.deep.equal({
+    expectJSON(await subscription.next()).toDeepEqual({
       done: false,
       value: {
         data: { newMessage: 'Bonjour' },

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -54,7 +54,7 @@ describe('Execute: synchronously when possible', () => {
       document: parse(doc),
       rootValue: 'rootValue',
     });
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [{ message: 'Must provide an operation.' }],
     });
   });
@@ -122,7 +122,7 @@ describe('Execute: synchronously when possible', () => {
         schema: badSchema,
         source: '{ __typename }',
       });
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [{ message: 'Query root type must be provided.' }],
       });
     });
@@ -133,7 +133,7 @@ describe('Execute: synchronously when possible', () => {
         schema,
         source: doc,
       });
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message: 'Syntax Error: Expected Name, found "{".',

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -198,7 +198,7 @@ describe('Execute: Handles inputs', () => {
           }
         `);
 
-        expectJSON(result).to.deep.equal({
+        expectJSON(result).toDeepEqual({
           data: {
             fieldWithObjectInput: null,
           },
@@ -371,7 +371,7 @@ describe('Execute: Handles inputs', () => {
         const params = { input: { a: 'foo', b: 'bar', c: null } };
         const result = executeQuery(doc, params);
 
-        expectJSON(result).to.deep.equal({
+        expectJSON(result).toDeepEqual({
           errors: [
             {
               message:
@@ -385,7 +385,7 @@ describe('Execute: Handles inputs', () => {
       it('errors on incorrect type', () => {
         const result = executeQuery(doc, { input: 'foo bar' });
 
-        expectJSON(result).to.deep.equal({
+        expectJSON(result).toDeepEqual({
           errors: [
             {
               message:
@@ -399,7 +399,7 @@ describe('Execute: Handles inputs', () => {
       it('errors on omission of nested non-null', () => {
         const result = executeQuery(doc, { input: { a: 'foo', b: 'bar' } });
 
-        expectJSON(result).to.deep.equal({
+        expectJSON(result).toDeepEqual({
           errors: [
             {
               message:
@@ -418,7 +418,7 @@ describe('Execute: Handles inputs', () => {
         `;
         const result = executeQuery(nestedDoc, { input: { na: { a: 'foo' } } });
 
-        expectJSON(result).to.deep.equal({
+        expectJSON(result).toDeepEqual({
           errors: [
             {
               message:
@@ -440,7 +440,7 @@ describe('Execute: Handles inputs', () => {
         };
         const result = executeQuery(doc, params);
 
-        expectJSON(result).to.deep.equal({
+        expectJSON(result).toDeepEqual({
           errors: [
             {
               message:
@@ -615,7 +615,7 @@ describe('Execute: Handles inputs', () => {
         }
       `);
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -634,7 +634,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { value: null });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -677,7 +677,7 @@ describe('Execute: Handles inputs', () => {
     it('reports error for missing non-nullable inputs', () => {
       const result = executeQuery('{ fieldWithNonNullableStringInput }');
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           fieldWithNonNullableStringInput: null,
         },
@@ -700,7 +700,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { value: [1, 2, 3] });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -725,7 +725,7 @@ describe('Execute: Handles inputs', () => {
         }
       `);
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           fieldWithNonNullableStringInput: null,
         },
@@ -783,7 +783,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { input: null });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -846,7 +846,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { input: ['A', null, 'B'] });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -865,7 +865,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { input: null });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -895,7 +895,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { input: ['A', null, 'B'] });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -914,7 +914,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { input: { list: ['A', 'B'] } });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -933,7 +933,7 @@ describe('Execute: Handles inputs', () => {
       `;
       const result = executeQuery(doc, { input: 'WhoKnows' });
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           {
             message:
@@ -977,7 +977,7 @@ describe('Execute: Handles inputs', () => {
         }
       `);
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         data: {
           fieldWithDefaultArgumentValue: null,
         },
@@ -1031,7 +1031,7 @@ describe('Execute: Handles inputs', () => {
     it('return all errors by default', () => {
       const result = getVariableValues(schema, variableDefinitions, inputValue);
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           invalidValueError(0, 0),
           invalidValueError(1, 1),
@@ -1048,7 +1048,7 @@ describe('Execute: Handles inputs', () => {
         { maxErrors: 3 },
       );
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           invalidValueError(0, 0),
           invalidValueError(1, 1),
@@ -1065,7 +1065,7 @@ describe('Execute: Handles inputs', () => {
         { maxErrors: 2 },
       );
 
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         errors: [
           invalidValueError(0, 0),
           invalidValueError(1, 1),

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -234,7 +234,7 @@ describe('Parser', () => {
       }
     `);
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       kind: Kind.DOCUMENT,
       loc: { start: 0, end: 40 },
       definitions: [
@@ -324,7 +324,7 @@ describe('Parser', () => {
       }
     `);
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       kind: Kind.DOCUMENT,
       loc: { start: 0, end: 29 },
       definitions: [
@@ -419,7 +419,7 @@ describe('Parser', () => {
   describe('parseValue', () => {
     it('parses null value', () => {
       const result = parseValue('null');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.NULL,
         loc: { start: 0, end: 4 },
       });
@@ -427,7 +427,7 @@ describe('Parser', () => {
 
     it('parses list values', () => {
       const result = parseValue('[123 "abc"]');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.LIST,
         loc: { start: 0, end: 11 },
         values: [
@@ -448,7 +448,7 @@ describe('Parser', () => {
 
     it('parses block strings', () => {
       const result = parseValue('["""long""" "short"]');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.LIST,
         loc: { start: 0, end: 20 },
         values: [
@@ -470,7 +470,7 @@ describe('Parser', () => {
 
     it('allows variables', () => {
       const result = parseValue('{ field: $var }');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.OBJECT,
         loc: { start: 0, end: 15 },
         fields: [
@@ -518,7 +518,7 @@ describe('Parser', () => {
   describe('parseConstValue', () => {
     it('parses values', () => {
       const result = parseConstValue('[123 "abc"]');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.LIST,
         loc: { start: 0, end: 11 },
         values: [
@@ -560,7 +560,7 @@ describe('Parser', () => {
   describe('parseType', () => {
     it('parses well known types', () => {
       const result = parseType('String');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.NAMED_TYPE,
         loc: { start: 0, end: 6 },
         name: {
@@ -573,7 +573,7 @@ describe('Parser', () => {
 
     it('parses custom types', () => {
       const result = parseType('MyType');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.NAMED_TYPE,
         loc: { start: 0, end: 6 },
         name: {
@@ -586,7 +586,7 @@ describe('Parser', () => {
 
     it('parses list types', () => {
       const result = parseType('[MyType]');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.LIST_TYPE,
         loc: { start: 0, end: 8 },
         type: {
@@ -603,7 +603,7 @@ describe('Parser', () => {
 
     it('parses non-null types', () => {
       const result = parseType('MyType!');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.NON_NULL_TYPE,
         loc: { start: 0, end: 7 },
         type: {
@@ -620,7 +620,7 @@ describe('Parser', () => {
 
     it('parses nested types', () => {
       const result = parseType('[MyType!]');
-      expectJSON(result).to.deep.equal({
+      expectJSON(result).toDeepEqual({
         kind: Kind.LIST_TYPE,
         loc: { start: 0, end: 9 },
         type: {

--- a/src/language/__tests__/schema-parser-test.ts
+++ b/src/language/__tests__/schema-parser-test.ts
@@ -83,7 +83,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -114,7 +114,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.nested.property('definitions[0].description', {
+    expectJSON(doc).toDeepNestedProperty('definitions[0].description', {
       kind: 'StringValue',
       value: 'Description',
       block: false,
@@ -133,7 +133,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.nested.property('definitions[0].description', {
+    expectJSON(doc).toDeepNestedProperty('definitions[0].description', {
       kind: 'StringValue',
       value: 'Description',
       block: true,
@@ -149,7 +149,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.nested.property('definitions[0].description', {
+    expectJSON(doc).toDeepNestedProperty('definitions[0].description', {
       kind: 'StringValue',
       value: 'Description',
       block: false,
@@ -171,7 +171,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -196,7 +196,7 @@ describe('Schema Parser', () => {
   it('Object extension without fields', () => {
     const doc = parse('extend type Hello implements Greeting');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -214,7 +214,7 @@ describe('Schema Parser', () => {
 
   it('Interface extension without fields', () => {
     const doc = parse('extend interface Hello implements Greeting');
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -237,7 +237,7 @@ describe('Schema Parser', () => {
       extend type Hello implements SecondGreeting
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -299,7 +299,7 @@ describe('Schema Parser', () => {
 
       extend interface Hello implements SecondGreeting
     `);
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -373,7 +373,7 @@ describe('Schema Parser', () => {
         mutation: Mutation
       }`;
     const doc = parse(body);
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -397,7 +397,7 @@ describe('Schema Parser', () => {
   it('Schema extension with only directives', () => {
     const body = 'extend schema @directive';
     const doc = parse(body);
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -439,7 +439,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -468,7 +468,7 @@ describe('Schema Parser', () => {
 
   it('Simple interface inheriting interface', () => {
     const doc = parse('interface Hello implements World { field: String }');
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -494,7 +494,7 @@ describe('Schema Parser', () => {
   it('Simple type inheriting interface', () => {
     const doc = parse('type Hello implements World { field: String }');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -520,7 +520,7 @@ describe('Schema Parser', () => {
   it('Simple type inheriting multiple interfaces', () => {
     const doc = parse('type Hello implements Wo & rld { field: String }');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -548,7 +548,7 @@ describe('Schema Parser', () => {
 
   it('Simple interface inheriting multiple interfaces', () => {
     const doc = parse('interface Hello implements Wo & rld { field: String }');
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -577,7 +577,7 @@ describe('Schema Parser', () => {
   it('Simple type inheriting multiple interfaces with leading ampersand', () => {
     const doc = parse('type Hello implements & Wo & rld { field: String }');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -607,7 +607,7 @@ describe('Schema Parser', () => {
     const doc = parse(
       'interface Hello implements & Wo & rld { field: String }',
     );
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -636,7 +636,7 @@ describe('Schema Parser', () => {
   it('Single value enum', () => {
     const doc = parse('enum Hello { WORLD }');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -655,7 +655,7 @@ describe('Schema Parser', () => {
   it('Double value enum', () => {
     const doc = parse('enum Hello { WO, RLD }');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -681,7 +681,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -711,7 +711,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -749,7 +749,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -791,7 +791,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -833,7 +833,7 @@ describe('Schema Parser', () => {
       }
     `);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -873,7 +873,7 @@ describe('Schema Parser', () => {
   it('Simple union', () => {
     const doc = parse('union Hello = World');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -892,7 +892,7 @@ describe('Schema Parser', () => {
   it('Union with two types', () => {
     const doc = parse('union Hello = Wo | Rld');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -914,7 +914,7 @@ describe('Schema Parser', () => {
   it('Union with two types and leading pipe', () => {
     const doc = parse('union Hello = | Wo | Rld');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -964,7 +964,7 @@ describe('Schema Parser', () => {
   it('Scalar', () => {
     const doc = parse('scalar Hello');
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -985,7 +985,7 @@ input Hello {
   world: String
 }`);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -1023,7 +1023,7 @@ input Hello {
     const body = 'directive @foo on OBJECT | INTERFACE';
     const doc = parse(body);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {
@@ -1059,7 +1059,7 @@ input Hello {
     const body = 'directive @foo repeatable on OBJECT | INTERFACE';
     const doc = parse(body);
 
-    expectJSON(doc).to.deep.equal({
+    expectJSON(doc).toDeepEqual({
       kind: 'Document',
       definitions: [
         {

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -149,7 +149,7 @@ describe('Type System: Enum Values', () => {
   it('does not accept string literals', () => {
     const result = executeQuery('{ colorEnum(fromEnum: "GREEN") }');
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -163,7 +163,7 @@ describe('Type System: Enum Values', () => {
   it('does not accept values not in the enum', () => {
     const result = executeQuery('{ colorEnum(fromEnum: GREENISH) }');
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -177,7 +177,7 @@ describe('Type System: Enum Values', () => {
   it('does not accept values with incorrect casing', () => {
     const result = executeQuery('{ colorEnum(fromEnum: green) }');
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -191,7 +191,7 @@ describe('Type System: Enum Values', () => {
   it('does not accept incorrect internal value', () => {
     const result = executeQuery('{ colorEnum(fromString: "GREEN") }');
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: { colorEnum: null },
       errors: [
         {
@@ -206,7 +206,7 @@ describe('Type System: Enum Values', () => {
   it('does not accept internal value in place of enum literal', () => {
     const result = executeQuery('{ colorEnum(fromEnum: 1) }');
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message: 'Enum "Color" cannot represent non-enum value: 1.',
@@ -219,7 +219,7 @@ describe('Type System: Enum Values', () => {
   it('does not accept enum literal in place of int', () => {
     const result = executeQuery('{ colorEnum(fromInt: GREEN) }');
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message: 'Int cannot represent non-integer value: GREEN',
@@ -261,7 +261,7 @@ describe('Type System: Enum Values', () => {
     const doc = 'query ($color: Color!) { colorEnum(fromEnum: $color) }';
     const result = executeQuery(doc, { color: 2 });
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -276,7 +276,7 @@ describe('Type System: Enum Values', () => {
     const doc = 'query ($color: String!) { colorEnum(fromEnum: $color) }';
     const result = executeQuery(doc, { color: 'BLUE' });
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -294,7 +294,7 @@ describe('Type System: Enum Values', () => {
     const doc = 'query ($color: Int!) { colorEnum(fromEnum: $color) }';
     const result = executeQuery(doc, { color: 2 });
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       errors: [
         {
           message:
@@ -381,7 +381,7 @@ describe('Type System: Enum Values', () => {
       }
     `);
 
-    expectJSON(result).to.deep.equal({
+    expectJSON(result).toDeepEqual({
       data: {
         first: 'ONE',
         second: 'TWO',

--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -1534,7 +1534,7 @@ describe('Introspection', () => {
       }
     `;
 
-    expectJSON(graphqlSync({ schema, source })).to.deep.equal({
+    expectJSON(graphqlSync({ schema, source })).toDeepEqual({
       errors: [
         {
           message:

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -121,7 +121,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -132,7 +132,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([]);
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([]);
   });
 
   it('accepts a Schema whose query and mutation types are object types', () => {
@@ -145,7 +145,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -161,7 +161,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([]);
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([]);
   });
 
   it('accepts a Schema whose query and subscription types are object types', () => {
@@ -174,7 +174,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
 
     const schemaWithDef = buildSchema(`
       schema {
@@ -190,7 +190,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([]);
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([]);
   });
 
   it('rejects a Schema without a query type', () => {
@@ -199,7 +199,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Query root type must be provided.',
       },
@@ -214,7 +214,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([
       {
         message: 'Query root type must be provided.',
         locations: [{ line: 2, column: 7 }],
@@ -228,7 +228,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Query root type must be Object type, it cannot be Query.',
         locations: [{ line: 2, column: 7 }],
@@ -244,7 +244,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([
       {
         message:
           'Query root type must be Object type, it cannot be SomeInputObject.',
@@ -263,7 +263,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Mutation root type must be Object type if provided, it cannot be Mutation.',
@@ -285,7 +285,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([
       {
         message:
           'Mutation root type must be Object type if provided, it cannot be SomeInputObject.',
@@ -304,7 +304,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Subscription root type must be Object type if provided, it cannot be Subscription.',
@@ -326,7 +326,7 @@ describe('Type System: A Schema must have Object root types', () => {
         test: String
       }
     `);
-    expectJSON(validateSchema(schemaWithDef)).to.deep.equal([
+    expectJSON(validateSchema(schemaWithDef)).toDeepEqual([
       {
         message:
           'Subscription root type must be Object type if provided, it cannot be SomeInputObject.',
@@ -369,7 +369,7 @@ describe('Type System: A Schema must have Object root types', () => {
       `),
     );
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Query root type must be Object type, it cannot be SomeInputObject.',
@@ -394,7 +394,7 @@ describe('Type System: A Schema must have Object root types', () => {
       // @ts-expect-error
       types: [{ name: 'SomeType' }, SomeDirective],
     });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Expected GraphQL named type but got: { name: "SomeType" }.',
       },
@@ -411,7 +411,7 @@ describe('Type System: A Schema must have Object root types', () => {
       // @ts-expect-error
       directives: [null, 'SomeDirective', SomeScalarType],
     });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Expected directive but got: null.',
       },
@@ -437,7 +437,7 @@ describe('Type System: Objects must have fields', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Object type with missing fields', () => {
@@ -448,7 +448,7 @@ describe('Type System: Objects must have fields', () => {
 
       type IncompleteObject
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Type IncompleteObject must define one or more fields.',
         locations: [{ line: 6, column: 7 }],
@@ -461,7 +461,7 @@ describe('Type System: Objects must have fields', () => {
         fields: {},
       }),
     );
-    expectJSON(validateSchema(manualSchema)).to.deep.equal([
+    expectJSON(validateSchema(manualSchema)).toDeepEqual([
       {
         message: 'Type IncompleteObject must define one or more fields.',
       },
@@ -475,7 +475,7 @@ describe('Type System: Objects must have fields', () => {
         },
       }),
     );
-    expectJSON(validateSchema(manualSchema2)).to.deep.equal([
+    expectJSON(validateSchema(manualSchema2)).toDeepEqual([
       {
         message: 'Type IncompleteObject must define one or more fields.',
       },
@@ -491,7 +491,7 @@ describe('Type System: Objects must have fields', () => {
         },
       }),
     );
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Name "__badName" must not begin with "__", which is reserved by GraphQL introspection.',
@@ -515,7 +515,7 @@ describe('Type System: Fields args must be properly named', () => {
         },
       }),
     );
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects field arg with invalid names', () => {
@@ -533,7 +533,7 @@ describe('Type System: Fields args must be properly named', () => {
       }),
     );
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Name "__badName" must not begin with "__", which is reserved by GraphQL introspection.',
@@ -561,7 +561,7 @@ describe('Type System: Union types must be valid', () => {
         | TypeA
         | TypeB
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects a Union type with empty types', () => {
@@ -582,7 +582,7 @@ describe('Type System: Union types must be valid', () => {
       `),
     );
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Union type BadUnion must define one or more member types.',
         locations: [
@@ -613,7 +613,7 @@ describe('Type System: Union types must be valid', () => {
         | TypeA
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Union type BadUnion can only include type TypeA once.',
         locations: [
@@ -625,7 +625,7 @@ describe('Type System: Union types must be valid', () => {
 
     schema = extendSchema(schema, parse('extend union BadUnion = TypeB'));
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Union type BadUnion can only include type TypeA once.',
         locations: [
@@ -665,7 +665,7 @@ describe('Type System: Union types must be valid', () => {
 
     schema = extendSchema(schema, parse('extend union BadUnion = Int'));
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Union type BadUnion can only include Object types, it cannot include String.',
@@ -694,7 +694,7 @@ describe('Type System: Union types must be valid', () => {
         types: [memberType],
       });
       const badSchema = schemaWithFieldType(badUnion);
-      expectJSON(validateSchema(badSchema)).to.deep.equal([
+      expectJSON(validateSchema(badSchema)).toDeepEqual([
         {
           message:
             'Union type BadUnion can only include Object types, ' +
@@ -716,7 +716,7 @@ describe('Type System: Input Objects must have fields', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Input Object type with missing fields', () => {
@@ -737,7 +737,7 @@ describe('Type System: Input Objects must have fields', () => {
       `),
     );
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Input Object type SomeInputObject must define one or more fields.',
@@ -768,7 +768,7 @@ describe('Type System: Input Objects must have fields', () => {
       }
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Input Object with non-breakable circular reference', () => {
@@ -782,7 +782,7 @@ describe('Type System: Input Objects must have fields', () => {
       }
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Cannot reference Input Object "SomeInputObject" within itself through a series of non-null fields: "nonNullSelf".',
@@ -810,7 +810,7 @@ describe('Type System: Input Objects must have fields', () => {
       }
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Cannot reference Input Object "SomeInputObject" within itself through a series of non-null fields: "startLoop.nextInLoop.closeLoop".',
@@ -844,7 +844,7 @@ describe('Type System: Input Objects must have fields', () => {
       }
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Cannot reference Input Object "SomeInputObject" within itself through a series of non-null fields: "startLoop.closeLoop".',
@@ -887,7 +887,7 @@ describe('Type System: Input Objects must have fields', () => {
         goodInputObject: SomeInputObject
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of SomeInputObject.badObject must be Input Type but got: SomeObject.',
@@ -913,7 +913,7 @@ describe('Type System: Input Objects must have fields', () => {
         anotherOptionalField: String! = "" @deprecated
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Required input field SomeInputObject.badField cannot be deprecated.',
@@ -945,7 +945,7 @@ describe('Type System: Enum types must be well defined', () => {
       `),
     );
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Enum type SomeEnum must define one or more values.',
         locations: [
@@ -966,7 +966,7 @@ describe('Type System: Enum types must be well defined', () => {
       }),
     );
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Name "__badName" must not begin with "__", which is reserved by GraphQL introspection.',
@@ -1001,14 +1001,14 @@ describe('Type System: Object fields must have output types', () => {
     const typeName = inspect(type);
     it(`accepts an output type as an Object field type: ${typeName}`, () => {
       const schema = schemaWithObjectField({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([]);
+      expectJSON(validateSchema(schema)).toDeepEqual([]);
     });
   }
 
   it('rejects an empty Object field type', () => {
     // @ts-expect-error (type field must not be undefined)
     const schema = schemaWithObjectField({ type: undefined });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of BadObject.badField must be Output Type but got: undefined.',
@@ -1021,7 +1021,7 @@ describe('Type System: Object fields must have output types', () => {
     it(`rejects a non-output type as an Object field type: ${typeStr}`, () => {
       // @ts-expect-error
       const schema = schemaWithObjectField({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([
+      expectJSON(validateSchema(schema)).toDeepEqual([
         {
           message: `The type of BadObject.badField must be Output Type but got: ${typeStr}.`,
         },
@@ -1032,7 +1032,7 @@ describe('Type System: Object fields must have output types', () => {
   it('rejects a non-type value as an Object field type', () => {
     // @ts-expect-error
     const schema = schemaWithObjectField({ type: Number });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of BadObject.badField must be Output Type but got: [function Number].',
@@ -1053,7 +1053,7 @@ describe('Type System: Object fields must have output types', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of Query.field must be Output Type but got: [SomeInputObject].',
@@ -1074,7 +1074,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
       }),
     });
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type BadObject must only implement Interface types, it cannot implement undefined.',
@@ -1096,7 +1096,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type BadObject must only implement Interface types, it cannot implement SomeInputObject.',
@@ -1119,7 +1119,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message: 'Type AnotherObject can only implement AnotherInterface once.',
         locations: [
@@ -1148,7 +1148,7 @@ describe('Type System: Objects can only implement unique interfaces', () => {
       schema,
       parse('extend type AnotherObject implements AnotherInterface'),
     );
-    expectJSON(validateSchema(extendedSchema)).to.deep.equal([
+    expectJSON(validateSchema(extendedSchema)).toDeepEqual([
       {
         message: 'Type AnotherObject can only implement AnotherInterface once.',
         locations: [
@@ -1187,7 +1187,7 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expectJSON(validateSchema(extendedSchema)).to.deep.equal([
+    expectJSON(validateSchema(extendedSchema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.newField expected but AnotherObject does not provide it.',
@@ -1226,7 +1226,7 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expectJSON(validateSchema(extendedSchema)).to.deep.equal([
+    expectJSON(validateSchema(extendedSchema)).toDeepEqual([
       {
         message:
           'Interface field argument AnotherInterface.newField(test:) expected but AnotherObject.newField does not provide it.',
@@ -1277,7 +1277,7 @@ describe('Type System: Interface extensions should be valid', () => {
         }
       `),
     );
-    expectJSON(validateSchema(extendedSchema)).to.deep.equal([
+    expectJSON(validateSchema(extendedSchema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.newInterfaceField expects type NewInterface but AnotherObject.newInterfaceField is type MismatchingInterface.',
@@ -1322,14 +1322,14 @@ describe('Type System: Interface fields must have output types', () => {
     const typeName = inspect(type);
     it(`accepts an output type as an Interface field type: ${typeName}`, () => {
       const schema = schemaWithInterfaceField({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([]);
+      expectJSON(validateSchema(schema)).toDeepEqual([]);
     });
   }
 
   it('rejects an empty Interface field type', () => {
     // @ts-expect-error (type field must not be undefined)
     const schema = schemaWithInterfaceField({ type: undefined });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of BadImplementing.badField must be Output Type but got: undefined.',
@@ -1346,7 +1346,7 @@ describe('Type System: Interface fields must have output types', () => {
     it(`rejects a non-output type as an Interface field type: ${typeStr}`, () => {
       // @ts-expect-error
       const schema = schemaWithInterfaceField({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([
+      expectJSON(validateSchema(schema)).toDeepEqual([
         {
           message: `The type of BadImplementing.badField must be Output Type but got: ${typeStr}.`,
         },
@@ -1360,7 +1360,7 @@ describe('Type System: Interface fields must have output types', () => {
   it('rejects a non-type value as an Interface field type', () => {
     // @ts-expect-error
     const schema = schemaWithInterfaceField({ type: Number });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of BadImplementing.badField must be Output Type but got: [function Number].',
@@ -1393,7 +1393,7 @@ describe('Type System: Interface fields must have output types', () => {
         field: SomeInputObject
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of SomeInterface.field must be Output Type but got: SomeInputObject.',
@@ -1417,7 +1417,7 @@ describe('Type System: Interface fields must have output types', () => {
         foo: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 });
 
@@ -1458,14 +1458,14 @@ describe('Type System: Arguments must have input types', () => {
     const typeName = inspect(type);
     it(`accepts an input type as a field arg type: ${typeName}`, () => {
       const schema = schemaWithArg({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([]);
+      expectJSON(validateSchema(schema)).toDeepEqual([]);
     });
   }
 
   it('rejects an empty field arg type', () => {
     // @ts-expect-error (type field must not be undefined)
     const schema = schemaWithArg({ type: undefined });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of @BadDirective(badArg:) must be Input Type but got: undefined.',
@@ -1482,7 +1482,7 @@ describe('Type System: Arguments must have input types', () => {
     it(`rejects a non-input type as a field arg type: ${typeStr}`, () => {
       // @ts-expect-error
       const schema = schemaWithArg({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([
+      expectJSON(validateSchema(schema)).toDeepEqual([
         {
           message: `The type of @BadDirective(badArg:) must be Input Type but got: ${typeStr}.`,
         },
@@ -1496,7 +1496,7 @@ describe('Type System: Arguments must have input types', () => {
   it('rejects a non-type value as a field arg type', () => {
     // @ts-expect-error
     const schema = schemaWithArg({ type: Number });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of @BadDirective(badArg:) must be Input Type but got: [function Number].',
@@ -1527,7 +1527,7 @@ describe('Type System: Arguments must have input types', () => {
         ): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Required argument @BadDirective(badArg:) cannot be deprecated.',
@@ -1556,7 +1556,7 @@ describe('Type System: Arguments must have input types', () => {
         foo: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of Query.test(arg:) must be Input Type but got: SomeObject.',
@@ -1596,14 +1596,14 @@ describe('Type System: Input Object fields must have input types', () => {
     const typeName = inspect(type);
     it(`accepts an input type as an input field type: ${typeName}`, () => {
       const schema = schemaWithInputField({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([]);
+      expectJSON(validateSchema(schema)).toDeepEqual([]);
     });
   }
 
   it('rejects an empty input field type', () => {
     // @ts-expect-error (type field must not be undefined)
     const schema = schemaWithInputField({ type: undefined });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of BadInputObject.badField must be Input Type but got: undefined.',
@@ -1616,7 +1616,7 @@ describe('Type System: Input Object fields must have input types', () => {
     it(`rejects a non-input type as an input field type: ${typeStr}`, () => {
       // @ts-expect-error
       const schema = schemaWithInputField({ type });
-      expectJSON(validateSchema(schema)).to.deep.equal([
+      expectJSON(validateSchema(schema)).toDeepEqual([
         {
           message: `The type of BadInputObject.badField must be Input Type but got: ${typeStr}.`,
         },
@@ -1627,7 +1627,7 @@ describe('Type System: Input Object fields must have input types', () => {
   it('rejects a non-type value as an input field type', () => {
     // @ts-expect-error
     const schema = schemaWithInputField({ type: Number });
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of BadInputObject.badField must be Input Type but got: [function Number].',
@@ -1652,7 +1652,7 @@ describe('Type System: Input Object fields must have input types', () => {
         bar: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
@@ -1677,7 +1677,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts an Object which implements an Interface along with more fields', () => {
@@ -1695,7 +1695,7 @@ describe('Objects must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts an Object which implements an Interface field along with additional optional arguments', () => {
@@ -1712,7 +1712,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String, anotherInput: String): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Object missing an Interface field', () => {
@@ -1729,7 +1729,7 @@ describe('Objects must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expected but AnotherObject does not provide it.',
@@ -1755,7 +1755,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: String): Int
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expects type String but AnotherObject.field is type Int.',
@@ -1784,7 +1784,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: B
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expects type A but AnotherObject.field is type B.',
@@ -1810,7 +1810,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: AnotherObject
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts an Object with a subtyped Interface field (union)', () => {
@@ -1833,7 +1833,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: SomeObject
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Object missing an Interface argument', () => {
@@ -1850,7 +1850,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field argument AnotherInterface.field(input:) expected but AnotherObject.field does not provide it.',
@@ -1876,7 +1876,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field argument AnotherInterface.field(input:) expects type String but AnotherObject.field(input:) is type Int.',
@@ -1902,7 +1902,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field(input: Int): Int
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expects type String but AnotherObject.field is type Int.',
@@ -1941,7 +1941,7 @@ describe('Objects must adhere to Interface they implement', () => {
         ): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Object field AnotherObject.field includes required argument requiredArg that is missing from the Interface field AnotherInterface.field.',
@@ -1967,7 +1967,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: [String]!
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Object with a non-list Interface field list type', () => {
@@ -1984,7 +1984,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expects type [String] but AnotherObject.field is type String.',
@@ -2010,7 +2010,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: [String]
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expects type String but AnotherObject.field is type [String].',
@@ -2036,7 +2036,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String!
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Object with a superset nullable Interface field type', () => {
@@ -2053,7 +2053,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field AnotherInterface.field expects type String! but AnotherObject.field is type String.',
@@ -2083,7 +2083,7 @@ describe('Objects must adhere to Interface they implement', () => {
         field: String!
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type AnotherObject must implement SuperInterface because it is implemented by AnotherInterface.',
@@ -2111,7 +2111,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field(input: String): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts an Interface which implements an Interface along with more fields', () => {
@@ -2129,7 +2129,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts an Interface which implements an Interface field along with additional optional arguments', () => {
@@ -2146,7 +2146,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field(input: String, anotherInput: String): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Interface missing an Interface field', () => {
@@ -2163,7 +2163,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         anotherField: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expected but ChildInterface does not provide it.',
@@ -2189,7 +2189,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field(input: String): Int
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expects type String but ChildInterface.field is type Int.',
@@ -2218,7 +2218,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: B
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expects type A but ChildInterface.field is type B.',
@@ -2244,7 +2244,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: ChildInterface
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts an Interface with a subtyped Interface field (union)', () => {
@@ -2267,7 +2267,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: SomeObject
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Interface implementing a non-Interface type', () => {
@@ -2284,7 +2284,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type BadInterface must only implement Interface types, it cannot implement SomeInputObject.',
@@ -2307,7 +2307,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field argument ParentInterface.field(input:) expected but ChildInterface.field does not provide it.',
@@ -2333,7 +2333,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field(input: Int): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field argument ParentInterface.field(input:) expects type String but ChildInterface.field(input:) is type Int.',
@@ -2359,7 +2359,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field(input: Int): Int
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expects type String but ChildInterface.field is type Int.',
@@ -2398,7 +2398,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         ): String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Object field ChildInterface.field includes required argument requiredArg that is missing from the Interface field ParentInterface.field.',
@@ -2424,7 +2424,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: [String]!
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Interface with a non-list Interface field list type', () => {
@@ -2441,7 +2441,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expects type [String] but ChildInterface.field is type String.',
@@ -2467,7 +2467,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: [String]
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expects type String but ChildInterface.field is type [String].',
@@ -2493,7 +2493,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: String!
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([]);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
   it('rejects an Interface with a superset nullable Interface field type', () => {
@@ -2510,7 +2510,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: String
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Interface field ParentInterface.field expects type String! but ChildInterface.field is type String.',
@@ -2540,7 +2540,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
         field: String!
       }
     `);
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type ChildInterface must implement SuperInterface because it is implemented by ParentInterface.',
@@ -2563,7 +2563,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
       }
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type FooInterface cannot implement itself because it would create a circular reference.',
@@ -2587,7 +2587,7 @@ describe('Interfaces must adhere to Interface they implement', () => {
       }
     `);
 
-    expectJSON(validateSchema(schema)).to.deep.equal([
+    expectJSON(validateSchema(schema)).toDeepEqual([
       {
         message:
           'Type FooInterface cannot implement BarInterface because it would create a circular reference.',

--- a/src/validation/__tests__/ExecutableDefinitionsRule-test.ts
+++ b/src/validation/__tests__/ExecutableDefinitionsRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Executable definitions', () => {
@@ -53,7 +53,7 @@ describe('Validate: Executable definitions', () => {
       extend type Dog {
         color: String
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'The "Cow" definition is not executable.',
         locations: [{ line: 8, column: 7 }],
@@ -76,7 +76,7 @@ describe('Validate: Executable definitions', () => {
       }
 
       extend schema @directive
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'The schema definition is not executable.',
         locations: [{ line: 2, column: 7 }],

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
@@ -21,7 +21,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 const testSchema = buildSchema(`
@@ -114,7 +114,7 @@ describe('Validate: Fields on correct type', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot query field "unknown_pet_field" on type "Pet".',
         locations: [{ line: 3, column: 9 }],
@@ -131,7 +131,7 @@ describe('Validate: Fields on correct type', () => {
       fragment fieldNotDefined on Dog {
         meowVolume
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot query field "meowVolume" on type "Dog". Did you mean "barkVolume"?',
@@ -147,7 +147,7 @@ describe('Validate: Fields on correct type', () => {
           deeper_unknown_field
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot query field "unknown_field" on type "Dog".',
         locations: [{ line: 3, column: 9 }],
@@ -162,7 +162,7 @@ describe('Validate: Fields on correct type', () => {
           unknown_field
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot query field "unknown_field" on type "Pet".',
         locations: [{ line: 4, column: 11 }],
@@ -177,7 +177,7 @@ describe('Validate: Fields on correct type', () => {
           meowVolume
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot query field "meowVolume" on type "Dog". Did you mean "barkVolume"?',
@@ -191,7 +191,7 @@ describe('Validate: Fields on correct type', () => {
       fragment aliasedFieldTargetNotDefined on Dog {
         volume : mooVolume
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot query field "mooVolume" on type "Dog". Did you mean "barkVolume"?',
@@ -205,7 +205,7 @@ describe('Validate: Fields on correct type', () => {
       fragment aliasedLyingFieldTargetNotDefined on Dog {
         barkVolume : kawVolume
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot query field "kawVolume" on type "Dog". Did you mean "barkVolume"?',
@@ -219,7 +219,7 @@ describe('Validate: Fields on correct type', () => {
       fragment notDefinedOnInterface on Pet {
         tailLength
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot query field "tailLength" on type "Pet".',
         locations: [{ line: 3, column: 9 }],
@@ -232,7 +232,7 @@ describe('Validate: Fields on correct type', () => {
       fragment definedOnImplementorsButNotInterface on Pet {
         nickname
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot query field "nickname" on type "Pet". Did you mean to use an inline fragment on "Cat" or "Dog"?',
@@ -254,7 +254,7 @@ describe('Validate: Fields on correct type', () => {
       fragment directFieldSelectionOnUnion on CatOrDog {
         directField
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot query field "directField" on type "CatOrDog".',
         locations: [{ line: 3, column: 9 }],
@@ -267,7 +267,7 @@ describe('Validate: Fields on correct type', () => {
       fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
         name
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot query field "name" on type "CatOrDog". Did you mean to use an inline fragment on "Pet", "Cat", or "Dog"?',

--- a/src/validation/__tests__/FragmentsOnCompositeTypesRule-test.ts
+++ b/src/validation/__tests__/FragmentsOnCompositeTypesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Fragments on composite types', () => {
@@ -72,7 +72,7 @@ describe('Validate: Fragments on composite types', () => {
       fragment scalarFragment on Boolean {
         bad
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "scalarFragment" cannot condition on non composite type "Boolean".',
@@ -86,7 +86,7 @@ describe('Validate: Fragments on composite types', () => {
       fragment scalarFragment on FurColor {
         bad
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "scalarFragment" cannot condition on non composite type "FurColor".',
@@ -100,7 +100,7 @@ describe('Validate: Fragments on composite types', () => {
       fragment inputFragment on ComplexInput {
         stringField
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "inputFragment" cannot condition on non composite type "ComplexInput".',
@@ -116,7 +116,7 @@ describe('Validate: Fragments on composite types', () => {
           barks
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Fragment cannot condition on non composite type "String".',
         locations: [{ line: 3, column: 16 }],

--- a/src/validation/__tests__/KnownArgumentNamesRule-test.ts
+++ b/src/validation/__tests__/KnownArgumentNamesRule-test.ts
@@ -16,7 +16,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
@@ -28,7 +28,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string) {
-  expectSDLErrors(sdlStr).to.deep.equal([]);
+  expectSDLErrors(sdlStr).toDeepEqual([]);
 }
 
 describe('Validate: Known argument names', () => {
@@ -102,7 +102,7 @@ describe('Validate: Known argument names', () => {
       {
         dog @skip(unless: true)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown argument "unless" on directive "@skip".',
         locations: [{ line: 3, column: 19 }],
@@ -123,7 +123,7 @@ describe('Validate: Known argument names', () => {
       {
         dog @onField(if: true)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown argument "if" on directive "@onField".',
         locations: [{ line: 3, column: 22 }],
@@ -136,7 +136,7 @@ describe('Validate: Known argument names', () => {
       {
         dog @skip(iff: true)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Unknown argument "iff" on directive "@skip". Did you mean "if"?',
@@ -150,7 +150,7 @@ describe('Validate: Known argument names', () => {
       fragment invalidArgName on Dog {
         doesKnowCommand(unknown: true)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown argument "unknown" on field "Dog.doesKnowCommand".',
         locations: [{ line: 3, column: 25 }],
@@ -163,7 +163,7 @@ describe('Validate: Known argument names', () => {
       fragment invalidArgName on Dog {
         doesKnowCommand(DogCommand: true)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Unknown argument "DogCommand" on field "Dog.doesKnowCommand". Did you mean "dogCommand"?',
@@ -177,7 +177,7 @@ describe('Validate: Known argument names', () => {
       fragment oneGoodArgOneInvalidArg on Dog {
         doesKnowCommand(whoKnows: 1, dogCommand: SIT, unknown: true)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown argument "whoKnows" on field "Dog.doesKnowCommand".',
         locations: [{ line: 3, column: 25 }],
@@ -203,7 +203,7 @@ describe('Validate: Known argument names', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown argument "unknown" on field "Dog.doesKnowCommand".',
         locations: [{ line: 4, column: 27 }],
@@ -233,7 +233,7 @@ describe('Validate: Known argument names', () => {
         }
 
         directive @test(arg: String) on FIELD_DEFINITION
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Unknown argument "unknown" on directive "@test".',
           locations: [{ line: 3, column: 29 }],
@@ -248,7 +248,7 @@ describe('Validate: Known argument names', () => {
         }
 
         directive @test(arg: String) on FIELD_DEFINITION
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Unknown argument "agr" on directive "@test". Did you mean "arg"?',
@@ -262,7 +262,7 @@ describe('Validate: Known argument names', () => {
         type Query {
           foo: String @deprecated(unknown: "")
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Unknown argument "unknown" on directive "@deprecated".',
           locations: [{ line: 3, column: 35 }],
@@ -276,7 +276,7 @@ describe('Validate: Known argument names', () => {
           foo: String @deprecated(reason: "")
         }
         directive @deprecated(arg: String) on FIELD
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Unknown argument "reason" on directive "@deprecated".',
           locations: [{ line: 3, column: 35 }],
@@ -297,7 +297,7 @@ describe('Validate: Known argument names', () => {
           extend type Query  @test(unknown: "")
         `,
         schema,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message: 'Unknown argument "unknown" on directive "@test".',
           locations: [{ line: 4, column: 36 }],
@@ -318,7 +318,7 @@ describe('Validate: Known argument names', () => {
           extend type Query @test(unknown: "")
         `,
         schema,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message: 'Unknown argument "unknown" on directive "@test".',
           locations: [{ line: 2, column: 35 }],

--- a/src/validation/__tests__/KnownDirectivesRule-test.ts
+++ b/src/validation/__tests__/KnownDirectivesRule-test.ts
@@ -20,7 +20,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
@@ -28,7 +28,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 const schemaWithDirectives = buildSchema(`
@@ -96,7 +96,7 @@ describe('Validate: Known directives', () => {
           name
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown directive "@unknown".',
         locations: [{ line: 3, column: 15 }],
@@ -115,7 +115,7 @@ describe('Validate: Known directives', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown directive "@unknown".',
         locations: [{ line: 3, column: 20 }],
@@ -178,7 +178,7 @@ describe('Validate: Known directives', () => {
       fragment Frag on Human @onQuery {
         name @onQuery
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Directive "@onQuery" may not be used on VARIABLE_DEFINITION.',
         locations: [{ line: 2, column: 28 }],
@@ -301,7 +301,7 @@ describe('Validate: Known directives', () => {
           extend type Query @unknown
         `,
         schema,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message: 'Unknown directive "@unknown".',
           locations: [{ line: 2, column: 29 }],
@@ -384,7 +384,7 @@ describe('Validate: Known directives', () => {
           extend schema @onObject
         `,
         schemaWithSDLDirectives,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message: 'Directive "@onInterface" may not be used on OBJECT.',
           locations: [{ line: 2, column: 45 }],

--- a/src/validation/__tests__/KnownFragmentNamesRule-test.ts
+++ b/src/validation/__tests__/KnownFragmentNamesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Known fragment names', () => {
@@ -53,7 +53,7 @@ describe('Validate: Known fragment names', () => {
         name
         ...UnknownFragment3
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown fragment "UnknownFragment1".',
         locations: [{ line: 4, column: 14 }],

--- a/src/validation/__tests__/KnownTypeNamesRule-test.ts
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.ts
@@ -21,7 +21,7 @@ function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
@@ -29,7 +29,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Known type names', () => {
@@ -62,7 +62,7 @@ describe('Validate: Known type names', () => {
       fragment PetFields on Peat {
         name
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Unknown type "JumbledUpLetters".',
         locations: [{ line: 2, column: 24 }],
@@ -85,7 +85,7 @@ describe('Validate: Known type names', () => {
         __typename
       }
     `;
-    expectErrorsWithSchema(schema, query).to.deep.equal([
+    expectErrorsWithSchema(schema, query).toDeepEqual([
       {
         message: 'Unknown type "ID".',
         locations: [{ line: 2, column: 19 }],
@@ -176,7 +176,7 @@ describe('Validate: Known type names', () => {
           mutation: M
           subscription: N
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Unknown type "C". Did you mean "A" or "B"?',
           locations: [{ line: 5, column: 36 }],
@@ -237,7 +237,7 @@ describe('Validate: Known type names', () => {
         type Query {
           foo: Foo
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Unknown type "Foo".',
           locations: [{ line: 7, column: 16 }],
@@ -307,7 +307,7 @@ describe('Validate: Known type names', () => {
         }
       `;
 
-      expectSDLErrors(sdl, schema).to.deep.equal([
+      expectSDLErrors(sdl, schema).toDeepEqual([
         {
           message: 'Unknown type "C". Did you mean "A" or "B"?',
           locations: [{ line: 4, column: 36 }],

--- a/src/validation/__tests__/LoneAnonymousOperationRule-test.ts
+++ b/src/validation/__tests__/LoneAnonymousOperationRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Anonymous operation must be alone', () => {
@@ -60,7 +60,7 @@ describe('Validate: Anonymous operation must be alone', () => {
       {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'This anonymous operation must be the only defined operation.',
         locations: [{ line: 2, column: 7 }],
@@ -80,7 +80,7 @@ describe('Validate: Anonymous operation must be alone', () => {
       mutation Foo {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'This anonymous operation must be the only defined operation.',
         locations: [{ line: 2, column: 7 }],
@@ -96,7 +96,7 @@ describe('Validate: Anonymous operation must be alone', () => {
       subscription Foo {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'This anonymous operation must be the only defined operation.',
         locations: [{ line: 2, column: 7 }],

--- a/src/validation/__tests__/LoneSchemaDefinitionRule-test.ts
+++ b/src/validation/__tests__/LoneSchemaDefinitionRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Schema definition should be alone', () => {
@@ -54,7 +54,7 @@ describe('Validate: Schema definition should be alone', () => {
       schema {
         subscription: Foo
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Must provide only one schema definition.',
         locations: [{ line: 10, column: 7 }],
@@ -80,7 +80,7 @@ describe('Validate: Schema definition should be alone', () => {
         }
       `,
       schema,
-    ).to.deep.equal([]);
+    ).toDeepEqual([]);
   });
 
   it('redefine schema in schema extension', () => {
@@ -101,7 +101,7 @@ describe('Validate: Schema definition should be alone', () => {
         }
       `,
       schema,
-    ).to.deep.equal([
+    ).toDeepEqual([
       {
         message: 'Cannot define a new schema within a schema extension.',
         locations: [{ line: 2, column: 9 }],
@@ -127,7 +127,7 @@ describe('Validate: Schema definition should be alone', () => {
         }
       `,
       schema,
-    ).to.deep.equal([
+    ).toDeepEqual([
       {
         message: 'Cannot define a new schema within a schema extension.',
         locations: [{ line: 2, column: 9 }],

--- a/src/validation/__tests__/NoDeprecatedCustomRule-test.ts
+++ b/src/validation/__tests__/NoDeprecatedCustomRule-test.ts
@@ -19,7 +19,7 @@ function buildAssertion(sdlStr: string) {
   }
 
   function expectValid(queryStr: string) {
-    expectErrors(queryStr).to.deep.equal([]);
+    expectErrors(queryStr).toDeepEqual([]);
   }
 }
 
@@ -64,7 +64,7 @@ describe('Validate: no deprecated', () => {
         fragment QueryFragment on Query {
           deprecatedField
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         { message, locations: [{ line: 3, column: 11 }] },
         { message, locations: [{ line: 7, column: 11 }] },
       ]);
@@ -103,7 +103,7 @@ describe('Validate: no deprecated', () => {
         {
           someField(deprecatedArg: "")
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "Query.someField" argument "deprecatedArg" is deprecated. Some arg reason.',
@@ -147,7 +147,7 @@ describe('Validate: no deprecated', () => {
         {
           someField @someDirective(deprecatedArg: "")
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Directive "@someDirective" argument "deprecatedArg" is deprecated. Some arg reason.',
@@ -209,7 +209,7 @@ describe('Validate: no deprecated', () => {
             someArg: { deprecatedField: "" }
           ) @someDirective(someArg: { deprecatedField: "" })
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         { message, locations: [{ line: 4, column: 24 }] },
         { message, locations: [{ line: 5, column: 39 }] },
       ]);
@@ -263,7 +263,7 @@ describe('Validate: no deprecated', () => {
         ) {
           someField(enumArg: DEPRECATED_VALUE)
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         { message, locations: [{ line: 3, column: 33 }] },
         { message, locations: [{ line: 5, column: 30 }] },
       ]);

--- a/src/validation/__tests__/NoFragmentCyclesRule-test.ts
+++ b/src/validation/__tests__/NoFragmentCyclesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: No circular fragment spreads', () => {
@@ -60,7 +60,7 @@ describe('Validate: No circular fragment spreads', () => {
   it('spreading recursively within field fails', () => {
     expectErrors(`
       fragment fragA on Human { relatives { ...fragA } },
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself.',
         locations: [{ line: 2, column: 45 }],
@@ -71,7 +71,7 @@ describe('Validate: No circular fragment spreads', () => {
   it('no spreading itself directly', () => {
     expectErrors(`
       fragment fragA on Dog { ...fragA }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself.',
         locations: [{ line: 2, column: 31 }],
@@ -86,7 +86,7 @@ describe('Validate: No circular fragment spreads', () => {
           ...fragA
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself.',
         locations: [{ line: 4, column: 11 }],
@@ -98,7 +98,7 @@ describe('Validate: No circular fragment spreads', () => {
     expectErrors(`
       fragment fragA on Dog { ...fragB }
       fragment fragB on Dog { ...fragA }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself via "fragB".',
         locations: [
@@ -113,7 +113,7 @@ describe('Validate: No circular fragment spreads', () => {
     expectErrors(`
       fragment fragB on Dog { ...fragA }
       fragment fragA on Dog { ...fragB }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragB" within itself via "fragA".',
         locations: [
@@ -136,7 +136,7 @@ describe('Validate: No circular fragment spreads', () => {
           ...fragA
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself via "fragB".',
         locations: [
@@ -157,7 +157,7 @@ describe('Validate: No circular fragment spreads', () => {
       fragment fragZ on Dog { ...fragO }
       fragment fragO on Dog { ...fragP }
       fragment fragP on Dog { ...fragA, ...fragX }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Cannot spread fragment "fragA" within itself via "fragB", "fragC", "fragO", "fragP".',
@@ -188,7 +188,7 @@ describe('Validate: No circular fragment spreads', () => {
       fragment fragA on Dog { ...fragB, ...fragC }
       fragment fragB on Dog { ...fragA }
       fragment fragC on Dog { ...fragA }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself via "fragB".',
         locations: [
@@ -211,7 +211,7 @@ describe('Validate: No circular fragment spreads', () => {
       fragment fragA on Dog { ...fragC }
       fragment fragB on Dog { ...fragC }
       fragment fragC on Dog { ...fragA, ...fragB }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragA" within itself via "fragC".',
         locations: [
@@ -234,7 +234,7 @@ describe('Validate: No circular fragment spreads', () => {
       fragment fragA on Dog { ...fragB }
       fragment fragB on Dog { ...fragB, ...fragC }
       fragment fragC on Dog { ...fragA, ...fragB }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot spread fragment "fragB" within itself.',
         locations: [{ line: 3, column: 31 }],

--- a/src/validation/__tests__/NoSchemaIntrospectionCustomRule-test.ts
+++ b/src/validation/__tests__/NoSchemaIntrospectionCustomRule-test.ts
@@ -15,7 +15,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 const schema = buildSchema(`
@@ -58,7 +58,7 @@ describe('Validate: Prohibit introspection queries', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'GraphQL introspection has been disabled, but the requested query contained the field "__schema".',
@@ -81,7 +81,7 @@ describe('Validate: Prohibit introspection queries', () => {
           }
         }
       }
-      `).to.deep.equal([
+      `).toDeepEqual([
       {
         message:
           'GraphQL introspection has been disabled, but the requested query contained the field "__schema".',
@@ -108,7 +108,7 @@ describe('Validate: Prohibit introspection queries', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'GraphQL introspection has been disabled, but the requested query contained the field "__schema".',
@@ -129,7 +129,7 @@ describe('Validate: Prohibit introspection queries', () => {
           introspectionField
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'GraphQL introspection has been disabled, but the requested query contained the field "introspectionField".',

--- a/src/validation/__tests__/NoUndefinedVariablesRule-test.ts
+++ b/src/validation/__tests__/NoUndefinedVariablesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: No undefined variables', () => {
@@ -119,7 +119,7 @@ describe('Validate: No undefined variables', () => {
       query Foo($a: String, $b: String, $c: String) {
         field(a: $a, b: $b, c: $c, d: $d)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$d" is not defined by operation "Foo".',
         locations: [
@@ -135,7 +135,7 @@ describe('Validate: No undefined variables', () => {
       {
         field(a: $a)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined.',
         locations: [
@@ -151,7 +151,7 @@ describe('Validate: No undefined variables', () => {
       query Foo($b: String) {
         field(a: $a, b: $b, c: $c)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined by operation "Foo".',
         locations: [
@@ -177,7 +177,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragA on Type {
         field(a: $a)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined.',
         locations: [
@@ -206,7 +206,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field(c: $c)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$c" is not defined by operation "Foo".',
         locations: [
@@ -235,7 +235,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field(c: $c)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined by operation "Foo".',
         locations: [
@@ -264,7 +264,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragAB on Type {
         field(a: $a, b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$b" is not defined by operation "Foo".',
         locations: [
@@ -293,7 +293,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragAB on Type {
         field(a: $a, b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined by operation "Foo".',
         locations: [
@@ -325,7 +325,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined by operation "Foo".',
         locations: [
@@ -359,7 +359,7 @@ describe('Validate: No undefined variables', () => {
       fragment FragC on Type {
         field2(c: $c)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is not defined by operation "Foo".',
         locations: [

--- a/src/validation/__tests__/NoUnusedFragmentsRule-test.ts
+++ b/src/validation/__tests__/NoUnusedFragmentsRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: No unused fragments', () => {
@@ -89,7 +89,7 @@ describe('Validate: No unused fragments', () => {
       fragment Unused2 on Human {
         name
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Fragment "Unused1" is never used.',
         locations: [{ line: 22, column: 7 }],
@@ -131,7 +131,7 @@ describe('Validate: No unused fragments', () => {
         name
         ...Unused1
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Fragment "Unused1" is never used.',
         locations: [{ line: 22, column: 7 }],
@@ -153,7 +153,7 @@ describe('Validate: No unused fragments', () => {
       fragment foo on Human {
         name
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Fragment "foo" is never used.',
         locations: [{ line: 7, column: 7 }],

--- a/src/validation/__tests__/NoUnusedVariablesRule-test.ts
+++ b/src/validation/__tests__/NoUnusedVariablesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: No unused variables', () => {
@@ -105,7 +105,7 @@ describe('Validate: No unused variables', () => {
       query ($a: String, $b: String, $c: String) {
         field(a: $a, b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$c" is never used.',
         locations: [{ line: 2, column: 38 }],
@@ -118,7 +118,7 @@ describe('Validate: No unused variables', () => {
       query Foo($a: String, $b: String, $c: String) {
         field(b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is never used in operation "Foo".',
         locations: [{ line: 2, column: 17 }],
@@ -148,7 +148,7 @@ describe('Validate: No unused variables', () => {
       fragment FragC on Type {
         field
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$c" is never used in operation "Foo".',
         locations: [{ line: 2, column: 41 }],
@@ -174,7 +174,7 @@ describe('Validate: No unused variables', () => {
       fragment FragC on Type {
         field
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$a" is never used in operation "Foo".',
         locations: [{ line: 2, column: 17 }],
@@ -197,7 +197,7 @@ describe('Validate: No unused variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$b" is never used in operation "Foo".',
         locations: [{ line: 2, column: 17 }],
@@ -219,7 +219,7 @@ describe('Validate: No unused variables', () => {
       fragment FragB on Type {
         field(b: $b)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Variable "$b" is never used in operation "Foo".',
         locations: [{ line: 2, column: 17 }],

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -16,7 +16,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
@@ -28,7 +28,7 @@ function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
 }
 
 function expectValidWithSchema(schema: GraphQLSchema, queryStr: string) {
-  expectErrorsWithSchema(schema, queryStr).to.deep.equal([]);
+  expectErrorsWithSchema(schema, queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Overlapping fields can be merged', () => {
@@ -104,7 +104,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         fido: name
         fido: nickname
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "fido" conflict because "name" and "nickname" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -137,7 +137,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         name: nickname
         name
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "name" conflict because "nickname" and "name" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -155,7 +155,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         doesKnowCommand
         doesKnowCommand(dogCommand: HEEL)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "doesKnowCommand" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional.',
@@ -173,7 +173,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         doesKnowCommand(dogCommand: SIT)
         doesKnowCommand
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "doesKnowCommand" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional.',
@@ -191,7 +191,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         doesKnowCommand(dogCommand: SIT)
         doesKnowCommand(dogCommand: HEEL)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "doesKnowCommand" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional.',
@@ -209,7 +209,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         isAtLocation(x: 0)
         isAtLocation(y: 0)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "isAtLocation" conflict because they have differing arguments. Use different aliases on the fields to fetch both if this was intentional.',
@@ -248,7 +248,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       fragment B on Type {
         x: b
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "x" conflict because "a" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -283,7 +283,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       fragment B on Type {
         x: b
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "x" conflict because "a" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -321,7 +321,7 @@ describe('Validate: Overlapping fields can be merged', () => {
           x: b
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "field" conflict because subfields "x" conflict because "a" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -347,7 +347,7 @@ describe('Validate: Overlapping fields can be merged', () => {
           y: d
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "field" conflict because subfields "x" conflict because "a" and "b" are different fields and subfields "y" conflict because "c" and "d" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -377,7 +377,7 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "field" conflict because subfields "deepField" conflict because subfields "x" conflict because "a" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -410,7 +410,7 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "deepField" conflict because subfields "x" conflict because "a" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -449,7 +449,7 @@ describe('Validate: Overlapping fields can be merged', () => {
           }
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "deeperField" conflict because subfields "x" conflict because "a" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -487,7 +487,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       fragment J on T {
         x: b
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "field" conflict because subfields "x" conflict because "a" and "b" are different fields and subfields "y" conflict because "c" and "d" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -601,7 +601,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "scalar" conflict because they return conflicting types "Int" and "String!". Use different aliases on the fields to fetch both if this was intentional.',
@@ -653,7 +653,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "scalar" conflict because they return conflicting types "Int" and "String". Use different aliases on the fields to fetch both if this was intentional.',
@@ -712,7 +712,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             scalar: unrelatedField
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "other" conflict because subfields "scalar" conflict because "scalar" and "unrelatedField" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -741,7 +741,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "scalar" conflict because they return conflicting types "String!" and "String". Use different aliases on the fields to fetch both if this was intentional.',
@@ -772,7 +772,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "box" conflict because they return conflicting types "[StringBox]" and "StringBox". Use different aliases on the fields to fetch both if this was intentional.',
@@ -801,7 +801,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "box" conflict because they return conflicting types "StringBox" and "[StringBox]". Use different aliases on the fields to fetch both if this was intentional.',
@@ -833,7 +833,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "val" conflict because "scalar" and "unrelatedField" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -864,7 +864,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "box" conflict because subfields "scalar" conflict because they return conflicting types "String" and "Int". Use different aliases on the fields to fetch both if this was intentional.',
@@ -951,7 +951,7 @@ describe('Validate: Overlapping fields can be merged', () => {
             }
           }
         `,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Fields "edges" conflict because subfields "node" conflict because subfields "id" conflict because "name" and "id" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
@@ -1036,7 +1036,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         fido: name
         fido: nickname
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fields "fido" conflict because "name" and "nickname" are different fields. Use different aliases on the fields to fetch both if this was intentional.',

--- a/src/validation/__tests__/PossibleFragmentSpreadsRule-test.ts
+++ b/src/validation/__tests__/PossibleFragmentSpreadsRule-test.ts
@@ -15,7 +15,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 const testSchema = buildSchema(`
@@ -158,7 +158,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidObjectWithinObject on Cat { ...dogFragment }
       fragment dogFragment on Dog { barkVolume }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "dogFragment" cannot be spread here as objects of type "Cat" can never be of type "Dog".',
@@ -172,7 +172,7 @@ describe('Validate: Possible fragment spreads', () => {
       fragment invalidObjectWithinObjectAnon on Cat {
         ... on Dog { barkVolume }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment cannot be spread here as objects of type "Cat" can never be of type "Dog".',
@@ -185,7 +185,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidObjectWithinInterface on Pet { ...humanFragment }
       fragment humanFragment on Human { pets { name } }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "humanFragment" cannot be spread here as objects of type "Pet" can never be of type "Human".',
@@ -198,7 +198,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidObjectWithinUnion on CatOrDog { ...humanFragment }
       fragment humanFragment on Human { pets { name } }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "humanFragment" cannot be spread here as objects of type "CatOrDog" can never be of type "Human".',
@@ -211,7 +211,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidUnionWithinObject on Human { ...catOrDogFragment }
       fragment catOrDogFragment on CatOrDog { __typename }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "catOrDogFragment" cannot be spread here as objects of type "Human" can never be of type "CatOrDog".',
@@ -224,7 +224,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidUnionWithinInterface on Pet { ...humanOrAlienFragment }
       fragment humanOrAlienFragment on HumanOrAlien { __typename }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "humanOrAlienFragment" cannot be spread here as objects of type "Pet" can never be of type "HumanOrAlien".',
@@ -237,7 +237,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidUnionWithinUnion on CatOrDog { ...humanOrAlienFragment }
       fragment humanOrAlienFragment on HumanOrAlien { __typename }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "humanOrAlienFragment" cannot be spread here as objects of type "CatOrDog" can never be of type "HumanOrAlien".',
@@ -250,7 +250,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidInterfaceWithinObject on Cat { ...intelligentFragment }
       fragment intelligentFragment on Intelligent { iq }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "intelligentFragment" cannot be spread here as objects of type "Cat" can never be of type "Intelligent".',
@@ -265,7 +265,7 @@ describe('Validate: Possible fragment spreads', () => {
         ...intelligentFragment
       }
       fragment intelligentFragment on Intelligent { iq }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "intelligentFragment" cannot be spread here as objects of type "Pet" can never be of type "Intelligent".',
@@ -279,7 +279,7 @@ describe('Validate: Possible fragment spreads', () => {
       fragment invalidInterfaceWithinInterfaceAnon on Pet {
         ...on Intelligent { iq }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment cannot be spread here as objects of type "Pet" can never be of type "Intelligent".',
@@ -292,7 +292,7 @@ describe('Validate: Possible fragment spreads', () => {
     expectErrors(`
       fragment invalidInterfaceWithinUnion on HumanOrAlien { ...petFragment }
       fragment petFragment on Pet { name }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Fragment "petFragment" cannot be spread here as objects of type "HumanOrAlien" can never be of type "Pet".',

--- a/src/validation/__tests__/PossibleTypeExtensionsRule-test.ts
+++ b/src/validation/__tests__/PossibleTypeExtensionsRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Possible type extensions', () => {
@@ -84,7 +84,7 @@ describe('Validate: Possible type extensions', () => {
       extend union Unknown @dummy
       extend enum Unknown @dummy
       extend input Unknown @dummy
-    `).to.deep.equal([
+    `).toDeepEqual([
       { message, locations: [{ line: 4, column: 21 }] },
       { message, locations: [{ line: 5, column: 19 }] },
       { message, locations: [{ line: 6, column: 24 }] },
@@ -108,7 +108,7 @@ describe('Validate: Possible type extensions', () => {
       extend union Foo @dummy
       extend enum Foo @dummy
       extend input Foo @dummy
-    `).to.deep.equal([
+    `).toDeepEqual([
       { message, locations: [{ line: 6, column: 21 }] },
       { message, locations: [{ line: 7, column: 19 }] },
       { message, locations: [{ line: 8, column: 24 }] },
@@ -133,7 +133,7 @@ describe('Validate: Possible type extensions', () => {
       extend enum FooUnion @dummy
       extend input FooEnum @dummy
       extend scalar FooInputObject @dummy
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Cannot extend non-object type "FooScalar".',
         locations: [
@@ -213,7 +213,7 @@ describe('Validate: Possible type extensions', () => {
 
     const message =
       'Cannot extend type "Unknown" because it is not defined. Did you mean "Known"?';
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       { message, locations: [{ line: 2, column: 21 }] },
       { message, locations: [{ line: 3, column: 19 }] },
       { message, locations: [{ line: 4, column: 24 }] },
@@ -241,7 +241,7 @@ describe('Validate: Possible type extensions', () => {
       extend scalar FooInputObject @dummy
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message: 'Cannot extend non-object type "FooScalar".',
         locations: [{ line: 2, column: 7 }],

--- a/src/validation/__tests__/ProvidedRequiredArgumentsRule-test.ts
+++ b/src/validation/__tests__/ProvidedRequiredArgumentsRule-test.ts
@@ -16,7 +16,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
@@ -28,7 +28,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string) {
-  expectSDLErrors(sdlStr).to.deep.equal([]);
+  expectSDLErrors(sdlStr).toDeepEqual([]);
 }
 
 describe('Validate: Provided required arguments', () => {
@@ -162,7 +162,7 @@ describe('Validate: Provided required arguments', () => {
             multipleReqs(req2: 2)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "multipleReqs" argument "req1" of type "Int!" is required, but it was not provided.',
@@ -178,7 +178,7 @@ describe('Validate: Provided required arguments', () => {
             multipleReqs
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "multipleReqs" argument "req1" of type "Int!" is required, but it was not provided.',
@@ -199,7 +199,7 @@ describe('Validate: Provided required arguments', () => {
             multipleReqs(req1: "one")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "multipleReqs" argument "req2" of type "Int!" is required, but it was not provided.',
@@ -238,7 +238,7 @@ describe('Validate: Provided required arguments', () => {
             name @skip
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Directive "@include" argument "if" of type "Boolean!" is required, but it was not provided.',
@@ -271,7 +271,7 @@ describe('Validate: Provided required arguments', () => {
         }
 
         directive @test(arg: String!) on FIELD_DEFINITION
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Directive "@test" argument "arg" of type "String!" is required, but it was not provided.',
@@ -285,7 +285,7 @@ describe('Validate: Provided required arguments', () => {
         type Query {
           foo: String @include
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Directive "@include" argument "if" of type "Boolean!" is required, but it was not provided.',
@@ -300,7 +300,7 @@ describe('Validate: Provided required arguments', () => {
           foo: String @deprecated
         }
         directive @deprecated(reason: String!) on FIELD
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Directive "@deprecated" argument "reason" of type "String!" is required, but it was not provided.',
@@ -322,7 +322,7 @@ describe('Validate: Provided required arguments', () => {
           extend type Query  @test
         `,
         schema,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Directive "@test" argument "arg" of type "String!" is required, but it was not provided.',
@@ -344,7 +344,7 @@ describe('Validate: Provided required arguments', () => {
           extend type Query @test
         `,
         schema,
-      ).to.deep.equal([
+      ).toDeepEqual([
         {
           message:
             'Directive "@test" argument "arg" of type "String!" is required, but it was not provided.',

--- a/src/validation/__tests__/ScalarLeafsRule-test.ts
+++ b/src/validation/__tests__/ScalarLeafsRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Scalar leafs', () => {
@@ -26,7 +26,7 @@ describe('Validate: Scalar leafs', () => {
       query directQueryOnObjectWithoutSubFields {
         human
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "human" of type "Human" must have a selection of subfields. Did you mean "human { ... }"?',
@@ -40,7 +40,7 @@ describe('Validate: Scalar leafs', () => {
       {
         human { pets }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "pets" of type "[Pet]" must have a selection of subfields. Did you mean "pets { ... }"?',
@@ -62,7 +62,7 @@ describe('Validate: Scalar leafs', () => {
       fragment scalarSelectionsNotAllowedOnBoolean on Dog {
         barks { sinceWhen }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "barks" must not have a selection since type "Boolean" has no subfields.',
@@ -76,7 +76,7 @@ describe('Validate: Scalar leafs', () => {
       fragment scalarSelectionsNotAllowedOnEnum on Cat {
         furColor { inHexDec }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "furColor" must not have a selection since type "FurColor" has no subfields.',
@@ -90,7 +90,7 @@ describe('Validate: Scalar leafs', () => {
       fragment scalarSelectionsNotAllowedWithArgs on Dog {
         doesKnowCommand(dogCommand: SIT) { sinceWhen }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "doesKnowCommand" must not have a selection since type "Boolean" has no subfields.',
@@ -104,7 +104,7 @@ describe('Validate: Scalar leafs', () => {
       fragment scalarSelectionsNotAllowedWithDirectives on Dog {
         name @include(if: true) { isAlsoHumanName }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "name" must not have a selection since type "String" has no subfields.',
@@ -118,7 +118,7 @@ describe('Validate: Scalar leafs', () => {
       fragment scalarSelectionsNotAllowedWithDirectivesAndArgs on Dog {
         doesKnowCommand(dogCommand: SIT) @include(if: true) { sinceWhen }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Field "doesKnowCommand" must not have a selection since type "Boolean" has no subfields.',

--- a/src/validation/__tests__/SingleFieldSubscriptionsRule-test.ts
+++ b/src/validation/__tests__/SingleFieldSubscriptionsRule-test.ts
@@ -15,7 +15,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 const schema = buildSchema(`
@@ -93,7 +93,7 @@ describe('Validate: Subscriptions with single field', () => {
         importantEmails
         notImportantEmails
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Subscription "ImportantEmails" must select only one top level field.',
@@ -108,7 +108,7 @@ describe('Validate: Subscriptions with single field', () => {
         importantEmails
         __typename
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Subscription "ImportantEmails" must select only one top level field.',
@@ -131,7 +131,7 @@ describe('Validate: Subscriptions with single field', () => {
       fragment Introspection on SubscriptionRoot {
         typename: __typename
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Subscription "ImportantEmails" must select only one top level field.',
@@ -152,7 +152,7 @@ describe('Validate: Subscriptions with single field', () => {
         notImportantEmails
         spamEmails
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Subscription "ImportantEmails" must select only one top level field.',
@@ -181,7 +181,7 @@ describe('Validate: Subscriptions with single field', () => {
       fragment SpamEmails on SubscriptionRoot {
         spamEmails
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Subscription "ImportantEmails" must select only one top level field.',
@@ -203,7 +203,7 @@ describe('Validate: Subscriptions with single field', () => {
       fragment A on SubscriptionRoot {
         ...A
       }
-    `).to.deep.equal([]);
+    `).toDeepEqual([]);
   });
 
   it('fails with many more than one root field via fragments (anonymous)', () => {
@@ -230,7 +230,7 @@ describe('Validate: Subscriptions with single field', () => {
         spamEmails
         ...NonExistentFragment
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Anonymous Subscription must select only one top level field.',
         locations: [
@@ -250,7 +250,7 @@ describe('Validate: Subscriptions with single field', () => {
         importantEmails
         notImportantEmails
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Anonymous Subscription must select only one top level field.',
         locations: [{ line: 4, column: 9 }],
@@ -263,7 +263,7 @@ describe('Validate: Subscriptions with single field', () => {
       subscription ImportantEmails {
         __typename
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Subscription "ImportantEmails" must not select an introspection top level field.',
@@ -277,7 +277,7 @@ describe('Validate: Subscriptions with single field', () => {
       subscription {
         __typename
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Anonymous Subscription must not select an introspection top level field.',
@@ -301,6 +301,6 @@ describe('Validate: Subscriptions with single field', () => {
           __typename
         }
       `,
-    ).to.deep.equal([]);
+    ).toDeepEqual([]);
   });
 });

--- a/src/validation/__tests__/UniqueArgumentDefinitionNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueArgumentDefinitionNamesRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string) {
 }
 
 function expectValidSDL(sdlStr: string) {
-  expectSDLErrors(sdlStr).to.deep.equal([]);
+  expectSDLErrors(sdlStr).toDeepEqual([]);
 }
 
 describe('Validate: Unique argument definition names', () => {
@@ -91,7 +91,7 @@ describe('Validate: Unique argument definition names', () => {
         bar: String
         foo: String
       ) on QUERY
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Argument "SomeObject.someField(foo:)" can only be defined once.',

--- a/src/validation/__tests__/UniqueArgumentNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueArgumentNamesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Unique argument names', () => {
@@ -91,7 +91,7 @@ describe('Validate: Unique argument names', () => {
       {
         field(arg1: "value", arg1: "value")
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one argument named "arg1".',
         locations: [
@@ -107,7 +107,7 @@ describe('Validate: Unique argument names', () => {
       {
         field(arg1: "value", arg1: "value", arg1: "value")
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one argument named "arg1".',
         locations: [
@@ -124,7 +124,7 @@ describe('Validate: Unique argument names', () => {
       {
         field @directive(arg1: "value", arg1: "value")
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one argument named "arg1".',
         locations: [
@@ -140,7 +140,7 @@ describe('Validate: Unique argument names', () => {
       {
         field @directive(arg1: "value", arg1: "value", arg1: "value")
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one argument named "arg1".',
         locations: [

--- a/src/validation/__tests__/UniqueDirectiveNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueDirectiveNamesRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Unique directive names', () => {
@@ -52,7 +52,7 @@ describe('Validate: Unique directive names', () => {
       directive @foo on SCHEMA
 
       directive @foo on SCHEMA
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one directive named "@foo".',
         locations: [
@@ -72,7 +72,7 @@ describe('Validate: Unique directive names', () => {
   it('adding new directive with standard name to existing schema', () => {
     const schema = buildSchema('type foo');
 
-    expectSDLErrors('directive @skip on SCHEMA', schema).to.deep.equal([
+    expectSDLErrors('directive @skip on SCHEMA', schema).toDeepEqual([
       {
         message:
           'Directive "@skip" already exists in the schema. It cannot be redefined.',
@@ -90,7 +90,7 @@ describe('Validate: Unique directive names', () => {
   it('adding conflicting directives to existing schema', () => {
     const schema = buildSchema('directive @foo on SCHEMA');
 
-    expectSDLErrors('directive @foo on SCHEMA', schema).to.deep.equal([
+    expectSDLErrors('directive @foo on SCHEMA', schema).toDeepEqual([
       {
         message:
           'Directive "@foo" already exists in the schema. It cannot be redefined.',

--- a/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.ts
+++ b/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.ts
@@ -31,7 +31,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
@@ -109,7 +109,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       fragment Test on Type {
         field @directive @directive
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@directive" can only be used once at this location.',
@@ -126,7 +126,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       fragment Test on Type {
         field @directive @directive @directive
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@directive" can only be used once at this location.',
@@ -151,7 +151,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       fragment Test on Type {
         field @directiveA @directiveB @directiveA @directiveB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@directiveA" can only be used once at this location.',
@@ -176,7 +176,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       fragment Test on Type @directive @directive {
         field @directive @directive
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@directive" can only be used once at this location.',
@@ -208,7 +208,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       interface TestInterface @nonRepeatable @nonRepeatable
       union TestUnion @nonRepeatable @nonRepeatable
       input TestInput @nonRepeatable @nonRepeatable
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@nonRepeatable" can only be used once at this location.',
@@ -272,7 +272,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       extend interface TestInterface @nonRepeatable @nonRepeatable
       extend union TestUnion @nonRepeatable @nonRepeatable
       extend input TestInput @nonRepeatable @nonRepeatable
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@nonRepeatable" can only be used once at this location.',
@@ -330,7 +330,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
 
       schema @nonRepeatable { query: Dummy }
       extend schema @nonRepeatable
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@nonRepeatable" can only be used once at this location.',
@@ -347,7 +347,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       scalar TestScalar @nonRepeatable
       extend scalar TestScalar @nonRepeatable
       scalar TestScalar @nonRepeatable
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@nonRepeatable" can only be used once at this location.',
@@ -372,7 +372,7 @@ describe('Validate: Directives Are Unique Per Location', () => {
       extend type TestObject @nonRepeatable
       type TestObject @nonRepeatable
       extend type TestObject @nonRepeatable
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'The directive "@nonRepeatable" can only be used once at this location.',

--- a/src/validation/__tests__/UniqueEnumValueNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueEnumValueNamesRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Unique enum value names', () => {
@@ -47,7 +47,7 @@ describe('Validate: Unique enum value names', () => {
         BAR
         FOO
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Enum value "SomeEnum.FOO" can only be defined once.',
         locations: [
@@ -80,7 +80,7 @@ describe('Validate: Unique enum value names', () => {
       enum SomeEnum {
         FOO
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Enum value "SomeEnum.FOO" can only be defined once.',
         locations: [
@@ -99,7 +99,7 @@ describe('Validate: Unique enum value names', () => {
         BAR
         FOO
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Enum value "SomeEnum.FOO" can only be defined once.',
         locations: [
@@ -119,7 +119,7 @@ describe('Validate: Unique enum value names', () => {
       extend enum SomeEnum {
         FOO
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Enum value "SomeEnum.FOO" can only be defined once.',
         locations: [
@@ -156,7 +156,7 @@ describe('Validate: Unique enum value names', () => {
       }
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message:
           'Enum value "SomeEnum.FOO" already exists in the schema. It cannot also be defined in this type extension.',
@@ -181,7 +181,7 @@ describe('Validate: Unique enum value names', () => {
       }
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message: 'Enum value "SomeEnum.FOO" can only be defined once.',
         locations: [

--- a/src/validation/__tests__/UniqueFieldDefinitionNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueFieldDefinitionNamesRule-test.ts
@@ -17,7 +17,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Unique field definition names', () => {
@@ -83,7 +83,7 @@ describe('Validate: Unique field definition names', () => {
         bar: String
         foo: String
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Field "SomeObject.foo" can only be defined once.',
         locations: [
@@ -164,7 +164,7 @@ describe('Validate: Unique field definition names', () => {
       input SomeInputObject {
         foo: String
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Field "SomeObject.foo" can only be defined once.',
         locations: [
@@ -211,7 +211,7 @@ describe('Validate: Unique field definition names', () => {
         bar: String
         foo: String
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Field "SomeObject.foo" can only be defined once.',
         locations: [
@@ -261,7 +261,7 @@ describe('Validate: Unique field definition names', () => {
       extend input SomeInputObject {
         foo: String
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'Field "SomeObject.foo" can only be defined once.',
         locations: [
@@ -345,7 +345,7 @@ describe('Validate: Unique field definition names', () => {
       }
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message:
           'Field "SomeObject.foo" already exists in the schema. It cannot also be defined in this type extension.',
@@ -408,7 +408,7 @@ describe('Validate: Unique field definition names', () => {
       }
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message: 'Field "SomeObject.foo" can only be defined once.',
         locations: [

--- a/src/validation/__tests__/UniqueFragmentNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueFragmentNamesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Unique fragment names', () => {
@@ -87,7 +87,7 @@ describe('Validate: Unique fragment names', () => {
       fragment fragA on Type {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one fragment named "fragA".',
         locations: [
@@ -106,7 +106,7 @@ describe('Validate: Unique fragment names', () => {
       fragment fragA on Type {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one fragment named "fragA".',
         locations: [

--- a/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Unique input field names', () => {
@@ -58,7 +58,7 @@ describe('Validate: Unique input field names', () => {
       {
         field(arg: { f1: "value", f1: "value" })
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one input field named "f1".',
         locations: [
@@ -74,7 +74,7 @@ describe('Validate: Unique input field names', () => {
       {
         field(arg: { f1: "value", f1: "value", f1: "value" })
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one input field named "f1".',
         locations: [
@@ -97,7 +97,7 @@ describe('Validate: Unique input field names', () => {
       {
         field(arg: { f1: {f2: "value", f2: "value" }})
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one input field named "f2".',
         locations: [

--- a/src/validation/__tests__/UniqueOperationNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueOperationNamesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Unique operation names', () => {
@@ -84,7 +84,7 @@ describe('Validate: Unique operation names', () => {
       query Foo {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one operation named "Foo".',
         locations: [
@@ -103,7 +103,7 @@ describe('Validate: Unique operation names', () => {
       mutation Foo {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one operation named "Foo".',
         locations: [
@@ -122,7 +122,7 @@ describe('Validate: Unique operation names', () => {
       subscription Foo {
         fieldB
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one operation named "Foo".',
         locations: [

--- a/src/validation/__tests__/UniqueOperationTypesRule-test.ts
+++ b/src/validation/__tests__/UniqueOperationTypesRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Unique operation types', () => {
@@ -82,7 +82,7 @@ describe('Validate: Unique operation types', () => {
         mutation: Foo
         subscription: Foo
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one query type in schema.',
         locations: [
@@ -122,7 +122,7 @@ describe('Validate: Unique operation types', () => {
         mutation: Foo
         subscription: Foo
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one query type in schema.',
         locations: [
@@ -168,7 +168,7 @@ describe('Validate: Unique operation types', () => {
         mutation: Foo
         subscription: Foo
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one query type in schema.',
         locations: [
@@ -232,7 +232,7 @@ describe('Validate: Unique operation types', () => {
         mutation: Foo
         subscription: Foo
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one query type in schema.',
         locations: [
@@ -308,7 +308,7 @@ describe('Validate: Unique operation types', () => {
       }
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message:
           'Type for query already defined in the schema. It cannot be redefined.',
@@ -348,7 +348,7 @@ describe('Validate: Unique operation types', () => {
       }
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message:
           'Type for query already defined in the schema. It cannot be redefined.',

--- a/src/validation/__tests__/UniqueTypeNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueTypeNamesRule-test.ts
@@ -13,7 +13,7 @@ function expectSDLErrors(sdlStr: string, schema?: GraphQLSchema) {
 }
 
 function expectValidSDL(sdlStr: string, schema?: GraphQLSchema) {
-  expectSDLErrors(sdlStr, schema).to.deep.equal([]);
+  expectSDLErrors(sdlStr, schema).toDeepEqual([]);
 }
 
 describe('Validate: Unique type names', () => {
@@ -57,7 +57,7 @@ describe('Validate: Unique type names', () => {
       union Foo
       enum Foo
       input Foo
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one type named "Foo".',
         locations: [
@@ -126,7 +126,7 @@ describe('Validate: Unique type names', () => {
       input Foo
     `;
 
-    expectSDLErrors(sdl, schema).to.deep.equal([
+    expectSDLErrors(sdl, schema).toDeepEqual([
       {
         message:
           'Type "Foo" already exists in the schema. It cannot also be defined in this type definition.',

--- a/src/validation/__tests__/UniqueVariableNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueVariableNamesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Unique variable names', () => {
@@ -25,7 +25,7 @@ describe('Validate: Unique variable names', () => {
       query A($x: Int, $x: Int, $x: String) { __typename }
       query B($x: String, $x: Int) { __typename }
       query C($x: Int, $x: Int) { __typename }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message: 'There can be only one variable named "$x".',
         locations: [

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -32,11 +32,11 @@ function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 function expectValidWithSchema(schema: GraphQLSchema, queryStr: string) {
-  expectErrorsWithSchema(schema, queryStr).to.deep.equal([]);
+  expectErrorsWithSchema(schema, queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Values of correct type', () => {
@@ -188,7 +188,7 @@ describe('Validate: Values of correct type', () => {
             stringArgField(stringArg: 1)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: 1',
           locations: [{ line: 4, column: 39 }],
@@ -203,7 +203,7 @@ describe('Validate: Values of correct type', () => {
             stringArgField(stringArg: 1.0)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: 1.0',
           locations: [{ line: 4, column: 39 }],
@@ -218,7 +218,7 @@ describe('Validate: Values of correct type', () => {
             stringArgField(stringArg: true)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: true',
           locations: [{ line: 4, column: 39 }],
@@ -233,7 +233,7 @@ describe('Validate: Values of correct type', () => {
             stringArgField(stringArg: BAR)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: BAR',
           locations: [{ line: 4, column: 39 }],
@@ -250,7 +250,7 @@ describe('Validate: Values of correct type', () => {
             intArgField(intArg: "3")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: "3"',
           locations: [{ line: 4, column: 33 }],
@@ -265,7 +265,7 @@ describe('Validate: Values of correct type', () => {
             intArgField(intArg: 829384293849283498239482938)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Int cannot represent non 32-bit signed integer value: 829384293849283498239482938',
@@ -281,7 +281,7 @@ describe('Validate: Values of correct type', () => {
             intArgField(intArg: FOO)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: FOO',
           locations: [{ line: 4, column: 33 }],
@@ -296,7 +296,7 @@ describe('Validate: Values of correct type', () => {
             intArgField(intArg: 3.0)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: 3.0',
           locations: [{ line: 4, column: 33 }],
@@ -311,7 +311,7 @@ describe('Validate: Values of correct type', () => {
             intArgField(intArg: 3.333)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: 3.333',
           locations: [{ line: 4, column: 33 }],
@@ -328,7 +328,7 @@ describe('Validate: Values of correct type', () => {
             floatArgField(floatArg: "3.333")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Float cannot represent non numeric value: "3.333"',
           locations: [{ line: 4, column: 37 }],
@@ -343,7 +343,7 @@ describe('Validate: Values of correct type', () => {
             floatArgField(floatArg: true)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Float cannot represent non numeric value: true',
           locations: [{ line: 4, column: 37 }],
@@ -358,7 +358,7 @@ describe('Validate: Values of correct type', () => {
             floatArgField(floatArg: FOO)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Float cannot represent non numeric value: FOO',
           locations: [{ line: 4, column: 37 }],
@@ -375,7 +375,7 @@ describe('Validate: Values of correct type', () => {
             booleanArgField(booleanArg: 2)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Boolean cannot represent a non boolean value: 2',
           locations: [{ line: 4, column: 41 }],
@@ -390,7 +390,7 @@ describe('Validate: Values of correct type', () => {
             booleanArgField(booleanArg: 1.0)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Boolean cannot represent a non boolean value: 1.0',
           locations: [{ line: 4, column: 41 }],
@@ -405,7 +405,7 @@ describe('Validate: Values of correct type', () => {
             booleanArgField(booleanArg: "true")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Boolean cannot represent a non boolean value: "true"',
           locations: [{ line: 4, column: 41 }],
@@ -420,7 +420,7 @@ describe('Validate: Values of correct type', () => {
             booleanArgField(booleanArg: TRUE)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Boolean cannot represent a non boolean value: TRUE',
           locations: [{ line: 4, column: 41 }],
@@ -437,7 +437,7 @@ describe('Validate: Values of correct type', () => {
             idArgField(idArg: 1.0)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'ID cannot represent a non-string and non-integer value: 1.0',
@@ -453,7 +453,7 @@ describe('Validate: Values of correct type', () => {
             idArgField(idArg: true)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'ID cannot represent a non-string and non-integer value: true',
@@ -469,7 +469,7 @@ describe('Validate: Values of correct type', () => {
             idArgField(idArg: SOMETHING)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'ID cannot represent a non-string and non-integer value: SOMETHING',
@@ -487,7 +487,7 @@ describe('Validate: Values of correct type', () => {
             doesKnowCommand(dogCommand: 2)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Enum "DogCommand" cannot represent non-enum value: 2.',
           locations: [{ line: 4, column: 41 }],
@@ -502,7 +502,7 @@ describe('Validate: Values of correct type', () => {
             doesKnowCommand(dogCommand: 1.0)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Enum "DogCommand" cannot represent non-enum value: 1.0.',
           locations: [{ line: 4, column: 41 }],
@@ -517,7 +517,7 @@ describe('Validate: Values of correct type', () => {
             doesKnowCommand(dogCommand: "SIT")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Enum "DogCommand" cannot represent non-enum value: "SIT". Did you mean the enum value "SIT"?',
@@ -533,7 +533,7 @@ describe('Validate: Values of correct type', () => {
             doesKnowCommand(dogCommand: true)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Enum "DogCommand" cannot represent non-enum value: true.',
           locations: [{ line: 4, column: 41 }],
@@ -548,7 +548,7 @@ describe('Validate: Values of correct type', () => {
             doesKnowCommand(dogCommand: JUGGLE)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Value "JUGGLE" does not exist in "DogCommand" enum.',
           locations: [{ line: 4, column: 41 }],
@@ -563,7 +563,7 @@ describe('Validate: Values of correct type', () => {
             doesKnowCommand(dogCommand: sit)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Value "sit" does not exist in "DogCommand" enum. Did you mean the enum value "SIT"?',
@@ -623,7 +623,7 @@ describe('Validate: Values of correct type', () => {
             stringListArgField(stringListArg: ["one", 2])
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: 2',
           locations: [{ line: 4, column: 55 }],
@@ -638,7 +638,7 @@ describe('Validate: Values of correct type', () => {
             stringListArgField(stringListArg: 1)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: 1',
           locations: [{ line: 4, column: 47 }],
@@ -757,7 +757,7 @@ describe('Validate: Values of correct type', () => {
             multipleReqs(req2: "two", req1: "one")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: "two"',
           locations: [{ line: 4, column: 32 }],
@@ -776,7 +776,7 @@ describe('Validate: Values of correct type', () => {
             multipleReqs(req1: "one")
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: "one"',
           locations: [{ line: 4, column: 32 }],
@@ -791,7 +791,7 @@ describe('Validate: Values of correct type', () => {
             multipleReqs(req1: null)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Expected value of type "Int!", found null.',
           locations: [{ line: 4, column: 32 }],
@@ -882,7 +882,7 @@ describe('Validate: Values of correct type', () => {
             complexArgField(complexArg: { intField: 4 })
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "ComplexInput.requiredField" of required type "Boolean!" was not provided.',
@@ -901,7 +901,7 @@ describe('Validate: Values of correct type', () => {
             })
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: 2',
           locations: [{ line: 5, column: 40 }],
@@ -919,7 +919,7 @@ describe('Validate: Values of correct type', () => {
             })
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Expected value of type "Boolean!", found null.',
           locations: [{ line: 6, column: 29 }],
@@ -937,7 +937,7 @@ describe('Validate: Values of correct type', () => {
             })
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "invalidField" is not defined by type "ComplexInput". Did you mean "intField"?',
@@ -971,7 +971,7 @@ describe('Validate: Values of correct type', () => {
       const doc = parse('{ invalidArg(arg: 123) }');
       const errors = validate(schema, doc, [ValuesOfCorrectTypeRule]);
 
-      expectJSON(errors).to.deep.equal([
+      expectJSON(errors).toDeepEqual([
         {
           message:
             'Expected value of type "Invalid", found 123; Invalid scalar is always invalid: 123',
@@ -1005,7 +1005,7 @@ describe('Validate: Values of correct type', () => {
         }),
       });
 
-      expectErrorsWithSchema(schema, '{ invalidArg(arg: 123) }').to.deep.equal([
+      expectErrorsWithSchema(schema, '{ invalidArg(arg: 123) }').toDeepEqual([
         {
           message: 'Expected value of type "CustomScalar", found 123.',
           locations: [{ line: 1, column: 19 }],
@@ -1062,7 +1062,7 @@ describe('Validate: Values of correct type', () => {
             name @skip(if: ENUM)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Boolean cannot represent a non boolean value: "yes"',
           locations: [{ line: 3, column: 28 }],
@@ -1110,7 +1110,7 @@ describe('Validate: Values of correct type', () => {
         ) {
           dog { name }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Expected value of type "Int!", found null.',
           locations: [{ line: 3, column: 22 }],
@@ -1135,7 +1135,7 @@ describe('Validate: Values of correct type', () => {
         ) {
           dog { name }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Int cannot represent non-integer value: "one"',
           locations: [{ line: 3, column: 21 }],
@@ -1159,7 +1159,7 @@ describe('Validate: Values of correct type', () => {
         ) {
           dog { name }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'Boolean cannot represent a non boolean value: 123',
           locations: [{ line: 3, column: 47 }],
@@ -1176,7 +1176,7 @@ describe('Validate: Values of correct type', () => {
         query MissingRequiredField($a: ComplexInput = {intField: 3}) {
           dog { name }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Field "ComplexInput.requiredField" of required type "Boolean!" was not provided.',
@@ -1190,7 +1190,7 @@ describe('Validate: Values of correct type', () => {
         query InvalidItem($a: [String] = ["one", 2]) {
           dog { name }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message: 'String cannot represent a non string value: 2',
           locations: [{ line: 2, column: 50 }],

--- a/src/validation/__tests__/VariablesAreInputTypesRule-test.ts
+++ b/src/validation/__tests__/VariablesAreInputTypesRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Variables are input types', () => {
@@ -34,7 +34,7 @@ describe('Validate: Variables are input types', () => {
       query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {
         field(a: $a, b: $b, c: $c)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         locations: [{ line: 2, column: 21 }],
         message: 'Variable "$a" cannot be non-input type "Dog".',

--- a/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
+++ b/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
@@ -9,7 +9,7 @@ function expectErrors(queryStr: string) {
 }
 
 function expectValid(queryStr: string) {
-  expectErrors(queryStr).to.deep.equal([]);
+  expectErrors(queryStr).toDeepEqual([]);
 }
 
 describe('Validate: Variables are in allowed positions', () => {
@@ -158,7 +158,7 @@ describe('Validate: Variables are in allowed positions', () => {
           nonNullIntArgField(nonNullIntArg: $intArg)
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$intArg" of type "Int" used in position expecting type "Int!".',
@@ -181,7 +181,7 @@ describe('Validate: Variables are in allowed positions', () => {
           ...nonNullIntArgFieldFrag
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$intArg" of type "Int" used in position expecting type "Int!".',
@@ -208,7 +208,7 @@ describe('Validate: Variables are in allowed positions', () => {
           ...outerFrag
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$intArg" of type "Int" used in position expecting type "Int!".',
@@ -227,7 +227,7 @@ describe('Validate: Variables are in allowed positions', () => {
           booleanArgField(booleanArg: $stringVar)
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$stringVar" of type "String" used in position expecting type "Boolean".',
@@ -246,7 +246,7 @@ describe('Validate: Variables are in allowed positions', () => {
           stringListArgField(stringListArg: $stringVar)
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$stringVar" of type "String" used in position expecting type "[String]".',
@@ -263,7 +263,7 @@ describe('Validate: Variables are in allowed positions', () => {
       query Query($boolVar: Boolean) {
         dog @include(if: $boolVar)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$boolVar" of type "Boolean" used in position expecting type "Boolean!".',
@@ -280,7 +280,7 @@ describe('Validate: Variables are in allowed positions', () => {
       query Query($stringVar: String) {
         dog @include(if: $stringVar)
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$stringVar" of type "String" used in position expecting type "Boolean!".',
@@ -300,7 +300,7 @@ describe('Validate: Variables are in allowed positions', () => {
           stringListNonNullArgField(stringListNonNullArg: $stringListVar)
         }
       }
-    `).to.deep.equal([
+    `).toDeepEqual([
       {
         message:
           'Variable "$stringListVar" of type "[String]" used in position expecting type "[String!]".',
@@ -320,7 +320,7 @@ describe('Validate: Variables are in allowed positions', () => {
             nonNullIntArgField(nonNullIntArg: $intVar)
           }
         }
-      `).to.deep.equal([
+      `).toDeepEqual([
         {
           message:
             'Variable "$intVar" of type "Int" used in position expecting type "Int!".',

--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -39,7 +39,7 @@ describe('Validate: Supports full validation', () => {
     `);
 
     const errors = validate(testSchema, doc);
-    expectJSON(errors).to.deep.equal([]);
+    expectJSON(errors).toDeepEqual([]);
   });
 
   it('detects unknown fields', () => {
@@ -50,7 +50,7 @@ describe('Validate: Supports full validation', () => {
     `);
 
     const errors = validate(testSchema, doc);
-    expectJSON(errors).to.deep.equal([
+    expectJSON(errors).toDeepEqual([
       {
         locations: [{ line: 3, column: 9 }],
         message: 'Cannot query field "unknown" on type "QueryRoot".',
@@ -116,7 +116,7 @@ describe('Validate: Supports full validation', () => {
     }
 
     const errors = validate(schema, doc, [customRule]);
-    expectJSON(errors).to.deep.equal([
+    expectJSON(errors).toDeepEqual([
       {
         message: 'Reporting directive: @custom',
         locations: [{ line: 3, column: 14 }],
@@ -148,7 +148,7 @@ describe('Validate: Limit maximum number of validation errors', () => {
 
   it('when maxErrors is equal to number of errors', () => {
     const errors = validateDocument({ maxErrors: 3 });
-    expectJSON(errors).to.be.deep.equal([
+    expectJSON(errors).toDeepEqual([
       invalidFieldError('firstUnknownField'),
       invalidFieldError('secondUnknownField'),
       invalidFieldError('thirdUnknownField'),
@@ -157,7 +157,7 @@ describe('Validate: Limit maximum number of validation errors', () => {
 
   it('when maxErrors is less than number of errors', () => {
     const errors = validateDocument({ maxErrors: 2 });
-    expectJSON(errors).to.be.deep.equal([
+    expectJSON(errors).toDeepEqual([
       invalidFieldError('firstUnknownField'),
       invalidFieldError('secondUnknownField'),
       {


### PR DESCRIPTION
Current behaviour was masking situation where you convert value into
JSON but comparing it against raw JS value.
Now we only compare JSON values.