### PR TITLE
Set TS 4.4 as minimal supported version

### DIFF
--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -6,9 +6,6 @@
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz",
-    "typescript-4.1": "npm:typescript@4.1.x",
-    "typescript-4.2": "npm:typescript@4.2.x",
-    "typescript-4.3": "npm:typescript@4.3.x",
     "typescript-4.4": "npm:typescript@4.4.x",
     "typescript-4.5": "npm:typescript@4.5.x",
     "typescript-4.6": "npm:typescript@4.6.x"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index",
   "module": "index.mjs",
   "typesVersions": {
-    ">=4.1.0": {
+    ">=4.4.0": {
       "*": [
         "*"
       ]


### PR DESCRIPTION
Motivation: https://github.com/graphql/graphql-js/pull/3511#issuecomment-1110015285