### PR TITLE
Add new 'GraphQLSchema.getField' method

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -44,11 +44,6 @@ import {
   isNonNullType,
   isObjectType,
 } from '../type/definition';
-import {
-  SchemaMetaFieldDef,
-  TypeMetaFieldDef,
-  TypeNameMetaFieldDef,
-} from '../type/introspection';
 import type { GraphQLSchema } from '../type/schema';
 import { assertValidSchema } from '../type/validate';
 
@@ -481,7 +476,8 @@ function executeField(
   fieldNodes: ReadonlyArray<FieldNode>,
   path: Path,
 ): PromiseOrValue<unknown> {
-  const fieldDef = getFieldDef(exeContext.schema, parentType, fieldNodes[0]);
+  const fieldName = fieldNodes[0].name.value;
+  const fieldDef = exeContext.schema.getField(parentType, fieldName);
   if (!fieldDef) {
     return;
   }
@@ -1013,37 +1009,3 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
       return property;
     }
   };
-
-/**
- * This method looks up the field on the given type definition.
- * It has special casing for the three introspection fields,
- * __schema, __type and __typename. __typename is special because
- * it can always be queried as a field, even in situations where no
- * other fields are allowed, like on a Union. __schema and __type
- * could get automatically added to the query type, but that would
- * require mutating type definitions, which would cause issues.
- *
- * @internal
- */
-export function getFieldDef(
-  schema: GraphQLSchema,
-  parentType: GraphQLObjectType,
-  fieldNode: FieldNode,
-): Maybe<GraphQLField<unknown, unknown>> {
-  const fieldName = fieldNode.name.value;
-
-  if (
-    fieldName === SchemaMetaFieldDef.name &&
-    schema.getQueryType() === parentType
-  ) {
-    return SchemaMetaFieldDef;
-  } else if (
-    fieldName === TypeMetaFieldDef.name &&
-    schema.getQueryType() === parentType
-  ) {
-    return TypeMetaFieldDef;
-  } else if (fieldName === TypeNameMetaFieldDef.name) {
-    return TypeNameMetaFieldDef;
-  }
-  return parentType.getFields()[fieldName];
-}

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -22,7 +22,6 @@ import {
   buildExecutionContext,
   buildResolveInfo,
   execute,
-  getFieldDef,
 } from './execute';
 import { mapAsyncIterator } from './mapAsyncIterator';
 import { getArgumentValues } from './values';
@@ -199,10 +198,10 @@ async function executeSubscription(
     operation.selectionSet,
   );
   const [responseName, fieldNodes] = [...rootFields.entries()][0];
-  const fieldDef = getFieldDef(schema, rootType, fieldNodes[0]);
+  const fieldName = fieldNodes[0].name.value;
+  const fieldDef = schema.getField(rootType, fieldName);
 
   if (!fieldDef) {
-    const fieldName = fieldNodes[0].name.value;
     throw new GraphQLError(
       `The subscription field "${fieldName}" is not defined.`,
       { nodes: fieldNodes },

--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -23,17 +23,11 @@ import {
   isEnumType,
   isInputObjectType,
   isInputType,
-  isInterfaceType,
   isListType,
   isObjectType,
   isOutputType,
 } from '../type/definition';
 import type { GraphQLDirective } from '../type/directives';
-import {
-  SchemaMetaFieldDef,
-  TypeMetaFieldDef,
-  TypeNameMetaFieldDef,
-} from '../type/introspection';
 import type { GraphQLSchema } from '../type/schema';
 
 import { typeFromAST } from './typeFromAST';
@@ -293,36 +287,16 @@ export class TypeInfo {
 
 type GetFieldDefFn = (
   schema: GraphQLSchema,
-  parentType: GraphQLType,
+  parentType: GraphQLCompositeType,
   fieldNode: FieldNode,
 ) => Maybe<GraphQLField<unknown, unknown>>;
 
-/**
- * Not exactly the same as the executor's definition of getFieldDef, in this
- * statically evaluated environment we do not always have an Object type,
- * and need to handle Interface and Union types.
- */
 function getFieldDef(
   schema: GraphQLSchema,
-  parentType: GraphQLType,
+  parentType: GraphQLCompositeType,
   fieldNode: FieldNode,
-): Maybe<GraphQLField<unknown, unknown>> {
-  const name = fieldNode.name.value;
-  if (
-    name === SchemaMetaFieldDef.name &&
-    schema.getQueryType() === parentType
-  ) {
-    return SchemaMetaFieldDef;
-  }
-  if (name === TypeMetaFieldDef.name && schema.getQueryType() === parentType) {
-    return TypeMetaFieldDef;
-  }
-  if (name === TypeNameMetaFieldDef.name && isCompositeType(parentType)) {
-    return TypeNameMetaFieldDef;
-  }
-  if (isObjectType(parentType) || isInterfaceType(parentType)) {
-    return parentType.getFields()[name];
-  }
+) {
+  return schema.getField(parentType, fieldNode.name.value);
 }
 
 /**

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -33,9 +33,13 @@ const testSchema = buildSchema(`
     name(surname: Boolean): String
   }
 
+  union HumanOrAlien = Human | Alien
+
   type QueryRoot {
     human(id: ID): Human
     alien: Alien
+    humanOrAlien: HumanOrAlien
+    pet: Pet
   }
 
   schema {
@@ -144,6 +148,62 @@ describe('visitWithTypeInfo', () => {
     );
 
     expect(visitorArgs).to.deep.equal(wrappedVisitorArgs);
+  });
+
+  it('supports introspection fields', () => {
+    const typeInfo = new TypeInfo(testSchema);
+
+    const ast = parse(`
+      {
+        __typename
+        __type(name: "Cat") { __typename }
+        __schema {
+          __typename # in object type
+        }
+        humanOrAlien {
+          __typename # in union type
+        }
+        pet {
+          __typename # in interface type
+        }
+        someUnknownType {
+          __typename # unknown
+        }
+        pet {
+          __type # unknown
+          __schema # unknown
+        }
+      }
+    `);
+
+    const visitedFields: Array<[string | undefined, string | undefined]> = [];
+    visit(
+      ast,
+      visitWithTypeInfo(typeInfo, {
+        Field() {
+          const typeName = typeInfo.getParentType()?.name;
+          const fieldName = typeInfo.getFieldDef()?.name;
+          visitedFields.push([typeName, fieldName]);
+        },
+      }),
+    );
+
+    expect(visitedFields).to.deep.equal([
+      ['QueryRoot', '__typename'],
+      ['QueryRoot', '__type'],
+      ['__Type', '__typename'],
+      ['QueryRoot', '__schema'],
+      ['__Schema', '__typename'],
+      ['QueryRoot', 'humanOrAlien'],
+      ['HumanOrAlien', '__typename'],
+      ['QueryRoot', 'pet'],
+      ['Pet', '__typename'],
+      ['QueryRoot', undefined],
+      [undefined, undefined],
+      ['QueryRoot', 'pet'],
+      ['Pet', undefined],
+      ['Pet', undefined],
+    ]);
   });
 
   it('maintains type info during visit', () => {


### PR DESCRIPTION
Motivation: generalize it and remove code dublication in two places and
also allow to use as public API outside of graphql-js