### PR TITLE
fix: remove security vulnerability of exposing graph in production environment

### DIFF
--- a/src/jsutils/didYouMean.ts
+++ b/src/jsutils/didYouMean.ts
@@ -12,7 +12,7 @@ export function didYouMean(
   firstArg: string | ReadonlyArray<string>,
   secondArg?: ReadonlyArray<string>,
 ) {
-  if (process.ENV.NODE_ENV === 'production') {
+  if (process.env.NODE_ENV === 'production') {
     return ''
   };
 

--- a/src/jsutils/didYouMean.ts
+++ b/src/jsutils/didYouMean.ts
@@ -12,6 +12,10 @@ export function didYouMean(
   firstArg: string | ReadonlyArray<string>,
   secondArg?: ReadonlyArray<string>,
 ) {
+  if (process.ENV.NODE_ENV === 'production') {
+    return ''
+  };
+
   const [subMessage, suggestionsArg] = secondArg
     ? [firstArg as string, secondArg]
     : [undefined, firstArg as ReadonlyArray<string>];


### PR DESCRIPTION
Resolves and related to: 
https://github.com/graphql/graphql-js/issues/3229
https://github.com/graphql/graphql-js/issues/2247

Following Node.js best practices of setting NODE_ENV=production we could use the same pattern to disable this security vulnerability in graphql-js at the core.

**Open for feedback to resolve this issue ASAP**