### PR TITLE
github actions: switch embedded JS to ESM

### DIFF
--- a/.github/workflows/cmd-publish-pr-on-npm.yml
+++ b/.github/workflows/cmd-publish-pr-on-npm.yml
@@ -66,8 +66,8 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const fs = require('fs');
-            const assert = require('assert');
+            import fs from 'node:fs';
+            import assert from 'node:assert';
 
             const pull_request = JSON.parse(process.env.PULL_REQUEST_JSON);
             const packageJSONPath = './npmDist/package.json';

--- a/.github/workflows/cmd-run-benchmark.yml
+++ b/.github/workflows/cmd-run-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const fs = require('fs');
+            import fs from 'node:fs';
 
             // GH doesn't expose job's id so we need to get it through API, see
             // https://github.community/t/job-id-is-string-in-github-job-but-integer-in-actions-api/139060

--- a/.github/workflows/github-actions-bot.yml
+++ b/.github/workflows/github-actions-bot.yml
@@ -37,10 +37,10 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const fs = require('fs');
+            import fs from 'node:fs';
 
             const event = JSON.parse(fs.readFileSync('./event.json', 'utf8'));
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               ...context.repo,
               issue_number: event.pull_request.number,
               body:
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/github-script@v5
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
+            await github.rest.reactions.createForIssueComment({
               ...context.repo,
               comment_id: context.payload.comment.id,
               content: 'eyes',
@@ -110,7 +110,7 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const fs = require('fs');
+            import fs from 'node:fs';
 
             const needs = JSON.parse(process.env.NEEDS);
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const fs = require('fs');
+            import fs from 'node:fs';
 
             const replyMessage = fs.readFileSync('./replyMessage.txt', 'utf-8');
             const { issue, comment, sender } = context.payload;
@@ -144,14 +144,14 @@ jobs:
               .map((line) => '> ' + line)
               .join('\n');
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               ...context.repo,
               issue_number: issue.number,
               body: quoteRequest + `\n\n@${sender.login} ` + replyMessage,
             });
 
             // `github.rest` doesn't have this method :( so use graphql instead
-            github.graphql(`
+            await github.graphql(`
               mutation ($subjectId: ID!) {
                 minimizeComment(input: { subjectId: $subjectId, classifier: RESOLVED})
                   { __typename }


### PR DESCRIPTION
Motivation: API calls to GH are async and require top-level await.
Also add 'node:' prefix to all node modules.