### PR TITLE
incrementalDelivery: original execute should not throw on new directives

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { expectMatchingValues } from '../../__testUtils__/expectMatchingValues.js';
 
 import { inspect } from '../../jsutils/inspect.js';
 
@@ -23,7 +24,19 @@ import {
 } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { execute, executeSync } from '../execute.js';
+import type { ExecutionArgs, ExecutionResult } from '../execute.js';
+import {
+  execute,
+  executeSync,
+  experimentalExecuteIncrementallySync,
+} from '../execute.js';
+
+function executeSyncWithBadArgs(args: ExecutionArgs): ExecutionResult {
+  return expectMatchingValues([
+    executeSync(args),
+    experimentalExecuteIncrementallySync(args),
+  ]);
+}
 
 describe('Execute: Handles basic execution tasks', () => {
   it('executes arbitrary code', async () => {
@@ -708,7 +721,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse('fragment Example on Type { a }');
     const rootValue = { a: 'b' };
 
-    const result = executeSync({ schema, document, rootValue });
+    const result = executeSyncWithBadArgs({ schema, document, rootValue });
     expectJSON(result).toDeepEqual({
       errors: [{ message: 'Must provide an operation.' }],
     });
@@ -728,7 +741,7 @@ describe('Execute: Handles basic execution tasks', () => {
       query OtherExample { a }
     `);
 
-    const result = executeSync({ schema, document });
+    const result = executeSyncWithBadArgs({ schema, document });
     expectJSON(result).toDeepEqual({
       errors: [
         {
@@ -754,7 +767,7 @@ describe('Execute: Handles basic execution tasks', () => {
     `);
     const operationName = 'UnknownExample';
 
-    const result = executeSync({ schema, document, operationName });
+    const result = executeSyncWithBadArgs({ schema, document, operationName });
     expectJSON(result).toDeepEqual({
       errors: [{ message: 'Unknown operation named "UnknownExample".' }],
     });
@@ -772,7 +785,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse('{ a }');
     const operationName = '';
 
-    const result = executeSync({ schema, document, operationName });
+    const result = executeSyncWithBadArgs({ schema, document, operationName });
     expectJSON(result).toDeepEqual({
       errors: [{ message: 'Unknown operation named "".' }],
     });
@@ -807,7 +820,12 @@ describe('Execute: Handles basic execution tasks', () => {
     const rootValue = { a: 'b', c: 'd' };
     const operationName = 'Q';
 
-    const result = executeSync({ schema, document, rootValue, operationName });
+    const result = executeSyncWithBadArgs({
+      schema,
+      document,
+      rootValue,
+      operationName,
+    });
     expect(result).to.deep.equal({ data: { a: 'b' } });
   });
 
@@ -873,7 +891,7 @@ describe('Execute: Handles basic execution tasks', () => {
     `);
 
     expectJSON(
-      executeSync({ schema, document, operationName: 'Q' }),
+      executeSyncWithBadArgs({ schema, document, operationName: 'Q' }),
     ).toDeepEqual({
       data: null,
       errors: [
@@ -885,7 +903,7 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     expectJSON(
-      executeSync({ schema, document, operationName: 'M' }),
+      executeSyncWithBadArgs({ schema, document, operationName: 'M' }),
     ).toDeepEqual({
       data: null,
       errors: [
@@ -897,7 +915,7 @@ describe('Execute: Handles basic execution tasks', () => {
     });
 
     expectJSON(
-      executeSync({ schema, document, operationName: 'S' }),
+      executeSyncWithBadArgs({ schema, document, operationName: 'S' }),
     ).toDeepEqual({
       data: null,
       errors: [

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -13,7 +13,11 @@ import { validate } from '../../validation/validate.js';
 
 import { graphqlSync } from '../../graphql.js';
 
-import { execute, executeSync } from '../execute.js';
+import {
+  execute,
+  executeSync,
+  experimentalExecuteIncrementallySync,
+} from '../execute.js';
 
 describe('Execute: synchronously when possible', () => {
   const schema = new GraphQLSchema({
@@ -114,6 +118,16 @@ describe('Execute: synchronously when possible', () => {
       }).to.throw('GraphQL execution failed to complete synchronously.');
     });
 
+    it('return successfully if incremental delivery is enabled but async iterable is not returned', () => {
+      const doc = 'query Example { syncField }';
+      const result = experimentalExecuteIncrementallySync({
+        schema,
+        document: parse(doc),
+        rootValue: 'rootValue',
+      });
+      expect(result).to.deep.equal({ data: { syncField: 'rootValue' } });
+    });
+
     it('throws if encountering async iterable execution', () => {
       const doc = `
         query Example {
@@ -124,7 +138,7 @@ describe('Execute: synchronously when possible', () => {
         }
       `;
       expect(() => {
-        executeSync({
+        experimentalExecuteIncrementallySync({
           schema,
           document: parse(doc),
           rootValue: 'rootValue',

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -81,6 +81,7 @@ const collectSubfields = memoize3(
       exeContext.variableValues,
       returnType,
       fieldNodes,
+      exeContext.enableIncremental,
     ),
 );
 
@@ -110,7 +111,9 @@ const collectSubfields = memoize3(
  * Namely, schema of the type system that is currently executing,
  * and the fragments defined in the query document
  */
-export interface ExecutionContext {
+export interface ExecutionContext<
+  TEnableIncremental extends boolean = boolean,
+> {
   schema: GraphQLSchema;
   fragments: ObjMap<FragmentDefinitionNode>;
   rootValue: unknown;
@@ -122,6 +125,7 @@ export interface ExecutionContext {
   subscribeFieldResolver: GraphQLFieldResolver<any, any>;
   errors: Array<GraphQLError>;
   subsequentPayloads: Set<AsyncPayloadRecord>;
+  enableIncremental: TEnableIncremental;
 }
 
 /**
@@ -263,8 +267,9 @@ export interface ExecutionArgs {
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
 }
 
-const UNEXPECTED_MULTIPLE_PAYLOADS =
-  'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)';
+export interface ExperimentalExecutionOptions {
+  enableIncremental?: boolean;
+}
 
 /**
  * Implements the "Executing requests" section of the GraphQL specification.
@@ -277,28 +282,21 @@ const UNEXPECTED_MULTIPLE_PAYLOADS =
  * a GraphQLError will be thrown immediately explaining the invalid input.
  *
  * This function does not support incremental delivery (`@defer` and `@stream`).
- * If an operation which would defer or stream data is executed with this
- * function, it will throw or resolve to an object containing an error instead.
- * Use `experimentalExecuteIncrementally` if you want to support incremental
- * delivery.
+ * If an operation using these directives is executed with this function, they
+ * will be ignored.
+ * Use `experimentalExecuteIncrementally` if you want to support incremental delivery.
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  const result = experimentalExecuteIncrementally(args);
-  if (!isPromise(result)) {
-    if ('initialResult' in result) {
-      throw new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
-    }
-    return result;
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const exeContext = buildExecutionContext(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in exeContext)) {
+    return { errors: exeContext };
   }
 
-  return result.then((incrementalResult) => {
-    if ('initialResult' in incrementalResult) {
-      return {
-        errors: [new GraphQLError(UNEXPECTED_MULTIPLE_PAYLOADS)],
-      };
-    }
-    return incrementalResult;
-  });
+  return executeImpl(exeContext) as PromiseOrValue<ExecutionResult>;
 }
 
 /**
@@ -318,7 +316,7 @@ export function experimentalExecuteIncrementally(
 ): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
-  const exeContext = buildExecutionContext(args);
+  const exeContext = buildExecutionContext(args, { enableIncremental: true });
 
   // Return early errors if execution context failed.
   if (!('schema' in exeContext)) {
@@ -386,8 +384,37 @@ function executeImpl(
  * Also implements the "Executing requests" section of the GraphQL specification.
  * However, it guarantees to complete synchronously (or throw an error) assuming
  * that all field resolvers are also synchronous.
+ *
+ * This function does not support incremental delivery (`@defer` and `@stream`).
+ * If an operation using these directives is executed with this function, they
+ * will be ignored.
+ * Use `experimentalExecuteIncrementallySync` if you want to check that operations using
+ * these directives do not result in incremental payloads.
  */
 export function executeSync(args: ExecutionArgs): ExecutionResult {
+  const result = execute(args);
+
+  // Assert that the execution was synchronous.
+  if (isPromise(result)) {
+    throw new Error('GraphQL execution failed to complete synchronously.');
+  }
+
+  return result;
+}
+
+/**
+ * Also implements the "Executing requests" section of the GraphQL specification.
+ * However, it guarantees to complete synchronously (or throw an error) assuming
+ * that all field resolvers are also synchronous.
+ *
+ * This function supports incremental delivery (`@defer` and `@stream`).
+ * If an operation using these directives is executed with this function, they
+ * will be ignored.
+ * Use `experimentalExecuteIncrementallySync` if you want to support incremental delivery.
+ */
+export function experimentalExecuteIncrementallySync(
+  args: ExecutionArgs,
+): ExecutionResult {
   const result = experimentalExecuteIncrementally(args);
 
   // Assert that the execution was synchronous.
@@ -420,6 +447,7 @@ function buildResponse(
  */
 export function buildExecutionContext(
   args: ExecutionArgs,
+  experimentalOptions: ExperimentalExecutionOptions = {},
 ): ReadonlyArray<GraphQLError> | ExecutionContext {
   const {
     schema,
@@ -494,6 +522,7 @@ export function buildExecutionContext(
     fieldResolver: fieldResolver ?? defaultFieldResolver,
     typeResolver: typeResolver ?? defaultTypeResolver,
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
+    enableIncremental: experimentalOptions.enableIncremental ?? false,
     subsequentPayloads: new Set(),
     errors: [],
   };
@@ -532,6 +561,7 @@ function executeOperation(
     variableValues,
     rootType,
     operation.selectionSet,
+    exeContext.enableIncremental,
   );
   const path = undefined;
   let result;
@@ -926,11 +956,13 @@ function getStreamValues(
 
   // validation only allows equivalent streams on multiple fields, so it is
   // safe to only check the first fieldNode for the stream directive
-  const stream = getDirectiveValues(
-    GraphQLStreamDirective,
-    fieldNodes[0],
-    exeContext.variableValues,
-  );
+  const stream =
+    exeContext.enableIncremental &&
+    getDirectiveValues(
+      GraphQLStreamDirective,
+      fieldNodes[0],
+      exeContext.variableValues,
+    );
 
   if (!stream) {
     return;
@@ -1476,13 +1508,10 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
  * If the operation succeeded, the promise resolves to an AsyncIterator, which
  * yields a stream of ExecutionResults representing the response stream.
  *
- * This function does not support incremental delivery (`@defer` and `@stream`).
- * If an operation which would defer or stream data is executed with this
- * function, each `InitialIncrementalExecutionResult` and
- * `SubsequentIncrementalExecutionResult` in the result stream will be replaced
- * with an `ExecutionResult` with a single error stating that defer/stream is
- * not supported.  Use `experimentalSubscribeIncrementally` if you want to
- * support incremental delivery.
+ * If an operation using these directives is executed with this function, they
+ * will be ignored.
+ * Use `experimentalSubscribeIncrementally` if you want to support incremental
+ * delivery.
  *
  * Accepts an object with named arguments.
  */
@@ -1491,31 +1520,24 @@ export function subscribe(
 ): PromiseOrValue<
   AsyncGenerator<ExecutionResult, void, void> | ExecutionResult
 > {
-  const maybePromise = experimentalSubscribeIncrementally(args);
-  if (isPromise(maybePromise)) {
-    return maybePromise.then((resultOrIterable) =>
-      isAsyncIterable(resultOrIterable)
-        ? mapAsyncIterable(resultOrIterable, ensureSingleExecutionResult)
-        : resultOrIterable,
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const exeContext = buildExecutionContext(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in exeContext)) {
+    return { errors: exeContext };
+  }
+
+  const resultOrStream = createSourceEventStreamImpl(exeContext);
+
+  if (isPromise(resultOrStream)) {
+    return resultOrStream.then((resolvedResultOrStream) =>
+      mapSourceToResponse(exeContext, resolvedResultOrStream),
     );
   }
-  return isAsyncIterable(maybePromise)
-    ? mapAsyncIterable(maybePromise, ensureSingleExecutionResult)
-    : maybePromise;
-}
 
-function ensureSingleExecutionResult(
-  result:
-    | ExecutionResult
-    | InitialIncrementalExecutionResult
-    | SubsequentIncrementalExecutionResult,
-): ExecutionResult {
-  if ('hasNext' in result) {
-    return {
-      errors: [new GraphQLError(UNEXPECTED_MULTIPLE_PAYLOADS)],
-    };
-  }
-  return result;
+  return mapSourceToResponse(exeContext, resultOrStream);
 }
 
 /**
@@ -1565,7 +1587,7 @@ export function experimentalSubscribeIncrementally(
 > {
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
-  const exeContext = buildExecutionContext(args);
+  const exeContext = buildExecutionContext(args, { enableIncremental: true });
 
   // Return early errors if execution context failed.
   if (!('schema' in exeContext)) {
@@ -1712,6 +1734,7 @@ function executeSubscription(
     variableValues,
     rootType,
     operation.selectionSet,
+    exeContext.enableIncremental,
   );
 
   const firstRootField = rootFields.entries().next().value;

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -5,6 +5,7 @@ export {
   execute,
   experimentalExecuteIncrementally,
   executeSync,
+  experimentalExecuteIncrementallySync,
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,

--- a/src/index.ts
+++ b/src/index.ts
@@ -321,6 +321,7 @@ export {
   execute,
   experimentalExecuteIncrementally,
   executeSync,
+  experimentalExecuteIncrementallySync,
   defaultFieldResolver,
   defaultTypeResolver,
   responsePathAsArray,


### PR DESCRIPTION
original execute and executeSync should ignore `@defer` and `@stream` rather than throw.

extracted from #3726