### PR TITLE
refactor: use `exeContext` strategically

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -186,8 +186,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   // at which point we still log the error and null the parent field, which
   // in this case is the entire response.
   try {
-    const { operation } = exeContext;
-    const result = executeOperation(exeContext, operation);
+    const result = executeOperation(exeContext);
     if (isPromise(result)) {
       return result.then(
         (data) => buildResponse(data, exeContext.errors),
@@ -325,8 +324,8 @@ export function buildExecutionContext(
  */
 function executeOperation(
   exeContext: ExecutionContext,
-  operation: OperationDefinitionNode,
 ): PromiseOrValue<ObjMap<unknown>> {
+  const { operation } = exeContext;
   const rootType = exeContext.schema.getRootType(operation.operation);
   if (rootType == null) {
     throw new GraphQLError(

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -325,8 +325,9 @@ export function buildExecutionContext(
 function executeOperation(
   exeContext: ExecutionContext,
 ): PromiseOrValue<ObjMap<unknown>> {
-  const { operation } = exeContext;
-  const rootType = exeContext.schema.getRootType(operation.operation);
+  const { operation, schema, fragments, variableValues, rootValue } =
+    exeContext;
+  const rootType = schema.getRootType(operation.operation);
   if (rootType == null) {
     throw new GraphQLError(
       `Schema is not configured to execute ${operation.operation} operation.`,
@@ -335,15 +336,13 @@ function executeOperation(
   }
 
   const rootFields = collectFields(
-    exeContext.schema,
-    exeContext.fragments,
-    exeContext.variableValues,
+    schema,
+    fragments,
+    variableValues,
     rootType,
     operation.selectionSet,
   );
   const path = undefined;
-
-  const { rootValue } = exeContext;
 
   switch (operation.operation) {
     case OperationTypeNode.QUERY:


### PR DESCRIPTION
1. `executeOperation` can take only one parameter, `operation` is included within `exeContext`
2. use spread syntax to retrieve properties from `exeContext`

@IvanGoncharov this is a small hopefully straightforward PR that can be merged (as two separate commits or as a squashed commit if you would prefer) if #3639 or #3644 are blocked.