### PR TITLE
polish: add tests for `expectPromise` and `expectEqualPromisesOrValues`

### DIFF
--- a/src/__testUtils__/__tests__/expectEqualPromisesOrValues-test.ts
+++ b/src/__testUtils__/__tests__/expectEqualPromisesOrValues-test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectEqualPromisesOrValues } from '../expectEqualPromisesOrValues';
+import { expectPromise } from '../expectPromise';
+
+describe('expectEqualPromisesOrValues', () => {
+  it('throws when given unequal values', () => {
+    expect(() => expectEqualPromisesOrValues([{}, {}, { test: 'test' }])).throw(
+      "expected { test: 'test' } to deeply equal {}",
+    );
+  });
+
+  it('does not throw when given equal values', () => {
+    const testValue = { test: 'test' };
+    expect(() =>
+      expectEqualPromisesOrValues([testValue, testValue, testValue]),
+    ).not.to.throw();
+  });
+
+  it('does not throw when given equal promises', async () => {
+    const testValue = Promise.resolve({ test: 'test' });
+
+    await expectPromise(
+      expectEqualPromisesOrValues([testValue, testValue, testValue]),
+    ).toResolve();
+  });
+
+  it('throws when given unequal promises', async () => {
+    await expectPromise(
+      expectEqualPromisesOrValues([
+        Promise.resolve({}),
+        Promise.resolve({}),
+        Promise.resolve({ test: 'test' }),
+      ]),
+    ).toRejectWith("expected { test: 'test' } to deeply equal {}");
+  });
+
+  it('throws when given equal values that are mixtures of values and promises', () => {
+    const testValue = { test: 'test' };
+    expect(() =>
+      expectEqualPromisesOrValues([testValue, Promise.resolve(testValue)]),
+    ).to.throw('Received an invalid mixture of promises and values.');
+  });
+});

--- a/src/__testUtils__/__tests__/expectMatchingValues-test.ts
+++ b/src/__testUtils__/__tests__/expectMatchingValues-test.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectEqualPromisesOrValues } from '../expectEqualPromisesOrValues';
+
+describe('expectMatchingValues', () => {
+  it('throws when given unequal values', () => {
+    expect(() => expectEqualPromisesOrValues([{}, {}, { test: 'test' }])).throw(
+      "expected { test: 'test' } to deeply equal {}",
+    );
+  });
+
+  it('does not throw when given equal values', () => {
+    const testValue = { test: 'test' };
+    expect(() =>
+      expectEqualPromisesOrValues([testValue, testValue, testValue]),
+    ).not.to.throw();
+  });
+});

--- a/src/__testUtils__/__tests__/expectPromise-test.ts
+++ b/src/__testUtils__/__tests__/expectPromise-test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectPromise } from '../expectPromise';
+
+describe('expectPromise', () => {
+  it('throws if passed a value', () => {
+    expect(() => expectPromise({})).to.throw(
+      "Expected a promise, received '{}'",
+    );
+  });
+
+  it('toResolve returns the resolved value', async () => {
+    const testValue = {};
+    const promise = Promise.resolve(testValue);
+    expect(await expectPromise(promise).toResolve()).to.equal(testValue);
+  });
+
+  it('toRejectWith throws if the promise does not reject', async () => {
+    try {
+      await expectPromise(Promise.resolve({})).toRejectWith(
+        'foo',
+      ); /* c8 ignore start */
+    } /* c8 ignore stop */ catch (err) {
+      expect(err.message).to.equal(
+        "Promise should have rejected with message 'foo', but resolved as '{}'",
+      );
+    }
+  });
+
+  it('toRejectWith throws if the promise rejects with the wrong reason', async () => {
+    try {
+      await expectPromise(Promise.reject(new Error('foo'))).toRejectWith(
+        'bar',
+      ); /* c8 ignore start */
+    } /* c8 ignore stop */ catch (err) {
+      expect(err.message).to.equal(
+        "expected Error: foo to have property 'message' of 'bar', but got 'foo'",
+      );
+    }
+  });
+
+  it('toRejectWith does not throw if the promise rejects with the right reason', async () => {
+    try {
+      await expectPromise(Promise.reject(new Error('foo'))).toRejectWith(
+        'foo',
+      ); /* c8 ignore start */
+    } catch (err) {
+      // Not reached.
+      expect.fail('promise threw unexpectedly');
+    } /* c8 ignore stop */
+  });
+});

--- a/src/__testUtils__/expectEqualPromisesOrValues.ts
+++ b/src/__testUtils__/expectEqualPromisesOrValues.ts
@@ -3,7 +3,7 @@ import { assert } from 'chai';
 import { isPromise } from '../jsutils/isPromise';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 
-import { expectJSON } from './expectJSON';
+import { expectMatchingValues } from './expectMatchingValues';
 
 export function expectEqualPromisesOrValues<T>(
   items: ReadonlyArray<PromiseOrValue<T>>,
@@ -20,12 +20,4 @@ export function expectEqualPromisesOrValues<T>(
   }
 
   assert(false, 'Received an invalid mixture of promises and values.');
-}
-
-function expectMatchingValues<T>(values: ReadonlyArray<T>): T {
-  const remainingValues = values.slice(1);
-  for (const value of remainingValues) {
-    expectJSON(value).toDeepEqual(values[0]);
-  }
-  return values[0];
 }

--- a/src/__testUtils__/expectEqualPromisesOrValues.ts
+++ b/src/__testUtils__/expectEqualPromisesOrValues.ts
@@ -1,0 +1,31 @@
+import { assert } from 'chai';
+
+import { isPromise } from '../jsutils/isPromise';
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
+
+import { expectJSON } from './expectJSON';
+
+export function expectEqualPromisesOrValues<T>(
+  items: ReadonlyArray<PromiseOrValue<T>>,
+): PromiseOrValue<T> {
+  const remainingItems = items.slice();
+  const firstItem = remainingItems.shift();
+
+  if (isPromise(firstItem)) {
+    if (remainingItems.every(isPromise)) {
+      return Promise.all(items).then(expectMatchingValues);
+    }
+  } else if (remainingItems.every((item) => !isPromise(item))) {
+    return expectMatchingValues(items);
+  }
+
+  assert(false, 'Received an invalid mixture of promises and values.');
+}
+
+function expectMatchingValues<T>(values: ReadonlyArray<T>): T {
+  const remainingValues = values.slice(1);
+  for (const value of remainingValues) {
+    expectJSON(value).toDeepEqual(values[0]);
+  }
+  return values[0];
+}

--- a/src/__testUtils__/expectEqualPromisesOrValues.ts
+++ b/src/__testUtils__/expectEqualPromisesOrValues.ts
@@ -8,9 +8,7 @@ import { expectMatchingValues } from './expectMatchingValues';
 export function expectEqualPromisesOrValues<T>(
   items: ReadonlyArray<PromiseOrValue<T>>,
 ): PromiseOrValue<T> {
-  const remainingItems = items.slice();
-  const firstItem = remainingItems.shift();
-
+  const [firstItem, ...remainingItems] = items;
   if (isPromise(firstItem)) {
     if (remainingItems.every(isPromise)) {
       return Promise.all(items).then(expectMatchingValues);

--- a/src/__testUtils__/expectMatchingValues.ts
+++ b/src/__testUtils__/expectMatchingValues.ts
@@ -1,9 +1,9 @@
 import { expectJSON } from './expectJSON';
 
 export function expectMatchingValues<T>(values: ReadonlyArray<T>): T {
-  const remainingValues = values.slice(1);
+  const [firstValue, ...remainingValues] = values;
   for (const value of remainingValues) {
-    expectJSON(value).toDeepEqual(values[0]);
+    expectJSON(value).toDeepEqual(firstValue);
   }
-  return values[0];
+  return firstValue;
 }

--- a/src/__testUtils__/expectMatchingValues.ts
+++ b/src/__testUtils__/expectMatchingValues.ts
@@ -1,0 +1,9 @@
+import { expectJSON } from './expectJSON';
+
+export function expectMatchingValues<T>(values: ReadonlyArray<T>): T {
+  const remainingValues = values.slice(1);
+  for (const value of remainingValues) {
+    expectJSON(value).toDeepEqual(values[0]);
+  }
+  return values[0];
+}

--- a/src/__testUtils__/expectPromise.ts
+++ b/src/__testUtils__/expectPromise.ts
@@ -1,0 +1,38 @@
+import { assert, expect } from 'chai';
+
+import { inspect } from '../jsutils/inspect';
+import { isPromise } from '../jsutils/isPromise';
+
+export function expectPromise(maybePromise: unknown) {
+  assert(
+    isPromise(maybePromise),
+    `Expected a promise, received '${inspect(maybePromise)}'`,
+  );
+
+  return {
+    toResolve() {
+      return maybePromise;
+    },
+    async toRejectWith(message: string) {
+      let caughtError: Error | undefined;
+      let resolved;
+      let rejected = false;
+      try {
+        resolved = await maybePromise;
+      } catch (error) {
+        rejected = true;
+        caughtError = error;
+      }
+
+      assert(
+        rejected,
+        `Promise should have rejected with message '${message}', but resolved as '${inspect(
+          resolved,
+        )}'`,
+      );
+
+      expect(caughtError).to.be.an.instanceOf(Error);
+      expect(caughtError).to.have.property('message', message);
+    },
+  };
+}


### PR DESCRIPTION
adds tests for `expectPromise` and `expectEqualPromisesOrValues`

#3620 introduced `expectEqualPromisesOrValues` with a TODO of moving to testUtils and testing.

This PR accomplishes that, and also moves the related `expectPromise` function, adding tests for that utility function as well.