### PR TITLE
Drop "eslint-plugin-istanbul" and implement as internal ESLint rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,7 +8,6 @@ reportUnusedDisableDirectives: true
 plugins:
   - internal-rules
   - node
-  - istanbul
   - import
 settings:
   node:
@@ -23,14 +22,7 @@ rules:
   internal-rules/only-ascii: error
   internal-rules/no-dir-import: error
   internal-rules/require-to-string-tag: off
-
-  ##############################################################################
-  # `eslint-plugin-istanbul` rule list based on `v0.1.2`
-  # https://github.com/istanbuljs/eslint-plugin-istanbul#rules
-  ##############################################################################
-
-  istanbul/no-ignore-file: error
-  istanbul/prefer-ignore-reason: error
+  internal-rules/require-coverage-ignore-reason: error
 
   ##############################################################################
   # `eslint-plugin-node` rule list based on `v11.1.x`

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "eslint": "7.32.0",
         "eslint-plugin-import": "2.25.2",
         "eslint-plugin-internal-rules": "file:./resources/eslint-internal-rules",
-        "eslint-plugin-istanbul": "0.1.2",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-tsdoc": "0.2.14",
         "mocha": "9.1.3",
@@ -3871,18 +3870,6 @@
     "node_modules/eslint-plugin-internal-rules": {
       "resolved": "resources/eslint-internal-rules",
       "link": true
-    },
-    "node_modules/eslint-plugin-istanbul": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-istanbul/-/eslint-plugin-istanbul-0.1.2.tgz",
-      "integrity": "sha512-lkH0DnPxdPUZ9HMG8wpcJcl481IXRHJX1Jj1SqTWtiNgeuz/s2OOJLbCEyrIoz4HJxC4OOS4tbbGOlqeovqHaw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0"
-      }
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -10512,13 +10499,6 @@
     },
     "eslint-plugin-internal-rules": {
       "version": "file:resources/eslint-internal-rules"
-    },
-    "eslint-plugin-istanbul": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-istanbul/-/eslint-plugin-istanbul-0.1.2.tgz",
-      "integrity": "sha512-lkH0DnPxdPUZ9HMG8wpcJcl481IXRHJX1Jj1SqTWtiNgeuz/s2OOJLbCEyrIoz4HJxC4OOS4tbbGOlqeovqHaw==",
-      "dev": true,
-      "requires": {}
     },
     "eslint-plugin-node": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "eslint": "7.32.0",
     "eslint-plugin-import": "2.25.2",
     "eslint-plugin-internal-rules": "file:./resources/eslint-internal-rules",
-    "eslint-plugin-istanbul": "0.1.2",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-tsdoc": "0.2.14",
     "mocha": "9.1.3",

--- a/resources/eslint-internal-rules/index.js
+++ b/resources/eslint-internal-rules/index.js
@@ -3,11 +3,13 @@
 const onlyASCII = require('./only-ascii.js');
 const noDirImport = require('./no-dir-import.js');
 const requireToStringTag = require('./require-to-string-tag.js');
+const requireCoverageIgnoreReason = require('./require-coverage-ignore-reason.js');
 
 module.exports = {
   rules: {
     'only-ascii': onlyASCII,
     'no-dir-import': noDirImport,
     'require-to-string-tag': requireToStringTag,
+    'require-coverage-ignore-reason': requireCoverageIgnoreReason,
   },
 };

--- a/resources/eslint-internal-rules/require-coverage-ignore-reason.js
+++ b/resources/eslint-internal-rules/require-coverage-ignore-reason.js
@@ -1,0 +1,24 @@
+'use strict';
+
+module.exports = function requireCoverageIgnoreReason(context) {
+  const istanbulRegExp = /^\s*istanbul\s+ignore\s+(if|else|next|file)\s+/;
+  return {
+    Program() {
+      const sourceCode = context.getSourceCode();
+
+      for (const node of sourceCode.getAllComments()) {
+        const comment = node.value;
+
+        if (comment.match(istanbulRegExp)) {
+          const reason = comment.replace(istanbulRegExp, '');
+          if (!reason.match(/\(.+\)$/)) {
+            context.report({
+              message: 'Add a reason why code coverage should be ignored',
+              node,
+            });
+          }
+        }
+      }
+    },
+  };
+};


### PR DESCRIPTION
It blocks us from using ESLint8, see:
https://github.com/istanbuljs/eslint-plugin-istanbul/pull/17