### PR TITLE
createSourceEventStream: remove deprecated positional argument overload

### DIFF
--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -421,49 +421,6 @@ describe('Subscription Initialization Phase', () => {
     expect(() => subscribe({ schema })).to.throw('Must provide document.');
   });
 
-  it('Deprecated: allows positional arguments to createSourceEventStream', () => {
-    async function* fooGenerator() {
-      /* c8 ignore next 2 */
-      yield { foo: 'FooValue' };
-    }
-
-    const schema = new GraphQLSchema({
-      query: DummyQueryType,
-      subscription: new GraphQLObjectType({
-        name: 'Subscription',
-        fields: {
-          foo: { type: GraphQLString, subscribe: fooGenerator },
-        },
-      }),
-    });
-    const document = parse('subscription { foo }');
-
-    const eventStream = createSourceEventStream(schema, document);
-    assert(isAsyncIterable(eventStream));
-  });
-
-  it('Deprecated: throws an error if document is missing when using positional arguments', async () => {
-    const schema = new GraphQLSchema({
-      query: DummyQueryType,
-      subscription: new GraphQLObjectType({
-        name: 'Subscription',
-        fields: {
-          foo: { type: GraphQLString },
-        },
-      }),
-    });
-
-    // @ts-expect-error
-    expect(() => createSourceEventStream(schema, null)).to.throw(
-      'Must provide document.',
-    );
-
-    // @ts-expect-error
-    expect(() => createSourceEventStream(schema)).to.throw(
-      'Must provide document.',
-    );
-  });
-
   it('resolves to an error if schema does not support subscriptions', async () => {
     const schema = new GraphQLSchema({ query: DummyQueryType });
     const document = parse('subscription { unknownField }');


### PR DESCRIPTION
See #3634, which introduced a named argument form for the exported function and deprecated the original positional argument overload. This is to be backported to v16.

This PR removes the deprecated format from v17. It is a BREAKING CHANGE and cannot be backported.

This PR depends on #3634.
