### PR TITLE
incrementalDelivery: refactoring and streamlining

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1948,7 +1948,6 @@ async function executeStreamIteratorItem(
   } catch (rawError) {
     const error = locatedError(rawError, fieldNodes, pathToArray(itemPath));
     const value = handleFieldError(error, itemType, asyncPayloadRecord.errors);
-    filterSubsequentPayloads(exeContext, itemPath, asyncPayloadRecord);
     // don't continue if iterator throws
     return { done: true, value };
   }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1045,9 +1045,8 @@ async function completeAsyncIteratorValue(
         handleFieldError(error, itemType, errors);
       }
     } catch (rawError) {
-      completedResults.push(null);
       const error = locatedError(rawError, fieldNodes, pathToArray(fieldPath));
-      handleFieldError(error, itemType, errors);
+      completedResults.push(handleFieldError(error, itemType, errors));
       break;
     }
     index += 1;

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1103,28 +1103,29 @@ function completeListValue(
     // No need to modify the info object containing the path,
     // since from here on it is not ever accessed by resolver functions.
     const itemPath = addPath(path, index, undefined);
+
+    if (
+      stream &&
+      typeof stream.initialCount === 'number' &&
+      index >= stream.initialCount
+    ) {
+      previousAsyncPayloadRecord = executeStreamField(
+        path,
+        itemPath,
+        item,
+        exeContext,
+        fieldNodes,
+        info,
+        itemType,
+        stream.label,
+        previousAsyncPayloadRecord,
+      );
+      index++;
+      continue;
+    }
+
     try {
       let completedItem;
-
-      if (
-        stream &&
-        typeof stream.initialCount === 'number' &&
-        index >= stream.initialCount
-      ) {
-        previousAsyncPayloadRecord = executeStreamField(
-          path,
-          itemPath,
-          item,
-          exeContext,
-          fieldNodes,
-          info,
-          itemType,
-          stream.label,
-          previousAsyncPayloadRecord,
-        );
-        index++;
-        continue;
-      }
       if (isPromise(item)) {
         completedItem = item.then((resolved) =>
           completeValue(


### PR DESCRIPTION
Each commit is meant to merged separately, i.e. "Rebase and Merge" rather than "Squash and Merge"

419fd37f: moves `executeStreamField` out of try block to better illustrate which code might throw
2991c79a: tiny refactor pushing the result of `handleFieldError` rather than explicit null, following convention elsewhere
71a8db4f: rename `fieldPath` to `itemPath` when dealing with items, as elsewhere
4df02ca7: skip unnecessary filtering when asyncIterator's next method throws, aligning stream to non-stream