### PR TITLE
diff-npm-package: move report into shared 'reports' folder

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,5 +34,5 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: npm-dist-diff.html
-          path: ./npm-dist-diff.html
+          path: ./reports/npm-dist-diff.html
           if-no-files-found: ignore

--- a/resources/diff-npm-package.ts
+++ b/resources/diff-npm-package.ts
@@ -32,7 +32,7 @@ const diff = execOutput(`npm diff --diff=${fromPackage} --diff=${toPackage}`);
 if (diff === '') {
   console.log('No changes found!');
 } else {
-  const reportPath = localRepoPath('npm-dist-diff.html');
+  const reportPath = localRepoPath('reports', 'npm-dist-diff.html');
   fs.writeFileSync(reportPath, generateReport(diff));
   console.log('Report saved to: ', reportPath);
 }


### PR DESCRIPTION
This folder already used for stryker's and c8's reports.
Motivation: Makes it easier to manage ignore files for various tools.