### PR TITLE
Fix: make public API compatible with 'exactOptionalPropertyTypes'

### DIFF
--- a/integrationTests/ts/kitchenSink-test.ts
+++ b/integrationTests/ts/kitchenSink-test.ts
@@ -1,0 +1,16 @@
+import { GraphQLScalarType } from 'graphql/type';
+import { GraphQLError } from 'graphql/error';
+import type { NameNode } from 'graphql/language';
+import { Kind } from 'graphql/language';
+
+// Test subset of public APIs with "exactOptionalPropertyTypes" flag enabled
+new GraphQLScalarType({
+  name: 'SomeScalar',
+  serialize: undefined,
+  parseValue: undefined,
+  parseLiteral: undefined,
+});
+
+new GraphQLError('test', { nodes: undefined });
+
+const nameNode: NameNode = { kind: Kind.NAME, loc: undefined, value: 'test' };

--- a/integrationTests/ts/tsconfig.json
+++ b/integrationTests/ts/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
-    "strict": true,
     "noEmit": true,
-    "types": []
+    "types": [],
+    "strict": true,
+    "exactOptionalPropertyTypes": true
   }
 }

--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -21,7 +21,7 @@ export interface GraphQLErrorExtensions {
 }
 
 export interface GraphQLErrorOptions {
-  nodes?: ReadonlyArray<ASTNode> | ASTNode | null;
+  nodes?: ReadonlyArray<ASTNode> | ASTNode | null | undefined;
   source?: Maybe<Source>;
   positions?: Maybe<ReadonlyArray<number>>;
   path?: Maybe<ReadonlyArray<string | number>>;

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -44,8 +44,8 @@ class Cat {
 
 class Person {
   name: string;
-  pets?: ReadonlyArray<Dog | Cat>;
-  friends?: ReadonlyArray<Dog | Cat | Person>;
+  pets: ReadonlyArray<Dog | Cat> | undefined;
+  friends: ReadonlyArray<Dog | Cat | Person> | undefined;
 
   constructor(
     name: string,

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -238,7 +238,7 @@ export function getArgumentValues(
  */
 export function getDirectiveValues(
   directiveDef: GraphQLDirective,
-  node: { readonly directives?: ReadonlyArray<DirectiveNode> },
+  node: { readonly directives?: ReadonlyArray<DirectiveNode> | undefined },
   variableValues?: Maybe<ObjMap<unknown>>,
 ): undefined | { [argument: string]: unknown } {
   const directiveNode = node.directives?.find(

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -310,7 +310,7 @@ export function isNode(maybeNode: any): maybeNode is ASTNode {
 
 export interface NameNode {
   readonly kind: Kind.NAME;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly value: string;
 }
 
@@ -318,7 +318,7 @@ export interface NameNode {
 
 export interface DocumentNode {
   readonly kind: Kind.DOCUMENT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly definitions: ReadonlyArray<DefinitionNode>;
 }
 
@@ -333,11 +333,13 @@ export type ExecutableDefinitionNode =
 
 export interface OperationDefinitionNode {
   readonly kind: Kind.OPERATION_DEFINITION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly operation: OperationTypeNode;
-  readonly name?: NameNode;
-  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
+  readonly name?: NameNode | undefined;
+  readonly variableDefinitions?:
+    | ReadonlyArray<VariableDefinitionNode>
+    | undefined;
+  readonly directives?: ReadonlyArray<DirectiveNode> | undefined;
   readonly selectionSet: SelectionSetNode;
 }
 
@@ -349,22 +351,22 @@ export enum OperationTypeNode {
 
 export interface VariableDefinitionNode {
   readonly kind: Kind.VARIABLE_DEFINITION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly variable: VariableNode;
   readonly type: TypeNode;
-  readonly defaultValue?: ConstValueNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly defaultValue?: ConstValueNode | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
 }
 
 export interface VariableNode {
   readonly kind: Kind.VARIABLE;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
 }
 
 export interface SelectionSetNode {
   kind: Kind.SELECTION_SET;
-  loc?: Location;
+  loc?: Location | undefined;
   selections: ReadonlyArray<SelectionNode>;
 }
 
@@ -372,15 +374,15 @@ export type SelectionNode = FieldNode | FragmentSpreadNode | InlineFragmentNode;
 
 export interface FieldNode {
   readonly kind: Kind.FIELD;
-  readonly loc?: Location;
-  readonly alias?: NameNode;
+  readonly loc?: Location | undefined;
+  readonly alias?: NameNode | undefined;
   readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<ArgumentNode>;
+  readonly arguments?: ReadonlyArray<ArgumentNode> | undefined;
   // Note: Client Controlled Nullability is experimental
   // and may be changed or removed in the future.
-  readonly nullabilityAssertion?: NullabilityAssertionNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
-  readonly selectionSet?: SelectionSetNode;
+  readonly nullabilityAssertion?: NullabilityAssertionNode | undefined;
+  readonly directives?: ReadonlyArray<DirectiveNode> | undefined;
+  readonly selectionSet?: SelectionSetNode | undefined;
 }
 
 export type NullabilityAssertionNode =
@@ -390,32 +392,32 @@ export type NullabilityAssertionNode =
 
 export interface ListNullabilityOperatorNode {
   readonly kind: Kind.LIST_NULLABILITY_OPERATOR;
-  readonly loc?: Location;
-  readonly nullabilityAssertion?: NullabilityAssertionNode;
+  readonly loc?: Location | undefined;
+  readonly nullabilityAssertion?: NullabilityAssertionNode | undefined;
 }
 
 export interface NonNullAssertionNode {
   readonly kind: Kind.NON_NULL_ASSERTION;
-  readonly loc?: Location;
-  readonly nullabilityAssertion?: ListNullabilityOperatorNode;
+  readonly loc?: Location | undefined;
+  readonly nullabilityAssertion?: ListNullabilityOperatorNode | undefined;
 }
 
 export interface ErrorBoundaryNode {
   readonly kind: Kind.ERROR_BOUNDARY;
-  readonly loc?: Location;
-  readonly nullabilityAssertion?: ListNullabilityOperatorNode;
+  readonly loc?: Location | undefined;
+  readonly nullabilityAssertion?: ListNullabilityOperatorNode | undefined;
 }
 
 export interface ArgumentNode {
   readonly kind: Kind.ARGUMENT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
   readonly value: ValueNode;
 }
 
 export interface ConstArgumentNode {
   readonly kind: Kind.ARGUMENT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
   readonly value: ConstValueNode;
 }
@@ -424,27 +426,29 @@ export interface ConstArgumentNode {
 
 export interface FragmentSpreadNode {
   readonly kind: Kind.FRAGMENT_SPREAD;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
+  readonly directives?: ReadonlyArray<DirectiveNode> | undefined;
 }
 
 export interface InlineFragmentNode {
   readonly kind: Kind.INLINE_FRAGMENT;
-  readonly loc?: Location;
-  readonly typeCondition?: NamedTypeNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
+  readonly loc?: Location | undefined;
+  readonly typeCondition?: NamedTypeNode | undefined;
+  readonly directives?: ReadonlyArray<DirectiveNode> | undefined;
   readonly selectionSet: SelectionSetNode;
 }
 
 export interface FragmentDefinitionNode {
   readonly kind: Kind.FRAGMENT_DEFINITION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
   /** @deprecated variableDefinitions will be removed in v17.0.0 */
-  readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
+  readonly variableDefinitions?:
+    | ReadonlyArray<VariableDefinitionNode>
+    | undefined;
   readonly typeCondition: NamedTypeNode;
-  readonly directives?: ReadonlyArray<DirectiveNode>;
+  readonly directives?: ReadonlyArray<DirectiveNode> | undefined;
   readonly selectionSet: SelectionSetNode;
 }
 
@@ -473,74 +477,74 @@ export type ConstValueNode =
 
 export interface IntValueNode {
   readonly kind: Kind.INT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly value: string;
 }
 
 export interface FloatValueNode {
   readonly kind: Kind.FLOAT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly value: string;
 }
 
 export interface StringValueNode {
   readonly kind: Kind.STRING;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly value: string;
-  readonly block?: boolean;
+  readonly block?: boolean | undefined;
 }
 
 export interface BooleanValueNode {
   readonly kind: Kind.BOOLEAN;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly value: boolean;
 }
 
 export interface NullValueNode {
   readonly kind: Kind.NULL;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
 }
 
 export interface EnumValueNode {
   readonly kind: Kind.ENUM;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly value: string;
 }
 
 export interface ListValueNode {
   readonly kind: Kind.LIST;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly values: ReadonlyArray<ValueNode>;
 }
 
 export interface ConstListValueNode {
   readonly kind: Kind.LIST;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly values: ReadonlyArray<ConstValueNode>;
 }
 
 export interface ObjectValueNode {
   readonly kind: Kind.OBJECT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly fields: ReadonlyArray<ObjectFieldNode>;
 }
 
 export interface ConstObjectValueNode {
   readonly kind: Kind.OBJECT;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly fields: ReadonlyArray<ConstObjectFieldNode>;
 }
 
 export interface ObjectFieldNode {
   readonly kind: Kind.OBJECT_FIELD;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
   readonly value: ValueNode;
 }
 
 export interface ConstObjectFieldNode {
   readonly kind: Kind.OBJECT_FIELD;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
   readonly value: ConstValueNode;
 }
@@ -549,16 +553,16 @@ export interface ConstObjectFieldNode {
 
 export interface DirectiveNode {
   readonly kind: Kind.DIRECTIVE;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<ArgumentNode>;
+  readonly arguments?: ReadonlyArray<ArgumentNode> | undefined;
 }
 
 export interface ConstDirectiveNode {
   readonly kind: Kind.DIRECTIVE;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<ConstArgumentNode>;
+  readonly arguments?: ReadonlyArray<ConstArgumentNode> | undefined;
 }
 
 /** Type Reference */
@@ -567,19 +571,19 @@ export type TypeNode = NamedTypeNode | ListTypeNode | NonNullTypeNode;
 
 export interface NamedTypeNode {
   readonly kind: Kind.NAMED_TYPE;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
 }
 
 export interface ListTypeNode {
   readonly kind: Kind.LIST_TYPE;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly type: TypeNode;
 }
 
 export interface NonNullTypeNode {
   readonly kind: Kind.NON_NULL_TYPE;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly type: NamedTypeNode | ListTypeNode;
 }
 
@@ -592,15 +596,15 @@ export type TypeSystemDefinitionNode =
 
 export interface SchemaDefinitionNode {
   readonly kind: Kind.SCHEMA_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
   readonly operationTypes: ReadonlyArray<OperationTypeDefinitionNode>;
 }
 
 export interface OperationTypeDefinitionNode {
   readonly kind: Kind.OPERATION_TYPE_DEFINITION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly operation: OperationTypeNode;
   readonly type: NamedTypeNode;
 }
@@ -617,95 +621,95 @@ export type TypeDefinitionNode =
 
 export interface ScalarTypeDefinitionNode {
   readonly kind: Kind.SCALAR_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
 }
 
 export interface ObjectTypeDefinitionNode {
   readonly kind: Kind.OBJECT_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  readonly interfaces?: ReadonlyArray<NamedTypeNode> | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly fields?: ReadonlyArray<FieldDefinitionNode> | undefined;
 }
 
 export interface FieldDefinitionNode {
   readonly kind: Kind.FIELD_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
+  readonly arguments?: ReadonlyArray<InputValueDefinitionNode> | undefined;
   readonly type: TypeNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
 }
 
 export interface InputValueDefinitionNode {
   readonly kind: Kind.INPUT_VALUE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
   readonly type: TypeNode;
-  readonly defaultValue?: ConstValueNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly defaultValue?: ConstValueNode | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
 }
 
 export interface InterfaceTypeDefinitionNode {
   readonly kind: Kind.INTERFACE_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  readonly interfaces?: ReadonlyArray<NamedTypeNode> | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly fields?: ReadonlyArray<FieldDefinitionNode> | undefined;
 }
 
 export interface UnionTypeDefinitionNode {
   readonly kind: Kind.UNION_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly types?: ReadonlyArray<NamedTypeNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly types?: ReadonlyArray<NamedTypeNode> | undefined;
 }
 
 export interface EnumTypeDefinitionNode {
   readonly kind: Kind.ENUM_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly values?: ReadonlyArray<EnumValueDefinitionNode> | undefined;
 }
 
 export interface EnumValueDefinitionNode {
   readonly kind: Kind.ENUM_VALUE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
 }
 
 export interface InputObjectTypeDefinitionNode {
   readonly kind: Kind.INPUT_OBJECT_TYPE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly fields?: ReadonlyArray<InputValueDefinitionNode> | undefined;
 }
 
 /** Directive Definitions */
 
 export interface DirectiveDefinitionNode {
   readonly kind: Kind.DIRECTIVE_DEFINITION;
-  readonly loc?: Location;
-  readonly description?: StringValueNode;
+  readonly loc?: Location | undefined;
+  readonly description?: StringValueNode | undefined;
   readonly name: NameNode;
-  readonly arguments?: ReadonlyArray<InputValueDefinitionNode>;
+  readonly arguments?: ReadonlyArray<InputValueDefinitionNode> | undefined;
   readonly repeatable: boolean;
   readonly locations: ReadonlyArray<NameNode>;
 }
@@ -716,9 +720,11 @@ export type TypeSystemExtensionNode = SchemaExtensionNode | TypeExtensionNode;
 
 export interface SchemaExtensionNode {
   readonly kind: Kind.SCHEMA_EXTENSION;
-  readonly loc?: Location;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly operationTypes?: ReadonlyArray<OperationTypeDefinitionNode>;
+  readonly loc?: Location | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly operationTypes?:
+    | ReadonlyArray<OperationTypeDefinitionNode>
+    | undefined;
 }
 
 /** Type Extensions */
@@ -733,49 +739,49 @@ export type TypeExtensionNode =
 
 export interface ScalarTypeExtensionNode {
   readonly kind: Kind.SCALAR_TYPE_EXTENSION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
 }
 
 export interface ObjectTypeExtensionNode {
   readonly kind: Kind.OBJECT_TYPE_EXTENSION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  readonly interfaces?: ReadonlyArray<NamedTypeNode> | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly fields?: ReadonlyArray<FieldDefinitionNode> | undefined;
 }
 
 export interface InterfaceTypeExtensionNode {
   readonly kind: Kind.INTERFACE_TYPE_EXTENSION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly interfaces?: ReadonlyArray<NamedTypeNode>;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+  readonly interfaces?: ReadonlyArray<NamedTypeNode> | undefined;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly fields?: ReadonlyArray<FieldDefinitionNode> | undefined;
 }
 
 export interface UnionTypeExtensionNode {
   readonly kind: Kind.UNION_TYPE_EXTENSION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly types?: ReadonlyArray<NamedTypeNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly types?: ReadonlyArray<NamedTypeNode> | undefined;
 }
 
 export interface EnumTypeExtensionNode {
   readonly kind: Kind.ENUM_TYPE_EXTENSION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly values?: ReadonlyArray<EnumValueDefinitionNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly values?: ReadonlyArray<EnumValueDefinitionNode> | undefined;
 }
 
 export interface InputObjectTypeExtensionNode {
   readonly kind: Kind.INPUT_OBJECT_TYPE_EXTENSION;
-  readonly loc?: Location;
+  readonly loc?: Location | undefined;
   readonly name: NameNode;
-  readonly directives?: ReadonlyArray<ConstDirectiveNode>;
-  readonly fields?: ReadonlyArray<InputValueDefinitionNode>;
+  readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+  readonly fields?: ReadonlyArray<InputValueDefinitionNode> | undefined;
 }

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -80,7 +80,7 @@ export interface ParseOptions {
    * in the source that they correspond to. This configuration flag
    * disables that behavior for performance or testing.
    */
-  noLocation?: boolean;
+  noLocation?: boolean | undefined;
 
   /**
    * @deprecated will be removed in the v17.0.0
@@ -97,7 +97,7 @@ export interface ParseOptions {
    * }
    * ```
    */
-  allowLegacyFragmentVariables?: boolean;
+  allowLegacyFragmentVariables?: boolean | undefined;
 
   /**
    * EXPERIMENTAL:
@@ -120,7 +120,7 @@ export interface ParseOptions {
    * Note: this feature is experimental and may change or be removed in the
    * future.
    */
-  experimentalClientControlledNullability?: boolean;
+  experimentalClientControlledNullability?: boolean | undefined;
 }
 
 /**
@@ -1451,7 +1451,10 @@ export class Parser {
    * location object, used to identify the place in the source that created a
    * given parsed object.
    */
-  node<T extends { loc?: Location }>(startToken: Token, node: T): T {
+  node<T extends { loc?: Location | undefined }>(
+    startToken: Token,
+    node: T,
+  ): T {
     if (this._options?.noLocation !== true) {
       node.loc = new Location(
         startToken,

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -18,8 +18,8 @@ type KindVisitor = {
 };
 
 interface EnterLeaveVisitor<TVisitedNode extends ASTNode> {
-  readonly enter?: ASTVisitFn<TVisitedNode>;
-  readonly leave?: ASTVisitFn<TVisitedNode>;
+  readonly enter?: ASTVisitFn<TVisitedNode> | undefined;
+  readonly leave?: ASTVisitFn<TVisitedNode> | undefined;
 }
 
 /**

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -625,11 +625,11 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   description?: Maybe<string>;
   specifiedByURL?: Maybe<string>;
   /** Serializes an internal value to include in a response. */
-  serialize?: GraphQLScalarSerializer<TExternal>;
+  serialize?: GraphQLScalarSerializer<TExternal> | undefined;
   /** Parses an externally provided value to use as an input. */
-  parseValue?: GraphQLScalarValueParser<TInternal>;
+  parseValue?: GraphQLScalarValueParser<TInternal> | undefined;
   /** Parses an externally provided literal value to use as an input. */
-  parseLiteral?: GraphQLScalarLiteralParser<TInternal>;
+  parseLiteral?: GraphQLScalarLiteralParser<TInternal> | undefined;
   extensions?: Maybe<Readonly<GraphQLScalarTypeExtensions>>;
   astNode?: Maybe<ScalarTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
@@ -847,7 +847,7 @@ export function argsToArgsConfig(
 export interface GraphQLObjectTypeConfig<TSource, TContext> {
   name: string;
   description?: Maybe<string>;
-  interfaces?: ThunkReadonlyArray<GraphQLInterfaceType>;
+  interfaces?: ThunkReadonlyArray<GraphQLInterfaceType> | undefined;
   fields: ThunkObjMap<GraphQLFieldConfig<TSource, TContext>>;
   isTypeOf?: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
   extensions?: Maybe<Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>>;
@@ -920,9 +920,9 @@ export interface GraphQLFieldExtensions<_TSource, _TContext, _TArgs = any> {
 export interface GraphQLFieldConfig<TSource, TContext, TArgs = any> {
   description?: Maybe<string>;
   type: GraphQLOutputType;
-  args?: GraphQLFieldConfigArgumentMap;
-  resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-  subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+  args?: GraphQLFieldConfigArgumentMap | undefined;
+  resolve?: GraphQLFieldResolver<TSource, TContext, TArgs> | undefined;
+  subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs> | undefined;
   deprecationReason?: Maybe<string>;
   extensions?: Maybe<
     Readonly<GraphQLFieldExtensions<TSource, TContext, TArgs>>
@@ -963,8 +963,8 @@ export interface GraphQLField<TSource, TContext, TArgs = any> {
   description: Maybe<string>;
   type: GraphQLOutputType;
   args: ReadonlyArray<GraphQLArgument>;
-  resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
-  subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs>;
+  resolve?: GraphQLFieldResolver<TSource, TContext, TArgs> | undefined;
+  subscribe?: GraphQLFieldResolver<TSource, TContext, TArgs> | undefined;
   deprecationReason: Maybe<string>;
   extensions: Readonly<GraphQLFieldExtensions<TSource, TContext, TArgs>>;
   astNode: Maybe<FieldDefinitionNode>;
@@ -1086,7 +1086,7 @@ export class GraphQLInterfaceType {
 export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
   name: string;
   description?: Maybe<string>;
-  interfaces?: ThunkReadonlyArray<GraphQLInterfaceType>;
+  interfaces?: ThunkReadonlyArray<GraphQLInterfaceType> | undefined;
   fields: ThunkObjMap<GraphQLFieldConfig<TSource, TContext>>;
   /**
    * Optionally provide a custom type resolver function. If one is not provided,

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -401,7 +401,7 @@ export interface GraphQLSchemaValidationOptions {
    *
    * Default: false
    */
-  assumeValid?: boolean;
+  assumeValid?: boolean | undefined;
 }
 
 export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -630,7 +630,9 @@ function getUnionMemberTypeNodes(
 }
 
 function getDeprecatedDirectiveNode(
-  definitionNode: Maybe<{ readonly directives?: ReadonlyArray<DirectiveNode> }>,
+  definitionNode: Maybe<{
+    readonly directives?: ReadonlyArray<DirectiveNode> | undefined;
+  }>,
 ): Maybe<DirectiveNode> {
   return definitionNode?.directives?.find(
     (node) => node.name.value === GraphQLDeprecatedDirective.name,

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -17,7 +17,7 @@ export interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
    *
    * Default: false
    */
-  assumeValidSDL?: boolean;
+  assumeValidSDL?: boolean | undefined;
 }
 
 /**

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -88,7 +88,7 @@ interface Options extends GraphQLSchemaValidationOptions {
    *
    * Default: false
    */
-  assumeValidSDL?: boolean;
+  assumeValidSDL?: boolean | undefined;
 }
 
 /**

--- a/src/validation/rules/UniqueArgumentDefinitionNamesRule.ts
+++ b/src/validation/rules/UniqueArgumentDefinitionNamesRule.ts
@@ -36,7 +36,7 @@ export function UniqueArgumentDefinitionNamesRule(
 
   function checkArgUniquenessPerField(typeNode: {
     readonly name: NameNode;
-    readonly fields?: ReadonlyArray<FieldDefinitionNode>;
+    readonly fields?: ReadonlyArray<FieldDefinitionNode> | undefined;
   }) {
     const typeName = typeNode.name.value;
 

--- a/src/validation/rules/UniqueArgumentNamesRule.ts
+++ b/src/validation/rules/UniqueArgumentNamesRule.ts
@@ -24,7 +24,7 @@ export function UniqueArgumentNamesRule(
   };
 
   function checkArgUniqueness(parentNode: {
-    arguments?: ReadonlyArray<ArgumentNode>;
+    arguments?: ReadonlyArray<ArgumentNode> | undefined;
   }) {
     // FIXME: https://github.com/graphql/graphql-js/issues/2203
     /* c8 ignore next */

--- a/src/validation/rules/UniqueFieldDefinitionNamesRule.ts
+++ b/src/validation/rules/UniqueFieldDefinitionNamesRule.ts
@@ -39,9 +39,9 @@ export function UniqueFieldDefinitionNamesRule(
 
   function checkFieldUniqueness(node: {
     readonly name: NameNode;
-    readonly fields?: ReadonlyArray<
-      InputValueDefinitionNode | FieldDefinitionNode
-    >;
+    readonly fields?:
+      | ReadonlyArray<InputValueDefinitionNode | FieldDefinitionNode>
+      | undefined;
   }) {
     const typeName = node.name.value;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     // All checks that are not part of "strict"
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
-    "exactOptionalPropertyTypes": false, // FIXME
+    "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": false, // TODO consider
     "noImplicitOverride": true,
     "noImplicitReturns": false, // TODO consider


### PR DESCRIPTION
`exactOptionalPropertyTypes` is recommended option that was added in TS 4.4 but our public API
was not compatible with it. 
Meaning if the project was using graphql-js and had this enabled this flag they lost the ability to pass `undefined` values explicitly.

Context: discovered as part of #3649 investigation.