### PR TITLE
Parser: allow 'options' to explicitly accept undefined

### DIFF
--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -102,7 +102,7 @@ export interface ParseOptions {
  */
 export function parse(
   source: string | Source,
-  options?: ParseOptions,
+  options?: ParseOptions | undefined,
 ): DocumentNode {
   const parser = new Parser(source, options);
   return parser.parseDocument();
@@ -120,7 +120,7 @@ export function parse(
  */
 export function parseValue(
   source: string | Source,
-  options?: ParseOptions,
+  options?: ParseOptions | undefined,
 ): ValueNode {
   const parser = new Parser(source, options);
   parser.expectToken(TokenKind.SOF);
@@ -135,7 +135,7 @@ export function parseValue(
  */
 export function parseConstValue(
   source: string | Source,
-  options?: ParseOptions,
+  options?: ParseOptions | undefined,
 ): ConstValueNode {
   const parser = new Parser(source, options);
   parser.expectToken(TokenKind.SOF);
@@ -156,7 +156,7 @@ export function parseConstValue(
  */
 export function parseType(
   source: string | Source,
-  options?: ParseOptions,
+  options?: ParseOptions | undefined,
 ): TypeNode {
   const parser = new Parser(source, options);
   parser.expectToken(TokenKind.SOF);
@@ -177,10 +177,10 @@ export function parseType(
  * @internal
  */
 export class Parser {
-  protected _options: Maybe<ParseOptions>;
+  protected _options: ParseOptions;
   protected _lexer: Lexer;
 
-  constructor(source: string | Source, options?: ParseOptions) {
+  constructor(source: string | Source, options: ParseOptions = {}) {
     const sourceObj = isSource(source) ? source : new Source(source);
 
     this._lexer = new Lexer(sourceObj);
@@ -510,7 +510,7 @@ export class Parser {
     // Legacy support for defining variables within fragments changes
     // the grammar of FragmentDefinition:
     //   - fragment FragmentName VariableDefinitions? on TypeCondition Directives? SelectionSet
-    if (this._options?.allowLegacyFragmentVariables === true) {
+    if (this._options.allowLegacyFragmentVariables === true) {
       return this.node<FragmentDefinitionNode>(start, {
         kind: Kind.FRAGMENT_DEFINITION,
         name: this.parseFragmentName(),
@@ -1387,7 +1387,7 @@ export class Parser {
    * given parsed object.
    */
   node<T extends { loc?: Location }>(startToken: Token, node: T): T {
-    if (this._options?.noLocation !== true) {
+    if (this._options.noLocation !== true) {
       node.loc = new Location(
         startToken,
         this._lexer.lastToken,


### PR DESCRIPTION
Backport of #3678
Basically allow to have code like this:
```js
parse(document, GraphQLServerConfig.parserOptions)
```
to pass TS check with 'exactOptionalPropertyTypes'