### PR TITLE
Fix typo in the error message for max tokens

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -91,16 +91,16 @@ describe('Parser', () => {
     `);
   });
 
-  it('limit maximum number of tokens', () => {
+  it('limits by a maximum number of tokens', () => {
     expect(() => parse('{ foo }', { maxTokens: 3 })).to.not.throw();
     expect(() => parse('{ foo }', { maxTokens: 2 })).to.throw(
-      'Syntax Error: Document contains more that 2 tokens. Parsing aborted.',
+      'Syntax Error: Document contains more than 2 tokens. Parsing aborted.',
     );
 
     expect(() => parse('{ foo(bar: "baz") }', { maxTokens: 8 })).to.not.throw();
 
     expect(() => parse('{ foo(bar: "baz") }', { maxTokens: 7 })).to.throw(
-      'Syntax Error: Document contains more that 7 tokens. Parsing aborted.',
+      'Syntax Error: Document contains more than 7 tokens. Parsing aborted.',
     );
   });
 

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -1638,7 +1638,7 @@ export class Parser {
         throw syntaxError(
           this._lexer.source,
           token.start,
-          `Document contains more that ${maxTokens} tokens. Parsing aborted.`,
+          `Document contains more than ${maxTokens} tokens. Parsing aborted.`,
         );
       }
     }


### PR DESCRIPTION
Note, this also exists in the 16.x.x branch.