### PR TITLE
ci: Fix imports in 'actions/github-script'

### DIFF
--- a/.github/workflows/cmd-publish-pr-on-npm.yml
+++ b/.github/workflows/cmd-publish-pr-on-npm.yml
@@ -68,8 +68,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            import fs from 'node:fs';
-            import assert from 'node:assert';
+            const fs = require('node:fs');
+            const assert = require('node:assert');
 
             const pull_request = JSON.parse(process.env.PULL_REQUEST_JSON);
             const packageJSONPath = './npmDist/package.json';

--- a/.github/workflows/cmd-run-benchmark.yml
+++ b/.github/workflows/cmd-run-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            import fs from 'node:fs';
+            const fs = require('node:fs');
 
             // GH doesn't expose job's id so we need to get it through API, see
             // https://github.community/t/job-id-is-string-in-github-job-but-integer-in-actions-api/139060

--- a/.github/workflows/github-actions-bot.yml
+++ b/.github/workflows/github-actions-bot.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            import fs from 'node:fs';
+            const fs = require('node:fs');
 
             const event = JSON.parse(fs.readFileSync('./event.json', 'utf8'));
             await github.rest.issues.createComment({
@@ -110,7 +110,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            import fs from 'node:fs';
+            const fs = require('node:fs');
 
             const needs = JSON.parse(process.env.NEEDS);
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            import fs from 'node:fs';
+            const fs = require('node:fs');
 
             const replyMessage = fs.readFileSync('./replyMessage.txt', 'utf-8');
             const { issue, comment, sender } = context.payload;


### PR DESCRIPTION
I did 'require => import' change together with top-level await change in #3612
I assumed if top-level `async` is working it means `import` should also work.
In reality, `actions/github-script` was passing code to async function
constructor. That means top-level await is not really top-level since it
gets injected into a function and we still execute in CJS context and
`import` will fail.