### PR TITLE
Use a type-safe way is differentiating ExecutionResult from Array<Error>

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
     "prism-react-renderer": "1.3.3",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "ts-node": "10.8.0",
-    "typedoc": "0.22.15",
-    "typescript": "4.6.4",
+    "ts-node": "10.8.1",
+    "typedoc": "0.22.17",
+    "typescript": "4.7.3",
     "url-loader": "4.1.1"
   },
   "publishConfig": {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -170,7 +170,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   const exeContext = buildExecutionContext(args);
 
   // Return early errors if execution context failed.
-  if (!('schema' in exeContext)) {
+  if (Array.isArray(exeContext)) {
     return { errors: exeContext };
   }
 
@@ -1090,7 +1090,7 @@ export function createSourceEventStream(
   const exeContext = buildExecutionContext(args);
 
   // Return early errors if execution context failed.
-  if (!('schema' in exeContext)) {
+  if (Array.isArray(exeContext)) {
     return { errors: exeContext };
   }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -170,7 +170,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   const exeContext = buildExecutionContext(args);
 
   // Return early errors if execution context failed.
-  if (Array.isArray(exeContext)) {
+  if (Array.isArray(exeContext) || !('schema' in exeContext)) {
     return { errors: exeContext };
   }
 
@@ -1090,7 +1090,7 @@ export function createSourceEventStream(
   const exeContext = buildExecutionContext(args);
 
   // Return early errors if execution context failed.
-  if (Array.isArray(exeContext)) {
+  if (Array.isArray(exeContext) || !('schema' in exeContext)) {
     return { errors: exeContext };
   }
 


### PR DESCRIPTION
### Motivation

Checking a string key on an array is not valid, correctly yielding a warning on a TS branch I'm playing in.
Narrow the type with Array.isArray instead.

### Performance
Running `yarn benchmark` (which is amazing, btw) on my 2019 MacBook Pro running macOS 12.4 and node 18.2.0, I see a few slight increases and slight decreases of my local vs HEAD. I exited all other user processes on the system, but there was still some slight variability from run to run regardless.

Here's a screenshot of the run, let me know if I need to dive into CPU profiler data to find another type-safe alternative that's cheaper at runtime.
<img width="651" alt="image" src="https://user-images.githubusercontent.com/1550766/174224158-e1358415-2412-4190-8836-a737393028df.png">
