### PR TITLE
Preserve non-error values thrown from resolvers

### DIFF
--- a/src/error/__tests__/locatedError-test.ts
+++ b/src/error/__tests__/locatedError-test.ts
@@ -16,6 +16,17 @@ describe('locatedError', () => {
     expect(locatedError(e, [], [])).to.deep.equal(e);
   });
 
+  it('wraps non-errors', () => {
+    const testObject = Object.freeze({});
+    const error = locatedError(testObject, [], []);
+
+    expect(error).to.be.instanceOf(GraphQLError);
+    expect(error.originalError).to.include({
+      name: 'NonErrorThrown',
+      thrownValue: testObject,
+    });
+  });
+
   it('passes GraphQLError-ish through', () => {
     const e = new Error();
     // @ts-expect-error

--- a/src/error/locatedError.ts
+++ b/src/error/locatedError.ts
@@ -1,5 +1,5 @@
-import { inspect } from '../jsutils/inspect';
 import type { Maybe } from '../jsutils/Maybe';
+import { toError } from '../jsutils/toError';
 
 import type { ASTNode } from '../language/ast';
 
@@ -15,11 +15,7 @@ export function locatedError(
   nodes: ASTNode | ReadonlyArray<ASTNode> | undefined | null,
   path?: Maybe<ReadonlyArray<string | number>>,
 ): GraphQLError {
-  // Sometimes a non-error is thrown, wrap it as an Error instance to ensure a consistent Error interface.
-  const originalError: Error | GraphQLError =
-    rawOriginalError instanceof Error
-      ? rawOriginalError
-      : new Error('Unexpected error value: ' + inspect(rawOriginalError));
+  const originalError = toError(rawOriginalError);
 
   // Note: this uses a brand-check to support GraphQL errors originating from other contexts.
   if (isLocatedGraphQLError(originalError)) {

--- a/src/jsutils/toError.ts
+++ b/src/jsutils/toError.ts
@@ -1,0 +1,20 @@
+import { inspect } from './inspect';
+
+/**
+ * Sometimes a non-error is thrown, wrap it as an Error instance to ensure a consistent Error interface.
+ */
+export function toError(thrownValue: unknown): Error {
+  return thrownValue instanceof Error
+    ? thrownValue
+    : new NonErrorThrown(thrownValue);
+}
+
+class NonErrorThrown extends Error {
+  thrownValue: unknown;
+
+  constructor(thrownValue: unknown) {
+    super('Unexpected error value: ' + inspect(thrownValue));
+    this.name = 'NonErrorThrown';
+    this.thrownValue = thrownValue;
+  }
+}


### PR DESCRIPTION
Fixes #3379