### PR TITLE
Allow interface resolveType functions to resolve to child interfaces

### DIFF
--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -669,6 +669,10 @@ describe('Execute: Handles execution of abstract types', () => {
         name: String
         isFriendly: Boolean
       }
+
+      type Person implements Named {
+        name: String
+      }
     `);
 
     const document = parse(`
@@ -706,6 +710,13 @@ describe('Execute: Handles execution of abstract types', () => {
     );
 
     const petType = assertInterfaceType(schema.getType('Pet'));
+    // FIXME: workaround since we can't inject resolveType into SDL
+    namedType.resolveType = () => 'Pet';
+    petType.resolveType = () => 'Person';
+    expectError().toEqual(
+      'Abstract type resolution for "Named" for field "Query.named" failed. Runtime Object type "Person" is not a possible type for encountered abstract type "Pet".',
+    );
+
     // FIXME: workaround since we can't inject resolveType into SDL
     namedType.resolveType = () => 'Pet';
     petType.resolveType = () => undefined;

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -698,46 +698,48 @@ describe('Execute: Handles execution of abstract types', () => {
       };
     }
 
+    const namedType = assertInterfaceType(schema.getType('Named'));
     // FIXME: workaround since we can't inject resolveType into SDL
-    assertInterfaceType(schema.getType('Named')).resolveType = () => 'Animal';
+    namedType.resolveType = () => 'Animal';
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" failed. Interface type "Animal" is not a subtype of encountered interface type "Named".',
     );
 
+    const petType = assertInterfaceType(schema.getType('Pet'));
     // FIXME: workaround since we can't inject resolveType into SDL
-    assertInterfaceType(schema.getType('Named')).resolveType = () => 'Pet';
-    assertInterfaceType(schema.getType('Pet')).resolveType = () => undefined;
+    namedType.resolveType = () => 'Pet';
+    petType.resolveType = () => undefined;
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime. Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
-    assertInterfaceType(schema.getType('Pet')).resolveType = () => 'Human';
+    petType.resolveType = () => 'Human';
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" was resolved to a type "Human" that does not exist inside the schema.',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
-    assertInterfaceType(schema.getType('Pet')).resolveType = () => 'String';
+    petType.resolveType = () => 'String';
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" was resolved to a non-object type "String".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
-    assertInterfaceType(schema.getType('Pet')).resolveType = () => '__Schema';
+    petType.resolveType = () => '__Schema';
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" failed. Runtime Object type "__Schema" is not a possible type for encountered abstract type "Pet".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     // @ts-expect-error
-    assertInterfaceType(schema.getType('Pet')).resolveType = () => [];
+    petType.resolveType = () => [];
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" with value {} failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime, received "[]".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
-    assertInterfaceType(schema.getType('Pet')).resolveType = () => 'Pet';
+    petType.resolveType = () => 'Pet';
     expectError().toEqual(
       'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" resolved to "Pet", causing a cycle.',
     );

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -655,7 +655,7 @@ describe('Execute: Handles execution of abstract types', () => {
         isFriendly: Boolean
       }
 
-      interface Pet implements Animal & Named {
+      interface Pet implements Named & Animal {
         name: String
         isFriendly: Boolean
       }
@@ -665,7 +665,7 @@ describe('Execute: Handles execution of abstract types', () => {
         isFriendly: Boolean
       }
 
-      type Dog implements Pet & Animal & Named {
+      type Dog implements Pet & Named & Animal {
         name: String
         isFriendly: Boolean
       }

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -752,7 +752,7 @@ describe('Execute: Handles execution of abstract types', () => {
     // FIXME: workaround since we can't inject resolveType into SDL
     petType.resolveType = () => 'Pet';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" resolved to "Pet", causing a cycle.',
+      'Abstract type resolution for "Named" for field "Query.named" failed. Interface type "Pet" is not a subtype of encountered interface type "Named".',
     );
   });
 });

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -271,7 +271,7 @@ describe('Execute: Handles execution of abstract types', () => {
       errors: [
         {
           message:
-            'Abstract type resolution for "Pet" for field "Query.pet" failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime. Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
+            'Abstract type "Pet" must resolve to an Object type or an intermediate Interface type at runtime for field "Query.pet". Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
           locations: [{ line: 3, column: 9 }],
           path: ['pet'],
         },
@@ -610,26 +610,26 @@ describe('Execute: Handles execution of abstract types', () => {
     }
 
     expectError({ forTypeName: undefined }).toEqual(
-      'Abstract type resolution for "Pet" for field "Query.pet" failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime. Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
+      'Abstract type "Pet" must resolve to an Object type or an intermediate Interface type at runtime for field "Query.pet". Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
     );
 
     expectError({ forTypeName: 'Human' }).toEqual(
-      'Abstract type resolution for "Pet" for field "Query.pet" failed. Encountered abstract type "Pet" was resolved to a type "Human" that does not exist inside the schema.',
+      'Abstract type "Pet" was resolved to a type "Human" that does not exist inside the schema.',
     );
 
     expectError({ forTypeName: 'String' }).toEqual(
-      'Abstract type resolution for "Pet" for field "Query.pet" failed. Encountered abstract type "Pet" was resolved to a non-object type "String".',
+      'Abstract type "Pet" was resolved to a non-object and non-interface type "String".',
     );
 
     expectError({ forTypeName: '__Schema' }).toEqual(
-      'Abstract type resolution for "Pet" for field "Query.pet" failed. Runtime Object type "__Schema" is not a possible type for encountered abstract type "Pet".',
+      'Runtime Object type "__Schema" is not a possible type for "Pet".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     // @ts-expect-error
     assertInterfaceType(schema.getType('Pet')).resolveType = () => [];
     expectError({ forTypeName: undefined }).toEqual(
-      'Abstract type resolution for "Pet" for field "Query.pet" with value { __typename: undefined } failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime, received "[]".',
+      'Abstract type "Pet" must resolve to an Object type or an intermediate Interface type at runtime for field "Query.pet" with value { __typename: undefined }, received "[]".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
@@ -706,7 +706,7 @@ describe('Execute: Handles execution of abstract types', () => {
     // FIXME: workaround since we can't inject resolveType into SDL
     namedType.resolveType = () => 'Animal';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Interface type "Animal" is not a subtype of encountered interface type "Named".',
+      'Interface type "Animal" is not a possible type for "Named".',
     );
 
     const petType = assertInterfaceType(schema.getType('Pet'));
@@ -714,45 +714,45 @@ describe('Execute: Handles execution of abstract types', () => {
     namedType.resolveType = () => 'Pet';
     petType.resolveType = () => 'Person';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Runtime Object type "Person" is not a possible type for encountered abstract type "Pet".',
+      'Runtime Object type "Person" is not a possible type for "Pet".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     namedType.resolveType = () => 'Pet';
     petType.resolveType = () => undefined;
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime. Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
+      'Abstract type "Pet" must resolve to an Object type or an intermediate Interface type at runtime for field "Query.named". Either the "Pet" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     petType.resolveType = () => 'Human';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" was resolved to a type "Human" that does not exist inside the schema.',
+      'Abstract type "Pet" was resolved to a type "Human" that does not exist inside the schema.',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     petType.resolveType = () => 'String';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Encountered abstract type "Pet" was resolved to a non-object type "String".',
+      'Abstract type "Pet" was resolved to a non-object and non-interface type "String".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     petType.resolveType = () => '__Schema';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Runtime Object type "__Schema" is not a possible type for encountered abstract type "Pet".',
+      'Runtime Object type "__Schema" is not a possible type for "Pet".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     // @ts-expect-error
     petType.resolveType = () => [];
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" with value {} failed. Encountered abstract type "Pet" must resolve to an Object or Interface type at runtime, received "[]".',
+      'Abstract type "Pet" must resolve to an Object type or an intermediate Interface type at runtime for field "Query.named" with value {}, received "[]".',
     );
 
     // FIXME: workaround since we can't inject resolveType into SDL
     petType.resolveType = () => 'Pet';
     expectError().toEqual(
-      'Abstract type resolution for "Named" for field "Query.named" failed. Interface type "Pet" is not a subtype of encountered interface type "Named".',
+      'Interface type "Pet" is not a possible type for "Pet".',
     );
   });
 });

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -836,7 +836,6 @@ function resolveType(
   fieldNodes: ReadonlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   result: unknown,
-  encounteredTypeNames: Set<string> = new Set(),
 ): GraphQLObjectType | Promise<GraphQLObjectType> {
   const resolveTypeFn = abstractType.resolveType ?? exeContext.typeResolver;
   const contextValue = exeContext.contextValue;
@@ -857,7 +856,6 @@ function resolveType(
         fieldNodes,
         info,
         result,
-        encounteredTypeNames,
       ),
     );
   }
@@ -869,7 +867,6 @@ function resolveType(
     fieldNodes,
     info,
     result,
-    encounteredTypeNames,
   );
 }
 
@@ -881,7 +878,6 @@ function deriveRuntimeType(
   fieldNodes: ReadonlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   result: unknown,
-  encounteredTypeNames: Set<string>,
 ): GraphQLObjectType | Promise<GraphQLObjectType> {
   if (runtimeTypeName == null) {
     throw new GraphQLError(
@@ -909,14 +905,6 @@ function deriveRuntimeType(
     );
   }
 
-  if (encounteredTypeNames.has(runtimeTypeName)) {
-    throw new GraphQLError(
-      `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
-        `Encountered abstract type "${currentAbstractType.name}" resolved to "${runtimeTypeName}", causing a cycle.`,
-    );
-  }
-  encounteredTypeNames.add(runtimeTypeName);
-
   const runtimeType = exeContext.schema.getType(runtimeTypeName);
   if (runtimeType == null) {
     throw new GraphQLError(
@@ -942,7 +930,6 @@ function deriveRuntimeType(
       fieldNodes,
       info,
       result,
-      encounteredTypeNames,
     );
   }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -840,17 +840,17 @@ function resolveType(
 ): GraphQLObjectType | Promise<GraphQLObjectType> {
   const resolveTypeFn = abstractType.resolveType ?? exeContext.typeResolver;
   const contextValue = exeContext.contextValue;
-  const possibleRuntimeType = resolveTypeFn(
+  const possibleRuntimeTypeName = resolveTypeFn(
     result,
     contextValue,
     info,
     abstractType,
   );
 
-  if (isPromise(possibleRuntimeType)) {
-    return possibleRuntimeType.then((resolvedPossibleRuntimeType) =>
-      ensureValidRuntimeType(
-        resolvedPossibleRuntimeType,
+  if (isPromise(possibleRuntimeTypeName)) {
+    return possibleRuntimeTypeName.then((resolvedPossibleRuntimeTypeName) =>
+      deriveRuntimeType(
+        resolvedPossibleRuntimeTypeName,
         exeContext,
         returnType,
         abstractType,
@@ -861,8 +861,8 @@ function resolveType(
       ),
     );
   }
-  return ensureValidRuntimeType(
-    possibleRuntimeType,
+  return deriveRuntimeType(
+    possibleRuntimeTypeName,
     exeContext,
     returnType,
     abstractType,
@@ -873,7 +873,7 @@ function resolveType(
   );
 }
 
-function ensureValidRuntimeType(
+function deriveRuntimeType(
   runtimeTypeName: unknown,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -877,7 +877,7 @@ function deriveRuntimeType(
   runtimeTypeName: unknown,
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
-  abstractType: GraphQLAbstractType,
+  currentAbstractType: GraphQLAbstractType,
   fieldNodes: ReadonlyArray<FieldNode>,
   info: GraphQLResolveInfo,
   result: unknown,
@@ -886,8 +886,8 @@ function deriveRuntimeType(
   if (runtimeTypeName == null) {
     throw new GraphQLError(
       `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
-        `Encountered abstract type "${abstractType.name}" must resolve to an Object or Interface type at runtime. ` +
-        `Either the "${abstractType.name}" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.`,
+        `Encountered abstract type "${currentAbstractType.name}" must resolve to an Object or Interface type at runtime. ` +
+        `Either the "${currentAbstractType.name}" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.`,
       { nodes: fieldNodes },
     );
   }
@@ -904,7 +904,7 @@ function deriveRuntimeType(
     throw new GraphQLError(
       `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" ` +
         `with value ${inspect(result)} failed. ` +
-        `Encountered abstract type "${abstractType.name}" must resolve to an Object or Interface type at runtime, ` +
+        `Encountered abstract type "${currentAbstractType.name}" must resolve to an Object or Interface type at runtime, ` +
         `received "${inspect(runtimeTypeName)}".`,
     );
   }
@@ -912,7 +912,7 @@ function deriveRuntimeType(
   if (encounteredTypeNames.has(runtimeTypeName)) {
     throw new GraphQLError(
       `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
-        `Encountered abstract type "${abstractType.name}" resolved to "${runtimeTypeName}", causing a cycle.`,
+        `Encountered abstract type "${currentAbstractType.name}" resolved to "${runtimeTypeName}", causing a cycle.`,
     );
   }
   encounteredTypeNames.add(runtimeTypeName);
@@ -921,13 +921,13 @@ function deriveRuntimeType(
   if (runtimeType == null) {
     throw new GraphQLError(
       `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
-        `Encountered abstract type "${abstractType.name}" was resolved to a type "${runtimeTypeName}" that does not exist inside the schema.`,
+        `Encountered abstract type "${currentAbstractType.name}" was resolved to a type "${runtimeTypeName}" that does not exist inside the schema.`,
       { nodes: fieldNodes },
     );
   }
 
   if (isInterfaceType(runtimeType)) {
-    if (!exeContext.schema.isSubType(returnType, runtimeType)) {
+    if (!exeContext.schema.isSubType(currentAbstractType, runtimeType)) {
       throw new GraphQLError(
         `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
           `Interface type "${runtimeType.name}" is not a subtype of encountered interface type "${returnType.name}".`,
@@ -949,15 +949,15 @@ function deriveRuntimeType(
   if (!isObjectType(runtimeType)) {
     throw new GraphQLError(
       `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
-        `Encountered abstract type "${abstractType.name}" was resolved to a non-object type "${runtimeTypeName}".`,
+        `Encountered abstract type "${currentAbstractType.name}" was resolved to a non-object type "${runtimeTypeName}".`,
       { nodes: fieldNodes },
     );
   }
 
-  if (!exeContext.schema.isSubType(returnType, runtimeType)) {
+  if (!exeContext.schema.isSubType(currentAbstractType, runtimeType)) {
     throw new GraphQLError(
       `Abstract type resolution for "${returnType.name}" for field "${info.parentType.name}.${info.fieldName}" failed. ` +
-        `Runtime Object type "${runtimeType.name}" is not a possible type for encountered abstract type "${abstractType.name}".`,
+        `Runtime Object type "${runtimeType.name}" is not a possible type for encountered abstract type "${currentAbstractType.name}".`,
       { nodes: fieldNodes },
     );
   }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -808,7 +808,7 @@ function completeAbstractValue(
     abstractType,
   );
 
-  return resolveRuntimeTypeName(
+  return completeAbstractValueImpl(
     exeContext,
     returnType,
     abstractType,
@@ -820,7 +820,7 @@ function completeAbstractValue(
   );
 }
 
-function resolveRuntimeTypeName(
+function completeAbstractValueImpl(
   exeContext: ExecutionContext,
   returnType: GraphQLAbstractType,
   currentAbstractType: GraphQLAbstractType,
@@ -832,7 +832,7 @@ function resolveRuntimeTypeName(
 ): PromiseOrValue<ObjMap<unknown>> {
   if (isPromise(runtimeTypeName)) {
     return runtimeTypeName.then((resolved) =>
-      resolveRuntimeTypeName(
+      completeAbstractValueImpl(
         exeContext,
         returnType,
         currentAbstractType,


### PR DESCRIPTION
= The child interfaces must eventually resolve to a runtime object type.

implements: #3253