### PR TITLE
Remove 'assertValidExecutionArguments' function

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -232,18 +232,6 @@ function buildResponse(
 }
 
 /**
- * Essential assertions before executing to provide developer feedback for
- * improper use of the GraphQL library.
- *
- * TODO: consider no longer exporting this function
- * @internal
- */
-export function assertValidExecutionArguments(schema: GraphQLSchema): void {
-  // If the schema used for execution is invalid, throw an error.
-  assertValidSchema(schema);
-}
-
-/**
  * Constructs a ExecutionContext object from the arguments passed to
  * execute, which we will pass throughout the other execution methods.
  *
@@ -267,8 +255,8 @@ export function buildExecutionContext(
     subscribeFieldResolver,
   } = args;
 
-  // If arguments are missing or incorrect, throw an error.
-  assertValidExecutionArguments(schema);
+  // If the schema used for execution is invalid, throw an error.
+  assertValidSchema(schema);
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);


### PR DESCRIPTION
After we drop runtime type checks that were duplicating TS types in #3642 
this function became a wrapper for 'assertValidSchema' so all clients
that rely on it can now use 'assertValidSchema' directly.