### PR TITLE
eslintrc: reorder rules to match order in the official docs

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -182,27 +182,33 @@ rules:
   ##############################################################################
 
   # Possible Errors
-  # https://eslint.org/docs/rules/#possible-errors
+  # https://eslint.org/docs/latest/rules/#possible-problems
 
+  array-callback-return: error
+  constructor-super: error
   for-direction: error
   getter-return: error
   no-async-promise-executor: error
   no-await-in-loop: error
+  no-class-assign: error
   no-compare-neg-zero: error
   no-cond-assign: error
+  no-const-assign: error
   no-constant-binary-expression: error
-  no-console: warn
   no-constant-condition: error
+  no-constructor-return: error
   no-control-regex: error
   no-debugger: warn
   no-dupe-args: error
+  no-dupe-class-members: error
   no-dupe-else-if: error
   no-dupe-keys: error
   no-duplicate-case: error
-  no-empty: error
+  no-duplicate-imports: off # Superseded by `import/no-duplicates`
   no-empty-character-class: error
+  no-empty-pattern: error
   no-ex-assign: error
-  no-extra-boolean-cast: error
+  no-fallthrough: error
   no-func-assign: error
   no-import-assign: error
   no-inner-declarations: [error, both]
@@ -210,203 +216,192 @@ rules:
   no-irregular-whitespace: error
   no-loss-of-precision: error
   no-misleading-character-class: error
+  no-new-symbol: error
   no-obj-calls: error
   no-promise-executor-return: off # TODO
   no-prototype-builtins: error
-  no-regex-spaces: error
+  no-self-assign: error
+  no-self-compare: off # TODO
   no-setter-return: error
   no-sparse-arrays: error
   no-template-curly-in-string: error
+  no-this-before-super: error
+  no-undef: error
+  no-unexpected-multiline: off
+  no-unmodified-loop-condition: error
   no-unreachable: error
   no-unreachable-loop: error
   no-unsafe-finally: error
   no-unsafe-negation: error
   no-unsafe-optional-chaining: [error, { disallowArithmeticOperators: true }]
   no-unused-private-class-members: error
+  no-unused-vars: [error, { vars: all, args: all, argsIgnorePattern: '^_' }]
+  no-use-before-define: off
   no-useless-backreference: error
   require-atomic-updates: error
   use-isnan: error
   valid-typeof: error
 
-  # Best Practices
-  # https://eslint.org/docs/rules/#best-practices
+  # Suggestions
+  # https://eslint.org/docs/latest/rules/#suggestions
 
   accessor-pairs: error
-  array-callback-return: error
+  arrow-body-style: error
   block-scoped-var: error
+  camelcase: error
+  capitalized-comments: off # maybe
   class-methods-use-this: off
   complexity: off
   consistent-return: off
+  consistent-this: off
   curly: error
   default-case: off
   default-case-last: error
   default-param-last: error
   dot-notation: error
   eqeqeq: [error, smart]
-  grouped-accessor-pairs: error
-  guard-for-in: error
-  max-classes-per-file: off
-  no-alert: error
-  no-caller: error
-  no-case-declarations: error
-  no-constructor-return: error
-  no-div-regex: error
-  no-else-return: error
-  no-empty-function: error
-  no-empty-pattern: error
-  no-eq-null: off
-  no-eval: error
-  no-extend-native: error
-  no-extra-bind: error
-  no-extra-label: error
-  no-fallthrough: error
-  no-global-assign: error
-  no-implicit-coercion: error
-  no-implicit-globals: off
-  no-implied-eval: error
-  no-invalid-this: error
-  no-iterator: error
-  no-labels: error
-  no-lone-blocks: error
-  no-loop-func: error
-  no-magic-numbers: off
-  no-multi-str: error
-  no-new: error
-  no-new-func: error
-  no-new-wrappers: error
-  no-nonoctal-decimal-escape: error
-  no-octal: error
-  no-octal-escape: error
-  no-param-reassign: error
-  no-proto: error
-  no-redeclare: error
-  no-restricted-properties: off
-  no-return-assign: error
-  no-return-await: error
-  no-script-url: error
-  no-self-assign: error
-  no-self-compare: off # TODO
-  no-sequences: error
-  no-throw-literal: error
-  no-unmodified-loop-condition: error
-  no-unused-expressions: error
-  no-unused-labels: error
-  no-useless-call: error
-  no-useless-catch: error
-  no-useless-concat: error
-  no-useless-escape: error
-  no-useless-return: error
-  no-void: error
-  no-warning-comments: off
-  no-with: error
-  prefer-named-capture-group: off # ES2018
-  prefer-promise-reject-errors: error
-  prefer-regex-literals: error
-  radix: error
-  require-await: error
-  require-unicode-regexp: off
-  vars-on-top: error
-  yoda: [error, never, { exceptRange: true }]
-
-  # Strict Mode
-  # https://eslint.org/docs/rules/#strict-mode
-
-  strict: error
-
-  # Variables
-  # https://eslint.org/docs/rules/#variables
-
-  init-declarations: off
-  logical-assignment-operators: error
-  no-delete-var: error
-  no-label-var: error
-  no-restricted-globals: off
-  no-shadow: error
-  no-shadow-restricted-names: error
-  no-undef: error
-  no-undef-init: error
-  no-undefined: off
-  no-unused-vars: [error, { vars: all, args: all, argsIgnorePattern: '^_' }]
-  no-use-before-define: off
-
-  # Stylistic Issues
-  # https://eslint.org/docs/rules/#stylistic-issues
-
-  camelcase: error
-  capitalized-comments: off # maybe
-  consistent-this: off
   func-name-matching: off
   func-names: [error, as-needed] # improve debug experience
   func-style: off
+  grouped-accessor-pairs: error
+  guard-for-in: error
   id-denylist: off
   id-length: off
   id-match: [error, '^(?:_?[a-zA-Z0-9]*)|[_A-Z0-9]+$']
-  line-comment-position: off
-  lines-around-comment: off
-  lines-between-class-members: [error, always, { exceptAfterSingleLine: true }]
+  init-declarations: off
+  logical-assignment-operators: error
+  max-classes-per-file: off
   max-depth: off
   max-lines: off
   max-lines-per-function: off
   max-nested-callbacks: off
   max-params: [error, 5] # TODO: drop to default number, which is 3
   max-statements: off
-  max-statements-per-line: off
   multiline-comment-style: off
   new-cap: error
+  no-alert: error
   no-array-constructor: error
   no-bitwise: off
+  no-caller: error
+  no-case-declarations: error
+  no-confusing-arrow: off
+  no-console: warn
   no-continue: off
+  no-delete-var: error
+  no-div-regex: error
+  no-else-return: error
+  no-empty: error
+  no-empty-function: error
+  no-eq-null: off
+  no-eval: error
+  no-extend-native: error
+  no-extra-bind: error
+  no-extra-boolean-cast: error
+  no-extra-label: error
+  no-extra-semi: off
+  no-floating-decimal: off
+  no-global-assign: error
+  no-implicit-coercion: error
+  no-implicit-globals: off
+  no-implied-eval: error
   no-inline-comments: off
+  no-invalid-this: error
+  no-iterator: error
+  no-label-var: error
+  no-labels: error
+  no-lone-blocks: error
   no-lonely-if: error
+  no-loop-func: error
+  no-magic-numbers: off
+  no-mixed-operators: off
   no-multi-assign: off
+  no-multi-str: error
   no-negated-condition: off
   no-nested-ternary: off
+  no-new: error
+  no-new-func: error
   no-new-object: error
+  no-new-wrappers: error
+  no-nonoctal-decimal-escape: error
+  no-octal: error
+  no-octal-escape: error
+  no-param-reassign: error
   no-plusplus: off
+  no-proto: error
+  no-redeclare: error
+  no-regex-spaces: error
+  no-restricted-exports: off
+  no-restricted-globals: off
+  no-restricted-imports: off
+  no-restricted-properties: off
   no-restricted-syntax: off
-  no-tabs: error
+  no-return-assign: error
+  no-return-await: error
+  no-script-url: error
+  no-sequences: error
+  no-shadow: error
+  no-shadow-restricted-names: error
   no-ternary: off
+  no-throw-literal: error
+  no-undef-init: error
+  no-undefined: off
   no-underscore-dangle: off # TODO
   no-unneeded-ternary: error
-  one-var: [error, never]
-  operator-assignment: error
-  padding-line-between-statements: off
-  prefer-exponentiation-operator: error
-  prefer-object-spread: error
-  quotes: [error, single, { avoidEscape: true }]
-  sort-keys: off
-  sort-vars: off
-  spaced-comment: error
-
-  # ECMAScript 6
-  # https://eslint.org/docs/rules/#ecmascript-6
-
-  arrow-body-style: error
-  constructor-super: error
-  no-class-assign: error
-  no-const-assign: error
-  no-dupe-class-members: error
-  no-duplicate-imports: off # Superseded by `import/no-duplicates`
-  no-new-symbol: error
-  no-restricted-exports: off
-  no-restricted-imports: off
-  no-this-before-super: error
+  no-unused-expressions: error
+  no-unused-labels: error
+  no-useless-call: error
+  no-useless-catch: error
   no-useless-computed-key: error
+  no-useless-concat: error
   no-useless-constructor: error
+  no-useless-escape: error
   no-useless-rename: error
+  no-useless-return: error
   no-var: error
+  no-void: error
+  no-warning-comments: off
+  no-with: error
   object-shorthand: error
+  one-var: [error, never]
+  one-var-declaration-per-line: off
+  operator-assignment: error
   prefer-arrow-callback: error
   prefer-const: error
   prefer-destructuring: off
+  prefer-exponentiation-operator: error
+  prefer-named-capture-group: off # ES2018
   prefer-numeric-literals: error
   prefer-object-has-own: off # TODO requires Node.js v16.9.0
+  prefer-object-spread: error
+  prefer-promise-reject-errors: error
+  prefer-regex-literals: error
   prefer-rest-params: off # TODO
   prefer-spread: error
   prefer-template: off
+  quote-props: off # Superseded by prettier
+  radix: error
+  require-await: error
+  require-unicode-regexp: off
   require-yield: error
   sort-imports: off
+  sort-keys: off
+  sort-vars: off
+  spaced-comment: error
+  strict: error
   symbol-description: off
+  vars-on-top: error
+  yoda: [error, never, { exceptRange: true }]
+
+  # Layout & Formatting
+  # https://eslint.org/docs/latest/rules/#layout--formatting
+
+  line-comment-position: off
+  lines-around-comment: off
+  lines-between-class-members: [error, always, { exceptAfterSingleLine: true }]
+  max-statements-per-line: off
+  no-tabs: error
+  padding-line-between-statements: off
+  quotes: [error, single, { avoidEscape: true }]
 
   # Bellow rules are disabled because coflicts with Prettier, see:
   # https://github.com/prettier/eslint-config-prettier/blob/master/index.js
@@ -437,25 +432,18 @@ rules:
   multiline-ternary: off
   newline-per-chained-call: off
   new-parens: off
-  no-confusing-arrow: off
   no-extra-parens: off
-  no-extra-semi: off
-  no-floating-decimal: off
-  no-mixed-operators: off
   no-mixed-spaces-and-tabs: off
   no-multi-spaces: off
   no-multiple-empty-lines: off
   no-trailing-spaces: off
-  no-unexpected-multiline: off
   no-whitespace-before-property: off
   nonblock-statement-body-position: off
   object-curly-newline: off
   object-curly-spacing: off
   object-property-newline: off
-  one-var-declaration-per-line: off
   operator-linebreak: off
   padded-blocks: off
-  quote-props: off
   rest-spread-spacing: off
   semi: off
   semi-spacing: off


### PR DESCRIPTION
Motivation: it useful to have rules in this order to make it easier to add new ESLint rules and also inspect docs of existing rules