### PR TITLE
feat: allow passing a contextValue to validation rules

### DIFF
--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -267,4 +267,7 @@ export class ValidationContext extends ASTValidationContext {
   }
 }
 
-export type ValidationRule = (context: ValidationContext) => ASTVisitor;
+export type ValidationRule = (
+  context: ValidationContext,
+  contextValue?: unknown,
+) => ASTVisitor;

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -43,6 +43,7 @@ export function validate(
 
   /** @deprecated will be removed in 17.0.0 */
   typeInfo: TypeInfo = new TypeInfo(schema),
+  contextValue?: unknown,
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
 
@@ -72,7 +73,9 @@ export function validate(
 
   // This uses a specialized visitor which runs multiple visitors in parallel,
   // while maintaining the visitor skip and break API.
-  const visitor = visitInParallel(rules.map((rule) => rule(context)));
+  const visitor = visitInParallel(
+    rules.map((rule) => rule(context, contextValue)),
+  );
 
   // Visit the whole document with each instance of all provided rules.
   try {


### PR DESCRIPTION
It should be possible to pass a `contextValue` into validation rules that can be used within for complex logic such as query complexity calculation or other more complex validation rules that require sharing/modifying a `contextValue` provided from the outside.