### PR TITLE
lexer-tests: Use tildas as invalid characters

### DIFF
--- a/src/language/__tests__/lexer-test.ts
+++ b/src/language/__tests__/lexer-test.ts
@@ -168,17 +168,17 @@ describe('Lexer', () => {
   it('errors respect whitespace', () => {
     let caughtError;
     try {
-      lexOne(['', '', '    ?', ''].join('\n'));
+      lexOne(['', '', ' ~', ''].join('\n'));
     } catch (error) {
       caughtError = error;
     }
     expect(String(caughtError)).to.equal(dedent`
-      Syntax Error: Unexpected character: "?".
+      Syntax Error: Unexpected character: "~".
 
-      GraphQL request:3:5
+      GraphQL request:3:2
       2 |
-      3 |     ?
-        |     ^
+      3 |  ~
+        |  ^
       4 |
     `);
   });
@@ -186,18 +186,18 @@ describe('Lexer', () => {
   it('updates line numbers in error for file context', () => {
     let caughtError;
     try {
-      const str = ['', '', '     ?', ''].join('\n');
+      const str = ['', '', '     ~', ''].join('\n');
       const source = new Source(str, 'foo.js', { line: 11, column: 12 });
       new Lexer(source).advance();
     } catch (error) {
       caughtError = error;
     }
     expect(String(caughtError)).to.equal(dedent`
-      Syntax Error: Unexpected character: "?".
+      Syntax Error: Unexpected character: "~".
 
       foo.js:13:6
       12 |
-      13 |      ?
+      13 |      ~
          |      ^
       14 |
     `);
@@ -206,16 +206,16 @@ describe('Lexer', () => {
   it('updates column numbers in error for file context', () => {
     let caughtError;
     try {
-      const source = new Source('?', 'foo.js', { line: 1, column: 5 });
+      const source = new Source('~', 'foo.js', { line: 1, column: 5 });
       new Lexer(source).advance();
     } catch (error) {
       caughtError = error;
     }
     expect(String(caughtError)).to.equal(dedent`
-      Syntax Error: Unexpected character: "?".
+      Syntax Error: Unexpected character: "~".
 
       foo.js:1:5
-      1 |     ?
+      1 |     ~
         |     ^
     `);
   });
@@ -1027,8 +1027,8 @@ describe('Lexer', () => {
       locations: [{ line: 1, column: 1 }],
     });
 
-    expectSyntaxError('?').to.deep.equal({
-      message: 'Syntax Error: Unexpected character: "?".',
+    expectSyntaxError('~').to.deep.equal({
+      message: 'Syntax Error: Unexpected character: "~".',
       locations: [{ line: 1, column: 1 }],
     });
 


### PR DESCRIPTION
This PR is in preparation for https://github.com/graphql/graphql-js/pull/3281

Question marks are valid characters after that PR, so we need to pick something new