### PR TITLE
gen-changelog: fix crash due to 'git rev-list' returning empty string

### DIFF
--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -16,8 +16,7 @@ export function execOutput(command: string, options?: { cwd: string }): string {
     encoding: 'utf-8',
     ...options,
   });
-  assert(output, `Missing output from "${command}"`);
-  return output?.trimEnd();
+  return output.trimEnd();
 }
 
 export function readdirRecursive(


### PR DESCRIPTION
`git rev-list` inside `resources/gen-changelog.js` returned empty list
and that caused `assert` to be triggered.
Moreover `execSync` always return string and can't return null or
undefined.