### PR TITLE
refactor: small refactors within execute

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -162,8 +162,6 @@ export interface ExecutionArgs {
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  const { rootValue } = args;
-
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeContext = buildExecutionContext(args);
@@ -186,7 +184,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   // in this case is the entire response.
   try {
     const { operation } = exeContext;
-    const result = executeOperation(exeContext, operation, rootValue);
+    const result = executeOperation(exeContext, operation);
     if (isPromise(result)) {
       return result.then(
         (data) => buildResponse(data, exeContext.errors),
@@ -349,7 +347,6 @@ export function buildExecutionContext(
 function executeOperation(
   exeContext: ExecutionContext,
   operation: OperationDefinitionNode,
-  rootValue: unknown,
 ): PromiseOrValue<ObjMap<unknown> | null> {
   const rootType = exeContext.schema.getRootType(operation.operation);
   if (rootType == null) {
@@ -367,6 +364,8 @@ function executeOperation(
     operation.selectionSet,
   );
   const path = undefined;
+
+  const { rootValue } = exeContext;
 
   switch (operation.operation) {
     case OperationTypeNode.QUERY:

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1106,27 +1106,9 @@ function mapSourceToResponse(
 export function createSourceEventStream(
   args: ExecutionArgs,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
-  const {
-    schema,
-    document,
-    rootValue,
-    contextValue,
-    variableValues,
-    operationName,
-    subscribeFieldResolver,
-  } = args;
-
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
-  const exeContext = buildExecutionContext({
-    schema,
-    document,
-    rootValue,
-    contextValue,
-    variableValues,
-    operationName,
-    subscribeFieldResolver,
-  });
+  const exeContext = buildExecutionContext(args);
 
   // Return early errors if execution context failed.
   if (!('schema' in exeContext)) {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -162,10 +162,7 @@ export interface ExecutionArgs {
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  const { schema, document, variableValues, rootValue } = args;
-
-  // If arguments are missing or incorrect, throw an error.
-  assertValidExecutionArguments(schema, document, variableValues);
+  const { rootValue } = args;
 
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
@@ -280,6 +277,9 @@ export function buildExecutionContext(
     typeResolver,
     subscribeFieldResolver,
   } = args;
+
+  // If arguments are missing or incorrect, throw an error.
+  assertValidExecutionArguments(schema, document, rawVariableValues);
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
@@ -1116,10 +1116,6 @@ export function createSourceEventStream(
     operationName,
     subscribeFieldResolver,
   } = args;
-
-  // If arguments are missing or incorrectly typed, this is an internal
-  // developer mistake which should throw an early error.
-  assertValidExecutionArguments(schema, document, variableValues);
 
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.


### PR DESCRIPTION
This PR includes 3 small refactors for execute:

1. move `assertValidExecutionArguments` into `buildExecutionContext`
2. remove `rootValue` argument from `executeOperation` in favor of `exeContext.rootValue`
3. pass `ExecutionArgs` through to `buildExecutionContext` within `createSourceEventStream`