### PR TITLE
extendSchema: Do not modify standard directives

### DIFF
--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -67,6 +67,7 @@ import {
   GraphQLDeprecatedDirective,
   GraphQLDirective,
   GraphQLSpecifiedByDirective,
+  isSpecifiedDirective,
 } from '../type/directives';
 import { introspectionTypes, isIntrospectionType } from '../type/introspection';
 import { isSpecifiedScalarType, specifiedScalarTypes } from '../type/scalars';
@@ -236,6 +237,11 @@ export function extendSchemaImpl(
   }
 
   function replaceDirective(directive: GraphQLDirective): GraphQLDirective {
+    if (isSpecifiedDirective(directive)) {
+      // Builtin directives are not extended.
+      return directive;
+    }
+
     const config = directive.toConfig();
     return new GraphQLDirective({
       ...config,


### PR DESCRIPTION
Without this change:
```
const extendedSchema = extendSchema(schema, parse(extensionSDL));
extendSchema.getDirective('skip') === GraphQLSkipDirective
// false
```

Maybe in future we need more comprehensive solution, but for now it's enouch to just match behaviour that we already have to standard types.