### PR TITLE
GraphQLError: revert `originalError` to be nullable

### DIFF
--- a/src/error/GraphQLError.d.ts
+++ b/src/error/GraphQLError.d.ts
@@ -76,7 +76,7 @@ export class GraphQLError extends Error {
   /**
    * The original error thrown from a field resolver during execution.
    */
-  readonly originalError: Error | undefined;
+  readonly originalError: Error | undefined | null;
 
   /**
    * Extension fields to add to the formatted error.

--- a/src/error/GraphQLError.js
+++ b/src/error/GraphQLError.js
@@ -56,7 +56,7 @@ export class GraphQLError extends Error {
   /**
    * The original error thrown from a field resolver during execution.
    */
-  +originalError: Error | void;
+  +originalError: Error | void | null;
 
   /**
    * Extension fields to add to the formatted error.


### PR DESCRIPTION
Partial revert of #3333
Were reverted due to conflict with Apollo Server, see
https://github.com/apollographql/apollo-server/issues/5843