### PR TITLE
fix: return correct originalError after normalize for deprecated GraphQLError

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -45,12 +45,17 @@ function toNormalizedOptions(
 ): GraphQLErrorOptions {
   const firstArg = args[0];
   if (firstArg == null || 'kind' in firstArg || 'length' in firstArg) {
+    const originalError =
+      args[4] instanceof GraphQLError && args[4].originalError
+        ? args[4].originalError
+        : args[4];
+
     return {
       nodes: firstArg,
       source: args[1],
       positions: args[2],
       path: args[3],
-      originalError: args[4],
+      originalError,
       extensions: args[5],
     };
   }

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -71,6 +71,30 @@ describe('GraphQLError', () => {
     });
   });
 
+  it('uses correct originalError for deprecated declaration of GraphQLError', () => {
+    const originalError = new Error('original');
+    const graphQLError = new GraphQLError('msg', {
+      originalError,
+    });
+    const deprecatedError = new GraphQLError(
+      'msg',
+      null,
+      undefined,
+      undefined,
+      undefined,
+      graphQLError,
+    );
+    const expectedError = new GraphQLError('msg', graphQLError);
+
+    expect(deprecatedError).to.include({
+      name: 'GraphQLError',
+      message: 'msg',
+      stack: originalError.stack,
+      originalError,
+    });
+    expect(deprecatedError).to.deep.equal(expectedError);
+  });
+
   it('creates new stack if original error has no stack', () => {
     const original = new Error('original');
     const e = new GraphQLError('msg', { originalError: original });


### PR DESCRIPTION
In `graphql-js v16` property becomes nested `error.originalError.originalError` in `toNormalizedOptions`, but should be just `error.originalError`.

Added condition to check if `error` instance of `GraphQLError` then just return `args[4].originalError`.

Issue happens in `executeFieldsSerially`.