### PR TITLE
type/definition: export `resolve*Thunk` functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ export { graphql, graphqlSync } from './graphql';
 
 /** Create and operate on GraphQL type definitions and schema. */
 export {
+  resolveObjMapThunk,
+  resolveReadonlyArrayThunk,
   /** Definitions */
   GraphQLSchema,
   GraphQLDirective,

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -532,13 +532,13 @@ export function getNamedType(
 export type ThunkReadonlyArray<T> = (() => ReadonlyArray<T>) | ReadonlyArray<T>;
 export type ThunkObjMap<T> = (() => ObjMap<T>) | ObjMap<T>;
 
-function resolveReadonlyArrayThunk<T>(
+export function resolveReadonlyArrayThunk<T>(
   thunk: ThunkReadonlyArray<T>,
 ): ReadonlyArray<T> {
   return typeof thunk === 'function' ? thunk() : thunk;
 }
 
-function resolveObjMapThunk<T>(thunk: ThunkObjMap<T>): ObjMap<T> {
+export function resolveObjMapThunk<T>(thunk: ThunkObjMap<T>): ObjMap<T> {
   return typeof thunk === 'function' ? thunk() : thunk;
 }
 

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -11,6 +11,8 @@ export {
 export type { GraphQLSchemaConfig, GraphQLSchemaExtensions } from './schema';
 
 export {
+  resolveObjMapThunk,
+  resolveReadonlyArrayThunk,
   /** Predicates */
   isType,
   isScalarType,


### PR DESCRIPTION
Required to migrate `graphql-relay` to `graphql@16`