### PR TITLE
resources: replace execSync with spawnSync

### DIFF
--- a/resources/gen-changelog.ts
+++ b/resources/gen-changelog.ts
@@ -1,4 +1,4 @@
-import { exec, readPackageJSON } from './utils';
+import { git, readPackageJSON } from './utils';
 
 const packageJSON = readPackageJSON();
 const labelsConfig: { [label: string]: { section: string; fold?: boolean } } = {
@@ -64,15 +64,15 @@ function getChangeLog(): Promise<string> {
   const { version } = packageJSON;
 
   let tag: string | null = null;
-  let commitsList = exec(`git rev-list --reverse v${version}..`);
+  let commitsList = git(['rev-list', '--reverse', `v${version}..`]);
   if (commitsList === '') {
-    const parentPackageJSON = exec('git cat-file blob HEAD~1:package.json');
+    const parentPackageJSON = git(['cat-file', 'blob', 'HEAD~1:package.json']);
     const parentVersion = JSON.parse(parentPackageJSON).version;
-    commitsList = exec(`git rev-list --reverse v${parentVersion}..HEAD~1`);
+    commitsList = git(['rev-list', '--reverse', `v${parentVersion}..HEAD~1`]);
     tag = `v${version}`;
   }
 
-  const date = exec('git log -1 --format=%cd --date=short');
+  const date = git(['log', '-1', '--format=%cd', '--date=short']);
   return getCommitsInfo(commitsList.split('\n'))
     .then((commitsInfo) => getPRsInfo(commitsInfoToPRs(commitsInfo)))
     .then((prsInfo) => genChangeLog(tag, date, prsInfo));

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -9,15 +9,36 @@ export function localRepoPath(...paths: ReadonlyArray<string>): string {
   return path.join(__dirname, '..', ...paths);
 }
 
-type ExecOptions = Parameters<typeof childProcess.execSync>[1];
-export function exec(command: string, options?: ExecOptions): string {
-  const output = childProcess.execSync(command, {
+export function npm(
+  args: ReadonlyArray<string>,
+  options?: SpawnOptions,
+): string {
+  return spawn('npm', args, options);
+}
+
+export function git(
+  args: ReadonlyArray<string>,
+  options?: SpawnOptions,
+): string {
+  return spawn('git', args, options);
+}
+
+interface SpawnOptions {
+  cwd?: string;
+}
+
+function spawn(
+  command: string,
+  args: ReadonlyArray<string>,
+  options?: SpawnOptions,
+): string {
+  const result = childProcess.spawnSync(command, args, {
     maxBuffer: 10 * 1024 * 1024, // 10MB
     stdio: ['inherit', 'pipe', 'inherit'],
     encoding: 'utf-8',
     ...options,
   });
-  return output.toString().trimEnd();
+  return result.stdout.toString().trimEnd();
 }
 
 export function readdirRecursive(


### PR DESCRIPTION
Extracted from #3700

CodeQL correctly reported that we using user supplied data in our scripts
that can lead to shell injection.
Running those scripts on untrusted PRs both locally and on CI can be problematic
Note I reviewed all places and none of them can be exploited but it good practice
to switch to spawnSync if we can.
Aditional benefit it automatically solves all the issues with command arguments
being misenterpritade by the shell.