### PR TITLE
deploy full ESM with "type": "module" in "latest-esm" npm tag

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,6 +5,7 @@
 /node_modules
 /reports
 /npmDist
+/npmEsmDist
 /denoDist
 /websiteDist
 

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -473,6 +473,10 @@ rules:
   yield-star-spacing: off
 
 overrides:
+  - files:
+      - 'integrationTests/node-esm/**/*.js'
+    parserOptions:
+      sourceType: module
   - files: '**/*.ts'
     parser: '@typescript-eslint/parser'
     parserOptions:

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 /node_modules
 /reports
 /npmDist
+/npmEsmDist
 /denoDist
 /websiteDist

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,5 +6,6 @@
 /node_modules
 /reports
 /npmDist
+/npmEsmDist
 /denoDist
 /websiteDist

--- a/integrationTests/node/index.mjs
+++ b/integrationTests/node/index.mjs
@@ -2,13 +2,13 @@
 import assert from 'assert';
 import { readFileSync } from 'fs';
 
-import { graphqlSync } from 'graphql';
-import { buildSchema } from 'graphql/utilities';
-import { version } from 'graphql/version';
+import { graphqlSync } from 'graphql-esm';
+import { buildSchema } from 'graphql-esm/utilities';
+import { version } from 'graphql-esm/version';
 
 assert.deepStrictEqual(
-  version,
-  JSON.parse(readFileSync('./node_modules/graphql/package.json')).version,
+  version + '+esm',
+  JSON.parse(readFileSync('./node_modules/graphql-esm/package.json')).version,
 );
 
 const schema = buildSchema('type Query { hello: String }');

--- a/integrationTests/node/package.json
+++ b/integrationTests/node/package.json
@@ -6,6 +6,7 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "graphql": "file:../graphql.tgz"
+    "graphql": "file:../graphql.tgz",
+    "graphql-esm": "file:../graphql-esm.tgz"
   }
 }

--- a/integrationTests/node/test.js
+++ b/integrationTests/node/test.js
@@ -14,7 +14,12 @@ for (const version of nodeVersions) {
   console.log(`Testing on node@${version} ...`);
 
   childProcess.execSync(
-    `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app node:${version}-slim node ./index.js`,
+    `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app node:${version}-slim node ./index.cjs`,
+    { stdio: 'inherit' },
+  );
+
+  childProcess.execSync(
+    `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app node:${version}-slim node ./index.mjs`,
     { stdio: 'inherit' },
   );
 }

--- a/integrationTests/ts/esm.ts
+++ b/integrationTests/ts/esm.ts
@@ -1,0 +1,38 @@
+import type { ExecutionResult } from 'graphql-esm/execution';
+
+import { graphqlSync } from 'graphql-esm';
+import {
+  GraphQLString,
+  GraphQLSchema,
+  GraphQLObjectType,
+} from 'graphql-esm/type';
+
+const queryType: GraphQLObjectType = new GraphQLObjectType({
+  name: 'Query',
+  fields: () => ({
+    sayHi: {
+      type: GraphQLString,
+      args: {
+        who: {
+          type: GraphQLString,
+          defaultValue: 'World',
+        },
+      },
+      resolve(_root, args: { who: string }) {
+        return 'Hello ' + args.who;
+      },
+    },
+  }),
+});
+
+const schema: GraphQLSchema = new GraphQLSchema({ query: queryType });
+
+const result: ExecutionResult = graphqlSync({
+  schema,
+  source: `
+    query helloWho($who: String){
+      test(who: $who)
+    }
+  `,
+  variableValues: { who: 'Dolly' },
+});

--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz",
+    "graphql-esm": "file:../graphql-esm.tgz",
     "typescript-4.4": "npm:typescript@4.4.x",
     "typescript-4.5": "npm:typescript@4.5.x",
     "typescript-4.6": "npm:typescript@4.6.x",

--- a/integrationTests/webpack/entry-esm.mjs
+++ b/integrationTests/webpack/entry-esm.mjs
@@ -1,0 +1,13 @@
+// eslint-disable-next-line node/no-missing-import, import/no-unresolved
+import { graphqlSync } from 'graphql-esm';
+
+// eslint-disable-next-line node/no-missing-import, import/no-unresolved
+import { buildSchema } from 'graphql-esm/utilities/buildASTSchema';
+
+const schema = buildSchema('type Query { hello: String }');
+
+export const result = graphqlSync({
+  schema,
+  source: '{ hello }',
+  rootValue: { hello: 'world' },
+});

--- a/integrationTests/webpack/package.json
+++ b/integrationTests/webpack/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz",
+    "graphql-esm": "file:../graphql-esm.tgz",
     "webpack": "5.x.x",
     "webpack-cli": "4.x.x"
   }

--- a/integrationTests/webpack/test.js
+++ b/integrationTests/webpack/test.js
@@ -1,11 +1,20 @@
 import assert from 'assert';
 
-import mainCJS from './dist/main.cjs';
+import cjs from './dist/main-cjs.cjs';
+import mjs from './dist/main-mjs.cjs';
 
-assert.deepStrictEqual(mainCJS.result, {
+assert.deepStrictEqual(cjs.result, {
   data: {
     __proto__: null,
     hello: 'world',
   },
 });
+
+assert.deepStrictEqual(mjs.result, {
+  data: {
+    __proto__: null,
+    hello: 'world',
+  },
+});
+
 console.log('Test script: Got correct result from Webpack bundle!');

--- a/integrationTests/webpack/webpack.config.json
+++ b/integrationTests/webpack/webpack.config.json
@@ -1,8 +1,11 @@
 {
   "mode": "production",
-  "entry": "./entry.js",
+  "entry": {
+    "cjs": "./entry.js",
+    "mjs": "./entry-esm.mjs"
+  },
   "output": {
-    "filename": "main.cjs",
+    "filename": "main-[name].cjs",
     "library": {
       "type": "commonjs2"
     }

--- a/resources/integration-test.ts
+++ b/resources/integration-test.ts
@@ -11,9 +11,16 @@ describe('Integration Tests', () => {
   });
 
   npm().run('build:npm');
+
   const distDir = localRepoPath('npmDist');
   const archiveName = npm({ cwd: tmpDirPath(), quiet: true }).pack(distDir);
   fs.renameSync(tmpDirPath(archiveName), tmpDirPath('graphql.tgz'));
+
+  const esmDistDir = localRepoPath('npmEsmDist');
+  const archiveEsmName = npm({ cwd: tmpDirPath(), quiet: true }).pack(
+    esmDistDir,
+  );
+  fs.renameSync(tmpDirPath(archiveEsmName), tmpDirPath('graphql-esm.tgz'));
 
   npm().run('build:deno');
 

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -198,7 +198,11 @@ interface PackageJSON {
   types?: string;
   typesVersions: { [ranges: string]: { [path: string]: Array<string> } };
   devDependencies?: { [name: string]: string };
-  publishConfig?: { tag?: string };
+  publishConfig: { tag: string };
+
+  // TODO: remove after we drop CJS support
+  main?: string;
+  module?: string;
 }
 
 export function readPackageJSON(


### PR DESCRIPTION
I also just re-published graphql@16.0.1 as graphql-esm@16.0.1 https://npm.im/graphql-esm, tested it in an example project using libraries with full ESM support https://github.com/PabloSzx/test-graphql-esm, everything works perfectly 👌 

It can be tested right now doing this:
```json
{
  "dependencies": {
    "graphql": "npm:graphql-esm@^16.0.1"
  }
}
```