### PR TITLE
change incorrect subscribe return type to a GraphQLError

### DIFF
--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -454,9 +454,16 @@ describe('Subscription Initialization Phase', () => {
   });
 
   it('throws an error if subscribe does not return an iterator', async () => {
-    (await expectPromise(subscribeWithBadFn(() => 'test'))).toRejectWith(
-      'Subscription field must return Async Iterable. Received: "test".',
-    );
+    expectJSON(await subscribeWithBadFn(() => 'test')).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Subscription field must return Async Iterable. Received: "test".',
+          locations: [{ line: 1, column: 16 }],
+          path: ['foo'],
+        },
+      ],
+    });
   });
 
   it('resolves to an error for subscription resolver errors', async () => {

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -157,28 +157,15 @@ export async function createSourceEventStream(
   try {
     const eventStream = await executeSubscription(exeContext);
 
-    // Assert field returned an event stream, otherwise yield an error.
-    if (!isAsyncIterable(eventStream)) {
-      throw new Error(
-        'Subscription field must return Async Iterable. ' +
-          `Received: ${inspect(eventStream)}.`,
-      );
-    }
-
     return eventStream;
   } catch (error) {
-    // If it GraphQLError, report it as an ExecutionResult, containing only errors and no data.
-    // Otherwise treat the error as a system-class error and re-throw it.
-    if (error instanceof GraphQLError) {
-      return { errors: [error] };
-    }
-    throw error;
+    return { errors: [error] };
   }
 }
 
 async function executeSubscription(
   exeContext: ExecutionContext,
-): Promise<unknown> {
+): Promise<AsyncIterable<unknown>> {
   const { schema, fragments, operation, variableValues, rootValue } =
     exeContext;
 
@@ -238,6 +225,15 @@ async function executeSubscription(
     if (eventStream instanceof Error) {
       throw eventStream;
     }
+
+    // Assert field returned an event stream, otherwise yield an error.
+    if (!isAsyncIterable(eventStream)) {
+      throw new GraphQLError(
+        'Subscription field must return Async Iterable. ' +
+          `Received: ${inspect(eventStream)}.`,
+      );
+    }
+
     return eventStream;
   } catch (error) {
     throw locatedError(error, fieldNodes, pathToArray(path));


### PR DESCRIPTION
…rather than a systems error

to match spec (in parallel to field-level resolver errors in execute)

note the addition of the path, as execution has begun