### PR TITLE
Remove superficial `.values()` and `.entries()` calls

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -391,7 +391,7 @@ function executeFieldsSerially(
   fields: Map<string, ReadonlyArray<FieldNode>>,
 ): PromiseOrValue<ObjMap<unknown>> {
   return promiseReduce(
-    fields.entries(),
+    fields,
     (results, [responseName, fieldNodes]) => {
       const fieldPath = addPath(path, responseName, parentType.name);
       const result = executeField(
@@ -431,7 +431,7 @@ function executeFields(
   const results = Object.create(null);
   let containsPromise = false;
 
-  for (const [responseName, fieldNodes] of fields.entries()) {
+  for (const [responseName, fieldNodes] of fields) {
     const fieldPath = addPath(path, responseName, parentType.name);
     const result = executeField(
       exeContext,
@@ -1227,7 +1227,9 @@ function executeSubscription(
     rootType,
     operation.selectionSet,
   );
-  const [responseName, fieldNodes] = [...rootFields.entries()][0];
+
+  const firstRootField = rootFields.entries().next().value;
+  const [responseName, fieldNodes] = firstRootField;
   const fieldName = fieldNodes[0].name.value;
   const fieldDef = schema.getField(rootType, fieldName);
 

--- a/src/jsutils/__tests__/AccumulatorMap-test.ts
+++ b/src/jsutils/__tests__/AccumulatorMap-test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import { AccumulatorMap } from '../AccumulatorMap';
 
 function expectMap<K, V>(map: Map<K, V>) {
-  return expect(Object.fromEntries(map.entries()));
+  return expect(Object.fromEntries(map));
 }
 
 describe('AccumulatorMap', () => {

--- a/src/jsutils/promiseForObject.ts
+++ b/src/jsutils/promiseForObject.ts
@@ -10,10 +10,13 @@ import type { ObjMap } from './ObjMap';
 export function promiseForObject<T>(
   object: ObjMap<Promise<T>>,
 ): Promise<ObjMap<T>> {
-  return Promise.all(Object.values(object)).then((resolvedValues) => {
+  const keys = Object.keys(object);
+  const values = Object.values(object);
+
+  return Promise.all(values).then((resolvedValues) => {
     const resolvedObject = Object.create(null);
-    for (const [i, key] of Object.keys(object).entries()) {
-      resolvedObject[key] = resolvedValues[i];
+    for (let i = 0; i < keys.length; ++i) {
+      resolvedObject[keys[i]] = resolvedValues[i];
     }
     return resolvedObject;
   });

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -144,7 +144,7 @@ function validateRootTypes(context: SchemaValidationContext): void {
     }
   }
 
-  for (const [rootType, operationTypes] of rootTypesMap.entries()) {
+  for (const [rootType, operationTypes] of rootTypesMap) {
     if (operationTypes.length > 1) {
       const operationList = andList(operationTypes);
       context.reportError(

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -62,8 +62,7 @@ export function SingleFieldSubscriptionsRule(
             );
           }
           for (const fieldNodes of fields.values()) {
-            const field = fieldNodes[0];
-            const fieldName = field.name.value;
+            const fieldName = fieldNodes[0].name.value;
             if (fieldName.startsWith('__')) {
               context.reportError(
                 new GraphQLError(


### PR DESCRIPTION
Motivation: Spotted during investigation of unrelated issue.
Maps and sets are iteratable, so no need to call these methods.