### PR TITLE
polish: remove misleading comment

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -933,8 +933,6 @@ async function completePromisedValue(
       asyncPayloadRecord,
     );
     if (isPromise(completed)) {
-      // see: https://github.com/tc39/proposal-faster-promise-adoption
-      // it is faster to await a promise prior to returning it from an async function
       completed = await completed;
     }
     return completed;


### PR DESCRIPTION
We could not demonstrate via actual benchmarking that the tick reduction from awaiting a promise prior to returning it translates into real-world performance gains. See #3796.

In any case, the promise must be awaited (irrespective of performance) to allow the catch block to handle rejection errors. Simply returning `completed` would result in test failures.