### PR TITLE
ESLint: error on function accepting more than 5 parameters

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -348,7 +348,7 @@ rules:
   max-lines: off
   max-lines-per-function: off
   max-nested-callbacks: off
-  max-params: off
+  max-params: [error, 5] # TODO: drop to default number, which is 3
   max-statements: off
   max-statements-per-line: off
   multiline-comment-style: off

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -86,6 +86,7 @@ export function collectSubfields(
   return subFieldNodes;
 }
 
+// eslint-disable-next-line max-params
 function collectFieldsImpl(
   schema: GraphQLSchema,
   fragments: ObjMap<FragmentDefinitionNode>,

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -55,6 +55,10 @@ import {
 import { mapAsyncIterator } from './mapAsyncIterator';
 import { getArgumentValues, getVariableValues } from './values';
 
+/* eslint-disable max-params */
+// This file contains a lot of such errors but we plan to refactor it anyway
+// so just disable it for entire file.
+
 /**
  * A memoized collection of relevant subfields with regard to the return
  * type. Memoizing ensures the subfields are not repeatedly calculated, which

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -95,6 +95,7 @@ export class Token {
   readonly prev: Token | null;
   readonly next: Token | null;
 
+  // eslint-disable-next-line max-params
   constructor(
     kind: TokenKind,
     start: number,

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -33,6 +33,10 @@ import { typeFromAST } from '../../utilities/typeFromAST';
 
 import type { ValidationContext } from '../ValidationContext';
 
+/* eslint-disable max-params */
+// This file contains a lot of such errors but we plan to refactor it anyway
+// so just disable it for entire file.
+
 function reasonMessage(reason: ConflictReasonMessage): string {
   if (Array.isArray(reason)) {
     return reason


### PR DESCRIPTION
We constantly have issues with public functions that overgrow this
limit, e.g. execute/subscribe/graphql, GraphQLError, etc.
Solving it afterwards create a long and problematic
deprecation/migration path toward "named arguments", so this PR adds
early warning of that problem.

Note: ESLint doesn't have mechanism to enforce it only on exported
functions so we need to apply this restriction on internal functions.
But I actually think it's also make sense in a long run, since we
frequently requested by community to make some of internal functions public.