### PR TITLE
Revert "Remove deprecated `TypeInfo` argument of `validate` function"

### DIFF
--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -9,6 +9,7 @@ import type { DirectiveNode } from '../../language/ast';
 import { parse } from '../../language/parser';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
+import { TypeInfo } from '../../utilities/TypeInfo';
 
 import { validate } from '../validate';
 import type { ValidationContext } from '../ValidationContext';
@@ -54,6 +55,35 @@ describe('Validate: Supports full validation', () => {
         locations: [{ line: 3, column: 9 }],
         message: 'Cannot query field "unknown" on type "QueryRoot".',
       },
+    ]);
+  });
+
+  it('Deprecated: validates using a custom TypeInfo', () => {
+    // This TypeInfo will never return a valid field.
+    const typeInfo = new TypeInfo(testSchema, null, () => null);
+
+    const doc = parse(`
+      query {
+        human {
+          pets {
+            ... on Cat {
+              meowsVolume
+            }
+            ... on Dog {
+              barkVolume
+            }
+          }
+        }
+      }
+    `);
+
+    const errors = validate(testSchema, doc, undefined, undefined, typeInfo);
+    const errorMessages = errors.map((error) => error.message);
+
+    expect(errorMessages).to.deep.equal([
+      'Cannot query field "human" on type "QueryRoot". Did you mean "human"?',
+      'Cannot query field "meowsVolume" on type "Cat". Did you mean "meowsVolume"?',
+      'Cannot query field "barkVolume" on type "Dog". Did you mean "barkVolume"?',
     ]);
   });
 

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -40,6 +40,9 @@ export function validate(
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
   options?: { maxErrors?: number },
+
+  /** @deprecated will be removed in 17.0.0 */
+  typeInfo: TypeInfo = new TypeInfo(schema),
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
 
@@ -49,7 +52,6 @@ export function validate(
 
   const abortObj = Object.freeze({});
   const errors: Array<GraphQLError> = [];
-  const typeInfo = new TypeInfo(schema);
   const context = new ValidationContext(
     schema,
     documentAST,


### PR DESCRIPTION
This reverts commit b4ad1282ce38449a953d9375307c9e45f8151a70 from #3574
For the context see #3519