### PR TITLE
fix permissions for codeql-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # for actions/checkout
-      security-events: write
+      security-events: write # for codeql-action
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,7 @@ jobs:
   ci:
     permissions:
       contents: read # for actions/checkout
+      security-events: write # for codeql-action
     uses: ./.github/workflows/ci.yml
 
   dependency-review:


### PR DESCRIPTION
see https://github.com/graphql/graphql-js/actions/runs/3688795010/workflow error:

> The workflow is not valid. .github/workflows/pull_request.yml (Line: 5, Col: 3): Error calling workflow 'graphql/graphql-js/.github/workflows/ci.yml@07f38221a71005a56927e4327c9d188c222403f7'. The nested job 'Run CodeQL security scan' is requesting 'security-events: write', but is only allowed 'security-events: none'.