### PR TITLE
fix: only access Node.js globals if available

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -743,3 +743,11 @@ overrides:
       # Ignore docusarus related webpack aliases
       import/no-unresolved:
         ['error', { 'ignore': ['^@theme', '^@docusaurus', '^@generated'] }]
+  - files:
+      - website/docusaurus.config.js
+      - website/sidebars.js
+      - integrationTests/**/*
+      - benchmark/**/*
+      - resources/**/*
+    env:
+      node: true

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -9,8 +9,7 @@ import { inspect } from './inspect';
 export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  // eslint-disable-next-line no-undef
-  process.env.NODE_ENV === 'production'
+  globalThis.process?.env.NODE_ENV === 'production'
     ? function instanceOf(value: unknown, constructor: Constructor): boolean {
         return value instanceof constructor;
       }


### PR DESCRIPTION
The `process` object is only available in Node.js and Node.js-like environments (e.g. webpack).

By introducing this simple change, the code can run in a browser environment without requiring polyfilling Node.js APIs such as the following:

```html
<script>
  window.process = globalThis.process = {
    env: {
      NODE_ENV: "development"
    }
  };
</script>
```

`globalThis` is part of the ECMA 2020 specification and is supported on any relevant platform.

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
- https://tc39.es/ecma262/multipage/global-object.html#sec-globalthis
- https://node.green/#ES2020-features-globalThis

The eslint config specifies ecma version 2020 but it seems like the `globalThis` is not automatically provided. I added the `es2020` env. (https://github.com/eslint/eslint/issues/15199#issuecomment-948724014)

_______

Closes https://github.com/graphql/graphql-js/pull/2409

