### PR TITLE
Declare fieldNodes always has at least 1 FieldNode

### DIFF
--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -36,7 +36,7 @@ export function collectFields(
   variableValues: { [variable: string]: unknown },
   runtimeType: GraphQLObjectType,
   selectionSet: SelectionSetNode,
-): Map<string, ReadonlyArray<FieldNode>> {
+): Map<string, readonly [FieldNode, ...Array<FieldNode>]> {
   const fields = new Map();
   collectFieldsImpl(
     schema,
@@ -65,8 +65,8 @@ export function collectSubfields(
   fragments: ObjMap<FragmentDefinitionNode>,
   variableValues: { [variable: string]: unknown },
   returnType: GraphQLObjectType,
-  fieldNodes: ReadonlyArray<FieldNode>,
-): Map<string, ReadonlyArray<FieldNode>> {
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
+): Map<string, readonly [FieldNode, ...Array<FieldNode>]> {
   const subFieldNodes = new Map();
   const visitedFragmentNames = new Set<string>();
   for (const node of fieldNodes) {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -67,7 +67,7 @@ const collectSubfields = memoize3(
   (
     exeContext: ExecutionContext,
     returnType: GraphQLObjectType,
-    fieldNodes: ReadonlyArray<FieldNode>,
+    fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   ) =>
     _collectSubfields(
       exeContext.schema,
@@ -402,7 +402,7 @@ function executeFieldsSerially(
   parentType: GraphQLObjectType,
   sourceValue: unknown,
   path: Path | undefined,
-  fields: Map<string, ReadonlyArray<FieldNode>>,
+  fields: Map<string, readonly [FieldNode, ...Array<FieldNode>]>,
 ): PromiseOrValue<ObjMap<unknown>> {
   return promiseReduce(
     fields.entries(),
@@ -440,7 +440,7 @@ function executeFields(
   parentType: GraphQLObjectType,
   sourceValue: unknown,
   path: Path | undefined,
-  fields: Map<string, ReadonlyArray<FieldNode>>,
+  fields: Map<string, readonly [FieldNode, ...Array<FieldNode>]>,
 ): PromiseOrValue<ObjMap<unknown>> {
   const results = Object.create(null);
   let containsPromise = false;
@@ -484,7 +484,7 @@ function executeField(
   exeContext: ExecutionContext,
   parentType: GraphQLObjectType,
   source: unknown,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   path: Path,
 ): PromiseOrValue<unknown> {
   const fieldDef = getFieldDef(exeContext.schema, parentType, fieldNodes[0]);
@@ -558,7 +558,7 @@ function executeField(
 export function buildResolveInfo(
   exeContext: ExecutionContext,
   fieldDef: GraphQLField<unknown, unknown>,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   parentType: GraphQLObjectType,
   path: Path,
 ): GraphQLResolveInfo {
@@ -619,7 +619,7 @@ function handleFieldError(
 function completeValue(
   exeContext: ExecutionContext,
   returnType: GraphQLOutputType,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   info: GraphQLResolveInfo,
   path: Path,
   result: unknown,
@@ -710,7 +710,7 @@ function completeValue(
 function completeListValue(
   exeContext: ExecutionContext,
   returnType: GraphQLList<GraphQLOutputType>,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   info: GraphQLResolveInfo,
   path: Path,
   result: unknown,
@@ -801,7 +801,7 @@ function completeLeafValue(
 function completeAbstractValue(
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   info: GraphQLResolveInfo,
   path: Path,
   result: unknown,
@@ -851,7 +851,7 @@ function ensureValidRuntimeType(
   runtimeTypeName: unknown,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   info: GraphQLResolveInfo,
   result: unknown,
 ): GraphQLObjectType {
@@ -908,7 +908,7 @@ function ensureValidRuntimeType(
 function completeObjectValue(
   exeContext: ExecutionContext,
   returnType: GraphQLObjectType,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
   info: GraphQLResolveInfo,
   path: Path,
   result: unknown,
@@ -948,7 +948,7 @@ function completeObjectValue(
 function invalidReturnTypeError(
   returnType: GraphQLObjectType,
   result: unknown,
-  fieldNodes: ReadonlyArray<FieldNode>,
+  fieldNodes: readonly [FieldNode, ...Array<FieldNode>],
 ): GraphQLError {
   return new GraphQLError(
     `Expected value of type "${returnType.name}" but got: ${inspect(result)}.`,

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -973,7 +973,7 @@ export type GraphQLFieldResolver<
 
 export interface GraphQLResolveInfo {
   readonly fieldName: string;
-  readonly fieldNodes: ReadonlyArray<FieldNode>;
+  readonly fieldNodes: readonly [FieldNode, ...FieldNode[]];
   readonly returnType: GraphQLOutputType;
   readonly parentType: GraphQLObjectType;
   readonly path: Path;

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -973,7 +973,7 @@ export type GraphQLFieldResolver<
 
 export interface GraphQLResolveInfo {
   readonly fieldName: string;
-  readonly fieldNodes: readonly [FieldNode, ...FieldNode[]];
+  readonly fieldNodes: readonly [FieldNode, ...Array<FieldNode>];
   readonly returnType: GraphQLOutputType;
   readonly parentType: GraphQLObjectType;
   readonly path: Path;


### PR DESCRIPTION
fieldNodes will never be an empty array.

```ts
// Before
const node = info.fieldNodes[0] // undefined | FieldNode

// After
const node = info.fieldNodes[0] // FieldNode
```

This is helpful when noUncheckedIndexAccess is turned on.