### PR TITLE
build-npm/deno: use TS to find all *.ts files

### DIFF
--- a/resources/build-deno.ts
+++ b/resources/build-deno.ts
@@ -5,36 +5,34 @@ import ts from 'typescript';
 
 import { changeExtensionInImportPaths } from './change-extension-in-import-paths.js';
 import { inlineInvariant } from './inline-invariant.js';
-import { readdirRecursive, showDirStats, writeGeneratedFile } from './utils.js';
+import { readTSConfig, showDirStats, writeGeneratedFile } from './utils.js';
 
 fs.rmSync('./denoDist', { recursive: true, force: true });
 fs.mkdirSync('./denoDist');
 
-const srcFiles = readdirRecursive('./src', { ignoreDir: /^__.*__$/ });
-for (const filepath of srcFiles) {
-  if (filepath.endsWith('.ts')) {
-    const srcPath = path.join('./src', filepath);
-
-    const sourceFile = ts.createSourceFile(
-      srcPath,
-      fs.readFileSync(srcPath, 'utf-8'),
-      ts.ScriptTarget.Latest,
-    );
-
-    const transformed = ts.transform(sourceFile, [
-      changeExtensionInImportPaths({ extension: '.ts' }),
-      inlineInvariant,
-    ]);
-    const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
-    const newContent = printer.printBundle(
-      ts.factory.createBundle(transformed.transformed),
-    );
-
-    transformed.dispose();
-
-    const destPath = path.join('./denoDist', filepath);
-    writeGeneratedFile(destPath, newContent);
+const tsProgram = ts.createProgram(['src/index.ts'], readTSConfig());
+for (const sourceFile of tsProgram.getSourceFiles()) {
+  if (
+    tsProgram.isSourceFileFromExternalLibrary(sourceFile) ||
+    tsProgram.isSourceFileDefaultLibrary(sourceFile)
+  ) {
+    continue;
   }
+
+  const transformed = ts.transform(sourceFile, [
+    changeExtensionInImportPaths({ extension: '.ts' }),
+    inlineInvariant,
+  ]);
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  const newContent = printer.printBundle(
+    ts.factory.createBundle(transformed.transformed),
+  );
+
+  transformed.dispose();
+
+  const filepath = path.relative('./src', sourceFile.fileName);
+  const destPath = path.join('./denoDist', filepath);
+  writeGeneratedFile(destPath, newContent);
 }
 
 fs.copyFileSync('./LICENSE', './denoDist/LICENSE');


### PR DESCRIPTION
Motivation: Remove custom code for finding *.ts files and reuse code from typescript library