### PR TITLE
fix: improve handling of promises in defaultTypeResolver

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1823,6 +1823,12 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
         if (isPromise(isTypeOfResult)) {
           promisedIsTypeOfResults[i] = isTypeOfResult;
         } else if (isTypeOfResult) {
+          if (promisedIsTypeOfResults.length > 0) {
+            Promise.all(promisedIsTypeOfResults).then(undefined, () => {
+              /* ignore errors */
+            });
+          }
+
           return type.name;
         }
       }


### PR DESCRIPTION
Currently it is possible to have unhandled promise rejections that arise from a mix of sync and async isTypeOf checks.


This should fix that issue.