### PR TITLE
feat: allow defining symbol error extensions

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -17,7 +17,7 @@ import type { Source } from '../language/source';
  * an object which can contain all the values you need.
  */
 export interface GraphQLErrorExtensions {
-  [attributeName: string]: unknown;
+  [attributeName: string | symbol]: unknown;
 }
 
 export interface GraphQLErrorOptions {


### PR DESCRIPTION
Using symbol keys is a useful approach when composing error handlers as symbol keys are omitted when the error is finally stringified.

It allows middlewares to read extensions without having to assign them to `undefined` afterwards or using the `delete` keyword.

