### PR TITLE
benchmark: replace failing on context switching with warning

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -122,9 +122,12 @@ function collectSamples(modulePath: string) {
 
     if (sample.involuntaryContextSwitches > 0) {
       numOfConsequentlyRejectedSamples++;
-      if (numOfConsequentlyRejectedSamples > 5) {
-        throw Error(
-          'Can not sample benchmark due to 5 consequent runs beings rejected because of context switching',
+      if (numOfConsequentlyRejectedSamples === 5) {
+        console.error(
+          yellow(
+            '  Five or more consequent runs beings rejected because of context switching.\n' +
+              '  Measurement can take a significantly longer time and its correctness can also be impacted.',
+          ),
         );
       }
       continue;


### PR DESCRIPTION
Consequently failed measurements due to context switches are bad.
It mean something is bad with our setup:
* Our test are taking too long to run (e.g. due to `count` being too
  big)
* Machine that we measure on is doing some heave background task.
* Some other factors, that are hard to predict.

Currently, it's easy to solve this issue locally just by disabling
background task on your machine, but it is non-trivial task to solve on
CI.