### PR TITLE
align return types from execution and subscription

### DIFF
--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -125,6 +125,7 @@ function createSubscription(pubsub: SimplePubSub<Email>) {
   return subscribe({ schema: emailSchema, document, rootValue: data });
 }
 
+// TODO: consider adding this method to testUtils (with tests)
 function expectPromise(maybePromise: unknown) {
   assert(isPromise(maybePromise));
 
@@ -149,6 +150,7 @@ function expectPromise(maybePromise: unknown) {
   };
 }
 
+// TODO: consider adding this method to testUtils (with tests)
 function expectEqualPromisesOrValues<T>(
   value1: PromiseOrValue<T>,
   value2: PromiseOrValue<T>,

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -207,7 +207,7 @@ export function createSourceEventStream(
 
 function executeSubscription(
   exeContext: ExecutionContext,
-): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
+): PromiseOrValue<AsyncIterable<unknown>> {
   const { schema, fragments, operation, variableValues, rootValue } =
     exeContext;
 

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -261,32 +261,32 @@ function executeSubscription(
     // Call the `subscribe()` resolver or the default resolver to produce an
     // AsyncIterable yielding raw payloads.
     const resolveFn = fieldDef.subscribe ?? exeContext.subscribeFieldResolver;
-    const eventStream = resolveFn(rootValue, args, contextValue, info);
+    const result = resolveFn(rootValue, args, contextValue, info);
 
-    if (isPromise(eventStream)) {
-      return eventStream.then(assertEventStream).then(undefined, (error) => {
+    if (isPromise(result)) {
+      return result.then(assertEventStream).then(undefined, (error) => {
         throw locatedError(error, fieldNodes, pathToArray(path));
       });
     }
 
-    return assertEventStream(eventStream);
+    return assertEventStream(result);
   } catch (error) {
     throw locatedError(error, fieldNodes, pathToArray(path));
   }
 }
 
-function assertEventStream(eventStream: unknown): AsyncIterable<unknown> {
-  if (eventStream instanceof Error) {
-    throw eventStream;
+function assertEventStream(result: unknown): AsyncIterable<unknown> {
+  if (result instanceof Error) {
+    throw result;
   }
 
   // Assert field returned an event stream, otherwise yield an error.
-  if (!isAsyncIterable(eventStream)) {
+  if (!isAsyncIterable(result)) {
     throw new GraphQLError(
       'Subscription field must return Async Iterable. ' +
-        `Received: ${inspect(eventStream)}.`,
+        `Received: ${inspect(result)}.`,
     );
   }
 
-  return eventStream;
+  return result;
 }


### PR DESCRIPTION
with respect to possible promises

motivations:
1. no need to enter event loop unnecessarily
2. further step toward integration of `subscribe` workflow into `execute`