### PR TITLE
execute: integrate subscriptions and refactor pipeline

### DIFF
--- a/integrationTests/ts/basic-test.ts
+++ b/integrationTests/ts/basic-test.ts
@@ -23,12 +23,13 @@ const queryType: GraphQLObjectType = new GraphQLObjectType({
 
 const schema: GraphQLSchema = new GraphQLSchema({ query: queryType });
 
-const result: ExecutionResult = graphqlSync({
-  schema,
-  source: `
+const result: ExecutionResult | AsyncGenerator<ExecutionResult, void, void> =
+  graphqlSync({
+    schema,
+    source: `
     query helloWho($who: String){
       test(who: $who)
     }
   `,
-  variableValues: { who: 'Dolly' },
-});
+    variableValues: { who: 'Dolly' },
+  });

--- a/src/__tests__/starWarsIntrospection-test.ts
+++ b/src/__tests__/starWarsIntrospection-test.ts
@@ -1,5 +1,7 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
+
+import { isAsyncIterable } from '../jsutils/isAsyncIterable';
 
 import { graphqlSync } from '../graphql';
 
@@ -8,6 +10,7 @@ import { StarWarsSchema } from './starWarsSchema';
 function queryStarWars(source: string) {
   const result = graphqlSync({ schema: StarWarsSchema, source });
   expect(Object.keys(result)).to.deep.equal(['data']);
+  assert(!isAsyncIterable(result));
   return result.data;
 }
 

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -20,7 +20,7 @@ import {
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
-import { execute, executeSync } from '../execute';
+import { execute, executeSubscriptionEvent, executeSync } from '../execute';
 
 describe('Execute: Handles basic execution tasks', () => {
   it('executes arbitrary code', async () => {
@@ -907,6 +907,19 @@ describe('Execute: Handles basic execution tasks', () => {
     expectJSON(
       executeSync({ schema, document, operationName: 'S' }),
     ).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Schema is not configured to execute subscription operation.',
+          locations: [{ line: 4, column: 7 }],
+        },
+      ],
+    });
+
+    expectJSON(
+      executeSubscriptionEvent({ schema, document, operationName: 'S' }),
+    ).toDeepEqual({
+      data: null,
       errors: [
         {
           message:

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -20,7 +20,7 @@ import {
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
-import { execute, executeSubscriptionEvent, executeSync } from '../execute';
+import { execute, executeSync } from '../execute';
 
 describe('Execute: Handles basic execution tasks', () => {
   it('executes arbitrary code', async () => {
@@ -907,19 +907,6 @@ describe('Execute: Handles basic execution tasks', () => {
     expectJSON(
       executeSync({ schema, document, operationName: 'S' }),
     ).toDeepEqual({
-      errors: [
-        {
-          message:
-            'Schema is not configured to execute subscription operation.',
-          locations: [{ line: 4, column: 7 }],
-        },
-      ],
-    });
-
-    expectJSON(
-      executeSubscriptionEvent({ schema, document, operationName: 'S' }),
-    ).toDeepEqual({
-      data: null,
       errors: [
         {
           message:

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -85,7 +85,9 @@ describe('Execute: Accepts async iterables as list value', () => {
 
   function completeObjectList(
     resolve: GraphQLFieldResolver<{ index: number }, unknown>,
-  ): PromiseOrValue<ExecutionResult> {
+  ): PromiseOrValue<
+    ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+  > {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -1,7 +1,10 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON';
+
+import { isAsyncIterable } from '../../jsutils/isAsyncIterable';
+import type { PromiseOrValue } from '../../jsutils/PromiseOrValue';
 
 import { parse } from '../../language/parser';
 
@@ -109,7 +112,9 @@ const schema = buildSchema(`
 function executeQuery(
   query: string,
   rootValue: unknown,
-): ExecutionResult | Promise<ExecutionResult> {
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
   return execute({ schema, document: parse(query), rootValue });
 }
 
@@ -132,6 +137,7 @@ async function executeSyncAndAsync(query: string, rootValue: unknown) {
     rootValue,
   });
 
+  assert(!isAsyncIterable(syncResult));
   expectJSON(asyncResult).toDeepEqual(patchData(syncResult));
   return syncResult;
 }

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -15,7 +15,7 @@ import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
 import type { ExecutionArgs, ExecutionResult } from '../execute';
-import { createSourceEventStream, execute, subscribe } from '../execute';
+import { execute, subscribe } from '../execute';
 
 import { SimplePubSub } from './simplePubSub';
 
@@ -221,7 +221,6 @@ function subscribeWithBadArgs(
 ): PromiseOrValue<ExecutionResult | AsyncIterable<unknown>> {
   return expectEqualPromisesOrValues([
     execute(args),
-    createSourceEventStream(args),
     subscribe(args),
   ]);
 }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -210,7 +210,7 @@ export function execute(
 /**
  * Implements the "Executing operations" section of the spec.
  */
-function executeOperation(
+export function executeOperation(
   exeInfo: ExecutionInfo,
 ): PromiseOrValue<
   ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
@@ -234,7 +234,7 @@ export function executeQuery(
   return executeQueryOrMutation(exeInfo, { errors: [] }, executeFields);
 }
 
-function executeMutation(
+export function executeMutation(
   exeInfo: ExecutionInfo,
 ): PromiseOrValue<ExecutionResult> {
   return executeQueryOrMutation(exeInfo, { errors: [] }, executeFieldsSerially);
@@ -1211,7 +1211,7 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
  * If the operation succeeded, the promise resolves to an AsyncIterator, which
  * yields a stream of ExecutionResults representing the response stream.
  */
-function executeSubscription(
+export function executeSubscription(
   exeInfo: ExecutionInfo,
 ): PromiseOrValue<
   ExecutionResult | AsyncGenerator<ExecutionResult, void, void>

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1217,19 +1217,7 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
  *
  * If the operation succeeded, the promise resolves to an AsyncIterator, which
  * yields a stream of ExecutionResults representing the response stream.
- *
- * Accepts either an object with named arguments, or individual arguments.
- *
- * @deprecated subscribe will be removed in v18; use execute instead
  */
-export function subscribe(
-  args: ExecutionArgs,
-): PromiseOrValue<
-  AsyncGenerator<ExecutionResult, void, void> | ExecutionResult
-> {
-  return execute(args);
-}
-
 function executeSubscription(
   exeInfo: ExecutionInfo,
 ): PromiseOrValue<

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1221,6 +1221,16 @@ export function createSourceEventStream(
   return prepareContextAndRunFn(args, createSourceEventStreamImpl);
 }
 
+/**
+ * Implements the "ExecuteSubscriptionEvent" algorithm described in the
+ * GraphQL specification.
+ */
+export function executeSubscriptionEvent(
+  args: ExecutionArgs,
+): PromiseOrValue<ExecutionResult> {
+  return prepareContextAndRunFn(args, executeQuery);
+}
+
 function createSourceEventStreamImpl(
   exeContext: ExecutionContext,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -235,7 +235,9 @@ function executeOperation(
   return executeSubscription(exeInfo);
 }
 
-function executeQuery(exeInfo: ExecutionInfo): PromiseOrValue<ExecutionResult> {
+export function executeQuery(
+  exeInfo: ExecutionInfo,
+): PromiseOrValue<ExecutionResult> {
   return executeQueryOrMutation(exeInfo, { errors: [] }, executeFields);
 }
 
@@ -1295,6 +1297,8 @@ function mapSourceToResponse(
  * different process or machine than the stateless GraphQL execution engine,
  * or otherwise separating these two steps. For more on this, see the
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
+ *
+ * @deprecated will be removed in the next major version
  */
 export function createSourceEventStream(
   args: ExecutionArgs,
@@ -1305,6 +1309,8 @@ export function createSourceEventStream(
 /**
  * Implements the "ExecuteSubscriptionEvent" algorithm described in the
  * GraphQL specification.
+ *
+ * @deprecated will be removed in the next major version
  */
 export function executeSubscriptionEvent(
   args: ExecutionArgs,
@@ -1312,7 +1318,7 @@ export function executeSubscriptionEvent(
   return prepareContextAndRunFn(args, executeQuery);
 }
 
-function createSourceEventStreamImpl(
+export function createSourceEventStreamImpl(
   exeInfo: ExecutionInfo,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
   try {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -195,13 +195,6 @@ export function execute(
 ): PromiseOrValue<
   ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
 > {
-  return prepareContextAndRunFn(args, executeOperation);
-}
-
-function prepareContextAndRunFn<T>(
-  args: ExecutionArgs,
-  fn: (exeInfo: ExecutionInfo) => T,
-): ExecutionResult | T {
   // If a valid execution info object cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeInfo = buildExecutionInfo(args);
@@ -211,7 +204,7 @@ function prepareContextAndRunFn<T>(
     return { errors: exeInfo };
   }
 
-  return fn(exeInfo);
+  return executeOperation(exeInfo);
 }
 
 /**

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -184,6 +184,9 @@ function prepareContextAndRunFn<T>(
   return fn(exeContext);
 }
 
+/**
+ * Implements the "Executing operations" section of the spec for queries and mutations.
+ */
 function executeImpl(
   exeContext: ExecutionContext,
 ): PromiseOrValue<ExecutionResult> {
@@ -199,7 +202,7 @@ function executeImpl(
   // at which point we still log the error and null the parent field, which
   // in this case is the entire response.
   try {
-    const result = executeOperation(exeContext);
+    const result = executeQueryOrMutationRootFields(exeContext);
     if (isPromise(result)) {
       return result.then(
         (data) => buildResponse(data, exeContext.errors),
@@ -343,10 +346,7 @@ function buildPerEventExecutionContext(
   };
 }
 
-/**
- * Implements the "Executing operations" section of the spec.
- */
-function executeOperation(
+function executeQueryOrMutationRootFields(
   exeContext: ExecutionContext,
 ): PromiseOrValue<ObjMap<unknown>> {
   const { operation, schema, fragments, variableValues, rootValue } =

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1186,7 +1186,7 @@ function createSourceEventStreamImpl(
   exeContext: ExecutionContext,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
   try {
-    const eventStream = executeSubscription(exeContext);
+    const eventStream = executeSubscriptionRootField(exeContext);
     if (isPromise(eventStream)) {
       return eventStream.then(undefined, (error) => ({ errors: [error] }));
     }
@@ -1197,7 +1197,7 @@ function createSourceEventStreamImpl(
   }
 }
 
-function executeSubscription(
+function executeSubscriptionRootField(
   exeContext: ExecutionContext,
 ): PromiseOrValue<AsyncIterable<unknown>> {
   const { schema, fragments, operation, variableValues, rootValue } =

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1235,7 +1235,7 @@ function executeSubscription(
 ): PromiseOrValue<
   ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
 > {
-  const resultOrStream = createSourceEventStreamImpl(exeInfo);
+  const resultOrStream = createSourceEventStream(exeInfo);
 
   if (isPromise(resultOrStream)) {
     return resultOrStream.then((resolvedResultOrStream) =>
@@ -1297,28 +1297,8 @@ function mapSourceToResponse(
  * different process or machine than the stateless GraphQL execution engine,
  * or otherwise separating these two steps. For more on this, see the
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
- *
- * @deprecated will be removed in the next major version
  */
 export function createSourceEventStream(
-  args: ExecutionArgs,
-): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
-  return prepareContextAndRunFn(args, createSourceEventStreamImpl);
-}
-
-/**
- * Implements the "ExecuteSubscriptionEvent" algorithm described in the
- * GraphQL specification.
- *
- * @deprecated will be removed in the next major version
- */
-export function executeSubscriptionEvent(
-  args: ExecutionArgs,
-): PromiseOrValue<ExecutionResult> {
-  return prepareContextAndRunFn(args, executeQuery);
-}
-
-export function createSourceEventStreamImpl(
   exeInfo: ExecutionInfo,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
   try {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -154,6 +154,14 @@ export interface ExecutionArgs {
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
 
+type FieldsExecutor = (
+  exeContext: ExecutionContext,
+  parentType: GraphQLObjectType,
+  sourceValue: unknown,
+  path: Path | undefined,
+  fields: Map<string, ReadonlyArray<FieldNode>>,
+) => PromiseOrValue<ObjMap<unknown>>;
+
 /**
  * Implements the "Executing requests" section of the GraphQL specification.
  *
@@ -164,8 +172,12 @@ export interface ExecutionArgs {
  * If the arguments to this function do not result in a legal execution context,
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
-export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  return prepareContextAndRunFn(args, executeImpl);
+export function execute(
+  args: ExecutionArgs,
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
+  return prepareContextAndRunFn(args, executeOperation);
 }
 
 function prepareContextAndRunFn<T>(
@@ -185,10 +197,41 @@ function prepareContextAndRunFn<T>(
 }
 
 /**
- * Implements the "Executing operations" section of the spec for queries and mutations.
+ * Implements the "Executing operations" section of the spec.
  */
-function executeImpl(
+function executeOperation(
   exeContext: ExecutionContext,
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
+  const operationType = exeContext.operation.operation;
+
+  if (operationType === OperationTypeNode.QUERY) {
+    return executeQuery(exeContext);
+  }
+
+  if (operationType === OperationTypeNode.MUTATION) {
+    return executeMutation(exeContext);
+  }
+
+  return executeSubscription(exeContext);
+}
+
+function executeQuery(
+  exeContext: ExecutionContext,
+): PromiseOrValue<ExecutionResult> {
+  return executeQueryOrMutation(exeContext, executeFields);
+}
+
+function executeMutation(
+  exeContext: ExecutionContext,
+): PromiseOrValue<ExecutionResult> {
+  return executeQueryOrMutation(exeContext, executeFieldsSerially);
+}
+
+function executeQueryOrMutation(
+  exeContext: ExecutionContext,
+  fieldsExecutor: FieldsExecutor,
 ): PromiseOrValue<ExecutionResult> {
   // Return a Promise that will eventually resolve to the data described by
   // The "Response" section of the GraphQL specification.
@@ -202,7 +245,7 @@ function executeImpl(
   // at which point we still log the error and null the parent field, which
   // in this case is the entire response.
   try {
-    const result = executeQueryOrMutationRootFields(exeContext);
+    const result = executeQueryOrMutationRootFields(exeContext, fieldsExecutor);
     if (isPromise(result)) {
       return result.then(
         (data) => buildResponse(data, exeContext.errors),
@@ -224,7 +267,9 @@ function executeImpl(
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
-export function executeSync(args: ExecutionArgs): ExecutionResult {
+export function executeSync(
+  args: ExecutionArgs,
+): ExecutionResult | AsyncGenerator<ExecutionResult, void, void> {
   const result = execute(args);
 
   // Assert that the execution was synchronous.
@@ -348,6 +393,7 @@ function buildPerEventExecutionContext(
 
 function executeQueryOrMutationRootFields(
   exeContext: ExecutionContext,
+  fieldsExecutor: FieldsExecutor,
 ): PromiseOrValue<ObjMap<unknown>> {
   const { operation, schema, fragments, variableValues, rootValue } =
     exeContext;
@@ -368,22 +414,7 @@ function executeQueryOrMutationRootFields(
   );
   const path = undefined;
 
-  switch (operation.operation) {
-    case OperationTypeNode.QUERY:
-      return executeFields(exeContext, rootType, rootValue, path, rootFields);
-    case OperationTypeNode.MUTATION:
-      return executeFieldsSerially(
-        exeContext,
-        rootType,
-        rootValue,
-        path,
-        rootFields,
-      );
-    case OperationTypeNode.SUBSCRIPTION:
-      // TODO: deprecate `subscribe` and move all logic here
-      // Temporary solution until we finish merging execute and subscribe together
-      return executeFields(exeContext, rootType, rootValue, path, rootFields);
-  }
+  return fieldsExecutor(exeContext, rootType, rootValue, path, rootFields);
 }
 
 /**
@@ -1108,23 +1139,31 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
  * yields a stream of ExecutionResults representing the response stream.
  *
  * Accepts either an object with named arguments, or individual arguments.
+ *
+ * @deprecated subscribe will be removed in v18; use execute instead
  */
 export function subscribe(
   args: ExecutionArgs,
 ): PromiseOrValue<
   AsyncGenerator<ExecutionResult, void, void> | ExecutionResult
 > {
-  return prepareContextAndRunFn(args, (exeContext: ExecutionContext) => {
-    const resultOrStream = createSourceEventStreamImpl(exeContext);
+  return execute(args);
+}
 
-    if (isPromise(resultOrStream)) {
-      return resultOrStream.then((resolvedResultOrStream) =>
-        mapSourceToResponse(exeContext, resolvedResultOrStream),
-      );
-    }
+function executeSubscription(
+  exeContext: ExecutionContext,
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
+  const resultOrStream = createSourceEventStreamImpl(exeContext);
 
-    return mapSourceToResponse(exeContext, resultOrStream);
-  });
+  if (isPromise(resultOrStream)) {
+    return resultOrStream.then((resolvedResultOrStream) =>
+      mapSourceToResponse(exeContext, resolvedResultOrStream),
+    );
+  }
+
+  return mapSourceToResponse(exeContext, resultOrStream);
 }
 
 function mapSourceToResponse(
@@ -1144,7 +1183,7 @@ function mapSourceToResponse(
   // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
   // "ExecuteQuery" algorithm, for which `execute` is also used.
   return mapAsyncIterator(resultOrStream, (payload: unknown) =>
-    executeImpl(buildPerEventExecutionContext(exeContext, payload)),
+    executeQuery(buildPerEventExecutionContext(exeContext, payload)),
   );
 }
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3,6 +3,7 @@ export { pathToArray as responsePathAsArray } from '../jsutils/Path';
 export {
   createSourceEventStream,
   execute,
+  executeSubscriptionEvent,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -5,7 +5,6 @@ export {
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
-  subscribe,
 } from './execute';
 
 export type {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,9 +1,7 @@
 export { pathToArray as responsePathAsArray } from '../jsutils/Path';
 
 export {
-  createSourceEventStream,
   execute,
-  executeSubscriptionEvent,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -5,6 +5,7 @@ export {
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
+  defaultSubscriptionEventExecutor,
 } from './execute';
 
 export type {

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -23,7 +23,7 @@ import { coerceInputValue } from '../utilities/coerceInputValue';
 import { typeFromAST } from '../utilities/typeFromAST';
 import { valueFromAST } from '../utilities/valueFromAST';
 
-type CoercedVariableValues =
+export type CoercedVariableValues =
   | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
   | { coerced: { [variable: string]: unknown }; errors?: never };
 

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -67,7 +67,9 @@ export interface GraphQLArgs {
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
 }
 
-export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {
+export function graphql(
+  args: GraphQLArgs,
+): Promise<ExecutionResult | AsyncGenerator<ExecutionResult, void, void>> {
   // Always return a Promise for a consistent API.
   return new Promise((resolve) => resolve(graphqlImpl(args)));
 }
@@ -78,7 +80,9 @@ export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
  */
-export function graphqlSync(args: GraphQLArgs): ExecutionResult {
+export function graphqlSync(
+  args: GraphQLArgs,
+): ExecutionResult | AsyncGenerator<ExecutionResult, void, void> {
   const result = graphqlImpl(args);
 
   // Assert that the execution was synchronous.
@@ -89,7 +93,11 @@ export function graphqlSync(args: GraphQLArgs): ExecutionResult {
   return result;
 }
 
-function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
+function graphqlImpl(
+  args: GraphQLArgs,
+): PromiseOrValue<
+  ExecutionResult | AsyncGenerator<ExecutionResult, void, void>
+> {
   const {
     schema,
     source,

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,8 +320,6 @@ export {
   getVariableValues,
   getDirectiveValues,
   subscribe,
-  createSourceEventStream,
-  executeSubscriptionEvent,
 } from './execution/index';
 
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,6 +315,7 @@ export {
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
+  defaultSubscriptionEventExecutor,
   responsePathAsArray,
   getArgumentValues,
   getVariableValues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,7 +319,6 @@ export {
   getArgumentValues,
   getVariableValues,
   getDirectiveValues,
-  subscribe,
 } from './execution/index';
 
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,6 +321,7 @@ export {
   getDirectiveValues,
   subscribe,
   createSourceEventStream,
+  executeSubscriptionEvent,
 } from './execution/index';
 
 export type {

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -110,6 +110,7 @@ const SubscriptionType = new GraphQLObjectType({
       async *subscribe(_source, { color }) {
         yield { subscribeToEnum: color }; /* c8 ignore start */
       } /* c8 ignore stop */,
+      resolve: (_source, { color }) => color,
     },
   },
 });

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent';
 
+import { isAsyncIterable } from '../../jsutils/isAsyncIterable';
 import type { Maybe } from '../../jsutils/Maybe';
 
 import type { ASTNode } from '../../language/ast';
@@ -76,6 +77,7 @@ describe('Schema Builder', () => {
       source: '{ str }',
       rootValue: { str: 123 },
     });
+    assert(!isAsyncIterable(result));
     expect(result.data).to.deep.equal({ str: '123' });
   });
 

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent';
 
+import { isAsyncIterable } from '../../jsutils/isAsyncIterable';
+
 import {
   assertEnumType,
   GraphQLEnumType,
@@ -591,6 +593,7 @@ describe('Type System: build schema from introspection', () => {
       variableValues: { v: 'baz' },
     });
 
+    assert(!isAsyncIterable(result));
     expect(result.data).to.deep.equal({ foo: 'bar' });
   });
 

--- a/src/utilities/introspectionFromSchema.ts
+++ b/src/utilities/introspectionFromSchema.ts
@@ -1,4 +1,5 @@
 import { invariant } from '../jsutils/invariant';
+import { isAsyncIterable } from '../jsutils/isAsyncIterable';
 
 import { parse } from '../language/parser';
 
@@ -35,6 +36,7 @@ export function introspectionFromSchema(
 
   const document = parse(getIntrospectionQuery(optionsWithDefaults));
   const result = executeSync({ schema, document });
+  invariant(!isAsyncIterable(result));
   invariant(result.errors == null && result.data != null);
   return result.data as any;
 }


### PR DESCRIPTION
`execute` no longer runs the query algorithm for subscription operations. Rather, subscription operations are performed, as per the spec. `subscribe` and `createSourceEventStream` are removed.

See additional comments below.