### PR TITLE
Use explicit extension for package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,
-  "main": "index",
+  "main": "index.js",
   "module": "index.mjs",
   "typesVersions": {
     ">=4.1.0": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "private": true,
   "main": "index.js",
+  "types": "index.d.ts",
   "module": "index.mjs",
   "typesVersions": {
     ">=4.1.0": {


### PR DESCRIPTION
This package can't be used inside a custom Vite plugin for a cjs project.

This is due to the fact that Vite reimplement a lot of node resolution logic to help pre-bundle the config file. This logic doesn't handle correctly extension-less main entrypoint which causes it to then resolve `index` to `index.mjs`.

I think it doesn't hurt to be have an explicit extension and would avoid yet another edge case in this complex part of Vite code.

Thanks!