### PR TITLE
automatically optimize array-destructuring

### DIFF
--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import ts from 'typescript';
 
 import { inlineInvariant } from './inline-invariant.js';
+import { transformArrayDestructuring } from './transform-array-destruct.js'
 import {
   localRepoPath,
   readdirRecursive,
@@ -51,6 +52,7 @@ tsHost.writeFile = writeGeneratedFile;
 
 const tsProgram = ts.createProgram(['src/index.ts'], tsOptions, tsHost);
 const tsResult = tsProgram.emit(undefined, undefined, undefined, undefined, {
+  before: [transformArrayDestructuring()],
   after: [inlineInvariant],
 });
 assert(

--- a/resources/transform-array-destruct.ts
+++ b/resources/transform-array-destruct.ts
@@ -1,0 +1,34 @@
+import * as ts from 'typescript';
+
+export function transformArrayDestructuring() {
+  return (context: ts.TransformationContext) => {
+    const { factory } = context;
+
+    return (sourceFile: ts.SourceFile) => {
+      const visitor = (node: ts.Node): ts.Node => {
+        if(ts.isArrayBindingPattern(node)) {
+          const elements = node.elements.map((el, i) => {
+            if (!el.getText()) {
+              return undefined;
+            }
+            return { key: String(i), name: el.getText() }
+          }).filter(Boolean)
+
+          const els = elements.map(el => {
+            if (!el) {
+              return undefined;
+            }
+            const key = factory.createIdentifier(el.key)
+            const name = factory.createIdentifier(el.name)
+            return factory.createBindingElement(undefined, key, name)
+          }).filter(Boolean) as Array<ts.BindingElement>
+          return factory.createObjectBindingPattern(els)
+        }
+
+        return ts.visitEachChild(node, visitor, context);
+      };
+      return ts.visitNode(sourceFile, visitor);
+    };
+  };
+};
+

--- a/resources/transform-array-destruct.ts
+++ b/resources/transform-array-destruct.ts
@@ -6,23 +6,27 @@ export function transformArrayDestructuring() {
 
     return (sourceFile: ts.SourceFile) => {
       const visitor = (node: ts.Node): ts.Node => {
-        if(ts.isArrayBindingPattern(node)) {
-          const elements = node.elements.map((el, i) => {
-            if (!el.getText()) {
-              return undefined;
-            }
-            return { key: String(i), name: el.getText() }
-          }).filter(Boolean)
+        if (ts.isArrayBindingPattern(node)) {
+          const elements = node.elements
+            .map((el, i) => {
+              if (!el.getText()) {
+                return undefined;
+              }
+              return { key: String(i), name: el.getText() };
+            })
+            .filter(Boolean);
 
-          const els = elements.map(el => {
-            if (!el) {
-              return undefined;
-            }
-            const key = factory.createIdentifier(el.key)
-            const name = factory.createIdentifier(el.name)
-            return factory.createBindingElement(undefined, key, name)
-          }).filter(Boolean) as Array<ts.BindingElement>
-          return factory.createObjectBindingPattern(els)
+          const els = elements
+            .map((el) => {
+              if (!el) {
+                return undefined;
+              }
+              const key = factory.createIdentifier(el.key);
+              const name = factory.createIdentifier(el.name);
+              return factory.createBindingElement(undefined, key, name);
+            })
+            .filter(Boolean) as Array<ts.BindingElement>;
+          return factory.createObjectBindingPattern(els);
         }
 
         return ts.visitEachChild(node, visitor, context);
@@ -30,5 +34,4 @@ export function transformArrayDestructuring() {
       return ts.visitNode(sourceFile, visitor);
     };
   };
-};
-
+}


### PR DESCRIPTION
Follow up to my comment on https://github.com/graphql/graphql-js/pull/3691 this will automatically optimize cases where arrays are destructured.

Demo: https://astexplorer.net/#/gist/54f452efefc94d565223d4296a91172e/cd6121f8ee2a7d974f7e8ccecb4933ad70e82bdb