### PR TITLE
pass valid value to codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,10 @@
 codecov:
   notify:
-    require_ci_to_pass: yes
+    require_ci_to_pass: true
 
 parsers:
   javascript:
-    enable_partials: yes
+    enable_partials: true
 
 comment: false
 coverage:

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ parsers:
   javascript:
     enable_partials: yes
 
-comment: no
+comment: false
 coverage:
   status:
     project:


### PR DESCRIPTION
This PR updates the Codecov config to pass the valid option.

https://docs.codecov.com/docs/pull-request-comments#disable-comment

> To disable the comment, simply set the top-level comment key to false in your codecov.yml, as shown below.
