### PR TITLE
feat: allow providing an object to the GraphQLError constructor

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -20,7 +20,7 @@ export interface GraphQLErrorExtensions {
   [attributeName: string]: unknown;
 }
 
-interface GraphQLErrorArgs {
+export interface GraphQLErrorArgs {
   nodes?: ReadonlyArray<ASTNode> | ASTNode | null;
   source?: Maybe<Source>;
   positions?: Maybe<ReadonlyArray<number>>;
@@ -111,14 +111,17 @@ export class GraphQLError extends Error {
    */
   readonly extensions: GraphQLErrorExtensions;
 
+  /**
+   * @deprecated Please use the `GraphQLErrorArgs` constructor overload instead.
+   */
   constructor(
     message: string,
-    nodes?: GraphQLErrorArgs['nodes'],
-    source?: GraphQLErrorArgs['source'],
-    positions?: GraphQLErrorArgs['positions'],
-    path?: GraphQLErrorArgs['path'],
-    originalError?: GraphQLErrorArgs['originalError'],
-    extensions?: GraphQLErrorArgs['extensions'],
+    nodes?: ReadonlyArray<ASTNode> | ASTNode | null,
+    source?: Maybe<Source>,
+    positions?: Maybe<ReadonlyArray<number>>,
+    path?: Maybe<ReadonlyArray<string | number>>,
+    originalError?: Maybe<Error & { readonly extensions?: unknown }>,
+    extensions?: Maybe<GraphQLErrorExtensions>,
   );
   constructor(message: string, args?: GraphQLErrorArgs);
   constructor(message: string, ...rawArgs: BackwardsCompatibleArgs) {

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -365,17 +365,10 @@ describe('toJSON', () => {
     });
 
     expect(error.toJSON()).to.deep.equal({
-      extensions: {
-        hee: 'I like turtles',
-      },
-      locations: [
-        {
-          column: 5,
-          line: 2,
-        },
-      ],
       message: 'msg',
+      locations: [{ column: 5, line: 2 }],
       path: ['path', 2, 'a'],
+      extensions: { hee: 'I like turtles' },
     });
   });
 });

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -361,13 +361,13 @@ describe('toJSON', () => {
       source,
       positions: [6],
       path: ['path', 2, 'a'],
-      originalError: new Error('Hee-HOOOO'),
-      extensions: { hee: 'hoooo' },
+      originalError: new Error('I like turtles'),
+      extensions: { hee: 'I like turtles' },
     });
 
     expect(error.toJSON()).to.deep.equal({
       extensions: {
-        hee: 'hoooo',
+        hee: 'I like turtles',
       },
       locations: [
         {

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -355,8 +355,7 @@ describe('toJSON', () => {
   });
 
   it('can be created with the alternative object argument', () => {
-    const error = new GraphQLError({
-      message: 'msg',
+    const error = new GraphQLError('msg', {
       nodes: [operationNode],
       source,
       positions: [6],

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -353,4 +353,30 @@ describe('toJSON', () => {
       extensions: { foo: 'bar' },
     });
   });
+
+  it('can be created with the alternative object argument', () => {
+    const error = new GraphQLError({
+      message: 'msg',
+      nodes: [operationNode],
+      source,
+      positions: [6],
+      path: ['path', 2, 'a'],
+      originalError: new Error('Hee-HOOOO'),
+      extensions: { hee: 'hoooo' },
+    });
+
+    expect(error.toJSON()).to.deep.equal({
+      extensions: {
+        hee: 'hoooo',
+      },
+      locations: [
+        {
+          column: 5,
+          line: 2,
+        },
+      ],
+      message: 'msg',
+      path: ['path', 2, 'a'],
+    });
+  });
 });


### PR DESCRIPTION
When using the `GraphQL` error within my schema code I usually only use the `message` and `extensions` parameters. However, this requires passing 4 undefined values to the constructor.

```ts
throw new GraphQLError("Oops.", undefined, undefined, undefined, undefined, { code: "SERVER_GOES_BRRT" })
```

This API allows writing this code, which feels less verbose to me.

```ts
throw new GraphQLError({
  message: "Oops.",
  extensions: { code: "SERVER_GOES_BRRT" },
})
```

Given that the `execute` and `subscribe` function signatures also evolved into a single object, this change feels natural to me. Please let me know what you think.

An alternative API might be the following, where the message is ALWAYS the first argument.

```ts
throw new GraphQLError("Oops.", {
  extensions: { code: "SERVER_GOES_BRRT" },
})
```