### PR TITLE
resources/utils: fix `git().revList`

### DIFF
--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -72,7 +72,8 @@ export function git(options?: GITOptions) {
     },
     revList(...args: ReadonlyArray<string>): Array<string> {
       const allArgs = ['rev-list', ...cmdOptions, ...args];
-      return spawnOutput('git', allArgs, options).split('\n');
+      const result = spawnOutput('git', allArgs, options);
+      return result === '' ? [] : result.split('\n');
     },
     catFile(...args: ReadonlyArray<string>): string {
       return spawnOutput('git', ['cat-file', ...cmdOptions, ...args], options);


### PR DESCRIPTION
Context: broke changelog generation in case of empty list since it returned `['']` instead of `[]`