### PR TITLE
fix vitest incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
   "version": "16.5.0",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
-  "private": true,
-  "main": "index",
-  "module": "index.mjs",
+  "type": "commonjs",
+  "main": "index.js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./index.mjs"
+    }
+  },
   "typesVersions": {
     ">=4.1.0": {
       "*": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "16.5.0",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
+  "private": true,
   "type": "commonjs",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
ATM vitest/vite cannot load graphql correctly. It always ends up loading both CJS and ESM source in my projects.
I have reported this to vite here: https://github.com/vitejs/vite/issues/7879
but I think a simple change here could resolve the problem. I think using "module" entry point is obsolete/deprecated with node.js.

I have tested this change with latest vitests and it seems to work correctly with this change. I will be using patch-package with graphql 16 for now, but it would be nice if this could land.

Also why was `private: true` set here?