### PR TITLE
defer/stream: split incremental delivery into new entry points

### DIFF
--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1,9 +1,8 @@
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON';
+import { expectPromise } from '../../__testUtils__/expectPromise';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick';
-
-import { isAsyncIterable } from '../../jsutils/isAsyncIterable';
 
 import type { DocumentNode } from '../../language/ast';
 import { parse } from '../../language/parser';
@@ -16,7 +15,11 @@ import {
 import { GraphQLID, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
-import { execute } from '../execute';
+import type {
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
+} from '../execute';
+import { execute, experimentalExecuteIncrementally } from '../execute';
 
 const friendType = new GraphQLObjectType({
   fields: {
@@ -77,23 +80,25 @@ const query = new GraphQLObjectType({
   name: 'Query',
 });
 
-async function complete(document: DocumentNode) {
-  const schema = new GraphQLSchema({ query });
+const schema = new GraphQLSchema({ query });
 
-  const result = await execute({
+async function complete(document: DocumentNode) {
+  const result = await experimentalExecuteIncrementally({
     schema,
     document,
     rootValue: {},
   });
 
-  if (isAsyncIterable(result)) {
-    const results = [];
-    for await (const patch of result) {
+  if ('initialResult' in result) {
+    const results: Array<
+      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+    > = [result.initialResult];
+    for await (const patch of result.subsequentResults) {
       results.push(patch);
     }
     return results;
   }
-  return result;
+  return result.singleResult;
 }
 
 describe('Execute: defer directive', () => {
@@ -669,5 +674,22 @@ describe('Execute: defer directive', () => {
         hasNext: false,
       },
     ]);
+  });
+
+  it('original execute function errors if anything is deferred', async () => {
+    const doc = `
+    query Deferred {
+      ... @defer { hero { id } }
+    }
+  `;
+    await expectPromise(
+      execute({
+        schema,
+        document: parse(doc),
+        rootValue: {},
+      }),
+    ).toRejectWith(
+      'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)',
+    );
   });
 });

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON';
 
+import type { PromiseOrValue } from '../../jsutils/PromiseOrValue';
+
 import { parse } from '../../language/parser';
 
 import type { GraphQLFieldResolver } from '../../type/definition';
@@ -87,7 +89,7 @@ describe('Execute: Accepts async iterables as list value', () => {
 
   function completeObjectList(
     resolve: GraphQLFieldResolver<{ index: number }, unknown>,
-  ): Promise<ExperimentalExecuteIncrementallyResults> {
+  ): PromiseOrValue<ExperimentalExecuteIncrementallyResults> {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -14,12 +14,8 @@ import { GraphQLSchema } from '../../type/schema';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
 
-import type { ExperimentalExecuteIncrementallyResults } from '../execute';
-import {
-  execute,
-  executeSync,
-  experimentalExecuteIncrementally,
-} from '../execute';
+import type { ExecutionResult } from '../execute';
+import { execute, executeSync } from '../execute';
 
 describe('Execute: Accepts any iterable as list value', () => {
   function complete(rootValue: unknown) {
@@ -89,7 +85,7 @@ describe('Execute: Accepts async iterables as list value', () => {
 
   function completeObjectList(
     resolve: GraphQLFieldResolver<{ index: number }, unknown>,
-  ): PromiseOrValue<ExperimentalExecuteIncrementallyResults> {
+  ): PromiseOrValue<ExecutionResult> {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
@@ -115,7 +111,7 @@ describe('Execute: Accepts async iterables as list value', () => {
         },
       }),
     });
-    return experimentalExecuteIncrementally({
+    return execute({
       schema,
       document: parse('{ listField { index } }'),
     });
@@ -193,9 +189,7 @@ describe('Execute: Accepts async iterables as list value', () => {
     expectJSON(
       await completeObjectList(({ index }) => Promise.resolve(index)),
     ).toDeepEqual({
-      singleResult: {
-        data: { listField: [{ index: '0' }, { index: '1' }, { index: '2' }] },
-      },
+      data: { listField: [{ index: '0' }, { index: '1' }, { index: '2' }] },
     });
   });
 
@@ -208,16 +202,14 @@ describe('Execute: Accepts async iterables as list value', () => {
         return Promise.resolve(index);
       }),
     ).toDeepEqual({
-      singleResult: {
-        data: { listField: [{ index: '0' }, { index: '1' }, { index: null }] },
-        errors: [
-          {
-            message: 'bad',
-            locations: [{ line: 1, column: 15 }],
-            path: ['listField', 2, 'index'],
-          },
-        ],
-      },
+      data: { listField: [{ index: '0' }, { index: '1' }, { index: null }] },
+      errors: [
+        {
+          message: 'bad',
+          locations: [{ line: 1, column: 15 }],
+          path: ['listField', 2, 'index'],
+        },
+      ],
     });
   });
   it('Handles nulls yielded by async generator', async () => {

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -4,15 +4,17 @@ import { describe, it } from 'mocha';
 import { expectJSON } from '../../__testUtils__/expectJSON';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick';
 
-import { isAsyncIterable } from '../../jsutils/isAsyncIterable';
-
 import { parse } from '../../language/parser';
 
 import { GraphQLObjectType } from '../../type/definition';
 import { GraphQLInt } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
-import { execute, executeSync } from '../execute';
+import {
+  execute,
+  executeSync,
+  experimentalExecuteIncrementally,
+} from '../execute';
 
 class NumberHolder {
   theNumber: number;
@@ -216,15 +218,16 @@ describe('Execute: Handles mutation execution ordering', () => {
     `);
 
     const rootValue = new Root(6);
-    const mutationResult = await execute({
+    const mutationResult = await experimentalExecuteIncrementally({
       schema,
       document,
       rootValue,
     });
     const patches = [];
 
-    assert(isAsyncIterable(mutationResult));
-    for await (const patch of mutationResult) {
+    assert('initialResult' in mutationResult);
+    patches.push(mutationResult.initialResult);
+    for await (const patch of mutationResult.subsequentResults) {
       patches.push(patch);
     }
 
@@ -291,15 +294,16 @@ describe('Execute: Handles mutation execution ordering', () => {
     `);
 
     const rootValue = new Root(6);
-    const mutationResult = await execute({
+    const mutationResult = await experimentalExecuteIncrementally({
       schema,
       document,
       rootValue,
     });
     const patches = [];
 
-    assert(isAsyncIterable(mutationResult));
-    for await (const patch of mutationResult) {
+    assert('initialResult' in mutationResult);
+    patches.push(mutationResult.initialResult);
+    for await (const patch of mutationResult.subsequentResults) {
       patches.push(patch);
     }
 

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -13,7 +13,7 @@ import { GraphQLSchema } from '../../type/schema';
 
 import { buildSchema } from '../../utilities/buildASTSchema';
 
-import type { AsyncExecutionResult, ExecutionResult } from '../execute';
+import type { ExecutionResult } from '../execute';
 import { execute, executeSync } from '../execute';
 
 const syncError = new Error('sync');
@@ -111,9 +111,7 @@ const schema = buildSchema(`
 function executeQuery(
   query: string,
   rootValue: unknown,
-): PromiseOrValue<
-  ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
-> {
+): PromiseOrValue<ExecutionResult> {
   return execute({ schema, document: parse(query), rootValue });
 }
 

--- a/src/execution/__tests__/simplePubSub.ts
+++ b/src/execution/__tests__/simplePubSub.ts
@@ -51,6 +51,7 @@ export class SimplePubSub<T> {
         emptyQueue();
         return Promise.resolve({ value: undefined, done: true });
       },
+      /* c8 ignore next 4 */
       throw(error: unknown) {
         emptyQueue();
         return Promise.reject(error);

--- a/src/execution/__tests__/simplePubSub.ts
+++ b/src/execution/__tests__/simplePubSub.ts
@@ -51,7 +51,6 @@ export class SimplePubSub<T> {
         emptyQueue();
         return Promise.resolve({ value: undefined, done: true });
       },
-      /* c8 ignore next 4 */
       throw(error: unknown) {
         emptyQueue();
         return Promise.reject(error);

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -17,7 +17,11 @@ import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
 import type { ExecutionArgs, ExecutionResult } from '../execute';
-import { createSourceEventStream, subscribe } from '../execute';
+import {
+  createSourceEventStream,
+  experimentalSubscribeIncrementally,
+  subscribe,
+} from '../execute';
 
 import { SimplePubSub } from './simplePubSub';
 
@@ -91,6 +95,7 @@ const emailSchema = new GraphQLSchema({
 function createSubscription(
   pubsub: SimplePubSub<Email>,
   variableValues?: { readonly [variable: string]: unknown },
+  originalSubscribe: boolean = false,
 ) {
   const document = parse(`
     subscription ($priority: Int = 0, $shouldDefer: Boolean = false, $asyncResolver: Boolean = false) {
@@ -136,7 +141,7 @@ function createSubscription(
     }),
   };
 
-  return subscribe({
+  return (originalSubscribe ? subscribe : experimentalSubscribeIncrementally)({
     schema: emailSchema,
     document,
     rootValue: data,
@@ -827,6 +832,75 @@ describe('Subscription Publish Phase', () => {
 
     // Awaiting a subscription after closing it results in completed results.
     expect(await subscription.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('original subscribe function returns errors with @defer', async () => {
+    const pubsub = new SimplePubSub<Email>();
+    const subscription = await createSubscription(
+      pubsub,
+      {
+        shouldDefer: true,
+      },
+      true,
+    );
+    assert(isAsyncIterable(subscription));
+    // Wait for the next subscription payload.
+    const payload = subscription.next();
+
+    // A new email arrives!
+    expect(
+      pubsub.emit({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright',
+        message: 'Tests are good',
+        unread: true,
+      }),
+    ).to.equal(true);
+
+    const errorPayload = {
+      done: false,
+      value: {
+        errors: [
+          {
+            message:
+              'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)',
+          },
+        ],
+      },
+    };
+
+    // The previously waited on payload now has a value.
+    expectJSON(await payload).toDeepEqual(errorPayload);
+
+    // Wait for the next payload from @defer
+    expectJSON(await subscription.next()).toDeepEqual(errorPayload);
+
+    // Another new email arrives, after all incrementally delivered payloads are received.
+    expect(
+      pubsub.emit({
+        from: 'hyo@graphql.org',
+        subject: 'Tools',
+        message: 'I <3 making things',
+        unread: true,
+      }),
+    ).to.equal(true);
+
+    // The next waited on payload will have a value.
+    expectJSON(await subscription.next()).toDeepEqual(errorPayload);
+    // The next waited on payload will have a value.
+    expectJSON(await subscription.next()).toDeepEqual(errorPayload);
+
+    // The client disconnects before the deferred payload is consumed.
+    expectJSON(await subscription.return()).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+
+    // Awaiting a subscription after closing it results in completed results.
+    expectJSON(await subscription.next()).toDeepEqual({
       done: true,
       value: undefined,
     });

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1459,19 +1459,92 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
  * is not an async iterable.
  *
  * If the client-provided arguments to this function do not result in a
- * compliant subscription, a GraphQL Response (ExecutionResult) with
- * descriptive errors and no data will be returned.
+ * compliant subscription, a GraphQL Response (ExecutionResult) with descriptive
+ * errors and no data will be returned.
  *
- * If the source stream could not be created due to faulty subscription
- * resolver logic or underlying systems, the promise will resolve to a single
+ * If the source stream could not be created due to faulty subscription resolver
+ * logic or underlying systems, the promise will resolve to a single
  * ExecutionResult containing `errors` and no `data`.
  *
  * If the operation succeeded, the promise resolves to an AsyncIterator, which
  * yields a stream of ExecutionResults representing the response stream.
  *
- * Accepts either an object with named arguments, or individual arguments.
+ * This function does not support incremental delivery (`@defer` and `@stream`).
+ * If an operation which would defer or stream data is executed with this
+ * function, each `InitialIncrementalExecutionResult` and
+ * `SubsequentIncrementalExecutionResult` in the result stream will be replaced
+ * with an `ExecutionResult` with a single error stating that defer/stream is
+ * not supported.  Use `experimentalSubscribeIncrementally` if you want to
+ * support incremental delivery.
+ *
+ * Accepts an object with named arguments.
  */
 export function subscribe(
+  args: ExecutionArgs,
+): PromiseOrValue<
+  AsyncGenerator<ExecutionResult, void, void> | ExecutionResult
+> {
+  const maybePromise = experimentalSubscribeIncrementally(args);
+  if (isPromise(maybePromise)) {
+    return maybePromise.then((resultOrIterable) =>
+      isAsyncIterable(resultOrIterable)
+        ? mapAsyncIterable(resultOrIterable, ensureSingleExecutionResult)
+        : resultOrIterable,
+    );
+  }
+  return isAsyncIterable(maybePromise)
+    ? mapAsyncIterable(maybePromise, ensureSingleExecutionResult)
+    : maybePromise;
+}
+
+function ensureSingleExecutionResult(
+  result:
+    | ExecutionResult
+    | InitialIncrementalExecutionResult
+    | SubsequentIncrementalExecutionResult,
+): ExecutionResult {
+  if ('hasNext' in result) {
+    return {
+      errors: [new GraphQLError(UNEXPECTED_MULTIPLE_PAYLOADS)],
+    };
+  }
+  return result;
+}
+
+/**
+ * Implements the "Subscribe" algorithm described in the GraphQL specification,
+ * including `@defer` and `@stream` as proposed in
+ * https://github.com/graphql/graphql-spec/pull/742
+ *
+ * Returns a Promise which resolves to either an AsyncIterator (if successful)
+ * or an ExecutionResult (error). The promise will be rejected if the schema or
+ * other arguments to this function are invalid, or if the resolved event stream
+ * is not an async iterable.
+ *
+ * If the client-provided arguments to this function do not result in a
+ * compliant subscription, a GraphQL Response (ExecutionResult) with descriptive
+ * errors and no data will be returned.
+ *
+ * If the source stream could not be created due to faulty subscription resolver
+ * logic or underlying systems, the promise will resolve to a single
+ * ExecutionResult containing `errors` and no `data`.
+ *
+ * If the operation succeeded, the promise resolves to an AsyncIterator, which
+ * yields a stream of result representing the response stream.
+ *
+ * Each result may be an ExecutionResult with no `hasNext` (if executing the
+ * event did not use `@defer` or `@stream`), or an
+ * `InitialIncrementalExecutionResult` or `SubsequentIncrementalExecutionResult`
+ * (if executing the event used `@defer` or `@stream`). In the case of
+ * incremental execution results, each event produces a single
+ * `InitialIncrementalExecutionResult` followed by one or more
+ * `SubsequentIncrementalExecutionResult`s; all but the last have `hasNext: true`,
+ * and the last has `hasNext: false`. There is no interleaving between results
+ * generated from the same original event.
+ *
+ * Accepts an object with named arguments.
+ */
+export function experimentalSubscribeIncrementally(
   args: ExecutionArgs,
 ): PromiseOrValue<
   | AsyncGenerator<

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -170,6 +170,8 @@ export interface InitialIncrementalExecutionResult<
   TExtensions = ObjMap<unknown>,
 > extends ExecutionResult<TData, TExtensions> {
   hasNext: boolean;
+  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  extensions?: TExtensions;
 }
 
 export interface FormattedInitialIncrementalExecutionResult<
@@ -177,6 +179,8 @@ export interface FormattedInitialIncrementalExecutionResult<
   TExtensions = ObjMap<unknown>,
 > extends FormattedExecutionResult<TData, TExtensions> {
   hasNext: boolean;
+  incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
+  extensions?: TExtensions;
 }
 
 export interface SubsequentIncrementalExecutionResult<
@@ -185,6 +189,7 @@ export interface SubsequentIncrementalExecutionResult<
 > {
   hasNext: boolean;
   incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  extensions?: TExtensions;
 }
 
 export interface FormattedSubsequentIncrementalExecutionResult<
@@ -193,6 +198,7 @@ export interface FormattedSubsequentIncrementalExecutionResult<
 > {
   hasNext: boolean;
   incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
+  extensions?: TExtensions;
 }
 
 export interface IncrementalDeferResult<

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3,10 +3,12 @@ export { pathToArray as responsePathAsArray } from '../jsutils/Path';
 export {
   createSourceEventStream,
   execute,
+  experimentalExecuteIncrementally,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,
+  experimentalSubscribeIncrementally,
 } from './execute';
 
 export type {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -12,12 +12,18 @@ export {
 export type {
   ExecutionArgs,
   ExecutionResult,
-  FormattedExecutionResult,
-  SubsequentExecutionResult,
+  ExperimentalExecuteIncrementallyResults,
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
   IncrementalDeferResult,
   IncrementalStreamResult,
   IncrementalResult,
-  AsyncExecutionResult,
+  FormattedExecutionResult,
+  FormattedInitialIncrementalExecutionResult,
+  FormattedSubsequentIncrementalExecutionResult,
+  FormattedIncrementalDeferResult,
+  FormattedIncrementalStreamResult,
+  FormattedIncrementalResult,
 } from './execute';
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,6 +319,7 @@ export type {
 // Execute GraphQL queries.
 export {
   execute,
+  experimentalExecuteIncrementally,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
@@ -327,6 +328,7 @@ export {
   getVariableValues,
   getDirectiveValues,
   subscribe,
+  experimentalSubscribeIncrementally,
   createSourceEventStream,
 } from './execution/index';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,12 +333,18 @@ export {
 export type {
   ExecutionArgs,
   ExecutionResult,
-  FormattedExecutionResult,
-  SubsequentExecutionResult,
+  ExperimentalExecuteIncrementallyResults,
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
   IncrementalDeferResult,
   IncrementalStreamResult,
   IncrementalResult,
-  AsyncExecutionResult,
+  FormattedExecutionResult,
+  FormattedInitialIncrementalExecutionResult,
+  FormattedSubsequentIncrementalExecutionResult,
+  FormattedIncrementalDeferResult,
+  FormattedIncrementalStreamResult,
+  FormattedIncrementalResult,
 } from './execution/index';
 
 // Validate GraphQL documents.


### PR DESCRIPTION
This PR changes the `execute`, `subscribe`, and `graphql` APIs on the
`defer-stream` branch back to having the same API as on `main`: they can only
produce a single `ExecutionResult` (or a stream of `ExecutionResult`s for
`subscribe`) which never has a `hasNext` field, and do not support incremental
delivery.

Incremental delivery is now provided by the new entry points
`experimentalExecuteIncrementally` and `experimentalSubscribeIncrementally`. (We
will remove "experimental" once the proposal has been merged into the GraphQL
spec.)

This will make upgrading to graphql@17 easier, and increases the clarity
of return types.

Use distinct types for "the only result of a single-payload execution",
"the first payload of a multi-payload execution", and "subsequent
payloads of a multi-payload execution", since the data structures are
different. (Multi-payload executions *always* have at least one payload,
and the structure differs, which is why the new types separate the
initial result from subsequent results.)

Namely, single results have no `hasNext` field; initial results have `hasNext`
and may combine `data`/`errors` with `incremental`; and subsequent results have
`hasNext` and `incremental`.

Note that with the previous types, you actually had to use a function
with a type guard like `isAsyncIterable`: you couldn't just write `if
(Symbol.asyncIterator in result)`. I think both explicitly separating
the first (differently-typed) element from the rest of the elements
*and* making it possible to differentiate the types with a simple `in`
check are improvements. Additionally, somebody using the API in
JavaScript who doesn't realize that there is new functionality available
who is confused that the result no longer has `data`/`errors` fields can
just print out the result and see and search for the terms
`initialResult` and `subsequentResults` instead of only seeing iterator
internals.

Fix `Formatted*Result` types to use `GraphQLFormattedError` rather than
`GraphQLError` for `errors` nested inside `incremental`.
