### PR TITLE
ci: Add CodeQL analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,25 @@ jobs:
       - name: Run Tests with coverage
         run: npm run testonly:cover
 
+  codeql:
+    name: Run CodeQL security scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: 'javascript, typescript'
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v2
+
   build-npm-dist:
     name: Build 'npmDist' artifact
     runs-on: ubuntu-latest


### PR DESCRIPTION
Motivation: codeql are quite popular now, moreover various projects use it
as metric on how secure certain OSS project is. Example: https://github.com/
ossf/scorecard/blob/main/docs/checks.md#sast
Also, it can uncover some real security issues both in our sorce code and GitHub
workflows.

So I don't see a lot of harm by enabling it, we can always ignore certain files
or disable it completely.

Fixes #3162