### PR TITLE
Remove 'devAssert' checks that duplicate TS types

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -22,54 +22,6 @@ import { GraphQLSchema } from '../../type/schema';
 import { execute, executeSync } from '../execute';
 
 describe('Execute: Handles basic execution tasks', () => {
-  it('throws if no document is provided', () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
-        name: 'Type',
-        fields: {
-          a: { type: GraphQLString },
-        },
-      }),
-    });
-
-    // @ts-expect-error
-    expect(() => executeSync({ schema })).to.throw('Must provide document.');
-  });
-
-  it('throws if no schema is provided', () => {
-    const document = parse('{ field }');
-
-    // @ts-expect-error
-    expect(() => executeSync({ document })).to.throw(
-      'Expected undefined to be a GraphQL schema.',
-    );
-  });
-
-  it('throws on invalid variables', () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
-        name: 'Type',
-        fields: {
-          fieldA: {
-            type: GraphQLString,
-            args: { argA: { type: GraphQLInt } },
-          },
-        },
-      }),
-    });
-    const document = parse(`
-      query ($a: Int) {
-        fieldA(argA: $a)
-      }
-    `);
-    const variableValues = '{ "a": 1 }';
-
-    // @ts-expect-error
-    expect(() => executeSync({ schema, document, variableValues })).to.throw(
-      'Variables must be provided as an Object where each property is a variable value. Perhaps look to see if an unparsed JSON string was provided.',
-    );
-  });
-
   it('executes arbitrary code', async () => {
     const data = {
       a: () => 'Apple',

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -390,37 +390,6 @@ describe('Subscription Initialization Phase', () => {
     });
   });
 
-  it('throws an error if some of required arguments are missing', async () => {
-    const document = parse('subscription { foo }');
-    const schema = new GraphQLSchema({
-      query: DummyQueryType,
-      subscription: new GraphQLObjectType({
-        name: 'Subscription',
-        fields: {
-          foo: { type: GraphQLString },
-        },
-      }),
-    });
-
-    // @ts-expect-error (schema must not be null)
-    expect(() => subscribe({ schema: null, document })).to.throw(
-      'Expected null to be a GraphQL schema.',
-    );
-
-    // @ts-expect-error
-    expect(() => subscribe({ document })).to.throw(
-      'Expected undefined to be a GraphQL schema.',
-    );
-
-    // @ts-expect-error (document must not be null)
-    expect(() => subscribe({ schema, document: null })).to.throw(
-      'Must provide document.',
-    );
-
-    // @ts-expect-error
-    expect(() => subscribe({ schema })).to.throw('Must provide document.');
-  });
-
   it('resolves to an error if schema does not support subscriptions', async () => {
     const schema = new GraphQLSchema({ query: DummyQueryType });
     const document = parse('subscription { unknownField }');

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1,4 +1,3 @@
-import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { invariant } from '../jsutils/invariant';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable';
@@ -239,21 +238,9 @@ function buildResponse(
  * TODO: consider no longer exporting this function
  * @internal
  */
-export function assertValidExecutionArguments(
-  schema: GraphQLSchema,
-  document: DocumentNode,
-  rawVariableValues: Maybe<{ readonly [variable: string]: unknown }>,
-): void {
-  devAssert(document != null, 'Must provide document.');
-
+export function assertValidExecutionArguments(schema: GraphQLSchema): void {
   // If the schema used for execution is invalid, throw an error.
   assertValidSchema(schema);
-
-  // Variables, if provided, must be an object.
-  devAssert(
-    rawVariableValues == null || isObjectLike(rawVariableValues),
-    'Variables must be provided as an Object where each property is a variable value. Perhaps look to see if an unparsed JSON string was provided.',
-  );
 }
 
 /**
@@ -281,7 +268,7 @@ export function buildExecutionContext(
   } = args;
 
   // If arguments are missing or incorrect, throw an error.
-  assertValidExecutionArguments(schema, document, rawVariableValues);
+  assertValidExecutionArguments(schema);
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);

--- a/src/language/__tests__/source-test.ts
+++ b/src/language/__tests__/source-test.ts
@@ -4,20 +4,6 @@ import { describe, it } from 'mocha';
 import { Source } from '../source';
 
 describe('Source', () => {
-  it('asserts that a body was provided', () => {
-    // @ts-expect-error
-    expect(() => new Source()).to.throw(
-      'Body must be a string. Received: undefined.',
-    );
-  });
-
-  it('asserts that a valid body was provided', () => {
-    // @ts-expect-error
-    expect(() => new Source({})).to.throw(
-      'Body must be a string. Received: {}.',
-    );
-  });
-
   it('can be Object.toStringified', () => {
     const source = new Source('');
 

--- a/src/language/source.ts
+++ b/src/language/source.ts
@@ -1,5 +1,4 @@
 import { devAssert } from '../jsutils/devAssert';
-import { inspect } from '../jsutils/inspect';
 import { instanceOf } from '../jsutils/instanceOf';
 
 interface Location {
@@ -24,11 +23,6 @@ export class Source {
     name: string = 'GraphQL request',
     locationOffset: Location = { line: 1, column: 1 },
   ) {
-    devAssert(
-      typeof body === 'string',
-      `Body must be a string. Received: ${inspect(body)}.`,
-    );
-
     this.body = body;
     this.name = name;
     this.locationOffset = locationOffset;

--- a/src/type/__tests__/assertName-test.ts
+++ b/src/type/__tests__/assertName-test.ts
@@ -8,11 +8,6 @@ describe('assertName', () => {
     expect(assertName('_ValidName123')).to.equal('_ValidName123');
   });
 
-  it('throws for non-strings', () => {
-    // @ts-expect-error
-    expect(() => assertName({})).to.throw('Expected name to be a string.');
-  });
-
   it('throws on empty strings', () => {
     expect(() => assertName('')).to.throw(
       'Expected name to be a non-empty string.',

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -92,24 +92,6 @@ describe('Type System: Scalars', () => {
     ).to.equal('parseValue: { foo: { bar: "baz" } }');
   });
 
-  it('rejects a Scalar type without name', () => {
-    // @ts-expect-error
-    expect(() => new GraphQLScalarType({})).to.throw('Must provide name.');
-  });
-
-  it('rejects a Scalar type defining serialize with an incorrect type', () => {
-    expect(
-      () =>
-        new GraphQLScalarType({
-          name: 'SomeScalar',
-          // @ts-expect-error
-          serialize: {},
-        }),
-    ).to.throw(
-      'SomeScalar must provide "serialize" function. If this custom Scalar is also used as an input type, ensure "parseValue" and "parseLiteral" functions are also provided.',
-    );
-  });
-
   it('rejects a Scalar type defining parseLiteral but not parseValue', () => {
     expect(
       () =>
@@ -119,34 +101,6 @@ describe('Type System: Scalars', () => {
         }),
     ).to.throw(
       'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
-    );
-  });
-
-  it('rejects a Scalar type defining parseValue and parseLiteral with an incorrect type', () => {
-    expect(
-      () =>
-        new GraphQLScalarType({
-          name: 'SomeScalar',
-          // @ts-expect-error
-          parseValue: {},
-          // @ts-expect-error
-          parseLiteral: {},
-        }),
-    ).to.throw(
-      'SomeScalar must provide both "parseValue" and "parseLiteral" functions.',
-    );
-  });
-
-  it('rejects a Scalar type defining specifiedByURL with an incorrect type', () => {
-    expect(
-      () =>
-        new GraphQLScalarType({
-          name: 'SomeScalar',
-          // @ts-expect-error
-          specifiedByURL: {},
-        }),
-    ).to.throw(
-      'SomeScalar must provide "specifiedByURL" as a string, but got: {}.',
     );
   });
 });
@@ -328,30 +282,6 @@ describe('Type System: Objects', () => {
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
-  it('rejects an Object type field with undefined config', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      fields: {
-        // @ts-expect-error (must not be undefined)
-        f: undefined,
-      },
-    });
-    expect(() => objType.getFields()).to.throw(
-      'SomeObject.f field config must be an object.',
-    );
-  });
-
-  it('rejects an Object type with incorrectly typed fields', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      // @ts-expect-error
-      fields: [{ field: ScalarType }],
-    });
-    expect(() => objType.getFields()).to.throw(
-      'SomeObject fields must be an object with field names as keys or a function which returns such an object.',
-    );
-  });
-
   it('rejects an Object type with incorrectly named fields', () => {
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
@@ -375,22 +305,6 @@ describe('Type System: Objects', () => {
     expect(() => objType.getFields()).to.throw();
   });
 
-  it('rejects an Object type with incorrectly typed field args', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      fields: {
-        badField: {
-          type: ScalarType,
-          // @ts-expect-error
-          args: [{ badArg: ScalarType }],
-        },
-      },
-    });
-    expect(() => objType.getFields()).to.throw(
-      'SomeObject.badField args must be an object with argument names as keys.',
-    );
-  });
-
   it('rejects an Object type with incorrectly named field args', () => {
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
@@ -405,74 +319,6 @@ describe('Type System: Objects', () => {
     });
     expect(() => objType.getFields()).to.throw(
       'Names must only contain [_a-zA-Z0-9] but "bad-name" does not.',
-    );
-  });
-
-  it('rejects an Object type with incorrectly typed interfaces', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      fields: {},
-      // @ts-expect-error
-      interfaces: {},
-    });
-    expect(() => objType.getInterfaces()).to.throw(
-      'SomeObject interfaces must be an Array or a function which returns an Array.',
-    );
-  });
-
-  it('rejects an Object type with interfaces as a function returning an incorrect type', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      fields: {},
-      // @ts-expect-error (Expected interfaces to return array)
-      interfaces() {
-        return {};
-      },
-    });
-    expect(() => objType.getInterfaces()).to.throw(
-      'SomeObject interfaces must be an Array or a function which returns an Array.',
-    );
-  });
-
-  it('rejects an empty Object field resolver', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      fields: {
-        // @ts-expect-error (Expected resolve to be a function)
-        field: { type: ScalarType, resolve: {} },
-      },
-    });
-
-    expect(() => objType.getFields()).to.throw(
-      'SomeObject.field field resolver must be a function if provided, but got: {}.',
-    );
-  });
-
-  it('rejects a constant scalar value resolver', () => {
-    const objType = new GraphQLObjectType({
-      name: 'SomeObject',
-      fields: {
-        // @ts-expect-error (Expected resolve to be a function)
-        field: { type: ScalarType, resolve: 0 },
-      },
-    });
-
-    expect(() => objType.getFields()).to.throw(
-      'SomeObject.field field resolver must be a function if provided, but got: 0.',
-    );
-  });
-
-  it('rejects an Object type with an incorrect type for isTypeOf', () => {
-    expect(
-      () =>
-        new GraphQLObjectType({
-          name: 'AnotherObject',
-          fields: {},
-          // @ts-expect-error
-          isTypeOf: {},
-        }),
-    ).to.throw(
-      'AnotherObject must provide "isTypeOf" as a function, but got: {}.',
     );
   });
 });
@@ -510,46 +356,6 @@ describe('Type System: Interfaces', () => {
     expect(
       () => new GraphQLInterfaceType({ name: 'bad-name', fields: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
-  });
-
-  it('rejects an Interface type with incorrectly typed interfaces', () => {
-    const objType = new GraphQLInterfaceType({
-      name: 'AnotherInterface',
-      fields: {},
-      // @ts-expect-error
-      interfaces: {},
-    });
-    expect(() => objType.getInterfaces()).to.throw(
-      'AnotherInterface interfaces must be an Array or a function which returns an Array.',
-    );
-  });
-
-  it('rejects an Interface type with interfaces as a function returning an incorrect type', () => {
-    const objType = new GraphQLInterfaceType({
-      name: 'AnotherInterface',
-      fields: {},
-      // @ts-expect-error (Expected Array return)
-      interfaces() {
-        return {};
-      },
-    });
-    expect(() => objType.getInterfaces()).to.throw(
-      'AnotherInterface interfaces must be an Array or a function which returns an Array.',
-    );
-  });
-
-  it('rejects an Interface type with an incorrect type for resolveType', () => {
-    expect(
-      () =>
-        new GraphQLInterfaceType({
-          name: 'AnotherInterface',
-          fields: {},
-          // @ts-expect-error
-          resolveType: {},
-        }),
-    ).to.throw(
-      'AnotherInterface must provide "resolveType" as a function, but got: {}.',
-    );
   });
 });
 
@@ -592,32 +398,6 @@ describe('Type System: Unions', () => {
     expect(
       () => new GraphQLUnionType({ name: 'bad-name', types: [] }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
-  });
-
-  it('rejects an Union type with an incorrect type for resolveType', () => {
-    expect(
-      () =>
-        new GraphQLUnionType({
-          name: 'SomeUnion',
-          types: [],
-          // @ts-expect-error
-          resolveType: {},
-        }),
-    ).to.throw(
-      'SomeUnion must provide "resolveType" as a function, but got: {}.',
-    );
-  });
-
-  it('rejects a Union type with incorrectly typed types', () => {
-    const unionType = new GraphQLUnionType({
-      name: 'SomeUnion',
-      // @ts-expect-error
-      types: { ObjectType },
-    });
-
-    expect(() => unionType.getTypes()).to.throw(
-      'Must provide Array of types or a function which returns such an array for Union SomeUnion.',
-    );
   });
 });
 
@@ -710,17 +490,6 @@ describe('Type System: Enums', () => {
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
-  it('rejects an Enum type with incorrectly typed values', () => {
-    expect(
-      () =>
-        new GraphQLEnumType({
-          name: 'SomeEnum',
-          // @ts-expect-error
-          values: [{ FOO: 10 }],
-        }),
-    ).to.throw('SomeEnum values must be an object with value names as keys.');
-  });
-
   it('rejects an Enum type with incorrectly named values', () => {
     expect(
       () =>
@@ -731,32 +500,6 @@ describe('Type System: Enums', () => {
           },
         }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
-  });
-
-  it('rejects an Enum type with missing value definition', () => {
-    expect(
-      () =>
-        new GraphQLEnumType({
-          name: 'SomeEnum',
-          // @ts-expect-error (must not be null)
-          values: { FOO: null },
-        }),
-    ).to.throw(
-      'SomeEnum.FOO must refer to an object with a "value" key representing an internal value but got: null.',
-    );
-  });
-
-  it('rejects an Enum type with incorrectly typed value definition', () => {
-    expect(
-      () =>
-        new GraphQLEnumType({
-          name: 'SomeEnum',
-          // @ts-expect-error
-          values: { FOO: 10 },
-        }),
-    ).to.throw(
-      'SomeEnum.FOO must refer to an object with a "value" key representing an internal value but got: 10.',
-    );
   });
 });
 
@@ -807,28 +550,6 @@ describe('Type System: Input Objects', () => {
         () => new GraphQLInputObjectType({ name: 'bad-name', fields: {} }),
       ).to.throw(
         'Names must only contain [_a-zA-Z0-9] but "bad-name" does not.',
-      );
-    });
-
-    it('rejects an Input Object type with incorrect fields', () => {
-      const inputObjType = new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        // @ts-expect-error
-        fields: [],
-      });
-      expect(() => inputObjType.getFields()).to.throw(
-        'SomeInputObject fields must be an object with field names as keys or a function which returns such an object.',
-      );
-    });
-
-    it('rejects an Input Object type with fields function that returns incorrect type', () => {
-      const inputObjType = new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        // @ts-expect-error
-        fields: () => [],
-      });
-      expect(() => inputObjType.getFields()).to.throw(
-        'SomeInputObject fields must be an object with field names as keys or a function which returns such an object.',
       );
     });
 
@@ -905,19 +626,6 @@ describe('Type System: List', () => {
     expectList(ListOfScalarsType).to.not.throw();
     expectList(NonNullScalarType).to.not.throw();
   });
-
-  it('rejects a non-type as item type of list', () => {
-    // @ts-expect-error
-    expectList({}).to.throw('Expected {} to be a GraphQL type.');
-    // @ts-expect-error
-    expectList(String).to.throw(
-      'Expected [function String] to be a GraphQL type.',
-    );
-    // @ts-expect-error (must provide type)
-    expectList(null).to.throw('Expected null to be a GraphQL type.');
-    // @ts-expect-error (must provide type)
-    expectList(undefined).to.throw('Expected undefined to be a GraphQL type.');
-  });
 });
 
 describe('Type System: Non-Null', () => {
@@ -934,26 +642,6 @@ describe('Type System: Non-Null', () => {
     expectNonNull(InputObjectType).to.not.throw();
     expectNonNull(ListOfScalarsType).to.not.throw();
     expectNonNull(ListOfNonNullScalarsType).to.not.throw();
-  });
-
-  it('rejects a non-type as nullable type of non-null', () => {
-    expectNonNull(NonNullScalarType).to.throw(
-      'Expected Scalar! to be a GraphQL nullable type.',
-    );
-    // @ts-expect-error
-    expectNonNull({}).to.throw('Expected {} to be a GraphQL nullable type.');
-    // @ts-expect-error
-    expectNonNull(String).to.throw(
-      'Expected [function String] to be a GraphQL nullable type.',
-    );
-    // @ts-expect-error (must provide type)
-    expectNonNull(null).to.throw(
-      'Expected null to be a GraphQL nullable type.',
-    );
-    // @ts-expect-error (must provide type)
-    expectNonNull(undefined).to.throw(
-      'Expected undefined to be a GraphQL nullable type.',
-    );
   });
 });
 

--- a/src/type/__tests__/directive-test.ts
+++ b/src/type/__tests__/directive-test.ts
@@ -96,18 +96,6 @@ describe('Type System: Directive', () => {
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
-  it('rejects a directive with incorrectly typed args', () => {
-    expect(
-      () =>
-        new GraphQLDirective({
-          name: 'Foo',
-          locations: [DirectiveLocation.QUERY],
-          // @ts-expect-error
-          args: [],
-        }),
-    ).to.throw('@Foo args must be an object with argument names as keys.');
-  });
-
   it('rejects a directive with incorrectly named arg', () => {
     expect(
       () =>
@@ -119,19 +107,5 @@ describe('Type System: Directive', () => {
           },
         }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
-  });
-
-  it('rejects a directive with undefined locations', () => {
-    // @ts-expect-error
-    expect(() => new GraphQLDirective({ name: 'Foo' })).to.throw(
-      '@Foo locations must be an Array.',
-    );
-  });
-
-  it('rejects a directive with incorrectly typed locations', () => {
-    // @ts-expect-error
-    expect(() => new GraphQLDirective({ name: 'Foo', locations: {} })).to.throw(
-      '@Foo locations must be an Array.',
-    );
   });
 });

--- a/src/type/__tests__/predicate-test.ts
+++ b/src/type/__tests__/predicate-test.ts
@@ -73,6 +73,7 @@ import {
   GraphQLString,
   isSpecifiedScalarType,
 } from '../scalars';
+import { assertSchema, GraphQLSchema, isSchema } from '../schema';
 
 const ObjectType = new GraphQLObjectType({ name: 'Object', fields: {} });
 const InterfaceType = new GraphQLInterfaceType({
@@ -699,6 +700,34 @@ describe('Directive predicates', () => {
 
     it('returns false for custom directive', () => {
       expect(isSpecifiedDirective(Directive)).to.equal(false);
+    });
+  });
+});
+
+describe('Schema predicates', () => {
+  const schema = new GraphQLSchema({});
+
+  describe('isSchema/assertSchema', () => {
+    it('returns true for schema', () => {
+      expect(isSchema(schema)).to.equal(true);
+      expect(() => assertSchema(schema)).to.not.throw();
+    });
+
+    it('returns false for schema class (rather than instance)', () => {
+      expect(isSchema(GraphQLSchema)).to.equal(false);
+      expect(() => assertSchema(GraphQLSchema)).to.throw();
+    });
+
+    it('returns false for non-schema', () => {
+      expect(isSchema(EnumType)).to.equal(false);
+      expect(() => assertSchema(EnumType)).to.throw();
+      expect(isSchema(ScalarType)).to.equal(false);
+      expect(() => assertSchema(ScalarType)).to.throw();
+    });
+
+    it('returns false for random garbage', () => {
+      expect(isSchema({ what: 'is this' })).to.equal(false);
+      expect(() => assertSchema({ what: 'is this' })).to.throw();
     });
   });
 });

--- a/src/type/__tests__/schema-test.ts
+++ b/src/type/__tests__/schema-test.ts
@@ -438,15 +438,6 @@ describe('Type System: Schema', () => {
           }).__validationErrors,
         ).to.equal(undefined);
       });
-
-      it('checks the configuration for mistakes', () => {
-        // @ts-expect-error
-        expect(() => new GraphQLSchema(JSON.parse)).to.throw();
-        // @ts-expect-error
-        expect(() => new GraphQLSchema({ types: {} })).to.throw();
-        // @ts-expect-error
-        expect(() => new GraphQLSchema({ directives: {} })).to.throw();
-      });
     });
 
     describe('A Schema must contain uniquely named types', () => {
@@ -463,19 +454,6 @@ describe('Type System: Schema', () => {
 
         expect(() => new GraphQLSchema({ query: QueryType })).to.throw(
           'Schema must contain uniquely named types but contains multiple types named "String".',
-        );
-      });
-
-      it('rejects a Schema when a provided type has no name', () => {
-        const query = new GraphQLObjectType({
-          name: 'Query',
-          fields: { foo: { type: GraphQLString } },
-        });
-        const types = [{}, query, {}];
-
-        // @ts-expect-error
-        expect(() => new GraphQLSchema({ query, types })).to.throw(
-          'One of the provided types for building the Schema is missing a name.',
         );
       });
 

--- a/src/type/assertName.ts
+++ b/src/type/assertName.ts
@@ -1,5 +1,3 @@
-import { devAssert } from '../jsutils/devAssert';
-
 import { GraphQLError } from '../error/GraphQLError';
 
 import { isNameContinue, isNameStart } from '../language/characterClasses';
@@ -8,9 +6,6 @@ import { isNameContinue, isNameStart } from '../language/characterClasses';
  * Upholds the spec rules about naming.
  */
 export function assertName(name: string): string {
-  devAssert(name != null, 'Must provide name.');
-  devAssert(typeof name === 'string', 'Expected name to be a string.');
-
   if (name.length === 0) {
     throw new GraphQLError('Expected name to be a non-empty string.');
   }

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -1,7 +1,5 @@
-import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { instanceOf } from '../jsutils/instanceOf';
-import { isObjectLike } from '../jsutils/isObjectLike';
 import type { Maybe } from '../jsutils/Maybe';
 import { toObjMap } from '../jsutils/toObjMap';
 
@@ -70,17 +68,7 @@ export class GraphQLDirective {
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
 
-    devAssert(
-      Array.isArray(config.locations),
-      `@${config.name} locations must be an Array.`,
-    );
-
     const args = config.args ?? {};
-    devAssert(
-      isObjectLike(args) && !Array.isArray(args),
-      `@${config.name} args must be an object with argument names as keys.`,
-    );
-
     this.args = defineArguments(args);
   }
 

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -1,7 +1,5 @@
-import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { instanceOf } from '../jsutils/instanceOf';
-import { isObjectLike } from '../jsutils/isObjectLike';
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
 import { toObjMap } from '../jsutils/toObjMap';
@@ -159,18 +157,6 @@ export class GraphQLSchema {
     // marked with assumeValid to avoid an additional type system validation.
     this.__validationErrors = config.assumeValid === true ? [] : undefined;
 
-    // Check for common mistakes during construction to produce early errors.
-    devAssert(isObjectLike(config), 'Must provide configuration object.');
-    devAssert(
-      !config.types || Array.isArray(config.types),
-      `"types" must be Array if provided but got: ${inspect(config.types)}.`,
-    );
-    devAssert(
-      !config.directives || Array.isArray(config.directives),
-      '"directives" must be Array if provided but got: ' +
-        `${inspect(config.directives)}.`,
-    );
-
     this.description = config.description;
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
@@ -226,10 +212,6 @@ export class GraphQLSchema {
       }
 
       const typeName = namedType.name;
-      devAssert(
-        typeName != null,
-        'One of the provided types for building the Schema is missing a name.',
-      );
       if (this._typeMap[typeName] !== undefined) {
         throw new Error(
           `Schema must contain uniquely named types but contains multiple types named "${typeName}".`,

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -1092,16 +1092,4 @@ describe('Schema Builder', () => {
       'Unknown type: "UnknownType".',
     );
   });
-
-  it('Rejects invalid AST', () => {
-    // @ts-expect-error (First parameter expected to be DocumentNode)
-    expect(() => buildASTSchema(null)).to.throw(
-      'Must provide valid Document AST',
-    );
-
-    // @ts-expect-error
-    expect(() => buildASTSchema({})).to.throw(
-      'Must provide valid Document AST',
-    );
-  });
 });

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -1167,20 +1167,6 @@ describe('extendSchema', () => {
     );
   });
 
-  it('Rejects invalid AST', () => {
-    const schema = new GraphQLSchema({});
-
-    // @ts-expect-error (Second argument expects DocumentNode)
-    expect(() => extendSchema(schema, null)).to.throw(
-      'Must provide valid Document AST',
-    );
-
-    // @ts-expect-error
-    expect(() => extendSchema(schema, {})).to.throw(
-      'Must provide valid Document AST',
-    );
-  });
-
   it('does not allow replacing a default directive', () => {
     const schema = new GraphQLSchema({});
     const extendAST = parse(`

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -1,7 +1,4 @@
-import { devAssert } from '../jsutils/devAssert';
-
 import type { DocumentNode } from '../language/ast';
-import { Kind } from '../language/kinds';
 import type { ParseOptions } from '../language/parser';
 import { parse } from '../language/parser';
 import type { Source } from '../language/source';
@@ -37,11 +34,6 @@ export function buildASTSchema(
   documentAST: DocumentNode,
   options?: BuildSchemaOptions,
 ): GraphQLSchema {
-  devAssert(
-    documentAST != null && documentAST.kind === Kind.DOCUMENT,
-    'Must provide valid Document AST.',
-  );
-
   if (options?.assumeValid !== true && options?.assumeValidSDL !== true) {
     assertValidSDL(documentAST);
   }

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -65,6 +65,8 @@ export function buildClientSchema(
   introspection: IntrospectionQuery,
   options?: GraphQLSchemaValidationOptions,
 ): GraphQLSchema {
+  // Even even though `introspection` argument is typed in most cases it's received
+  // as untyped value from server, so we will do an additional check here.
   devAssert(
     isObjectLike(introspection) && isObjectLike(introspection.__schema),
     `Invalid or incomplete introspection result. Ensure that you are passing "data" property of introspection response and no "errors" was returned alongside: ${inspect(

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -1,4 +1,3 @@
-import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { invariant } from '../jsutils/invariant';
 import { keyMap } from '../jsutils/keyMap';
@@ -110,11 +109,6 @@ export function extendSchema(
   options?: Options,
 ): GraphQLSchema {
   assertSchema(schema);
-
-  devAssert(
-    documentAST != null && documentAST.kind === Kind.DOCUMENT,
-    'Must provide valid Document AST.',
-  );
 
   if (options?.assumeValid !== true && options?.assumeValidSDL !== true) {
     assertValidSDLExtension(documentAST, schema);

--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -17,11 +17,6 @@ import type { ValidationContext } from '../ValidationContext';
 import { testSchema } from './harness';
 
 describe('Validate: Supports full validation', () => {
-  it('rejects invalid documents', () => {
-    // @ts-expect-error (expects a DocumentNode as a second parameter)
-    expect(() => validate(testSchema, null)).to.throw('Must provide document.');
-  });
-
   it('validates queries', () => {
     const doc = parse(`
       query {

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -1,4 +1,3 @@
-import { devAssert } from '../jsutils/devAssert';
 import type { Maybe } from '../jsutils/Maybe';
 
 import { GraphQLError } from '../error/GraphQLError';
@@ -46,7 +45,6 @@ export function validate(
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
 
-  devAssert(documentAST != null, 'Must provide document.');
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
 


### PR DESCRIPTION
`graphql` provides TS types since `14.5.0` (released 3 years ago)
and we fully switched to TS in `15.0.0` so I think it's time to drop
runtime typechecks.

Motivations: This type checks were added long time ago since we shifted
towards TS we just maintained them without adding new ones.
In general, this check increase bundle size add runtime cost and we
can't realistically check all arguments to all functions.
Instead we should focus on adding more asserts on stuff that can't be
checked by TS.