### PR TITLE
benchmark: add Windows compatibility

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -376,10 +376,13 @@ interface BenchmarkSample {
 }
 
 function sampleModule(modulePath: string): BenchmarkSample {
+  // To support Windows we need to use URL instead of path
+  const moduleURL = url.pathToFileURL(modulePath);
+
   const sampleCode = `
     import fs from 'node:fs';
 
-    import { benchmark } from '${url.pathToFileURL(modulePath)}';
+    import { benchmark } from '${moduleURL}';
 
     // warm up, it looks like 7 is a magic number to reliably trigger JIT
     benchmark.measure();


### PR DESCRIPTION
1. use local git clone instead of git archive | tar
2. normalize module path within sampleCode

Motivation: Windows users should not be required to use WSL to run benchmark (or any other scripts). The library should be cross-platform as possible both at runtime and in development.

Furthermore: it may be valuable to benchmark in multiple environemnts, including unix-type environments, WSL, and native Windows runtimes.