### PR TITLE
execute: fix spec section names in comments

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -472,7 +472,7 @@ function executeFields(
 }
 
 /**
- * Implements the "Executing field" section of the spec
+ * Implements the "Executing fields" section of the spec
  * In particular, this function figures out the value that the field returns by
  * calling its resolve function, then calls completeValue to complete promises,
  * serialize scalars, or execute the sub-selection-set for objects.
@@ -594,7 +594,7 @@ function handleFieldError(
 
 /**
  * Implements the instructions for completeValue as defined in the
- * "Field entries" section of the spec.
+ * "Value Completion" section of the spec.
  *
  * If the field type is Non-Null, then this recursively completes the value
  * for the inner type. It throws a field error if that completion returns null,


### PR DESCRIPTION
Altered a couple of them to be more in line with the names in the current spec