### PR TITLE
resources: add new `localRepoPath` utility function

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -4,6 +4,8 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import { localRepoPath } from './utils';
+
 const NS_PER_SEC = 1e9;
 const LOCAL = 'local';
 
@@ -20,10 +22,6 @@ function runBenchmarks() {
   for (const benchmark of benchmarks) {
     runBenchmark(benchmark, benchmarkProjects);
   }
-}
-
-function localDir(...paths: ReadonlyArray<string>) {
-  return path.join(__dirname, '..', ...paths);
 }
 
 function exec(command: string, options = {}) {
@@ -58,7 +56,7 @@ function prepareBenchmarkProjects(
     fs.rmSync(projectPath, { recursive: true, force: true });
     fs.mkdirSync(projectPath);
 
-    fs.cpSync(localDir('benchmark'), path.join(projectPath, 'benchmark'), {
+    fs.cpSync(localRepoPath('benchmark'), path.join(projectPath, 'benchmark'), {
       recursive: true,
     });
 
@@ -80,7 +78,7 @@ function prepareBenchmarkProjects(
 
   function prepareNPMPackage(revision: string) {
     if (revision === LOCAL) {
-      const repoDir = localDir();
+      const repoDir = localRepoPath();
       const archivePath = path.join(tmpDir, 'graphql-local.tgz');
       fs.renameSync(buildNPMArchive(repoDir), archivePath);
       return archivePath;
@@ -334,7 +332,7 @@ function getArguments(argv: ReadonlyArray<string>) {
 
 function findAllBenchmarks() {
   return fs
-    .readdirSync(localDir('benchmark'), { withFileTypes: true })
+    .readdirSync(localRepoPath('benchmark'), { withFileTypes: true })
     .filter((dirent) => dirent.isFile())
     .map((dirent) => dirent.name)
     .filter((name) => name.endsWith('-benchmark.js'))

--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -7,6 +7,7 @@ import * as ts from 'typescript';
 import { addExtensionToImportPaths } from './add-extension-to-import-paths';
 import { inlineInvariant } from './inline-invariant';
 import {
+  localRepoPath,
   readdirRecursive,
   readPackageJSON,
   showDirStats,
@@ -18,7 +19,7 @@ fs.mkdirSync('./npmDist');
 
 // Based on https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#getting-the-dts-from-a-javascript-file
 const tsConfig = JSON.parse(
-  fs.readFileSync(require.resolve('../tsconfig.json'), 'utf-8'),
+  fs.readFileSync(localRepoPath('tsconfig.json'), 'utf-8'),
 );
 assert(
   tsConfig.compilerOptions,

--- a/resources/diff-npm-package.ts
+++ b/resources/diff-npm-package.ts
@@ -3,10 +3,9 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { exec, execOutput } from './utils';
+import { exec, execOutput, localRepoPath } from './utils';
 
 const LOCAL = 'local';
-const localRepoDir = path.join(__dirname, '..');
 const tmpDir = path.join(os.tmpdir(), 'graphql-js-npm-diff');
 fs.rmSync(tmpDir, { recursive: true, force: true });
 fs.mkdirSync(tmpDir);
@@ -33,7 +32,7 @@ const diff = execOutput(`npm diff --diff=${fromPackage} --diff=${toPackage}`);
 if (diff === '') {
   console.log('No changes found!');
 } else {
-  const reportPath = path.join(localRepoDir, 'npm-dist-diff.html');
+  const reportPath = localRepoPath('npm-dist-diff.html');
   fs.writeFileSync(reportPath, generateReport(diff));
   console.log('Report saved to: ', reportPath);
 }
@@ -76,10 +75,11 @@ function generateReport(diffString: string): string {
     </html>
   `;
 }
+
 function prepareNPMPackage(revision: string): string {
   if (revision === LOCAL) {
-    exec('npm --quiet run build:npm', { cwd: localRepoDir });
-    return path.join(localRepoDir, 'npmDist');
+    exec('npm --quiet run build:npm', { cwd: localRepoPath() });
+    return localRepoPath('npmDist');
   }
 
   // Returns the complete git hash for a given git revision reference.

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -5,6 +5,10 @@ import * as path from 'node:path';
 
 import * as prettier from 'prettier';
 
+export function localRepoPath(...paths: ReadonlyArray<string>): string {
+  return path.join(__dirname, '..', ...paths);
+}
+
 export function exec(command: string, options?: { cwd: string }): void {
   childProcess.execSync(command, options);
 }
@@ -97,7 +101,7 @@ export function showDirStats(dirPath: string): void {
 }
 
 const prettierConfig = JSON.parse(
-  fs.readFileSync(require.resolve('../.prettierrc'), 'utf-8'),
+  fs.readFileSync(localRepoPath('.prettierrc'), 'utf-8'),
 );
 
 export function writeGeneratedFile(filepath: string, body: string): void {
@@ -119,7 +123,5 @@ interface PackageJSON {
 }
 
 export function readPackageJSON(): PackageJSON {
-  return JSON.parse(
-    fs.readFileSync(require.resolve('../package.json'), 'utf-8'),
-  );
+  return JSON.parse(fs.readFileSync(localRepoPath('package.json'), 'utf-8'));
 }


### PR DESCRIPTION
Extracted from #3564
Motivation: `__dirname` and `require.resolve` is CJS specific mechanism
and we use them in multiple places. Even without ESM migration this
function makes internal scripts more high-level and thus readable.