### PR TITLE
defer/stream: fix flattenAsyncIterable concurrency

### DIFF
--- a/src/execution/flattenAsyncIterable.ts
+++ b/src/execution/flattenAsyncIterable.ts
@@ -1,49 +1,105 @@
-import { isAsyncIterable } from '../jsutils/isAsyncIterable';
-
 type AsyncIterableOrGenerator<T> =
   | AsyncGenerator<T, void, void>
   | AsyncIterable<T>;
 
 /**
- * Given an AsyncIterable that could potentially yield other async iterators,
- * flatten all yielded results into a single AsyncIterable
+ * Given an AsyncIterable of AsyncIterables, flatten all yielded results into a
+ * single AsyncIterable.
  */
-export function flattenAsyncIterable<T, AT>(
-  iterable: AsyncIterableOrGenerator<T | AsyncIterableOrGenerator<AT>>,
-): AsyncGenerator<T | AT, void, void> {
-  const iteratorMethod = iterable[Symbol.asyncIterator];
-  const iterator: any = iteratorMethod.call(iterable);
-  let iteratorStack: Array<AsyncIterator<T>> = [iterator];
+export function flattenAsyncIterable<T>(
+  iterable: AsyncIterableOrGenerator<AsyncIterableOrGenerator<T>>,
+): AsyncGenerator<T, void, void> {
+  // You might think this whole function could be replaced with
+  //
+  //    async function* flattenAsyncIterable(iterable) {
+  //      for await (const subIterator of iterable) {
+  //        yield* subIterator;
+  //      }
+  //    }
+  //
+  // but calling `.return()` on the iterator it returns won't interrupt the `for await`.
 
-  async function next(): Promise<IteratorResult<T | AT, void>> {
-    const currentIterator = iteratorStack[0];
-    if (!currentIterator) {
+  const topIterator = iterable[Symbol.asyncIterator]();
+  let currentNestedIterator: AsyncIterator<T> | undefined;
+  let waitForCurrentNestedIterator: Promise<void> | undefined;
+  let done = false;
+
+  async function next(): Promise<IteratorResult<T, void>> {
+    if (done) {
       return { value: undefined, done: true };
     }
-    const result = await currentIterator.next();
-    if (result.done) {
-      iteratorStack.shift();
-      return next();
-    } else if (isAsyncIterable(result.value)) {
-      const childIterator = result.value[
-        Symbol.asyncIterator
-      ]() as AsyncIterator<T>;
-      iteratorStack.unshift(childIterator);
-      return next();
+
+    try {
+      if (!currentNestedIterator) {
+        // Somebody else is getting it already.
+        if (waitForCurrentNestedIterator) {
+          await waitForCurrentNestedIterator;
+          return await next();
+        }
+        // Nobody else is getting it. We should!
+        let resolve: () => void;
+        waitForCurrentNestedIterator = new Promise<void>((r) => {
+          resolve = r;
+        });
+        const topIteratorResult = await topIterator.next();
+        if (topIteratorResult.done) {
+          // Given that done only ever transitions from false to true,
+          // require-atomic-updates is being unnecessarily cautious.
+          // eslint-disable-next-line require-atomic-updates
+          done = true;
+          return await next();
+        }
+        // eslint is making a reasonable point here, but we've explicitly protected
+        // ourself from the race condition by ensuring that only the single call
+        // that assigns to waitForCurrentNestedIterator is allowed to assign to
+        // currentNestedIterator or waitForCurrentNestedIterator.
+        // eslint-disable-next-line require-atomic-updates
+        currentNestedIterator = topIteratorResult.value[Symbol.asyncIterator]();
+        // eslint-disable-next-line require-atomic-updates
+        waitForCurrentNestedIterator = undefined;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        resolve!();
+        return await next();
+      }
+
+      const rememberCurrentNestedIterator = currentNestedIterator;
+      const nestedIteratorResult = await currentNestedIterator.next();
+      if (!nestedIteratorResult.done) {
+        return nestedIteratorResult;
+      }
+
+      // The nested iterator is done. If it's still the current one, make it not
+      // current. (If it's not the current one, somebody else has made us move on.)
+      if (currentNestedIterator === rememberCurrentNestedIterator) {
+        currentNestedIterator = undefined;
+      }
+      return await next();
+    } catch (err) {
+      done = true;
+      throw err;
     }
-    return result;
   }
   return {
     next,
-    return() {
-      iteratorStack = [];
-      return iterator.return();
+    async return() {
+      done = true;
+      await Promise.all([
+        currentNestedIterator?.return?.(),
+        topIterator.return?.(),
+      ]);
+      return { value: undefined, done: true };
     },
-    throw(error?: unknown): Promise<IteratorResult<T | AT>> {
-      iteratorStack = [];
-      return iterator.throw(error);
+    async throw(error?: unknown): Promise<IteratorResult<T>> {
+      done = true;
+      await Promise.all([
+        currentNestedIterator?.throw?.(error),
+        topIterator.throw?.(error),
+      ]);
+      /* c8 ignore next */
+      throw error;
     },
     [Symbol.asyncIterator]() {
+      /* c8 ignore next */
       return this;
     },
   };


### PR DESCRIPTION
Fixes the bug demonstrated in #3709 (which has already been incorporated
into the defer-stream branch).

This fix is extracted from #3703, which also updates the typing and API
around execute. This particular change doesn't affect the API (other
than making the `subscribe` return type more honest, as its returned
generator could yield AsyncExecutionResult before this change as well).