### PR TITLE
original `execute` should throw if defer/stream directives are present

### DIFF
--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -723,21 +723,14 @@ describe('Execute: defer directive', () => {
       ... @defer { hero { id } }
     }
   `;
-    expectJSON(
-      await expectPromise(
-        execute({
-          schema,
-          document: parse(doc),
-          rootValue: {},
-        }),
-      ).toResolve(),
-    ).toDeepEqual({
-      errors: [
-        {
-          message:
-            'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)',
-        },
-      ],
-    });
+    await expectPromise(
+      execute({
+        schema,
+        document: parse(doc),
+        rootValue: {},
+      }),
+    ).toRejectWith(
+      'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)',
+    );
   });
 });

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -18,6 +18,10 @@ import {
   GraphQLUnionType,
 } from '../../type/definition.js';
 import {
+  GraphQLDeferDirective,
+  GraphQLStreamDirective,
+} from '../../type/directives.js';
+import {
   GraphQLBoolean,
   GraphQLInt,
   GraphQLString,
@@ -912,6 +916,40 @@ describe('Execute: Handles basic execution tasks', () => {
 
     const result = executeSync({ schema, document, rootValue, operationName });
     expect(result).to.deep.equal({ data: { a: 'b' } });
+  });
+
+  it('errors when using original execute with schemas including experimental @defer directive', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Q',
+        fields: {
+          a: { type: GraphQLString },
+        },
+      }),
+      directives: [GraphQLDeferDirective],
+    });
+    const document = parse('query Q { a }');
+
+    expect(() => execute({ schema, document })).to.throw(
+      'Use function `experimentalExecuteIncrementally` to execute operations against schemas that define the experimental @defer or @stream directives.',
+    );
+  });
+
+  it('errors when using original execute with schemas including experimental @stream directive', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Q',
+        fields: {
+          a: { type: GraphQLString },
+        },
+      }),
+      directives: [GraphQLStreamDirective],
+    });
+    const document = parse('query Q { a }');
+
+    expect(() => execute({ schema, document })).to.throw(
+      'Use function `experimentalExecuteIncrementally` to execute operations against schemas that define the experimental @defer or @stream directives.',
+    );
   });
 
   it('resolves to an error if schema does not support operation', () => {

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -931,7 +931,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse('query Q { a }');
 
     expect(() => execute({ schema, document })).to.throw(
-      'Use function `experimentalExecuteIncrementally` to execute operations against schemas that define the experimental @defer or @stream directives.',
+      'The provided schema unexpectedly contains experimental directives (@defer or @stream). These directives may only be utilized if experimental execution features are explicitly enabled.',
     );
   });
 
@@ -948,7 +948,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse('query Q { a }');
 
     expect(() => execute({ schema, document })).to.throw(
-      'Use function `experimentalExecuteIncrementally` to execute operations against schemas that define the experimental @defer or @stream directives.',
+      'The provided schema unexpectedly contains experimental directives (@defer or @stream). These directives may only be utilized if experimental execution features are explicitly enabled.',
     );
   });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -263,6 +263,9 @@ export interface ExecutionArgs {
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
 
+const UNEXPECTED_EXPERIMENTAL_DIRECTIVES =
+  'The provided schema unexpectedly contains experimental directives (@defer or @stream). These directives may only be utilized if experimental execution features are explicitly enabled.';
+
 const UNEXPECTED_MULTIPLE_PAYLOADS =
   'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)';
 
@@ -284,9 +287,7 @@ const UNEXPECTED_MULTIPLE_PAYLOADS =
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   if (args.schema.getDirective('defer') || args.schema.getDirective('stream')) {
-    throw new Error(
-      'Use function `experimentalExecuteIncrementally` to execute operations against schemas that define the experimental @defer or @stream directives.',
-    );
+    throw new Error(UNEXPECTED_EXPERIMENTAL_DIRECTIVES);
   }
 
   const result = experimentalExecuteIncrementally(args);

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -278,7 +278,7 @@ const UNEXPECTED_MULTIPLE_PAYLOADS =
  *
  * This function does not support incremental delivery (`@defer` and `@stream`).
  * If an operation which would defer or stream data is executed with this
- * function, it will throw or resolve to an object containing an error instead.
+ * function, it will throw or return a rejected promise.
  * Use `experimentalExecuteIncrementally` if you want to support incremental
  * delivery.
  */
@@ -293,9 +293,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
 
   return result.then((incrementalResult) => {
     if ('initialResult' in incrementalResult) {
-      return {
-        errors: [new GraphQLError(UNEXPECTED_MULTIPLE_PAYLOADS)],
-      };
+      throw new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
     }
     return incrementalResult;
   });


### PR DESCRIPTION
Currently, when the defer/stream directives are not present in the schema, defer/stream will not be triggered, and so the directives will be ignored even when used with the original function.

But -- if the directives are in the schema, the original functions will sometimes throw (if the first result from `execute` is synchronous), but sometimes return maps with errors (when the first result from `execute` is async or when any (sync or async) `subscribe` payload has incremental results.

This PR just aligns the behavior in terms of throwing or returning a map with errors. We really shouldn't return a map with errors after execution has begun.

I think another viable alternative that potentially makes more sense is to have the original `execute` and `subscribe` functions ignore the directives. To enable the experimental behavior, you would need to have the directives in the schema and use the experimental functions.

@glasser @robrichard @IvanGoncharov @n1ru4l