### PR TITLE
v16 regression: parsed GraphQL comments has invalid (negative) `token.column`

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -11,6 +11,7 @@ import { Kind } from '../kinds';
 import { Source } from '../source';
 import { TokenKind } from '../tokenKind';
 import { parse, parseValue, parseConstValue, parseType } from '../parser';
+import { Token, visit } from '..';
 
 function expectSyntaxError(text: string) {
   return expectToThrowJSON(() => parse(text));
@@ -637,6 +638,25 @@ describe('Parser', () => {
           },
         },
       });
+    });
+
+    it('parses comments with correct location', () => {
+      const sdl = /* GraphQL */ `
+        """
+        generic query placeholder
+        """
+        type Query
+      `;
+      const result = parse(sdl, {
+        noLocation: false,
+      });
+
+      let token: Token | null | undefined = result.loc?.startToken;
+
+      do {
+        expect(token?.column, 'token column is negative').to.greaterThan(-1);
+        token = token?.next;
+      } while (token?.kind !== TokenKind.EOF);
     });
   });
 });


### PR DESCRIPTION
While working on `graphql-eslint` (https://github.com/dotansimha/graphql-eslint/pull/724) and upgrading it to v16, we noticed that parsed comments has negative values in `startToken.column`. v15 was working fine.

Managed to add a failing test to ensure all columns are positive. I think it happens only when there are GraphQL comments at the beginning of the document. 

@IvanGoncharov @saihaj thoughts? 

> the test case I added isn't ideal, it just tries to confirm the existence of the bug, and not the correctness of the positions 