### PR TITLE
Update documentation on deprecated formatError(..)

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -290,7 +290,7 @@ export function printError(error: GraphQLError): string {
  * Given a GraphQLError, format it according to the rules described by the
  * Response Format, Errors section of the GraphQL Specification.
  *
- * @deprecated Please use `error.toString` instead. Will be removed in v17
+ * @deprecated Please use `error.toJSON` instead. Will be removed in v17
  */
 export function formatError(error: GraphQLError): GraphQLFormattedError {
   return error.toJSON();


### PR DESCRIPTION
Not positive, but given that the deprecated method calls `error.toJSON()` I'm assuming the docs should reflect this?