### PR TITLE
ci: Move 'integration-test.ts' into 'resources'

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prettier": "prettier --cache --cache-strategy metadata --write --list-different .",
     "prettier:check": "prettier --cache --cache-strategy metadata --check .",
     "check:spelling": "cspell --cache --no-progress '**/*'",
-    "check:integrations": "npm run build:npm && npm run build:deno && mocha --full-trace integrationTests/*-test.ts",
+    "check:integrations": "npm run build:npm && npm run build:deno && mocha --full-trace resources/integration-test.ts",
     "serve": "docusaurus serve --dir websiteDist/ --config website/docusaurus.config.cjs",
     "start": "npm run build:website && npm run serve",
     "build:website": "ts-node resources/build-docusaurus.ts",

--- a/resources/integration-test.ts
+++ b/resources/integration-test.ts
@@ -1,26 +1,17 @@
-import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
 import { describe, it } from 'mocha';
 
-function npm(args: ReadonlyArray<string>, options = {}): string {
-  const result = childProcess.spawnSync('npm', [...args], {
-    maxBuffer: 10 * 1024 * 1024, // 10MB
-    stdio: ['inherit', 'pipe', 'inherit'],
-    encoding: 'utf-8',
-    ...options,
-  });
-  return result.stdout.toString().trimEnd();
-}
+import { localRepoPath, npm } from './utils.js';
 
 describe('Integration Tests', () => {
   const tmpDir = path.join(os.tmpdir(), 'graphql-js-integrationTmp');
   fs.rmSync(tmpDir, { recursive: true, force: true });
   fs.mkdirSync(tmpDir);
 
-  const distDir = path.resolve('./npmDist');
+  const distDir = localRepoPath('npmDist');
   const archiveName = npm(['--quiet', 'pack', distDir], { cwd: tmpDir });
   fs.renameSync(
     path.join(tmpDir, archiveName),
@@ -28,7 +19,7 @@ describe('Integration Tests', () => {
   );
 
   function testOnNodeProject(projectName: string) {
-    const projectPath = new URL(projectName, import.meta.url).pathname;
+    const projectPath = localRepoPath('integrationTests', projectName);
 
     const packageJSONPath = path.join(projectPath, 'package.json');
     const packageJSON = JSON.parse(fs.readFileSync(packageJSONPath, 'utf-8'));


### PR DESCRIPTION
Motivation: allow to reuse more stuff from 'resources/utils.ts'
Working on rebasing #3361 that adds even more code into integrationTests
so want to keep it simple by reusing code from 'utils.ts'