### PR TITLE
resources/util: spawn command fail on error

### DIFF
--- a/integrationTests/node/index.cjs
+++ b/integrationTests/node/index.cjs
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const { readFileSync } = require('fs');
+
+const { graphqlSync } = require('graphql');
+const { buildSchema } = require('graphql/utilities');
+const { version } = require('graphql/version');
+
+assert.deepStrictEqual(
+  version,
+  JSON.parse(readFileSync('./node_modules/graphql/package.json')).version,
+);
+
+const schema = buildSchema('type Query { hello: String }');
+
+const result = graphqlSync({
+  schema,
+  source: '{ hello }',
+  rootValue: { hello: 'world' },
+});
+
+assert.deepStrictEqual(result, {
+  data: {
+    __proto__: null,
+    hello: 'world',
+  },
+});

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -99,6 +99,11 @@ function spawnOutput(
     encoding: 'utf-8',
     ...options,
   });
+
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+  }
+
   return result.stdout.toString().trimEnd();
 }
 
@@ -107,7 +112,13 @@ function spawn(
   args: ReadonlyArray<string>,
   options?: SpawnOptions,
 ): void {
-  childProcess.spawnSync(command, args, { stdio: 'inherit', ...options });
+  const result = childProcess.spawnSync(command, args, {
+    stdio: 'inherit',
+    ...options,
+  });
+  if (result.status !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(' ')}`);
+  }
 }
 
 function* readdirRecursive(dirPath: string): Generator<{


### PR DESCRIPTION
Context: previously we switched from `exec` to `spawn` to fix security issues. But `spawn` doesn't throw on failed command, this change tooks it into account.