### PR TITLE
fix: re-initialize subsequentPayloads

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -506,6 +506,7 @@ function buildPerEventExecutionContext(
   return {
     ...exeContext,
     rootValue: payload,
+    subsequentPayloads: new Set(),
     errors: [],
   };
 }


### PR DESCRIPTION
`buildPerEventExecutionContext` must use a new rootValue, and re-initialize the execution "state" portion of the `ExecutionContext`