### PR TITLE
 Prevent Infinite Loop in OverlappingFieldsCanBeMergedRule

### DIFF
--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1023,7 +1023,7 @@ describe('Validate: Overlapping fields can be merged', () => {
 
   it('does not infinite loop on immediately recursive fragment mentioned in queries', () => {
     expectValid(`
-      query myQuery {
+      {
         ...fragA
       }
 
@@ -1031,8 +1031,54 @@ describe('Validate: Overlapping fields can be merged', () => {
     `);
   });
 
+  it('does not infinite loop on recursive fragment with a field named after fragment', () => {
+    expectValid(`
+      {
+        ...fragA
+        fragA
+      }
+
+      fragment fragA on Query { ...fragA }
+    `);
+  });
+
+  it('finds invalid cases even with field named after fragment', () => {
+    expectErrors(`
+      {
+        fragA
+        ...fragA
+      }
+
+      fragment fragA on Type { 
+        fragA: b
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Fields "fragA" conflict because "fragA" and "b" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 8, column: 9 },
+        ],
+      },
+    ]);
+  });
+
   it('does not infinite loop on transitively recursive fragment', () => {
     expectValid(`
+      fragment fragA on Human { name, ...fragB }
+      fragment fragB on Human { name, ...fragC }
+      fragment fragC on Human { name, ...fragA }
+    `);
+  });
+
+  it('does not infinite loop on transitively recursive fragment mentioned in queries', () => {
+    expectValid(`
+      {
+        ...fragA
+        fragB
+      }
+
       fragment fragA on Human { name, ...fragB }
       fragment fragB on Human { name, ...fragC }
       fragment fragC on Human { name, ...fragA }

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1021,7 +1021,7 @@ describe('Validate: Overlapping fields can be merged', () => {
     `);
   });
 
-  it('does not infinite loop on immediately recursive fragment mentionned in queries', () => {
+  it('does not infinite loop on immediately recursive fragment mentioned in queries', () => {
     expectValid(`
       query myQuery {
         ...fragA

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1011,23 +1011,21 @@ describe('Validate: Overlapping fields can be merged', () => {
 
   it('does not infinite loop on recursive fragment', () => {
     expectValid(`
+      {
+        ...fragA
+      }
+
       fragment fragA on Human { name, relatives { name, ...fragA } }
     `);
   });
 
   it('does not infinite loop on immediately recursive fragment', () => {
     expectValid(`
-      fragment fragA on Human { name, ...fragA }
-    `);
-  });
-
-  it('does not infinite loop on immediately recursive fragment mentioned in queries', () => {
-    expectValid(`
       {
         ...fragA
       }
 
-      fragment fragA on Query { ...fragA }
+      fragment fragA on Human { name, ...fragA }
     `);
   });
 
@@ -1049,7 +1047,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         ...fragA
       }
 
-      fragment fragA on Type { 
+      fragment fragA on Type {
         fragA: b
       }
     `).toDeepEqual([
@@ -1065,14 +1063,6 @@ describe('Validate: Overlapping fields can be merged', () => {
   });
 
   it('does not infinite loop on transitively recursive fragment', () => {
-    expectValid(`
-      fragment fragA on Human { name, ...fragB }
-      fragment fragB on Human { name, ...fragC }
-      fragment fragC on Human { name, ...fragA }
-    `);
-  });
-
-  it('does not infinite loop on transitively recursive fragment mentioned in queries', () => {
     expectValid(`
       {
         ...fragA

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1021,6 +1021,17 @@ describe('Validate: Overlapping fields can be merged', () => {
     `);
   });
 
+  it('does not infinite loop on immediately recursive fragment mentionned in queries', () => {
+    expectValid(`
+      query myQuery {
+        todoRemove
+        ...fragA
+      }
+
+      fragment fragA on Query { ...fragA }
+    `);
+  });
+
   it('does not infinite loop on transitively recursive fragment', () => {
     expectValid(`
       fragment fragA on Human { name, ...fragB }

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1024,7 +1024,6 @@ describe('Validate: Overlapping fields can be merged', () => {
   it('does not infinite loop on immediately recursive fragment mentionned in queries', () => {
     expectValid(`
       query myQuery {
-        todoRemove
         ...fragA
       }
 

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -267,6 +267,10 @@ function collectConflictsBetweenFieldsAndFragment(
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
   for (const referencedFragmentName of referencedFragmentNames) {
+    if (referencedFragmentName === fragmentName) {
+      continue;
+    }
+
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -267,6 +267,7 @@ function collectConflictsBetweenFieldsAndFragment(
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
   for (const referencedFragmentName of referencedFragmentNames) {
+    // Don't compare this fragment with itself
     if (referencedFragmentName === fragmentName) {
       continue;
     }

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -267,10 +267,21 @@ function collectConflictsBetweenFieldsAndFragment(
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
   for (const referencedFragmentName of referencedFragmentNames) {
-    // Don't compare this fragment with itself
-    if (referencedFragmentName === fragmentName) {
+    // Memoize so two fragments are not compared for conflicts more than once.
+    if (
+      comparedFragmentPairs.has(
+        referencedFragmentName,
+        fragmentName,
+        areMutuallyExclusive,
+      )
+    ) {
       continue;
     }
+    comparedFragmentPairs.add(
+      referencedFragmentName,
+      fragmentName,
+      areMutuallyExclusive,
+    );
 
     collectConflictsBetweenFieldsAndFragment(
       context,


### PR DESCRIPTION
We have spotted some `RangeError: Maximum call stack size exceeded` exceptions while testing our own setup, and traced it to this validation rule.

Note: I don't feel 100% confident that I understand the logic flow and intent of this code in detail. Perhaps the bugfix I'm providing is isolated, or perhaps it's a whole class of use case that has been omitted in tests in which cases this might break some valid use cases but not be detected?