### PR TITLE
ci: speed up 'ci' workflow by removing unneeded internal dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
   build-npm-dist:
     name: Build 'npmDist' artifact
     runs-on: ubuntu-latest
-    needs: [test, fuzz, lint, integrationTests]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -185,7 +184,6 @@ jobs:
   build-deno-dist:
     name: Build 'denoDist' artifact
     runs-on: ubuntu-latest
-    needs: [test, fuzz, lint, integrationTests]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
This depedency was originaly added because those jobs were doing actual
deploying, now that they simply build artifacts there are no reasons for
them to be locked on other jobs