### PR TITLE
validate: remove warning about throwing literal

### DIFF
--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -48,7 +48,9 @@ export function validate(
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
 
-  const abortObj = Object.freeze({});
+  const abortError = new GraphQLError(
+    'Too many validation errors, error limit reached. Validation aborted.',
+  );
   const errors: Array<GraphQLError> = [];
   const context = new ValidationContext(
     schema,
@@ -56,13 +58,7 @@ export function validate(
     typeInfo,
     (error) => {
       if (errors.length >= maxErrors) {
-        errors.push(
-          new GraphQLError(
-            'Too many validation errors, error limit reached. Validation aborted.',
-          ),
-        );
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
-        throw abortObj;
+        throw abortError;
       }
       errors.push(error);
     },
@@ -75,8 +71,10 @@ export function validate(
   // Visit the whole document with each instance of all provided rules.
   try {
     visit(documentAST, visitWithTypeInfo(typeInfo, visitor));
-  } catch (e) {
-    if (e !== abortObj) {
+  } catch (e: unknown) {
+    if (e === abortError) {
+      errors.push(abortError);
+    } else {
       throw e;
     }
   }


### PR DESCRIPTION
Motivation: I'm working on the similar code in parser and don't want to
replicate ESLint disable comment so figured out a proper way to solve
it. Also throwing error with message will help with debuging if someone
will have an issue with `validate` code.