### PR TITLE
fix type for first argument to isTypeOf

### DIFF
--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -158,7 +158,7 @@ describe('Execute: Handles execution of abstract types', () => {
     const DogType = new GraphQLObjectType<Dog, Context>({
       name: 'Dog',
       interfaces: [PetType],
-      isTypeOf(_source, context) {
+      isTypeOf(_value, context) {
         const error = new Error('We are testing this error');
         if (context.async) {
           return Promise.reject(error);
@@ -240,7 +240,7 @@ describe('Execute: Handles execution of abstract types', () => {
     const DogType = new GraphQLObjectType<Dog, Context>({
       name: 'Dog',
       interfaces: [PetType],
-      isTypeOf(_source, context) {
+      isTypeOf(_value, context) {
         return context.async ? Promise.resolve(false) : false;
       },
       fields: {

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -902,7 +902,7 @@ export class GraphQLObjectType<TSource = any, TContext = any>
   readonly __kind = objectSymbol;
   name: string;
   description: Maybe<string>;
-  isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
+  isTypeOf: Maybe<GraphQLIsTypeOfFn<unknown, TContext>>;
   extensions: Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
@@ -992,7 +992,7 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
   description?: Maybe<string>;
   interfaces?: ThunkReadonlyArray<GraphQLInterfaceType> | undefined;
   fields: ThunkObjMap<GraphQLFieldConfig<TSource, TContext>>;
-  isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
+  isTypeOf?: Maybe<GraphQLIsTypeOfFn<unknown, TContext>>;
   extensions?: Maybe<Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>>;
   astNode?: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -896,13 +896,13 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  * });
  * ```
  */
-export class GraphQLObjectType<TSource = any, TContext = any>
+export class GraphQLObjectType<TSource = any, TContext = any, TAbstract = any>
   implements GraphQLSchemaElement
 {
   readonly __kind = objectSymbol;
   name: string;
   description: Maybe<string>;
-  isTypeOf: Maybe<GraphQLIsTypeOfFn<unknown, TContext>>;
+  isTypeOf: Maybe<GraphQLIsTypeOfFn<TAbstract, TContext>>;
   extensions: Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>;
   astNode: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
@@ -910,7 +910,9 @@ export class GraphQLObjectType<TSource = any, TContext = any>
   private _fields: ThunkObjMap<GraphQLField<TSource, TContext>>;
   private _interfaces: ThunkReadonlyArray<GraphQLInterfaceType>;
 
-  constructor(config: Readonly<GraphQLObjectTypeConfig<TSource, TContext>>) {
+  constructor(
+    config: Readonly<GraphQLObjectTypeConfig<TSource, TContext, TAbstract>>,
+  ) {
     this.__kind = objectSymbol;
     this.name = assertName(config.name);
     this.description = config.description;
@@ -944,7 +946,7 @@ export class GraphQLObjectType<TSource = any, TContext = any>
     return this._interfaces;
   }
 
-  toConfig(): GraphQLObjectTypeNormalizedConfig<TSource, TContext> {
+  toConfig(): GraphQLObjectTypeNormalizedConfig<TSource, TContext, TAbstract> {
     return {
       name: this.name,
       description: this.description,
@@ -987,19 +989,26 @@ function defineFieldMap<TSource, TContext>(
   );
 }
 
-export interface GraphQLObjectTypeConfig<TSource, TContext> {
+export interface GraphQLObjectTypeConfig<
+  TSource,
+  TContext,
+  TAbstract = unknown,
+> {
   name: string;
   description?: Maybe<string>;
   interfaces?: ThunkReadonlyArray<GraphQLInterfaceType> | undefined;
   fields: ThunkObjMap<GraphQLFieldConfig<TSource, TContext>>;
-  isTypeOf?: Maybe<GraphQLIsTypeOfFn<unknown, TContext>>;
+  isTypeOf?: Maybe<GraphQLIsTypeOfFn<TAbstract, TContext>>;
   extensions?: Maybe<Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>>;
   astNode?: Maybe<ObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
 
-export interface GraphQLObjectTypeNormalizedConfig<TSource, TContext>
-  extends GraphQLObjectTypeConfig<TSource, TContext> {
+export interface GraphQLObjectTypeNormalizedConfig<
+  TSource,
+  TContext,
+  TAbstract = unknown,
+> extends GraphQLObjectTypeConfig<TSource, TContext, TAbstract> {
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
   fields: GraphQLFieldNormalizedConfigMap<TSource, TContext>;
   extensions: Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>;
@@ -1013,8 +1022,8 @@ export type GraphQLTypeResolver<TSource, TContext> = (
   abstractType: GraphQLAbstractType,
 ) => PromiseOrValue<string | undefined>;
 
-export type GraphQLIsTypeOfFn<TSource, TContext> = (
-  source: TSource,
+export type GraphQLIsTypeOfFn<TAbstract, TContext> = (
+  value: TAbstract,
   context: TContext,
   info: GraphQLResolveInfo,
 ) => PromiseOrValue<boolean>;


### PR DESCRIPTION
Hi,

Currently the type of `source` argument in `isTypeOf` is `TSource` (the source type of `GraphQLObjectType`), but I think it is wrong since `isTypeOf` may be called with a source value of any type that implements the same interface or that belongs to the same union. Therefore I changed the type of `source` to `unknown`.

For example, the following code passes type check but results in an error at runtime.

```typescript
import {
  graphql,
  GraphQLSchema,
  GraphQLObjectType,
  GraphQLString,
  GraphQLInterfaceType,
} from "graphql";

class Human {
  constructor(readonly name: string) {}
}

class Droid {
  constructor(readonly name: string, readonly primaryFunction: string) {}
  serialNumber = () => "-";
}

const CharacterType = new GraphQLInterfaceType({
  name: "Character",
  fields: { name: { type: GraphQLString } },
});

const HumanType = new GraphQLObjectType<Human>({
  name: "Human",
  fields: {
    name: { type: GraphQLString },
  },
  interfaces: [CharacterType],
  isTypeOf: (source) => {
    return source instanceof Human;
  },
});

const DroidType = new GraphQLObjectType<Droid>({
  name: "Droid",
  interfaces: [CharacterType],
  fields: {
    name: { type: GraphQLString },
    primaryFunction: { type: GraphQLString },
  },
  isTypeOf: (source) => {
    // XXX: Here the type of source is inferred as Droid, but it can be Human.
    // In that case this results in error at runtime.
    console.log("debug", source.serialNumber());
    return source instanceof Droid;
  },
});

const QueryType = new GraphQLObjectType({
  name: "Query",
  fields: {
    anyCharacter: {
      type: CharacterType,
      resolve: () => new Human("Han Solo"),
    },
  },
});

const schema = new GraphQLSchema({ query: QueryType, types: [DroidType, HumanType] });
const query = "query Test { anyCharacter { name } }";
graphql({ schema, source: query, rootValue: {} }).then((res) => {
  console.log(res);
  //=> res.errors: [TypeError: source.serialNumber is not a function]
});
```

