### PR TITLE
Fix crash in node when mixing sync/async resolvers

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -582,7 +582,7 @@ describe('Execute: Handles basic execution tasks', () => {
   });
 
   it('handles sync errors combined with rejections', async () => {
-    let isAsyncResolverCalled = false;
+    let isAsyncResolverFinished = false;
 
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -598,8 +598,8 @@ describe('Execute: Handles basic execution tasks', () => {
               await resolveOnNextTick();
               await resolveOnNextTick();
               await resolveOnNextTick();
-              isAsyncResolverCalled = true;
-              return Promise.resolve(null);
+              isAsyncResolverFinished = true;
+              return null;
             },
           },
         },
@@ -614,10 +614,10 @@ describe('Execute: Handles basic execution tasks', () => {
       }
     `);
 
-    const result = await execute({ schema, document });
+    const result = execute({ schema, document });
 
-    expect(isAsyncResolverCalled).to.equal(true);
-    expectJSON(result).toDeepEqual({
+    expect(isAsyncResolverFinished).to.equal(false);
+    expectJSON(await result).toDeepEqual({
       data: null,
       errors: [
         {
@@ -628,6 +628,7 @@ describe('Execute: Handles basic execution tasks', () => {
         },
       ],
     });
+    expect(isAsyncResolverFinished).to.equal(true);
   });
 
   it('Full response path is included for non-nullable fields', () => {

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import { inspect } from '../../jsutils/inspect.js';
 
@@ -575,6 +576,55 @@ describe('Execute: Handles basic execution tasks', () => {
           locations: [{ column: 9, line: 3 }],
           message: 'Oops',
           path: ['foods'],
+        },
+      ],
+    });
+  });
+
+  it('handles sync errors combined with rejections', async () => {
+    let isAsyncResolverCalled = false;
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          syncNullError: {
+            type: new GraphQLNonNull(GraphQLString),
+            resolve: () => null,
+          },
+          asyncNullError: {
+            type: new GraphQLNonNull(GraphQLString),
+            async resolve() {
+              await resolveOnNextTick();
+              await resolveOnNextTick();
+              await resolveOnNextTick();
+              isAsyncResolverCalled = true;
+              return Promise.resolve(null);
+            },
+          },
+        },
+      }),
+    });
+
+    // Order is important here, as the promise has to be created before the synchronous error is thrown
+    const document = parse(`
+      {
+        asyncNullError
+        syncNullError
+      }
+    `);
+
+    const result = await execute({ schema, document });
+
+    expect(isAsyncResolverCalled).to.equal(true);
+    expectJSON(result).toDeepEqual({
+      data: null,
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field Query.syncNullError.',
+          locations: [{ line: 4, column: 9 }],
+          path: ['syncNullError'],
         },
       ],
     });

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -623,23 +623,33 @@ function executeFields(
   const results = Object.create(null);
   let containsPromise = false;
 
-  for (const [responseName, fieldNodes] of fields) {
-    const fieldPath = addPath(path, responseName, parentType.name);
-    const result = executeField(
-      exeContext,
-      parentType,
-      sourceValue,
-      fieldNodes,
-      fieldPath,
-      asyncPayloadRecord,
-    );
+  try {
+    for (const [responseName, fieldNodes] of fields) {
+      const fieldPath = addPath(path, responseName, parentType.name);
+      const result = executeField(
+        exeContext,
+        parentType,
+        sourceValue,
+        fieldNodes,
+        fieldPath,
+        asyncPayloadRecord,
+      );
 
-    if (result !== undefined) {
-      results[responseName] = result;
-      if (isPromise(result)) {
-        containsPromise = true;
+      if (result !== undefined) {
+        results[responseName] = result;
+        if (isPromise(result)) {
+          containsPromise = true;
+        }
       }
     }
+  } catch (error) {
+    if (containsPromise) {
+      // Ensure that any promises returned by other fields are handled, as they may also reject.
+      return promiseForObject(results).finally(() => {
+        throw error;
+      });
+    }
+    throw error;
   }
 
   // If there are no promises, we can just return the object


### PR DESCRIPTION
Fixes #3528

Ensures that if `executeFields` encounters a mix of promises and thrown errors, the promises will be awaited before throwing the error.