### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
 on: workflow_call
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint source files
@@ -158,6 +160,7 @@ jobs:
     name: Run CodeQL security scan
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
       - name: Checkout repo

--- a/.github/workflows/cmd-publish-pr-on-npm.yml
+++ b/.github/workflows/cmd-publish-pr-on-npm.yml
@@ -10,6 +10,8 @@ on:
       npm_canary_pr_publish_token:
         description: NPM token to publish canary release.
         required: true
+permissions:
+  contents: read
 jobs:
   build-npm-dist:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmd-run-benchmark.yml
+++ b/.github/workflows/cmd-run-benchmark.yml
@@ -6,6 +6,9 @@ on:
         description: String that contain JSON payload for `pull_request` event.
         required: true
         type: string
+permissions:
+  contents: read # for checkout
+  actions: read # to list workflow runs
 jobs:
   benchmark:
     name: Run benchmark

--- a/.github/workflows/deploy-artifact-as-branch.yml
+++ b/.github/workflows/deploy-artifact-as-branch.yml
@@ -18,8 +18,11 @@ on:
         description: Commit message
         required: true
         type: string
+permissions: {}
 jobs:
   deploy-artifact-as-branch:
+    permissions:
+      contents: write # to push branch
     environment:
       name: ${{ inputs.environment }}
       url: ${{ github.server_url }}/${{ github.repository }}/tree/${{ inputs.target_branch }}

--- a/.github/workflows/github-actions-bot.yml
+++ b/.github/workflows/github-actions-bot.yml
@@ -21,8 +21,13 @@ env:
     * `@github-actions run-benchmark` - Run benchmark comparing base and merge commits for this PR
     * `@github-actions publish-pr-on-npm` - Build package from this PR and publish it on NPM
     </details>
+permissions: {}
 jobs:
   hello-message:
+    permissions:
+      actions: read # to download event.json
+      pull-requests: write # to add comment to pull request
+
     if: github.event_name == 'workflow_run'
     runs-on: ubuntu-latest
     steps:
@@ -49,6 +54,9 @@ jobs:
             })
 
   accept-cmd:
+    permissions:
+      pull-requests: write # to add comment to pull request
+
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
@@ -95,6 +103,9 @@ jobs:
       pull_request_json: ${{ needs.accept-cmd.outputs.pull_request_json }}
 
   respond-to-cmd:
+    permissions:
+      pull-requests: write # to add comment to pull request
+
     needs:
       - accept-cmd
       - cmd-publish-pr-on-npm

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # run once every day at 00:00 UTC
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   lint:
     name: Run mutation testing

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,6 @@
 name: Push
 on: push
+permissions: {}
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.