### PR TITLE
incrementalDelivery: fix iterable streaming with errors

### DIFF
--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -823,10 +823,7 @@ describe('Execute: stream directive', () => {
       }
     `);
     const result = await complete(document, {
-      async *scalarList() {
-        yield await Promise.resolve(friends[0].name);
-        yield await Promise.resolve({});
-      },
+      scalarList: () => [friends[0].name, {}],
     });
     expectJSON(result).toDeepEqual([
       {
@@ -849,9 +846,6 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        hasNext: true,
-      },
-      {
         hasNext: false,
       },
     ]);

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1838,7 +1838,6 @@ function executeStreamField(
     exeContext,
   });
   let completedItem: PromiseOrValue<unknown>;
-  let completedItems: PromiseOrValue<Array<unknown> | null>;
   try {
     try {
       if (isPromise(item)) {
@@ -1885,7 +1884,7 @@ function executeStreamField(
       }
     } catch (rawError) {
       const error = locatedError(rawError, fieldNodes, pathToArray(itemPath));
-      completedItems = handleFieldError(
+      completedItem = handleFieldError(
         error,
         itemType,
         asyncPayloadRecord.errors,
@@ -1899,6 +1898,7 @@ function executeStreamField(
     return asyncPayloadRecord;
   }
 
+  let completedItems: PromiseOrValue<Array<unknown> | null>;
   if (isPromise(completedItem)) {
     completedItems = completedItem.then(
       (value) => [value],


### PR DESCRIPTION
When iterables (not asyncIterables) are streamed, and completeValue throws an error, we currently send undefined rather than null, due to a typo.

This change corrects the typo, and also modifies the test intended to check this case to correctly check a streamed iterable, rather than an asyncIterable.

Code coverage was complete prior to this change, because the line involving this change was reached in the case where the error was non-recoverable, albeit with the line throwing.