### PR TITLE
parser: limit maximum number of tokens

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -88,6 +88,19 @@ describe('Parser', () => {
     `);
   });
 
+  it('limit maximum number of tokens', () => {
+    expect(() => parse('{ foo }', { maxTokens: 3 })).to.not.throw();
+    expect(() => parse('{ foo }', { maxTokens: 2 })).to.throw(
+      'Syntax Error: Document contains more that 2 tokens. Parsing aborted.',
+    );
+
+    expect(() => parse('{ foo(bar: "baz") }', { maxTokens: 8 })).to.not.throw();
+
+    expect(() => parse('{ foo(bar: "baz") }', { maxTokens: 7 })).to.throw(
+      'Syntax Error: Document contains more that 7 tokens. Parsing aborted.',
+    );
+  });
+
   it('parses variable inline values', () => {
     expect(() =>
       parse('{ field(complex: { a: { b: [ $var ] } }) }'),

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -85,9 +85,9 @@ export interface ParseOptions {
   /**
    * Parser CPU and memory usage is linear to the number of tokens in a document
    * however in extreme cases it becomes quadratic due to memory exhaustion.
-   * Parsing happens before validation so even invalid queries can burn a lots of
+   * Parsing happens before validation so even invalid queries can burn lots of
    * CPU time and memory.
-   * To prevent this you can set limit on maximum number of tokens.
+   * To prevent this you can set a maximum number of tokens allowed within a document.
    */
   maxTokens?: number | undefined;
 


### PR DESCRIPTION
Motivation: Parser CPU and memory usage are linear to the number of tokens in a document however, in extreme cases, it becomes quadratic due to memory exhaustion.
On my machine, it happens on queries with 2k tokens.
For example:
```
{ a a <repeat 2k times> a }
```
It takes 741ms on my machine.
But if we create a document of the same size but a smaller number of tokens, it would be a lot faster.
Example:
```
{ a(arg: "a <repeat 2k times> a" }
```
Now it takes only 17ms to process, which is 43 times faster.

If we just limit document size, we should make this limit small since it takes only two bytes to create a token, e.g. ` a`.
But that will create issues for legit documents with long tokens (comments, descriptions, strings, long names, etc.).

That's why this PR adds a mechanism to limit the number of tokens in the parsed document.
Also, exact same mechanism is implemented in graphql-java, see:
https://github.com/graphql-java/graphql-java/pull/2549

I also tried the alternative approach of counting nodes, and it gives
slightly better approximation of how many resources would be consumed.
However, compared to the tokens, AST nodes are an implementation detail of graphql-js
so it's impossible to replicate in other implementations (e.g. to count
this number on a client).