### PR TITLE
extendSchema: preserve "description" and "extensions"

### DIFF
--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -196,6 +196,27 @@ describe('extendSchema', () => {
     expect(extendedTwiceSchema.getType('ID')).to.equal(GraphQLID);
   });
 
+  it('copies original schema description to extended schema', () => {
+    const description = 'A schema description';
+
+    const extendedSchema = extendSchema(
+      buildSchema(`
+        "${description}"
+        schema {
+          query: Foo
+        }
+        
+        type Foo {
+          foo: String
+        }
+      `),
+      parse('scalar Bar'),
+    );
+
+    expect(extendedSchema.astNode?.description?.value).to.equal(description);
+    expect(extendedSchema.description).to.equal(description);
+  });
+
   it('extends enums by adding new values', () => {
     const schema = buildSchema(`
       type Query {

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -113,6 +113,17 @@ describe('extendSchema', () => {
     expect(extendedSchema.getDirectives()).to.have.members(specifiedDirectives);
   });
 
+  it('preserves original schema config', () => {
+    const description = 'A schema description';
+    const extensions = Object.freeze({ foo: 'bar' });
+    const schema = new GraphQLSchema({ description, extensions });
+
+    const extendedSchema = extendSchema(schema, parse('scalar Bar'));
+
+    expect(extendedSchema.description).to.equal(description);
+    expect(extendedSchema.extensions).to.deep.equal(extensions);
+  });
+
   it('extends objects by adding new fields', () => {
     const schema = buildSchema(`
       type Query {
@@ -194,27 +205,6 @@ describe('extendSchema', () => {
     expect(extendedTwiceSchema.getType('String')).to.equal(GraphQLString);
     expect(extendedTwiceSchema.getType('Boolean')).to.equal(GraphQLBoolean);
     expect(extendedTwiceSchema.getType('ID')).to.equal(GraphQLID);
-  });
-
-  it('copies original schema description to extended schema', () => {
-    const description = 'A schema description';
-
-    const extendedSchema = extendSchema(
-      buildSchema(`
-        "${description}"
-        schema {
-          query: Foo
-        }
-        
-        type Foo {
-          foo: String
-        }
-      `),
-      parse('scalar Bar'),
-    );
-
-    expect(extendedSchema.astNode?.description?.value).to.equal(description);
-    expect(extendedSchema.description).to.equal(description);
   });
 
   it('extends enums by adding new values', () => {

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -246,7 +246,7 @@ export function extendSchemaImpl(
       ...schemaConfig.directives.map(replaceDirective),
       ...directiveDefs.map(buildDirective),
     ],
-    extensions: Object.create(null),
+    extensions: schemaConfig.extensions,
     astNode: schemaDef ?? schemaConfig.astNode,
     extensionASTNodes: schemaConfig.extensionASTNodes.concat(schemaExtensions),
     assumeValid: options?.assumeValid ?? false,

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -239,7 +239,7 @@ export function extendSchemaImpl(
 
   // Then produce and return a Schema config with these types.
   return {
-    description: schemaDef?.description?.value,
+    description: schemaDef?.description?.value ?? schemaConfig.description,
     ...operationTypes,
     types: Object.values(typeMap),
     directives: [


### PR DESCRIPTION
👋 

Closes https://github.com/graphql/graphql-js/issues/3629

### Current behavior:

When calling `extendSchema(schema, schemaModification)`, extended schema description is calculated as `schemaDef?.description?.value`, where
* `schemaDef` is a _nullable_ schema definition, that will not be null only if `schemaModification` declares the `type schema` (it happens only when we call `buildSchema` _or_ call `extendSchema(schema, 'extend type __Schema { ... }')`)
* `schemaDef?.description` is not undefined only when `extendSchema` is called from `buildSchema`, otherwise it's undefined because we don't allow a construction like:
```
"my awesome description" // error - graphql-js doesn't allow you to set the description when you extend schema
extend type __Schema { ... }
```

As a result, every `extendSchema` call besides the one in `buildSchema` will cause `description` to become `undefined`

### Proposed solution:
Always fallback to the original schema description: 
```description: schemaDef?.description?.value ?? schemaConfig.description```

It will allow us to make sure that we take a description from `schemaDef` when schema is being built and take original schema description in any other cases
