### PR TITLE
fix: allow async errors to bubble to AsyncIterable list items

### DIFF
--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -8,7 +8,11 @@ import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 import { parse } from '../../language/parser.js';
 
 import type { GraphQLFieldResolver } from '../../type/definition.js';
-import { GraphQLList, GraphQLObjectType } from '../../type/definition.js';
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from '../../type/definition.js';
 import { GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
@@ -101,7 +105,7 @@ describe('Execute: Accepts async iterables as list value', () => {
                 name: 'ObjectWrapper',
                 fields: {
                   index: {
-                    type: GraphQLString,
+                    type: new GraphQLNonNull(GraphQLString),
                     resolve,
                   },
                 },
@@ -202,7 +206,7 @@ describe('Execute: Accepts async iterables as list value', () => {
         return Promise.resolve(index);
       }),
     ).toDeepEqual({
-      data: { listField: [{ index: '0' }, { index: '1' }, { index: null }] },
+      data: { listField: [{ index: '0' }, { index: '1' }, null] },
       errors: [
         {
           message: 'bad',

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1017,8 +1017,22 @@ async function completeAsyncIteratorValue(
         );
         if (isPromise(completedItem)) {
           containsPromise = true;
+          // Note: we don't rely on a `catch` method, but we do expect "thenable"
+          // to take a second callback for the error case.
+          completedResults.push(
+            completedItem.then(undefined, (rawError) => {
+              const error = locatedError(
+                rawError,
+                fieldNodes,
+                pathToArray(fieldPath),
+              );
+              const handledError = handleFieldError(error, itemType, errors);
+              return handledError;
+            }),
+          );
+        } else {
+          completedResults.push(completedItem);
         }
-        completedResults.push(completedItem);
       } catch (rawError) {
         completedResults.push(null);
         const error = locatedError(


### PR DESCRIPTION
Previously, async errors from further down in the tree would bubble to the parent list rather than the individual item.

This change also fixes the test so that `completeValue` rejects for the AsyncIterable itself -- the true intent of this test -- and not just for the nested object.