### PR TITLE
Fix crash in node when mixing sync/async resolvers (backport of #3529)

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick';
 
 import { inspect } from '../../jsutils/inspect';
 
@@ -571,6 +572,55 @@ describe('Execute: Handles basic execution tasks', () => {
           locations: [{ column: 9, line: 3 }],
           message: 'Oops',
           path: ['foods'],
+        },
+      ],
+    });
+  });
+
+  it('handles sync errors combined with rejections', async () => {
+    let isAsyncResolverCalled = false;
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          syncNullError: {
+            type: new GraphQLNonNull(GraphQLString),
+            resolve: () => null,
+          },
+          asyncNullError: {
+            type: new GraphQLNonNull(GraphQLString),
+            async resolve() {
+              await resolveOnNextTick();
+              await resolveOnNextTick();
+              await resolveOnNextTick();
+              isAsyncResolverCalled = true;
+              return Promise.resolve(null);
+            },
+          },
+        },
+      }),
+    });
+
+    // Order is important here, as the promise has to be created before the synchronous error is thrown
+    const document = parse(`
+      {
+        asyncNullError
+        syncNullError
+      }
+    `);
+
+    const result = await execute({ schema, document });
+
+    expect(isAsyncResolverCalled).to.equal(true);
+    expectJSON(result).toDeepEqual({
+      data: null,
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field Query.syncNullError.',
+          locations: [{ line: 4, column: 9 }],
+          path: ['syncNullError'],
         },
       ],
     });

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -416,22 +416,32 @@ function executeFields(
   const results = Object.create(null);
   let containsPromise = false;
 
-  for (const [responseName, fieldNodes] of fields.entries()) {
-    const fieldPath = addPath(path, responseName, parentType.name);
-    const result = executeField(
-      exeContext,
-      parentType,
-      sourceValue,
-      fieldNodes,
-      fieldPath,
-    );
+  try {
+    for (const [responseName, fieldNodes] of fields.entries()) {
+      const fieldPath = addPath(path, responseName, parentType.name);
+      const result = executeField(
+        exeContext,
+        parentType,
+        sourceValue,
+        fieldNodes,
+        fieldPath,
+      );
 
-    if (result !== undefined) {
-      results[responseName] = result;
-      if (isPromise(result)) {
-        containsPromise = true;
+      if (result !== undefined) {
+        results[responseName] = result;
+        if (isPromise(result)) {
+          containsPromise = true;
+        }
       }
     }
+  } catch (error) {
+    if (containsPromise) {
+      // Ensure that any promises returned by other fields are handled, as they may also reject.
+      return promiseForObject(results).finally(() => {
+        throw error;
+      });
+    }
+    throw error;
   }
 
   // If there are no promises, we can just return the object


### PR DESCRIPTION
Fixes #3528 

This PR is a clone of #3529, which is currently held up by CLA approvals.  Full credit goes to @asztal for identifying and fixing the underlying issue.  @hobby203, the current steward of the original PR, has given their blessing for the PR to be re-created.

@asztal's notes from the original PR:

> Ensures that if `executeFields` encounters a mix of promises and thrown errors, the promises will be awaited before throwing the error.
> 
> This does technically change `executeFields` to return a rejected promise in this scenario as opposed to throwing the not-null error synchronously, but I figured if any of the resolvers are asynchronous then returning a promise will be expected anyway, and this was better than crashing the process.
> 
> Note: I had to add an `unhandledRejection` event listener myself, as it seems mocha doesn't do it.

This PR has been backported to the `15.x` branch as #3573 and to the `16.x` branch as #3576.
