### PR TITLE
Reuse GraphQLWrappingType in 'GraphQLType' definition

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -50,10 +50,7 @@ import type { GraphQLSchema } from './schema';
 /**
  * These are all of the possible kinds of types.
  */
-export type GraphQLType =
-  | GraphQLNamedType
-  | GraphQLList<GraphQLType>
-  | GraphQLNonNull<GraphQLNullableType>;
+export type GraphQLType = GraphQLNamedType | GraphQLWrappingType;
 
 export function isType(type: unknown): type is GraphQLType {
   return (


### PR DESCRIPTION
Now GraphQLType is union of named types and wrapping types.
Spotted during review of #3622