### PR TITLE
resources/utils.ts: npm/git will inherit stdout by default

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -57,7 +57,7 @@ function prepareBenchmarkProjects(
       path.join(projectPath, 'package.json'),
       JSON.stringify(packageJSON, null, 2),
     );
-    npm(['--quiet', 'install', '--ignore-scripts'], { cwd: projectPath });
+    npm({ cwd: projectPath, quiet: true }).install('--ignore-scripts');
 
     return { revision, projectPath };
   });
@@ -71,7 +71,7 @@ function prepareBenchmarkProjects(
     }
 
     // Returns the complete git hash for a given git revision reference.
-    const hash = git(['rev-parse', revision]);
+    const hash = git().revParse(revision);
 
     const archivePath = tmpDirPath(`graphql-${hash}.tgz`);
     if (fs.existsSync(archivePath)) {
@@ -81,21 +81,19 @@ function prepareBenchmarkProjects(
     const repoDir = tmpDirPath(hash);
     fs.rmSync(repoDir, { recursive: true, force: true });
     fs.mkdirSync(repoDir);
-    git(['clone', '--quiet', localRepoPath(), repoDir]);
-    git(['checkout', '--quiet', '--detach', hash], { cwd: repoDir });
-    npm(['--quiet', 'ci', '--ignore-scripts'], { cwd: repoDir });
+    git({ quiet: true }).clone(localRepoPath(), repoDir);
+    git({ cwd: repoDir, quiet: true }).checkout('--detach', hash);
+    npm({ cwd: repoDir, quiet: true }).ci('--ignore-scripts');
     fs.renameSync(buildNPMArchive(repoDir), archivePath);
     fs.rmSync(repoDir, { recursive: true });
     return archivePath;
   }
 
   function buildNPMArchive(repoDir: string) {
-    npm(['--quiet', 'run', 'build:npm'], { cwd: repoDir });
+    npm({ cwd: repoDir, quiet: true }).run('build:npm');
 
     const distDir = path.join(repoDir, 'npmDist');
-    const archiveName = npm(['--quiet', 'pack', distDir], {
-      cwd: repoDir,
-    });
+    const archiveName = npm({ cwd: repoDir, quiet: true }).pack(distDir);
     return path.join(repoDir, archiveName);
   }
 }

--- a/resources/build-docusaurus.ts
+++ b/resources/build-docusaurus.ts
@@ -17,22 +17,20 @@ copyToTmpDir('tsconfig.json');
 copyToTmpDir('src');
 copyToTmpDir('website');
 
-npm(['install', 'ci'], { cwd: tmpDirPath() });
+npm({ cwd: tmpDirPath(), quiet: true }).ci('--ignore-scripts');
 
 const env = {
   ...process.env,
   DOCUSAURUS_GENERATED_FILES_DIR_NAME: tmpDirPath('.docusaurus'),
 };
-const docusaurusArgs = [
+npm({ env, cwd: tmpDirPath() }).exec(
+  'docusaurus',
+  '--',
   'build',
   '--out-dir',
   localRepoPath('websiteDist'),
   tmpDirPath('website'),
-];
-npm(['exec', 'docusaurus', '--', ...docusaurusArgs], {
-  env,
-  cwd: tmpDirPath(),
-});
+);
 
 function copyToTmpDir(relativePath: string) {
   fs.cpSync(localRepoPath(relativePath), tmpDirPath(relativePath), {

--- a/resources/diff-npm-package.ts
+++ b/resources/diff-npm-package.ts
@@ -31,7 +31,7 @@ console.log(`📦 Building NPM package for ${toRevision}...`);
 const toPackage = prepareNPMPackage(toRevision);
 
 console.log('➖➕ Generating diff...');
-const diff = npm(['diff', '--diff', fromPackage, '--diff', toPackage]);
+const diff = npm().diff('--diff', fromPackage, '--diff', toPackage);
 
 if (diff === '') {
   console.log('No changes found!');
@@ -82,19 +82,19 @@ function generateReport(diffString: string): string {
 
 function prepareNPMPackage(revision: string): string {
   if (revision === LOCAL) {
-    npm(['--quiet', 'run', 'build:npm'], { cwd: localRepoPath() });
+    npm({ cwd: localRepoPath(), quiet: true }).run('build:npm');
     return localRepoPath('npmDist');
   }
 
   // Returns the complete git hash for a given git revision reference.
-  const hash = git(['rev-parse', revision]);
+  const hash = git().revParse(revision);
   assert(hash != null);
 
   const repoDir = tmpDirPath(hash);
   fs.rmSync(repoDir, { recursive: true, force: true });
   fs.mkdirSync(repoDir);
   childProcess.execSync(`git archive "${hash}" | tar -xC "${repoDir}"`);
-  npm(['--quiet', 'ci', '--ignore-scripts'], { cwd: repoDir });
-  npm(['--quiet', 'run', 'build:npm'], { cwd: repoDir });
+  npm({ cwd: repoDir, quiet: true }).ci('--ignore-scripts');
+  npm({ cwd: repoDir, quiet: true }).run('build:npm');
   return path.join(repoDir, 'npmDist');
 }

--- a/resources/gen-changelog.ts
+++ b/resources/gen-changelog.ts
@@ -64,15 +64,15 @@ function getChangeLog(): Promise<string> {
   const { version } = packageJSON;
 
   let tag: string | null = null;
-  let commitsList = git(['rev-list', '--reverse', `v${version}..`]);
+  let commitsList = git().revList('--reverse', `v${version}..`);
   if (commitsList === '') {
-    const parentPackageJSON = git(['cat-file', 'blob', 'HEAD~1:package.json']);
+    const parentPackageJSON = git().catFile('blob', 'HEAD~1:package.json');
     const parentVersion = JSON.parse(parentPackageJSON).version;
-    commitsList = git(['rev-list', '--reverse', `v${parentVersion}..HEAD~1`]);
+    commitsList = git().revList('--reverse', `v${parentVersion}..HEAD~1`);
     tag = `v${version}`;
   }
 
-  const date = git(['log', '-1', '--format=%cd', '--date=short']);
+  const date = git().log('-1', '--format=%cd', '--date=short');
   return getCommitsInfo(commitsList.split('\n'))
     .then((commitsInfo) => getPRsInfo(commitsInfoToPRs(commitsInfo)))
     .then((prsInfo) => genChangeLog(tag, date, prsInfo));

--- a/resources/integration-test.ts
+++ b/resources/integration-test.ts
@@ -10,12 +10,12 @@ describe('Integration Tests', () => {
     recursive: true,
   });
 
-  npm(['run', 'build:npm']);
+  npm().run('build:npm');
   const distDir = localRepoPath('npmDist');
-  const archiveName = npm(['--quiet', 'pack', distDir], { cwd: tmpDirPath() });
+  const archiveName = npm({ cwd: tmpDirPath(), quiet: true }).pack(distDir);
   fs.renameSync(tmpDirPath(archiveName), tmpDirPath('graphql.tgz'));
 
-  npm(['run', 'build:deno']);
+  npm().run('build:deno');
 
   function testOnNodeProject(projectName: string) {
     const projectPath = tmpDirPath(projectName);
@@ -23,8 +23,8 @@ describe('Integration Tests', () => {
 
     it(packageJSON.description, () => {
       // TODO: figure out a way to run it with --ignore-scripts
-      npm(['--quiet', 'install'], { cwd: projectPath });
-      npm(['--quiet', 'test'], { cwd: projectPath });
+      npm({ cwd: projectPath, quiet: true }).install();
+      npm({ cwd: projectPath, quiet: true }).run('test');
     }).timeout(120000);
   }
 


### PR DESCRIPTION
Motivation: it's hard to debug scripts if stdout is not inherit
at the same time we need to capture output of some git/npm commands.
AFAIK node.js doesn't allow both "inherit" and "pipe" stdout, so
instead we create wrapper for npm/git where subcommands that doesn't
return values just "inherit" stdout.