### PR TITLE
Fix defaultFieldResolver to take alias if it has

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1002,9 +1002,9 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
   function (source: any, args, contextValue, info) {
     // ensure source is a value for which property access is acceptable.
     if (isObjectLike(source) || typeof source === 'function') {
-      const property = source[info.fieldName];
+      const property = source[info.path.key];
       if (typeof property === 'function') {
-        return source[info.fieldName](args, contextValue, info);
+        return source[info.path.key](args, contextValue, info);
       }
       return property;
     }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1002,9 +1002,10 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
   function (source: any, args, contextValue, info) {
     // ensure source is a value for which property access is acceptable.
     if (isObjectLike(source) || typeof source === 'function') {
-      const property = source[info.path.key];
+      const key = info.rootValue ? info.fieldName : info.path.key;
+      const property = source[key];
       if (typeof property === 'function') {
-        return source[info.path.key](args, contextValue, info);
+        return source[key](args, contextValue, info);
       }
       return property;
     }


### PR DESCRIPTION
I'm using @nest-js/graphql and experiencing a strange behavior. When declaring a type which has inside objectTypes, if there isn't any resolver for those objectTypes, aliasing won't work for me, because defaultFieldResolver is being called, and it doesn't considering if field has alias.

Example:
Suppose those 2 things:
1. We have those types
```
type Owner {
  id: Int!
  name: String!
  age: Int
  cat(id: ID!): Cat
}


type Cat {
  id: Int
  name: String
  age: Int
  owner: Owner
}

```

2. We have this resolver, with query
```
import { Query, Resolver } from '@nestjs/graphql';

@Resolver('Owner')
export class OwnersResolver {
  @Query('owners')
  getOwners() {
    return [
      {
        id: 1,
        name: 'Yannai',
        cat: { id: 1, name: 'CatA' },
      },
    ];
  }
}

```

3. We execute this query:
```
{
  owners {
    catA: cat(id: 1) {
      name
    }
    catB: cat(id: 2) {
      name
    }
}
}
```


actual behavior: 
```
{
  "data": {
    "owners": [
      {
        "catA": {
          "name": "CatA"
        },
        "catB": {
          "name": "CatA"
        }
      }
    ]
  }
}
```

I want a way to be able to tell the executer there is aliasing, but without creating a resolver for the nested query.
In my solution, changing `owners` query to this would fix the issue:

 ```
 @Query('owners')
  getOwners() {
    return [
      {
        id: 1,
        name: 'Yannai',
        catA: { id: 1, name: 'CatA' },
        catB: { id: 2, name: 'CatB' },
      },
    ];
  }
```