### PR TITLE
Allow scalar `parse*` and `serialized` methods to access context

### DIFF
--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -180,8 +180,17 @@ export async function createSourceEventStream(
 async function executeSubscription(
   exeContext: ExecutionContext,
 ): Promise<unknown> {
-  const { schema, fragments, operation, variableValues, rootValue } =
-    exeContext;
+  // The resolve function's optional third argument is a context value that
+  // is provided to every resolve function within an execution. It is commonly
+  // used to represent an authenticated user, or request-specific caches.
+  const {
+    schema,
+    fragments,
+    operation,
+    contextValue,
+    variableValues,
+    rootValue,
+  } = exeContext;
 
   const rootType = schema.getSubscriptionType();
   if (rootType == null) {
@@ -224,12 +233,12 @@ async function executeSubscription(
 
     // Build a JS object of arguments from the field.arguments AST, using the
     // variables scope to fulfill any variable references.
-    const args = getArgumentValues(fieldDef, fieldNodes[0], variableValues);
-
-    // The resolve function's optional third argument is a context value that
-    // is provided to every resolve function within an execution. It is commonly
-    // used to represent an authenticated user, or request-specific caches.
-    const contextValue = exeContext.contextValue;
+    const args = getArgumentValues(
+      fieldDef,
+      fieldNodes[0],
+      contextValue,
+      variableValues,
+    );
 
     // Call the `subscribe()` resolver or the default resolver to produce an
     // AsyncIterable yielding raw payloads.

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -88,8 +88,23 @@ describe('Type System: Scalars', () => {
       'parseValue: { foo: "bar" }',
     );
     expect(
-      scalar.parseLiteral(parseValue('{ foo: { bar: $var } }'), { var: 'baz' }),
+      scalar.parseLiteral(parseValue('{ foo: { bar: $var } }'), undefined, {
+        var: 'baz',
+      }),
     ).to.equal('parseValue: { foo: { bar: "baz" } }');
+  });
+
+  it('pass context to scalar methods', () => {
+    const scalar = new GraphQLScalarType({
+      name: 'Foo',
+      serialize: (_value, context) => context,
+      parseValue: (_value, context) => context,
+      parseLiteral: (_value, context) => context,
+    });
+
+    expect(scalar.serialize(undefined, 1)).to.equal(1);
+    expect(scalar.parseValue(undefined, 1)).to.equal(1);
+    expect(scalar.parseLiteral(parseValue('null'), 1)).to.equal(1);
   });
 
   it('rejects a Scalar type without name', () => {

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -393,9 +393,9 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
         type: GraphQLString,
         description:
           'A GraphQL-formatted string representing the default value for this input value.',
-        resolve(inputValue) {
+        resolve(inputValue, _args, context) {
           const { type, defaultValue } = inputValue;
-          const valueAST = astFromValue(defaultValue, type);
+          const valueAST = astFromValue(defaultValue, type, context);
           return valueAST ? print(valueAST) : null;
         },
       },

--- a/src/utilities/__tests__/astFromValue-test.ts
+++ b/src/utilities/__tests__/astFromValue-test.ts
@@ -212,6 +212,18 @@ describe('astFromValue', () => {
       'Cannot convert value to AST: Infinity.',
     );
 
+    const contextScalar = new GraphQLScalarType({
+      name: 'ContextScalar',
+      serialize(_value, context) {
+        return context;
+      },
+    });
+
+    expect(astFromValue('value', contextScalar, 1)).to.deep.equal({
+      kind: 'IntValue',
+      value: '1',
+    });
+
     const returnNullScalar = new GraphQLScalarType({
       name: 'ReturnNullScalar',
       serialize() {

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -38,12 +38,13 @@ import { GraphQLID } from '../type/scalars';
  * | null          | NullValue            |
  *
  */
-export function astFromValue(
+export function astFromValue<TContext = any>(
   value: unknown,
   type: GraphQLInputType,
+  context?: Maybe<TContext>,
 ): Maybe<ValueNode> {
   if (isNonNullType(type)) {
-    const astValue = astFromValue(value, type.ofType);
+    const astValue = astFromValue(value, type.ofType, context);
     if (astValue?.kind === Kind.NULL) {
       return null;
     }
@@ -67,7 +68,7 @@ export function astFromValue(
     if (isIterableObject(value)) {
       const valuesNodes = [];
       for (const item of value) {
-        const itemNode = astFromValue(item, itemType);
+        const itemNode = astFromValue(item, itemType, context);
         if (itemNode != null) {
           valuesNodes.push(itemNode);
         }
@@ -85,7 +86,7 @@ export function astFromValue(
     }
     const fieldNodes: Array<ObjectFieldNode> = [];
     for (const field of Object.values(type.getFields())) {
-      const fieldValue = astFromValue(value[field.name], field.type);
+      const fieldValue = astFromValue(value[field.name], field.type, context);
       if (fieldValue) {
         fieldNodes.push({
           kind: Kind.OBJECT_FIELD,
@@ -100,7 +101,7 @@ export function astFromValue(
   if (isLeafType(type)) {
     // Since value is an internally represented value, it must be serialized
     // to an externally represented value before converting into an AST.
-    const serialized = type.serialize(value);
+    const serialized = type.serialize(value, context);
     if (serialized == null) {
       return null;
     }

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -35,9 +35,10 @@ import {
  * | NullValue            | null          |
  *
  */
-export function valueFromAST(
+export function valueFromAST<TContext = any>(
   valueNode: Maybe<ValueNode>,
   type: GraphQLInputType,
+  context?: Maybe<TContext>,
   variables?: Maybe<ObjMap<unknown>>,
 ): unknown {
   if (!valueNode) {
@@ -66,7 +67,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.NULL) {
       return; // Invalid: intentionally return no value.
     }
-    return valueFromAST(valueNode, type.ofType, variables);
+    return valueFromAST(valueNode, type.ofType, context, variables);
   }
 
   if (valueNode.kind === Kind.NULL) {
@@ -87,7 +88,12 @@ export function valueFromAST(
           }
           coercedValues.push(null);
         } else {
-          const itemValue = valueFromAST(itemNode, itemType, variables);
+          const itemValue = valueFromAST(
+            itemNode,
+            itemType,
+            context,
+            variables,
+          );
           if (itemValue === undefined) {
             return; // Invalid: intentionally return no value.
           }
@@ -96,7 +102,7 @@ export function valueFromAST(
       }
       return coercedValues;
     }
-    const coercedValue = valueFromAST(valueNode, itemType, variables);
+    const coercedValue = valueFromAST(valueNode, itemType, context, variables);
     if (coercedValue === undefined) {
       return; // Invalid: intentionally return no value.
     }
@@ -119,7 +125,12 @@ export function valueFromAST(
         }
         continue;
       }
-      const fieldValue = valueFromAST(fieldNode.value, field.type, variables);
+      const fieldValue = valueFromAST(
+        fieldNode.value,
+        field.type,
+        context,
+        variables,
+      );
       if (fieldValue === undefined) {
         return; // Invalid: intentionally return no value.
       }
@@ -134,7 +145,7 @@ export function valueFromAST(
     // no value is returned.
     let result;
     try {
-      result = type.parseLiteral(valueNode, variables);
+      result = type.parseLiteral(valueNode, context, variables);
     } catch (_error) {
       return; // Invalid: intentionally return no value.
     }

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -126,7 +126,11 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // Scalars and Enums determine if a literal value is valid via parseLiteral(),
   // which may throw or return an invalid value to indicate failure.
   try {
-    const parseResult = type.parseLiteral(node, undefined /* variables */);
+    const parseResult = type.parseLiteral(
+      node,
+      undefined /* context */,
+      undefined /* variables */,
+    );
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(


### PR DESCRIPTION
See #3539 for more details.

Even when provided, `context` must be optional because:
1. Default values for scalar are parsed when building a schema, outside of the execution context.
2. Default values for scalar are serialized during findBreakingChanges and other schema operations, also be outside of the execution context.

BREAKING CHANGES are included for argument lists of several functions to include the optional context parameter:
1. `getVariableValues`
2. `getArgumentValues`
3. `coerceInputValue`
4. `valueFromAST`
5. `astFromValue`