### PR TITLE
Separate interfaces from implementations for exported classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ import {
   GraphQLString,
 } from 'graphql';
 
-var schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
+var schema = new GraphQLSchemaImpl({
+  query: new GraphQLObjectTypeImpl({
     name: 'RootQueryType',
     fields: {
       hello: {

--- a/docs-old/APIReference-GraphQL.md
+++ b/docs-old/APIReference-GraphQL.md
@@ -32,8 +32,8 @@ _Schema_
 
 <ul class="apiIndex">
   <li>
-    <a href="../type/#graphqlschema">
-      <pre>class GraphQLSchema</pre>
+    <a href="../type/#graphqlschemaimpl">
+      <pre>class GraphQLSchemaImpl</pre>
       A representation of the capabilities of a GraphQL Server.
     </a>
   </li>
@@ -43,50 +43,50 @@ _Type Definitions_
 
 <ul class="apiIndex">
   <li>
-    <a href="../type/#graphqlscalartype">
-      <pre>class GraphQLScalarType</pre>
+    <a href="../type/#graphqlscalartypeimpl">
+      <pre>class GraphQLScalarTypeImpl</pre>
       A scalar type within GraphQL.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlobjecttype">
-      <pre>class GraphQLObjectType</pre>
+    <a href="../type/#graphqlobjecttypeimpl">
+      <pre>class GraphQLObjectTypeImpl</pre>
       An object type within GraphQL that contains fields.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlinterfacetype">
-      <pre>class GraphQLInterfaceType</pre>
+    <a href="../type/#graphqlinterfacetypeimpl">
+      <pre>class GraphQLInterfaceTypeImpl</pre>
       An interface type within GraphQL that defines fields implementations will contain.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqluniontype">
-      <pre>class GraphQLUnionType</pre>
+    <a href="../type/#graphqluniontypeimpl">
+      <pre>class GraphQLUnionTypeImpl</pre>
       A union type within GraphQL that defines a list of implementations.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlenumtype">
-      <pre>class GraphQLEnumType</pre>
+    <a href="../type/#graphqlenumtypeimpl">
+      <pre>class GraphQLEnumTypeImpl</pre>
       An enum type within GraphQL that defines a list of valid values.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlinputobjecttype">
-      <pre>class GraphQLInputObjectType</pre>
+    <a href="../type/#graphqlinputobjecttypeimpl">
+      <pre>class GraphQLInputObjectTypeImpl</pre>
       An input object type within GraphQL that represents structured inputs.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqllist">
-      <pre>class GraphQLList</pre>
+    <a href="../type/#graphqllistimpl">
+      <pre>class GraphQLListImpl</pre>
       A type wrapper around other types that represents a list of those types.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlnonnull">
-      <pre>class GraphQLNonNull</pre>
+    <a href="../type/#graphqlnonnullimpl">
+      <pre>class GraphQLNonNullImpl</pre>
       A type wrapper around other types that represents a non-null version of those types.
     </a>
   </li>

--- a/docs-old/APIReference-Language.md
+++ b/docs-old/APIReference-Language.md
@@ -3,7 +3,7 @@ title: graphql/language
 layout: ../_core/GraphQLJSLayout
 category: API Reference
 permalink: /graphql-js/language/
-sublinks: BREAK,getLocation,Kind,lex,parse,parseValue,printSource,visit
+sublinks: getLocation,Kind,lex,parse,parseValue,printSource,visit
 next: /graphql-js/type/
 ---
 
@@ -74,12 +74,6 @@ _Visitor_
     <a href="#visit">
       <pre>function visit</pre>
       A general-purpose visitor to traverse a parsed GraphQL AST
-    </a>
-  </li>
-  <li>
-    <a href="#break">
-      <pre>var BREAK</pre>
-      A token to allow breaking out of the visitor.
     </a>
   </li>
 </ul>
@@ -215,7 +209,7 @@ visit function.
 
 ```js
 var editedAST = visit(ast, {
-  enter(node, key, parent, path, ancestors) {
+  enter(node, key, parent, path, ancestors, BREAK) {
     // @return
     //   undefined: no action
     //   false: skip visiting this node
@@ -223,7 +217,7 @@ var editedAST = visit(ast, {
     //   null: delete this node
     //   any value: replace this node with the returned value
   },
-  leave(node, key, parent, path, ancestors) {
+  leave(node, key, parent, path, ancestors, BREAK) {
     // @return
     //   undefined: no action
     //   false: no action
@@ -294,10 +288,6 @@ visit(ast, {
   },
 });
 ```
-
-### BREAK
-
-The sentinel `BREAK` value described in the documentation of `visitor`.
 
 ## Printer
 

--- a/docs-old/APIReference-TypeSystem.md
+++ b/docs-old/APIReference-TypeSystem.md
@@ -3,15 +3,15 @@ title: graphql/type
 layout: ../_core/GraphQLJSLayout
 category: API Reference
 permalink: /graphql-js/type/
-sublinks: getNamedType,getNullableType,GraphQLBoolean,GraphQLEnumType,GraphQLFloat,GraphQLID,GraphQLInputObjectType,GraphQLInt,GraphQLInterfaceType,GraphQLList,GraphQLNonNull,GraphQLObjectType,GraphQLScalarType,GraphQLSchema,GraphQLString,GraphQLUnionType,isAbstractType,isCompositeType,isInputType,isLeafType,isOutputType
+sublinks: getNamedType,getNullableType,GraphQLBoolean,GraphQLEnumTypeImpl,GraphQLFloat,GraphQLID,GraphQLInputObjectTypeImpl,GraphQLInt,GraphQLInterfaceTypeImpl,GraphQLListImpl,GraphQLNonNullImpl,GraphQLObjectTypeImpl,GraphQLScalarTypeImpl,GraphQLSchemaImpl,GraphQLString,GraphQLUnionTypeImpl,isAbstractType,isCompositeType,isInputType,isLeafType,isOutputType
 next: /graphql-js/utilities/
 ---
 
 The `graphql/type` module is responsible for defining GraphQL types and schema. You can import either from the `graphql/type` module, or from the root `graphql` module. For example:
 
 ```js
-import { GraphQLSchema } from 'graphql'; // ES6
-var { GraphQLSchema } = require('graphql'); // CommonJS
+import { GraphQLSchemaImpl } from 'graphql'; // ES6
+var { GraphQLSchemaImpl } = require('graphql'); // CommonJS
 ```
 
 ## Overview
@@ -20,8 +20,8 @@ _Schema_
 
 <ul class="apiIndex">
   <li>
-    <a href="#graphqlschema">
-      <pre>class GraphQLSchema</pre>
+    <a href="#graphqlschemaimpl">
+      <pre>class GraphQLSchemaImpl</pre>
       A representation of the capabilities of a GraphQL Server.
     </a>
   </li>
@@ -31,50 +31,50 @@ _Definitions_
 
 <ul class="apiIndex">
   <li>
-    <a href="#graphqlscalartype">
-      <pre>class GraphQLScalarType</pre>
+    <a href="#graphqlscalartypeimpl">
+      <pre>class GraphQLScalarTypeImpl</pre>
       A scalar type within GraphQL.
     </a>
   </li>
   <li>
-    <a href="#graphqlobjecttype">
-      <pre>class GraphQLObjectType</pre>
+    <a href="#graphqlobjecttypeimpl">
+      <pre>class GraphQLObjectTypeImpl</pre>
       An object type within GraphQL that contains fields.
     </a>
   </li>
   <li>
-    <a href="#graphqlinterfacetype">
-      <pre>class GraphQLInterfaceType</pre>
+    <a href="#graphqlinterfacetypeimpl">
+      <pre>class GraphQLInterfaceTypeImpl</pre>
       An interface type within GraphQL that defines fields implementations will contain.
     </a>
   </li>
   <li>
-    <a href="#graphqluniontype">
-      <pre>class GraphQLUnionType</pre>
+    <a href="#graphqluniontypeimpl">
+      <pre>class GraphQLUnionTypeImpl</pre>
       A union type within GraphQL that defines a list of implementations.
     </a>
   </li>
   <li>
-    <a href="#graphqlenumtype">
-      <pre>class GraphQLEnumType</pre>
+    <a href="#graphqlenumtypeimpl">
+      <pre>class GraphQLEnumTypeImpl</pre>
       An enum type within GraphQL that defines a list of valid values.
     </a>
   </li>
   <li>
-    <a href="#graphqlinputobjecttype">
-      <pre>class GraphQLInputObjectType</pre>
+    <a href="#graphqlinputobjecttypeimpl">
+      <pre>class GraphQLInputObjectTypeImpl</pre>
       An input object type within GraphQL that represents structured inputs.
     </a>
   </li>
   <li>
-    <a href="#graphqllist">
-      <pre>class GraphQLList</pre>
+    <a href="#graphqllistimpl">
+      <pre>class GraphQLListImpl</pre>
       A type wrapper around other types that represents a list of those types.
     </a>
   </li>
   <li>
-    <a href="#graphqlnonnull">
-      <pre>class GraphQLNonNull</pre>
+    <a href="#graphqlnonnullimpl">
+      <pre>class GraphQLNonNullImpl</pre>
       A type wrapper around other types that represents a non-null version of those types.
     </a>
   </li>
@@ -188,7 +188,7 @@ validator and executor.
 #### Example
 
 ```js
-var MyAppSchema = new GraphQLSchema({
+var MyAppSchema = new GraphQLSchemaImpl({
   query: MyAppQueryRootType
   mutation: MyAppMutationRootType
 });
@@ -220,7 +220,7 @@ functions used to ensure validity.
 #### Example
 
 ```js
-var OddType = new GraphQLScalarType({
+var OddType = new GraphQLScalarTypeImpl({
   name: 'Odd',
   serialize: oddValue,
   parseValue: oddValue,
@@ -315,7 +315,7 @@ that value can always be referenced with `this`.
 #### Examples
 
 ```js
-var AddressType = new GraphQLObjectType({
+var AddressType = new GraphQLObjectTypeImpl({
   name: 'Address',
   fields: {
     street: { type: GraphQLString },
@@ -329,7 +329,7 @@ var AddressType = new GraphQLObjectType({
   },
 });
 
-var PersonType = new GraphQLObjectType({
+var PersonType = new GraphQLObjectTypeImpl({
   name: 'Person',
   fields: () => ({
     name: { type: GraphQLString },
@@ -361,7 +361,7 @@ when the field is resolved.
 #### Example
 
 ```js
-var EntityType = new GraphQLInterfaceType({
+var EntityType = new GraphQLInterfaceTypeImpl({
   name: 'Entity',
   fields: {
     name: { type: GraphQLString },
@@ -393,7 +393,7 @@ to determine which type is actually used when the field is resolved.
 ### Example
 
 ```js
-var PetType = new GraphQLUnionType({
+var PetType = new GraphQLUnionTypeImpl({
   name: 'Pet',
   types: [DogType, CatType],
   resolveType(value) {
@@ -448,7 +448,7 @@ will be used as its internal value.
 #### Example
 
 ```js
-var RGBType = new GraphQLEnumType({
+var RGBType = new GraphQLEnumTypeImpl({
   name: 'RGB',
   values: {
     RED: { value: 0 },
@@ -503,11 +503,11 @@ Using `NonNull` will ensure that a value must be provided by the query
 #### Example
 
 ```js
-var GeoPoint = new GraphQLInputObjectType({
+var GeoPoint = new GraphQLInputObjectTypeImpl({
   name: 'GeoPoint',
   fields: {
-    lat: { type: new GraphQLNonNull(GraphQLFloat) },
-    lon: { type: new GraphQLNonNull(GraphQLFloat) },
+    lat: { type: new GraphQLNonNullImpl(GraphQLFloat) },
+    lon: { type: new GraphQLNonNullImpl(GraphQLFloat) },
     alt: { type: GraphQLFloat, defaultValue: 0 },
   },
 });
@@ -528,11 +528,11 @@ an object type.
 #### Example
 
 ```js
-var PersonType = new GraphQLObjectType({
+var PersonType = new GraphQLObjectTypeImpl({
   name: 'Person',
   fields: () => ({
-    parents: { type: new GraphQLList(Person) },
-    children: { type: new GraphQLList(Person) },
+    parents: { type: new GraphQLListImpl(Person) },
+    children: { type: new GraphQLListImpl(Person) },
   }),
 });
 ```
@@ -554,10 +554,10 @@ usually the id field of a database row will never be null.
 #### Example
 
 ```js
-var RowType = new GraphQLObjectType({
+var RowType = new GraphQLObjectTypeImpl({
   name: 'Row',
   fields: () => ({
-    id: { type: new GraphQLNonNull(String) },
+    id: { type: new GraphQLNonNullImpl(String) },
   }),
 });
 ```

--- a/integrationTests/ts/basic-test.ts
+++ b/integrationTests/ts/basic-test.ts
@@ -1,9 +1,14 @@
 import type { ExecutionResult } from 'graphql/execution';
 
 import { graphqlSync } from 'graphql';
-import { GraphQLString, GraphQLSchema, GraphQLObjectType } from 'graphql/type';
+import type { GraphQLSchema, GraphQLObjectType } from 'graphql/type';
+import {
+  GraphQLString,
+  GraphQLSchemaImpl,
+  GraphQLObjectTypeImpl,
+} from 'graphql/type';
 
-const queryType: GraphQLObjectType = new GraphQLObjectType({
+const queryType: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: 'Query',
   fields: () => ({
     sayHi: {
@@ -21,7 +26,7 @@ const queryType: GraphQLObjectType = new GraphQLObjectType({
   }),
 });
 
-const schema: GraphQLSchema = new GraphQLSchema({ query: queryType });
+const schema: GraphQLSchema = new GraphQLSchemaImpl({ query: queryType });
 
 const result: ExecutionResult = graphqlSync({
   schema,

--- a/integrationTests/ts/extensions-test.ts
+++ b/integrationTests/ts/extensions-test.ts
@@ -1,5 +1,6 @@
 import { GraphQLError } from 'graphql/error';
-import { GraphQLString, GraphQLObjectType } from 'graphql/type';
+import { GraphQLString, GraphQLObjectTypeImpl } from 'graphql/type';
+import type { GraphQLObjectType } from 'graphql/type';
 
 interface SomeExtension {
   meaningOfLife: 42;
@@ -19,7 +20,7 @@ declare module 'graphql' {
   }
 }
 
-const queryType: GraphQLObjectType = new GraphQLObjectType({
+const queryType: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: 'Query',
   fields: () => ({
     sayHi: {

--- a/src/__tests__/starWarsSchema.ts
+++ b/src/__tests__/starWarsSchema.ts
@@ -1,12 +1,14 @@
+import type { GraphQLInterfaceType } from '../type/definition';
 import {
-  GraphQLEnumType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
+  GraphQLEnumTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
 } from '../type/definition';
 import { GraphQLString } from '../type/scalars';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
+import { GraphQLSchemaImpl } from '../type/schema';
 
 import { getDroid, getFriends, getHero, getHuman } from './starWarsData';
 
@@ -69,7 +71,7 @@ import { getDroid, getFriends, getHero, getHuman } from './starWarsData';
  * enum Episode { NEW_HOPE, EMPIRE, JEDI }
  * ```
  */
-const episodeEnum = new GraphQLEnumType({
+const episodeEnum = new GraphQLEnumTypeImpl({
   name: 'Episode',
   description: 'One of the films in the Star Wars Trilogy',
   values: {
@@ -102,12 +104,12 @@ const episodeEnum = new GraphQLEnumType({
  * }
  * ```
  */
-const characterInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
+const characterInterface: GraphQLInterfaceType = new GraphQLInterfaceTypeImpl({
   name: 'Character',
   description: 'A character in the Star Wars Trilogy',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
       description: 'The id of the character.',
     },
     name: {
@@ -115,12 +117,12 @@ const characterInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
       description: 'The name of the character.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: new GraphQLListImpl(characterInterface),
       description:
         'The friends of the character, or an empty list if they have none.',
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: new GraphQLListImpl(episodeEnum),
       description: 'Which movies they appear in.',
     },
     secretBackstory: {
@@ -152,12 +154,12 @@ const characterInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
  * }
  * ```
  */
-const humanType = new GraphQLObjectType({
+const humanType = new GraphQLObjectTypeImpl({
   name: 'Human',
   description: 'A humanoid creature in the Star Wars universe.',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
       description: 'The id of the human.',
     },
     name: {
@@ -165,13 +167,13 @@ const humanType = new GraphQLObjectType({
       description: 'The name of the human.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: new GraphQLListImpl(characterInterface),
       description:
         'The friends of the human, or an empty list if they have none.',
       resolve: (human) => getFriends(human),
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: new GraphQLListImpl(episodeEnum),
       description: 'Which movies they appear in.',
     },
     homePlanet: {
@@ -204,12 +206,12 @@ const humanType = new GraphQLObjectType({
  * }
  * ```
  */
-const droidType = new GraphQLObjectType({
+const droidType = new GraphQLObjectTypeImpl({
   name: 'Droid',
   description: 'A mechanical creature in the Star Wars universe.',
   fields: () => ({
     id: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
       description: 'The id of the droid.',
     },
     name: {
@@ -217,13 +219,13 @@ const droidType = new GraphQLObjectType({
       description: 'The name of the droid.',
     },
     friends: {
-      type: new GraphQLList(characterInterface),
+      type: new GraphQLListImpl(characterInterface),
       description:
         'The friends of the droid, or an empty list if they have none.',
       resolve: (droid) => getFriends(droid),
     },
     appearsIn: {
-      type: new GraphQLList(episodeEnum),
+      type: new GraphQLListImpl(episodeEnum),
       description: 'Which movies they appear in.',
     },
     secretBackstory: {
@@ -256,7 +258,7 @@ const droidType = new GraphQLObjectType({
  * }
  * ```
  */
-const queryType = new GraphQLObjectType({
+const queryType = new GraphQLObjectTypeImpl({
   name: 'Query',
   fields: () => ({
     hero: {
@@ -275,7 +277,7 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the human',
-          type: new GraphQLNonNull(GraphQLString),
+          type: new GraphQLNonNullImpl(GraphQLString),
         },
       },
       resolve: (_source, { id }) => getHuman(id),
@@ -285,7 +287,7 @@ const queryType = new GraphQLObjectType({
       args: {
         id: {
           description: 'id of the droid',
-          type: new GraphQLNonNull(GraphQLString),
+          type: new GraphQLNonNullImpl(GraphQLString),
         },
       },
       resolve: (_source, { id }) => getDroid(id),
@@ -297,7 +299,7 @@ const queryType = new GraphQLObjectType({
  * Finally, we construct our schema (whose starting query type is the query
  * type we defined above) and export it.
  */
-export const StarWarsSchema: GraphQLSchema = new GraphQLSchema({
+export const StarWarsSchema: GraphQLSchema = new GraphQLSchemaImpl({
   query: queryType,
   types: [humanType, droidType],
 });

--- a/src/__tests__/starWarsValidation-test.ts
+++ b/src/__tests__/starWarsValidation-test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { parse } from '../language/parser';
-import { Source } from '../language/source';
+import { SourceImpl } from '../language/source';
 
 import { validate } from '../validation/validate';
 
@@ -12,7 +12,7 @@ import { StarWarsSchema } from './starWarsSchema';
  * Helper function to test a query and the expected response.
  */
 function validationErrors(query: string) {
-  const source = new Source(query, 'StarWars.graphql');
+  const source = new SourceImpl(query, 'StarWars.graphql');
   const ast = parse(source);
   return validate(StarWarsSchema, ast);
 }

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -5,11 +5,11 @@ import { dedent } from '../../__testUtils__/dedent';
 
 import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
-import { Source } from '../../language/source';
+import { SourceImpl } from '../../language/source';
 
 import { GraphQLError } from '../GraphQLError';
 
-const source = new Source(dedent`
+const source = new SourceImpl(dedent`
   {
     field
   }
@@ -237,7 +237,7 @@ describe('toString', () => {
 
   it('prints an error with nodes from different sources', () => {
     const docA = parse(
-      new Source(
+      new SourceImpl(
         dedent`
           type Foo {
             field: String
@@ -251,7 +251,7 @@ describe('toString', () => {
     const fieldA = opA.fields[0];
 
     const docB = parse(
-      new Source(
+      new SourceImpl(
         dedent`
           type Foo {
             field: Int

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -7,13 +7,14 @@ import { parse } from '../../language/parser';
 
 import {
   assertInterfaceType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLObjectType,
-  GraphQLUnionType,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../../type/definition';
 import { GraphQLBoolean, GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import type { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
 
@@ -65,14 +66,14 @@ class Cat {
 
 describe('Execute: Handles execution of abstract types', () => {
   it('isTypeOf used to resolve runtime type for Interface', async () => {
-    const PetType = new GraphQLInterfaceType({
+    const PetType = new GraphQLInterfaceTypeImpl({
       name: 'Pet',
       fields: {
         name: { type: GraphQLString },
       },
     });
 
-    const DogType = new GraphQLObjectType({
+    const DogType = new GraphQLObjectTypeImpl({
       name: 'Dog',
       interfaces: [PetType],
       isTypeOf(obj, context) {
@@ -85,7 +86,7 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const CatType = new GraphQLObjectType({
+    const CatType = new GraphQLObjectTypeImpl({
       name: 'Cat',
       interfaces: [PetType],
       isTypeOf(obj, context) {
@@ -98,12 +99,12 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: new GraphQLListImpl(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -144,14 +145,14 @@ describe('Execute: Handles execution of abstract types', () => {
   });
 
   it('isTypeOf can throw', async () => {
-    const PetType = new GraphQLInterfaceType({
+    const PetType = new GraphQLInterfaceTypeImpl({
       name: 'Pet',
       fields: {
         name: { type: GraphQLString },
       },
     });
 
-    const DogType = new GraphQLObjectType({
+    const DogType = new GraphQLObjectTypeImpl({
       name: 'Dog',
       interfaces: [PetType],
       isTypeOf(_source, context) {
@@ -167,7 +168,7 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const CatType = new GraphQLObjectType({
+    const CatType = new GraphQLObjectTypeImpl({
       name: 'Cat',
       interfaces: [PetType],
       isTypeOf: undefined,
@@ -177,12 +178,12 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: new GraphQLListImpl(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -226,14 +227,14 @@ describe('Execute: Handles execution of abstract types', () => {
   });
 
   it('isTypeOf can return false', async () => {
-    const PetType = new GraphQLInterfaceType({
+    const PetType = new GraphQLInterfaceTypeImpl({
       name: 'Pet',
       fields: {
         name: { type: GraphQLString },
       },
     });
 
-    const DogType = new GraphQLObjectType({
+    const DogType = new GraphQLObjectTypeImpl({
       name: 'Dog',
       interfaces: [PetType],
       isTypeOf(_source, context) {
@@ -245,8 +246,8 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           pet: {
@@ -280,7 +281,7 @@ describe('Execute: Handles execution of abstract types', () => {
   });
 
   it('isTypeOf used to resolve runtime type for Union', async () => {
-    const DogType = new GraphQLObjectType({
+    const DogType = new GraphQLObjectTypeImpl({
       name: 'Dog',
       isTypeOf(obj, context) {
         const isDog = obj instanceof Dog;
@@ -292,7 +293,7 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const CatType = new GraphQLObjectType({
+    const CatType = new GraphQLObjectTypeImpl({
       name: 'Cat',
       isTypeOf(obj, context) {
         const isCat = obj instanceof Cat;
@@ -304,17 +305,17 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const PetType = new GraphQLUnionType({
+    const PetType = new GraphQLUnionTypeImpl({
       name: 'Pet',
       types: [DogType, CatType],
     });
 
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: new GraphQLListImpl(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },
@@ -353,7 +354,7 @@ describe('Execute: Handles execution of abstract types', () => {
   });
 
   it('resolveType can throw', async () => {
-    const PetType = new GraphQLInterfaceType({
+    const PetType = new GraphQLInterfaceTypeImpl({
       name: 'Pet',
       resolveType(_source, context) {
         const error = new Error('We are testing this error');
@@ -367,7 +368,7 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const DogType = new GraphQLObjectType({
+    const DogType = new GraphQLObjectTypeImpl({
       name: 'Dog',
       interfaces: [PetType],
       fields: {
@@ -376,7 +377,7 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const CatType = new GraphQLObjectType({
+    const CatType = new GraphQLObjectTypeImpl({
       name: 'Cat',
       interfaces: [PetType],
       fields: {
@@ -385,12 +386,12 @@ describe('Execute: Handles execution of abstract types', () => {
       },
     });
 
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           pets: {
-            type: new GraphQLList(PetType),
+            type: new GraphQLListImpl(PetType),
             resolve() {
               return [new Dog('Odie', true), new Cat('Garfield', false)];
             },

--- a/src/execution/__tests__/directives-test.ts
+++ b/src/execution/__tests__/directives-test.ts
@@ -3,14 +3,14 @@ import { describe, it } from 'mocha';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLObjectType } from '../../type/definition';
+import { GraphQLObjectTypeImpl } from '../../type/definition';
 import { GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { executeSync } from '../execute';
 
-const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
+const schema = new GraphQLSchemaImpl({
+  query: new GraphQLObjectTypeImpl({
     name: 'TestType',
     fields: {
       a: { type: GraphQLString },

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -6,9 +6,9 @@ import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLObjectType } from '../../type/definition';
+import { GraphQLObjectTypeImpl } from '../../type/definition';
 import { GraphQLInt } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { execute, executeSync } from '../execute';
 
@@ -47,21 +47,21 @@ class Root {
   }
 }
 
-const numberHolderType = new GraphQLObjectType({
+const numberHolderType = new GraphQLObjectTypeImpl({
   fields: {
     theNumber: { type: GraphQLInt },
   },
   name: 'NumberHolder',
 });
 
-const schema = new GraphQLSchema({
-  query: new GraphQLObjectType({
+const schema = new GraphQLSchemaImpl({
+  query: new GraphQLObjectTypeImpl({
     fields: {
       numberHolder: { type: numberHolderType },
     },
     name: 'Query',
   }),
-  mutation: new GraphQLObjectType({
+  mutation: new GraphQLObjectTypeImpl({
     fields: {
       immediatelyChangeTheNumber: {
         type: numberHolderType,

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -5,9 +5,12 @@ import { expectJSON } from '../../__testUtils__/expectJSON';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLNonNull, GraphQLObjectType } from '../../type/definition';
+import {
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+} from '../../type/definition';
 import { GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
 
@@ -525,15 +528,15 @@ describe('Execute: handles non-nullable types', () => {
   });
 
   describe('Handles non-null argument', () => {
-    const schemaWithNonNullArg = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schemaWithNonNullArg = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           withNonNullArg: {
             type: GraphQLString,
             args: {
               cannotBeNull: {
-                type: new GraphQLNonNull(GraphQLString),
+                type: new GraphQLNonNullImpl(GraphQLString),
               },
             },
             resolve: (_, args) => 'Passed: ' + String(args.cannotBeNull),

--- a/src/execution/__tests__/resolve-test.ts
+++ b/src/execution/__tests__/resolve-test.ts
@@ -4,16 +4,16 @@ import { describe, it } from 'mocha';
 import { parse } from '../../language/parser';
 
 import type { GraphQLFieldConfig } from '../../type/definition';
-import { GraphQLObjectType } from '../../type/definition';
+import { GraphQLObjectTypeImpl } from '../../type/definition';
 import { GraphQLInt, GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { executeSync } from '../execute';
 
 describe('Execute: resolve function', () => {
   function testSchema(testField: GraphQLFieldConfig<any, any>) {
-    return new GraphQLSchema({
-      query: new GraphQLObjectType({
+    return new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'Query',
         fields: {
           test: testField,

--- a/src/execution/__tests__/schema-test.ts
+++ b/src/execution/__tests__/schema-test.ts
@@ -3,10 +3,11 @@ import { describe, it } from 'mocha';
 
 import { parse } from '../../language/parser';
 
+import type { GraphQLObjectType } from '../../type/definition';
 import {
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
 } from '../../type/definition';
 import {
   GraphQLBoolean,
@@ -14,13 +15,13 @@ import {
   GraphQLInt,
   GraphQLString,
 } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { executeSync } from '../execute';
 
 describe('Execute: Handles execution with a complex schema', () => {
   it('executes using a schema', () => {
-    const BlogImage = new GraphQLObjectType({
+    const BlogImage = new GraphQLObjectTypeImpl({
       name: 'Image',
       fields: {
         url: { type: GraphQLString },
@@ -29,7 +30,7 @@ describe('Execute: Handles execution with a complex schema', () => {
       },
     });
 
-    const BlogAuthor: GraphQLObjectType = new GraphQLObjectType({
+    const BlogAuthor: GraphQLObjectType = new GraphQLObjectTypeImpl({
       name: 'Author',
       fields: () => ({
         id: { type: GraphQLString },
@@ -43,19 +44,19 @@ describe('Execute: Handles execution with a complex schema', () => {
       }),
     });
 
-    const BlogArticle = new GraphQLObjectType({
+    const BlogArticle = new GraphQLObjectTypeImpl({
       name: 'Article',
       fields: {
-        id: { type: new GraphQLNonNull(GraphQLString) },
+        id: { type: new GraphQLNonNullImpl(GraphQLString) },
         isPublished: { type: GraphQLBoolean },
         author: { type: BlogAuthor },
         title: { type: GraphQLString },
         body: { type: GraphQLString },
-        keywords: { type: new GraphQLList(GraphQLString) },
+        keywords: { type: new GraphQLListImpl(GraphQLString) },
       },
     });
 
-    const BlogQuery = new GraphQLObjectType({
+    const BlogQuery = new GraphQLObjectTypeImpl({
       name: 'Query',
       fields: {
         article: {
@@ -64,7 +65,7 @@ describe('Execute: Handles execution with a complex schema', () => {
           resolve: (_, { id }) => article(id),
         },
         feed: {
-          type: new GraphQLList(BlogArticle),
+          type: new GraphQLListImpl(BlogArticle),
           resolve: () => [
             article(1),
             article(2),
@@ -81,7 +82,7 @@ describe('Execute: Handles execution with a complex schema', () => {
       },
     });
 
-    const BlogSchema = new GraphQLSchema({
+    const BlogSchema = new GraphQLSchemaImpl({
       query: BlogQuery,
     });
 

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -8,9 +8,9 @@ import { isAsyncIterable } from '../../jsutils/isAsyncIterable';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLList, GraphQLObjectType } from '../../type/definition';
+import { GraphQLListImpl, GraphQLObjectTypeImpl } from '../../type/definition';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { createSourceEventStream, subscribe } from '../subscribe';
 
@@ -23,7 +23,7 @@ interface Email {
   unread: boolean;
 }
 
-const EmailType = new GraphQLObjectType({
+const EmailType = new GraphQLObjectTypeImpl({
   name: 'Email',
   fields: {
     from: { type: GraphQLString },
@@ -33,7 +33,7 @@ const EmailType = new GraphQLObjectType({
   },
 });
 
-const InboxType = new GraphQLObjectType({
+const InboxType = new GraphQLObjectTypeImpl({
   name: 'Inbox',
   fields: {
     total: {
@@ -45,18 +45,18 @@ const InboxType = new GraphQLObjectType({
       resolve: (inbox) =>
         inbox.emails.filter((email: any) => email.unread).length,
     },
-    emails: { type: new GraphQLList(EmailType) },
+    emails: { type: new GraphQLListImpl(EmailType) },
   },
 });
 
-const QueryType = new GraphQLObjectType({
+const QueryType = new GraphQLObjectTypeImpl({
   name: 'Query',
   fields: {
     inbox: { type: InboxType },
   },
 });
 
-const EmailEventType = new GraphQLObjectType({
+const EmailEventType = new GraphQLObjectTypeImpl({
   name: 'EmailEvent',
   fields: {
     email: { type: EmailType },
@@ -64,9 +64,9 @@ const EmailEventType = new GraphQLObjectType({
   },
 });
 
-const emailSchema = new GraphQLSchema({
+const emailSchema = new GraphQLSchemaImpl({
   query: QueryType,
-  subscription: new GraphQLObjectType({
+  subscription: new GraphQLObjectTypeImpl({
     name: 'Subscription',
     fields: {
       importantEmail: {
@@ -144,7 +144,7 @@ async function expectPromise(promise: Promise<unknown>) {
   };
 }
 
-const DummyQueryType = new GraphQLObjectType({
+const DummyQueryType = new GraphQLObjectTypeImpl({
   name: 'Query',
   fields: {
     dummy: { type: GraphQLString },
@@ -155,9 +155,9 @@ const DummyQueryType = new GraphQLObjectType({
 // Check all error cases when initializing the subscription.
 describe('Subscription Initialization Phase', () => {
   it('accepts multiple subscription fields defined in schema', async () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: { type: GraphQLString },
@@ -193,9 +193,9 @@ describe('Subscription Initialization Phase', () => {
       yield { foo: 'FooValue' };
     }
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: {
@@ -228,9 +228,9 @@ describe('Subscription Initialization Phase', () => {
       yield { foo: 'FooValue' };
     }
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: {
@@ -262,9 +262,9 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('uses a custom default subscribeFieldResolver', async () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: { type: GraphQLString },
@@ -303,9 +303,9 @@ describe('Subscription Initialization Phase', () => {
     let didResolveFoo = false;
     let didResolveBar = false;
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: {
@@ -345,9 +345,9 @@ describe('Subscription Initialization Phase', () => {
 
   it('throws an error if some of required arguments are missing', async () => {
     const document = parse('subscription { foo }');
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: { type: GraphQLString },
@@ -377,7 +377,7 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('resolves to an error if schema does not support subscriptions', async () => {
-    const schema = new GraphQLSchema({ query: DummyQueryType });
+    const schema = new GraphQLSchemaImpl({ query: DummyQueryType });
     const document = parse('subscription { unknownField }');
 
     const result = await subscribe({ schema, document });
@@ -393,9 +393,9 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('resolves to an error for unknown subscription field', async () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: { type: GraphQLString },
@@ -416,9 +416,9 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('should pass through unexpected errors thrown in subscribe', async () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: { type: GraphQLString },
@@ -431,9 +431,9 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('throws an error if subscribe does not return an iterator', async () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: {
@@ -453,9 +453,9 @@ describe('Subscription Initialization Phase', () => {
 
   it('resolves to an error for subscription resolver errors', async () => {
     async function subscribeWithFn(subscribeFn: () => unknown) {
-      const schema = new GraphQLSchema({
+      const schema = new GraphQLSchemaImpl({
         query: DummyQueryType,
-        subscription: new GraphQLObjectType({
+        subscription: new GraphQLObjectTypeImpl({
           name: 'Subscription',
           fields: {
             foo: { type: GraphQLString, subscribe: subscribeFn },
@@ -505,9 +505,9 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('resolves to an error if variables were wrong type', async () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           foo: {
@@ -920,9 +920,9 @@ describe('Subscription Publish Phase', () => {
       yield 'Bonjour';
     }
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           newMessage: {
@@ -986,9 +986,9 @@ describe('Subscription Publish Phase', () => {
       throw new Error('test error');
     }
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: DummyQueryType,
-      subscription: new GraphQLObjectType({
+      subscription: new GraphQLObjectTypeImpl({
         name: 'Subscription',
         fields: {
           newMessage: {

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -5,9 +5,9 @@ import { expectJSON } from '../../__testUtils__/expectJSON';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLObjectType } from '../../type/definition';
+import { GraphQLObjectTypeImpl } from '../../type/definition';
 import { GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { validate } from '../../validation/validate';
 
@@ -16,8 +16,8 @@ import { graphqlSync } from '../../graphql';
 import { execute, executeSync } from '../execute';
 
 describe('Execute: synchronously when possible', () => {
-  const schema = new GraphQLSchema({
-    query: new GraphQLObjectType({
+  const schema = new GraphQLSchemaImpl({
+    query: new GraphQLObjectTypeImpl({
       name: 'Query',
       fields: {
         syncField: {
@@ -34,7 +34,7 @@ describe('Execute: synchronously when possible', () => {
         },
       },
     }),
-    mutation: new GraphQLObjectType({
+    mutation: new GraphQLObjectTypeImpl({
       name: 'Mutation',
       fields: {
         syncMutationField: {
@@ -117,7 +117,7 @@ describe('Execute: synchronously when possible', () => {
 
   describe('graphqlSync', () => {
     it('report errors raised during schema validation', () => {
-      const badSchema = new GraphQLSchema({});
+      const badSchema = new GraphQLSchemaImpl({});
       const result = graphqlSync({
         schema: badSchema,
         source: '{ __typename }',

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -3,14 +3,18 @@ import { describe, it } from 'mocha';
 
 import { parse } from '../../language/parser';
 
-import {
+import type {
   GraphQLInterfaceType,
-  GraphQLList,
   GraphQLObjectType,
-  GraphQLUnionType,
+} from '../../type/definition';
+import {
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../../type/definition';
 import { GraphQLBoolean, GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { executeSync } from '../execute';
 
@@ -58,57 +62,57 @@ class Person {
   }
 }
 
-const NamedType = new GraphQLInterfaceType({
+const NamedType = new GraphQLInterfaceTypeImpl({
   name: 'Named',
   fields: {
     name: { type: GraphQLString },
   },
 });
 
-const LifeType: GraphQLInterfaceType = new GraphQLInterfaceType({
+const LifeType: GraphQLInterfaceType = new GraphQLInterfaceTypeImpl({
   name: 'Life',
   fields: () => ({
-    progeny: { type: new GraphQLList(LifeType) },
+    progeny: { type: new GraphQLListImpl(LifeType) },
   }),
 });
 
-const MammalType: GraphQLInterfaceType = new GraphQLInterfaceType({
+const MammalType: GraphQLInterfaceType = new GraphQLInterfaceTypeImpl({
   name: 'Mammal',
   interfaces: [LifeType],
   fields: () => ({
-    progeny: { type: new GraphQLList(MammalType) },
+    progeny: { type: new GraphQLListImpl(MammalType) },
     mother: { type: MammalType },
     father: { type: MammalType },
   }),
 });
 
-const DogType: GraphQLObjectType = new GraphQLObjectType({
+const DogType: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: 'Dog',
   interfaces: [MammalType, LifeType, NamedType],
   fields: () => ({
     name: { type: GraphQLString },
     barks: { type: GraphQLBoolean },
-    progeny: { type: new GraphQLList(DogType) },
+    progeny: { type: new GraphQLListImpl(DogType) },
     mother: { type: DogType },
     father: { type: DogType },
   }),
   isTypeOf: (value) => value instanceof Dog,
 });
 
-const CatType: GraphQLObjectType = new GraphQLObjectType({
+const CatType: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: 'Cat',
   interfaces: [MammalType, LifeType, NamedType],
   fields: () => ({
     name: { type: GraphQLString },
     meows: { type: GraphQLBoolean },
-    progeny: { type: new GraphQLList(CatType) },
+    progeny: { type: new GraphQLListImpl(CatType) },
     mother: { type: CatType },
     father: { type: CatType },
   }),
   isTypeOf: (value) => value instanceof Cat,
 });
 
-const PetType = new GraphQLUnionType({
+const PetType = new GraphQLUnionTypeImpl({
   name: 'Pet',
   types: [DogType, CatType],
   resolveType(value) {
@@ -124,21 +128,21 @@ const PetType = new GraphQLUnionType({
   },
 });
 
-const PersonType: GraphQLObjectType = new GraphQLObjectType({
+const PersonType: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: 'Person',
   interfaces: [NamedType, MammalType, LifeType],
   fields: () => ({
     name: { type: GraphQLString },
-    pets: { type: new GraphQLList(PetType) },
-    friends: { type: new GraphQLList(NamedType) },
-    progeny: { type: new GraphQLList(PersonType) },
+    pets: { type: new GraphQLListImpl(PetType) },
+    friends: { type: new GraphQLListImpl(NamedType) },
+    progeny: { type: new GraphQLListImpl(PersonType) },
     mother: { type: PersonType },
     father: { type: PersonType },
   }),
   isTypeOf: (value) => value instanceof Person,
 });
 
-const schema = new GraphQLSchema({
+const schema = new GraphQLSchemaImpl({
   query: PersonType,
   types: [PetType],
 });
@@ -502,7 +506,7 @@ describe('Execute: Union and intersection types', () => {
     let encounteredSchema;
     let encounteredRootValue;
 
-    const NamedType2: GraphQLInterfaceType = new GraphQLInterfaceType({
+    const NamedType2: GraphQLInterfaceType = new GraphQLInterfaceTypeImpl({
       name: 'Named',
       fields: {
         name: { type: GraphQLString },
@@ -515,15 +519,15 @@ describe('Execute: Union and intersection types', () => {
       },
     });
 
-    const PersonType2: GraphQLObjectType = new GraphQLObjectType({
+    const PersonType2: GraphQLObjectType = new GraphQLObjectTypeImpl({
       name: 'Person',
       interfaces: [NamedType2],
       fields: {
         name: { type: GraphQLString },
-        friends: { type: new GraphQLList(NamedType2) },
+        friends: { type: new GraphQLListImpl(NamedType2) },
       },
     });
-    const schema2 = new GraphQLSchema({ query: PersonType2 });
+    const schema2 = new GraphQLSchemaImpl({ query: PersonType2 });
     const document = parse('{ name, friends { name } }');
     const rootValue = new Person('John', [], [liz]);
     const contextValue = { authToken: '123abc' };

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -13,20 +13,20 @@ import type {
   GraphQLFieldConfig,
 } from '../../type/definition';
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLScalarType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
 } from '../../type/definition';
 import { GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { executeSync } from '../execute';
 import { getVariableValues } from '../values';
 
-const TestComplexScalar = new GraphQLScalarType({
+const TestComplexScalar = new GraphQLScalarTypeImpl({
   name: 'ComplexScalar',
   parseValue(value) {
     expect(value).to.equal('SerializedValue');
@@ -38,25 +38,25 @@ const TestComplexScalar = new GraphQLScalarType({
   },
 });
 
-const TestInputObject = new GraphQLInputObjectType({
+const TestInputObject = new GraphQLInputObjectTypeImpl({
   name: 'TestInputObject',
   fields: {
     a: { type: GraphQLString },
-    b: { type: new GraphQLList(GraphQLString) },
-    c: { type: new GraphQLNonNull(GraphQLString) },
+    b: { type: new GraphQLListImpl(GraphQLString) },
+    c: { type: new GraphQLNonNullImpl(GraphQLString) },
     d: { type: TestComplexScalar },
   },
 });
 
-const TestNestedInputObject = new GraphQLInputObjectType({
+const TestNestedInputObject = new GraphQLInputObjectTypeImpl({
   name: 'TestNestedInputObject',
   fields: {
-    na: { type: new GraphQLNonNull(TestInputObject) },
-    nb: { type: new GraphQLNonNull(GraphQLString) },
+    na: { type: new GraphQLNonNullImpl(TestInputObject) },
+    nb: { type: new GraphQLNonNullImpl(GraphQLString) },
   },
 });
 
-const TestEnum = new GraphQLEnumType({
+const TestEnum = new GraphQLEnumTypeImpl({
   name: 'TestEnum',
   values: {
     NULL: { value: null },
@@ -82,46 +82,46 @@ function fieldWithInputArg(
   };
 }
 
-const TestType = new GraphQLObjectType({
+const TestType = new GraphQLObjectTypeImpl({
   name: 'TestType',
   fields: {
     fieldWithEnumInput: fieldWithInputArg({ type: TestEnum }),
     fieldWithNonNullableEnumInput: fieldWithInputArg({
-      type: new GraphQLNonNull(TestEnum),
+      type: new GraphQLNonNullImpl(TestEnum),
     }),
     fieldWithObjectInput: fieldWithInputArg({ type: TestInputObject }),
     fieldWithNullableStringInput: fieldWithInputArg({ type: GraphQLString }),
     fieldWithNonNullableStringInput: fieldWithInputArg({
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
     }),
     fieldWithDefaultArgumentValue: fieldWithInputArg({
       type: GraphQLString,
       defaultValue: 'Hello World',
     }),
     fieldWithNonNullableStringInputAndDefaultArgumentValue: fieldWithInputArg({
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
       defaultValue: 'Hello World',
     }),
     fieldWithNestedInputObject: fieldWithInputArg({
       type: TestNestedInputObject,
       defaultValue: 'Hello World',
     }),
-    list: fieldWithInputArg({ type: new GraphQLList(GraphQLString) }),
+    list: fieldWithInputArg({ type: new GraphQLListImpl(GraphQLString) }),
     nnList: fieldWithInputArg({
-      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      type: new GraphQLNonNullImpl(new GraphQLListImpl(GraphQLString)),
     }),
     listNN: fieldWithInputArg({
-      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      type: new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
     }),
     nnListNN: fieldWithInputArg({
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      type: new GraphQLNonNullImpl(
+        new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
       ),
     }),
   },
 });
 
-const schema = new GraphQLSchema({ query: TestType });
+const schema = new GraphQLSchemaImpl({ query: TestType });
 
 function executeQuery(
   query: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,16 +38,16 @@ export {
   resolveObjMapThunk,
   resolveReadonlyArrayThunk,
   // Definitions
-  GraphQLSchema,
-  GraphQLDirective,
-  GraphQLScalarType,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
+  GraphQLSchemaImpl,
+  GraphQLDirectiveImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLUnionTypeImpl,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
   // Standard GraphQL Scalars
   specifiedScalarTypes,
   GraphQLInt,
@@ -201,7 +201,7 @@ export type {
 // Parse and operate on GraphQL language source files.
 export {
   Token,
-  Source,
+  SourceImpl,
   Location,
   OperationTypeNode,
   getLocation,
@@ -222,7 +222,6 @@ export {
   visit,
   visitInParallel,
   getEnterLeaveForKind,
-  BREAK,
   Kind,
   DirectiveLocation,
   // Predicates
@@ -240,6 +239,7 @@ export {
 
 export type {
   ParseOptions,
+  Source,
   SourceLocation,
   // Visitor utilities
   ASTVisitor,
@@ -440,9 +440,30 @@ export {
   DangerousChangeType,
   findBreakingChanges,
   findDangerousChanges,
+  // Base class containing version.
+  GraphQLEntityImpl,
+  // Enum of GraphQL entity kinds.
+  GraphQLEntityKind,
+  // Symbol for GraphQL entity version
+  GRAPHQL_VERSION_SYMBOL,
+  // Symbols for GraphQL entity kinds
+  GRAPHQL_SCALAR_TYPE_SYMBOL,
+  GRAPHQL_OBJECT_TYPE_SYMBOL,
+  GRAPHQL_INTERFACE_TYPE_SYMBOL,
+  GRAPHQL_UNION_TYPE_SYMBOL,
+  GRAPHQL_ENUM_TYPE_SYMBOL,
+  GRAPHQL_INPUT_OBJECT_TYPE_SYMBOL,
+  GRAPHQL_LIST_TYPE_SYMBOL,
+  GRAPHQL_NON_NULL_TYPE_SYMBOL,
+  GRAPHQL_DIRECTIVE_SYMBOL,
+  GRAPHQL_SCHEMA_SYMBOL,
+  GRAPHQL_SOURCE_SYMBOL,
+  isEntity,
+  ofVersion,
 } from './utilities/index';
 
 export type {
+  GraphQLEntity,
   IntrospectionOptions,
   IntrospectionQuery,
   IntrospectionSchema,

--- a/src/jsutils/__tests__/instanceOf-test.ts
+++ b/src/jsutils/__tests__/instanceOf-test.ts
@@ -1,79 +1,49 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { GraphQLScalarTypeImpl } from '../../type/definition';
+
+import {
+  GRAPHQL_VERSION_SYMBOL,
+  GraphQLEntityKind,
+} from '../../utilities/entities';
+
+import { identityFunc } from '../identityFunc';
 import { instanceOf } from '../instanceOf';
 
 describe('instanceOf', () => {
-  it('do not throw on values without prototype', () => {
-    class Foo {
-      get [Symbol.toStringTag]() {
-        return 'Foo';
-      }
-    }
-
-    expect(instanceOf(true, Foo)).to.equal(false);
-    expect(instanceOf(null, Foo)).to.equal(false);
-    expect(instanceOf(Object.create(null), Foo)).to.equal(false);
+  it('do not throw on unknown entities', () => {
+    // @ts-expect-error
+    expect(instanceOf(true, '')).to.equal(false);
+    // @ts-expect-error
+    expect(instanceOf(null, '')).to.equal(false);
+    // @ts-expect-error
+    expect(instanceOf(Object.create(null), '')).to.equal(false);
   });
 
   it('detect name clashes with older versions of this lib', () => {
-    function oldVersion() {
-      class Foo {}
-      return Foo;
-    }
+    const scalar = new GraphQLScalarTypeImpl({
+      name: 'Scalar',
+      serialize: identityFunc,
+    });
 
-    function newVersion() {
-      class Foo {
-        get [Symbol.toStringTag]() {
-          return 'Foo';
-        }
-      }
-      return Foo;
-    }
+    // @ts-expect-error
+    delete scalar[GRAPHQL_VERSION_SYMBOL];
 
-    const NewClass = newVersion();
-    const OldClass = oldVersion();
-    expect(instanceOf(new NewClass(), NewClass)).to.equal(true);
-    expect(() => instanceOf(new OldClass(), NewClass)).to.throw();
-  });
-
-  it('allows instances to have share the same constructor name', () => {
-    function getMinifiedClass(tag: string) {
-      class SomeNameAfterMinification {
-        get [Symbol.toStringTag]() {
-          return tag;
-        }
-      }
-      return SomeNameAfterMinification;
-    }
-
-    const Foo = getMinifiedClass('Foo');
-    const Bar = getMinifiedClass('Bar');
-    expect(instanceOf(new Foo(), Bar)).to.equal(false);
-    expect(instanceOf(new Bar(), Foo)).to.equal(false);
-
-    const DuplicateOfFoo = getMinifiedClass('Foo');
-    expect(() => instanceOf(new DuplicateOfFoo(), Foo)).to.throw();
-    expect(() => instanceOf(new Foo(), DuplicateOfFoo)).to.throw();
+    expect(() => instanceOf(scalar, GraphQLEntityKind.SCALAR_TYPE)).to.throw();
   });
 
   it('fails with descriptive error message', () => {
-    function getFoo() {
-      class Foo {
-        get [Symbol.toStringTag]() {
-          return 'Foo';
-        }
-      }
-      return Foo;
-    }
-    const Foo1 = getFoo();
-    const Foo2 = getFoo();
+    const scalar = new GraphQLScalarTypeImpl({
+      name: 'Scalar',
+      serialize: identityFunc,
+    });
 
-    expect(() => instanceOf(new Foo1(), Foo2)).to.throw(
-      /^Cannot use Foo "{}" from another module or realm./m,
-    );
-    expect(() => instanceOf(new Foo2(), Foo1)).to.throw(
-      /^Cannot use Foo "{}" from another module or realm./m,
+    // @ts-expect-error
+    delete scalar[GRAPHQL_VERSION_SYMBOL];
+
+    expect(() => instanceOf(scalar, GraphQLEntityKind.SCALAR_TYPE)).to.throw(
+      /^Cannot use value "Scalar" for entity type "ScalarType"./m,
     );
   });
 });

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,54 +1,49 @@
+import type { GraphQLEntityKind } from '../utilities/entities';
+import { isEntity, ofVersion } from '../utilities/entities';
+
 import { inspect } from './inspect';
+import { isObjectLike } from './isObjectLike';
 
 /**
- * A replacement for instanceof which includes an error warning when multi-realm
- * constructors are detected.
+ * A replacement for instanceof which:
+ * 1. uses cross-realm symbols
+ * 2. includes an error warning with different versions
  * See: https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production
  * See: https://webpack.js.org/guides/production/
  */
-export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
+export const instanceOf: (value: unknown, type: GraphQLEntityKind) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
   globalThis.process?.env.NODE_ENV === 'production'
-    ? function instanceOf(value: unknown, constructor: Constructor): boolean {
-        return value instanceof constructor;
+    ? function instanceOf(value: unknown, type: GraphQLEntityKind): boolean {
+        return isObjectLike(value) && isEntity(value, type);
       }
-    : function instanceOf(value: unknown, constructor: Constructor): boolean {
-        if (value instanceof constructor) {
-          return true;
+    : function instanceOf(value: unknown, type: GraphQLEntityKind): boolean {
+        if (!isObjectLike(value)) {
+          return false;
         }
-        if (typeof value === 'object' && value !== null) {
-          // Prefer Symbol.toStringTag since it is immune to minification.
-          const className = constructor.prototype[Symbol.toStringTag];
-          const valueClassName =
-            // We still need to support constructor's name to detect conflicts with older versions of this library.
-            Symbol.toStringTag in value
-              ? // @ts-expect-error TS bug see, https://github.com/microsoft/TypeScript/issues/38009
-                value[Symbol.toStringTag]
-              : value.constructor?.name;
-          if (className === valueClassName) {
+
+        if (isEntity(value, type)) {
+          if (!ofVersion(value)) {
             const stringifiedValue = inspect(value);
             throw new Error(
-              `Cannot use ${className} "${stringifiedValue}" from another module or realm.
+              `Cannot use value "${stringifiedValue}" for entity type "${type}".
+The value is tagged with a different version of "graphql".
 
-Ensure that there is only one instance of "graphql" in the node_modules
+Ensure that there is only one version of "graphql" in the node_modules
 directory. If different versions of "graphql" are the dependencies of other
 relied on modules, use "resolutions" to ensure only one version is installed.
 
 https://yarnpkg.com/en/docs/selective-version-resolutions
 
-Duplicate "graphql" modules cannot be used at the same time since different
-versions may have different capabilities and behavior. The data from one
-version used in the function from another could produce confusing and
-spurious results.`,
+Duplicate "graphql" modules of different versions cannot be used at the same
+time since different versions may have different capabilities and behavior.
+The data from one version used in the function from another could produce
+confusing and spurious results.`,
             );
           }
+          return true;
         }
+
         return false;
       };
-
-interface Constructor extends Function {
-  prototype: {
-    [Symbol.toStringTag]: string;
-  };
-}

--- a/src/language/__tests__/blockString-fuzz.ts
+++ b/src/language/__tests__/blockString-fuzz.ts
@@ -7,10 +7,10 @@ import { inspectStr } from '../../__testUtils__/inspectStr';
 
 import { isPrintableAsBlockString, printBlockString } from '../blockString';
 import { Lexer } from '../lexer';
-import { Source } from '../source';
+import { SourceImpl } from '../source';
 
 function lexValue(str: string): string {
-  const lexer = new Lexer(new Source(str));
+  const lexer = new Lexer(new SourceImpl(str));
   const value = lexer.advance().value;
 
   assert(typeof value === 'string');

--- a/src/language/__tests__/lexer-test.ts
+++ b/src/language/__tests__/lexer-test.ts
@@ -10,16 +10,16 @@ import { GraphQLError } from '../../error/GraphQLError';
 
 import type { Token } from '../ast';
 import { isPunctuatorTokenKind, Lexer } from '../lexer';
-import { Source } from '../source';
+import { SourceImpl } from '../source';
 import { TokenKind } from '../tokenKind';
 
 function lexOne(str: string) {
-  const lexer = new Lexer(new Source(str));
+  const lexer = new Lexer(new SourceImpl(str));
   return lexer.advance();
 }
 
 function lexSecond(str: string) {
-  const lexer = new Lexer(new Source(str));
+  const lexer = new Lexer(new SourceImpl(str));
   lexer.advance();
   return lexer.advance();
 }
@@ -109,7 +109,7 @@ describe('Lexer', () => {
   });
 
   it('can be Object.toStringified, JSON.stringified, or jsutils.inspected', () => {
-    const lexer = new Lexer(new Source('foo'));
+    const lexer = new Lexer(new SourceImpl('foo'));
     const token = lexer.advance();
 
     expect(Object.prototype.toString.call(lexer)).to.equal('[object Lexer]');
@@ -187,7 +187,7 @@ describe('Lexer', () => {
     let caughtError;
     try {
       const str = ['', '', '     ~', ''].join('\n');
-      const source = new Source(str, 'foo.js', { line: 11, column: 12 });
+      const source = new SourceImpl(str, 'foo.js', { line: 11, column: 12 });
       new Lexer(source).advance();
     } catch (error) {
       caughtError = error;
@@ -206,7 +206,7 @@ describe('Lexer', () => {
   it('updates column numbers in error for file context', () => {
     let caughtError;
     try {
-      const source = new Source('~', 'foo.js', { line: 1, column: 5 });
+      const source = new SourceImpl('~', 'foo.js', { line: 1, column: 5 });
       new Lexer(source).advance();
     } catch (error) {
       caughtError = error;
@@ -1084,7 +1084,7 @@ describe('Lexer', () => {
   });
 
   it('lex reports useful information for dashes in names', () => {
-    const source = new Source('a-b');
+    const source = new SourceImpl('a-b');
     const lexer = new Lexer(source);
     const firstToken = lexer.advance();
     expect(firstToken).to.contain({
@@ -1103,7 +1103,7 @@ describe('Lexer', () => {
   });
 
   it('produces double linked list of tokens, including comments', () => {
-    const source = new Source(`
+    const source = new SourceImpl(`
       {
         #comment
         field

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -9,7 +9,7 @@ import { inspect } from '../../jsutils/inspect';
 
 import { Kind } from '../kinds';
 import { parse, parseConstValue, parseType, parseValue } from '../parser';
-import { Source } from '../source';
+import { SourceImpl } from '../source';
 import { TokenKind } from '../tokenKind';
 
 function expectSyntaxError(text: string) {
@@ -71,7 +71,7 @@ describe('Parser', () => {
   it('parse provides useful error when using source', () => {
     let caughtError;
     try {
-      parse(new Source('query', 'MyQuery.graphql'));
+      parse(new SourceImpl('query', 'MyQuery.graphql'));
     } catch (error) {
       caughtError = error;
     }
@@ -400,7 +400,7 @@ describe('Parser', () => {
   });
 
   it('contains references to source', () => {
-    const source = new Source('{ id }');
+    const source = new SourceImpl('{ id }');
     const result = parse(source);
 
     expect(result).to.have.nested.property('loc.source', source);

--- a/src/language/__tests__/printLocation-test.ts
+++ b/src/language/__tests__/printLocation-test.ts
@@ -4,11 +4,11 @@ import { describe, it } from 'mocha';
 import { dedent } from '../../__testUtils__/dedent';
 
 import { printSourceLocation } from '../printLocation';
-import { Source } from '../source';
+import { SourceImpl } from '../source';
 
 describe('printSourceLocation', () => {
   it('prints minified documents', () => {
-    const minifiedSource = new Source(
+    const minifiedSource = new SourceImpl(
       'query SomeMinifiedQueryWithErrorInside($foo:String!=FIRST_ERROR_HERE$bar:String){someField(foo:$foo bar:$bar baz:SECOND_ERROR_HERE){fieldA fieldB{fieldC fieldD...on THIRD_ERROR_HERE}}}',
     );
 
@@ -50,7 +50,7 @@ describe('printSourceLocation', () => {
 
   it('prints single digit line number with no padding', () => {
     const result = printSourceLocation(
-      new Source('*', 'Test', { line: 9, column: 1 }),
+      new SourceImpl('*', 'Test', { line: 9, column: 1 }),
       { line: 1, column: 1 },
     );
 
@@ -63,7 +63,7 @@ describe('printSourceLocation', () => {
 
   it('prints an line numbers with correct padding', () => {
     const result = printSourceLocation(
-      new Source('*\n', 'Test', { line: 9, column: 1 }),
+      new SourceImpl('*\n', 'Test', { line: 9, column: 1 }),
       { line: 1, column: 1 },
     );
 

--- a/src/language/__tests__/source-test.ts
+++ b/src/language/__tests__/source-test.ts
@@ -1,32 +1,32 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { Source } from '../source';
+import { SourceImpl } from '../source';
 
 describe('Source', () => {
   it('asserts that a body was provided', () => {
     // @ts-expect-error
-    expect(() => new Source()).to.throw(
+    expect(() => new SourceImpl()).to.throw(
       'Body must be a string. Received: undefined.',
     );
   });
 
   it('asserts that a valid body was provided', () => {
     // @ts-expect-error
-    expect(() => new Source({})).to.throw(
+    expect(() => new SourceImpl({})).to.throw(
       'Body must be a string. Received: {}.',
     );
   });
 
   it('can be Object.toStringified', () => {
-    const source = new Source('');
+    const source = new SourceImpl('');
 
     expect(Object.prototype.toString.call(source)).to.equal('[object Source]');
   });
 
   it('rejects invalid locationOffset', () => {
     function createSource(locationOffset: { line: number; column: number }) {
-      return new Source('', '', locationOffset);
+      return new SourceImpl('', '', locationOffset);
     }
 
     expect(() => createSource({ line: 0, column: 1 })).to.throw(

--- a/src/language/__tests__/visitor-test.ts
+++ b/src/language/__tests__/visitor-test.ts
@@ -8,7 +8,7 @@ import { isNode } from '../ast';
 import { Kind } from '../kinds';
 import { parse } from '../parser';
 import type { ASTVisitor, ASTVisitorKeyMap } from '../visitor';
-import { BREAK, visit, visitInParallel } from '../visitor';
+import { visit, visitInParallel } from '../visitor';
 
 function checkVisitorFnArgs(ast: any, args: any, isEdited: boolean = false) {
   const [node, key, parent, path, ancestors] = args;
@@ -320,7 +320,7 @@ describe('Visitor', () => {
 
     const ast = parse('{ a, b { x }, c }', { noLocation: true });
     visit(ast, {
-      enter(node) {
+      enter(node, _key, _parent, _path, _ancestors, BREAK) {
         checkVisitorFnArgs(ast, arguments);
         visited.push(['enter', node.kind, getValue(node)]);
         if (node.kind === 'Name' && node.value === 'x') {
@@ -360,7 +360,7 @@ describe('Visitor', () => {
         visited.push(['enter', node.kind, getValue(node)]);
       },
 
-      leave(node) {
+      leave(node, _key, _parent, _path, _ancestors, BREAK) {
         checkVisitorFnArgs(ast, arguments);
         visited.push(['leave', node.kind, getValue(node)]);
         if (node.kind === 'Name' && node.value === 'x') {
@@ -1016,7 +1016,7 @@ describe('Visitor', () => {
         ast,
         visitInParallel([
           {
-            enter(node) {
+            enter(node, _key, _parent, _path, _ancestors, BREAK) {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['enter', node.kind, getValue(node)]);
               if (node.kind === 'Name' && node.value === 'x') {
@@ -1056,7 +1056,7 @@ describe('Visitor', () => {
         ast,
         visitInParallel([
           {
-            enter(node) {
+            enter(node, _key, _parent, _path, _ancestors, BREAK) {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['break-a', 'enter', node.kind, getValue(node)]);
               if (node.kind === 'Name' && node.value === 'a') {
@@ -1069,7 +1069,7 @@ describe('Visitor', () => {
             },
           },
           {
-            enter(node) {
+            enter(node, _key, _parent, _path, _ancestors, BREAK) {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['break-b', 'enter', node.kind, getValue(node)]);
               if (node.kind === 'Name' && node.value === 'b') {
@@ -1122,7 +1122,7 @@ describe('Visitor', () => {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['enter', node.kind, getValue(node)]);
             },
-            leave(node) {
+            leave(node, _key, _parent, _path, _ancestors, BREAK) {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['leave', node.kind, getValue(node)]);
               if (node.kind === 'Name' && node.value === 'x') {
@@ -1163,7 +1163,7 @@ describe('Visitor', () => {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['break-a', 'enter', node.kind, getValue(node)]);
             },
-            leave(node) {
+            leave(node, _key, _parent, _path, _ancestors, BREAK) {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['break-a', 'leave', node.kind, getValue(node)]);
               if (node.kind === 'Field' && node.name.value === 'a') {
@@ -1176,7 +1176,7 @@ describe('Visitor', () => {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['break-b', 'enter', node.kind, getValue(node)]);
             },
-            leave(node) {
+            leave(node, _key, _parent, _path, _ancestors, BREAK) {
               checkVisitorFnArgs(ast, arguments);
               visited.push(['break-b', 'leave', node.kind, getValue(node)]);
               if (node.kind === 'Field' && node.name.value === 'b') {

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -1,4 +1,5 @@
-export { Source } from './source';
+export type { Source } from './source';
+export { SourceImpl } from './source';
 
 export { getLocation } from './location';
 export type { SourceLocation } from './location';
@@ -16,7 +17,7 @@ export type { ParseOptions } from './parser';
 
 export { print } from './printer';
 
-export { visit, visitInParallel, getEnterLeaveForKind, BREAK } from './visitor';
+export { visit, visitInParallel, getEnterLeaveForKind } from './visitor';
 export type { ASTVisitor, ASTVisitFn, ASTVisitorKeyMap } from './visitor';
 
 export { Location, Token, OperationTypeNode } from './ast';

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -64,7 +64,8 @@ import { Location, OperationTypeNode } from './ast';
 import { DirectiveLocation } from './directiveLocation';
 import { Kind } from './kinds';
 import { isPunctuatorTokenKind, Lexer } from './lexer';
-import { isSource, Source } from './source';
+import type { Source } from './source';
+import { isSource, SourceImpl } from './source';
 import { TokenKind } from './tokenKind';
 
 /**
@@ -181,7 +182,7 @@ export class Parser {
   protected _lexer: Lexer;
 
   constructor(source: string | Source, options?: ParseOptions) {
-    const sourceObj = isSource(source) ? source : new Source(source);
+    const sourceObj = isSource(source) ? source : new SourceImpl(source);
 
     this._lexer = new Lexer(sourceObj);
     this._options = options;

--- a/src/language/source.ts
+++ b/src/language/source.ts
@@ -2,9 +2,23 @@ import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { instanceOf } from '../jsutils/instanceOf';
 
+import type { GraphQLEntity } from '../utilities/entities';
+import {
+  GRAPHQL_SOURCE_SYMBOL,
+  GraphQLEntityImpl,
+  GraphQLEntityKind,
+} from '../utilities/entities';
+
 interface Location {
   line: number;
   column: number;
+}
+
+export interface Source extends GraphQLEntity {
+  readonly [GRAPHQL_SOURCE_SYMBOL]: unknown;
+  body: string;
+  name: string;
+  locationOffset: Location;
 }
 
 /**
@@ -14,7 +28,8 @@ interface Location {
  * be useful for `name` to be `"Foo.graphql"` and location to be `{ line: 40, column: 1 }`.
  * The `line` and `column` properties in `locationOffset` are 1-indexed.
  */
-export class Source {
+export class SourceImpl extends GraphQLEntityImpl implements Source {
+  readonly [GRAPHQL_SOURCE_SYMBOL] = true;
   body: string;
   name: string;
   locationOffset: Location;
@@ -24,6 +39,7 @@ export class Source {
     name: string = 'GraphQL request',
     locationOffset: Location = { line: 1, column: 1 },
   ) {
+    super();
     devAssert(
       typeof body === 'string',
       `Body must be a string. Received: ${inspect(body)}.`,
@@ -53,5 +69,5 @@ export class Source {
  * @internal
  */
 export function isSource(source: unknown): source is Source {
-  return instanceOf(source, Source);
+  return instanceOf(source, GraphQLEntityKind.SOURCE);
 }

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -41,6 +41,7 @@ export type ASTVisitFn<TVisitedNode extends ASTNode> = (
    * Note: ancestors includes arrays which contain the parent of visited node.
    */
   ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
+  BREAK: unknown,
 ) => any;
 
 /**
@@ -84,7 +85,7 @@ export type ASTVisitorKeyMap = {
   [NodeT in ASTNode as NodeT['kind']]?: ReadonlyArray<keyof NodeT>;
 };
 
-export const BREAK: unknown = Object.freeze({});
+const BREAK: unknown = Object.freeze({});
 
 /**
  * visit() will walk through an AST using a depth-first traversal, calling
@@ -251,7 +252,15 @@ export function visit(
         ? enterLeaveMap.get(node.kind)?.leave
         : enterLeaveMap.get(node.kind)?.enter;
 
-      result = visitFn?.call(visitor, node, key, parent, path, ancestors);
+      result = visitFn?.call(
+        visitor,
+        node,
+        key,
+        parent,
+        path,
+        ancestors,
+        BREAK,
+      );
 
       if (result === BREAK) {
         break;

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -8,46 +8,51 @@ import { parseValue } from '../../language/parser';
 
 import type { GraphQLNullableType, GraphQLType } from '../definition';
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLUnionType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../definition';
 
-const ScalarType = new GraphQLScalarType({ name: 'Scalar' });
-const ObjectType = new GraphQLObjectType({ name: 'Object', fields: {} });
-const InterfaceType = new GraphQLInterfaceType({
+const ScalarType = new GraphQLScalarTypeImpl({ name: 'Scalar' });
+const ObjectType = new GraphQLObjectTypeImpl({ name: 'Object', fields: {} });
+const InterfaceType = new GraphQLInterfaceTypeImpl({
   name: 'Interface',
   fields: {},
 });
-const UnionType = new GraphQLUnionType({ name: 'Union', types: [ObjectType] });
-const EnumType = new GraphQLEnumType({ name: 'Enum', values: { foo: {} } });
-const InputObjectType = new GraphQLInputObjectType({
+const UnionType = new GraphQLUnionTypeImpl({
+  name: 'Union',
+  types: [ObjectType],
+});
+const EnumType = new GraphQLEnumTypeImpl({ name: 'Enum', values: { foo: {} } });
+const InputObjectType = new GraphQLInputObjectTypeImpl({
   name: 'InputObject',
   fields: {},
 });
 
-const ListOfScalarsType = new GraphQLList(ScalarType);
-const NonNullScalarType = new GraphQLNonNull(ScalarType);
-const ListOfNonNullScalarsType = new GraphQLList(NonNullScalarType);
-const NonNullListOfScalars = new GraphQLNonNull(ListOfScalarsType);
+const ListOfScalarsType = new GraphQLListImpl(ScalarType);
+const NonNullScalarType = new GraphQLNonNullImpl(ScalarType);
+const ListOfNonNullScalarsType = new GraphQLListImpl(NonNullScalarType);
+const NonNullListOfScalars = new GraphQLNonNullImpl(ListOfScalarsType);
 
 /* c8 ignore next */
 const dummyFunc = () => expect.fail('Never called and used as a placeholder');
 
 describe('Type System: Scalars', () => {
   it('accepts a Scalar type defining serialize', () => {
-    expect(() => new GraphQLScalarType({ name: 'SomeScalar' })).to.not.throw();
+    expect(
+      () => new GraphQLScalarTypeImpl({ name: 'SomeScalar' }),
+    ).to.not.throw();
   });
 
   it('accepts a Scalar type defining specifiedByURL', () => {
     expect(
       () =>
-        new GraphQLScalarType({
+        new GraphQLScalarTypeImpl({
           name: 'SomeScalar',
           specifiedByURL: 'https://example.com/foo_spec',
         }),
@@ -57,7 +62,7 @@ describe('Type System: Scalars', () => {
   it('accepts a Scalar type defining parseValue and parseLiteral', () => {
     expect(
       () =>
-        new GraphQLScalarType({
+        new GraphQLScalarTypeImpl({
           name: 'SomeScalar',
           parseValue: dummyFunc,
           parseLiteral: dummyFunc,
@@ -66,7 +71,7 @@ describe('Type System: Scalars', () => {
   });
 
   it('provides default methods if omitted', () => {
-    const scalar = new GraphQLScalarType({ name: 'Foo' });
+    const scalar = new GraphQLScalarTypeImpl({ name: 'Foo' });
 
     expect(scalar.serialize).to.equal(identityFunc);
     expect(scalar.parseValue).to.equal(identityFunc);
@@ -74,7 +79,7 @@ describe('Type System: Scalars', () => {
   });
 
   it('use parseValue for parsing literals if parseLiteral omitted', () => {
-    const scalar = new GraphQLScalarType({
+    const scalar = new GraphQLScalarTypeImpl({
       name: 'Foo',
       parseValue(value) {
         return 'parseValue: ' + inspect(value);
@@ -94,13 +99,13 @@ describe('Type System: Scalars', () => {
 
   it('rejects a Scalar type without name', () => {
     // @ts-expect-error
-    expect(() => new GraphQLScalarType({})).to.throw('Must provide name.');
+    expect(() => new GraphQLScalarTypeImpl({})).to.throw('Must provide name.');
   });
 
   it('rejects a Scalar type defining serialize with an incorrect type', () => {
     expect(
       () =>
-        new GraphQLScalarType({
+        new GraphQLScalarTypeImpl({
           name: 'SomeScalar',
           // @ts-expect-error
           serialize: {},
@@ -113,7 +118,7 @@ describe('Type System: Scalars', () => {
   it('rejects a Scalar type defining parseLiteral but not parseValue', () => {
     expect(
       () =>
-        new GraphQLScalarType({
+        new GraphQLScalarTypeImpl({
           name: 'SomeScalar',
           parseLiteral: dummyFunc,
         }),
@@ -125,7 +130,7 @@ describe('Type System: Scalars', () => {
   it('rejects a Scalar type defining parseValue and parseLiteral with an incorrect type', () => {
     expect(
       () =>
-        new GraphQLScalarType({
+        new GraphQLScalarTypeImpl({
           name: 'SomeScalar',
           // @ts-expect-error
           parseValue: {},
@@ -140,7 +145,7 @@ describe('Type System: Scalars', () => {
   it('rejects a Scalar type defining specifiedByURL with an incorrect type', () => {
     expect(
       () =>
-        new GraphQLScalarType({
+        new GraphQLScalarTypeImpl({
           name: 'SomeScalar',
           // @ts-expect-error
           specifiedByURL: {},
@@ -162,11 +167,11 @@ describe('Type System: Objects', () => {
         },
       },
     };
-    const testObject1 = new GraphQLObjectType({
+    const testObject1 = new GraphQLObjectTypeImpl({
       name: 'Test1',
       fields: outputFields,
     });
-    const testObject2 = new GraphQLObjectType({
+    const testObject2 = new GraphQLObjectTypeImpl({
       name: 'Test2',
       fields: outputFields,
     });
@@ -188,11 +193,11 @@ describe('Type System: Objects', () => {
       field1: { type: ScalarType },
       field2: { type: ScalarType },
     };
-    const testInputObject1 = new GraphQLInputObjectType({
+    const testInputObject1 = new GraphQLInputObjectTypeImpl({
       name: 'Test1',
       fields: inputFields,
     });
-    const testInputObject2 = new GraphQLInputObjectType({
+    const testInputObject2 = new GraphQLInputObjectTypeImpl({
       name: 'Test2',
       fields: inputFields,
     });
@@ -207,7 +212,7 @@ describe('Type System: Objects', () => {
   });
 
   it('defines an object type with deprecated field', () => {
-    const TypeWithDeprecatedField = new GraphQLObjectType({
+    const TypeWithDeprecatedField = new GraphQLObjectTypeImpl({
       name: 'foo',
       fields: {
         bar: {
@@ -233,7 +238,7 @@ describe('Type System: Objects', () => {
   });
 
   it('accepts an Object type with a field function', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: () => ({
         f: { type: ScalarType },
@@ -255,7 +260,7 @@ describe('Type System: Objects', () => {
   });
 
   it('accepts an Object type with field args', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         f: {
@@ -292,7 +297,7 @@ describe('Type System: Objects', () => {
   });
 
   it('accepts an Object type with array interfaces', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {},
       interfaces: [InterfaceType],
@@ -301,7 +306,7 @@ describe('Type System: Objects', () => {
   });
 
   it('accepts an Object type with interfaces as a function returning an array', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {},
       interfaces: () => [InterfaceType],
@@ -310,7 +315,7 @@ describe('Type System: Objects', () => {
   });
 
   it('accepts a lambda as an Object field resolver', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         f: {
@@ -324,12 +329,12 @@ describe('Type System: Objects', () => {
 
   it('rejects an Object type with invalid name', () => {
     expect(
-      () => new GraphQLObjectType({ name: 'bad-name', fields: {} }),
+      () => new GraphQLObjectTypeImpl({ name: 'bad-name', fields: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
   it('rejects an Object type field with undefined config', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         // @ts-expect-error (must not be undefined)
@@ -342,7 +347,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with incorrectly typed fields', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       // @ts-expect-error
       fields: [{ field: ScalarType }],
@@ -353,7 +358,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with incorrectly named fields', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         'bad-name': { type: ScalarType },
@@ -365,7 +370,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with a field function that returns incorrect type', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       // @ts-expect-error (Wrong type of return)
       fields() {
@@ -376,7 +381,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with incorrectly typed field args', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         badField: {
@@ -392,7 +397,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with incorrectly named field args', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         badField: {
@@ -409,7 +414,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with incorrectly typed interfaces', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {},
       // @ts-expect-error
@@ -421,7 +426,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an Object type with interfaces as a function returning an incorrect type', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {},
       // @ts-expect-error (Expected interfaces to return array)
@@ -435,7 +440,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects an empty Object field resolver', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         // @ts-expect-error (Expected resolve to be a function)
@@ -449,7 +454,7 @@ describe('Type System: Objects', () => {
   });
 
   it('rejects a constant scalar value resolver', () => {
-    const objType = new GraphQLObjectType({
+    const objType = new GraphQLObjectTypeImpl({
       name: 'SomeObject',
       fields: {
         // @ts-expect-error (Expected resolve to be a function)
@@ -465,7 +470,7 @@ describe('Type System: Objects', () => {
   it('rejects an Object type with an incorrect type for isTypeOf', () => {
     expect(
       () =>
-        new GraphQLObjectType({
+        new GraphQLObjectTypeImpl({
           name: 'AnotherObject',
           fields: {},
           // @ts-expect-error
@@ -481,7 +486,7 @@ describe('Type System: Interfaces', () => {
   it('accepts an Interface type defining resolveType', () => {
     expect(
       () =>
-        new GraphQLInterfaceType({
+        new GraphQLInterfaceTypeImpl({
           name: 'AnotherInterface',
           fields: { f: { type: ScalarType } },
         }),
@@ -489,7 +494,7 @@ describe('Type System: Interfaces', () => {
   });
 
   it('accepts an Interface type with an array of interfaces', () => {
-    const implementing = new GraphQLInterfaceType({
+    const implementing = new GraphQLInterfaceTypeImpl({
       name: 'AnotherInterface',
       fields: {},
       interfaces: [InterfaceType],
@@ -498,7 +503,7 @@ describe('Type System: Interfaces', () => {
   });
 
   it('accepts an Interface type with interfaces as a function returning an array', () => {
-    const implementing = new GraphQLInterfaceType({
+    const implementing = new GraphQLInterfaceTypeImpl({
       name: 'AnotherInterface',
       fields: {},
       interfaces: () => [InterfaceType],
@@ -508,12 +513,12 @@ describe('Type System: Interfaces', () => {
 
   it('rejects an Interface type with invalid name', () => {
     expect(
-      () => new GraphQLInterfaceType({ name: 'bad-name', fields: {} }),
+      () => new GraphQLInterfaceTypeImpl({ name: 'bad-name', fields: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
   it('rejects an Interface type with incorrectly typed interfaces', () => {
-    const objType = new GraphQLInterfaceType({
+    const objType = new GraphQLInterfaceTypeImpl({
       name: 'AnotherInterface',
       fields: {},
       // @ts-expect-error
@@ -525,7 +530,7 @@ describe('Type System: Interfaces', () => {
   });
 
   it('rejects an Interface type with interfaces as a function returning an incorrect type', () => {
-    const objType = new GraphQLInterfaceType({
+    const objType = new GraphQLInterfaceTypeImpl({
       name: 'AnotherInterface',
       fields: {},
       // @ts-expect-error (Expected Array return)
@@ -541,7 +546,7 @@ describe('Type System: Interfaces', () => {
   it('rejects an Interface type with an incorrect type for resolveType', () => {
     expect(
       () =>
-        new GraphQLInterfaceType({
+        new GraphQLInterfaceTypeImpl({
           name: 'AnotherInterface',
           fields: {},
           // @ts-expect-error
@@ -557,7 +562,7 @@ describe('Type System: Unions', () => {
   it('accepts a Union type defining resolveType', () => {
     expect(
       () =>
-        new GraphQLUnionType({
+        new GraphQLUnionTypeImpl({
           name: 'SomeUnion',
           types: [ObjectType],
         }),
@@ -565,7 +570,7 @@ describe('Type System: Unions', () => {
   });
 
   it('accepts a Union type with array types', () => {
-    const unionType = new GraphQLUnionType({
+    const unionType = new GraphQLUnionTypeImpl({
       name: 'SomeUnion',
       types: [ObjectType],
     });
@@ -573,7 +578,7 @@ describe('Type System: Unions', () => {
   });
 
   it('accepts a Union type with function returning an array of types', () => {
-    const unionType = new GraphQLUnionType({
+    const unionType = new GraphQLUnionTypeImpl({
       name: 'SomeUnion',
       types: () => [ObjectType],
     });
@@ -581,7 +586,7 @@ describe('Type System: Unions', () => {
   });
 
   it('accepts a Union type without types', () => {
-    const unionType = new GraphQLUnionType({
+    const unionType = new GraphQLUnionTypeImpl({
       name: 'SomeUnion',
       types: [],
     });
@@ -590,14 +595,14 @@ describe('Type System: Unions', () => {
 
   it('rejects an Union type with invalid name', () => {
     expect(
-      () => new GraphQLUnionType({ name: 'bad-name', types: [] }),
+      () => new GraphQLUnionTypeImpl({ name: 'bad-name', types: [] }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
   it('rejects an Union type with an incorrect type for resolveType', () => {
     expect(
       () =>
-        new GraphQLUnionType({
+        new GraphQLUnionTypeImpl({
           name: 'SomeUnion',
           types: [],
           // @ts-expect-error
@@ -609,7 +614,7 @@ describe('Type System: Unions', () => {
   });
 
   it('rejects a Union type with incorrectly typed types', () => {
-    const unionType = new GraphQLUnionType({
+    const unionType = new GraphQLUnionTypeImpl({
       name: 'SomeUnion',
       // @ts-expect-error
       types: { ObjectType },
@@ -623,7 +628,7 @@ describe('Type System: Unions', () => {
 
 describe('Type System: Enums', () => {
   it('defines an enum type with deprecated value', () => {
-    const EnumTypeWithDeprecatedValue = new GraphQLEnumType({
+    const EnumTypeWithDeprecatedValue = new GraphQLEnumTypeImpl({
       name: 'EnumWithDeprecatedValue',
       values: {
         foo: { deprecationReason: 'Just because' },
@@ -643,7 +648,7 @@ describe('Type System: Enums', () => {
   });
 
   it('defines an enum type with a value of `null` and `undefined`', () => {
-    const EnumTypeWithNullishValue = new GraphQLEnumType({
+    const EnumTypeWithNullishValue = new GraphQLEnumTypeImpl({
       name: 'EnumWithNullishValue',
       values: {
         NULL: { value: null },
@@ -681,7 +686,7 @@ describe('Type System: Enums', () => {
   });
 
   it('accepts a well defined Enum type with empty value definition', () => {
-    const enumType = new GraphQLEnumType({
+    const enumType = new GraphQLEnumTypeImpl({
       name: 'SomeEnum',
       values: {
         FOO: {},
@@ -693,7 +698,7 @@ describe('Type System: Enums', () => {
   });
 
   it('accepts a well defined Enum type with internal value definition', () => {
-    const enumType = new GraphQLEnumType({
+    const enumType = new GraphQLEnumTypeImpl({
       name: 'SomeEnum',
       values: {
         FOO: { value: 10 },
@@ -706,14 +711,14 @@ describe('Type System: Enums', () => {
 
   it('rejects an Enum type with invalid name', () => {
     expect(
-      () => new GraphQLEnumType({ name: 'bad-name', values: {} }),
+      () => new GraphQLEnumTypeImpl({ name: 'bad-name', values: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
   it('rejects an Enum type with incorrectly typed values', () => {
     expect(
       () =>
-        new GraphQLEnumType({
+        new GraphQLEnumTypeImpl({
           name: 'SomeEnum',
           // @ts-expect-error
           values: [{ FOO: 10 }],
@@ -724,7 +729,7 @@ describe('Type System: Enums', () => {
   it('rejects an Enum type with incorrectly named values', () => {
     expect(
       () =>
-        new GraphQLEnumType({
+        new GraphQLEnumTypeImpl({
           name: 'SomeEnum',
           values: {
             'bad-name': {},
@@ -736,7 +741,7 @@ describe('Type System: Enums', () => {
   it('rejects an Enum type with missing value definition', () => {
     expect(
       () =>
-        new GraphQLEnumType({
+        new GraphQLEnumTypeImpl({
           name: 'SomeEnum',
           // @ts-expect-error (must not be null)
           values: { FOO: null },
@@ -749,7 +754,7 @@ describe('Type System: Enums', () => {
   it('rejects an Enum type with incorrectly typed value definition', () => {
     expect(
       () =>
-        new GraphQLEnumType({
+        new GraphQLEnumTypeImpl({
           name: 'SomeEnum',
           // @ts-expect-error
           values: { FOO: 10 },
@@ -763,7 +768,7 @@ describe('Type System: Enums', () => {
 describe('Type System: Input Objects', () => {
   describe('Input Objects must have fields', () => {
     it('accepts an Input Object type with fields', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: {
           f: { type: ScalarType },
@@ -783,7 +788,7 @@ describe('Type System: Input Objects', () => {
     });
 
     it('accepts an Input Object type with a field function', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: () => ({
           f: { type: ScalarType },
@@ -804,14 +809,14 @@ describe('Type System: Input Objects', () => {
 
     it('rejects an Input Object type with invalid name', () => {
       expect(
-        () => new GraphQLInputObjectType({ name: 'bad-name', fields: {} }),
+        () => new GraphQLInputObjectTypeImpl({ name: 'bad-name', fields: {} }),
       ).to.throw(
         'Names must only contain [_a-zA-Z0-9] but "bad-name" does not.',
       );
     });
 
     it('rejects an Input Object type with incorrect fields', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         // @ts-expect-error
         fields: [],
@@ -822,7 +827,7 @@ describe('Type System: Input Objects', () => {
     });
 
     it('rejects an Input Object type with fields function that returns incorrect type', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         // @ts-expect-error
         fields: () => [],
@@ -833,7 +838,7 @@ describe('Type System: Input Objects', () => {
     });
 
     it('rejects an Input Object type with incorrectly named fields', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: {
           'bad-name': { type: ScalarType },
@@ -847,7 +852,7 @@ describe('Type System: Input Objects', () => {
 
   describe('Input Object fields must not have resolvers', () => {
     it('rejects an Input Object type with resolvers', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: {
           // @ts-expect-error (Input fields cannot have resolvers)
@@ -860,7 +865,7 @@ describe('Type System: Input Objects', () => {
     });
 
     it('rejects an Input Object type with resolver constant', () => {
-      const inputObjType = new GraphQLInputObjectType({
+      const inputObjType = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: {
           // @ts-expect-error (Input fields cannot have resolvers)
@@ -874,7 +879,7 @@ describe('Type System: Input Objects', () => {
   });
 
   it('Deprecation reason is preserved on fields', () => {
-    const inputObjType = new GraphQLInputObjectType({
+    const inputObjType = new GraphQLInputObjectTypeImpl({
       name: 'SomeInputObject',
       fields: {
         deprecatedField: {
@@ -892,7 +897,7 @@ describe('Type System: Input Objects', () => {
 
 describe('Type System: List', () => {
   function expectList(type: GraphQLType) {
-    return expect(() => new GraphQLList(type));
+    return expect(() => new GraphQLListImpl(type));
   }
 
   it('accepts an type as item type of list', () => {
@@ -922,7 +927,7 @@ describe('Type System: List', () => {
 
 describe('Type System: Non-Null', () => {
   function expectNonNull(type: GraphQLNullableType) {
-    return expect(() => new GraphQLNonNull(type));
+    return expect(() => new GraphQLNonNullImpl(type));
   }
 
   it('accepts an type as nullable type of non-null', () => {
@@ -937,6 +942,7 @@ describe('Type System: Non-Null', () => {
   });
 
   it('rejects a non-type as nullable type of non-null', () => {
+    // @ts-expect-error
     expectNonNull(NonNullScalarType).to.throw(
       'Expected Scalar! to be a GraphQL nullable type.',
     );
@@ -970,7 +976,9 @@ describe('Type System: test utility methods', () => {
     expect(String(ListOfScalarsType)).to.equal('[Scalar]');
     expect(String(NonNullListOfScalars)).to.equal('[Scalar]!');
     expect(String(ListOfNonNullScalarsType)).to.equal('[Scalar!]');
-    expect(String(new GraphQLList(ListOfScalarsType))).to.equal('[[Scalar]]');
+    expect(String(new GraphQLListImpl(ListOfScalarsType))).to.equal(
+      '[[Scalar]]',
+    );
   });
 
   it('JSON.stringifies types', () => {
@@ -985,7 +993,7 @@ describe('Type System: test utility methods', () => {
     expect(JSON.stringify(ListOfScalarsType)).to.equal('"[Scalar]"');
     expect(JSON.stringify(NonNullListOfScalars)).to.equal('"[Scalar]!"');
     expect(JSON.stringify(ListOfNonNullScalarsType)).to.equal('"[Scalar!]"');
-    expect(JSON.stringify(new GraphQLList(ListOfScalarsType))).to.equal(
+    expect(JSON.stringify(new GraphQLListImpl(ListOfScalarsType))).to.equal(
       '"[[Scalar]]"',
     );
   });

--- a/src/type/__tests__/directive-test.ts
+++ b/src/type/__tests__/directive-test.ts
@@ -3,12 +3,12 @@ import { describe, it } from 'mocha';
 
 import { DirectiveLocation } from '../../language/directiveLocation';
 
-import { GraphQLDirective } from '../directives';
+import { GraphQLDirectiveImpl } from '../directives';
 import { GraphQLInt, GraphQLString } from '../scalars';
 
 describe('Type System: Directive', () => {
   it('defines a directive with no args', () => {
-    const directive = new GraphQLDirective({
+    const directive = new GraphQLDirectiveImpl({
       name: 'Foo',
       locations: [DirectiveLocation.QUERY],
     });
@@ -22,7 +22,7 @@ describe('Type System: Directive', () => {
   });
 
   it('defines a directive with multiple args', () => {
-    const directive = new GraphQLDirective({
+    const directive = new GraphQLDirectiveImpl({
       name: 'Foo',
       args: {
         foo: { type: GraphQLString },
@@ -59,7 +59,7 @@ describe('Type System: Directive', () => {
   });
 
   it('defines a repeatable directive', () => {
-    const directive = new GraphQLDirective({
+    const directive = new GraphQLDirectiveImpl({
       name: 'Foo',
       isRepeatable: true,
       locations: [DirectiveLocation.QUERY],
@@ -74,7 +74,7 @@ describe('Type System: Directive', () => {
   });
 
   it('can be stringified, JSON.stringified and Object.toStringified', () => {
-    const directive = new GraphQLDirective({
+    const directive = new GraphQLDirectiveImpl({
       name: 'Foo',
       locations: [DirectiveLocation.QUERY],
     });
@@ -89,7 +89,7 @@ describe('Type System: Directive', () => {
   it('rejects a directive with invalid name', () => {
     expect(
       () =>
-        new GraphQLDirective({
+        new GraphQLDirectiveImpl({
           name: 'bad-name',
           locations: [DirectiveLocation.QUERY],
         }),
@@ -99,7 +99,7 @@ describe('Type System: Directive', () => {
   it('rejects a directive with incorrectly typed args', () => {
     expect(
       () =>
-        new GraphQLDirective({
+        new GraphQLDirectiveImpl({
           name: 'Foo',
           locations: [DirectiveLocation.QUERY],
           // @ts-expect-error
@@ -111,7 +111,7 @@ describe('Type System: Directive', () => {
   it('rejects a directive with incorrectly named arg', () => {
     expect(
       () =>
-        new GraphQLDirective({
+        new GraphQLDirectiveImpl({
           name: 'Foo',
           locations: [DirectiveLocation.QUERY],
           args: {
@@ -123,15 +123,15 @@ describe('Type System: Directive', () => {
 
   it('rejects a directive with undefined locations', () => {
     // @ts-expect-error
-    expect(() => new GraphQLDirective({ name: 'Foo' })).to.throw(
+    expect(() => new GraphQLDirectiveImpl({ name: 'Foo' })).to.throw(
       '@Foo locations must be an Array.',
     );
   });
 
   it('rejects a directive with incorrectly typed locations', () => {
-    // @ts-expect-error
-    expect(() => new GraphQLDirective({ name: 'Foo', locations: {} })).to.throw(
-      '@Foo locations must be an Array.',
-    );
+    expect(
+      // @ts-expect-error
+      () => new GraphQLDirectiveImpl({ name: 'Foo', locations: {} }),
+    ).to.throw('@Foo locations must be an Array.');
   });
 });

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -7,11 +7,11 @@ import { introspectionFromSchema } from '../../utilities/introspectionFromSchema
 
 import { graphqlSync } from '../../graphql';
 
-import { GraphQLEnumType, GraphQLObjectType } from '../definition';
+import { GraphQLEnumTypeImpl, GraphQLObjectTypeImpl } from '../definition';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../scalars';
-import { GraphQLSchema } from '../schema';
+import { GraphQLSchemaImpl } from '../schema';
 
-const ColorType = new GraphQLEnumType({
+const ColorType = new GraphQLEnumTypeImpl({
   name: 'Color',
   values: {
     RED: { value: 0 },
@@ -23,7 +23,7 @@ const ColorType = new GraphQLEnumType({
 const Complex1 = { someRandomObject: new Date() };
 const Complex2 = { someRandomValue: 123 };
 
-const ComplexEnum = new GraphQLEnumType({
+const ComplexEnum = new GraphQLEnumTypeImpl({
   name: 'Complex',
   values: {
     ONE: { value: Complex1 },
@@ -31,7 +31,7 @@ const ComplexEnum = new GraphQLEnumType({
   },
 });
 
-const QueryType = new GraphQLObjectType({
+const QueryType = new GraphQLObjectTypeImpl({
   name: 'Query',
   fields: {
     colorEnum: {
@@ -87,7 +87,7 @@ const QueryType = new GraphQLObjectType({
   },
 });
 
-const MutationType = new GraphQLObjectType({
+const MutationType = new GraphQLObjectTypeImpl({
   name: 'Mutation',
   fields: {
     favoriteEnum: {
@@ -98,7 +98,7 @@ const MutationType = new GraphQLObjectType({
   },
 });
 
-const SubscriptionType = new GraphQLObjectType({
+const SubscriptionType = new GraphQLObjectTypeImpl({
   name: 'Subscription',
   fields: {
     subscribeToEnum: {
@@ -109,7 +109,7 @@ const SubscriptionType = new GraphQLObjectType({
   },
 });
 
-const schema = new GraphQLSchema({
+const schema = new GraphQLSchemaImpl({
   query: QueryType,
   mutation: MutationType,
   subscription: SubscriptionType,

--- a/src/type/__tests__/extensions-test.ts
+++ b/src/type/__tests__/extensions-test.ts
@@ -2,17 +2,17 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLUnionType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../definition';
-import { GraphQLDirective } from '../directives';
-import { GraphQLSchema } from '../schema';
+import { GraphQLDirectiveImpl } from '../directives';
+import { GraphQLSchemaImpl } from '../schema';
 
-const dummyType = new GraphQLScalarType({ name: 'DummyScalar' });
+const dummyType = new GraphQLScalarTypeImpl({ name: 'DummyScalar' });
 
 function expectObjMap(value: unknown) {
   assert(value != null && typeof value === 'object');
@@ -23,7 +23,7 @@ function expectObjMap(value: unknown) {
 describe('Type System: Extensions', () => {
   describe('GraphQLScalarType', () => {
     it('without extensions', () => {
-      const someScalar = new GraphQLScalarType({ name: 'SomeScalar' });
+      const someScalar = new GraphQLScalarTypeImpl({ name: 'SomeScalar' });
       expect(someScalar.extensions).to.deep.equal({});
 
       const config = someScalar.toConfig();
@@ -32,7 +32,7 @@ describe('Type System: Extensions', () => {
 
     it('with extensions', () => {
       const scalarExtensions = Object.freeze({ SomeScalarExt: 'scalar' });
-      const someScalar = new GraphQLScalarType({
+      const someScalar = new GraphQLScalarTypeImpl({
         name: 'SomeScalar',
         extensions: scalarExtensions,
       });
@@ -46,7 +46,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLObjectType', () => {
     it('without extensions', () => {
-      const someObject = new GraphQLObjectType({
+      const someObject = new GraphQLObjectTypeImpl({
         name: 'SomeObject',
         fields: {
           someField: {
@@ -80,7 +80,7 @@ describe('Type System: Extensions', () => {
       const fieldExtensions = Object.freeze({ SomeFieldExt: 'field' });
       const argExtensions = Object.freeze({ SomeArgExt: 'arg' });
 
-      const someObject = new GraphQLObjectType({
+      const someObject = new GraphQLObjectTypeImpl({
         name: 'SomeObject',
         fields: {
           someField: {
@@ -115,7 +115,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLInterfaceType', () => {
     it('without extensions', () => {
-      const someInterface = new GraphQLInterfaceType({
+      const someInterface = new GraphQLInterfaceTypeImpl({
         name: 'SomeInterface',
         fields: {
           someField: {
@@ -151,7 +151,7 @@ describe('Type System: Extensions', () => {
       const fieldExtensions = Object.freeze({ SomeFieldExt: 'field' });
       const argExtensions = Object.freeze({ SomeArgExt: 'arg' });
 
-      const someInterface = new GraphQLInterfaceType({
+      const someInterface = new GraphQLInterfaceTypeImpl({
         name: 'SomeInterface',
         fields: {
           someField: {
@@ -186,7 +186,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLUnionType', () => {
     it('without extensions', () => {
-      const someUnion = new GraphQLUnionType({
+      const someUnion = new GraphQLUnionTypeImpl({
         name: 'SomeUnion',
         types: [],
       });
@@ -200,7 +200,7 @@ describe('Type System: Extensions', () => {
     it('with extensions', () => {
       const unionExtensions = Object.freeze({ SomeUnionExt: 'union' });
 
-      const someUnion = new GraphQLUnionType({
+      const someUnion = new GraphQLUnionTypeImpl({
         name: 'SomeUnion',
         types: [],
         extensions: unionExtensions,
@@ -215,7 +215,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLEnumType', () => {
     it('without extensions', () => {
-      const someEnum = new GraphQLEnumType({
+      const someEnum = new GraphQLEnumTypeImpl({
         name: 'SomeEnum',
         values: {
           SOME_VALUE: {},
@@ -236,7 +236,7 @@ describe('Type System: Extensions', () => {
       const enumExtensions = Object.freeze({ SomeEnumExt: 'enum' });
       const valueExtensions = Object.freeze({ SomeValueExt: 'value' });
 
-      const someEnum = new GraphQLEnumType({
+      const someEnum = new GraphQLEnumTypeImpl({
         name: 'SomeEnum',
         values: {
           SOME_VALUE: {
@@ -259,7 +259,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLInputObjectType', () => {
     it('without extensions', () => {
-      const someInputObject = new GraphQLInputObjectType({
+      const someInputObject = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: {
           someInputField: {
@@ -286,7 +286,7 @@ describe('Type System: Extensions', () => {
         SomeInputFieldExt: 'inputField',
       });
 
-      const someInputObject = new GraphQLInputObjectType({
+      const someInputObject = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: {
           someInputField: {
@@ -316,7 +316,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLDirective', () => {
     it('without extensions', () => {
-      const someDirective = new GraphQLDirective({
+      const someDirective = new GraphQLDirectiveImpl({
         name: 'SomeDirective',
         args: {
           someArg: {
@@ -342,7 +342,7 @@ describe('Type System: Extensions', () => {
       });
       const argExtensions = Object.freeze({ SomeArgExt: 'arg' });
 
-      const someDirective = new GraphQLDirective({
+      const someDirective = new GraphQLDirectiveImpl({
         name: 'SomeDirective',
         args: {
           someArg: {
@@ -367,7 +367,7 @@ describe('Type System: Extensions', () => {
 
   describe('GraphQLSchema', () => {
     it('without extensions', () => {
-      const schema = new GraphQLSchema({});
+      const schema = new GraphQLSchemaImpl({});
 
       expect(schema.extensions).to.deep.equal({});
 
@@ -380,7 +380,7 @@ describe('Type System: Extensions', () => {
         schemaExtension: 'schema',
       });
 
-      const schema = new GraphQLSchema({ extensions: schemaExtensions });
+      const schema = new GraphQLSchemaImpl({ extensions: schemaExtensions });
 
       expectObjMap(schema.extensions).to.deep.equal(schemaExtensions);
 

--- a/src/type/__tests__/predicate-test.ts
+++ b/src/type/__tests__/predicate-test.ts
@@ -28,14 +28,14 @@ import {
   assertWrappingType,
   getNamedType,
   getNullableType,
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLUnionType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLUnionTypeImpl,
   isAbstractType,
   isCompositeType,
   isEnumType,
@@ -59,7 +59,7 @@ import {
 import {
   assertDirective,
   GraphQLDeprecatedDirective,
-  GraphQLDirective,
+  GraphQLDirectiveImpl,
   GraphQLIncludeDirective,
   GraphQLSkipDirective,
   isDirective,
@@ -74,19 +74,22 @@ import {
   isSpecifiedScalarType,
 } from '../scalars';
 
-const ObjectType = new GraphQLObjectType({ name: 'Object', fields: {} });
-const InterfaceType = new GraphQLInterfaceType({
+const ObjectType = new GraphQLObjectTypeImpl({ name: 'Object', fields: {} });
+const InterfaceType = new GraphQLInterfaceTypeImpl({
   name: 'Interface',
   fields: {},
 });
-const UnionType = new GraphQLUnionType({ name: 'Union', types: [ObjectType] });
-const EnumType = new GraphQLEnumType({ name: 'Enum', values: { foo: {} } });
-const InputObjectType = new GraphQLInputObjectType({
+const UnionType = new GraphQLUnionTypeImpl({
+  name: 'Union',
+  types: [ObjectType],
+});
+const EnumType = new GraphQLEnumTypeImpl({ name: 'Enum', values: { foo: {} } });
+const InputObjectType = new GraphQLInputObjectTypeImpl({
   name: 'InputObject',
   fields: {},
 });
-const ScalarType = new GraphQLScalarType({ name: 'Scalar' });
-const Directive = new GraphQLDirective({
+const ScalarType = new GraphQLScalarTypeImpl({ name: 'Scalar' });
+const Directive = new GraphQLDirectiveImpl({
   name: 'Directive',
   locations: [DirectiveLocation.QUERY],
 });
@@ -101,15 +104,15 @@ describe('Type predicates', () => {
     });
 
     it('returns true for wrapped types', () => {
-      expect(isType(new GraphQLNonNull(GraphQLString))).to.equal(true);
+      expect(isType(new GraphQLNonNullImpl(GraphQLString))).to.equal(true);
       expect(() =>
-        assertType(new GraphQLNonNull(GraphQLString)),
+        assertType(new GraphQLNonNullImpl(GraphQLString)),
       ).to.not.throw();
     });
 
     it('returns false for type classes (rather than instances)', () => {
-      expect(isType(GraphQLObjectType)).to.equal(false);
-      expect(() => assertType(GraphQLObjectType)).to.throw();
+      expect(isType(GraphQLObjectTypeImpl)).to.equal(false);
+      expect(() => assertType(GraphQLObjectTypeImpl)).to.throw();
     });
 
     it('returns false for random garbage', () => {
@@ -130,13 +133,15 @@ describe('Type predicates', () => {
     });
 
     it('returns false for scalar class (rather than instance)', () => {
-      expect(isScalarType(GraphQLScalarType)).to.equal(false);
-      expect(() => assertScalarType(GraphQLScalarType)).to.throw();
+      expect(isScalarType(GraphQLScalarTypeImpl)).to.equal(false);
+      expect(() => assertScalarType(GraphQLScalarTypeImpl)).to.throw();
     });
 
     it('returns false for wrapped scalar', () => {
-      expect(isScalarType(new GraphQLList(ScalarType))).to.equal(false);
-      expect(() => assertScalarType(new GraphQLList(ScalarType))).to.throw();
+      expect(isScalarType(new GraphQLListImpl(ScalarType))).to.equal(false);
+      expect(() =>
+        assertScalarType(new GraphQLListImpl(ScalarType)),
+      ).to.throw();
     });
 
     it('returns false for non-scalar', () => {
@@ -173,8 +178,10 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped object type', () => {
-      expect(isObjectType(new GraphQLList(ObjectType))).to.equal(false);
-      expect(() => assertObjectType(new GraphQLList(ObjectType))).to.throw();
+      expect(isObjectType(new GraphQLListImpl(ObjectType))).to.equal(false);
+      expect(() =>
+        assertObjectType(new GraphQLListImpl(ObjectType)),
+      ).to.throw();
     });
 
     it('returns false for non-object type', () => {
@@ -190,9 +197,11 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped interface type', () => {
-      expect(isInterfaceType(new GraphQLList(InterfaceType))).to.equal(false);
+      expect(isInterfaceType(new GraphQLListImpl(InterfaceType))).to.equal(
+        false,
+      );
       expect(() =>
-        assertInterfaceType(new GraphQLList(InterfaceType)),
+        assertInterfaceType(new GraphQLListImpl(InterfaceType)),
       ).to.throw();
     });
 
@@ -209,8 +218,8 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped union type', () => {
-      expect(isUnionType(new GraphQLList(UnionType))).to.equal(false);
-      expect(() => assertUnionType(new GraphQLList(UnionType))).to.throw();
+      expect(isUnionType(new GraphQLListImpl(UnionType))).to.equal(false);
+      expect(() => assertUnionType(new GraphQLListImpl(UnionType))).to.throw();
     });
 
     it('returns false for non-union type', () => {
@@ -226,8 +235,8 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped enum type', () => {
-      expect(isEnumType(new GraphQLList(EnumType))).to.equal(false);
-      expect(() => assertEnumType(new GraphQLList(EnumType))).to.throw();
+      expect(isEnumType(new GraphQLListImpl(EnumType))).to.equal(false);
+      expect(() => assertEnumType(new GraphQLListImpl(EnumType))).to.throw();
     });
 
     it('returns false for non-enum type', () => {
@@ -243,11 +252,11 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped input object type', () => {
-      expect(isInputObjectType(new GraphQLList(InputObjectType))).to.equal(
+      expect(isInputObjectType(new GraphQLListImpl(InputObjectType))).to.equal(
         false,
       );
       expect(() =>
-        assertInputObjectType(new GraphQLList(InputObjectType)),
+        assertInputObjectType(new GraphQLListImpl(InputObjectType)),
       ).to.throw();
     });
 
@@ -259,8 +268,10 @@ describe('Type predicates', () => {
 
   describe('isListType', () => {
     it('returns true for a list wrapped type', () => {
-      expect(isListType(new GraphQLList(ObjectType))).to.equal(true);
-      expect(() => assertListType(new GraphQLList(ObjectType))).to.not.throw();
+      expect(isListType(new GraphQLListImpl(ObjectType))).to.equal(true);
+      expect(() =>
+        assertListType(new GraphQLListImpl(ObjectType)),
+      ).to.not.throw();
     });
 
     it('returns false for an unwrapped type', () => {
@@ -270,19 +281,19 @@ describe('Type predicates', () => {
 
     it('returns false for a non-list wrapped type', () => {
       expect(
-        isListType(new GraphQLNonNull(new GraphQLList(ObjectType))),
+        isListType(new GraphQLNonNullImpl(new GraphQLListImpl(ObjectType))),
       ).to.equal(false);
       expect(() =>
-        assertListType(new GraphQLNonNull(new GraphQLList(ObjectType))),
+        assertListType(new GraphQLNonNullImpl(new GraphQLListImpl(ObjectType))),
       ).to.throw();
     });
   });
 
   describe('isNonNullType', () => {
     it('returns true for a non-null wrapped type', () => {
-      expect(isNonNullType(new GraphQLNonNull(ObjectType))).to.equal(true);
+      expect(isNonNullType(new GraphQLNonNullImpl(ObjectType))).to.equal(true);
       expect(() =>
-        assertNonNullType(new GraphQLNonNull(ObjectType)),
+        assertNonNullType(new GraphQLNonNullImpl(ObjectType)),
       ).to.not.throw();
     });
 
@@ -293,10 +304,12 @@ describe('Type predicates', () => {
 
     it('returns false for a not non-null wrapped type', () => {
       expect(
-        isNonNullType(new GraphQLList(new GraphQLNonNull(ObjectType))),
+        isNonNullType(new GraphQLListImpl(new GraphQLNonNullImpl(ObjectType))),
       ).to.equal(false);
       expect(() =>
-        assertNonNullType(new GraphQLList(new GraphQLNonNull(ObjectType))),
+        assertNonNullType(
+          new GraphQLListImpl(new GraphQLNonNullImpl(ObjectType)),
+        ),
       ).to.throw();
     });
   });
@@ -314,13 +327,13 @@ describe('Type predicates', () => {
     });
 
     it('returns true for a wrapped input type', () => {
-      expectInputType(new GraphQLList(GraphQLString));
-      expectInputType(new GraphQLList(EnumType));
-      expectInputType(new GraphQLList(InputObjectType));
+      expectInputType(new GraphQLListImpl(GraphQLString));
+      expectInputType(new GraphQLListImpl(EnumType));
+      expectInputType(new GraphQLListImpl(InputObjectType));
 
-      expectInputType(new GraphQLNonNull(GraphQLString));
-      expectInputType(new GraphQLNonNull(EnumType));
-      expectInputType(new GraphQLNonNull(InputObjectType));
+      expectInputType(new GraphQLNonNullImpl(GraphQLString));
+      expectInputType(new GraphQLNonNullImpl(EnumType));
+      expectInputType(new GraphQLNonNullImpl(InputObjectType));
     });
 
     function expectNonInputType(type: unknown) {
@@ -335,13 +348,13 @@ describe('Type predicates', () => {
     });
 
     it('returns false for a wrapped output type', () => {
-      expectNonInputType(new GraphQLList(ObjectType));
-      expectNonInputType(new GraphQLList(InterfaceType));
-      expectNonInputType(new GraphQLList(UnionType));
+      expectNonInputType(new GraphQLListImpl(ObjectType));
+      expectNonInputType(new GraphQLListImpl(InterfaceType));
+      expectNonInputType(new GraphQLListImpl(UnionType));
 
-      expectNonInputType(new GraphQLNonNull(ObjectType));
-      expectNonInputType(new GraphQLNonNull(InterfaceType));
-      expectNonInputType(new GraphQLNonNull(UnionType));
+      expectNonInputType(new GraphQLNonNullImpl(ObjectType));
+      expectNonInputType(new GraphQLNonNullImpl(InterfaceType));
+      expectNonInputType(new GraphQLNonNullImpl(UnionType));
     });
   });
 
@@ -360,17 +373,17 @@ describe('Type predicates', () => {
     });
 
     it('returns true for a wrapped output type', () => {
-      expectOutputType(new GraphQLList(GraphQLString));
-      expectOutputType(new GraphQLList(ObjectType));
-      expectOutputType(new GraphQLList(InterfaceType));
-      expectOutputType(new GraphQLList(UnionType));
-      expectOutputType(new GraphQLList(EnumType));
+      expectOutputType(new GraphQLListImpl(GraphQLString));
+      expectOutputType(new GraphQLListImpl(ObjectType));
+      expectOutputType(new GraphQLListImpl(InterfaceType));
+      expectOutputType(new GraphQLListImpl(UnionType));
+      expectOutputType(new GraphQLListImpl(EnumType));
 
-      expectOutputType(new GraphQLNonNull(GraphQLString));
-      expectOutputType(new GraphQLNonNull(ObjectType));
-      expectOutputType(new GraphQLNonNull(InterfaceType));
-      expectOutputType(new GraphQLNonNull(UnionType));
-      expectOutputType(new GraphQLNonNull(EnumType));
+      expectOutputType(new GraphQLNonNullImpl(GraphQLString));
+      expectOutputType(new GraphQLNonNullImpl(ObjectType));
+      expectOutputType(new GraphQLNonNullImpl(InterfaceType));
+      expectOutputType(new GraphQLNonNullImpl(UnionType));
+      expectOutputType(new GraphQLNonNullImpl(EnumType));
     });
 
     function expectNonOutputType(type: unknown) {
@@ -383,8 +396,8 @@ describe('Type predicates', () => {
     });
 
     it('returns false for a wrapped input type', () => {
-      expectNonOutputType(new GraphQLList(InputObjectType));
-      expectNonOutputType(new GraphQLNonNull(InputObjectType));
+      expectNonOutputType(new GraphQLListImpl(InputObjectType));
+      expectNonOutputType(new GraphQLNonNullImpl(InputObjectType));
     });
   });
 
@@ -397,8 +410,8 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped leaf type', () => {
-      expect(isLeafType(new GraphQLList(ScalarType))).to.equal(false);
-      expect(() => assertLeafType(new GraphQLList(ScalarType))).to.throw();
+      expect(isLeafType(new GraphQLListImpl(ScalarType))).to.equal(false);
+      expect(() => assertLeafType(new GraphQLListImpl(ScalarType))).to.throw();
     });
 
     it('returns false for non-leaf type', () => {
@@ -407,8 +420,8 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped non-leaf type', () => {
-      expect(isLeafType(new GraphQLList(ObjectType))).to.equal(false);
-      expect(() => assertLeafType(new GraphQLList(ObjectType))).to.throw();
+      expect(isLeafType(new GraphQLListImpl(ObjectType))).to.equal(false);
+      expect(() => assertLeafType(new GraphQLListImpl(ObjectType))).to.throw();
     });
   });
 
@@ -423,8 +436,10 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped composite type', () => {
-      expect(isCompositeType(new GraphQLList(ObjectType))).to.equal(false);
-      expect(() => assertCompositeType(new GraphQLList(ObjectType))).to.throw();
+      expect(isCompositeType(new GraphQLListImpl(ObjectType))).to.equal(false);
+      expect(() =>
+        assertCompositeType(new GraphQLListImpl(ObjectType)),
+      ).to.throw();
     });
 
     it('returns false for non-composite type', () => {
@@ -433,9 +448,11 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped non-composite type', () => {
-      expect(isCompositeType(new GraphQLList(InputObjectType))).to.equal(false);
+      expect(isCompositeType(new GraphQLListImpl(InputObjectType))).to.equal(
+        false,
+      );
       expect(() =>
-        assertCompositeType(new GraphQLList(InputObjectType)),
+        assertCompositeType(new GraphQLListImpl(InputObjectType)),
       ).to.throw();
     });
   });
@@ -449,9 +466,11 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped abstract type', () => {
-      expect(isAbstractType(new GraphQLList(InterfaceType))).to.equal(false);
+      expect(isAbstractType(new GraphQLListImpl(InterfaceType))).to.equal(
+        false,
+      );
       expect(() =>
-        assertAbstractType(new GraphQLList(InterfaceType)),
+        assertAbstractType(new GraphQLListImpl(InterfaceType)),
       ).to.throw();
     });
 
@@ -461,20 +480,22 @@ describe('Type predicates', () => {
     });
 
     it('returns false for wrapped non-abstract type', () => {
-      expect(isAbstractType(new GraphQLList(ObjectType))).to.equal(false);
-      expect(() => assertAbstractType(new GraphQLList(ObjectType))).to.throw();
+      expect(isAbstractType(new GraphQLListImpl(ObjectType))).to.equal(false);
+      expect(() =>
+        assertAbstractType(new GraphQLListImpl(ObjectType)),
+      ).to.throw();
     });
   });
 
   describe('isWrappingType', () => {
     it('returns true for list and non-null types', () => {
-      expect(isWrappingType(new GraphQLList(ObjectType))).to.equal(true);
+      expect(isWrappingType(new GraphQLListImpl(ObjectType))).to.equal(true);
       expect(() =>
-        assertWrappingType(new GraphQLList(ObjectType)),
+        assertWrappingType(new GraphQLListImpl(ObjectType)),
       ).to.not.throw();
-      expect(isWrappingType(new GraphQLNonNull(ObjectType))).to.equal(true);
+      expect(isWrappingType(new GraphQLNonNullImpl(ObjectType))).to.equal(true);
       expect(() =>
-        assertWrappingType(new GraphQLNonNull(ObjectType)),
+        assertWrappingType(new GraphQLNonNullImpl(ObjectType)),
       ).to.not.throw();
     });
 
@@ -492,17 +513,21 @@ describe('Type predicates', () => {
 
     it('returns true for list of non-null types', () => {
       expect(
-        isNullableType(new GraphQLList(new GraphQLNonNull(ObjectType))),
+        isNullableType(new GraphQLListImpl(new GraphQLNonNullImpl(ObjectType))),
       ).to.equal(true);
       expect(() =>
-        assertNullableType(new GraphQLList(new GraphQLNonNull(ObjectType))),
+        assertNullableType(
+          new GraphQLListImpl(new GraphQLNonNullImpl(ObjectType)),
+        ),
       ).to.not.throw();
     });
 
     it('returns false for non-null types', () => {
-      expect(isNullableType(new GraphQLNonNull(ObjectType))).to.equal(false);
+      expect(isNullableType(new GraphQLNonNullImpl(ObjectType))).to.equal(
+        false,
+      );
       expect(() =>
-        assertNullableType(new GraphQLNonNull(ObjectType)),
+        assertNullableType(new GraphQLNonNullImpl(ObjectType)),
       ).to.throw();
     });
   });
@@ -515,12 +540,12 @@ describe('Type predicates', () => {
 
     it('returns self for a nullable type', () => {
       expect(getNullableType(ObjectType)).to.equal(ObjectType);
-      const listOfObj = new GraphQLList(ObjectType);
+      const listOfObj = new GraphQLListImpl(ObjectType);
       expect(getNullableType(listOfObj)).to.equal(listOfObj);
     });
 
     it('unwraps non-null type', () => {
-      expect(getNullableType(new GraphQLNonNull(ObjectType))).to.equal(
+      expect(getNullableType(new GraphQLNonNullImpl(ObjectType))).to.equal(
         ObjectType,
       );
     });
@@ -533,10 +558,12 @@ describe('Type predicates', () => {
     });
 
     it('returns false for list and non-null types', () => {
-      expect(isNamedType(new GraphQLList(ObjectType))).to.equal(false);
-      expect(() => assertNamedType(new GraphQLList(ObjectType))).to.throw();
-      expect(isNamedType(new GraphQLNonNull(ObjectType))).to.equal(false);
-      expect(() => assertNamedType(new GraphQLNonNull(ObjectType))).to.throw();
+      expect(isNamedType(new GraphQLListImpl(ObjectType))).to.equal(false);
+      expect(() => assertNamedType(new GraphQLListImpl(ObjectType))).to.throw();
+      expect(isNamedType(new GraphQLNonNullImpl(ObjectType))).to.equal(false);
+      expect(() =>
+        assertNamedType(new GraphQLNonNullImpl(ObjectType)),
+      ).to.throw();
     });
   });
 
@@ -551,14 +578,20 @@ describe('Type predicates', () => {
     });
 
     it('unwraps wrapper types', () => {
-      expect(getNamedType(new GraphQLNonNull(ObjectType))).to.equal(ObjectType);
-      expect(getNamedType(new GraphQLList(ObjectType))).to.equal(ObjectType);
+      expect(getNamedType(new GraphQLNonNullImpl(ObjectType))).to.equal(
+        ObjectType,
+      );
+      expect(getNamedType(new GraphQLListImpl(ObjectType))).to.equal(
+        ObjectType,
+      );
     });
 
     it('unwraps deeply wrapper types', () => {
       expect(
         getNamedType(
-          new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(ObjectType))),
+          new GraphQLNonNullImpl(
+            new GraphQLListImpl(new GraphQLNonNullImpl(ObjectType)),
+          ),
         ),
       ).to.equal(ObjectType);
     });
@@ -582,7 +615,7 @@ describe('Type predicates', () => {
 
     it('returns true for required arguments', () => {
       const requiredArg = buildArg({
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
       });
       expect(isRequiredArgument(requiredArg)).to.equal(true);
     });
@@ -600,12 +633,12 @@ describe('Type predicates', () => {
       expect(isRequiredArgument(optArg2)).to.equal(false);
 
       const optArg3 = buildArg({
-        type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
       });
       expect(isRequiredArgument(optArg3)).to.equal(false);
 
       const optArg4 = buildArg({
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
         defaultValue: 'default',
       });
       expect(isRequiredArgument(optArg4)).to.equal(false);
@@ -630,7 +663,7 @@ describe('Type predicates', () => {
 
     it('returns true for required input field', () => {
       const requiredField = buildInputField({
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
       });
       expect(isRequiredInputField(requiredField)).to.equal(true);
     });
@@ -648,12 +681,12 @@ describe('Type predicates', () => {
       expect(isRequiredInputField(optField2)).to.equal(false);
 
       const optField3 = buildInputField({
-        type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
       });
       expect(isRequiredInputField(optField3)).to.equal(false);
 
       const optField4 = buildInputField({
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
         defaultValue: 'default',
       });
       expect(isRequiredInputField(optField4)).to.equal(false);
@@ -674,8 +707,8 @@ describe('Directive predicates', () => {
     });
 
     it('returns false for directive class (rather than instance)', () => {
-      expect(isDirective(GraphQLDirective)).to.equal(false);
-      expect(() => assertDirective(GraphQLDirective)).to.throw();
+      expect(isDirective(GraphQLDirectiveImpl)).to.equal(false);
+      expect(() => assertDirective(GraphQLDirectiveImpl)).to.throw();
     });
 
     it('returns false for non-directive', () => {

--- a/src/type/__tests__/schema-test.ts
+++ b/src/type/__tests__/schema-test.ts
@@ -7,27 +7,27 @@ import { DirectiveLocation } from '../../language/directiveLocation';
 
 import { printSchema } from '../../utilities/printSchema';
 
-import type { GraphQLCompositeType } from '../definition';
+import type { GraphQLCompositeType, GraphQLObjectType } from '../definition';
 import {
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLUnionType,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../definition';
-import { GraphQLDirective } from '../directives';
+import { GraphQLDirectiveImpl } from '../directives';
 import {
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
 } from '../introspection';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../scalars';
-import { GraphQLSchema } from '../schema';
+import { GraphQLSchemaImpl } from '../schema';
 
 describe('Type System: Schema', () => {
   it('Define sample schema', () => {
-    const BlogImage = new GraphQLObjectType({
+    const BlogImage = new GraphQLObjectTypeImpl({
       name: 'Image',
       fields: {
         url: { type: GraphQLString },
@@ -36,7 +36,7 @@ describe('Type System: Schema', () => {
       },
     });
 
-    const BlogAuthor: GraphQLObjectType = new GraphQLObjectType({
+    const BlogAuthor: GraphQLObjectType = new GraphQLObjectTypeImpl({
       name: 'Author',
       fields: () => ({
         id: { type: GraphQLString },
@@ -49,7 +49,7 @@ describe('Type System: Schema', () => {
       }),
     });
 
-    const BlogArticle: GraphQLObjectType = new GraphQLObjectType({
+    const BlogArticle: GraphQLObjectType = new GraphQLObjectTypeImpl({
       name: 'Article',
       fields: {
         id: { type: GraphQLString },
@@ -60,7 +60,7 @@ describe('Type System: Schema', () => {
       },
     });
 
-    const BlogQuery = new GraphQLObjectType({
+    const BlogQuery = new GraphQLObjectTypeImpl({
       name: 'Query',
       fields: {
         article: {
@@ -68,12 +68,12 @@ describe('Type System: Schema', () => {
           type: BlogArticle,
         },
         feed: {
-          type: new GraphQLList(BlogArticle),
+          type: new GraphQLListImpl(BlogArticle),
         },
       },
     });
 
-    const BlogMutation = new GraphQLObjectType({
+    const BlogMutation = new GraphQLObjectTypeImpl({
       name: 'Mutation',
       fields: {
         writeArticle: {
@@ -82,7 +82,7 @@ describe('Type System: Schema', () => {
       },
     });
 
-    const BlogSubscription = new GraphQLObjectType({
+    const BlogSubscription = new GraphQLObjectTypeImpl({
       name: 'Subscription',
       fields: {
         articleSubscribe: {
@@ -92,7 +92,7 @@ describe('Type System: Schema', () => {
       },
     });
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       description: 'Sample schema',
       query: BlogQuery,
       mutation: BlogMutation,
@@ -144,22 +144,25 @@ describe('Type System: Schema', () => {
   });
 
   describe('Root types', () => {
-    const testType = new GraphQLObjectType({ name: 'TestType', fields: {} });
+    const testType = new GraphQLObjectTypeImpl({
+      name: 'TestType',
+      fields: {},
+    });
 
     it('defines a query root', () => {
-      const schema = new GraphQLSchema({ query: testType });
+      const schema = new GraphQLSchemaImpl({ query: testType });
       expect(schema.getQueryType()).to.equal(testType);
       expect(schema.getTypeMap()).to.include.keys('TestType');
     });
 
     it('defines a mutation root', () => {
-      const schema = new GraphQLSchema({ mutation: testType });
+      const schema = new GraphQLSchemaImpl({ mutation: testType });
       expect(schema.getMutationType()).to.equal(testType);
       expect(schema.getTypeMap()).to.include.keys('TestType');
     });
 
     it('defines a subscription root', () => {
-      const schema = new GraphQLSchema({ subscription: testType });
+      const schema = new GraphQLSchemaImpl({ subscription: testType });
       expect(schema.getSubscriptionType()).to.equal(testType);
       expect(schema.getTypeMap()).to.include.keys('TestType');
     });
@@ -167,19 +170,19 @@ describe('Type System: Schema', () => {
 
   describe('Type Map', () => {
     it('includes interface possible types in the type map', () => {
-      const SomeInterface = new GraphQLInterfaceType({
+      const SomeInterface = new GraphQLInterfaceTypeImpl({
         name: 'SomeInterface',
         fields: {},
       });
 
-      const SomeSubtype = new GraphQLObjectType({
+      const SomeSubtype = new GraphQLObjectTypeImpl({
         name: 'SomeSubtype',
         fields: {},
         interfaces: [SomeInterface],
       });
 
-      const schema = new GraphQLSchema({
-        query: new GraphQLObjectType({
+      const schema = new GraphQLSchemaImpl({
+        query: new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
             iface: { type: SomeInterface },
@@ -195,24 +198,24 @@ describe('Type System: Schema', () => {
     });
 
     it("includes interface's thunk subtypes in the type map", () => {
-      const SomeInterface = new GraphQLInterfaceType({
+      const SomeInterface = new GraphQLInterfaceTypeImpl({
         name: 'SomeInterface',
         fields: {},
         interfaces: () => [AnotherInterface],
       });
 
-      const AnotherInterface = new GraphQLInterfaceType({
+      const AnotherInterface = new GraphQLInterfaceTypeImpl({
         name: 'AnotherInterface',
         fields: {},
       });
 
-      const SomeSubtype = new GraphQLObjectType({
+      const SomeSubtype = new GraphQLObjectTypeImpl({
         name: 'SomeSubtype',
         fields: {},
         interfaces: () => [SomeInterface],
       });
 
-      const schema = new GraphQLSchema({ types: [SomeSubtype] });
+      const schema = new GraphQLSchemaImpl({ types: [SomeSubtype] });
 
       expect(schema.getType('SomeInterface')).to.equal(SomeInterface);
       expect(schema.getType('AnotherInterface')).to.equal(AnotherInterface);
@@ -220,18 +223,18 @@ describe('Type System: Schema', () => {
     });
 
     it('includes nested input objects in the map', () => {
-      const NestedInputObject = new GraphQLInputObjectType({
+      const NestedInputObject = new GraphQLInputObjectTypeImpl({
         name: 'NestedInputObject',
         fields: {},
       });
 
-      const SomeInputObject = new GraphQLInputObjectType({
+      const SomeInputObject = new GraphQLInputObjectTypeImpl({
         name: 'SomeInputObject',
         fields: { nested: { type: NestedInputObject } },
       });
 
-      const schema = new GraphQLSchema({
-        query: new GraphQLObjectType({
+      const schema = new GraphQLSchemaImpl({
+        query: new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
             something: {
@@ -247,48 +250,48 @@ describe('Type System: Schema', () => {
     });
 
     it('includes input types only used in directives', () => {
-      const directive = new GraphQLDirective({
+      const directive = new GraphQLDirectiveImpl({
         name: 'dir',
         locations: [DirectiveLocation.OBJECT],
         args: {
           arg: {
-            type: new GraphQLInputObjectType({ name: 'Foo', fields: {} }),
+            type: new GraphQLInputObjectTypeImpl({ name: 'Foo', fields: {} }),
           },
           argList: {
-            type: new GraphQLList(
-              new GraphQLInputObjectType({ name: 'Bar', fields: {} }),
+            type: new GraphQLListImpl(
+              new GraphQLInputObjectTypeImpl({ name: 'Bar', fields: {} }),
             ),
           },
         },
       });
-      const schema = new GraphQLSchema({ directives: [directive] });
+      const schema = new GraphQLSchemaImpl({ directives: [directive] });
 
       expect(schema.getTypeMap()).to.include.keys('Foo', 'Bar');
     });
   });
 
   it('preserves the order of user provided types', () => {
-    const aType = new GraphQLObjectType({
+    const aType = new GraphQLObjectTypeImpl({
       name: 'A',
       fields: {
-        sub: { type: new GraphQLScalarType({ name: 'ASub' }) },
+        sub: { type: new GraphQLScalarTypeImpl({ name: 'ASub' }) },
       },
     });
-    const zType = new GraphQLObjectType({
+    const zType = new GraphQLObjectTypeImpl({
       name: 'Z',
       fields: {
-        sub: { type: new GraphQLScalarType({ name: 'ZSub' }) },
+        sub: { type: new GraphQLScalarTypeImpl({ name: 'ZSub' }) },
       },
     });
-    const queryType = new GraphQLObjectType({
+    const queryType = new GraphQLObjectTypeImpl({
       name: 'Query',
       fields: {
         a: { type: aType },
         z: { type: zType },
-        sub: { type: new GraphQLScalarType({ name: 'QuerySub' }) },
+        sub: { type: new GraphQLScalarTypeImpl({ name: 'QuerySub' }) },
       },
     });
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       types: [zType, queryType, aType],
       query: queryType,
     });
@@ -314,12 +317,12 @@ describe('Type System: Schema', () => {
     ]);
 
     // Also check that this order is stable
-    const copySchema = new GraphQLSchema(schema.toConfig());
+    const copySchema = new GraphQLSchemaImpl(schema.toConfig());
     expect(Object.keys(copySchema.getTypeMap())).to.deep.equal(typeNames);
   });
 
   it('can be Object.toStringified', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
 
     expect(Object.prototype.toString.call(schema)).to.equal(
       '[object GraphQLSchema]',
@@ -327,14 +330,14 @@ describe('Type System: Schema', () => {
   });
 
   describe('getField', () => {
-    const petType = new GraphQLInterfaceType({
+    const petType = new GraphQLInterfaceTypeImpl({
       name: 'Pet',
       fields: {
         name: { type: GraphQLString },
       },
     });
 
-    const catType = new GraphQLObjectType({
+    const catType = new GraphQLObjectTypeImpl({
       name: 'Cat',
       interfaces: [petType],
       fields: {
@@ -342,7 +345,7 @@ describe('Type System: Schema', () => {
       },
     });
 
-    const dogType = new GraphQLObjectType({
+    const dogType = new GraphQLObjectTypeImpl({
       name: 'Dog',
       interfaces: [petType],
       fields: {
@@ -350,29 +353,29 @@ describe('Type System: Schema', () => {
       },
     });
 
-    const catOrDog = new GraphQLUnionType({
+    const catOrDog = new GraphQLUnionTypeImpl({
       name: 'CatOrDog',
       types: [catType, dogType],
     });
 
-    const queryType = new GraphQLObjectType({
+    const queryType = new GraphQLObjectTypeImpl({
       name: 'Query',
       fields: {
         catOrDog: { type: catOrDog },
       },
     });
 
-    const mutationType = new GraphQLObjectType({
+    const mutationType = new GraphQLObjectTypeImpl({
       name: 'Mutation',
       fields: {},
     });
 
-    const subscriptionType = new GraphQLObjectType({
+    const subscriptionType = new GraphQLObjectTypeImpl({
       name: 'Subscription',
       fields: {},
     });
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       query: queryType,
       mutation: mutationType,
       subscription: subscriptionType,
@@ -433,7 +436,7 @@ describe('Type System: Schema', () => {
     describe('when not assumed valid', () => {
       it('configures the schema to still needing validation', () => {
         expect(
-          new GraphQLSchema({
+          new GraphQLSchemaImpl({
             assumeValid: false,
           }).__validationErrors,
         ).to.equal(undefined);
@@ -441,19 +444,19 @@ describe('Type System: Schema', () => {
 
       it('checks the configuration for mistakes', () => {
         // @ts-expect-error
-        expect(() => new GraphQLSchema(JSON.parse)).to.throw();
+        expect(() => new GraphQLSchemaImpl(JSON.parse)).to.throw();
         // @ts-expect-error
-        expect(() => new GraphQLSchema({ types: {} })).to.throw();
+        expect(() => new GraphQLSchemaImpl({ types: {} })).to.throw();
         // @ts-expect-error
-        expect(() => new GraphQLSchema({ directives: {} })).to.throw();
+        expect(() => new GraphQLSchemaImpl({ directives: {} })).to.throw();
       });
     });
 
     describe('A Schema must contain uniquely named types', () => {
       it('rejects a Schema which redefines a built-in type', () => {
-        const FakeString = new GraphQLScalarType({ name: 'String' });
+        const FakeString = new GraphQLScalarTypeImpl({ name: 'String' });
 
-        const QueryType = new GraphQLObjectType({
+        const QueryType = new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
             normal: { type: GraphQLString },
@@ -461,46 +464,50 @@ describe('Type System: Schema', () => {
           },
         });
 
-        expect(() => new GraphQLSchema({ query: QueryType })).to.throw(
+        expect(() => new GraphQLSchemaImpl({ query: QueryType })).to.throw(
           'Schema must contain uniquely named types but contains multiple types named "String".',
         );
       });
 
       it('rejects a Schema when a provided type has no name', () => {
-        const query = new GraphQLObjectType({
+        const query = new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: { foo: { type: GraphQLString } },
         });
         const types = [{}, query, {}];
 
         // @ts-expect-error
-        expect(() => new GraphQLSchema({ query, types })).to.throw(
+        expect(() => new GraphQLSchemaImpl({ query, types })).to.throw(
           'One of the provided types for building the Schema is missing a name.',
         );
       });
 
       it('rejects a Schema which defines an object type twice', () => {
         const types = [
-          new GraphQLObjectType({ name: 'SameName', fields: {} }),
-          new GraphQLObjectType({ name: 'SameName', fields: {} }),
+          new GraphQLObjectTypeImpl({ name: 'SameName', fields: {} }),
+          new GraphQLObjectTypeImpl({ name: 'SameName', fields: {} }),
         ];
 
-        expect(() => new GraphQLSchema({ types })).to.throw(
+        expect(() => new GraphQLSchemaImpl({ types })).to.throw(
           'Schema must contain uniquely named types but contains multiple types named "SameName".',
         );
       });
 
       it('rejects a Schema which defines fields with conflicting types', () => {
         const fields = {};
-        const QueryType = new GraphQLObjectType({
+        const QueryType = new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
-            a: { type: new GraphQLObjectType({ name: 'SameName', fields }) },
-            b: { type: new GraphQLObjectType({ name: 'SameName', fields }) },
+            a: {
+              type: new GraphQLObjectTypeImpl({ name: 'SameName', fields }),
+            },
+            b: {
+              type: new GraphQLObjectTypeImpl({ name: 'SameName', fields }),
+            },
           },
         });
 
-        expect(() => new GraphQLSchema({ query: QueryType })).to.throw(
+        expect(() => new GraphQLSchemaImpl({ query: QueryType })).to.throw(
           'Schema must contain uniquely named types but contains multiple types named "SameName".',
         );
       });
@@ -509,7 +516,7 @@ describe('Type System: Schema', () => {
     describe('when assumed valid', () => {
       it('configures the schema to have no errors', () => {
         expect(
-          new GraphQLSchema({
+          new GraphQLSchemaImpl({
             assumeValid: true,
           }).__validationErrors,
         ).to.deep.equal([]);

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,15 +1,30 @@
 export type { Path as ResponsePath } from '../jsutils/Path';
 
+export type {
+  // GraphQL Schema interface
+  GraphQLSchema,
+} from './schema';
 export {
   // Predicate
   isSchema,
   // Assertion
   assertSchema,
   // GraphQL Schema definition
-  GraphQLSchema,
+  GraphQLSchemaImpl,
 } from './schema';
 export type { GraphQLSchemaConfig, GraphQLSchemaExtensions } from './schema';
 
+export type {
+  // Interfaces
+  GraphQLScalarType,
+  GraphQLObjectType,
+  GraphQLInterfaceType,
+  GraphQLUnionType,
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+} from './definition';
 export {
   resolveObjMapThunk,
   resolveReadonlyArrayThunk,
@@ -55,15 +70,15 @@ export {
   getNullableType,
   getNamedType,
   // Definitions
-  GraphQLScalarType,
-  GraphQLObjectType,
-  GraphQLInterfaceType,
-  GraphQLUnionType,
-  GraphQLEnumType,
-  GraphQLInputObjectType,
+  GraphQLScalarTypeImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLUnionTypeImpl,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
   // Type Wrappers
-  GraphQLList,
-  GraphQLNonNull,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
 } from './definition';
 
 export type {
@@ -121,13 +136,17 @@ export type {
   GraphQLScalarLiteralParser,
 } from './definition';
 
+export type {
+  // Directive Interface
+  GraphQLDirective,
+} from './directives';
 export {
   // Predicate
   isDirective,
   // Assertion
   assertDirective,
   // Directives Definition
-  GraphQLDirective,
+  GraphQLDirectiveImpl,
   // Built-in Directives defined by the Spec
   isSpecifiedDirective,
   specifiedDirectives,

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -7,18 +7,20 @@ import { print } from '../language/printer';
 import { astFromValue } from '../utilities/astFromValue';
 
 import type {
+  GraphQLEnumType,
   GraphQLEnumValue,
   GraphQLField,
   GraphQLFieldConfigMap,
   GraphQLInputField,
   GraphQLNamedType,
+  GraphQLObjectType,
   GraphQLType,
 } from './definition';
 import {
-  GraphQLEnumType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
+  GraphQLEnumTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
   isAbstractType,
   isEnumType,
   isInputObjectType,
@@ -33,7 +35,7 @@ import type { GraphQLDirective } from './directives';
 import { GraphQLBoolean, GraphQLString } from './scalars';
 import type { GraphQLSchema } from './schema';
 
-export const __Schema: GraphQLObjectType = new GraphQLObjectType({
+export const __Schema: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: '__Schema',
   description:
     'A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.',
@@ -45,14 +47,16 @@ export const __Schema: GraphQLObjectType = new GraphQLObjectType({
       },
       types: {
         description: 'A list of all types supported by this server.',
-        type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(__Type))),
+        type: new GraphQLNonNullImpl(
+          new GraphQLListImpl(new GraphQLNonNullImpl(__Type)),
+        ),
         resolve(schema) {
           return Object.values(schema.getTypeMap());
         },
       },
       queryType: {
         description: 'The type that query operations will be rooted at.',
-        type: new GraphQLNonNull(__Type),
+        type: new GraphQLNonNullImpl(__Type),
         resolve: (schema) => schema.getQueryType(),
       },
       mutationType: {
@@ -69,22 +73,22 @@ export const __Schema: GraphQLObjectType = new GraphQLObjectType({
       },
       directives: {
         description: 'A list of all directives supported by this server.',
-        type: new GraphQLNonNull(
-          new GraphQLList(new GraphQLNonNull(__Directive)),
+        type: new GraphQLNonNullImpl(
+          new GraphQLListImpl(new GraphQLNonNullImpl(__Directive)),
         ),
         resolve: (schema) => schema.getDirectives(),
       },
     } as GraphQLFieldConfigMap<GraphQLSchema, unknown>),
 });
 
-export const __Directive: GraphQLObjectType = new GraphQLObjectType({
+export const __Directive: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: '__Directive',
   description:
     "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
   fields: () =>
     ({
       name: {
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
         resolve: (directive) => directive.name,
       },
       description: {
@@ -92,18 +96,18 @@ export const __Directive: GraphQLObjectType = new GraphQLObjectType({
         resolve: (directive) => directive.description,
       },
       isRepeatable: {
-        type: new GraphQLNonNull(GraphQLBoolean),
+        type: new GraphQLNonNullImpl(GraphQLBoolean),
         resolve: (directive) => directive.isRepeatable,
       },
       locations: {
-        type: new GraphQLNonNull(
-          new GraphQLList(new GraphQLNonNull(__DirectiveLocation)),
+        type: new GraphQLNonNullImpl(
+          new GraphQLListImpl(new GraphQLNonNullImpl(__DirectiveLocation)),
         ),
         resolve: (directive) => directive.locations,
       },
       args: {
-        type: new GraphQLNonNull(
-          new GraphQLList(new GraphQLNonNull(__InputValue)),
+        type: new GraphQLNonNullImpl(
+          new GraphQLListImpl(new GraphQLNonNullImpl(__InputValue)),
         ),
         args: {
           includeDeprecated: {
@@ -120,7 +124,7 @@ export const __Directive: GraphQLObjectType = new GraphQLObjectType({
     } as GraphQLFieldConfigMap<GraphQLDirective, unknown>),
 });
 
-export const __DirectiveLocation: GraphQLEnumType = new GraphQLEnumType({
+export const __DirectiveLocation: GraphQLEnumType = new GraphQLEnumTypeImpl({
   name: '__DirectiveLocation',
   description:
     'A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.',
@@ -204,14 +208,14 @@ export const __DirectiveLocation: GraphQLEnumType = new GraphQLEnumType({
   },
 });
 
-export const __Type: GraphQLObjectType = new GraphQLObjectType({
+export const __Type: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: '__Type',
   description:
     'The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.',
   fields: () =>
     ({
       kind: {
-        type: new GraphQLNonNull(__TypeKind),
+        type: new GraphQLNonNullImpl(__TypeKind),
         resolve(type) {
           if (isScalarType(type)) {
             return TypeKind.SCALAR;
@@ -259,7 +263,7 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
           'specifiedByURL' in obj ? obj.specifiedByURL : undefined,
       },
       fields: {
-        type: new GraphQLList(new GraphQLNonNull(__Field)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(__Field)),
         args: {
           includeDeprecated: { type: GraphQLBoolean, defaultValue: false },
         },
@@ -273,7 +277,7 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         },
       },
       interfaces: {
-        type: new GraphQLList(new GraphQLNonNull(__Type)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(__Type)),
         resolve(type) {
           if (isObjectType(type) || isInterfaceType(type)) {
             return type.getInterfaces();
@@ -281,7 +285,7 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         },
       },
       possibleTypes: {
-        type: new GraphQLList(new GraphQLNonNull(__Type)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(__Type)),
         resolve(type, _args, _context, { schema }) {
           if (isAbstractType(type)) {
             return schema.getPossibleTypes(type);
@@ -289,7 +293,7 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         },
       },
       enumValues: {
-        type: new GraphQLList(new GraphQLNonNull(__EnumValue)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(__EnumValue)),
         args: {
           includeDeprecated: { type: GraphQLBoolean, defaultValue: false },
         },
@@ -303,7 +307,7 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         },
       },
       inputFields: {
-        type: new GraphQLList(new GraphQLNonNull(__InputValue)),
+        type: new GraphQLListImpl(new GraphQLNonNullImpl(__InputValue)),
         args: {
           includeDeprecated: {
             type: GraphQLBoolean,
@@ -326,14 +330,14 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
     } as GraphQLFieldConfigMap<GraphQLType, unknown>),
 });
 
-export const __Field: GraphQLObjectType = new GraphQLObjectType({
+export const __Field: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: '__Field',
   description:
     'Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.',
   fields: () =>
     ({
       name: {
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
         resolve: (field) => field.name,
       },
       description: {
@@ -341,8 +345,8 @@ export const __Field: GraphQLObjectType = new GraphQLObjectType({
         resolve: (field) => field.description,
       },
       args: {
-        type: new GraphQLNonNull(
-          new GraphQLList(new GraphQLNonNull(__InputValue)),
+        type: new GraphQLNonNullImpl(
+          new GraphQLListImpl(new GraphQLNonNullImpl(__InputValue)),
         ),
         args: {
           includeDeprecated: {
@@ -357,11 +361,11 @@ export const __Field: GraphQLObjectType = new GraphQLObjectType({
         },
       },
       type: {
-        type: new GraphQLNonNull(__Type),
+        type: new GraphQLNonNullImpl(__Type),
         resolve: (field) => field.type,
       },
       isDeprecated: {
-        type: new GraphQLNonNull(GraphQLBoolean),
+        type: new GraphQLNonNullImpl(GraphQLBoolean),
         resolve: (field) => field.deprecationReason != null,
       },
       deprecationReason: {
@@ -371,14 +375,14 @@ export const __Field: GraphQLObjectType = new GraphQLObjectType({
     } as GraphQLFieldConfigMap<GraphQLField<unknown, unknown>, unknown>),
 });
 
-export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
+export const __InputValue: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: '__InputValue',
   description:
     'Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.',
   fields: () =>
     ({
       name: {
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
         resolve: (inputValue) => inputValue.name,
       },
       description: {
@@ -386,7 +390,7 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
         resolve: (inputValue) => inputValue.description,
       },
       type: {
-        type: new GraphQLNonNull(__Type),
+        type: new GraphQLNonNullImpl(__Type),
         resolve: (inputValue) => inputValue.type,
       },
       defaultValue: {
@@ -400,7 +404,7 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
         },
       },
       isDeprecated: {
-        type: new GraphQLNonNull(GraphQLBoolean),
+        type: new GraphQLNonNullImpl(GraphQLBoolean),
         resolve: (field) => field.deprecationReason != null,
       },
       deprecationReason: {
@@ -410,14 +414,14 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
     } as GraphQLFieldConfigMap<GraphQLInputField, unknown>),
 });
 
-export const __EnumValue: GraphQLObjectType = new GraphQLObjectType({
+export const __EnumValue: GraphQLObjectType = new GraphQLObjectTypeImpl({
   name: '__EnumValue',
   description:
     'One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.',
   fields: () =>
     ({
       name: {
-        type: new GraphQLNonNull(GraphQLString),
+        type: new GraphQLNonNullImpl(GraphQLString),
         resolve: (enumValue) => enumValue.name,
       },
       description: {
@@ -425,7 +429,7 @@ export const __EnumValue: GraphQLObjectType = new GraphQLObjectType({
         resolve: (enumValue) => enumValue.description,
       },
       isDeprecated: {
-        type: new GraphQLNonNull(GraphQLBoolean),
+        type: new GraphQLNonNullImpl(GraphQLBoolean),
         resolve: (enumValue) => enumValue.deprecationReason != null,
       },
       deprecationReason: {
@@ -446,7 +450,7 @@ export enum TypeKind {
   NON_NULL = 'NON_NULL',
 }
 
-export const __TypeKind: GraphQLEnumType = new GraphQLEnumType({
+export const __TypeKind: GraphQLEnumType = new GraphQLEnumTypeImpl({
   name: '__TypeKind',
   description: 'An enum describing what kind of type a given `__Type` is.',
   values: {
@@ -498,7 +502,7 @@ export const __TypeKind: GraphQLEnumType = new GraphQLEnumType({
 
 export const SchemaMetaFieldDef: GraphQLField<unknown, unknown> = {
   name: '__schema',
-  type: new GraphQLNonNull(__Schema),
+  type: new GraphQLNonNullImpl(__Schema),
   description: 'Access the current type schema of this server.',
   args: [],
   resolve: (_source, _args, _context, { schema }) => schema,
@@ -515,7 +519,7 @@ export const TypeMetaFieldDef: GraphQLField<unknown, unknown> = {
     {
       name: 'name',
       description: undefined,
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
       defaultValue: undefined,
       deprecationReason: undefined,
       extensions: Object.create(null),
@@ -530,7 +534,7 @@ export const TypeMetaFieldDef: GraphQLField<unknown, unknown> = {
 
 export const TypeNameMetaFieldDef: GraphQLField<unknown, unknown> = {
   name: '__typename',
-  type: new GraphQLNonNull(GraphQLString),
+  type: new GraphQLNonNullImpl(GraphQLString),
   description: 'The name of the current Object type at runtime.',
   args: [],
   resolve: (_source, _args, _context, { parentType }) => parentType.name,

--- a/src/type/scalars.ts
+++ b/src/type/scalars.ts
@@ -6,8 +6,8 @@ import { GraphQLError } from '../error/GraphQLError';
 import { Kind } from '../language/kinds';
 import { print } from '../language/printer';
 
-import type { GraphQLNamedType } from './definition';
-import { GraphQLScalarType } from './definition';
+import type { GraphQLNamedType, GraphQLScalarType } from './definition';
+import { GraphQLScalarTypeImpl } from './definition';
 
 /**
  * Maximum possible Int value as per GraphQL Spec (32-bit signed integer).
@@ -21,7 +21,7 @@ export const GRAPHQL_MAX_INT = 2147483647;
  * */
 export const GRAPHQL_MIN_INT = -2147483648;
 
-export const GraphQLInt = new GraphQLScalarType<number>({
+export const GraphQLInt = new GraphQLScalarTypeImpl<number>({
   name: 'Int',
   description:
     'The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.',
@@ -84,7 +84,7 @@ export const GraphQLInt = new GraphQLScalarType<number>({
   },
 });
 
-export const GraphQLFloat = new GraphQLScalarType<number>({
+export const GraphQLFloat = new GraphQLScalarTypeImpl<number>({
   name: 'Float',
   description:
     'The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).',
@@ -129,7 +129,7 @@ export const GraphQLFloat = new GraphQLScalarType<number>({
   },
 });
 
-export const GraphQLString = new GraphQLScalarType<string>({
+export const GraphQLString = new GraphQLScalarTypeImpl<string>({
   name: 'String',
   description:
     'The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.',
@@ -173,7 +173,7 @@ export const GraphQLString = new GraphQLScalarType<string>({
   },
 });
 
-export const GraphQLBoolean = new GraphQLScalarType<boolean>({
+export const GraphQLBoolean = new GraphQLScalarTypeImpl<boolean>({
   name: 'Boolean',
   description: 'The `Boolean` scalar type represents `true` or `false`.',
 
@@ -211,7 +211,7 @@ export const GraphQLBoolean = new GraphQLScalarType<boolean>({
   },
 });
 
-export const GraphQLID = new GraphQLScalarType<string>({
+export const GraphQLID = new GraphQLScalarTypeImpl<string>({
   name: 'ID',
   description:
     'The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.',

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -6,7 +6,7 @@ import { print } from '../../language/printer';
 import { visit } from '../../language/visitor';
 
 import { getNamedType, isCompositeType } from '../../type/definition';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { buildSchema } from '../buildASTSchema';
 import { TypeInfo, visitWithTypeInfo } from '../TypeInfo';
@@ -48,7 +48,7 @@ const testSchema = buildSchema(`
 `);
 
 describe('TypeInfo', () => {
-  const schema = new GraphQLSchema({});
+  const schema = new GraphQLSchemaImpl({});
 
   it('can be Object.toStringified', () => {
     const typeInfo = new TypeInfo(schema);

--- a/src/utilities/__tests__/astFromValue-test.ts
+++ b/src/utilities/__tests__/astFromValue-test.ts
@@ -2,11 +2,11 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLScalarType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLScalarTypeImpl,
 } from '../../type/definition';
 import {
   GraphQLBoolean,
@@ -46,7 +46,7 @@ describe('astFromValue', () => {
       value: true,
     });
 
-    const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
+    const NonNullBoolean = new GraphQLNonNullImpl(GraphQLBoolean);
     expect(astFromValue(0, NonNullBoolean)).to.deep.equal({
       kind: 'BooleanValue',
       value: false,
@@ -193,7 +193,7 @@ describe('astFromValue', () => {
   });
 
   it('converts using serialize from a custom scalar type', () => {
-    const passthroughScalar = new GraphQLScalarType({
+    const passthroughScalar = new GraphQLScalarTypeImpl({
       name: 'PassthroughScalar',
       serialize(value) {
         return value;
@@ -212,7 +212,7 @@ describe('astFromValue', () => {
       'Cannot convert value to AST: Infinity.',
     );
 
-    const returnNullScalar = new GraphQLScalarType({
+    const returnNullScalar = new GraphQLScalarTypeImpl({
       name: 'ReturnNullScalar',
       serialize() {
         return null;
@@ -223,7 +223,7 @@ describe('astFromValue', () => {
 
     class SomeClass {}
 
-    const returnCustomClassScalar = new GraphQLScalarType({
+    const returnCustomClassScalar = new GraphQLScalarTypeImpl({
       name: 'ReturnCustomClassScalar',
       serialize() {
         return new SomeClass();
@@ -236,13 +236,13 @@ describe('astFromValue', () => {
   });
 
   it('does not converts NonNull values to NullValue', () => {
-    const NonNullBoolean = new GraphQLNonNull(GraphQLBoolean);
+    const NonNullBoolean = new GraphQLNonNullImpl(GraphQLBoolean);
     expect(astFromValue(null, NonNullBoolean)).to.deep.equal(null);
   });
 
   const complexValue = { someArbitrary: 'complexValue' };
 
-  const myEnum = new GraphQLEnumType({
+  const myEnum = new GraphQLEnumTypeImpl({
     name: 'MyEnum',
     values: {
       HELLO: {},
@@ -275,7 +275,7 @@ describe('astFromValue', () => {
 
   it('converts array values to List ASTs', () => {
     expect(
-      astFromValue(['FOO', 'BAR'], new GraphQLList(GraphQLString)),
+      astFromValue(['FOO', 'BAR'], new GraphQLListImpl(GraphQLString)),
     ).to.deep.equal({
       kind: 'ListValue',
       values: [
@@ -285,7 +285,7 @@ describe('astFromValue', () => {
     });
 
     expect(
-      astFromValue(['HELLO', 'GOODBYE'], new GraphQLList(myEnum)),
+      astFromValue(['HELLO', 'GOODBYE'], new GraphQLListImpl(myEnum)),
     ).to.deep.equal({
       kind: 'ListValue',
       values: [
@@ -301,7 +301,7 @@ describe('astFromValue', () => {
     }
 
     expect(
-      astFromValue(listGenerator(), new GraphQLList(GraphQLInt)),
+      astFromValue(listGenerator(), new GraphQLListImpl(GraphQLInt)),
     ).to.deep.equal({
       kind: 'ListValue',
       values: [
@@ -313,7 +313,9 @@ describe('astFromValue', () => {
   });
 
   it('converts list singletons', () => {
-    expect(astFromValue('FOO', new GraphQLList(GraphQLString))).to.deep.equal({
+    expect(
+      astFromValue('FOO', new GraphQLListImpl(GraphQLString)),
+    ).to.deep.equal({
       kind: 'StringValue',
       value: 'FOO',
     });
@@ -322,7 +324,7 @@ describe('astFromValue', () => {
   it('skip invalid list items', () => {
     const ast = astFromValue(
       ['FOO', null, 'BAR'],
-      new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
     );
 
     expect(ast).to.deep.equal({
@@ -334,7 +336,7 @@ describe('astFromValue', () => {
     });
   });
 
-  const inputObj = new GraphQLInputObjectType({
+  const inputObj = new GraphQLInputObjectTypeImpl({
     name: 'MyInputObj',
     fields: {
       foo: { type: GraphQLFloat },

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -33,7 +33,7 @@ import {
   GraphQLInt,
   GraphQLString,
 } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 import { validateSchema } from '../../type/validate';
 
 import { graphqlSync } from '../../graphql';
@@ -109,7 +109,7 @@ describe('Schema Builder', () => {
   });
 
   it('Match order of default types and directives', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const sdlSchema = buildASTSchema({
       kind: Kind.DOCUMENT,
       definitions: [],

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -5,8 +5,8 @@ import { dedent } from '../../__testUtils__/dedent';
 
 import {
   assertEnumType,
-  GraphQLEnumType,
-  GraphQLObjectType,
+  GraphQLEnumTypeImpl,
+  GraphQLObjectTypeImpl,
 } from '../../type/definition';
 import {
   GraphQLBoolean,
@@ -15,7 +15,7 @@ import {
   GraphQLInt,
   GraphQLString,
 } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { graphqlSync } from '../../graphql';
 
@@ -331,7 +331,7 @@ describe('Type System: build schema from introspection', () => {
   });
 
   it('builds a schema with an enum', () => {
-    const foodEnum = new GraphQLEnumType({
+    const foodEnum = new GraphQLEnumTypeImpl({
       name: 'Food',
       description: 'Varieties of food stuffs',
       values: {
@@ -348,8 +348,8 @@ describe('Type System: build schema from introspection', () => {
         },
       },
     });
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({
         name: 'EnumFields',
         fields: {
           food: {

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -3,11 +3,11 @@ import { describe, it } from 'mocha';
 
 import type { GraphQLInputType } from '../../type/definition';
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLScalarType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLScalarTypeImpl,
 } from '../../type/definition';
 import { GraphQLInt } from '../../type/scalars';
 
@@ -51,7 +51,7 @@ function expectErrors(result: CoerceResult) {
 
 describe('coerceInputValue', () => {
   describe('for GraphQLNonNull', () => {
-    const TestNonNull = new GraphQLNonNull(GraphQLInt);
+    const TestNonNull = new GraphQLNonNullImpl(GraphQLInt);
 
     it('returns no error for non-null value', () => {
       const result = coerceValue(1, TestNonNull);
@@ -82,7 +82,7 @@ describe('coerceInputValue', () => {
   });
 
   describe('for GraphQLScalar', () => {
-    const TestScalar = new GraphQLScalarType({
+    const TestScalar = new GraphQLScalarTypeImpl({
       name: 'TestScalar',
       parseValue(input: any) {
         if (input.error != null) {
@@ -132,7 +132,7 @@ describe('coerceInputValue', () => {
   });
 
   describe('for GraphQLEnum', () => {
-    const TestEnum = new GraphQLEnumType({
+    const TestEnum = new GraphQLEnumTypeImpl({
       name: 'TestEnum',
       values: {
         FOO: { value: 'InternalFoo' },
@@ -183,10 +183,10 @@ describe('coerceInputValue', () => {
   });
 
   describe('for GraphQLInputObject', () => {
-    const TestInputObject = new GraphQLInputObjectType({
+    const TestInputObject = new GraphQLInputObjectTypeImpl({
       name: 'TestInputObject',
       fields: {
-        foo: { type: new GraphQLNonNull(GraphQLInt) },
+        foo: { type: new GraphQLNonNullImpl(GraphQLInt) },
         bar: { type: GraphQLInt },
       },
     });
@@ -275,11 +275,11 @@ describe('coerceInputValue', () => {
 
   describe('for GraphQLInputObject with default value', () => {
     const makeTestInputObject = (defaultValue: any) =>
-      new GraphQLInputObjectType({
+      new GraphQLInputObjectTypeImpl({
         name: 'TestInputObject',
         fields: {
           foo: {
-            type: new GraphQLScalarType({ name: 'TestScalar' }),
+            type: new GraphQLScalarTypeImpl({ name: 'TestScalar' }),
             defaultValue,
           },
         },
@@ -307,7 +307,7 @@ describe('coerceInputValue', () => {
   });
 
   describe('for GraphQLList', () => {
-    const TestList = new GraphQLList(GraphQLInt);
+    const TestList = new GraphQLListImpl(GraphQLInt);
 
     it('returns no error for a valid input', () => {
       const result = coerceValue([1, 2, 3], TestList);
@@ -347,8 +347,8 @@ describe('coerceInputValue', () => {
     });
 
     it('returns a list for a non-list object value', () => {
-      const TestListOfObjects = new GraphQLList(
-        new GraphQLInputObjectType({
+      const TestListOfObjects = new GraphQLListImpl(
+        new GraphQLInputObjectTypeImpl({
           name: 'TestObject',
           fields: {
             length: { type: GraphQLInt },
@@ -378,7 +378,7 @@ describe('coerceInputValue', () => {
   });
 
   describe('for nested GraphQLList', () => {
-    const TestNestedList = new GraphQLList(new GraphQLList(GraphQLInt));
+    const TestNestedList = new GraphQLListImpl(new GraphQLListImpl(GraphQLInt));
 
     it('returns no error for a valid input', () => {
       const result = coerceValue([[1], [2, 3]], TestNestedList);
@@ -409,7 +409,7 @@ describe('coerceInputValue', () => {
   describe('with default onError', () => {
     it('throw error without path', () => {
       expect(() =>
-        coerceInputValue(null, new GraphQLNonNull(GraphQLInt)),
+        coerceInputValue(null, new GraphQLNonNullImpl(GraphQLInt)),
       ).to.throw(
         'Invalid value null: Expected non-nullable type "Int!" not to be null.',
       );
@@ -419,7 +419,7 @@ describe('coerceInputValue', () => {
       expect(() =>
         coerceInputValue(
           [null],
-          new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLInt)),
         ),
       ).to.throw(
         'Invalid value null at "value[0]": Expected non-nullable type "Int!" not to be null.',

--- a/src/utilities/__tests__/concatAST-test.ts
+++ b/src/utilities/__tests__/concatAST-test.ts
@@ -5,17 +5,17 @@ import { dedent } from '../../__testUtils__/dedent';
 
 import { parse } from '../../language/parser';
 import { print } from '../../language/printer';
-import { Source } from '../../language/source';
+import { SourceImpl } from '../../language/source';
 
 import { concatAST } from '../concatAST';
 
 describe('concatAST', () => {
   it('concatenates two ASTs together', () => {
-    const sourceA = new Source(`
+    const sourceA = new SourceImpl(`
       { a, b, ...Frag }
     `);
 
-    const sourceB = new Source(`
+    const sourceB = new SourceImpl(`
       fragment Frag on T {
         c
       }

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -25,7 +25,8 @@ import {
   GraphQLInt,
   GraphQLString,
 } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import type { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 import { validateSchema } from '../../type/validate';
 
 import { graphqlSync } from '../../graphql';
@@ -498,7 +499,7 @@ describe('extendSchema', () => {
   });
 
   it('builds types with deprecated fields/values', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const extendAST = parse(`
       type SomeObject {
         deprecatedField: String @deprecated(reason: "not used anymore")
@@ -1111,7 +1112,7 @@ describe('extendSchema', () => {
   });
 
   it('Rejects invalid SDL', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const extendAST = parse('extend schema @unknown');
 
     expect(() => extendSchema(schema, extendAST)).to.throw(
@@ -1120,7 +1121,7 @@ describe('extendSchema', () => {
   });
 
   it('Allows to disable SDL validation', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const extendAST = parse('extend schema @unknown');
 
     extendSchema(schema, extendAST, { assumeValid: true });
@@ -1128,7 +1129,7 @@ describe('extendSchema', () => {
   });
 
   it('Throws on unknown types', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const ast = parse(`
       type Query {
         unknown: UnknownType
@@ -1140,7 +1141,7 @@ describe('extendSchema', () => {
   });
 
   it('Rejects invalid AST', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
 
     // @ts-expect-error (Second argument expects DocumentNode)
     expect(() => extendSchema(schema, null)).to.throw(
@@ -1154,7 +1155,7 @@ describe('extendSchema', () => {
   });
 
   it('does not allow replacing a default directive', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const extendAST = parse(`
       directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD
     `);
@@ -1183,7 +1184,7 @@ describe('extendSchema', () => {
 
   describe('can add additional root operation types', () => {
     it('does not automatically include common root type names', () => {
-      const schema = new GraphQLSchema({});
+      const schema = new GraphQLSchemaImpl({});
       const extendedSchema = extendSchema(schema, parse('type Mutation'));
 
       expect(extendedSchema.getType('Mutation')).to.not.equal(undefined);

--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -7,7 +7,7 @@ import {
   GraphQLSkipDirective,
   GraphQLSpecifiedByDirective,
 } from '../../type/directives';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { buildSchema } from '../buildASTSchema';
 import {
@@ -795,9 +795,9 @@ describe('findBreakingChanges', () => {
   });
 
   it('should detect if a directive was implicitly removed', () => {
-    const oldSchema = new GraphQLSchema({});
+    const oldSchema = new GraphQLSchemaImpl({});
 
-    const newSchema = new GraphQLSchema({
+    const newSchema = new GraphQLSchemaImpl({
       directives: [
         GraphQLSkipDirective,
         GraphQLIncludeDirective,

--- a/src/utilities/__tests__/introspectionFromSchema-test.ts
+++ b/src/utilities/__tests__/introspectionFromSchema-test.ts
@@ -3,9 +3,9 @@ import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent';
 
-import { GraphQLObjectType } from '../../type/definition';
+import { GraphQLObjectTypeImpl } from '../../type/definition';
 import { GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { buildClientSchema } from '../buildClientSchema';
 import type { IntrospectionQuery } from '../getIntrospectionQuery';
@@ -17,9 +17,9 @@ function introspectionToSDL(introspection: IntrospectionQuery): string {
 }
 
 describe('introspectionFromSchema', () => {
-  const schema = new GraphQLSchema({
+  const schema = new GraphQLSchemaImpl({
     description: 'This is a simple schema',
-    query: new GraphQLObjectType({
+    query: new GraphQLObjectTypeImpl({
       name: 'Simple',
       description: 'This is a simple type',
       fields: {

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -7,18 +7,19 @@ import { DirectiveLocation } from '../../language/directiveLocation';
 
 import type { GraphQLFieldConfig } from '../../type/definition';
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLUnionType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../../type/definition';
-import { GraphQLDirective } from '../../type/directives';
+import { GraphQLDirectiveImpl } from '../../type/directives';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import type { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { buildSchema } from '../buildASTSchema';
 import { printIntrospectionSchema, printSchema } from '../printSchema';
@@ -33,11 +34,11 @@ function expectPrintedSchema(schema: GraphQLSchema) {
 function buildSingleFieldSchema(
   fieldConfig: GraphQLFieldConfig<unknown, unknown>,
 ) {
-  const Query = new GraphQLObjectType({
+  const Query = new GraphQLObjectTypeImpl({
     name: 'Query',
     fields: { singleField: fieldConfig },
   });
-  return new GraphQLSchema({ query: Query });
+  return new GraphQLSchemaImpl({ query: Query });
 }
 
 describe('Type System Printer', () => {
@@ -52,7 +53,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String] Field', () => {
     const schema = buildSingleFieldSchema({
-      type: new GraphQLList(GraphQLString),
+      type: new GraphQLListImpl(GraphQLString),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -64,7 +65,7 @@ describe('Type System Printer', () => {
 
   it('Prints String! Field', () => {
     const schema = buildSingleFieldSchema({
-      type: new GraphQLNonNull(GraphQLString),
+      type: new GraphQLNonNullImpl(GraphQLString),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -76,7 +77,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String]! Field', () => {
     const schema = buildSingleFieldSchema({
-      type: new GraphQLNonNull(new GraphQLList(GraphQLString)),
+      type: new GraphQLNonNullImpl(new GraphQLListImpl(GraphQLString)),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -88,7 +89,7 @@ describe('Type System Printer', () => {
 
   it('Prints [String!] Field', () => {
     const schema = buildSingleFieldSchema({
-      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      type: new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -100,8 +101,8 @@ describe('Type System Printer', () => {
 
   it('Prints [String!]! Field', () => {
     const schema = buildSingleFieldSchema({
-      type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      type: new GraphQLNonNullImpl(
+        new GraphQLListImpl(new GraphQLNonNullImpl(GraphQLString)),
       ),
     });
 
@@ -113,11 +114,11 @@ describe('Type System Printer', () => {
   });
 
   it('Print Object Field', () => {
-    const FooType = new GraphQLObjectType({
+    const FooType = new GraphQLObjectTypeImpl({
       name: 'Foo',
       fields: { str: { type: GraphQLString } },
     });
-    const schema = new GraphQLSchema({ types: [FooType] });
+    const schema = new GraphQLSchemaImpl({ types: [FooType] });
 
     expectPrintedSchema(schema).to.equal(dedent`
       type Foo {
@@ -183,7 +184,7 @@ describe('Type System Printer', () => {
   it('Prints String Field With Int! Arg', () => {
     const schema = buildSingleFieldSchema({
       type: GraphQLString,
-      args: { argOne: { type: new GraphQLNonNull(GraphQLInt) } },
+      args: { argOne: { type: new GraphQLNonNullImpl(GraphQLInt) } },
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -261,9 +262,9 @@ describe('Type System Printer', () => {
   });
 
   it('Prints schema with description', () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       description: 'Schema description.',
-      query: new GraphQLObjectType({ name: 'Query', fields: {} }),
+      query: new GraphQLObjectTypeImpl({ name: 'Query', fields: {} }),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -277,10 +278,13 @@ describe('Type System Printer', () => {
   });
 
   it('Omits schema of common names', () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({ name: 'Query', fields: {} }),
-      mutation: new GraphQLObjectType({ name: 'Mutation', fields: {} }),
-      subscription: new GraphQLObjectType({ name: 'Subscription', fields: {} }),
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({ name: 'Query', fields: {} }),
+      mutation: new GraphQLObjectTypeImpl({ name: 'Mutation', fields: {} }),
+      subscription: new GraphQLObjectTypeImpl({
+        name: 'Subscription',
+        fields: {},
+      }),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -293,8 +297,8 @@ describe('Type System Printer', () => {
   });
 
   it('Prints custom query root types', () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({ name: 'CustomType', fields: {} }),
+    const schema = new GraphQLSchemaImpl({
+      query: new GraphQLObjectTypeImpl({ name: 'CustomType', fields: {} }),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -307,8 +311,8 @@ describe('Type System Printer', () => {
   });
 
   it('Prints custom mutation root types', () => {
-    const schema = new GraphQLSchema({
-      mutation: new GraphQLObjectType({ name: 'CustomType', fields: {} }),
+    const schema = new GraphQLSchemaImpl({
+      mutation: new GraphQLObjectTypeImpl({ name: 'CustomType', fields: {} }),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -321,8 +325,11 @@ describe('Type System Printer', () => {
   });
 
   it('Prints custom subscription root types', () => {
-    const schema = new GraphQLSchema({
-      subscription: new GraphQLObjectType({ name: 'CustomType', fields: {} }),
+    const schema = new GraphQLSchemaImpl({
+      subscription: new GraphQLObjectTypeImpl({
+        name: 'CustomType',
+        fields: {},
+      }),
     });
 
     expectPrintedSchema(schema).to.equal(dedent`
@@ -335,18 +342,18 @@ describe('Type System Printer', () => {
   });
 
   it('Print Interface', () => {
-    const FooType = new GraphQLInterfaceType({
+    const FooType = new GraphQLInterfaceTypeImpl({
       name: 'Foo',
       fields: { str: { type: GraphQLString } },
     });
 
-    const BarType = new GraphQLObjectType({
+    const BarType = new GraphQLObjectTypeImpl({
       name: 'Bar',
       fields: { str: { type: GraphQLString } },
       interfaces: [FooType],
     });
 
-    const schema = new GraphQLSchema({ types: [BarType] });
+    const schema = new GraphQLSchemaImpl({ types: [BarType] });
     expectPrintedSchema(schema).to.equal(dedent`
       type Bar implements Foo {
         str: String
@@ -359,17 +366,17 @@ describe('Type System Printer', () => {
   });
 
   it('Print Multiple Interface', () => {
-    const FooType = new GraphQLInterfaceType({
+    const FooType = new GraphQLInterfaceTypeImpl({
       name: 'Foo',
       fields: { str: { type: GraphQLString } },
     });
 
-    const BazType = new GraphQLInterfaceType({
+    const BazType = new GraphQLInterfaceTypeImpl({
       name: 'Baz',
       fields: { int: { type: GraphQLInt } },
     });
 
-    const BarType = new GraphQLObjectType({
+    const BarType = new GraphQLObjectTypeImpl({
       name: 'Bar',
       fields: {
         str: { type: GraphQLString },
@@ -378,7 +385,7 @@ describe('Type System Printer', () => {
       interfaces: [FooType, BazType],
     });
 
-    const schema = new GraphQLSchema({ types: [BarType] });
+    const schema = new GraphQLSchemaImpl({ types: [BarType] });
     expectPrintedSchema(schema).to.equal(dedent`
       type Bar implements Foo & Baz {
         str: String
@@ -396,12 +403,12 @@ describe('Type System Printer', () => {
   });
 
   it('Print Hierarchical Interface', () => {
-    const FooType = new GraphQLInterfaceType({
+    const FooType = new GraphQLInterfaceTypeImpl({
       name: 'Foo',
       fields: { str: { type: GraphQLString } },
     });
 
-    const BazType = new GraphQLInterfaceType({
+    const BazType = new GraphQLInterfaceTypeImpl({
       name: 'Baz',
       interfaces: [FooType],
       fields: {
@@ -410,7 +417,7 @@ describe('Type System Printer', () => {
       },
     });
 
-    const BarType = new GraphQLObjectType({
+    const BarType = new GraphQLObjectTypeImpl({
       name: 'Bar',
       fields: {
         str: { type: GraphQLString },
@@ -419,12 +426,12 @@ describe('Type System Printer', () => {
       interfaces: [FooType, BazType],
     });
 
-    const Query = new GraphQLObjectType({
+    const Query = new GraphQLObjectTypeImpl({
       name: 'Query',
       fields: { bar: { type: BarType } },
     });
 
-    const schema = new GraphQLSchema({ query: Query, types: [BarType] });
+    const schema = new GraphQLSchemaImpl({ query: Query, types: [BarType] });
     expectPrintedSchema(schema).to.equal(dedent`
       type Bar implements Foo & Baz {
         str: String
@@ -447,31 +454,33 @@ describe('Type System Printer', () => {
   });
 
   it('Print Unions', () => {
-    const FooType = new GraphQLObjectType({
+    const FooType = new GraphQLObjectTypeImpl({
       name: 'Foo',
       fields: {
         bool: { type: GraphQLBoolean },
       },
     });
 
-    const BarType = new GraphQLObjectType({
+    const BarType = new GraphQLObjectTypeImpl({
       name: 'Bar',
       fields: {
         str: { type: GraphQLString },
       },
     });
 
-    const SingleUnion = new GraphQLUnionType({
+    const SingleUnion = new GraphQLUnionTypeImpl({
       name: 'SingleUnion',
       types: [FooType],
     });
 
-    const MultipleUnion = new GraphQLUnionType({
+    const MultipleUnion = new GraphQLUnionTypeImpl({
       name: 'MultipleUnion',
       types: [FooType, BarType],
     });
 
-    const schema = new GraphQLSchema({ types: [SingleUnion, MultipleUnion] });
+    const schema = new GraphQLSchemaImpl({
+      types: [SingleUnion, MultipleUnion],
+    });
     expectPrintedSchema(schema).to.equal(dedent`
       union SingleUnion = Foo
 
@@ -488,14 +497,14 @@ describe('Type System Printer', () => {
   });
 
   it('Print Input Type', () => {
-    const InputType = new GraphQLInputObjectType({
+    const InputType = new GraphQLInputObjectTypeImpl({
       name: 'InputType',
       fields: {
         int: { type: GraphQLInt },
       },
     });
 
-    const schema = new GraphQLSchema({ types: [InputType] });
+    const schema = new GraphQLSchemaImpl({ types: [InputType] });
     expectPrintedSchema(schema).to.equal(dedent`
       input InputType {
         int: Int
@@ -504,28 +513,28 @@ describe('Type System Printer', () => {
   });
 
   it('Custom Scalar', () => {
-    const OddType = new GraphQLScalarType({ name: 'Odd' });
+    const OddType = new GraphQLScalarTypeImpl({ name: 'Odd' });
 
-    const schema = new GraphQLSchema({ types: [OddType] });
+    const schema = new GraphQLSchemaImpl({ types: [OddType] });
     expectPrintedSchema(schema).to.equal(dedent`
       scalar Odd
     `);
   });
 
   it('Custom Scalar with specifiedByURL', () => {
-    const FooType = new GraphQLScalarType({
+    const FooType = new GraphQLScalarTypeImpl({
       name: 'Foo',
       specifiedByURL: 'https://example.com/foo_spec',
     });
 
-    const schema = new GraphQLSchema({ types: [FooType] });
+    const schema = new GraphQLSchemaImpl({ types: [FooType] });
     expectPrintedSchema(schema).to.equal(dedent`
       scalar Foo @specifiedBy(url: "https://example.com/foo_spec")
     `);
   });
 
   it('Enum', () => {
-    const RGBType = new GraphQLEnumType({
+    const RGBType = new GraphQLEnumTypeImpl({
       name: 'RGB',
       values: {
         RED: {},
@@ -534,7 +543,7 @@ describe('Type System Printer', () => {
       },
     });
 
-    const schema = new GraphQLSchema({ types: [RGBType] });
+    const schema = new GraphQLSchemaImpl({ types: [RGBType] });
     expectPrintedSchema(schema).to.equal(dedent`
       enum RGB {
         RED
@@ -545,13 +554,13 @@ describe('Type System Printer', () => {
   });
 
   it('Prints empty types', () => {
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       types: [
-        new GraphQLEnumType({ name: 'SomeEnum', values: {} }),
-        new GraphQLInputObjectType({ name: 'SomeInputObject', fields: {} }),
-        new GraphQLInterfaceType({ name: 'SomeInterface', fields: {} }),
-        new GraphQLObjectType({ name: 'SomeObject', fields: {} }),
-        new GraphQLUnionType({ name: 'SomeUnion', types: [] }),
+        new GraphQLEnumTypeImpl({ name: 'SomeEnum', values: {} }),
+        new GraphQLInputObjectTypeImpl({ name: 'SomeInputObject', fields: {} }),
+        new GraphQLInterfaceTypeImpl({ name: 'SomeInterface', fields: {} }),
+        new GraphQLObjectTypeImpl({ name: 'SomeObject', fields: {} }),
+        new GraphQLUnionTypeImpl({ name: 'SomeUnion', types: [] }),
       ],
     });
 
@@ -569,11 +578,11 @@ describe('Type System Printer', () => {
   });
 
   it('Prints custom directives', () => {
-    const SimpleDirective = new GraphQLDirective({
+    const SimpleDirective = new GraphQLDirectiveImpl({
       name: 'simpleDirective',
       locations: [DirectiveLocation.FIELD],
     });
-    const ComplexDirective = new GraphQLDirective({
+    const ComplexDirective = new GraphQLDirectiveImpl({
       name: 'complexDirective',
       description: 'Complex Directive',
       args: {
@@ -584,7 +593,7 @@ describe('Type System Printer', () => {
       locations: [DirectiveLocation.FIELD, DirectiveLocation.QUERY],
     });
 
-    const schema = new GraphQLSchema({
+    const schema = new GraphQLSchemaImpl({
       directives: [SimpleDirective, ComplexDirective],
     });
     expectPrintedSchema(schema).to.equal(dedent`
@@ -638,7 +647,7 @@ describe('Type System Printer', () => {
   });
 
   it('Print Introspection Schema', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const output = printIntrospectionSchema(schema);
 
     expect(output).to.equal(dedent`

--- a/src/utilities/__tests__/stripIgnoredCharacters-fuzz.ts
+++ b/src/utilities/__tests__/stripIgnoredCharacters-fuzz.ts
@@ -6,7 +6,7 @@ import { genFuzzStrings } from '../../__testUtils__/genFuzzStrings';
 import { inspectStr } from '../../__testUtils__/inspectStr';
 
 import { Lexer } from '../../language/lexer';
-import { Source } from '../../language/source';
+import { SourceImpl } from '../../language/source';
 
 import { stripIgnoredCharacters } from '../stripIgnoredCharacters';
 
@@ -55,7 +55,7 @@ const nonPunctuatorTokens = [
 ];
 
 function lexValue(str: string) {
-  const lexer = new Lexer(new Source(str));
+  const lexer = new Lexer(new SourceImpl(str));
   const value = lexer.advance().value;
 
   assert(lexer.advance().kind === '<EOF>', 'Expected EOF');

--- a/src/utilities/__tests__/stripIgnoredCharacters-test.ts
+++ b/src/utilities/__tests__/stripIgnoredCharacters-test.ts
@@ -9,12 +9,12 @@ import type { Maybe } from '../../jsutils/Maybe';
 
 import { Lexer } from '../../language/lexer';
 import { parse } from '../../language/parser';
-import { Source } from '../../language/source';
+import { SourceImpl } from '../../language/source';
 
 import { stripIgnoredCharacters } from '../stripIgnoredCharacters';
 
 function lexValue(str: string): Maybe<string> {
-  const lexer = new Lexer(new Source(str));
+  const lexer = new Lexer(new SourceImpl(str));
   const value = lexer.advance().value;
 
   assert(lexer.advance().kind === '<EOF>', 'Expected EOF');
@@ -56,7 +56,7 @@ describe('stripIgnoredCharacters', () => {
   });
 
   it('accepts Source object', () => {
-    expect(stripIgnoredCharacters(new Source('{ a }'))).to.equal('{a}');
+    expect(stripIgnoredCharacters(new SourceImpl('{ a }'))).to.equal('{a}');
   });
 
   it('strips ignored characters from GraphQL SDL document', () => {

--- a/src/utilities/__tests__/typeComparators-test.ts
+++ b/src/utilities/__tests__/typeComparators-test.ts
@@ -3,14 +3,14 @@ import { describe, it } from 'mocha';
 
 import type { GraphQLFieldConfigMap } from '../../type/definition';
 import {
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLUnionType,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLUnionTypeImpl,
 } from '../../type/definition';
 import { GraphQLFloat, GraphQLInt, GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { isEqualType, isTypeSubTypeOf } from '../typeComparators';
 
@@ -26,12 +26,15 @@ describe('typeComparators', () => {
 
     it('lists of same type are equal', () => {
       expect(
-        isEqualType(new GraphQLList(GraphQLInt), new GraphQLList(GraphQLInt)),
+        isEqualType(
+          new GraphQLListImpl(GraphQLInt),
+          new GraphQLListImpl(GraphQLInt),
+        ),
       ).to.equal(true);
     });
 
     it('lists is not equal to item', () => {
-      expect(isEqualType(new GraphQLList(GraphQLInt), GraphQLInt)).to.equal(
+      expect(isEqualType(new GraphQLListImpl(GraphQLInt), GraphQLInt)).to.equal(
         false,
       );
     });
@@ -39,23 +42,23 @@ describe('typeComparators', () => {
     it('non-null of same type are equal', () => {
       expect(
         isEqualType(
-          new GraphQLNonNull(GraphQLInt),
-          new GraphQLNonNull(GraphQLInt),
+          new GraphQLNonNullImpl(GraphQLInt),
+          new GraphQLNonNullImpl(GraphQLInt),
         ),
       ).to.equal(true);
     });
 
     it('non-null is not equal to nullable', () => {
-      expect(isEqualType(new GraphQLNonNull(GraphQLInt), GraphQLInt)).to.equal(
-        false,
-      );
+      expect(
+        isEqualType(new GraphQLNonNullImpl(GraphQLInt), GraphQLInt),
+      ).to.equal(false);
     });
   });
 
   describe('isTypeSubTypeOf', () => {
     function testSchema(fields: GraphQLFieldConfigMap<unknown, unknown>) {
-      return new GraphQLSchema({
-        query: new GraphQLObjectType({
+      return new GraphQLSchemaImpl({
+        query: new GraphQLObjectTypeImpl({
           name: 'Query',
           fields,
         }),
@@ -77,51 +80,54 @@ describe('typeComparators', () => {
     it('non-null is subtype of nullable', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLNonNull(GraphQLInt), GraphQLInt),
+        isTypeSubTypeOf(schema, new GraphQLNonNullImpl(GraphQLInt), GraphQLInt),
       ).to.equal(true);
     });
 
     it('nullable is not subtype of non-null', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLNonNull(GraphQLInt)),
+        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLNonNullImpl(GraphQLInt)),
       ).to.equal(false);
     });
 
     it('item is not subtype of list', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLList(GraphQLInt)),
+        isTypeSubTypeOf(schema, GraphQLInt, new GraphQLListImpl(GraphQLInt)),
       ).to.equal(false);
     });
 
     it('list is not subtype of item', () => {
       const schema = testSchema({ field: { type: GraphQLString } });
       expect(
-        isTypeSubTypeOf(schema, new GraphQLList(GraphQLInt), GraphQLInt),
+        isTypeSubTypeOf(schema, new GraphQLListImpl(GraphQLInt), GraphQLInt),
       ).to.equal(false);
     });
 
     it('member is subtype of union', () => {
-      const member = new GraphQLObjectType({
+      const member = new GraphQLObjectTypeImpl({
         name: 'Object',
         fields: {
           field: { type: GraphQLString },
         },
       });
-      const union = new GraphQLUnionType({ name: 'Union', types: [member] });
+      const union = new GraphQLUnionTypeImpl({
+        name: 'Union',
+        types: [member],
+      });
       const schema = testSchema({ field: { type: union } });
       expect(isTypeSubTypeOf(schema, member, union)).to.equal(true);
     });
 
     it('implementing object is subtype of interface', () => {
-      const iface = new GraphQLInterfaceType({
+      const iface = new GraphQLInterfaceTypeImpl({
         name: 'Interface',
         fields: {
           field: { type: GraphQLString },
         },
       });
-      const impl = new GraphQLObjectType({
+      const impl = new GraphQLObjectTypeImpl({
         name: 'Object',
         interfaces: [iface],
         fields: {
@@ -133,20 +139,20 @@ describe('typeComparators', () => {
     });
 
     it('implementing interface is subtype of interface', () => {
-      const iface = new GraphQLInterfaceType({
+      const iface = new GraphQLInterfaceTypeImpl({
         name: 'Interface',
         fields: {
           field: { type: GraphQLString },
         },
       });
-      const iface2 = new GraphQLInterfaceType({
+      const iface2 = new GraphQLInterfaceTypeImpl({
         name: 'Interface2',
         interfaces: [iface],
         fields: {
           field: { type: GraphQLString },
         },
       });
-      const impl = new GraphQLObjectType({
+      const impl = new GraphQLObjectTypeImpl({
         name: 'Object',
         interfaces: [iface2, iface],
         fields: {

--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -8,11 +8,11 @@ import { parseValue } from '../../language/parser';
 
 import type { GraphQLInputType } from '../../type/definition';
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLScalarType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLScalarTypeImpl,
 } from '../../type/definition';
 import {
   GraphQLBoolean,
@@ -62,7 +62,7 @@ describe('valueFromAST', () => {
   });
 
   it('convert using parseLiteral from a custom scalar type', () => {
-    const passthroughScalar = new GraphQLScalarType({
+    const passthroughScalar = new GraphQLScalarTypeImpl({
       name: 'PassthroughScalar',
       parseLiteral(node) {
         assert(node.kind === 'StringValue');
@@ -73,7 +73,7 @@ describe('valueFromAST', () => {
 
     expectValueFrom('"value"', passthroughScalar).to.equal('value');
 
-    const throwScalar = new GraphQLScalarType({
+    const throwScalar = new GraphQLScalarTypeImpl({
       name: 'ThrowScalar',
       parseLiteral() {
         throw new Error('Test');
@@ -83,7 +83,7 @@ describe('valueFromAST', () => {
 
     expectValueFrom('value', throwScalar).to.equal(undefined);
 
-    const returnUndefinedScalar = new GraphQLScalarType({
+    const returnUndefinedScalar = new GraphQLScalarTypeImpl({
       name: 'ReturnUndefinedScalar',
       parseLiteral() {
         return undefined;
@@ -95,7 +95,7 @@ describe('valueFromAST', () => {
   });
 
   it('converts enum values according to input coercion rules', () => {
-    const testEnum = new GraphQLEnumType({
+    const testEnum = new GraphQLEnumTypeImpl({
       name: 'TestColor',
       values: {
         RED: { value: 1 },
@@ -113,21 +113,21 @@ describe('valueFromAST', () => {
     expectValueFrom('"BLUE"', testEnum).to.equal(undefined);
     expectValueFrom('null', testEnum).to.equal(null);
     expectValueFrom('NULL', testEnum).to.equal(null);
-    expectValueFrom('NULL', new GraphQLNonNull(testEnum)).to.equal(null);
+    expectValueFrom('NULL', new GraphQLNonNullImpl(testEnum)).to.equal(null);
     expectValueFrom('NAN', testEnum).to.deep.equal(NaN);
     expectValueFrom('NO_CUSTOM_VALUE', testEnum).to.equal('NO_CUSTOM_VALUE');
   });
 
   // Boolean!
-  const nonNullBool = new GraphQLNonNull(GraphQLBoolean);
+  const nonNullBool = new GraphQLNonNullImpl(GraphQLBoolean);
   // [Boolean]
-  const listOfBool = new GraphQLList(GraphQLBoolean);
+  const listOfBool = new GraphQLListImpl(GraphQLBoolean);
   // [Boolean!]
-  const listOfNonNullBool = new GraphQLList(nonNullBool);
+  const listOfNonNullBool = new GraphQLListImpl(nonNullBool);
   // [Boolean]!
-  const nonNullListOfBool = new GraphQLNonNull(listOfBool);
+  const nonNullListOfBool = new GraphQLNonNullImpl(listOfBool);
   // [Boolean!]!
-  const nonNullListOfNonNullBool = new GraphQLNonNull(listOfNonNullBool);
+  const nonNullListOfNonNullBool = new GraphQLNonNullImpl(listOfNonNullBool);
 
   it('coerces to null unless non-null', () => {
     expectValueFrom('null', GraphQLBoolean).to.equal(null);
@@ -187,7 +187,7 @@ describe('valueFromAST', () => {
     );
   });
 
-  const testInputObj = new GraphQLInputObjectType({
+  const testInputObj = new GraphQLInputObjectTypeImpl({
     name: 'TestInput',
     fields: {
       int: { type: GraphQLInt, defaultValue: 42 },

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -7,8 +7,11 @@ import { parse } from '../language/parser';
 import type { Source } from '../language/source';
 
 import { specifiedDirectives } from '../type/directives';
-import type { GraphQLSchemaValidationOptions } from '../type/schema';
-import { GraphQLSchema } from '../type/schema';
+import type {
+  GraphQLSchema,
+  GraphQLSchemaValidationOptions,
+} from '../type/schema';
+import { GraphQLSchemaImpl } from '../type/schema';
 
 import { assertValidSDL } from '../validation/validate';
 
@@ -88,7 +91,7 @@ export function buildASTSchema(
     ),
   ];
 
-  return new GraphQLSchema({ ...config, directives });
+  return new GraphQLSchemaImpl({ ...config, directives });
 }
 
 /**

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -6,31 +6,41 @@ import { keyValMap } from '../jsutils/keyValMap';
 import { parseValue } from '../language/parser';
 
 import type {
+  GraphQLEnumType,
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
   GraphQLNamedType,
+  GraphQLObjectType,
+  GraphQLScalarType,
   GraphQLType,
+  GraphQLUnionType,
 } from '../type/definition';
 import {
   assertInterfaceType,
   assertNullableType,
   assertObjectType,
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLScalarType,
-  GraphQLUnionType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+  GraphQLUnionTypeImpl,
   isInputType,
   isOutputType,
 } from '../type/definition';
-import { GraphQLDirective } from '../type/directives';
+import type { GraphQLDirective } from '../type/directives';
+import { GraphQLDirectiveImpl } from '../type/directives';
 import { introspectionTypes, TypeKind } from '../type/introspection';
 import { specifiedScalarTypes } from '../type/scalars';
-import type { GraphQLSchemaValidationOptions } from '../type/schema';
-import { GraphQLSchema } from '../type/schema';
+import type {
+  GraphQLSchema,
+  GraphQLSchemaValidationOptions,
+} from '../type/schema';
+import { GraphQLSchemaImpl } from '../type/schema';
 
 import type {
   IntrospectionDirective,
@@ -109,7 +119,7 @@ export function buildClientSchema(
     : [];
 
   // Then produce and return a Schema with these types.
-  return new GraphQLSchema({
+  return new GraphQLSchemaImpl({
     description: schemaIntrospection.description,
     query: queryType,
     mutation: mutationType,
@@ -127,7 +137,7 @@ export function buildClientSchema(
       if (!itemRef) {
         throw new Error('Decorated type deeper than introspection query.');
       }
-      return new GraphQLList(getType(itemRef));
+      return new GraphQLListImpl(getType(itemRef));
     }
     if (typeRef.kind === TypeKind.NON_NULL) {
       const nullableRef = typeRef.ofType;
@@ -135,7 +145,7 @@ export function buildClientSchema(
         throw new Error('Decorated type deeper than introspection query.');
       }
       const nullableType = getType(nullableRef);
-      return new GraphQLNonNull(assertNullableType(nullableType));
+      return new GraphQLNonNullImpl(assertNullableType(nullableType));
     }
     return getNamedType(typeRef);
   }
@@ -199,7 +209,7 @@ export function buildClientSchema(
   function buildScalarDef(
     scalarIntrospection: IntrospectionScalarType,
   ): GraphQLScalarType {
-    return new GraphQLScalarType({
+    return new GraphQLScalarTypeImpl({
       name: scalarIntrospection.name,
       description: scalarIntrospection.description,
       specifiedByURL: scalarIntrospection.specifiedByURL,
@@ -233,7 +243,7 @@ export function buildClientSchema(
   function buildObjectDef(
     objectIntrospection: IntrospectionObjectType,
   ): GraphQLObjectType {
-    return new GraphQLObjectType({
+    return new GraphQLObjectTypeImpl({
       name: objectIntrospection.name,
       description: objectIntrospection.description,
       interfaces: () => buildImplementationsList(objectIntrospection),
@@ -244,7 +254,7 @@ export function buildClientSchema(
   function buildInterfaceDef(
     interfaceIntrospection: IntrospectionInterfaceType,
   ): GraphQLInterfaceType {
-    return new GraphQLInterfaceType({
+    return new GraphQLInterfaceTypeImpl({
       name: interfaceIntrospection.name,
       description: interfaceIntrospection.description,
       interfaces: () => buildImplementationsList(interfaceIntrospection),
@@ -261,7 +271,7 @@ export function buildClientSchema(
         `Introspection result missing possibleTypes: ${unionIntrospectionStr}.`,
       );
     }
-    return new GraphQLUnionType({
+    return new GraphQLUnionTypeImpl({
       name: unionIntrospection.name,
       description: unionIntrospection.description,
       types: () => unionIntrospection.possibleTypes.map(getObjectType),
@@ -277,7 +287,7 @@ export function buildClientSchema(
         `Introspection result missing enumValues: ${enumIntrospectionStr}.`,
       );
     }
-    return new GraphQLEnumType({
+    return new GraphQLEnumTypeImpl({
       name: enumIntrospection.name,
       description: enumIntrospection.description,
       values: keyValMap(
@@ -300,7 +310,7 @@ export function buildClientSchema(
         `Introspection result missing inputFields: ${inputObjectIntrospectionStr}.`,
       );
     }
-    return new GraphQLInputObjectType({
+    return new GraphQLInputObjectTypeImpl({
       name: inputObjectIntrospection.name,
       description: inputObjectIntrospection.description,
       fields: () => buildInputValueDefMap(inputObjectIntrospection.inputFields),
@@ -395,7 +405,7 @@ export function buildClientSchema(
         `Introspection result missing directive locations: ${directiveIntrospectionStr}.`,
       );
     }
-    return new GraphQLDirective({
+    return new GraphQLDirectiveImpl({
       name: directiveIntrospection.name,
       description: directiveIntrospection.description,
       isRepeatable: directiveIntrospection.isRepeatable,

--- a/src/utilities/entities.ts
+++ b/src/utilities/entities.ts
@@ -1,0 +1,81 @@
+import { version } from '../version';
+
+/**
+ * A symbol containing the version of the GraphQL.js library
+ */
+export const GRAPHQL_VERSION_SYMBOL = Symbol.for(version);
+
+/**
+ * Applies the GraphQL version symbol to an object.
+ * Used as a base class for GraphQL Entity Implementations
+ */
+export interface GraphQLEntity {
+  [GRAPHQL_VERSION_SYMBOL]: undefined;
+}
+
+/**
+ * Applies the GraphQL version symbol to an object.
+ * Used as a base class for GraphQL Entity Implementations
+ *
+ * @internal
+ */
+export class GraphQLEntityImpl implements GraphQLEntity {
+  readonly [GRAPHQL_VERSION_SYMBOL] = undefined;
+}
+
+export enum GraphQLEntityKind {
+  SCALAR_TYPE = 'ScalarType',
+  OBJECT_TYPE = 'ObjectType',
+  INTERFACE_TYPE = 'InterfaceType',
+  UNION_TYPE = 'UnionType',
+  ENUM_TYPE = 'EnumType',
+  INPUT_OBJECT_TYPE = 'InputObjectType',
+  LIST_TYPE = 'ListType',
+  NON_NULL_TYPE = 'NonNullType',
+  DIRECTIVE = 'Directive',
+  SCHEMA = 'Schema',
+  SOURCE = 'Source',
+}
+
+export const GRAPHQL_SCALAR_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.SCALAR_TYPE}`,
+);
+export const GRAPHQL_OBJECT_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.OBJECT_TYPE}`,
+);
+export const GRAPHQL_INTERFACE_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.INTERFACE_TYPE}`,
+);
+export const GRAPHQL_UNION_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.UNION_TYPE}`,
+);
+export const GRAPHQL_ENUM_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.ENUM_TYPE}`,
+);
+export const GRAPHQL_INPUT_OBJECT_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.INPUT_OBJECT_TYPE}`,
+);
+export const GRAPHQL_LIST_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.LIST_TYPE}`,
+);
+export const GRAPHQL_NON_NULL_TYPE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.NON_NULL_TYPE}`,
+);
+export const GRAPHQL_DIRECTIVE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.DIRECTIVE}`,
+);
+export const GRAPHQL_SCHEMA_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.SCHEMA}`,
+);
+export const GRAPHQL_SOURCE_SYMBOL = Symbol.for(
+  `graphql.${GraphQLEntityKind.SOURCE}`,
+);
+
+export function isEntity(value: object, entity: GraphQLEntityKind): boolean {
+  const symbol = Symbol.for(`graphql.${entity}`);
+  return symbol in value;
+}
+
+export function ofVersion(value: object): boolean {
+  return GRAPHQL_VERSION_SYMBOL in value;
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -97,3 +97,23 @@ export type { BreakingChange, DangerousChange } from './findBreakingChanges';
 
 // Wrapper type that contains DocumentNode and types that can be deduced from it.
 export type { TypedQueryDocumentNode } from './typedQueryDocumentNode';
+
+export type { GraphQLEntity } from './entities';
+export {
+  GraphQLEntityImpl,
+  GraphQLEntityKind,
+  GRAPHQL_SCALAR_TYPE_SYMBOL,
+  GRAPHQL_OBJECT_TYPE_SYMBOL,
+  GRAPHQL_INTERFACE_TYPE_SYMBOL,
+  GRAPHQL_UNION_TYPE_SYMBOL,
+  GRAPHQL_ENUM_TYPE_SYMBOL,
+  GRAPHQL_INPUT_OBJECT_TYPE_SYMBOL,
+  GRAPHQL_LIST_TYPE_SYMBOL,
+  GRAPHQL_NON_NULL_TYPE_SYMBOL,
+  GRAPHQL_DIRECTIVE_SYMBOL,
+  GRAPHQL_SCHEMA_SYMBOL,
+  GRAPHQL_SOURCE_SYMBOL,
+  GRAPHQL_VERSION_SYMBOL,
+  isEntity,
+  ofVersion,
+} from './entities';

--- a/src/utilities/lexicographicSortSchema.ts
+++ b/src/utilities/lexicographicSortSchema.ts
@@ -13,13 +13,13 @@ import type {
   GraphQLType,
 } from '../type/definition';
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLUnionType,
+  GraphQLEnumTypeImpl,
+  GraphQLInputObjectTypeImpl,
+  GraphQLInterfaceTypeImpl,
+  GraphQLListImpl,
+  GraphQLNonNullImpl,
+  GraphQLObjectTypeImpl,
+  GraphQLUnionTypeImpl,
   isEnumType,
   isInputObjectType,
   isInterfaceType,
@@ -29,9 +29,11 @@ import {
   isScalarType,
   isUnionType,
 } from '../type/definition';
-import { GraphQLDirective } from '../type/directives';
+import type { GraphQLDirective } from '../type/directives';
+import { GraphQLDirectiveImpl } from '../type/directives';
 import { isIntrospectionType } from '../type/introspection';
-import { GraphQLSchema } from '../type/schema';
+import type { GraphQLSchema } from '../type/schema';
+import { GraphQLSchemaImpl } from '../type/schema';
 
 /**
  * Sort GraphQLSchema.
@@ -46,7 +48,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     sortNamedType,
   );
 
-  return new GraphQLSchema({
+  return new GraphQLSchemaImpl({
     ...schemaConfig,
     types: Object.values(typeMap),
     directives: sortByName(schemaConfig.directives).map(sortDirective),
@@ -58,10 +60,10 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
   function replaceType<T extends GraphQLType>(type: T): T {
     if (isListType(type)) {
       // @ts-expect-error
-      return new GraphQLList(replaceType(type.ofType));
+      return new GraphQLListImpl(replaceType(type.ofType));
     } else if (isNonNullType(type)) {
       // @ts-expect-error
-      return new GraphQLNonNull(replaceType(type.ofType));
+      return new GraphQLNonNullImpl(replaceType(type.ofType));
     }
     // @ts-expect-error FIXME: TS Conversion
     return replaceNamedType<GraphQLNamedType>(type);
@@ -79,7 +81,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
 
   function sortDirective(directive: GraphQLDirective) {
     const config = directive.toConfig();
-    return new GraphQLDirective({
+    return new GraphQLDirectiveImpl({
       ...config,
       locations: sortBy(config.locations, (x) => x),
       args: sortArgs(config.args),
@@ -120,7 +122,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     }
     if (isObjectType(type)) {
       const config = type.toConfig();
-      return new GraphQLObjectType({
+      return new GraphQLObjectTypeImpl({
         ...config,
         interfaces: () => sortTypes(config.interfaces),
         fields: () => sortFields(config.fields),
@@ -128,7 +130,7 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     }
     if (isInterfaceType(type)) {
       const config = type.toConfig();
-      return new GraphQLInterfaceType({
+      return new GraphQLInterfaceTypeImpl({
         ...config,
         interfaces: () => sortTypes(config.interfaces),
         fields: () => sortFields(config.fields),
@@ -136,21 +138,21 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
     }
     if (isUnionType(type)) {
       const config = type.toConfig();
-      return new GraphQLUnionType({
+      return new GraphQLUnionTypeImpl({
         ...config,
         types: () => sortTypes(config.types),
       });
     }
     if (isEnumType(type)) {
       const config = type.toConfig();
-      return new GraphQLEnumType({
+      return new GraphQLEnumTypeImpl({
         ...config,
         values: sortObjMap(config.values, (value) => value),
       });
     }
     if (isInputObjectType(type)) {
       const config = type.toConfig();
-      return new GraphQLInputObjectType({
+      return new GraphQLInputObjectTypeImpl({
         ...config,
         fields: () => sortInputFields(config.fields),
       });

--- a/src/utilities/stripIgnoredCharacters.ts
+++ b/src/utilities/stripIgnoredCharacters.ts
@@ -1,6 +1,7 @@
 import { printBlockString } from '../language/blockString';
 import { isPunctuatorTokenKind, Lexer } from '../language/lexer';
-import { isSource, Source } from '../language/source';
+import type { Source } from '../language/source';
+import { isSource, SourceImpl } from '../language/source';
 import { TokenKind } from '../language/tokenKind';
 
 /**
@@ -64,7 +65,7 @@ import { TokenKind } from '../language/tokenKind';
  * ```
  */
 export function stripIgnoredCharacters(source: string | Source): string {
-  const sourceObj = isSource(source) ? source : new Source(source);
+  const sourceObj = isSource(source) ? source : new SourceImpl(source);
 
   const body = sourceObj.body;
   const lexer = new Lexer(sourceObj);

--- a/src/utilities/typeFromAST.ts
+++ b/src/utilities/typeFromAST.ts
@@ -6,8 +6,14 @@ import type {
 } from '../language/ast';
 import { Kind } from '../language/kinds';
 
-import type { GraphQLNamedType, GraphQLType } from '../type/definition';
-import { GraphQLList, GraphQLNonNull } from '../type/definition';
+import type {
+  GraphQLList,
+  GraphQLNamedType,
+  GraphQLNonNull,
+  GraphQLNullableType,
+  GraphQLType,
+} from '../type/definition';
+import { GraphQLListImpl, GraphQLNonNullImpl } from '../type/definition';
 import type { GraphQLSchema } from '../type/schema';
 
 /**
@@ -40,11 +46,13 @@ export function typeFromAST(
   switch (typeNode.kind) {
     case Kind.LIST_TYPE: {
       const innerType = typeFromAST(schema, typeNode.type);
-      return innerType && new GraphQLList(innerType);
+      return innerType && new GraphQLListImpl(innerType);
     }
     case Kind.NON_NULL_TYPE: {
       const innerType = typeFromAST(schema, typeNode.type);
-      return innerType && new GraphQLNonNull(innerType);
+      return (
+        innerType && new GraphQLNonNullImpl(innerType as GraphQLNullableType)
+      );
     }
     case Kind.NAMED_TYPE:
       return schema.getType(typeNode.name.value);

--- a/src/validation/__tests__/ValidationContext-test.ts
+++ b/src/validation/__tests__/ValidationContext-test.ts
@@ -5,7 +5,7 @@ import { identityFunc } from '../../jsutils/identityFunc';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { TypeInfo } from '../../utilities/TypeInfo';
 
@@ -17,7 +17,7 @@ import {
 
 describe('ValidationContext', () => {
   it('can be Object.toStringified', () => {
-    const schema = new GraphQLSchema({});
+    const schema = new GraphQLSchemaImpl({});
     const typeInfo = new TypeInfo(schema);
     const ast = parse('{ foo }');
     const onError = identityFunc;

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -7,9 +7,13 @@ import { inspect } from '../../jsutils/inspect';
 
 import { parse } from '../../language/parser';
 
-import { GraphQLObjectType, GraphQLScalarType } from '../../type/definition';
+import {
+  GraphQLObjectTypeImpl,
+  GraphQLScalarTypeImpl,
+} from '../../type/definition';
 import { GraphQLString } from '../../type/scalars';
-import { GraphQLSchema } from '../../type/schema';
+import type { GraphQLSchema } from '../../type/schema';
+import { GraphQLSchemaImpl } from '../../type/schema';
 
 import { ValuesOfCorrectTypeRule } from '../rules/ValuesOfCorrectTypeRule';
 import { validate } from '../validate';
@@ -947,7 +951,7 @@ describe('Validate: Values of correct type', () => {
     });
 
     it('reports original error for custom scalar which throws', () => {
-      const customScalar = new GraphQLScalarType({
+      const customScalar = new GraphQLScalarTypeImpl({
         name: 'Invalid',
         parseValue(value) {
           throw new Error(
@@ -956,8 +960,8 @@ describe('Validate: Values of correct type', () => {
         },
       });
 
-      const schema = new GraphQLSchema({
-        query: new GraphQLObjectType({
+      const schema = new GraphQLSchemaImpl({
+        query: new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
             invalidArg: {
@@ -986,15 +990,15 @@ describe('Validate: Values of correct type', () => {
     });
 
     it('reports error for custom scalar that returns undefined', () => {
-      const customScalar = new GraphQLScalarType({
+      const customScalar = new GraphQLScalarTypeImpl({
         name: 'CustomScalar',
         parseValue() {
           return undefined;
         },
       });
 
-      const schema = new GraphQLSchema({
-        query: new GraphQLObjectType({
+      const schema = new GraphQLSchemaImpl({
+        query: new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
             invalidArg: {
@@ -1014,9 +1018,9 @@ describe('Validate: Values of correct type', () => {
     });
 
     it('allows custom scalar to accept complex literals', () => {
-      const customScalar = new GraphQLScalarType({ name: 'Any' });
-      const schema = new GraphQLSchema({
-        query: new GraphQLObjectType({
+      const customScalar = new GraphQLScalarTypeImpl({ name: 'Any' });
+      const schema = new GraphQLSchemaImpl({
+        query: new GraphQLObjectTypeImpl({
           name: 'Query',
           fields: {
             anyArg: {


### PR DESCRIPTION
= allows for custom implementations of the GraphQL entity implementations, e.g. the `execute` function from GraphQL can be used for any object that implements the `GraphQLSchema` interface, even if does not conform to the default `GraphQLSchemaImpl` class.
= currently provides symbols for predicates for the following interfaces: `GraphQLScalarType`, `GraphQLObjectType`,
`GraphQLInterfaceType`, `GraphQLUnionType`, `GraphQLEnumType`, `GraphQLInputObjectType`, `GraphQLList`, `GraphQLNonNull`, `GraphQLDirective`, `GraphQLSchema`, and `Source`, i.e. all classes that made internal use of the `instanceOf` method.
= the `instanceOf` method now uses symbols instead of `instanceof`.
= the exported BREAK object is now passed into the visitor function to allow for cross-compatibility between `graphql` library instances.