### PR TITLE
Add enableDeferStream to GraphQLSchema::toConfig()

### DIFF
--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -379,6 +379,7 @@ export class GraphQLSchema {
       extensions: this.extensions,
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
+      enableDeferStream: this._enableDeferStream,
       assumeValid: this.__validationErrors !== undefined,
     };
   }


### PR DESCRIPTION
schema.toConfig() doesn't carry through the `enableDeferStream` setting currently; this fixes that omission.

Note: this is a PR to the defer-stream branch.