### PR TITLE
incrementalDelivery: use experimental options rather than experimental functions

### DIFF
--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -19,7 +19,7 @@ import type {
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,
 } from '../execute.js';
-import { execute, experimentalExecuteIncrementally } from '../execute.js';
+import { execute } from '../execute.js';
 
 const friendType = new GraphQLObjectType({
   fields: {
@@ -83,11 +83,16 @@ const query = new GraphQLObjectType({
 const schema = new GraphQLSchema({ query });
 
 async function complete(document: DocumentNode) {
-  const result = await experimentalExecuteIncrementally({
-    schema,
-    document,
-    rootValue: {},
-  });
+  const result = await execute(
+    {
+      schema,
+      document,
+      rootValue: {},
+    },
+    {
+      enableIncremental: true,
+    },
+  );
 
   if ('initialResult' in result) {
     const results: Array<
@@ -656,7 +661,7 @@ describe('Execute: defer directive', () => {
     ]);
   });
 
-  it('original execute function ignores defer if anything is deferred and everything else is sync', () => {
+  it('execute with enableIncremental set to false ignores defer if anything is deferred and everything else is sync', () => {
     const doc = `
     query Deferred {
       ... @defer { hero { id } }
@@ -675,7 +680,7 @@ describe('Execute: defer directive', () => {
     });
   });
 
-  it('original execute function ignores if anything is deferred and something else is async', async () => {
+  it('execute with enableIncremental set to false ignores if anything is deferred and something else is async', async () => {
     const doc = `
     query Deferred {
       hero { slowField }

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -25,16 +25,14 @@ import {
 import { GraphQLSchema } from '../../type/schema.js';
 
 import type { ExecutionArgs, ExecutionResult } from '../execute.js';
-import {
-  execute,
-  executeSync,
-  experimentalExecuteIncrementallySync,
-} from '../execute.js';
+import { execute, executeSync } from '../execute.js';
 
 function executeSyncWithBadArgs(args: ExecutionArgs): ExecutionResult {
   return expectMatchingValues([
     executeSync(args),
-    experimentalExecuteIncrementallySync(args),
+    executeSync(args, {
+      enableIncremental: true,
+    }),
   ]);
 }
 

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { expectMatchingValues } from '../../__testUtils__/expectMatchingValues.js';
 
 import { inspect } from '../../jsutils/inspect.js';
 
@@ -23,7 +24,19 @@ import {
 } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { execute, executeSync } from '../execute.js';
+import type { ExecutionArgs, ExecutionResult } from '../execute.js';
+import {
+  execute,
+  executeSync,
+  experimentalExecuteIncrementallySync,
+} from '../execute.js';
+
+function executeSyncWithBadArgs(args: ExecutionArgs): ExecutionResult {
+  return expectMatchingValues([
+    executeSync(args),
+    experimentalExecuteIncrementallySync(args),
+  ]);
+}
 
 describe('Execute: Handles basic execution tasks', () => {
   it('executes arbitrary code', async () => {
@@ -708,7 +721,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse('fragment Example on Type { a }');
     const rootValue = { a: 'b' };
 
-    const result = executeSync({ schema, document, rootValue });
+    const result = executeSyncWithBadArgs({ schema, document, rootValue });
     expectJSON(result).toDeepEqual({
       errors: [{ message: 'Must provide an operation.' }],
     });
@@ -728,7 +741,7 @@ describe('Execute: Handles basic execution tasks', () => {
       query OtherExample { a }
     `);
 
-    const result = executeSync({ schema, document });
+    const result = executeSyncWithBadArgs({ schema, document });
     expectJSON(result).toDeepEqual({
       errors: [
         {
@@ -754,7 +767,7 @@ describe('Execute: Handles basic execution tasks', () => {
     `);
     const operationName = 'UnknownExample';
 
-    const result = executeSync({ schema, document, operationName });
+    const result = executeSyncWithBadArgs({ schema, document, operationName });
     expectJSON(result).toDeepEqual({
       errors: [{ message: 'Unknown operation named "UnknownExample".' }],
     });
@@ -772,7 +785,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse('{ a }');
     const operationName = '';
 
-    const result = executeSync({ schema, document, operationName });
+    const result = executeSyncWithBadArgs({ schema, document, operationName });
     expectJSON(result).toDeepEqual({
       errors: [{ message: 'Unknown operation named "".' }],
     });
@@ -807,7 +820,12 @@ describe('Execute: Handles basic execution tasks', () => {
     const rootValue = { a: 'b', c: 'd' };
     const operationName = 'Q';
 
-    const result = executeSync({ schema, document, rootValue, operationName });
+    const result = executeSyncWithBadArgs({
+      schema,
+      document,
+      rootValue,
+      operationName,
+    });
     expect(result).to.deep.equal({ data: { a: 'b' } });
   });
 
@@ -873,7 +891,7 @@ describe('Execute: Handles basic execution tasks', () => {
     `);
 
     expectJSON(
-      executeSync({ schema, document, operationName: 'Q' }),
+      executeSyncWithBadArgs({ schema, document, operationName: 'Q' }),
     ).toDeepEqual({
       data: null,
       errors: [
@@ -885,7 +903,7 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     expectJSON(
-      executeSync({ schema, document, operationName: 'M' }),
+      executeSyncWithBadArgs({ schema, document, operationName: 'M' }),
     ).toDeepEqual({
       data: null,
       errors: [
@@ -897,7 +915,7 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     expectJSON(
-      executeSync({ schema, document, operationName: 'S' }),
+      executeSyncWithBadArgs({ schema, document, operationName: 'S' }),
     ).toDeepEqual({
       data: null,
       errors: [

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -10,11 +10,7 @@ import { GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLInt } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import {
-  execute,
-  executeSync,
-  experimentalExecuteIncrementally,
-} from '../execute.js';
+import { execute, executeSync } from '../execute.js';
 
 class NumberHolder {
   theNumber: number;
@@ -218,11 +214,16 @@ describe('Execute: Handles mutation execution ordering', () => {
     `);
 
     const rootValue = new Root(6);
-    const mutationResult = await experimentalExecuteIncrementally({
-      schema,
-      document,
-      rootValue,
-    });
+    const mutationResult = await execute(
+      {
+        schema,
+        document,
+        rootValue,
+      },
+      {
+        enableIncremental: true,
+      },
+    );
     const patches = [];
 
     assert('initialResult' in mutationResult);
@@ -294,11 +295,16 @@ describe('Execute: Handles mutation execution ordering', () => {
     `);
 
     const rootValue = new Root(6);
-    const mutationResult = await experimentalExecuteIncrementally({
-      schema,
-      document,
-      rootValue,
-    });
+    const mutationResult = await execute(
+      {
+        schema,
+        document,
+        rootValue,
+      },
+      {
+        enableIncremental: true,
+      },
+    );
     const patches = [];
 
     assert('initialResult' in mutationResult);

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -17,10 +17,12 @@ import { GraphQLID, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
 import type {
+  ExecutionArgs,
+  ExperimentalExecuteIncrementallyResults,
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,
 } from '../execute.js';
-import { experimentalExecuteIncrementally } from '../execute.js';
+import { execute } from '../execute.js';
 
 const friendType = new GraphQLObjectType({
   fields: {
@@ -67,6 +69,14 @@ const query = new GraphQLObjectType({
 });
 
 const schema = new GraphQLSchema({ query });
+
+function experimentalExecuteIncrementally(
+  args: ExecutionArgs,
+): PromiseOrValue<ExperimentalExecuteIncrementallyResults> {
+  return execute(args, {
+    enableIncremental: true,
+  });
+}
 
 async function complete(document: DocumentNode, rootValue: unknown = {}) {
   const result = await experimentalExecuteIncrementally({

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -21,11 +21,7 @@ import {
 import { GraphQLSchema } from '../../type/schema.js';
 
 import type { ExecutionArgs, ExecutionResult } from '../execute.js';
-import {
-  createSourceEventStream,
-  experimentalSubscribeIncrementally,
-  subscribe,
-} from '../execute.js';
+import { createSourceEventStream, subscribe } from '../execute.js';
 
 import { SimplePubSub } from './simplePubSub.js';
 
@@ -145,12 +141,17 @@ function createSubscription(
     }),
   };
 
-  return (originalSubscribe ? subscribe : experimentalSubscribeIncrementally)({
-    schema: emailSchema,
-    document,
-    rootValue: data,
-    variableValues,
-  });
+  return subscribe(
+    {
+      schema: emailSchema,
+      document,
+      rootValue: data,
+      variableValues,
+    },
+    {
+      enableIncremental: !originalSubscribe,
+    },
+  );
 }
 
 const DummyQueryType = new GraphQLObjectType({
@@ -182,7 +183,6 @@ function subscribeWithBadArgs(
 ): PromiseOrValue<ExecutionResult | AsyncIterable<unknown>> {
   return expectEqualPromisesOrValues([
     subscribe(args),
-    experimentalSubscribeIncrementally(args),
     createSourceEventStream(args),
   ]);
 }

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -13,11 +13,7 @@ import { validate } from '../../validation/validate.js';
 
 import { graphqlSync } from '../../graphql.js';
 
-import {
-  execute,
-  executeSync,
-  experimentalExecuteIncrementallySync,
-} from '../execute.js';
+import { execute, executeSync } from '../execute.js';
 
 describe('Execute: synchronously when possible', () => {
   const schema = new GraphQLSchema({
@@ -120,11 +116,16 @@ describe('Execute: synchronously when possible', () => {
 
     it('return successfully if incremental delivery is enabled but async iterable is not returned', () => {
       const doc = 'query Example { syncField }';
-      const result = experimentalExecuteIncrementallySync({
-        schema,
-        document: parse(doc),
-        rootValue: 'rootValue',
-      });
+      const result = executeSync(
+        {
+          schema,
+          document: parse(doc),
+          rootValue: 'rootValue',
+        },
+        {
+          enableIncremental: true,
+        },
+      );
       expect(result).to.deep.equal({ data: { syncField: 'rootValue' } });
     });
 
@@ -138,11 +139,16 @@ describe('Execute: synchronously when possible', () => {
         }
       `;
       expect(() => {
-        experimentalExecuteIncrementallySync({
-          schema,
-          document: parse(doc),
-          rootValue: 'rootValue',
-        });
+        executeSync(
+          {
+            schema,
+            document: parse(doc),
+            rootValue: 'rootValue',
+          },
+          {
+            enableIncremental: true,
+          },
+        );
       }).to.throw('GraphQL execution failed to complete synchronously.');
     });
   });

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -13,7 +13,11 @@ import { validate } from '../../validation/validate.js';
 
 import { graphqlSync } from '../../graphql.js';
 
-import { execute, executeSync } from '../execute.js';
+import {
+  execute,
+  executeSync,
+  experimentalExecuteIncrementallySync,
+} from '../execute.js';
 
 describe('Execute: synchronously when possible', () => {
   const schema = new GraphQLSchema({
@@ -114,6 +118,16 @@ describe('Execute: synchronously when possible', () => {
       }).to.throw('GraphQL execution failed to complete synchronously.');
     });
 
+    it('return successfully if incremental delivery is enabled but async iterable is not returned', () => {
+      const doc = 'query Example { syncField }';
+      const result = experimentalExecuteIncrementallySync({
+        schema,
+        document: parse(doc),
+        rootValue: 'rootValue',
+      });
+      expect(result).to.deep.equal({ data: { syncField: 'rootValue' } });
+    });
+
     it('throws if encountering async iterable execution', () => {
       const doc = `
         query Example {
@@ -124,7 +138,7 @@ describe('Execute: synchronously when possible', () => {
         }
       `;
       expect(() => {
-        executeSync({
+        experimentalExecuteIncrementallySync({
           schema,
           document: parse(doc),
           rootValue: 'rootValue',

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3,19 +3,17 @@ export { pathToArray as responsePathAsArray } from '../jsutils/Path.js';
 export {
   createSourceEventStream,
   execute,
-  experimentalExecuteIncrementally,
   executeSync,
-  experimentalExecuteIncrementallySync,
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,
-  experimentalSubscribeIncrementally,
 } from './execute.js';
 
 export type {
   ExecutionArgs,
   ExecutionResult,
   ExperimentalExecuteIncrementallyResults,
+  ExperimentalExecutionOptions,
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,
   IncrementalDeferResult,

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -5,6 +5,7 @@ export {
   execute,
   experimentalExecuteIncrementally,
   executeSync,
+  experimentalExecuteIncrementallySync,
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,6 +321,7 @@ export {
   execute,
   experimentalExecuteIncrementally,
   executeSync,
+  experimentalExecuteIncrementallySync,
   defaultFieldResolver,
   defaultTypeResolver,
   responsePathAsArray,

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,9 +319,7 @@ export type {
 // Execute GraphQL queries.
 export {
   execute,
-  experimentalExecuteIncrementally,
   executeSync,
-  experimentalExecuteIncrementallySync,
   defaultFieldResolver,
   defaultTypeResolver,
   responsePathAsArray,
@@ -329,7 +327,6 @@ export {
   getVariableValues,
   getDirectiveValues,
   subscribe,
-  experimentalSubscribeIncrementally,
   createSourceEventStream,
 } from './execution/index.js';
 
@@ -337,6 +334,7 @@ export type {
   ExecutionArgs,
   ExecutionResult,
   ExperimentalExecuteIncrementallyResults,
+  ExperimentalExecutionOptions,
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,
   IncrementalDeferResult,


### PR DESCRIPTION
Using TS conditional types, when `enableExperimental` is set to true, return type of `execute` will correspond to the new types; otherwise, `execute` will return the old types.

When the option is set to `true`, incremental results will be delivered; otherwise, the `@defer` and `@stream` directives will be ignored.

@glasser @IvanGoncharov @robrichard @n1ru4l https://github.com/orgs/graphql/teams/graphql-js-reviewers

Not so experienced with conditional types, but from the test files, it seems to be working as expected, with the new return type selected only when setting the experimental option enableIncremental to true.