### PR TITLE
GraphQLError: switch constructor overload order

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -111,6 +111,7 @@ export class GraphQLError extends Error {
    */
   readonly extensions: GraphQLErrorExtensions;
 
+  constructor(message: string, args?: GraphQLErrorArgs);
   /**
    * @deprecated Please use the `GraphQLErrorArgs` constructor overload instead.
    */
@@ -123,7 +124,6 @@ export class GraphQLError extends Error {
     originalError?: Maybe<Error & { readonly extensions?: unknown }>,
     extensions?: Maybe<GraphQLErrorExtensions>,
   );
-  constructor(message: string, args?: GraphQLErrorArgs);
   constructor(message: string, ...rawArgs: BackwardsCompatibleArgs) {
     const { nodes, source, positions, path, originalError, extensions } =
       toNormalizedArgs(rawArgs);


### PR DESCRIPTION
The GraphQLError constructor has two overloads. The GraphQLErrorArgs one
is recommended and the one with a bunch of position arguments is
deprecated.

When typechecking, TypeScript chooses the *first* matching overload (see
eg
https://github.com/microsoft/TypeScript/issues/1860#issuecomment-72154737).
Passing just a message argument matches both overloads, so this
currently displays as deprecated.

This PR reverses the order so that passing just a message does not
display as deprecated.