### PR TITLE
workflows: fix and cleanup permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,12 @@
 name: CI
 on: workflow_call
-permissions:
-  contents: read
+permissions: {}
 jobs:
   lint:
     name: Lint source files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -41,6 +42,8 @@ jobs:
   checkForCommonlyIgnoredFiles:
     name: Check for commonly ignored files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -64,6 +67,8 @@ jobs:
   checkPackageLock:
     name: Check health of package-lock.json file
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -92,6 +97,8 @@ jobs:
   integrationTests:
     name: Run integration tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -114,6 +121,8 @@ jobs:
   fuzz:
     name: Run fuzzing tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -138,6 +147,8 @@ jobs:
     strategy:
       matrix:
         node_version_to_setup: [14, 16, 18]
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -160,7 +171,7 @@ jobs:
     name: Run CodeQL security scan
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # for actions/checkout
       security-events: write
     steps:
       - name: Checkout repo
@@ -179,6 +190,8 @@ jobs:
   build-npm-dist:
     name: Build 'npmDist' artifact
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -206,6 +219,8 @@ jobs:
   build-deno-dist:
     name: Build 'denoDist' artifact
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -233,6 +248,8 @@ jobs:
   build-website-dist:
     name: Build website
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/cmd-publish-pr-on-npm.yml
+++ b/.github/workflows/cmd-publish-pr-on-npm.yml
@@ -10,11 +10,12 @@ on:
       npm_canary_pr_publish_token:
         description: NPM token to publish canary release.
         required: true
-permissions:
-  contents: read
+permissions: {}
 jobs:
   build-npm-dist:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -45,6 +46,8 @@ jobs:
     name: Publish Canary
     environment: canary-pr-npm
     needs: [build-npm-dist]
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/cmd-run-benchmark.yml
+++ b/.github/workflows/cmd-run-benchmark.yml
@@ -6,13 +6,14 @@ on:
         description: String that contain JSON payload for `pull_request` event.
         required: true
         type: string
-permissions:
-  contents: read # for checkout
-  actions: read # to list workflow runs
+permissions: {}
 jobs:
   benchmark:
     name: Run benchmark
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
+      actions: read # to list workflow runs
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-artifact-as-branch.yml
+++ b/.github/workflows/deploy-artifact-as-branch.yml
@@ -21,12 +21,12 @@ on:
 permissions: {}
 jobs:
   deploy-artifact-as-branch:
-    permissions:
-      contents: write # to push branch
     environment:
       name: ${{ inputs.environment }}
       url: ${{ github.server_url }}/${{ github.repository }}/tree/${{ inputs.target_branch }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for actions/checkout and to push branch
     steps:
       - name: Checkout `${{ inputs.target_branch }}` branch
         uses: actions/checkout@v3

--- a/.github/workflows/github-actions-bot.yml
+++ b/.github/workflows/github-actions-bot.yml
@@ -24,12 +24,11 @@ env:
 permissions: {}
 jobs:
   hello-message:
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-latest
     permissions:
       actions: read # to download event.json
       pull-requests: write # to add comment to pull request
-
-    if: github.event_name == 'workflow_run'
-    runs-on: ubuntu-latest
     steps:
       - name: Download event.json
         run: gh run download "$WORKFLOW_ID" --repo "$REPO" --name event.json
@@ -54,14 +53,13 @@ jobs:
             })
 
   accept-cmd:
-    permissions:
-      pull-requests: write # to add comment to pull request
-
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '@github-actions ')
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to add comment to pull request
     outputs:
       cmd: ${{ steps.parse-cmd.outputs.cmd }}
       pull_request_json: ${{ steps.parse-cmd.outputs.pull_request_json }}
@@ -90,7 +88,7 @@ jobs:
     needs: [accept-cmd]
     if: needs.accept-cmd.outputs.cmd == 'publish-pr-on-npm'
     permissions:
-      contents: read
+      contents: read # for actions/checkout
     uses: ./.github/workflows/cmd-publish-pr-on-npm.yml
     with:
       pull_request_json: ${{ needs.accept-cmd.outputs.pull_request_json }}
@@ -101,22 +99,21 @@ jobs:
     needs: [accept-cmd]
     if: needs.accept-cmd.outputs.cmd == 'run-benchmark'
     permissions:
-      contents: read # for checkout
+      contents: read # for actions/checkout
       actions: read # to list workflow runs
     uses: ./.github/workflows/cmd-run-benchmark.yml
     with:
       pull_request_json: ${{ needs.accept-cmd.outputs.pull_request_json }}
 
   respond-to-cmd:
-    permissions:
-      pull-requests: write # to add comment to pull request
-
     needs:
       - accept-cmd
       - cmd-publish-pr-on-npm
       - cmd-run-benchmark
     if: needs.accept-cmd.result != 'skipped' && always()
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # to add comment to pull request
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -3,14 +3,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *' # run once every day at 00:00 UTC
-
-permissions:
-  contents: read # to fetch code (actions/checkout)
-
+permissions: {}
 jobs:
   lint:
     name: Run mutation testing
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,12 +1,17 @@
 name: PullRequest
 on: pull_request
+permissions: {}
 jobs:
   ci:
+    permissions:
+      contents: read # for actions/checkout
     uses: ./.github/workflows/ci.yml
 
   dependency-review:
     name: Security check of added dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -19,6 +24,8 @@ jobs:
   diff-npm-package:
     name: Diff content of NPM package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # for actions/checkout
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -2,6 +2,7 @@ name: PullRequestOpened
 on:
   pull_request:
     types: [opened]
+permissions: {}
 jobs:
   save-github-event:
     name: "Save `github.event` as an artifact to use in subsequent 'workflow_run' actions"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,11 +3,16 @@ on: push
 permissions: {}
 jobs:
   ci:
+    permissions:
+      contents: read # for actions/checkout
+      security-events: write
     uses: ./.github/workflows/ci.yml
   deploy-to-npm-branch:
     name: Deploy to `npm` branch
     needs: ci
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write # for actions/checkout and to push branch
     uses: ./.github/workflows/deploy-artifact-as-branch.yml
     with:
       environment: npm-branch
@@ -19,6 +24,8 @@ jobs:
     name: Deploy to `deno` branch
     needs: ci
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write # for actions/checkout and to push branch
     uses: ./.github/workflows/deploy-artifact-as-branch.yml
     with:
       environment: deno-branch


### PR DESCRIPTION
Context: #3751 added permissions to workflows.
It broke some of the workflows and was partially fixed in #3759 
This PR attempt to fix the rest of the workflows and also clean up permissions in general. 
Assigning granular permissions is error-prone, especially if we need to account for top-level workflow permissions. 
This PR attempt to solve this by explicitly listing permissions on each individual job. 
It slightly increases verbosity for some workflows but is more maintainable by keeping permissions closer to the required steps.