### PR TITLE
Make GraphQLFormattedError.extensions have type GraphQLErrorExtensions

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -231,7 +231,7 @@ export interface GraphQLFormattedError {
    * Reserved for implementors to extend the protocol however they see fit,
    * and hence there are no additional restrictions on its contents.
    */
-  readonly extensions?: { [key: string]: unknown };
+  readonly extensions?: GraphQLErrorExtensions;
 }
 
 /**


### PR DESCRIPTION
The `GraphQLFormattedError.extensions` field comes from the `GraphQLError.extensions`, which is of type `GraphQLErrorExtensions`. Having the mismatch means that trying to access the extensions produces weird type errors, even if 3rd party libraries correctly extend `GraphQLErrorExtensions`.