### PR TITLE
ES2020 optimizations

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -561,7 +561,7 @@ overrides:
       '@typescript-eslint/parameter-properties': error
       '@typescript-eslint/prefer-as-const': error
       '@typescript-eslint/prefer-enum-initializers': error
-      '@typescript-eslint/prefer-for-of': error
+      '@typescript-eslint/prefer-for-of': off
       '@typescript-eslint/prefer-function-type': error
       '@typescript-eslint/prefer-includes': error
       '@typescript-eslint/prefer-literal-enum-member': error

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -70,7 +70,8 @@ export function collectSubfields(
 ): Map<string, ReadonlyArray<FieldNode>> {
   const subFieldNodes = new AccumulatorMap<string, FieldNode>();
   const visitedFragmentNames = new Set<string>();
-  for (const node of fieldNodes) {
+  for (let i = 0; i < fieldNodes.length; i++) {
+    const node = fieldNodes[i]
     if (node.selectionSet) {
       collectFieldsImpl(
         schema,
@@ -96,7 +97,8 @@ function collectFieldsImpl(
   fields: AccumulatorMap<string, FieldNode>,
   visitedFragmentNames: Set<string>,
 ): void {
-  for (const selection of selectionSet.selections) {
+  for (let i = 0; i < selectionSet.selections.length; i++) {
+    const selection = selectionSet.selections[i]
     switch (selection.kind) {
       case Kind.FIELD: {
         if (!shouldIncludeNode(variableValues, selection)) {

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -71,7 +71,7 @@ export function collectSubfields(
   const subFieldNodes = new AccumulatorMap<string, FieldNode>();
   const visitedFragmentNames = new Set<string>();
   for (let i = 0; i < fieldNodes.length; i++) {
-    const node = fieldNodes[i]
+    const node = fieldNodes[i];
     if (node.selectionSet) {
       collectFieldsImpl(
         schema,
@@ -98,7 +98,7 @@ function collectFieldsImpl(
   visitedFragmentNames: Set<string>,
 ): void {
   for (let i = 0; i < selectionSet.selections.length; i++) {
-    const selection = selectionSet.selections[i]
+    const selection = selectionSet.selections[i];
     switch (selection.kind) {
       case Kind.FIELD: {
         if (!shouldIncludeNode(variableValues, selection)) {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -266,7 +266,7 @@ export function buildExecutionContext(
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
   for (let i = 0; i < document.definitions.length; i++) {
-    const definition = document.definitions[i]
+    const definition = document.definitions[i];
     switch (definition.kind) {
       case Kind.OPERATION_DEFINITION:
         if (operationName == null) {
@@ -432,9 +432,9 @@ function executeFields(
   const results = Object.create(null);
   let containsPromise = false;
 
-  const fieldsEntries = Array.from(fields.entries())
+  const fieldsEntries = Array.from(fields.entries());
   for (let i = 0; i < fieldsEntries.length; i++) {
-    const { 0: responseName, 1: fieldNodes } = fieldsEntries[i]
+    const { 0: responseName, 1: fieldNodes } = fieldsEntries[i];
     const fieldPath = addPath(path, responseName, parentType.name);
     const result = executeField(
       exeContext,
@@ -1230,7 +1230,9 @@ function executeSubscription(
     rootType,
     operation.selectionSet,
   );
-  const {0:responseName, 1:fieldNodes} = Array.from(rootFields.entries())[0];
+  const { 0: responseName, 1: fieldNodes } = Array.from(
+    rootFields.entries(),
+  )[0];
   const fieldName = fieldNodes[0].name.value;
   const fieldDef = schema.getField(rootType, fieldName);
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -265,7 +265,8 @@ export function buildExecutionContext(
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
-  for (const definition of document.definitions) {
+  for (let i = 0; i < document.definitions.length; i++) {
+    const definition = document.definitions[i]
     switch (definition.kind) {
       case Kind.OPERATION_DEFINITION:
         if (operationName == null) {
@@ -431,7 +432,9 @@ function executeFields(
   const results = Object.create(null);
   let containsPromise = false;
 
-  for (const [responseName, fieldNodes] of fields.entries()) {
+  const fieldsEntries = Array.from(fields.entries())
+  for (let i = 0; i < fieldsEntries.length; i++) {
+    const { 0: responseName, 1: fieldNodes } = fieldsEntries[i]
     const fieldPath = addPath(path, responseName, parentType.name);
     const result = executeField(
       exeContext,
@@ -1227,7 +1230,7 @@ function executeSubscription(
     rootType,
     operation.selectionSet,
   );
-  const [responseName, fieldNodes] = [...rootFields.entries()][0];
+  const {0:responseName, 1:fieldNodes} = Array.from(rootFields.entries())[0];
   const fieldName = fieldNodes[0].name.value;
   const fieldDef = schema.getField(rootType, fieldName);
 

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -76,7 +76,8 @@ function coerceVariableValues(
   onError: (error: GraphQLError) => void,
 ): { [variable: string]: unknown } {
   const coercedValues: { [variable: string]: unknown } = {};
-  for (const varDefNode of varDefNodes) {
+  for (let i = 0; i < varDefNodes.length; i++) {
+    const varDefNode = varDefNodes[i]
     const varName = varDefNode.variable.name.value;
     const varType = typeFromAST(schema, varDefNode.type);
     if (!isInputType(varType)) {
@@ -161,7 +162,8 @@ export function getArgumentValues(
   const argumentNodes = node.arguments ?? [];
   const argNodeMap = keyMap(argumentNodes, (arg) => arg.name.value);
 
-  for (const argDef of def.args) {
+  for (let i = 0; i < def.args.length; i++) {
+    const argDef = def.args[i]
     const name = argDef.name;
     const argType = argDef.type;
     const argumentNode = argNodeMap[name];

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -77,7 +77,7 @@ function coerceVariableValues(
 ): { [variable: string]: unknown } {
   const coercedValues: { [variable: string]: unknown } = {};
   for (let i = 0; i < varDefNodes.length; i++) {
-    const varDefNode = varDefNodes[i]
+    const varDefNode = varDefNodes[i];
     const varName = varDefNode.variable.name.value;
     const varType = typeFromAST(schema, varDefNode.type);
     if (!isInputType(varType)) {
@@ -163,7 +163,7 @@ export function getArgumentValues(
   const argNodeMap = keyMap(argumentNodes, (arg) => arg.name.value);
 
   for (let i = 0; i < def.args.length; i++) {
-    const argDef = def.args[i]
+    const argDef = def.args[i];
     const name = argDef.name;
     const argType = argDef.type;
     const argumentNode = argNodeMap[name];

--- a/src/jsutils/groupBy.ts
+++ b/src/jsutils/groupBy.ts
@@ -8,7 +8,8 @@ export function groupBy<K, T>(
   keyFn: (item: T) => K,
 ): Map<K, ReadonlyArray<T>> {
   const result = new AccumulatorMap<K, T>();
-  for (const item of list) {
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i]
     result.add(keyFn(item), item);
   }
   return result;

--- a/src/jsutils/groupBy.ts
+++ b/src/jsutils/groupBy.ts
@@ -9,7 +9,7 @@ export function groupBy<K, T>(
 ): Map<K, ReadonlyArray<T>> {
   const result = new AccumulatorMap<K, T>();
   for (let i = 0; i < list.length; i++) {
-    const item = list[i]
+    const item = list[i];
     result.add(keyFn(item), item);
   }
   return result;

--- a/src/jsutils/keyMap.ts
+++ b/src/jsutils/keyMap.ts
@@ -33,7 +33,7 @@ export function keyMap<T>(
 ): ObjMap<T> {
   const result = Object.create(null);
   for (let i = 0; i < list.length; i++) {
-    const key = list[i]
+    const key = list[i];
     result[keyFn(key)] = key;
   }
   return result;

--- a/src/jsutils/keyMap.ts
+++ b/src/jsutils/keyMap.ts
@@ -32,8 +32,9 @@ export function keyMap<T>(
   keyFn: (item: T) => string,
 ): ObjMap<T> {
   const result = Object.create(null);
-  for (const item of list) {
-    result[keyFn(item)] = item;
+  for (let i = 0; i < list.length; i++) {
+    const key = list[i]
+    result[keyFn(key)] = key;
   }
   return result;
 }

--- a/src/jsutils/keyValMap.ts
+++ b/src/jsutils/keyValMap.ts
@@ -24,7 +24,7 @@ export function keyValMap<T, V>(
 ): ObjMap<V> {
   const result = Object.create(null);
   for (let i = 0; i < list.length; i++) {
-    const item = list[i]
+    const item = list[i];
     result[keyFn(item)] = valFn(item);
   }
   return result;

--- a/src/jsutils/keyValMap.ts
+++ b/src/jsutils/keyValMap.ts
@@ -23,7 +23,8 @@ export function keyValMap<T, V>(
   valFn: (item: T) => V,
 ): ObjMap<V> {
   const result = Object.create(null);
-  for (const item of list) {
+  for (let i = 0; i < list.length; i++) {
+    const item = list[i]
     result[keyFn(item)] = valFn(item);
   }
   return result;

--- a/src/jsutils/mapValue.ts
+++ b/src/jsutils/mapValue.ts
@@ -9,8 +9,9 @@ export function mapValue<T, V>(
   fn: (value: T, key: string) => V,
 ): ObjMap<V> {
   const result = Object.create(null);
-
-  for (const key of Object.keys(map)) {
+  const keys = Object.keys(map)
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
     result[key] = fn(map[key], key);
   }
   return result;

--- a/src/jsutils/mapValue.ts
+++ b/src/jsutils/mapValue.ts
@@ -9,9 +9,9 @@ export function mapValue<T, V>(
   fn: (value: T, key: string) => V,
 ): ObjMap<V> {
   const result = Object.create(null);
-  const keys = Object.keys(map)
+  const keys = Object.keys(map);
   for (let i = 0; i < keys.length; i++) {
-    const key = keys[i]
+    const key = keys[i];
     result[key] = fn(map[key], key);
   }
   return result;

--- a/src/jsutils/promiseForObject.ts
+++ b/src/jsutils/promiseForObject.ts
@@ -12,7 +12,7 @@ export function promiseForObject<T>(
 ): Promise<ObjMap<T>> {
   return Promise.all(Object.values(object)).then((resolvedValues) => {
     const resolvedObject = Object.create(null);
-    for (const [i, key] of Object.keys(object).entries()) {
+    for (const { 0: i, 1: key } of Object.keys(object).entries()) {
       resolvedObject[key] = resolvedValues[i];
     }
     return resolvedObject;

--- a/src/jsutils/toObjMap.ts
+++ b/src/jsutils/toObjMap.ts
@@ -13,9 +13,9 @@ export function toObjMap<T>(
   }
 
   const map = Object.create(null);
-  const entries = Object.entries(obj)
+  const entries = Object.entries(obj);
   for (let i = 0; i < entries.length; i++) {
-    const { 0: key, 1: value } = entries[i]
+    const { 0: key, 1: value } = entries[i];
     map[key] = value;
   }
   return map;

--- a/src/jsutils/toObjMap.ts
+++ b/src/jsutils/toObjMap.ts
@@ -13,7 +13,9 @@ export function toObjMap<T>(
   }
 
   const map = Object.create(null);
-  for (const [key, value] of Object.entries(obj)) {
+  const entries = Object.entries(obj)
+  for (let i = 0; i < entries.length; i++) {
+    const { 0: key, 1: value } = entries[i]
     map[key] = value;
   }
   return map;

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -85,6 +85,7 @@ export type ASTVisitorKeyMap = {
 };
 
 export const BREAK: unknown = Object.freeze({});
+const KINDS = Object.values(Kind)
 
 /**
  * visit() will walk through an AST using a depth-first traversal, calling
@@ -180,7 +181,8 @@ export function visit(
   visitorKeys: ASTVisitorKeyMap = QueryDocumentKeys,
 ): any {
   const enterLeaveMap = new Map<Kind, EnterLeaveVisitor<ASTNode>>();
-  for (const kind of Object.values(Kind)) {
+  for (let i = 0; i < KINDS.length; i++) {
+    const kind = KINDS[i]
     enterLeaveMap.set(kind, getEnterLeaveForKind(visitor, kind));
   }
 
@@ -210,8 +212,8 @@ export function visit(
           node = node.slice();
 
           let editOffset = 0;
-          for (const edit of edits) {
-            const { 0: editKey, 1: editValue } = edit
+          for (let i = 0; i < edits.length; i++) {
+            const { 0: editKey, 1: editValue } = edits[i]
             const arrayKey = editKey - editOffset;
             if (editValue === null) {
               node.splice(arrayKey, 1);
@@ -225,8 +227,8 @@ export function visit(
             {},
             Object.getOwnPropertyDescriptors(node),
           );
-          for (const edit of edits) {
-            const { 0: editKey, 1: editValue } = edit
+          for (let i = 0; i < edits.length; i++) {
+            const { 0: editKey, 1: editValue } = edits[i]
             node[editKey] = editValue;
           }
         }
@@ -316,7 +318,8 @@ export function visitInParallel(
   const skipping = new Array(visitors.length).fill(null);
   const mergedVisitor = Object.create(null);
 
-  for (const kind of Object.values(Kind)) {
+  for (let j = 0; j < KINDS.length; j++) {
+    const kind = KINDS[j]
     let hasVisitor = false;
     const enterList = new Array(visitors.length).fill(undefined);
     const leaveList = new Array(visitors.length).fill(undefined);

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -85,7 +85,7 @@ export type ASTVisitorKeyMap = {
 };
 
 export const BREAK: unknown = Object.freeze({});
-const KINDS = Object.values(Kind)
+const KINDS = Object.values(Kind);
 
 /**
  * visit() will walk through an AST using a depth-first traversal, calling
@@ -182,7 +182,7 @@ export function visit(
 ): any {
   const enterLeaveMap = new Map<Kind, EnterLeaveVisitor<ASTNode>>();
   for (let i = 0; i < KINDS.length; i++) {
-    const kind = KINDS[i]
+    const kind = KINDS[i];
     enterLeaveMap.set(kind, getEnterLeaveForKind(visitor, kind));
   }
 
@@ -213,7 +213,7 @@ export function visit(
 
           let editOffset = 0;
           for (let i = 0; i < edits.length; i++) {
-            const { 0: editKey, 1: editValue } = edits[i]
+            const { 0: editKey, 1: editValue } = edits[i];
             const arrayKey = editKey - editOffset;
             if (editValue === null) {
               node.splice(arrayKey, 1);
@@ -228,7 +228,7 @@ export function visit(
             Object.getOwnPropertyDescriptors(node),
           );
           for (let i = 0; i < edits.length; i++) {
-            const { 0: editKey, 1: editValue } = edits[i]
+            const { 0: editKey, 1: editValue } = edits[i];
             node[editKey] = editValue;
           }
         }
@@ -319,7 +319,7 @@ export function visitInParallel(
   const mergedVisitor = Object.create(null);
 
   for (let j = 0; j < KINDS.length; j++) {
-    const kind = KINDS[j]
+    const kind = KINDS[j];
     let hasVisitor = false;
     const enterList = new Array(visitors.length).fill(undefined);
     const leaveList = new Array(visitors.length).fill(undefined);

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -210,7 +210,8 @@ export function visit(
           node = node.slice();
 
           let editOffset = 0;
-          for (const [editKey, editValue] of edits) {
+          for (const edit of edits) {
+            const { 0: editKey, 1: editValue } = edit
             const arrayKey = editKey - editOffset;
             if (editValue === null) {
               node.splice(arrayKey, 1);
@@ -224,7 +225,8 @@ export function visit(
             {},
             Object.getOwnPropertyDescriptors(node),
           );
-          for (const [editKey, editValue] of edits) {
+          for (const edit of edits) {
+            const { 0: editKey, 1: editValue } = edit
             node[editKey] = editValue;
           }
         }

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -209,7 +209,9 @@ export class GraphQLSchema {
     // Keep track of all implementations by interface name.
     this._implementationsMap = Object.create(null);
 
-    for (const namedType of allReferencedTypes) {
+    const refTypes = Array.from(allReferencedTypes)
+    for (let j = 0; j < refTypes.length; j++) {
+      const namedType = refTypes[j]
       if (namedType == null) {
         continue;
       }

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -173,7 +173,7 @@ export class GraphQLSchema {
     const allReferencedTypes = new Set<GraphQLNamedType>(config.types);
     if (config.types != null) {
       for (let i = 0; i < config.types.length; i++) {
-        const type = config.types[i]
+        const type = config.types[i];
         // When we ready to process this type, we remove it from "collected" types
         // and then add it together with all dependent types in the correct position.
         allReferencedTypes.delete(type);
@@ -192,11 +192,11 @@ export class GraphQLSchema {
     }
 
     for (let i = 0; i < this._directives.length; i++) {
-      const directive = this._directives[i]
+      const directive = this._directives[i];
       // Directives are not validated until validateSchema() is called.
       if (isDirective(directive)) {
-      for (let j = 0; j < directive.args.length; j++) {
-        const arg = directive.args[j]
+        for (let j = 0; j < directive.args.length; j++) {
+          const arg = directive.args[j];
           collectReferencedTypes(arg.type, allReferencedTypes);
         }
       }
@@ -209,9 +209,9 @@ export class GraphQLSchema {
     // Keep track of all implementations by interface name.
     this._implementationsMap = Object.create(null);
 
-    const refTypes = Array.from(allReferencedTypes)
+    const refTypes = Array.from(allReferencedTypes);
     for (let j = 0; j < refTypes.length; j++) {
-      const namedType = refTypes[j]
+      const namedType = refTypes[j];
       if (namedType == null) {
         continue;
       }
@@ -228,7 +228,7 @@ export class GraphQLSchema {
         // Store implementations by interface.
         const interfaces = namedType.getInterfaces();
         for (let i = 0; i < interfaces.length; i++) {
-          const iface = interfaces[i]
+          const iface = interfaces[i];
           if (isInterfaceType(iface)) {
             let implementations = this._implementationsMap[iface.name];
             if (implementations === undefined) {
@@ -245,7 +245,7 @@ export class GraphQLSchema {
         // Store implementations by objects.
         const interfaces = namedType.getInterfaces();
         for (let i = 0; i < interfaces.length; i++) {
-          const iface = interfaces[i]
+          const iface = interfaces[i];
           if (isInterfaceType(iface)) {
             let implementations = this._implementationsMap[iface.name];
             if (implementations === undefined) {
@@ -322,7 +322,7 @@ export class GraphQLSchema {
       map = Object.create(null);
 
       if (isUnionType(abstractType)) {
-        const types = abstractType.getTypes()
+        const types = abstractType.getTypes();
         for (let i = 0; i < types.length; i++) {
           map[types[i].name] = true;
         }
@@ -452,21 +452,21 @@ function collectReferencedTypes(
         collectReferencedTypes(types[i], typeSet);
       }
     } else if (isObjectType(namedType) || isInterfaceType(namedType)) {
-      const interfaces = namedType.getInterfaces()
+      const interfaces = namedType.getInterfaces();
       for (let i = 0; i < interfaces.length; i++) {
         collectReferencedTypes(interfaces[i], typeSet);
       }
 
-      const fields = Object.values(namedType.getFields())
+      const fields = Object.values(namedType.getFields());
       for (let i = 0; i < fields.length; i++) {
-        const field = fields[i]
+        const field = fields[i];
         collectReferencedTypes(field.type, typeSet);
         for (let j = 0; j < field.args.length; j++) {
           collectReferencedTypes(field.args[j].type, typeSet);
         }
       }
     } else if (isInputObjectType(namedType)) {
-      const fields = Object.values(namedType.getFields())
+      const fields = Object.values(namedType.getFields());
       for (let i = 0; i < fields.length; i++) {
         collectReferencedTypes(fields[i].type, typeSet);
       }

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -224,7 +224,9 @@ export class GraphQLSchema {
 
       if (isInterfaceType(namedType)) {
         // Store implementations by interface.
-        for (const iface of namedType.getInterfaces()) {
+        const interfaces = namedType.getInterfaces();
+        for (let i = 0; i < interfaces.length; i++) {
+          const iface = interfaces[i]
           if (isInterfaceType(iface)) {
             let implementations = this._implementationsMap[iface.name];
             if (implementations === undefined) {
@@ -239,7 +241,9 @@ export class GraphQLSchema {
         }
       } else if (isObjectType(namedType)) {
         // Store implementations by objects.
-        for (const iface of namedType.getInterfaces()) {
+        const interfaces = namedType.getInterfaces();
+        for (let i = 0; i < interfaces.length; i++) {
+          const iface = interfaces[i]
           if (isInterfaceType(iface)) {
             let implementations = this._implementationsMap[iface.name];
             if (implementations === undefined) {
@@ -316,16 +320,17 @@ export class GraphQLSchema {
       map = Object.create(null);
 
       if (isUnionType(abstractType)) {
-        for (const type of abstractType.getTypes()) {
-          map[type.name] = true;
+        const types = abstractType.getTypes()
+        for (let i = 0; i < types.length; i++) {
+          map[types[i].name] = true;
         }
       } else {
         const implementations = this.getImplementations(abstractType);
-        for (const type of implementations.objects) {
-          map[type.name] = true;
+        for (let i = 0; i < implementations.objects.length; i++) {
+          map[implementations.objects[i].name] = true;
         }
-        for (const type of implementations.interfaces) {
-          map[type.name] = true;
+        for (let i = 0; i < implementations.interfaces.length; i++) {
+          map[implementations.interfaces[i].name] = true;
         }
       }
 
@@ -440,23 +445,28 @@ function collectReferencedTypes(
   if (!typeSet.has(namedType)) {
     typeSet.add(namedType);
     if (isUnionType(namedType)) {
-      for (const memberType of namedType.getTypes()) {
-        collectReferencedTypes(memberType, typeSet);
+      const types = namedType.getTypes();
+      for (let i = 0; i < types.length; i++) {
+        collectReferencedTypes(types[i], typeSet);
       }
     } else if (isObjectType(namedType) || isInterfaceType(namedType)) {
-      for (const interfaceType of namedType.getInterfaces()) {
-        collectReferencedTypes(interfaceType, typeSet);
+      const interfaces = namedType.getInterfaces()
+      for (let i = 0; i < interfaces.length; i++) {
+        collectReferencedTypes(interfaces[i], typeSet);
       }
 
-      for (const field of Object.values(namedType.getFields())) {
+      const fields = Object.values(namedType.getFields())
+      for (let i = 0; i < fields.length; i++) {
+        const field = fields[i]
         collectReferencedTypes(field.type, typeSet);
-        for (const arg of field.args) {
-          collectReferencedTypes(arg.type, typeSet);
+        for (let j = 0; j < field.args.length; j++) {
+          collectReferencedTypes(field.args[j].type, typeSet);
         }
       }
     } else if (isInputObjectType(namedType)) {
-      for (const field of Object.values(namedType.getFields())) {
-        collectReferencedTypes(field.type, typeSet);
+      const fields = Object.values(namedType.getFields())
+      for (let i = 0; i < fields.length; i++) {
+        collectReferencedTypes(fields[i].type, typeSet);
       }
     }
   }

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -172,7 +172,8 @@ export class GraphQLSchema {
     // the set of "collected" types, so `collectReferencedTypes` ignore them.
     const allReferencedTypes = new Set<GraphQLNamedType>(config.types);
     if (config.types != null) {
-      for (const type of config.types) {
+      for (let i = 0; i < config.types.length; i++) {
+        const type = config.types[i]
         // When we ready to process this type, we remove it from "collected" types
         // and then add it together with all dependent types in the correct position.
         allReferencedTypes.delete(type);
@@ -190,10 +191,12 @@ export class GraphQLSchema {
       collectReferencedTypes(this._subscriptionType, allReferencedTypes);
     }
 
-    for (const directive of this._directives) {
+    for (let i = 0; i < this._directives.length; i++) {
+      const directive = this._directives[i]
       // Directives are not validated until validateSchema() is called.
       if (isDirective(directive)) {
-        for (const arg of directive.args) {
+      for (let j = 0; j < directive.args.length; j++) {
+        const arg = directive.args[j]
           collectReferencedTypes(arg.type, allReferencedTypes);
         }
       }

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -124,9 +124,9 @@ function validateRootTypes(context: SchemaValidationContext): void {
     GraphQLObjectType,
     OperationTypeNode
   >();
-  const operationTypeNodes = Object.values(OperationTypeNode)
+  const operationTypeNodes = Object.values(OperationTypeNode);
   for (let i = 0; i < operationTypeNodes.length; i++) {
-    const operationType = operationTypeNodes[i]
+    const operationType = operationTypeNodes[i];
     const rootType = schema.getRootType(operationType);
 
     if (rootType != null) {
@@ -146,9 +146,9 @@ function validateRootTypes(context: SchemaValidationContext): void {
     }
   }
 
-  const rootTypeEntries = Array.from(rootTypesMap.entries())
+  const rootTypeEntries = Array.from(rootTypesMap.entries());
   for (let i = 0; i < rootTypeEntries.length; i++) {
-    const { 0: rootType, 1: operationTypes } = rootTypeEntries[i]
+    const { 0: rootType, 1: operationTypes } = rootTypeEntries[i];
     if (operationTypes.length > 1) {
       const operationList = andList(operationTypes);
       context.reportError(
@@ -174,9 +174,9 @@ function getOperationTypeNode(
 }
 
 function validateDirectives(context: SchemaValidationContext): void {
-  const directives = context.schema.getDirectives()
+  const directives = context.schema.getDirectives();
   for (let i = 0; i < directives.length; i++) {
-    const directive = directives[i]
+    const directive = directives[i];
     // Ensure all directives are in fact GraphQL directives.
     if (!isDirective(directive)) {
       context.reportError(
@@ -193,7 +193,7 @@ function validateDirectives(context: SchemaValidationContext): void {
 
     // Ensure the arguments are valid.
     for (let j = 0; j < directive.args.length; j++) {
-      const arg = directive.args[j]
+      const arg = directive.args[j];
       // Ensure they are named correctly.
       validateName(context, arg);
 
@@ -234,7 +234,7 @@ function validateTypes(context: SchemaValidationContext): void {
     createInputObjectCircularRefsValidator(context);
   const types = Object.values(context.schema.getTypeMap());
   for (let i = 0; i < types.length; i++) {
-    const type = types[i]
+    const type = types[i];
     // Ensure all provided types are in fact GraphQL type.
     if (!isNamedType(type)) {
       context.reportError(
@@ -292,7 +292,7 @@ function validateFields(
   }
 
   for (let i = 0; i < fields.length; i++) {
-    const field = fields[i]
+    const field = fields[i];
     // Ensure they are named correctly.
     validateName(context, field);
 
@@ -307,7 +307,7 @@ function validateFields(
 
     // Ensure the arguments are valid
     for (let j = 0; j < field.args.length; j++) {
-      const arg = field.args[j]
+      const arg = field.args[j];
       const argName = arg.name;
 
       // Ensure they are named correctly.
@@ -339,7 +339,7 @@ function validateInterfaces(
   const ifaceTypeNames = Object.create(null);
   const interfaces = type.getInterfaces();
   for (let i = 0; i < interfaces.length; i++) {
-    const iface = interfaces[i]
+    const iface = interfaces[i];
     if (!isInterfaceType(iface)) {
       context.reportError(
         `Type ${inspect(type)} must only implement Interface types, ` +
@@ -380,9 +380,9 @@ function validateTypeImplementsInterface(
   const typeFieldMap = type.getFields();
 
   // Assert each interface field is implemented.
-  const interfaceFields = Object.values(iface.getFields())
+  const interfaceFields = Object.values(iface.getFields());
   for (let i = 0; i < interfaceFields.length; i++) {
-    const ifaceField = interfaceFields[i]
+    const ifaceField = interfaceFields[i];
     const fieldName = ifaceField.name;
     const typeField = typeFieldMap[fieldName];
 
@@ -407,8 +407,8 @@ function validateTypeImplementsInterface(
     }
 
     // Assert each interface field arg is implemented.
-    for (let j = 0; j  < ifaceField.args.length; j++) {
-      const ifaceArg = ifaceField.args[j]
+    for (let j = 0; j < ifaceField.args.length; j++) {
+      const ifaceArg = ifaceField.args[j];
       const argName = ifaceArg.name;
       const typeArg = typeField.args.find((arg) => arg.name === argName);
 
@@ -438,8 +438,8 @@ function validateTypeImplementsInterface(
     }
 
     // Assert additional arguments must not be required.
-    for (let j = 0; j  < typeField.args.length; j++) {
-      const typeArg = typeField.args[j]
+    for (let j = 0; j < typeField.args.length; j++) {
+      const typeArg = typeField.args[j];
       const argName = typeArg.name;
       const ifaceArg = ifaceField.args.find((arg) => arg.name === argName);
       if (!ifaceArg && isRequiredArgument(typeArg)) {
@@ -458,9 +458,9 @@ function validateTypeImplementsAncestors(
   iface: GraphQLInterfaceType,
 ): void {
   const ifaceInterfaces = type.getInterfaces();
-  const interfaces = iface.getInterfaces()
+  const interfaces = iface.getInterfaces();
   for (let i = 0; i < interfaces.length; i++) {
-    const transitive = interfaces[i]
+    const transitive = interfaces[i];
     if (!ifaceInterfaces.includes(transitive)) {
       context.reportError(
         transitive === type
@@ -490,7 +490,7 @@ function validateUnionMembers(
 
   const includedTypeNames = Object.create(null);
   for (let i = 0; i < memberTypes.length; i++) {
-    const memberType = memberTypes[i]
+    const memberType = memberTypes[i];
     if (includedTypeNames[memberType.name]) {
       context.reportError(
         `Union type ${union.name} can only include type ${memberType.name} once.`,
@@ -543,7 +543,7 @@ function validateInputFields(
 
   // Ensure the arguments are valid
   for (let i = 0; i < fields.length; i++) {
-    const field = fields[i]
+    const field = fields[i];
     // Ensure they are named correctly.
     validateName(context, field);
 
@@ -594,7 +594,7 @@ function createInputObjectCircularRefsValidator(
 
     const fields = Object.values(inputObj.getFields());
     for (let i = 0; i < fields.length; i++) {
-      const field = fields[i]
+      const field = fields[i];
       if (isNonNullType(field.type) && isInputObjectType(field.type.ofType)) {
         const fieldType = field.type.ofType;
         const cycleIndex = fieldPathIndexByTypeName[fieldType.name];

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -306,7 +306,8 @@ function validateFields(
     }
 
     // Ensure the arguments are valid
-    for (const arg of field.args) {
+    for (let j = 0; j < field.args.length; j++) {
+      const arg = field.args[j]
       const argName = arg.name;
 
       // Ensure they are named correctly.
@@ -336,7 +337,9 @@ function validateInterfaces(
   type: GraphQLObjectType | GraphQLInterfaceType,
 ): void {
   const ifaceTypeNames = Object.create(null);
-  for (const iface of type.getInterfaces()) {
+  const interfaces = type.getInterfaces();
+  for (let i = 0; i < interfaces.length; i++) {
+    const iface = interfaces[i]
     if (!isInterfaceType(iface)) {
       context.reportError(
         `Type ${inspect(type)} must only implement Interface types, ` +
@@ -377,7 +380,9 @@ function validateTypeImplementsInterface(
   const typeFieldMap = type.getFields();
 
   // Assert each interface field is implemented.
-  for (const ifaceField of Object.values(iface.getFields())) {
+  const interfaceFields = Object.values(iface.getFields())
+  for (let i = 0; i < interfaceFields.length; i++) {
+    const ifaceField = interfaceFields[i]
     const fieldName = ifaceField.name;
     const typeField = typeFieldMap[fieldName];
 
@@ -402,7 +407,8 @@ function validateTypeImplementsInterface(
     }
 
     // Assert each interface field arg is implemented.
-    for (const ifaceArg of ifaceField.args) {
+    for (let j = 0; j  < ifaceField.args.length; j++) {
+      const ifaceArg = ifaceField.args[j]
       const argName = ifaceArg.name;
       const typeArg = typeField.args.find((arg) => arg.name === argName);
 
@@ -432,7 +438,8 @@ function validateTypeImplementsInterface(
     }
 
     // Assert additional arguments must not be required.
-    for (const typeArg of typeField.args) {
+    for (let j = 0; j  < typeField.args.length; j++) {
+      const typeArg = typeField.args[j]
       const argName = typeArg.name;
       const ifaceArg = ifaceField.args.find((arg) => arg.name === argName);
       if (!ifaceArg && isRequiredArgument(typeArg)) {
@@ -451,7 +458,9 @@ function validateTypeImplementsAncestors(
   iface: GraphQLInterfaceType,
 ): void {
   const ifaceInterfaces = type.getInterfaces();
-  for (const transitive of iface.getInterfaces()) {
+  const interfaces = iface.getInterfaces()
+  for (let i = 0; i < interfaces.length; i++) {
+    const transitive = interfaces[i]
     if (!ifaceInterfaces.includes(transitive)) {
       context.reportError(
         transitive === type
@@ -480,7 +489,8 @@ function validateUnionMembers(
   }
 
   const includedTypeNames = Object.create(null);
-  for (const memberType of memberTypes) {
+  for (let i = 0; i < memberTypes.length; i++) {
+    const memberType = memberTypes[i]
     if (includedTypeNames[memberType.name]) {
       context.reportError(
         `Union type ${union.name} can only include type ${memberType.name} once.`,
@@ -512,9 +522,9 @@ function validateEnumValues(
     );
   }
 
-  for (const enumValue of enumValues) {
+  for (let i = 0; i < enumValues.length; i++) {
     // Ensure valid name.
-    validateName(context, enumValue);
+    validateName(context, enumValues[i]);
   }
 }
 
@@ -532,7 +542,8 @@ function validateInputFields(
   }
 
   // Ensure the arguments are valid
-  for (const field of fields) {
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
     // Ensure they are named correctly.
     validateName(context, field);
 
@@ -582,7 +593,8 @@ function createInputObjectCircularRefsValidator(
     fieldPathIndexByTypeName[inputObj.name] = fieldPath.length;
 
     const fields = Object.values(inputObj.getFields());
-    for (const field of fields) {
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i]
       if (isNonNullType(field.type) && isInputObjectType(field.type.ofType)) {
         const fieldType = field.type.ofType;
         const cycleIndex = fieldPathIndexByTypeName[fieldType.name];

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -124,7 +124,9 @@ function validateRootTypes(context: SchemaValidationContext): void {
     GraphQLObjectType,
     OperationTypeNode
   >();
-  for (const operationType of Object.values(OperationTypeNode)) {
+  const operationTypeNodes = Object.values(OperationTypeNode)
+  for (let i = 0; i < operationTypeNodes.length; i++) {
+    const operationType = operationTypeNodes[i]
     const rootType = schema.getRootType(operationType);
 
     if (rootType != null) {
@@ -144,7 +146,9 @@ function validateRootTypes(context: SchemaValidationContext): void {
     }
   }
 
-  for (const [rootType, operationTypes] of rootTypesMap.entries()) {
+  const rootTypeEntries = Array.from(rootTypesMap.entries())
+  for (let i = 0; i < rootTypeEntries.length; i++) {
+    const { 0: rootType, 1: operationTypes } = rootTypeEntries[i]
     if (operationTypes.length > 1) {
       const operationList = andList(operationTypes);
       context.reportError(
@@ -170,7 +174,9 @@ function getOperationTypeNode(
 }
 
 function validateDirectives(context: SchemaValidationContext): void {
-  for (const directive of context.schema.getDirectives()) {
+  const directives = context.schema.getDirectives()
+  for (let i = 0; i < directives.length; i++) {
+    const directive = directives[i]
     // Ensure all directives are in fact GraphQL directives.
     if (!isDirective(directive)) {
       context.reportError(
@@ -186,7 +192,8 @@ function validateDirectives(context: SchemaValidationContext): void {
     // TODO: Ensure proper locations.
 
     // Ensure the arguments are valid.
-    for (const arg of directive.args) {
+    for (let j = 0; j < directive.args.length; j++) {
+      const arg = directive.args[j]
       // Ensure they are named correctly.
       validateName(context, arg);
 
@@ -225,8 +232,9 @@ function validateName(
 function validateTypes(context: SchemaValidationContext): void {
   const validateInputObjectCircularRefs =
     createInputObjectCircularRefsValidator(context);
-  const typeMap = context.schema.getTypeMap();
-  for (const type of Object.values(typeMap)) {
+  const types = Object.values(context.schema.getTypeMap());
+  for (let i = 0; i < types.length; i++) {
+    const type = types[i]
     // Ensure all provided types are in fact GraphQL type.
     if (!isNamedType(type)) {
       context.reportError(
@@ -283,7 +291,8 @@ function validateFields(
     ]);
   }
 
-  for (const field of fields) {
+  for (let i = 0; i < fields.length; i++) {
+    const field = fields[i]
     // Ensure they are named correctly.
     validateName(context, field);
 

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -84,7 +84,9 @@ export function astFromValue(
       return null;
     }
     const fieldNodes: Array<ObjectFieldNode> = [];
-    for (const field of Object.values(type.getFields())) {
+    const fields = Object.values(type.getFields())
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i]
       const fieldValue = astFromValue(value[field.name], field.type);
       if (fieldValue) {
         fieldNodes.push({

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -84,9 +84,9 @@ export function astFromValue(
       return null;
     }
     const fieldNodes: Array<ObjectFieldNode> = [];
-    const fields = Object.values(type.getFields())
+    const fields = Object.values(type.getFields());
     for (let i = 0; i < fields.length; i++) {
-      const field = fields[i]
+      const field = fields[i];
       const fieldValue = astFromValue(value[field.name], field.type);
       if (fieldValue) {
         fieldNodes.push({

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -49,7 +49,8 @@ export function buildASTSchema(
   const config = extendSchemaImpl(emptySchemaConfig, documentAST, options);
 
   if (config.astNode == null) {
-    for (const type of config.types) {
+    for (let i = 0; i < config.types.length; i++) {
+      const type = config.types[i]
       switch (type.name) {
         // Note: While this could make early assertions to get the correctly
         // typed values below, that would throw immediately while type system

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -50,7 +50,7 @@ export function buildASTSchema(
 
   if (config.astNode == null) {
     for (let i = 0; i < config.types.length; i++) {
-      const type = config.types[i]
+      const type = config.types[i];
       switch (type.name) {
         // Note: While this could make early assertions to get the correctly
         // typed values below, that would throw immediately while type system

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -85,7 +85,9 @@ export function buildClientSchema(
   );
 
   // Include standard types only if they are used.
-  for (const stdType of [...specifiedScalarTypes, ...introspectionTypes]) {
+  const stdTypes = [...specifiedScalarTypes, ...introspectionTypes]
+  for (let i = 0; i < stdTypes.length; i++) {
+    const stdType = stdTypes[i]
     if (typeMap[stdType.name]) {
       typeMap[stdType.name] = stdType;
     }

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -85,9 +85,9 @@ export function buildClientSchema(
   );
 
   // Include standard types only if they are used.
-  const stdTypes = [...specifiedScalarTypes, ...introspectionTypes]
+  const stdTypes = [...specifiedScalarTypes, ...introspectionTypes];
   for (let i = 0; i < stdTypes.length; i++) {
-    const stdType = stdTypes[i]
+    const stdType = stdTypes[i];
     if (typeMap[stdType.name]) {
       typeMap[stdType.name] = stdType;
     }

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -97,8 +97,10 @@ function coerceInputValueImpl(
 
     const coercedValue: any = {};
     const fieldDefs = type.getFields();
+    const fields = Object.values(fieldDefs)
 
-    for (const field of Object.values(fieldDefs)) {
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i]
       const fieldValue = inputValue[field.name];
 
       if (fieldValue === undefined) {
@@ -126,7 +128,9 @@ function coerceInputValueImpl(
     }
 
     // Ensure every provided field is defined.
-    for (const fieldName of Object.keys(inputValue)) {
+    const inputKeys = Object.keys(inputValue)
+    for (let i = 0; i < inputKeys.length; i++) {
+      const fieldName = inputKeys[i]
       if (!fieldDefs[fieldName]) {
         const suggestions = suggestionList(
           fieldName,

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -97,10 +97,10 @@ function coerceInputValueImpl(
 
     const coercedValue: any = {};
     const fieldDefs = type.getFields();
-    const fields = Object.values(fieldDefs)
+    const fields = Object.values(fieldDefs);
 
     for (let i = 0; i < fields.length; i++) {
-      const field = fields[i]
+      const field = fields[i];
       const fieldValue = inputValue[field.name];
 
       if (fieldValue === undefined) {
@@ -128,9 +128,9 @@ function coerceInputValueImpl(
     }
 
     // Ensure every provided field is defined.
-    const inputKeys = Object.keys(inputValue)
+    const inputKeys = Object.keys(inputValue);
     for (let i = 0; i < inputKeys.length; i++) {
-      const fieldName = inputKeys[i]
+      const fieldName = inputKeys[i];
       if (!fieldDefs[fieldName]) {
         const suggestions = suggestionList(
           fieldName,

--- a/src/utilities/concatAST.ts
+++ b/src/utilities/concatAST.ts
@@ -10,8 +10,8 @@ export function concatAST(
   documents: ReadonlyArray<DocumentNode>,
 ): DocumentNode {
   const definitions: Array<DefinitionNode> = [];
-  for (const doc of documents) {
-    definitions.push(...doc.definitions);
+  for (let i = 0; i < documents.length; i++) {
+    definitions.push(...documents[i].definitions);
   }
   return { kind: Kind.DOCUMENT, definitions };
 }

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -141,7 +141,8 @@ export function extendSchemaImpl(
   // Schema extensions are collected which may add additional operation types.
   const schemaExtensions: Array<SchemaExtensionNode> = [];
 
-  for (const def of documentAST.definitions) {
+  for (let i = 0; i < documentAST.definitions.length; i++) {
+    const def = documentAST.definitions[i]
     if (def.kind === Kind.SCHEMA_DEFINITION) {
       schemaDef = def;
     } else if (def.kind === Kind.SCHEMA_EXTENSION) {
@@ -172,11 +173,13 @@ export function extendSchemaImpl(
   }
 
   const typeMap = Object.create(null);
-  for (const existingType of schemaConfig.types) {
+  for (let i = 0; i < schemaConfig.types.length; i++) {
+    const existingType = schemaConfig.types[i]
     typeMap[existingType.name] = extendNamedType(existingType);
   }
 
-  for (const typeNode of typeDefs) {
+  for (let i = 0; i < typeDefs.length; i++) {
+    const typeNode = typeDefs[i]
     const name = typeNode.name.value;
     typeMap[name] = stdTypeMap[name] ?? buildType(typeNode);
   }
@@ -309,7 +312,8 @@ export function extendSchemaImpl(
     const extensions = typeExtensionsMap[config.name] ?? [];
 
     let specifiedByURL = config.specifiedByURL;
-    for (const extensionNode of extensions) {
+    for (let i = 0; i < extensions.length; i++) {
+      const extensionNode = extensions[i]
       specifiedByURL = getSpecifiedByURL(extensionNode) ?? specifiedByURL;
     }
 
@@ -397,12 +401,14 @@ export function extendSchemaImpl(
     subscription?: Maybe<GraphQLObjectType>;
   } {
     const opTypes = {};
-    for (const node of nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i]
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const operationTypesNodes =
         /* c8 ignore next */ node.operationTypes ?? [];
 
-      for (const operationType of operationTypesNodes) {
+      for (let j = 0; j < operationTypesNodes.length; j++) {
+        const operationType = operationTypesNodes[j]
         // Note: While this could make early assertions to get the correctly
         // typed values below, that would throw immediately while type system
         // validation with validateSchema() will produce more actionable results.
@@ -455,11 +461,13 @@ export function extendSchemaImpl(
     >,
   ): GraphQLFieldConfigMap<unknown, unknown> {
     const fieldConfigMap = Object.create(null);
-    for (const node of nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i]
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const nodeFields = /* c8 ignore next */ node.fields ?? [];
 
-      for (const field of nodeFields) {
+      for (let j = 0; j < nodeFields.length; j++) {
+        const field = nodeFields[j]
         fieldConfigMap[field.name.value] = {
           // Note: While this could make assertions to get the correctly typed
           // value, that would throw immediately while type system validation
@@ -482,7 +490,8 @@ export function extendSchemaImpl(
     const argsNodes = /* c8 ignore next */ args ?? [];
 
     const argConfigMap = Object.create(null);
-    for (const arg of argsNodes) {
+    for (let i = 0; i < argsNodes.length; i++) {
+      const arg = argsNodes[i]
       // Note: While this could make assertions to get the correctly typed
       // value, that would throw immediately while type system validation
       // with validateSchema() will produce more actionable results.
@@ -505,11 +514,13 @@ export function extendSchemaImpl(
     >,
   ): GraphQLInputFieldConfigMap {
     const inputFieldMap = Object.create(null);
-    for (const node of nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i]
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const fieldsNodes = /* c8 ignore next */ node.fields ?? [];
 
-      for (const field of fieldsNodes) {
+      for (let j = 0; j < fieldsNodes.length; j++) {
+        const field = fieldsNodes[j]
         // Note: While this could make assertions to get the correctly typed
         // value, that would throw immediately while type system validation
         // with validateSchema() will produce more actionable results.
@@ -531,11 +542,13 @@ export function extendSchemaImpl(
     nodes: ReadonlyArray<EnumTypeDefinitionNode | EnumTypeExtensionNode>,
   ): GraphQLEnumValueConfigMap {
     const enumValueMap = Object.create(null);
-    for (const node of nodes) {
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i]
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const valuesNodes = /* c8 ignore next */ node.values ?? [];
 
-      for (const value of valuesNodes) {
+      for (let j = 0; j < valuesNodes.length; j++) {
+        const value = valuesNodes[j]
         enumValueMap[value.name.value] = {
           description: value.description?.value,
           deprecationReason: getDeprecationReason(value),

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -142,7 +142,7 @@ export function extendSchemaImpl(
   const schemaExtensions: Array<SchemaExtensionNode> = [];
 
   for (let i = 0; i < documentAST.definitions.length; i++) {
-    const def = documentAST.definitions[i]
+    const def = documentAST.definitions[i];
     if (def.kind === Kind.SCHEMA_DEFINITION) {
       schemaDef = def;
     } else if (def.kind === Kind.SCHEMA_EXTENSION) {
@@ -174,12 +174,12 @@ export function extendSchemaImpl(
 
   const typeMap = Object.create(null);
   for (let i = 0; i < schemaConfig.types.length; i++) {
-    const existingType = schemaConfig.types[i]
+    const existingType = schemaConfig.types[i];
     typeMap[existingType.name] = extendNamedType(existingType);
   }
 
   for (let i = 0; i < typeDefs.length; i++) {
-    const typeNode = typeDefs[i]
+    const typeNode = typeDefs[i];
     const name = typeNode.name.value;
     typeMap[name] = stdTypeMap[name] ?? buildType(typeNode);
   }
@@ -313,7 +313,7 @@ export function extendSchemaImpl(
 
     let specifiedByURL = config.specifiedByURL;
     for (let i = 0; i < extensions.length; i++) {
-      const extensionNode = extensions[i]
+      const extensionNode = extensions[i];
       specifiedByURL = getSpecifiedByURL(extensionNode) ?? specifiedByURL;
     }
 
@@ -402,13 +402,13 @@ export function extendSchemaImpl(
   } {
     const opTypes = {};
     for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i]
+      const node = nodes[i];
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const operationTypesNodes =
         /* c8 ignore next */ node.operationTypes ?? [];
 
       for (let j = 0; j < operationTypesNodes.length; j++) {
-        const operationType = operationTypesNodes[j]
+        const operationType = operationTypesNodes[j];
         // Note: While this could make early assertions to get the correctly
         // typed values below, that would throw immediately while type system
         // validation with validateSchema() will produce more actionable results.
@@ -462,12 +462,12 @@ export function extendSchemaImpl(
   ): GraphQLFieldConfigMap<unknown, unknown> {
     const fieldConfigMap = Object.create(null);
     for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i]
+      const node = nodes[i];
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const nodeFields = /* c8 ignore next */ node.fields ?? [];
 
       for (let j = 0; j < nodeFields.length; j++) {
-        const field = nodeFields[j]
+        const field = nodeFields[j];
         fieldConfigMap[field.name.value] = {
           // Note: While this could make assertions to get the correctly typed
           // value, that would throw immediately while type system validation
@@ -491,7 +491,7 @@ export function extendSchemaImpl(
 
     const argConfigMap = Object.create(null);
     for (let i = 0; i < argsNodes.length; i++) {
-      const arg = argsNodes[i]
+      const arg = argsNodes[i];
       // Note: While this could make assertions to get the correctly typed
       // value, that would throw immediately while type system validation
       // with validateSchema() will produce more actionable results.
@@ -515,12 +515,12 @@ export function extendSchemaImpl(
   ): GraphQLInputFieldConfigMap {
     const inputFieldMap = Object.create(null);
     for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i]
+      const node = nodes[i];
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const fieldsNodes = /* c8 ignore next */ node.fields ?? [];
 
       for (let j = 0; j < fieldsNodes.length; j++) {
-        const field = fieldsNodes[j]
+        const field = fieldsNodes[j];
         // Note: While this could make assertions to get the correctly typed
         // value, that would throw immediately while type system validation
         // with validateSchema() will produce more actionable results.
@@ -543,12 +543,12 @@ export function extendSchemaImpl(
   ): GraphQLEnumValueConfigMap {
     const enumValueMap = Object.create(null);
     for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i]
+      const node = nodes[i];
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const valuesNodes = /* c8 ignore next */ node.values ?? [];
 
       for (let j = 0; j < valuesNodes.length; j++) {
-        const value = valuesNodes[j]
+        const value = valuesNodes[j];
         enumValueMap[value.name.value] = {
           description: value.description?.value,
           deprecationReason: getDeprecationReason(value),

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -128,7 +128,7 @@ function findDirectiveChanges(
     });
   }
 
-  for (const [oldDirective, newDirective] of directivesDiff.persisted) {
+  for (const { 0: oldDirective, 1: newDirective } of directivesDiff.persisted) {
     const argsDiff = diff(oldDirective.args, newDirective.args);
 
     for (const newArg of argsDiff.added) {
@@ -187,7 +187,7 @@ function findTypeChanges(
     });
   }
 
-  for (const [oldType, newType] of typesDiff.persisted) {
+  for (const { 0: oldType, 1: newType } of typesDiff.persisted) {
     if (isEnumType(oldType) && isEnumType(newType)) {
       schemaChanges.push(...findEnumTypeChanges(oldType, newType));
     } else if (isUnionType(oldType) && isUnionType(newType)) {
@@ -248,7 +248,7 @@ function findInputObjectTypeChanges(
     });
   }
 
-  for (const [oldField, newField] of fieldsDiff.persisted) {
+  for (const { 0: oldField, 1: newField } of fieldsDiff.persisted) {
     const isSafe = isChangeSafeForInputObjectFieldOrFieldArg(
       oldField.type,
       newField.type,
@@ -355,7 +355,7 @@ function findFieldChanges(
     });
   }
 
-  for (const [oldField, newField] of fieldsDiff.persisted) {
+  for (const { 0: oldField, 1: newField } of fieldsDiff.persisted) {
     schemaChanges.push(...findArgChanges(oldType, oldField, newField));
 
     const isSafe = isChangeSafeForObjectOrInterfaceField(
@@ -390,7 +390,7 @@ function findArgChanges(
     });
   }
 
-  for (const [oldArg, newArg] of argsDiff.persisted) {
+  for (const { 0: oldArg, 1: newArg } of argsDiff.persisted) {
     const isSafe = isChangeSafeForInputObjectFieldOrFieldArg(
       oldArg.type,
       newArg.type,

--- a/src/utilities/getOperationAST.ts
+++ b/src/utilities/getOperationAST.ts
@@ -14,7 +14,7 @@ export function getOperationAST(
 ): Maybe<OperationDefinitionNode> {
   let operation = null;
   for (let i = 0; i < documentAST.definitions.length; i++) {
-    const definition = documentAST.definitions[i]
+    const definition = documentAST.definitions[i];
     if (definition.kind === Kind.OPERATION_DEFINITION) {
       if (operationName == null) {
         // If no operation name was provided, only return an Operation if there

--- a/src/utilities/getOperationAST.ts
+++ b/src/utilities/getOperationAST.ts
@@ -13,7 +13,8 @@ export function getOperationAST(
   operationName?: Maybe<string>,
 ): Maybe<OperationDefinitionNode> {
   let operation = null;
-  for (const definition of documentAST.definitions) {
+  for (let i = 0; i < documentAST.definitions.length; i++) {
+    const definition = documentAST.definitions[i]
     if (definition.kind === Kind.OPERATION_DEFINITION) {
       if (operationName == null) {
         // If no operation name was provided, only return an Operation if there

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -109,7 +109,9 @@ export function valueFromAST(
     }
     const coercedObj = Object.create(null);
     const fieldNodes = keyMap(valueNode.fields, (field) => field.name.value);
-    for (const field of Object.values(type.getFields())) {
+    const typeFields = Object.values(type.getFields())
+    for (let i = 0; i < typeFields.length; i++) {
+      const field = typeFields[i]
       const fieldNode = fieldNodes[field.name];
       if (!fieldNode || isMissingVariable(fieldNode.value, variables)) {
         if (field.defaultValue !== undefined) {

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -110,9 +110,9 @@ export function valueFromAST(
     }
     const coercedObj = Object.create(null);
     const fieldNodes = keyMap(valueNode.fields, (field) => field.name.value);
-    const typeFields = Object.values(type.getFields())
+    const typeFields = Object.values(type.getFields());
     for (let i = 0; i < typeFields.length; i++) {
-      const field = typeFields[i]
+      const field = typeFields[i];
       const fieldNode = fieldNodes[field.name];
       if (!fieldNode || isMissingVariable(fieldNode.value, variables)) {
         if (field.defaultValue !== undefined) {

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -78,7 +78,8 @@ export function valueFromAST(
     const itemType = type.ofType;
     if (valueNode.kind === Kind.LIST) {
       const coercedValues = [];
-      for (const itemNode of valueNode.values) {
+      for (let i = 0; i < valueNode.values.length; i++) {
+        const itemNode = valueNode.values[i];
         if (isMissingVariable(itemNode, variables)) {
           // If an array contains a missing variable, it is either coerced to
           // null or if the item type is non-null, it considered invalid.

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -78,7 +78,7 @@ export class ASTValidationContext {
       fragments = Object.create(null);
       const docDefs = this.getDocument().definitions;
       for (let i = 0; i < docDefs.length; i++) {
-        const defNode = docDefs[i]
+        const defNode = docDefs[i];
         if (defNode.kind === Kind.FRAGMENT_DEFINITION) {
           fragments[defNode.name.value] = defNode;
         }
@@ -98,7 +98,7 @@ export class ASTValidationContext {
       let set: SelectionSetNode | undefined;
       while ((set = setsToVisit.pop())) {
         for (let i = 0; i < set.selections.length; i++) {
-          const selection = set.selections[i]
+          const selection = set.selections[i];
           if (selection.kind === Kind.FRAGMENT_SPREAD) {
             spreads.push(selection);
           } else if (selection.selectionSet) {
@@ -121,9 +121,9 @@ export class ASTValidationContext {
       const nodesToVisit: Array<SelectionSetNode> = [operation.selectionSet];
       let node: SelectionSetNode | undefined;
       while ((node = nodesToVisit.pop())) {
-        const spreads = this.getFragmentSpreads(node)
+        const spreads = this.getFragmentSpreads(node);
         for (let i = 0; i < spreads.length; i++) {
-          const spread = spreads[i]
+          const spread = spreads[i];
           const fragName = spread.name.value;
           if (collectedNames[fragName] !== true) {
             collectedNames[fragName] = true;
@@ -230,9 +230,12 @@ export class ValidationContext extends ASTValidationContext {
     let usages = this._recursiveVariableUsages.get(operation);
     if (!usages) {
       usages = this.getVariableUsages(operation);
-      const recursivelyReferencedFragments = this.getRecursivelyReferencedFragments(operation)
+      const recursivelyReferencedFragments =
+        this.getRecursivelyReferencedFragments(operation);
       for (let i = 0; i < recursivelyReferencedFragments.length; i++) {
-        usages = usages.concat(this.getVariableUsages(recursivelyReferencedFragments[i]));
+        usages = usages.concat(
+          this.getVariableUsages(recursivelyReferencedFragments[i]),
+        );
       }
       this._recursiveVariableUsages.set(operation, usages);
     }

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -76,7 +76,9 @@ export class ASTValidationContext {
       fragments = this._fragments;
     } else {
       fragments = Object.create(null);
-      for (const defNode of this.getDocument().definitions) {
+      const docDefs = this.getDocument().definitions;
+      for (let i = 0; i < docDefs.length; i++) {
+        const defNode = docDefs[i]
         if (defNode.kind === Kind.FRAGMENT_DEFINITION) {
           fragments[defNode.name.value] = defNode;
         }
@@ -95,7 +97,8 @@ export class ASTValidationContext {
       const setsToVisit: Array<SelectionSetNode> = [node];
       let set: SelectionSetNode | undefined;
       while ((set = setsToVisit.pop())) {
-        for (const selection of set.selections) {
+        for (let i = 0; i < set.selections.length; i++) {
+          const selection = set.selections[i]
           if (selection.kind === Kind.FRAGMENT_SPREAD) {
             spreads.push(selection);
           } else if (selection.selectionSet) {
@@ -118,7 +121,9 @@ export class ASTValidationContext {
       const nodesToVisit: Array<SelectionSetNode> = [operation.selectionSet];
       let node: SelectionSetNode | undefined;
       while ((node = nodesToVisit.pop())) {
-        for (const spread of this.getFragmentSpreads(node)) {
+        const spreads = this.getFragmentSpreads(node)
+        for (let i = 0; i < spreads.length; i++) {
+          const spread = spreads[i]
           const fragName = spread.name.value;
           if (collectedNames[fragName] !== true) {
             collectedNames[fragName] = true;
@@ -225,8 +230,9 @@ export class ValidationContext extends ASTValidationContext {
     let usages = this._recursiveVariableUsages.get(operation);
     if (!usages) {
       usages = this.getVariableUsages(operation);
-      for (const frag of this.getRecursivelyReferencedFragments(operation)) {
-        usages = usages.concat(this.getVariableUsages(frag));
+      const recursivelyReferencedFragments = this.getRecursivelyReferencedFragments(operation)
+      for (let i = 0; i < recursivelyReferencedFragments.length; i++) {
+        usages = usages.concat(this.getVariableUsages(recursivelyReferencedFragments[i]));
       }
       this._recursiveVariableUsages.set(operation, usages);
     }

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -81,11 +81,11 @@ export function OverlappingFieldsCanBeMergedRule(
         context.getParentType(),
         selectionSet,
       );
-      for (const [[responseName, reason], fields1, fields2] of conflicts) {
-        const reasonMsg = reasonMessage(reason);
+      for (const { 0: response, 1: fields1, 2: fields2 } of conflicts) {
+        const reasonMsg = reasonMessage(response[1]);
         context.reportError(
           new GraphQLError(
-            `Fields "${responseName}" conflict because ${reasonMsg}. Use different aliases on the fields to fetch both if this was intentional.`,
+            `Fields "${response[0]}" conflict because ${reasonMsg}. Use different aliases on the fields to fetch both if this was intentional.`,
             { nodes: fields1.concat(fields2) },
           ),
         );
@@ -484,7 +484,7 @@ function collectConflictsWithin(
   // name and the value at that key is a list of all fields which provide that
   // response name. For every response name, if there are multiple fields, they
   // must be compared to find a potential conflict.
-  for (const [responseName, fields] of Object.entries(fieldMap)) {
+  for (const { 0: responseName, 1: fields } of Object.entries(fieldMap)) {
     // This compares every field in the list to every other field in this list
     // (except to itself). If the list only has one item, nothing needs to
     // be compared.
@@ -528,7 +528,7 @@ function collectConflictsBetween(
   // response name. For any response name which appears in both provided field
   // maps, each field from the first field map must be compared to every field
   // in the second field map to find potential conflicts.
-  for (const [responseName, fields1] of Object.entries(fieldMap1)) {
+  for (const { 0: responseName, 1: fields1 } of Object.entries(fieldMap1)) {
     const fields2 = fieldMap2[responseName];
     if (fields2) {
       for (const field1 of fields1) {

--- a/src/validation/rules/ProvidedRequiredArgumentsRule.ts
+++ b/src/validation/rules/ProvidedRequiredArgumentsRule.ts
@@ -103,7 +103,9 @@ export function ProvidedRequiredArgumentsOnDirectivesRule(
           /* c8 ignore next */
           const argNodes = directiveNode.arguments ?? [];
           const argNodeMap = new Set(argNodes.map((arg) => arg.name.value));
-          for (const { 0: argName, 1: argDef } of Object.entries(requiredArgs)) {
+          for (const { 0: argName, 1: argDef } of Object.entries(
+            requiredArgs,
+          )) {
             if (!argNodeMap.has(argName)) {
               const argType = isType(argDef.type)
                 ? inspect(argDef.type)

--- a/src/validation/rules/ProvidedRequiredArgumentsRule.ts
+++ b/src/validation/rules/ProvidedRequiredArgumentsRule.ts
@@ -103,7 +103,7 @@ export function ProvidedRequiredArgumentsOnDirectivesRule(
           /* c8 ignore next */
           const argNodes = directiveNode.arguments ?? [];
           const argNodeMap = new Set(argNodes.map((arg) => arg.name.value));
-          for (const [argName, argDef] of Object.entries(requiredArgs)) {
+          for (const { 0: argName, 1: argDef } of Object.entries(requiredArgs)) {
             if (!argNodeMap.has(argName)) {
               const argType = isType(argDef.type)
                 ? inspect(argDef.type)

--- a/src/validation/rules/UniqueArgumentDefinitionNamesRule.ts
+++ b/src/validation/rules/UniqueArgumentDefinitionNamesRule.ts
@@ -63,7 +63,7 @@ export function UniqueArgumentDefinitionNamesRule(
   ) {
     const seenArgs = groupBy(argumentNodes, (arg) => arg.name.value);
 
-    for (const [argName, argNodes] of seenArgs) {
+    for (const { 0: argName, 1: argNodes } of seenArgs) {
       if (argNodes.length > 1) {
         context.reportError(
           new GraphQLError(

--- a/src/validation/rules/UniqueArgumentNamesRule.ts
+++ b/src/validation/rules/UniqueArgumentNamesRule.ts
@@ -32,7 +32,7 @@ export function UniqueArgumentNamesRule(
 
     const seenArgs = groupBy(argumentNodes, (arg) => arg.name.value);
 
-    for (const [argName, argNodes] of seenArgs) {
+    for (const { 0: argName, 1: argNodes } of seenArgs) {
       if (argNodes.length > 1) {
         context.reportError(
           new GraphQLError(

--- a/src/validation/rules/UniqueVariableNamesRule.ts
+++ b/src/validation/rules/UniqueVariableNamesRule.ts
@@ -25,7 +25,7 @@ export function UniqueVariableNamesRule(
         (node) => node.variable.name.value,
       );
 
-      for (const [variableName, variableNodes] of seenVariableDefinitions) {
+      for (const { 0: variableName, 1: variableNodes} of seenVariableDefinitions) {
         if (variableNodes.length > 1) {
           context.reportError(
             new GraphQLError(

--- a/src/validation/rules/UniqueVariableNamesRule.ts
+++ b/src/validation/rules/UniqueVariableNamesRule.ts
@@ -25,7 +25,10 @@ export function UniqueVariableNamesRule(
         (node) => node.variable.name.value,
       );
 
-      for (const { 0: variableName, 1: variableNodes} of seenVariableDefinitions) {
+      for (const {
+        0: variableName,
+        1: variableNodes,
+      } of seenVariableDefinitions) {
         if (variableNodes.length > 1) {
           context.reportError(
             new GraphQLError(


### PR DESCRIPTION
This PR aims to explain what's going on for #3648 the main issues seem to be:

- using `for..of` in hot paths
- using array destructuring

If we find this to be sufficient we can find a way to add a build step or merge as-is with some lint-rules. This currently touches the following issues in hot-paths only.

There are more issues to be found. Other slowdowns could be due to raw ES6 classes, ....
EDIT: verifies yes, ES5 classes are a lot faster like [these](https://www.runpkg.com/?graphql@15.8.0/type/schema.mjs#96) but imho it's not worth writing that as opposed to the little change of avoiding `for..of` in hot paths 😅 

I have a suspicion that the custom extension of Map (AccumulatorMap) is also to blame as it lives on the hot-path

Preliminary results where local is ES5 and the other is this branch. (some benches don't run when I use ES5 in tsconfig)

```
⏱   Recreate a GraphQLSchema
  2 tests completed.

  local                                    x 1,774 ops/sec ±0.21% x 288 KB/op (25 runs sampled)
  a6a240321b7ae96622eb120b7c1fa5eaafc6f16f x 1,386 ops/sec ±0.26% x 453 KB/op (22 runs sampled)

⏱   Build Schema from AST
  2 tests completed.

  local                                    x 145 ops/sec ±0.11% x  3.6 MB/op (9 runs sampled)
  a6a240321b7ae96622eb120b7c1fa5eaafc6f16f x 166 ops/sec ±0.58% x 3.55 MB/op (11 runs sampled)

⏱   Build Schema from Introspection
  2 tests completed.

  local                                    x 169 ops/sec ±0.13% x 3.95 MB/op (15 runs sampled)
  a6a240321b7ae96622eb120b7c1fa5eaafc6f16f x 163 ops/sec ±0.23% x 3.98 MB/op (12 runs sampled)

⏱   Execute Introspection Query
  2 tests completed.

  local                                    x 94,695 ops/sec ±1.99% x 2.85 KB/op (23 runs sampled)
  a6a240321b7ae96622eb120b7c1fa5eaafc6f16f x  74.84 ops/sec ±0.60% x 29.2 MB/op (5 runs sampled)
```