### PR TITLE
use named parameters for node visit context info

### DIFF
--- a/docs-old/APIReference-Language.md
+++ b/docs-old/APIReference-Language.md
@@ -215,7 +215,7 @@ visit function.
 
 ```js
 var editedAST = visit(ast, {
-  enter(node, key, parent, path, ancestors) {
+  enter(node, { key, parent, path, ancestors }) {
     // @return
     //   undefined: no action
     //   false: skip visiting this node
@@ -223,7 +223,7 @@ var editedAST = visit(ast, {
     //   null: delete this node
     //   any value: replace this node with the returned value
   },
-  leave(node, key, parent, path, ancestors) {
+  leave(node, { key, parent, path, ancestors }) {
     // @return
     //   undefined: no action
     //   false: no action

--- a/src/language/__tests__/visitor-test.ts
+++ b/src/language/__tests__/visitor-test.ts
@@ -11,7 +11,7 @@ import type { ASTVisitor, ASTVisitorKeyMap } from '../visitor';
 import { BREAK, visit, visitInParallel } from '../visitor';
 
 function checkVisitorFnArgs(ast: any, args: any, isEdited: boolean = false) {
-  const [node, key, parent, path, ancestors] = args;
+  const [node, { key, parent, path, ancestors }] = args;
 
   expect(node).to.be.an.instanceof(Object);
   expect(node.kind).to.be.oneOf(Object.values(Kind));
@@ -67,11 +67,11 @@ describe('Visitor', () => {
     const ast = parse('{ a }', { noLocation: true });
 
     visit(ast, {
-      enter(_node, _key, _parent, path) {
+      enter(_node, { path }) {
         checkVisitorFnArgs(ast, arguments);
         visited.push(['enter', path.slice()]);
       },
-      leave(_node, _key, _parent, path) {
+      leave(_node, { path }) {
         checkVisitorFnArgs(ast, arguments);
         visited.push(['leave', path.slice()]);
       },
@@ -96,7 +96,7 @@ describe('Visitor', () => {
     const visitedNodes: Array<any> = [];
 
     visit(ast, {
-      enter(node, key, parent, _path, ancestors) {
+      enter(node, { key, parent, ancestors }) {
         const inArray = typeof key === 'number';
         if (inArray) {
           visitedNodes.push(parent);
@@ -106,7 +106,7 @@ describe('Visitor', () => {
         const expectedAncestors = visitedNodes.slice(0, -2);
         expect(ancestors).to.deep.equal(expectedAncestors);
       },
-      leave(_node, key, _parent, _path, ancestors) {
+      leave(_node, { key, ancestors }) {
         const expectedAncestors = visitedNodes.slice(0, -2);
         expect(ancestors).to.deep.equal(expectedAncestors);
 
@@ -511,7 +511,7 @@ describe('Visitor', () => {
     const argsStack: Array<any> = [];
 
     visit(ast, {
-      enter(node, key, parent) {
+      enter(node, { key, parent }) {
         visited.push([
           'enter',
           node.kind,
@@ -523,7 +523,7 @@ describe('Visitor', () => {
         argsStack.push([...arguments]);
       },
 
-      leave(node, key, parent) {
+      leave(node, { key, parent }) {
         visited.push([
           'leave',
           node.kind,

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -22,6 +22,21 @@ interface EnterLeaveVisitor<TVisitedNode extends ASTNode> {
   readonly leave?: ASTVisitFn<TVisitedNode>;
 }
 
+interface VisitContext {
+  /** The index or key to this node from the parent node or Array. */
+  key: string | number | undefined;
+  /** The parent immediately above this node, which may be an Array. */
+  parent: ASTNode | ReadonlyArray<ASTNode> | undefined;
+  /** The key path to get to this node from the root node. */
+  path: ReadonlyArray<string | number>;
+  /**
+   * All nodes and Arrays visited before reaching parent of this node.
+   * These correspond to array indices in `path`.
+   * Note: ancestors includes arrays which contain the parent of visited node.
+   */
+  ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>;
+}
+
 /**
  * A visitor is comprised of visit functions, which are called on each node
  * during the visitor's traversal.
@@ -29,18 +44,7 @@ interface EnterLeaveVisitor<TVisitedNode extends ASTNode> {
 export type ASTVisitFn<TVisitedNode extends ASTNode> = (
   /** The current node being visiting. */
   node: TVisitedNode,
-  /** The index or key to this node from the parent node or Array. */
-  key: string | number | undefined,
-  /** The parent immediately above this node, which may be an Array. */
-  parent: ASTNode | ReadonlyArray<ASTNode> | undefined,
-  /** The key path to get to this node from the root node. */
-  path: ReadonlyArray<string | number>,
-  /**
-   * All nodes and Arrays visited before reaching parent of this node.
-   * These correspond to array indices in `path`.
-   * Note: ancestors includes arrays which contain the parent of visited node.
-   */
-  ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
+  context: VisitContext,
 ) => any;
 
 /**
@@ -57,18 +61,7 @@ export type ASTReducer<R> = {
 type ASTReducerFn<TReducedNode extends ASTNode, R> = (
   /** The current node being visiting. */
   node: { [K in keyof TReducedNode]: ReducedField<TReducedNode[K], R> },
-  /** The index or key to this node from the parent node or Array. */
-  key: string | number | undefined,
-  /** The parent immediately above this node, which may be an Array. */
-  parent: ASTNode | ReadonlyArray<ASTNode> | undefined,
-  /** The key path to get to this node from the root node. */
-  path: ReadonlyArray<string | number>,
-  /**
-   * All nodes and Arrays visited before reaching parent of this node.
-   * These correspond to array indices in `path`.
-   * Note: ancestors includes arrays which contain the parent of visited node.
-   */
-  ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
+  context: VisitContext,
 ) => R;
 
 type ReducedField<T, R> = T extends null | undefined
@@ -102,7 +95,7 @@ export const BREAK: unknown = Object.freeze({});
  *
  * ```ts
  * const editedAST = visit(ast, {
- *   enter(node, key, parent, path, ancestors) {
+ *   enter(node, { key, parent, path, ancestors }) {
  *     // @return
  *     //   undefined: no action
  *     //   false: skip visiting this node
@@ -110,7 +103,7 @@ export const BREAK: unknown = Object.freeze({});
  *     //   null: delete this node
  *     //   any value: replace this node with the returned value
  *   },
- *   leave(node, key, parent, path, ancestors) {
+ *   leave(node, { key, parent, path, ancestors }) {
  *     // @return
  *     //   undefined: no action
  *     //   false: no action
@@ -251,7 +244,7 @@ export function visit(
         ? enterLeaveMap.get(node.kind)?.leave
         : enterLeaveMap.get(node.kind)?.enter;
 
-      result = visitFn?.call(visitor, node, key, parent, path, ancestors);
+      result = visitFn?.call(visitor, node, { key, parent, path, ancestors });
 
       if (result === BREAK) {
         break;

--- a/src/validation/rules/KnownDirectivesRule.ts
+++ b/src/validation/rules/KnownDirectivesRule.ts
@@ -45,7 +45,7 @@ export function KnownDirectivesRule(
   }
 
   return {
-    Directive(node, _key, _parent, _path, ancestors) {
+    Directive(node, { ancestors }) {
       const name = node.name.value;
       const locations = locationsMap[name];
 

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -46,7 +46,7 @@ export function KnownTypeNamesRule(
   ];
 
   return {
-    NamedType(node, _1, parent, _2, ancestors) {
+    NamedType(node, { parent, ancestors }) {
       const typeName = node.name.value;
       if (!existingTypesMap[typeName] && !definedTypes[typeName]) {
         const definitionNode = ancestors[2] ?? parent;


### PR DESCRIPTION
Motivation:

1. Some visit context information is rarely used, this could be pathway toward refactoring, future-proofing any breaking changes to come. (see: https://github.com/graphql/graphql-js/issues/3225)
2. Eventually, BREAK and/or other visit controllers could be added as third argument directly to the visitor method rarely than exported from the library. (see https://github.com/graphql/graphql-js/pull/3616)