### PR TITLE
resources: merge execOutput and exec into single function

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -5,7 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as url from 'node:url';
 
-import { exec, execOutput, localRepoPath } from './utils';
+import { exec, localRepoPath } from './utils';
 
 const NS_PER_SEC = 1e9;
 const LOCAL = 'local';
@@ -77,7 +77,7 @@ function prepareBenchmarkProjects(
     }
 
     // Returns the complete git hash for a given git revision reference.
-    const hash = execOutput(`git rev-parse "${revision}"`);
+    const hash = exec(`git rev-parse "${revision}"`);
 
     const archivePath = path.join(tmpDir, `graphql-${hash}.tgz`);
     if (fs.existsSync(archivePath)) {
@@ -99,7 +99,7 @@ function prepareBenchmarkProjects(
     exec('npm --quiet run build:npm', { cwd: repoDir });
 
     const distDir = path.join(repoDir, 'npmDist');
-    const archiveName = execOutput(`npm --quiet pack ${distDir}`, {
+    const archiveName = exec(`npm --quiet pack ${distDir}`, {
       cwd: repoDir,
     });
     return path.join(repoDir, archiveName);

--- a/resources/diff-npm-package.ts
+++ b/resources/diff-npm-package.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { exec, execOutput, localRepoPath, writeGeneratedFile } from './utils';
+import { exec, localRepoPath, writeGeneratedFile } from './utils';
 
 const LOCAL = 'local';
 const tmpDir = path.join(os.tmpdir(), 'graphql-js-npm-diff');
@@ -27,7 +27,7 @@ console.log(`📦 Building NPM package for ${toRevision}...`);
 const toPackage = prepareNPMPackage(toRevision);
 
 console.log('➖➕ Generating diff...');
-const diff = execOutput(`npm diff --diff=${fromPackage} --diff=${toPackage}`);
+const diff = exec(`npm diff --diff=${fromPackage} --diff=${toPackage}`);
 
 if (diff === '') {
   console.log('No changes found!');
@@ -83,7 +83,7 @@ function prepareNPMPackage(revision: string): string {
   }
 
   // Returns the complete git hash for a given git revision reference.
-  const hash = execOutput(`git rev-parse "${revision}"`);
+  const hash = exec(`git rev-parse "${revision}"`);
   assert(hash != null);
 
   const repoDir = path.join(tmpDir, hash);

--- a/resources/gen-changelog.ts
+++ b/resources/gen-changelog.ts
@@ -1,4 +1,4 @@
-import { execOutput, readPackageJSON } from './utils';
+import { exec, readPackageJSON } from './utils';
 
 const packageJSON = readPackageJSON();
 const labelsConfig: { [label: string]: { section: string; fold?: boolean } } = {
@@ -64,19 +64,15 @@ function getChangeLog(): Promise<string> {
   const { version } = packageJSON;
 
   let tag: string | null = null;
-  let commitsList = execOutput(`git rev-list --reverse v${version}..`);
+  let commitsList = exec(`git rev-list --reverse v${version}..`);
   if (commitsList === '') {
-    const parentPackageJSON = execOutput(
-      'git cat-file blob HEAD~1:package.json',
-    );
+    const parentPackageJSON = exec('git cat-file blob HEAD~1:package.json');
     const parentVersion = JSON.parse(parentPackageJSON).version;
-    commitsList = execOutput(
-      `git rev-list --reverse v${parentVersion}..HEAD~1`,
-    );
+    commitsList = exec(`git rev-list --reverse v${parentVersion}..HEAD~1`);
     tag = `v${version}`;
   }
 
-  const date = execOutput('git log -1 --format=%cd --date=short');
+  const date = exec('git log -1 --format=%cd --date=short');
   return getCommitsInfo(commitsList.split('\n'))
     .then((commitsInfo) => getPRsInfo(commitsInfoToPRs(commitsInfo)))
     .then((prsInfo) => genChangeLog(tag, date, prsInfo));

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -9,18 +9,15 @@ export function localRepoPath(...paths: ReadonlyArray<string>): string {
   return path.join(__dirname, '..', ...paths);
 }
 
-export function exec(command: string, options?: { cwd: string }): void {
-  childProcess.execSync(command, options);
-}
-
-export function execOutput(command: string, options?: { cwd: string }): string {
+type ExecOptions = Parameters<typeof childProcess.execSync>[1];
+export function exec(command: string, options?: ExecOptions): string {
   const output = childProcess.execSync(command, {
     maxBuffer: 10 * 1024 * 1024, // 10MB
     stdio: ['inherit', 'pipe', 'inherit'],
     encoding: 'utf-8',
     ...options,
   });
-  return output.trimEnd();
+  return output.toString().trimEnd();
 }
 
 export function readdirRecursive(


### PR DESCRIPTION
Context: This code existed before we started to use TS for scripts and I
wrote it incorrectly assuming that not every `exec` call will return
string.
Also improved a typing for `options` arguments reusing type from
`@types/node`.