### PR TITLE
execution: Preserve extensions in parseValue errors

### DIFF
--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -131,7 +131,7 @@ function coerceVariableValues(
         onError(
           new GraphQLError(prefix + '; ' + error.message, {
             nodes: varDefNode,
-            originalError: error.originalError,
+            originalError: error,
           }),
         );
       },


### PR DESCRIPTION
Previously, the only fields observed on an error thrown by (for example)
parseValue were `message` and `originalError`. Now, the error itself is
used as the `originalError`; this may be mildly backwards-incompatible
if you added extensions on the error itself which you for some reason
wanted to disappear, but that seems unlikely.

Addresses an issue raised in
https://github.com/apollographql/apollo-server/issues/7178