### PR TITLE
Improve directive tests

### DIFF
--- a/src/validation/__tests__/KnownDirectivesRule-test.ts
+++ b/src/validation/__tests__/KnownDirectivesRule-test.ts
@@ -348,6 +348,9 @@ describe('Validate: Known directives', () => {
             query: MyQuery
           }
 
+          directive @myDirective(arg:String) on ARGUMENT_DEFINITION 
+          directive @myDirective2(arg:String @myDirective) on FIELD 
+
           extend schema @onSchema
         `,
         schemaWithSDLDirectives,


### PR DESCRIPTION
Improving directive tests by adding a new example for directives used on other directive arguments:

```graphql
          directive @myDirective(arg:String) on ARGUMENT_DEFINITION 
          directive @myDirective2(arg:String @myDirective) on FIELD 
```

As far as I could see that was not clearly documented through tests before.