### PR TITLE
fix(validate): no reusing root types

### DIFF
--- a/src/jsutils/didYouMean.ts
+++ b/src/jsutils/didYouMean.ts
@@ -1,3 +1,5 @@
+import { orList } from './formatList';
+
 const MAX_SUGGESTIONS = 5;
 
 /**
@@ -12,26 +14,21 @@ export function didYouMean(
   firstArg: string | ReadonlyArray<string>,
   secondArg?: ReadonlyArray<string>,
 ) {
-  const [subMessage, suggestionsArg] = secondArg
+  const [subMessage, suggestions] = secondArg
     ? [firstArg as string, secondArg]
     : [undefined, firstArg as ReadonlyArray<string>];
+
+  if (suggestions.length === 0) {
+    return '';
+  }
 
   let message = ' Did you mean ';
   if (subMessage) {
     message += subMessage + ' ';
   }
 
-  const suggestions = suggestionsArg.map((x) => `"${x}"`);
-  switch (suggestions.length) {
-    case 0:
-      return '';
-    case 1:
-      return message + suggestions[0] + '?';
-    case 2:
-      return message + suggestions[0] + ' or ' + suggestions[1] + '?';
-  }
-
-  const selected = suggestions.slice(0, MAX_SUGGESTIONS);
-  const lastItem = selected.pop();
-  return message + selected.join(', ') + ', or ' + lastItem + '?';
+  const suggestionList = orList(
+    suggestions.slice(0, MAX_SUGGESTIONS).map((x) => `"${x}"`),
+  );
+  return message + suggestionList + '?';
 }

--- a/src/jsutils/formatList.ts
+++ b/src/jsutils/formatList.ts
@@ -1,0 +1,30 @@
+import { invariant } from './invariant';
+
+/**
+ * Given [ A, B, C ] return 'A, B, or C'.
+ */
+export function orList(items: ReadonlyArray<string>): string {
+  return formatList('or', items);
+}
+
+/**
+ * Given [ A, B, C ] return 'A, B, and C'.
+ */
+export function andList(items: ReadonlyArray<string>): string {
+  return formatList('and', items);
+}
+
+function formatList(conjunction: string, items: ReadonlyArray<string>): string {
+  invariant(items.length !== 0);
+
+  switch (items.length) {
+    case 1:
+      return items[0];
+    case 2:
+      return items[0] + ' ' + conjunction + ' ' + items[1];
+  }
+
+  const allButLast = items.slice(0, -1);
+  const lastItem = items[items.length - 1];
+  return allButLast.join(', ') + ', ' + conjunction + ' ' + lastItem;
+}

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -435,7 +435,19 @@ describe('Type System: A Schema must have Object root types', () => {
 
 describe('Type System: Root types must all be different if provided', () => {
   it('rejects a Schema where the same type is used for the "query" and "mutation" root types', () => {
-    const schema = buildSchema(`
+    const schema = new GraphQLSchema({
+      query: SomeObjectType,
+      mutation: SomeObjectType,
+    });
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'All root types must be different, SomeObject is already used for "query" and cannot also be used for "mutation".',
+        locations: [{ line: 6, column: 3 }],
+      },
+    ]);
+
+    const schemaFromSDL = buildSchema(`
       type SomeObject {
         f: SomeObject
       }
@@ -445,7 +457,7 @@ describe('Type System: Root types must all be different if provided', () => {
         mutation: SomeObject
       }
     `);
-    expectJSON(validateSchema(schema)).toDeepEqual([
+    expectJSON(validateSchema(schemaFromSDL)).toDeepEqual([
       {
         message:
           'All root types must be different, SomeObject is already used for "query" and cannot also be used for "mutation".',
@@ -455,7 +467,19 @@ describe('Type System: Root types must all be different if provided', () => {
   });
 
   it('rejects a Schema where the same type is used for the "query" and "subscription" root types', () => {
-    const schema = buildSchema(`
+    const schema = new GraphQLSchema({
+      query: SomeObjectType,
+      subscription: SomeObjectType,
+    });
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'All root types must be different, SomeObject is already used for "query" and cannot also be used for "subscription".',
+        locations: [{ line: 6, column: 3 }],
+      },
+    ]);
+
+    const schemaFromSDL = buildSchema(`
       type SomeObject {
         f: SomeObject
       }
@@ -465,7 +489,7 @@ describe('Type System: Root types must all be different if provided', () => {
         subscription: SomeObject
       }
     `);
-    expectJSON(validateSchema(schema)).toDeepEqual([
+    expectJSON(validateSchema(schemaFromSDL)).toDeepEqual([
       {
         message:
           'All root types must be different, SomeObject is already used for "query" and cannot also be used for "subscription".',
@@ -475,7 +499,23 @@ describe('Type System: Root types must all be different if provided', () => {
   });
 
   it('rejects a Schema where the same type is used for the "mutation" and "subscription" root types', () => {
-    const schema = buildSchema(`
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: { hello: { type: GraphQLString } },
+      }),
+      mutation: SomeObjectType,
+      subscription: SomeObjectType,
+    });
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'All root types must be different, SomeObject is already used for "mutation" and cannot also be used for "subscription".',
+        locations: [{ line: 6, column: 3 }],
+      },
+    ]);
+
+    const schemaFromSDL = buildSchema(`
       type SomeObject {
         f: SomeObject
       }
@@ -490,7 +530,7 @@ describe('Type System: Root types must all be different if provided', () => {
         subscription: SomeObject
       }
     `);
-    expectJSON(validateSchema(schema)).toDeepEqual([
+    expectJSON(validateSchema(schemaFromSDL)).toDeepEqual([
       {
         message:
           'All root types must be different, SomeObject is already used for "mutation" and cannot also be used for "subscription".',

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -433,6 +433,73 @@ describe('Type System: A Schema must have Object root types', () => {
   });
 });
 
+describe('Type System: Root types must all be different if provided', () => {
+  it('rejects a Schema where the same type is used for the "query" and "mutation" root types', () => {
+    const schema = buildSchema(`
+      type SomeObject {
+        f: SomeObject
+      }
+
+      schema {
+        query: SomeObject
+        mutation: SomeObject
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'All root types must be different, SomeObject is already used for "query" and cannot also be used for "mutation".',
+        locations: [{ line: 8, column: 19 }],
+      },
+    ]);
+  });
+
+  it('rejects a Schema where the same type is used for the "query" and "subscription" root types', () => {
+    const schema = buildSchema(`
+      type SomeObject {
+        f: SomeObject
+      }
+
+      schema {
+        query: SomeObject
+        subscription: SomeObject
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'All root types must be different, SomeObject is already used for "query" and cannot also be used for "subscription".',
+        locations: [{ line: 8, column: 23 }],
+      },
+    ]);
+  });
+
+  it('rejects a Schema where the same type is used for the "mutation" and "subscription" root types', () => {
+    const schema = buildSchema(`
+      type SomeObject {
+        f: SomeObject
+      }
+
+      type Query {
+        f: SomeObject
+      }
+
+      schema {
+        query: Query
+        mutation: SomeObject
+        subscription: SomeObject
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'All root types must be different, SomeObject is already used for "mutation" and cannot also be used for "subscription".',
+        locations: [{ line: 13, column: 23 }],
+      },
+    ]);
+  });
+});
+
 describe('Type System: Objects must have fields', () => {
   it('accepts an Object type with fields object', () => {
     const schema = buildSchema(`

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -134,7 +134,7 @@ function validateRootTypes(context: SchemaValidationContext): void {
     }
   }
 
-  if (queryType && mutationType && queryType.name === mutationType.name) {
+  if (queryType && mutationType && queryType === mutationType) {
     context.reportError(
       'All root types must be different, ' +
         queryType.name +
@@ -144,11 +144,7 @@ function validateRootTypes(context: SchemaValidationContext): void {
     );
   }
 
-  if (
-    queryType &&
-    subscriptionType &&
-    queryType.name === subscriptionType.name
-  ) {
+  if (queryType && subscriptionType && queryType === subscriptionType) {
     context.reportError(
       'All root types must be different, ' +
         queryType.name +
@@ -158,11 +154,7 @@ function validateRootTypes(context: SchemaValidationContext): void {
     );
   }
 
-  if (
-    mutationType &&
-    subscriptionType &&
-    mutationType.name === subscriptionType.name
-  ) {
+  if (mutationType && subscriptionType && mutationType === subscriptionType) {
     context.reportError(
       'All root types must be different, ' +
         mutationType.name +

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -133,6 +133,44 @@ function validateRootTypes(context: SchemaValidationContext): void {
       );
     }
   }
+
+  if (queryType && mutationType && queryType.name === mutationType.name) {
+    context.reportError(
+      'All root types must be different, ' +
+        queryType.name +
+        ' is already used for "query" and cannot also be used for "mutation".',
+      getOperationTypeNode(schema, OperationTypeNode.MUTATION) ??
+        mutationType.astNode,
+    );
+  }
+
+  if (
+    queryType &&
+    subscriptionType &&
+    queryType.name === subscriptionType.name
+  ) {
+    context.reportError(
+      'All root types must be different, ' +
+        queryType.name +
+        ' is already used for "query" and cannot also be used for "subscription".',
+      getOperationTypeNode(schema, OperationTypeNode.SUBSCRIPTION) ??
+        subscriptionType.astNode,
+    );
+  }
+
+  if (
+    mutationType &&
+    subscriptionType &&
+    mutationType.name === subscriptionType.name
+  ) {
+    context.reportError(
+      'All root types must be different, ' +
+        mutationType.name +
+        ' is already used for "mutation" and cannot also be used for "subscription".',
+      getOperationTypeNode(schema, OperationTypeNode.SUBSCRIPTION) ??
+        subscriptionType.astNode,
+    );
+  }
 }
 
 function getOperationTypeNode(


### PR DESCRIPTION
Hello `graphql-js` folks 👋 While playing with schema and SDL validation, I noticed that the reference implementation does not follow the following rule from the [latest spec](https://spec.graphql.org/draft/#sec-Root-Operation-Types):

> The query, mutation, and subscription root types must all be different types if provided.

Not sure if that's an error in the spec or in the reference implementation 🤔 I went ahead and proposed a fix in here, but happy to open a PR on the spec instead if that's the preferred. This is after all a breaking change, even though I doubt that it would have a big impact. (At least I've never seen a schema that does this.)