### PR TITLE
polish: mapAsyncIterator

### DIFF
--- a/src/execution/__tests__/mapAsyncIterable-test.ts
+++ b/src/execution/__tests__/mapAsyncIterable-test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { expectPromise } from '../../__testUtils__/expectPromise';
+
 import { mapAsyncIterable } from '../mapAsyncIterable';
 
 /* eslint-disable @typescript-eslint/require-await */
@@ -209,14 +211,9 @@ describe('mapAsyncIterable', () => {
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
 
     // Throw error
-    let caughtError;
-    try {
-      /* c8 ignore next 2 */
-      await doubles.throw('ouch');
-    } catch (e) {
-      caughtError = e;
-    }
-    expect(caughtError).to.equal('ouch');
+    const message = 'allows throwing errors when mapping async iterable';
+    const thrown = doubles.throw(new Error(message));
+    await expectPromise(thrown).toRejectWith(message);
   });
 
   it('passes through caught errors through async generators', async () => {
@@ -265,17 +262,7 @@ describe('mapAsyncIterable', () => {
       done: false,
     });
 
-    let caughtError;
-    try {
-      /* c8 ignore next 2 */
-      await doubles.next();
-    } catch (e) {
-      caughtError = e;
-    }
-
-    expect(caughtError)
-      .to.be.an.instanceOf(Error)
-      .with.property('message', 'Goodbye');
+    await expectPromise(doubles.next()).toRejectWith('Goodbye');
   });
 
   async function testClosesSourceWithMapper<T>(mapper: (value: number) => T) {
@@ -297,17 +284,7 @@ describe('mapAsyncIterable', () => {
 
     expect(await throwOver1.next()).to.deep.equal({ value: 1, done: false });
 
-    let expectedError;
-    try {
-      /* c8 ignore next 2 */
-      await throwOver1.next();
-    } catch (error) {
-      expectedError = error;
-    }
-
-    expect(expectedError)
-      .to.be.an.instanceOf(Error)
-      .with.property('message', 'Cannot count to 2');
+    await expectPromise(throwOver1.next()).toRejectWith('Cannot count to 2');
 
     expect(await throwOver1.next()).to.deep.equal({
       value: undefined,

--- a/src/execution/__tests__/mapAsyncIterable-test.ts
+++ b/src/execution/__tests__/mapAsyncIterable-test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { mapAsyncIterator } from '../mapAsyncIterator';
+import { mapAsyncIterable } from '../mapAsyncIterable';
 
 /* eslint-disable @typescript-eslint/require-await */
-describe('mapAsyncIterator', () => {
+describe('mapAsyncIterable', () => {
   it('maps over async generator', async () => {
     async function* source() {
       yield 1;
@@ -12,7 +12,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -42,7 +42,7 @@ describe('mapAsyncIterator', () => {
       },
     };
 
-    const doubles = mapAsyncIterator(iterable, (x) => x + x);
+    const doubles = mapAsyncIterable(iterable, (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -60,7 +60,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     const result = [];
     for await (const x of doubles) {
@@ -76,7 +76,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => Promise.resolve(x + x));
+    const doubles = mapAsyncIterable(source(), (x) => Promise.resolve(x + x));
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -100,7 +100,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -139,7 +139,7 @@ describe('mapAsyncIterator', () => {
       },
     };
 
-    const doubles = mapAsyncIterator(iterable, (x) => x + x);
+    const doubles = mapAsyncIterable(iterable, (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -164,7 +164,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 'aa', done: false });
     expect(await doubles.next()).to.deep.equal({ value: 'bb', done: false });
@@ -203,7 +203,7 @@ describe('mapAsyncIterator', () => {
       },
     };
 
-    const doubles = mapAsyncIterator(iterable, (x) => x + x);
+    const doubles = mapAsyncIterable(iterable, (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -231,7 +231,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -258,7 +258,7 @@ describe('mapAsyncIterator', () => {
       throw new Error('Goodbye');
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({
       value: 'HelloHello',
@@ -293,7 +293,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const throwOver1 = mapAsyncIterator(source(), mapper);
+    const throwOver1 = mapAsyncIterable(source(), mapper);
 
     expect(await throwOver1.next()).to.deep.equal({ value: 1, done: false });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -51,7 +51,7 @@ import {
   collectFields,
   collectSubfields as _collectSubfields,
 } from './collectFields';
-import { mapAsyncIterator } from './mapAsyncIterator';
+import { mapAsyncIterable } from './mapAsyncIterable';
 import { getArgumentValues, getVariableValues } from './values';
 
 /* eslint-disable max-params */
@@ -1143,7 +1143,7 @@ function mapSourceToResponse(
   // the GraphQL specification. The `execute` function provides the
   // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
   // "ExecuteQuery" algorithm, for which `execute` is also used.
-  return mapAsyncIterator(resultOrStream, (payload: unknown) =>
+  return mapAsyncIterable(resultOrStream, (payload: unknown) =>
     executeImpl(buildPerEventExecutionContext(exeContext, payload)),
   );
 }

--- a/src/execution/mapAsyncIterable.ts
+++ b/src/execution/mapAsyncIterable.ts
@@ -4,7 +4,7 @@ import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
  * Given an AsyncIterable and a callback function, return an AsyncIterator
  * which produces values mapped via calling the callback function.
  */
-export function mapAsyncIterator<T, U, R = undefined>(
+export function mapAsyncIterable<T, U, R = undefined>(
   iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
   callback: (value: T) => PromiseOrValue<U>,
 ): AsyncGenerator<U, R, void> {


### PR DESCRIPTION
1. rename to mapAsyncIterable => to better reflect function argument
2. use `expectPromise` in tests

extracted from #3694