### PR TITLE
Add `GraphQLValidationError` as a subclass of `GraphQLError`

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -237,3 +237,21 @@ export interface GraphQLFormattedError {
    */
   readonly extensions?: { [key: string]: unknown };
 }
+
+export interface GraphQLValidationErrorOptions {
+  nodes: ReadonlyArray<ASTNode> | ASTNode;
+  originalError?: Error | undefined;
+  extensions?: GraphQLErrorExtensions | undefined;
+}
+
+export class GraphQLValidationError extends GraphQLError {
+  constructor(message: string, options: GraphQLValidationErrorOptions) {
+    super(message, options);
+
+    this.name = 'GraphQLValidationError';
+  }
+
+  get [Symbol.toStringTag](): string {
+    return 'GraphQLValidationError';
+  }
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -1,6 +1,7 @@
-export { GraphQLError } from './GraphQLError';
+export { GraphQLError, GraphQLValidationError } from './GraphQLError';
 export type {
   GraphQLErrorOptions,
+  GraphQLValidationErrorOptions,
   GraphQLFormattedError,
   GraphQLErrorExtensions,
 } from './GraphQLError';

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,10 +377,16 @@ export {
 export type { ValidationRule } from './validation/index';
 
 // Create, format, and print GraphQL errors.
-export { GraphQLError, syntaxError, locatedError } from './error/index';
+export {
+  GraphQLError,
+  GraphQLValidationError,
+  syntaxError,
+  locatedError,
+} from './error/index';
 
 export type {
   GraphQLErrorOptions,
+  GraphQLValidationErrorOptions,
   GraphQLFormattedError,
   GraphQLErrorExtensions,
 } from './error/index';

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -1,9 +1,14 @@
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
 
-import type { GraphQLError } from '../error/GraphQLError';
+import type {
+  GraphQLError,
+  GraphQLErrorExtensions,
+} from '../error/GraphQLError';
+import { GraphQLValidationError } from '../error/GraphQLError';
 
 import type {
+  ASTNode,
   DocumentNode,
   FragmentDefinitionNode,
   FragmentSpreadNode,
@@ -35,6 +40,13 @@ interface VariableUsage {
   readonly defaultValue: Maybe<unknown>;
 }
 
+interface ValidationReportOptions {
+  message: string;
+  nodes: ReadonlyArray<ASTNode> | ASTNode;
+  originalError?: Error | undefined;
+  extensions?: GraphQLErrorExtensions | undefined;
+}
+
 /**
  * An instance of this class is passed as the "this" context to all validators,
  * allowing access to commonly useful contextual information from within a
@@ -62,7 +74,19 @@ export class ASTValidationContext {
     return 'ASTValidationContext';
   }
 
+  // TODO: when remove change `onError` to use GraphQLValidationError type instead
+  /* c8 ignore next 4 */
+  /** @deprecated Use `report` instead, will be removed in v18 */
   reportError(error: GraphQLError): void {
+    this._onError(error);
+  }
+
+  report(options: ValidationReportOptions): void {
+    const error = new GraphQLValidationError(options.message, {
+      nodes: options.nodes,
+      originalError: options.originalError,
+      extensions: options.extensions,
+    });
     this._onError(error);
   }
 

--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -3,8 +3,6 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { DirectiveNode } from '../../language/ast';
 import { parse } from '../../language/parser';
 
@@ -76,11 +74,10 @@ describe('Validate: Supports full validation', () => {
       return {
         Directive(node: DirectiveNode) {
           const directiveDef = context.getDirective();
-          const error = new GraphQLError(
-            'Reporting directive: ' + String(directiveDef),
-            { nodes: node },
-          );
-          context.reportError(error);
+          context.report({
+            message: 'Reporting directive: ' + String(directiveDef),
+            nodes: node,
+          });
         },
       };
     }

--- a/src/validation/rules/ExecutableDefinitionsRule.ts
+++ b/src/validation/rules/ExecutableDefinitionsRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import { Kind } from '../../language/kinds';
 import { isExecutableDefinitionNode } from '../../language/predicates';
 import type { ASTVisitor } from '../../language/visitor';
@@ -26,11 +24,10 @@ export function ExecutableDefinitionsRule(
             definition.kind === Kind.SCHEMA_EXTENSION
               ? 'schema'
               : '"' + definition.name.value + '"';
-          context.reportError(
-            new GraphQLError(`The ${defName} definition is not executable.`, {
-              nodes: definition,
-            }),
-          );
+          context.report({
+            message: `The ${defName} definition is not executable.`,
+            nodes: definition,
+          });
         }
       }
       return false;

--- a/src/validation/rules/FieldsOnCorrectTypeRule.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.ts
@@ -2,8 +2,6 @@ import { didYouMean } from '../../jsutils/didYouMean';
 import { naturalCompare } from '../../jsutils/naturalCompare';
 import { suggestionList } from '../../jsutils/suggestionList';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { FieldNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -54,13 +52,12 @@ export function FieldsOnCorrectTypeRule(
           }
 
           // Report an error, including helpful suggestions.
-          context.reportError(
-            new GraphQLError(
+          context.report({
+            message:
               `Cannot query field "${fieldName}" on type "${type.name}".` +
-                suggestion,
-              { nodes: node },
-            ),
-          );
+              suggestion,
+            nodes: node,
+          });
         }
       }
     },

--- a/src/validation/rules/FragmentsOnCompositeTypesRule.ts
+++ b/src/validation/rules/FragmentsOnCompositeTypesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import { print } from '../../language/printer';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -28,12 +26,10 @@ export function FragmentsOnCompositeTypesRule(
         const type = typeFromAST(context.getSchema(), typeCondition);
         if (type && !isCompositeType(type)) {
           const typeStr = print(typeCondition);
-          context.reportError(
-            new GraphQLError(
-              `Fragment cannot condition on non composite type "${typeStr}".`,
-              { nodes: typeCondition },
-            ),
-          );
+          context.report({
+            message: `Fragment cannot condition on non composite type "${typeStr}".`,
+            nodes: typeCondition,
+          });
         }
       }
     },
@@ -41,12 +37,10 @@ export function FragmentsOnCompositeTypesRule(
       const type = typeFromAST(context.getSchema(), node.typeCondition);
       if (type && !isCompositeType(type)) {
         const typeStr = print(node.typeCondition);
-        context.reportError(
-          new GraphQLError(
-            `Fragment "${node.name.value}" cannot condition on non composite type "${typeStr}".`,
-            { nodes: node.typeCondition },
-          ),
-        );
+        context.report({
+          message: `Fragment "${node.name.value}" cannot condition on non composite type "${typeStr}".`,
+          nodes: node.typeCondition,
+        });
       }
     },
   };

--- a/src/validation/rules/KnownArgumentNamesRule.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.ts
@@ -1,8 +1,6 @@
 import { didYouMean } from '../../jsutils/didYouMean';
 import { suggestionList } from '../../jsutils/suggestionList';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import { Kind } from '../../language/kinds';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -35,13 +33,12 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
         const argName = argNode.name.value;
         const knownArgsNames = fieldDef.args.map((arg) => arg.name);
         const suggestions = suggestionList(argName, knownArgsNames);
-        context.reportError(
-          new GraphQLError(
+        context.report({
+          message:
             `Unknown argument "${argName}" on field "${parentType.name}.${fieldDef.name}".` +
-              didYouMean(suggestions),
-            { nodes: argNode },
-          ),
-        );
+            didYouMean(suggestions),
+          nodes: argNode,
+        });
       }
     },
   };
@@ -84,13 +81,12 @@ export function KnownArgumentNamesOnDirectivesRule(
           const argName = argNode.name.value;
           if (!knownArgs.includes(argName)) {
             const suggestions = suggestionList(argName, knownArgs);
-            context.reportError(
-              new GraphQLError(
+            context.report({
+              message:
                 `Unknown argument "${argName}" on directive "@${directiveName}".` +
-                  didYouMean(suggestions),
-                { nodes: argNode },
-              ),
-            );
+                didYouMean(suggestions),
+              nodes: argNode,
+            });
           }
         }
       }

--- a/src/validation/rules/KnownDirectivesRule.ts
+++ b/src/validation/rules/KnownDirectivesRule.ts
@@ -1,8 +1,6 @@
 import { inspect } from '../../jsutils/inspect';
 import { invariant } from '../../jsutils/invariant';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTNode } from '../../language/ast';
 import { OperationTypeNode } from '../../language/ast';
 import { DirectiveLocation } from '../../language/directiveLocation';
@@ -50,20 +48,19 @@ export function KnownDirectivesRule(
       const locations = locationsMap[name];
 
       if (!locations) {
-        context.reportError(
-          new GraphQLError(`Unknown directive "@${name}".`, { nodes: node }),
-        );
+        context.report({
+          message: `Unknown directive "@${name}".`,
+          nodes: node,
+        });
         return;
       }
 
       const candidateLocation = getDirectiveLocationForASTPath(ancestors);
       if (candidateLocation && !locations.includes(candidateLocation)) {
-        context.reportError(
-          new GraphQLError(
-            `Directive "@${name}" may not be used on ${candidateLocation}.`,
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `Directive "@${name}" may not be used on ${candidateLocation}.`,
+          nodes: node,
+        });
       }
     },
   };

--- a/src/validation/rules/KnownFragmentNamesRule.ts
+++ b/src/validation/rules/KnownFragmentNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { ValidationContext } from '../ValidationContext';
@@ -18,11 +16,10 @@ export function KnownFragmentNamesRule(context: ValidationContext): ASTVisitor {
       const fragmentName = node.name.value;
       const fragment = context.getFragment(fragmentName);
       if (!fragment) {
-        context.reportError(
-          new GraphQLError(`Unknown fragment "${fragmentName}".`, {
-            nodes: node.name,
-          }),
-        );
+        context.report({
+          message: `Unknown fragment "${fragmentName}".`,
+          nodes: node.name,
+        });
       }
     },
   };

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -1,8 +1,6 @@
 import { didYouMean } from '../../jsutils/didYouMean';
 import { suggestionList } from '../../jsutils/suggestionList';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTNode } from '../../language/ast';
 import {
   isTypeDefinitionNode,
@@ -59,12 +57,10 @@ export function KnownTypeNamesRule(
           typeName,
           isSDL ? standardTypeNames.concat(typeNames) : typeNames,
         );
-        context.reportError(
-          new GraphQLError(
-            `Unknown type "${typeName}".` + didYouMean(suggestedTypes),
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `Unknown type "${typeName}".` + didYouMean(suggestedTypes),
+          nodes: node,
+        });
       }
     },
   };

--- a/src/validation/rules/LoneAnonymousOperationRule.ts
+++ b/src/validation/rules/LoneAnonymousOperationRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import { Kind } from '../../language/kinds';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -25,12 +23,11 @@ export function LoneAnonymousOperationRule(
     },
     OperationDefinition(node) {
       if (!node.name && operationCount > 1) {
-        context.reportError(
-          new GraphQLError(
+        context.report({
+          message:
             'This anonymous operation must be the only defined operation.',
-            { nodes: node },
-          ),
-        );
+          nodes: node,
+        });
       }
     },
   };

--- a/src/validation/rules/LoneSchemaDefinitionRule.ts
+++ b/src/validation/rules/LoneSchemaDefinitionRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { SDLValidationContext } from '../ValidationContext';
@@ -23,21 +21,18 @@ export function LoneSchemaDefinitionRule(
   return {
     SchemaDefinition(node) {
       if (alreadyDefined) {
-        context.reportError(
-          new GraphQLError(
-            'Cannot define a new schema within a schema extension.',
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: 'Cannot define a new schema within a schema extension.',
+          nodes: node,
+        });
         return;
       }
 
       if (schemaDefinitionsCount > 0) {
-        context.reportError(
-          new GraphQLError('Must provide only one schema definition.', {
-            nodes: node,
-          }),
-        );
+        context.report({
+          message: 'Must provide only one schema definition.',
+          nodes: node,
+        });
       }
       ++schemaDefinitionsCount;
     },

--- a/src/validation/rules/NoFragmentCyclesRule.ts
+++ b/src/validation/rules/NoFragmentCyclesRule.ts
@@ -1,7 +1,5 @@
 import type { ObjMap } from '../../jsutils/ObjMap';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   FragmentDefinitionNode,
   FragmentSpreadNode,
@@ -74,13 +72,12 @@ export function NoFragmentCyclesRule(
           .map((s) => '"' + s.name.value + '"')
           .join(', ');
 
-        context.reportError(
-          new GraphQLError(
+        context.report({
+          message:
             `Cannot spread fragment "${spreadName}" within itself` +
-              (viaPath !== '' ? ` via ${viaPath}.` : '.'),
-            { nodes: cyclePath },
-          ),
-        );
+            (viaPath !== '' ? ` via ${viaPath}.` : '.'),
+          nodes: cyclePath,
+        });
       }
       spreadPath.pop();
     }

--- a/src/validation/rules/NoUndefinedVariablesRule.ts
+++ b/src/validation/rules/NoUndefinedVariablesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { ValidationContext } from '../ValidationContext';
@@ -28,14 +26,12 @@ export function NoUndefinedVariablesRule(
         for (const { node } of usages) {
           const varName = node.name.value;
           if (variableNameDefined[varName] !== true) {
-            context.reportError(
-              new GraphQLError(
-                operation.name
-                  ? `Variable "$${varName}" is not defined by operation "${operation.name.value}".`
-                  : `Variable "$${varName}" is not defined.`,
-                { nodes: [node, operation] },
-              ),
-            );
+            context.report({
+              message: operation.name
+                ? `Variable "$${varName}" is not defined by operation "${operation.name.value}".`
+                : `Variable "$${varName}" is not defined.`,
+              nodes: [node, operation],
+            });
           }
         }
       },

--- a/src/validation/rules/NoUnusedFragmentsRule.ts
+++ b/src/validation/rules/NoUnusedFragmentsRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   FragmentDefinitionNode,
   OperationDefinitionNode,
@@ -45,11 +43,10 @@ export function NoUnusedFragmentsRule(
         for (const fragmentDef of fragmentDefs) {
           const fragName = fragmentDef.name.value;
           if (fragmentNameUsed[fragName] !== true) {
-            context.reportError(
-              new GraphQLError(`Fragment "${fragName}" is never used.`, {
-                nodes: fragmentDef,
-              }),
-            );
+            context.report({
+              message: `Fragment "${fragName}" is never used.`,
+              nodes: fragmentDef,
+            });
           }
         }
       },

--- a/src/validation/rules/NoUnusedVariablesRule.ts
+++ b/src/validation/rules/NoUnusedVariablesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { VariableDefinitionNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -32,14 +30,12 @@ export function NoUnusedVariablesRule(context: ValidationContext): ASTVisitor {
         for (const variableDef of variableDefs) {
           const variableName = variableDef.variable.name.value;
           if (variableNameUsed[variableName] !== true) {
-            context.reportError(
-              new GraphQLError(
-                operation.name
-                  ? `Variable "$${variableName}" is never used in operation "${operation.name.value}".`
-                  : `Variable "$${variableName}" is never used.`,
-                { nodes: variableDef },
-              ),
-            );
+            context.report({
+              message: operation.name
+                ? `Variable "$${variableName}" is never used in operation "${operation.name.value}".`
+                : `Variable "$${variableName}" is never used.`,
+              nodes: variableDef,
+            });
           }
         }
       },

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -2,8 +2,6 @@ import { inspect } from '../../jsutils/inspect';
 import type { Maybe } from '../../jsutils/Maybe';
 import type { ObjMap } from '../../jsutils/ObjMap';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   FieldNode,
   FragmentDefinitionNode,
@@ -79,12 +77,10 @@ export function OverlappingFieldsCanBeMergedRule(
       );
       for (const [[responseName, reason], fields1, fields2] of conflicts) {
         const reasonMsg = reasonMessage(reason);
-        context.reportError(
-          new GraphQLError(
-            `Fields "${responseName}" conflict because ${reasonMsg}. Use different aliases on the fields to fetch both if this was intentional.`,
-            { nodes: fields1.concat(fields2) },
-          ),
-        );
+        context.report({
+          message: `Fields "${responseName}" conflict because ${reasonMsg}. Use different aliases on the fields to fetch both if this was intentional.`,
+          nodes: fields1.concat(fields2),
+        });
       }
     },
   };

--- a/src/validation/rules/PossibleFragmentSpreadsRule.ts
+++ b/src/validation/rules/PossibleFragmentSpreadsRule.ts
@@ -1,8 +1,6 @@
 import { inspect } from '../../jsutils/inspect';
 import type { Maybe } from '../../jsutils/Maybe';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { GraphQLCompositeType } from '../../type/definition';
@@ -34,12 +32,10 @@ export function PossibleFragmentSpreadsRule(
       ) {
         const parentTypeStr = inspect(parentType);
         const fragTypeStr = inspect(fragType);
-        context.reportError(
-          new GraphQLError(
-            `Fragment cannot be spread here as objects of type "${parentTypeStr}" can never be of type "${fragTypeStr}".`,
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `Fragment cannot be spread here as objects of type "${parentTypeStr}" can never be of type "${fragTypeStr}".`,
+          nodes: node,
+        });
       }
     },
     FragmentSpread(node) {
@@ -53,12 +49,10 @@ export function PossibleFragmentSpreadsRule(
       ) {
         const parentTypeStr = inspect(parentType);
         const fragTypeStr = inspect(fragType);
-        context.reportError(
-          new GraphQLError(
-            `Fragment "${fragName}" cannot be spread here as objects of type "${parentTypeStr}" can never be of type "${fragTypeStr}".`,
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `Fragment "${fragName}" cannot be spread here as objects of type "${parentTypeStr}" can never be of type "${fragTypeStr}".`,
+          nodes: node,
+        });
       }
     },
   };

--- a/src/validation/rules/PossibleTypeExtensionsRule.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.ts
@@ -4,8 +4,6 @@ import { invariant } from '../../jsutils/invariant';
 import type { ObjMap } from '../../jsutils/ObjMap';
 import { suggestionList } from '../../jsutils/suggestionList';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { DefinitionNode, TypeExtensionNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { isTypeDefinitionNode } from '../../language/predicates';
@@ -64,11 +62,10 @@ export function PossibleTypeExtensionsRule(
     if (expectedKind) {
       if (expectedKind !== node.kind) {
         const kindStr = extensionKindToTypeName(node.kind);
-        context.reportError(
-          new GraphQLError(`Cannot extend non-${kindStr} type "${typeName}".`, {
-            nodes: defNode ? [defNode, node] : node,
-          }),
-        );
+        context.report({
+          message: `Cannot extend non-${kindStr} type "${typeName}".`,
+          nodes: defNode ? [defNode, node] : node,
+        });
       }
     } else {
       const allTypeNames = Object.keys({
@@ -77,13 +74,12 @@ export function PossibleTypeExtensionsRule(
       });
 
       const suggestedTypes = suggestionList(typeName, allTypeNames);
-      context.reportError(
-        new GraphQLError(
+      context.report({
+        message:
           `Cannot extend type "${typeName}" because it is not defined.` +
-            didYouMean(suggestedTypes),
-          { nodes: node.name },
-        ),
-      );
+          didYouMean(suggestedTypes),
+        nodes: node.name,
+      });
     }
   }
 }

--- a/src/validation/rules/ProvidedRequiredArgumentsRule.ts
+++ b/src/validation/rules/ProvidedRequiredArgumentsRule.ts
@@ -2,8 +2,6 @@ import { inspect } from '../../jsutils/inspect';
 import { keyMap } from '../../jsutils/keyMap';
 import type { ObjMap } from '../../jsutils/ObjMap';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { InputValueDefinitionNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
@@ -46,12 +44,10 @@ export function ProvidedRequiredArgumentsRule(
         for (const argDef of fieldDef.args) {
           if (!providedArgs.has(argDef.name) && isRequiredArgument(argDef)) {
             const argTypeStr = inspect(argDef.type);
-            context.reportError(
-              new GraphQLError(
-                `Field "${fieldDef.name}" argument "${argDef.name}" of type "${argTypeStr}" is required, but it was not provided.`,
-                { nodes: fieldNode },
-              ),
-            );
+            context.report({
+              message: `Field "${fieldDef.name}" argument "${argDef.name}" of type "${argTypeStr}" is required, but it was not provided.`,
+              nodes: fieldNode,
+            });
           }
         }
       },
@@ -108,12 +104,10 @@ export function ProvidedRequiredArgumentsOnDirectivesRule(
               const argType = isType(argDef.type)
                 ? inspect(argDef.type)
                 : print(argDef.type);
-              context.reportError(
-                new GraphQLError(
-                  `Directive "@${directiveName}" argument "${argName}" of type "${argType}" is required, but it was not provided.`,
-                  { nodes: directiveNode },
-                ),
-              );
+              context.report({
+                message: `Directive "@${directiveName}" argument "${argName}" of type "${argType}" is required, but it was not provided.`,
+                nodes: directiveNode,
+              });
             }
           }
         }

--- a/src/validation/rules/ScalarLeafsRule.ts
+++ b/src/validation/rules/ScalarLeafsRule.ts
@@ -1,7 +1,5 @@
 import { inspect } from '../../jsutils/inspect';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { FieldNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -25,22 +23,18 @@ export function ScalarLeafsRule(context: ValidationContext): ASTVisitor {
           if (selectionSet) {
             const fieldName = node.name.value;
             const typeStr = inspect(type);
-            context.reportError(
-              new GraphQLError(
-                `Field "${fieldName}" must not have a selection since type "${typeStr}" has no subfields.`,
-                { nodes: selectionSet },
-              ),
-            );
+            context.report({
+              message: `Field "${fieldName}" must not have a selection since type "${typeStr}" has no subfields.`,
+              nodes: selectionSet,
+            });
           }
         } else if (!selectionSet) {
           const fieldName = node.name.value;
           const typeStr = inspect(type);
-          context.reportError(
-            new GraphQLError(
-              `Field "${fieldName}" of type "${typeStr}" must have a selection of subfields. Did you mean "${fieldName} { ... }"?`,
-              { nodes: node },
-            ),
-          );
+          context.report({
+            message: `Field "${fieldName}" of type "${typeStr}" must have a selection of subfields. Did you mean "${fieldName} { ... }"?`,
+            nodes: node,
+          });
         }
       }
     },

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -1,7 +1,5 @@
 import type { ObjMap } from '../../jsutils/ObjMap';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   FragmentDefinitionNode,
   OperationDefinitionNode,
@@ -52,27 +50,25 @@ export function SingleFieldSubscriptionsRule(
             const fieldSelectionLists = [...fields.values()];
             const extraFieldSelectionLists = fieldSelectionLists.slice(1);
             const extraFieldSelections = extraFieldSelectionLists.flat();
-            context.reportError(
-              new GraphQLError(
+            context.report({
+              message:
                 operationName != null
                   ? `Subscription "${operationName}" must select only one top level field.`
                   : 'Anonymous Subscription must select only one top level field.',
-                { nodes: extraFieldSelections },
-              ),
-            );
+              nodes: extraFieldSelections,
+            });
           }
           for (const fieldNodes of fields.values()) {
             const field = fieldNodes[0];
             const fieldName = field.name.value;
             if (fieldName.startsWith('__')) {
-              context.reportError(
-                new GraphQLError(
+              context.report({
+                message:
                   operationName != null
                     ? `Subscription "${operationName}" must not select an introspection top level field.`
                     : 'Anonymous Subscription must not select an introspection top level field.',
-                  { nodes: fieldNodes },
-                ),
-              );
+                nodes: fieldNodes,
+              });
             }
           }
         }

--- a/src/validation/rules/UniqueArgumentDefinitionNamesRule.ts
+++ b/src/validation/rules/UniqueArgumentDefinitionNamesRule.ts
@@ -1,7 +1,5 @@
 import { groupBy } from '../../jsutils/groupBy';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   FieldDefinitionNode,
   InputValueDefinitionNode,
@@ -65,12 +63,10 @@ export function UniqueArgumentDefinitionNamesRule(
 
     for (const [argName, argNodes] of seenArgs) {
       if (argNodes.length > 1) {
-        context.reportError(
-          new GraphQLError(
-            `Argument "${parentName}(${argName}:)" can only be defined once.`,
-            { nodes: argNodes.map((node) => node.name) },
-          ),
-        );
+        context.report({
+          message: `Argument "${parentName}(${argName}:)" can only be defined once.`,
+          nodes: argNodes.map((node) => node.name),
+        });
       }
     }
 

--- a/src/validation/rules/UniqueArgumentNamesRule.ts
+++ b/src/validation/rules/UniqueArgumentNamesRule.ts
@@ -1,7 +1,5 @@
 import { groupBy } from '../../jsutils/groupBy';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ArgumentNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -34,12 +32,10 @@ export function UniqueArgumentNamesRule(
 
     for (const [argName, argNodes] of seenArgs) {
       if (argNodes.length > 1) {
-        context.reportError(
-          new GraphQLError(
-            `There can be only one argument named "${argName}".`,
-            { nodes: argNodes.map((node) => node.name) },
-          ),
-        );
+        context.report({
+          message: `There can be only one argument named "${argName}".`,
+          nodes: argNodes.map((node) => node.name),
+        });
       }
     }
   }

--- a/src/validation/rules/UniqueDirectiveNamesRule.ts
+++ b/src/validation/rules/UniqueDirectiveNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { SDLValidationContext } from '../ValidationContext';
@@ -20,22 +18,18 @@ export function UniqueDirectiveNamesRule(
       const directiveName = node.name.value;
 
       if (schema?.getDirective(directiveName)) {
-        context.reportError(
-          new GraphQLError(
-            `Directive "@${directiveName}" already exists in the schema. It cannot be redefined.`,
-            { nodes: node.name },
-          ),
-        );
+        context.report({
+          message: `Directive "@${directiveName}" already exists in the schema. It cannot be redefined.`,
+          nodes: node.name,
+        });
         return;
       }
 
       if (knownDirectiveNames[directiveName]) {
-        context.reportError(
-          new GraphQLError(
-            `There can be only one directive named "@${directiveName}".`,
-            { nodes: [knownDirectiveNames[directiveName], node.name] },
-          ),
-        );
+        context.report({
+          message: `There can be only one directive named "@${directiveName}".`,
+          nodes: [knownDirectiveNames[directiveName], node.name],
+        });
       } else {
         knownDirectiveNames[directiveName] = node.name;
       }

--- a/src/validation/rules/UniqueDirectivesPerLocationRule.ts
+++ b/src/validation/rules/UniqueDirectivesPerLocationRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import { Kind } from '../../language/kinds';
 import {
   isTypeDefinitionNode,
@@ -75,12 +73,10 @@ export function UniqueDirectivesPerLocationRule(
 
         if (uniqueDirectiveMap[directiveName]) {
           if (seenDirectives[directiveName]) {
-            context.reportError(
-              new GraphQLError(
-                `The directive "@${directiveName}" can only be used once at this location.`,
-                { nodes: [seenDirectives[directiveName], directive] },
-              ),
-            );
+            context.report({
+              message: `The directive "@${directiveName}" can only be used once at this location.`,
+              nodes: [seenDirectives[directiveName], directive],
+            });
           } else {
             seenDirectives[directiveName] = directive;
           }

--- a/src/validation/rules/UniqueEnumValueNamesRule.ts
+++ b/src/validation/rules/UniqueEnumValueNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   EnumTypeDefinitionNode,
   EnumTypeExtensionNode,
@@ -46,19 +44,15 @@ export function UniqueEnumValueNamesRule(
 
       const existingType = existingTypeMap[typeName];
       if (isEnumType(existingType) && existingType.getValue(valueName)) {
-        context.reportError(
-          new GraphQLError(
-            `Enum value "${typeName}.${valueName}" already exists in the schema. It cannot also be defined in this type extension.`,
-            { nodes: valueDef.name },
-          ),
-        );
+        context.report({
+          message: `Enum value "${typeName}.${valueName}" already exists in the schema. It cannot also be defined in this type extension.`,
+          nodes: valueDef.name,
+        });
       } else if (valueNames[valueName]) {
-        context.reportError(
-          new GraphQLError(
-            `Enum value "${typeName}.${valueName}" can only be defined once.`,
-            { nodes: [valueNames[valueName], valueDef.name] },
-          ),
-        );
+        context.report({
+          message: `Enum value "${typeName}.${valueName}" can only be defined once.`,
+          nodes: [valueNames[valueName], valueDef.name],
+        });
       } else {
         valueNames[valueName] = valueDef.name;
       }

--- a/src/validation/rules/UniqueFieldDefinitionNamesRule.ts
+++ b/src/validation/rules/UniqueFieldDefinitionNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   FieldDefinitionNode,
   InputValueDefinitionNode,
@@ -58,19 +56,15 @@ export function UniqueFieldDefinitionNamesRule(
       const fieldName = fieldDef.name.value;
 
       if (hasField(existingTypeMap[typeName], fieldName)) {
-        context.reportError(
-          new GraphQLError(
-            `Field "${typeName}.${fieldName}" already exists in the schema. It cannot also be defined in this type extension.`,
-            { nodes: fieldDef.name },
-          ),
-        );
+        context.report({
+          message: `Field "${typeName}.${fieldName}" already exists in the schema. It cannot also be defined in this type extension.`,
+          nodes: fieldDef.name,
+        });
       } else if (fieldNames[fieldName]) {
-        context.reportError(
-          new GraphQLError(
-            `Field "${typeName}.${fieldName}" can only be defined once.`,
-            { nodes: [fieldNames[fieldName], fieldDef.name] },
-          ),
-        );
+        context.report({
+          message: `Field "${typeName}.${fieldName}" can only be defined once.`,
+          nodes: [fieldNames[fieldName], fieldDef.name],
+        });
       } else {
         fieldNames[fieldName] = fieldDef.name;
       }

--- a/src/validation/rules/UniqueFragmentNamesRule.ts
+++ b/src/validation/rules/UniqueFragmentNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { ASTValidationContext } from '../ValidationContext';
@@ -20,12 +18,10 @@ export function UniqueFragmentNamesRule(
     FragmentDefinition(node) {
       const fragmentName = node.name.value;
       if (knownFragmentNames[fragmentName]) {
-        context.reportError(
-          new GraphQLError(
-            `There can be only one fragment named "${fragmentName}".`,
-            { nodes: [knownFragmentNames[fragmentName], node.name] },
-          ),
-        );
+        context.report({
+          message: `There can be only one fragment named "${fragmentName}".`,
+          nodes: [knownFragmentNames[fragmentName], node.name],
+        });
       } else {
         knownFragmentNames[fragmentName] = node.name;
       }

--- a/src/validation/rules/UniqueInputFieldNamesRule.ts
+++ b/src/validation/rules/UniqueInputFieldNamesRule.ts
@@ -1,8 +1,6 @@
 import { invariant } from '../../jsutils/invariant';
 import type { ObjMap } from '../../jsutils/ObjMap';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { NameNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -37,12 +35,10 @@ export function UniqueInputFieldNamesRule(
     ObjectField(node) {
       const fieldName = node.name.value;
       if (knownNames[fieldName]) {
-        context.reportError(
-          new GraphQLError(
-            `There can be only one input field named "${fieldName}".`,
-            { nodes: [knownNames[fieldName], node.name] },
-          ),
-        );
+        context.report({
+          message: `There can be only one input field named "${fieldName}".`,
+          nodes: [knownNames[fieldName], node.name],
+        });
       } else {
         knownNames[fieldName] = node.name;
       }

--- a/src/validation/rules/UniqueOperationNamesRule.ts
+++ b/src/validation/rules/UniqueOperationNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { ASTValidationContext } from '../ValidationContext';
@@ -20,17 +18,10 @@ export function UniqueOperationNamesRule(
       const operationName = node.name;
       if (operationName) {
         if (knownOperationNames[operationName.value]) {
-          context.reportError(
-            new GraphQLError(
-              `There can be only one operation named "${operationName.value}".`,
-              {
-                nodes: [
-                  knownOperationNames[operationName.value],
-                  operationName,
-                ],
-              },
-            ),
-          );
+          context.report({
+            message: `There can be only one operation named "${operationName.value}".`,
+            nodes: [knownOperationNames[operationName.value], operationName],
+          });
         } else {
           knownOperationNames[operationName.value] = operationName;
         }

--- a/src/validation/rules/UniqueOperationTypesRule.ts
+++ b/src/validation/rules/UniqueOperationTypesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type {
   SchemaDefinitionNode,
   SchemaExtensionNode,
@@ -43,19 +41,15 @@ export function UniqueOperationTypesRule(
       const alreadyDefinedOperationType = definedOperationTypes[operation];
 
       if (existingOperationTypes[operation]) {
-        context.reportError(
-          new GraphQLError(
-            `Type for ${operation} already defined in the schema. It cannot be redefined.`,
-            { nodes: operationType },
-          ),
-        );
+        context.report({
+          message: `Type for ${operation} already defined in the schema. It cannot be redefined.`,
+          nodes: operationType,
+        });
       } else if (alreadyDefinedOperationType) {
-        context.reportError(
-          new GraphQLError(
-            `There can be only one ${operation} type in schema.`,
-            { nodes: [alreadyDefinedOperationType, operationType] },
-          ),
-        );
+        context.report({
+          message: `There can be only one ${operation} type in schema.`,
+          nodes: [alreadyDefinedOperationType, operationType],
+        });
       } else {
         definedOperationTypes[operation] = operationType;
       }

--- a/src/validation/rules/UniqueTypeNamesRule.ts
+++ b/src/validation/rules/UniqueTypeNamesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { TypeDefinitionNode } from '../../language/ast';
 import type { ASTVisitor } from '../../language/visitor';
 
@@ -27,21 +25,18 @@ export function UniqueTypeNamesRule(context: SDLValidationContext): ASTVisitor {
     const typeName = node.name.value;
 
     if (schema?.getType(typeName)) {
-      context.reportError(
-        new GraphQLError(
-          `Type "${typeName}" already exists in the schema. It cannot also be defined in this type definition.`,
-          { nodes: node.name },
-        ),
-      );
+      context.report({
+        message: `Type "${typeName}" already exists in the schema. It cannot also be defined in this type definition.`,
+        nodes: node.name,
+      });
       return;
     }
 
     if (knownTypeNames[typeName]) {
-      context.reportError(
-        new GraphQLError(`There can be only one type named "${typeName}".`, {
-          nodes: [knownTypeNames[typeName], node.name],
-        }),
-      );
+      context.report({
+        message: `There can be only one type named "${typeName}".`,
+        nodes: [knownTypeNames[typeName], node.name],
+      });
     } else {
       knownTypeNames[typeName] = node.name;
     }

--- a/src/validation/rules/UniqueVariableNamesRule.ts
+++ b/src/validation/rules/UniqueVariableNamesRule.ts
@@ -1,7 +1,5 @@
 import { groupBy } from '../../jsutils/groupBy';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../language/visitor';
 
 import type { ASTValidationContext } from '../ValidationContext';
@@ -27,12 +25,10 @@ export function UniqueVariableNamesRule(
 
       for (const [variableName, variableNodes] of seenVariableDefinitions) {
         if (variableNodes.length > 1) {
-          context.reportError(
-            new GraphQLError(
-              `There can be only one variable named "$${variableName}".`,
-              { nodes: variableNodes.map((node) => node.variable.name) },
-            ),
-          );
+          context.report({
+            message: `There can be only one variable named "$${variableName}".`,
+            nodes: variableNodes.map((node) => node.variable.name),
+          });
         }
       }
     },

--- a/src/validation/rules/VariablesAreInputTypesRule.ts
+++ b/src/validation/rules/VariablesAreInputTypesRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { VariableDefinitionNode } from '../../language/ast';
 import { print } from '../../language/printer';
 import type { ASTVisitor } from '../../language/visitor';
@@ -29,12 +27,10 @@ export function VariablesAreInputTypesRule(
         const variableName = node.variable.name.value;
         const typeName = print(node.type);
 
-        context.reportError(
-          new GraphQLError(
-            `Variable "$${variableName}" cannot be non-input type "${typeName}".`,
-            { nodes: node.type },
-          ),
-        );
+        context.report({
+          message: `Variable "$${variableName}" cannot be non-input type "${typeName}".`,
+          nodes: node.type,
+        });
       }
     },
   };

--- a/src/validation/rules/VariablesInAllowedPositionRule.ts
+++ b/src/validation/rules/VariablesInAllowedPositionRule.ts
@@ -1,8 +1,6 @@
 import { inspect } from '../../jsutils/inspect';
 import type { Maybe } from '../../jsutils/Maybe';
 
-import { GraphQLError } from '../../error/GraphQLError';
-
 import type { ValueNode } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import type { ASTVisitor } from '../../language/visitor';
@@ -59,12 +57,10 @@ export function VariablesInAllowedPositionRule(
             ) {
               const varTypeStr = inspect(varType);
               const typeStr = inspect(type);
-              context.reportError(
-                new GraphQLError(
-                  `Variable "$${varName}" of type "${varTypeStr}" used in position expecting type "${typeStr}".`,
-                  { nodes: [varDef, node] },
-                ),
-              );
+              context.report({
+                message: `Variable "$${varName}" of type "${varTypeStr}" used in position expecting type "${typeStr}".`,
+                nodes: [varDef, node],
+              });
             }
           }
         }

--- a/src/validation/rules/custom/NoDeprecatedCustomRule.ts
+++ b/src/validation/rules/custom/NoDeprecatedCustomRule.ts
@@ -1,7 +1,5 @@
 import { invariant } from '../../../jsutils/invariant';
 
-import { GraphQLError } from '../../../error/GraphQLError';
-
 import type { ASTVisitor } from '../../../language/visitor';
 
 import { getNamedType, isInputObjectType } from '../../../type/definition';
@@ -26,12 +24,10 @@ export function NoDeprecatedCustomRule(context: ValidationContext): ASTVisitor {
       if (fieldDef && deprecationReason != null) {
         const parentType = context.getParentType();
         invariant(parentType != null);
-        context.reportError(
-          new GraphQLError(
-            `The field ${parentType.name}.${fieldDef.name} is deprecated. ${deprecationReason}`,
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `The field ${parentType.name}.${fieldDef.name} is deprecated. ${deprecationReason}`,
+          nodes: node,
+        });
       }
     },
     Argument(node) {
@@ -40,22 +36,18 @@ export function NoDeprecatedCustomRule(context: ValidationContext): ASTVisitor {
       if (argDef && deprecationReason != null) {
         const directiveDef = context.getDirective();
         if (directiveDef != null) {
-          context.reportError(
-            new GraphQLError(
-              `Directive "@${directiveDef.name}" argument "${argDef.name}" is deprecated. ${deprecationReason}`,
-              { nodes: node },
-            ),
-          );
+          context.report({
+            message: `Directive "@${directiveDef.name}" argument "${argDef.name}" is deprecated. ${deprecationReason}`,
+            nodes: node,
+          });
         } else {
           const parentType = context.getParentType();
           const fieldDef = context.getFieldDef();
           invariant(parentType != null && fieldDef != null);
-          context.reportError(
-            new GraphQLError(
-              `Field "${parentType.name}.${fieldDef.name}" argument "${argDef.name}" is deprecated. ${deprecationReason}`,
-              { nodes: node },
-            ),
-          );
+          context.report({
+            message: `Field "${parentType.name}.${fieldDef.name}" argument "${argDef.name}" is deprecated. ${deprecationReason}`,
+            nodes: node,
+          });
         }
       }
     },
@@ -65,12 +57,10 @@ export function NoDeprecatedCustomRule(context: ValidationContext): ASTVisitor {
         const inputFieldDef = inputObjectDef.getFields()[node.name.value];
         const deprecationReason = inputFieldDef?.deprecationReason;
         if (deprecationReason != null) {
-          context.reportError(
-            new GraphQLError(
-              `The input field ${inputObjectDef.name}.${inputFieldDef.name} is deprecated. ${deprecationReason}`,
-              { nodes: node },
-            ),
-          );
+          context.report({
+            message: `The input field ${inputObjectDef.name}.${inputFieldDef.name} is deprecated. ${deprecationReason}`,
+            nodes: node,
+          });
         }
       }
     },
@@ -80,12 +70,10 @@ export function NoDeprecatedCustomRule(context: ValidationContext): ASTVisitor {
       if (enumValueDef && deprecationReason != null) {
         const enumTypeDef = getNamedType(context.getInputType());
         invariant(enumTypeDef != null);
-        context.reportError(
-          new GraphQLError(
-            `The enum value "${enumTypeDef.name}.${enumValueDef.name}" is deprecated. ${deprecationReason}`,
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `The enum value "${enumTypeDef.name}.${enumValueDef.name}" is deprecated. ${deprecationReason}`,
+          nodes: node,
+        });
       }
     },
   };

--- a/src/validation/rules/custom/NoSchemaIntrospectionCustomRule.ts
+++ b/src/validation/rules/custom/NoSchemaIntrospectionCustomRule.ts
@@ -1,5 +1,3 @@
-import { GraphQLError } from '../../../error/GraphQLError';
-
 import type { FieldNode } from '../../../language/ast';
 import type { ASTVisitor } from '../../../language/visitor';
 
@@ -25,12 +23,10 @@ export function NoSchemaIntrospectionCustomRule(
     Field(node: FieldNode) {
       const type = getNamedType(context.getType());
       if (type && isIntrospectionType(type)) {
-        context.reportError(
-          new GraphQLError(
-            `GraphQL introspection has been disabled, but the requested query contained the field "${node.name.value}".`,
-            { nodes: node },
-          ),
-        );
+        context.report({
+          message: `GraphQL introspection has been disabled, but the requested query contained the field "${node.name.value}".`,
+          nodes: node,
+        });
       }
     },
   };


### PR DESCRIPTION
Also deprecated `ValidationContext.reportError` in favor of new `report`
function with named argument.

Motivation: subclassing allows you to distinguish between errors produced by `graphql-js`.
Idea is to subclass all errors into different types e.g. GraphQLValidationError, GraphQLSyntaxError, etc.
That way clients can be sure what type of error it is.

```js
const { data, errors, extensions } = graphql({ /* ... */ });

const response = {
  data,
  errors.map((error) => {
    if (error instanceof GraphQLValidationError) {
      // do a special handling of validation errors
    } else if (error instanceof GraphQLSyntaxError) {
      // do a special handling of syntax errors
    }
  }),
  extensions,
};
```

Without this change, you can't distinguish one type of error from other types of errors.
Subclassing errors for that purpose is a standard approach in JS (e.g. `TypeError` is a subclass of `Error`) and other OOP languages.