### PR TITLE
Refactor `GraphQL*Type` TS types to be more DRY

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -51,22 +51,9 @@ import type { GraphQLSchema } from './schema';
  * These are all of the possible kinds of types.
  */
 export type GraphQLType =
-  | GraphQLScalarType
-  | GraphQLObjectType
-  | GraphQLInterfaceType
-  | GraphQLUnionType
-  | GraphQLEnumType
-  | GraphQLInputObjectType
+  | GraphQLNamedType
   | GraphQLList<GraphQLType>
-  | GraphQLNonNull<
-      | GraphQLScalarType
-      | GraphQLObjectType
-      | GraphQLInterfaceType
-      | GraphQLUnionType
-      | GraphQLEnumType
-      | GraphQLInputObjectType
-      | GraphQLList<GraphQLType>
-    >;
+  | GraphQLNonNull<GraphQLNullableType>;
 
 export function isType(type: unknown): type is GraphQLType {
   return (
@@ -207,9 +194,7 @@ export function assertNonNullType(type: unknown): GraphQLNonNull<GraphQLType> {
  * These types may be used as input types for arguments and directives.
  */
 export type GraphQLNullableInputType =
-  | GraphQLScalarType
-  | GraphQLEnumType
-  | GraphQLInputObjectType
+  | GraphQLNamedInputType
   | GraphQLList<GraphQLInputType>;
 
 export type GraphQLInputType =
@@ -236,11 +221,7 @@ export function assertInputType(type: unknown): GraphQLInputType {
  * These types may be used as output types as the result of fields.
  */
 export type GraphQLNullableOutputType =
-  | GraphQLScalarType
-  | GraphQLObjectType
-  | GraphQLInterfaceType
-  | GraphQLUnionType
-  | GraphQLEnumType
+  | GraphQLNamedOutputType
   | GraphQLList<GraphQLOutputType>;
 
 export type GraphQLOutputType =
@@ -430,14 +411,7 @@ export function assertWrappingType(type: unknown): GraphQLWrappingType {
 /**
  * These types can all accept null as a value.
  */
-export type GraphQLNullableType =
-  | GraphQLScalarType
-  | GraphQLObjectType
-  | GraphQLInterfaceType
-  | GraphQLUnionType
-  | GraphQLEnumType
-  | GraphQLInputObjectType
-  | GraphQLList<GraphQLType>;
+export type GraphQLNullableType = GraphQLNamedType | GraphQLList<GraphQLType>;
 
 export function isNullableType(type: unknown): type is GraphQLNullableType {
   return isType(type) && !isNonNullType(type);


### PR DESCRIPTION
Motivation:
1. Makes it easier to understand the type hierarchy.
2. Adding a new type, were it ever to happen, would require fewer code changes.

Depends on #3597