### PR TITLE
Allow type overriding

### DIFF
--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -212,7 +212,7 @@ export class GraphQLSchema {
       }
 
       const typeName = namedType.name;
-      if (this._typeMap[typeName] !== undefined) {
+      if (this._typeMap[typeName] !== undefined && !config.allowOverride) {
         throw new Error(
           `Schema must contain uniquely named types but contains multiple types named "${typeName}".`,
         );
@@ -414,6 +414,7 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
   extensions?: Maybe<Readonly<GraphQLSchemaExtensions>>;
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;
+  allowOverride?: Maybe<boolean>;
 }
 
 /**


### PR DESCRIPTION
This means whichever last type that has the same name will triumph, if it follows a certain order.

Fixes https://github.com/axe-me/vite-plugin-node/issues/52