### PR TITLE
createSourceEventStream: introduce named arguments and deprecate positional arguments

### DIFF
--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -458,6 +458,7 @@ describe('Subscription Initialization Phase', () => {
       'Must provide document.',
     );
 
+    // @ts-expect-error
     expect(() => createSourceEventStream(schema)).to.throw(
       'Must provide document.',
     );

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -191,7 +191,7 @@ function subscribeWithBadFn(
 
   return expectEqualPromisesOrValues(
     subscribe({ schema, document }),
-    createSourceEventStream(schema, document),
+    createSourceEventStream({ schema, document }),
   );
 }
 
@@ -419,6 +419,48 @@ describe('Subscription Initialization Phase', () => {
 
     // @ts-expect-error
     expect(() => subscribe({ schema })).to.throw('Must provide document.');
+  });
+
+  it('allows positional arguments to createSourceEventStream', () => {
+    async function* fooGenerator() {
+      /* c8 ignore next 2 */
+      yield { foo: 'FooValue' };
+    }
+
+    const schema = new GraphQLSchema({
+      query: DummyQueryType,
+      subscription: new GraphQLObjectType({
+        name: 'Subscription',
+        fields: {
+          foo: { type: GraphQLString, subscribe: fooGenerator },
+        },
+      }),
+    });
+    const document = parse('subscription { foo }');
+
+    const eventStream = createSourceEventStream(schema, document);
+    assert(isAsyncIterable(eventStream));
+  });
+
+  it('throws an error if document is missing when using positional arguments', async () => {
+    const schema = new GraphQLSchema({
+      query: DummyQueryType,
+      subscription: new GraphQLObjectType({
+        name: 'Subscription',
+        fields: {
+          foo: { type: GraphQLString },
+        },
+      }),
+    });
+
+    // @ts-expect-error
+    expect(() => createSourceEventStream(schema, null)).to.throw(
+      'Must provide document.',
+    );
+
+    expect(() => createSourceEventStream(schema)).to.throw(
+      'Must provide document.',
+    );
   });
 
   it('resolves to an error if schema does not support subscriptions', async () => {

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -421,7 +421,7 @@ describe('Subscription Initialization Phase', () => {
     expect(() => subscribe({ schema })).to.throw('Must provide document.');
   });
 
-  it('allows positional arguments to createSourceEventStream', () => {
+  it('Deprecated: allows positional arguments to createSourceEventStream', () => {
     async function* fooGenerator() {
       /* c8 ignore next 2 */
       yield { foo: 'FooValue' };

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -442,7 +442,7 @@ describe('Subscription Initialization Phase', () => {
     assert(isAsyncIterable(eventStream));
   });
 
-  it('throws an error if document is missing when using positional arguments', async () => {
+  it('Deprecated: throws an error if document is missing when using positional arguments', async () => {
     const schema = new GraphQLSchema({
       query: DummyQueryType,
       subscription: new GraphQLObjectType({

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -1,5 +1,4 @@
 import { inspect } from '../jsutils/inspect';
-import { invariant } from '../jsutils/invariant';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable';
 import { isPromise } from '../jsutils/isPromise';
 import type { Maybe } from '../jsutils/Maybe';
@@ -108,11 +107,10 @@ function toNormalizedArgs(args: BackwardsCompatibleArgs): ExecutionArgs {
     return firstArg;
   }
 
-  invariant(args[1] != null, 'Must provide document.');
-
   return {
     schema: firstArg,
-    document: args[1],
+    // FIXME: when underlying TS bug fixed, see https://github.com/microsoft/TypeScript/issues/31613
+    document: args[1] as DocumentNode,
     rootValue: args[2],
     contextValue: args[3],
     variableValues: args[4],

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -120,19 +120,25 @@ function mapSourceToResponse(
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
  */
 export function createSourceEventStream(
-  argsOrSchema: ExecutionArgs | GraphQLSchema,
-  /** Note: document argument is required if positional arguments are used */
-  /** @deprecated will be removed in next major version in favor of named arguments */
-  document?: DocumentNode,
-  /** @deprecated will be removed in next major version in favor of named arguments */
+  args: ExecutionArgs,
+): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult>;
+/** @deprecated will be removed in next major version in favor of named arguments */
+export function createSourceEventStream(
+  schema: GraphQLSchema,
+  document: DocumentNode,
   rootValue?: unknown,
-  /** @deprecated will be removed in next major version in favor of named arguments */
   contextValue?: unknown,
-  /** @deprecated will be removed in next major version in favor of named arguments */
   variableValues?: Maybe<{ readonly [variable: string]: unknown }>,
-  /** @deprecated will be removed in next major version in favor of named arguments */
   operationName?: Maybe<string>,
-  /** @deprecated will be removed in next major version in favor of named arguments */
+  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
+): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult>;
+export function createSourceEventStream(
+  argsOrSchema: ExecutionArgs | GraphQLSchema,
+  document?: DocumentNode,
+  rootValue?: unknown,
+  contextValue?: unknown,
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>,
+  operationName?: Maybe<string>,
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
   if (isSchema(argsOrSchema)) {


### PR DESCRIPTION
Deprecates the positional arguments to `createSourceEventStream`, to be removed in the next major version, in favor of named arguments.

Motivation:
1. aligns `createSourceEventStream` with the other exported entrypoints `graphql`, `execute`, and `subscribe`
2. allows simplification of `mapSourceToResponse`

suggested by @IvanGoncharov 