### PR TITLE
fix: update remaining `GraphQLNonNull<GraphQLType>` codepoints to `GraphQLNonNull<GraphQLNullableType>` 

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -183,7 +183,9 @@ export function isNonNullType(
   return instanceOf(type, GraphQLNonNull);
 }
 
-export function assertNonNullType(type: unknown): GraphQLNonNull<GraphQLType> {
+export function assertNonNullType(
+  type: unknown,
+): GraphQLNonNull<GraphQLNullableType> {
   if (!isNonNullType(type)) {
     throw new Error(`Expected ${inspect(type)} to be a GraphQL Non-Null type.`);
   }
@@ -395,7 +397,7 @@ export class GraphQLNonNull<T extends GraphQLNullableType> {
 
 export type GraphQLWrappingType =
   | GraphQLList<GraphQLType>
-  | GraphQLNonNull<GraphQLType>;
+  | GraphQLNonNull<GraphQLNullableType>;
 
 export function isWrappingType(type: unknown): type is GraphQLWrappingType {
   return isListType(type) || isNonNullType(type);


### PR DESCRIPTION
This is related to #3597, in the sense that #3597 made the `GraphQLNonNull<GraphQL*Type>` => `GraphQLNonNull<GraphQLNullable*Type>` change in other code points related to the `isNonNullType` function, but not within `GraphQLWrappingType` or assertNonNullType.

This PR was prompted by the uncovering of a bug by a different PR, see: https://github.com/graphql/graphql-js/pull/3617#discussion_r885544662