### PR TITLE
Add coordinate field to schema element definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,24 +34,23 @@ export type { GraphQLArgs } from './graphql.js';
 export { graphql, graphqlSync } from './graphql.js';
 
 // Create and operate on GraphQL type definitions and schema.
-export type {
-  GraphQLField,
-  GraphQLArgument,
-  GraphQLEnumValue,
-  GraphQLInputField,
-} from './type/index.js';
 export {
   resolveObjMapThunk,
   resolveReadonlyArrayThunk,
   // Definitions
   GraphQLSchema,
   GraphQLDirective,
+  GraphQLSchemaElement,
   GraphQLScalarType,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
+  GraphQLField,
+  GraphQLArgument,
+  GraphQLEnumValue,
+  GraphQLInputField,
   GraphQLList,
   GraphQLNonNull,
   // Standard GraphQL Scalars

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -329,6 +329,7 @@ describe('Type System: Objects', () => {
       }),
     });
     expect(objType.getFields().f).to.deep.include({
+      coordinate: 'SomeObject.f',
       parentType: objType,
       name: 'f',
       description: undefined,
@@ -358,6 +359,7 @@ describe('Type System: Objects', () => {
     const f = objType.getFields().f;
 
     expect(f).to.deep.include({
+      coordinate: 'SomeObject.f',
       parentType: objType,
       name: 'f',
       description: undefined,
@@ -372,6 +374,7 @@ describe('Type System: Objects', () => {
     expect(f.args).to.have.lengthOf(1);
 
     expect(f.args[0]).to.deep.include({
+      coordinate: 'SomeObject.f(arg:)',
       parent: f,
       name: 'arg',
       description: undefined,
@@ -736,6 +739,8 @@ describe('Type System: Enums', () => {
     expect(values).to.have.lengthOf(3);
 
     expect(values[0]).to.deep.include({
+      coordinate: 'EnumWithNullishValue.NULL',
+      parentEnum: EnumTypeWithNullishValue,
       name: 'NULL',
       description: undefined,
       value: null,
@@ -745,6 +750,8 @@ describe('Type System: Enums', () => {
     });
 
     expect(values[1]).to.deep.include({
+      coordinate: 'EnumWithNullishValue.NAN',
+      parentEnum: EnumTypeWithNullishValue,
       name: 'NAN',
       description: undefined,
       value: NaN,
@@ -754,6 +761,8 @@ describe('Type System: Enums', () => {
     });
 
     expect(values[2]).to.deep.include({
+      coordinate: 'EnumWithNullishValue.NO_CUSTOM_VALUE',
+      parentEnum: EnumTypeWithNullishValue,
       name: 'NO_CUSTOM_VALUE',
       description: undefined,
       value: 'NO_CUSTOM_VALUE',
@@ -856,6 +865,7 @@ describe('Type System: Input Objects', () => {
         },
       });
       expect(inputObjType.getFields().f).to.deep.include({
+        coordinate: 'SomeInputObject.f',
         parentType: inputObjType,
         name: 'f',
         description: undefined,
@@ -876,6 +886,7 @@ describe('Type System: Input Objects', () => {
         }),
       });
       expect(inputObjType.getFields().f).to.deep.include({
+        coordinate: 'SomeInputObject.f',
         parentType: inputObjType,
         name: 'f',
         description: undefined,

--- a/src/type/__tests__/directive-test.ts
+++ b/src/type/__tests__/directive-test.ts
@@ -40,6 +40,7 @@ describe('Type System: Directive', () => {
     expect(directive.args).to.have.lengthOf(2);
 
     expect(directive.args[0]).to.deep.include({
+      coordinate: '@Foo(foo:)',
       parent: directive,
       name: 'foo',
       description: undefined,
@@ -52,6 +53,7 @@ describe('Type System: Directive', () => {
     });
 
     expect(directive.args[1]).to.deep.include({
+      coordinate: '@Foo(bar:)',
       parent: directive,
       name: 'bar',
       description: undefined,

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -398,6 +398,7 @@ describe('Type System: Enum Values', () => {
 
     expect(values[0]).to.deep.include({
       parentEnum: ComplexEnum,
+      coordinate: 'Complex.ONE',
       name: 'ONE',
       description: undefined,
       value: Complex1,
@@ -408,6 +409,7 @@ describe('Type System: Enum Values', () => {
 
     expect(values[1]).to.deep.include({
       parentEnum: ComplexEnum,
+      coordinate: 'Complex.TWO',
       name: 'TWO',
       description: undefined,
       value: Complex2,

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -365,9 +365,7 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType {
  * })
  * ```
  */
-export class GraphQLList<T extends GraphQLType>
-  implements GraphQLSchemaElement
-{
+export class GraphQLList<T extends GraphQLType> {
   readonly ofType: T;
 
   constructor(ofType: T) {
@@ -408,9 +406,7 @@ export class GraphQLList<T extends GraphQLType>
  * ```
  * Note: the enforcement of non-nullability occurs within the executor.
  */
-export class GraphQLNonNull<T extends GraphQLNullableType>
-  implements GraphQLSchemaElement
-{
+export class GraphQLNonNull<T extends GraphQLNullableType> {
   readonly ofType: T;
 
   constructor(ofType: T) {
@@ -535,12 +531,28 @@ export function getNamedType(
 }
 
 /**
- * An interface for all Schema Elements.
+ * The base class for all Schema Elements.
  */
+export class GraphQLSchemaElement {
+  readonly coordinate: string;
 
-export interface GraphQLSchemaElement {
-  toString: () => string;
-  toJSON: () => string;
+  constructor(coordinate: string) {
+    this.coordinate = coordinate;
+  }
+
+  // TODO: add coverage
+  /* c8 ignore next 3*/
+  get [Symbol.toStringTag]() {
+    return 'GraphQLSchemaElement';
+  }
+
+  toString(): string {
+    return this.coordinate;
+  }
+
+  toJSON(): string {
+    return this.toString();
+  }
 }
 
 /**
@@ -648,9 +660,10 @@ export interface GraphQLScalarTypeExtensions {
  *    `coerceInputLiteral()` method.
  *
  */
-export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
-  implements GraphQLSchemaElement
-{
+export class GraphQLScalarType<
+  TInternal = unknown,
+  TExternal = TInternal,
+> extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   specifiedByURL: Maybe<string>;
@@ -669,6 +682,8 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
   extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
 
   constructor(config: Readonly<GraphQLScalarTypeConfig<TInternal, TExternal>>) {
+    const coordinate = config.name;
+    super(coordinate);
     this.name = assertName(config.name);
     this.description = config.description;
     this.specifiedByURL = config.specifiedByURL;
@@ -709,7 +724,7 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
     }
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLScalarType';
   }
 
@@ -729,14 +744,6 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
     };
-  }
-
-  toString(): string {
-    return this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -866,9 +873,10 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  * });
  * ```
  */
-export class GraphQLObjectType<TSource = any, TContext = any>
-  implements GraphQLSchemaElement
-{
+export class GraphQLObjectType<
+  TSource = any,
+  TContext = any,
+> extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
@@ -880,6 +888,8 @@ export class GraphQLObjectType<TSource = any, TContext = any>
   private _interfaces: ThunkReadonlyArray<GraphQLInterfaceType>;
 
   constructor(config: Readonly<GraphQLObjectTypeConfig<TSource, TContext>>) {
+    const coordinate = config.name;
+    super(coordinate);
     this.name = assertName(config.name);
     this.description = config.description;
     this.isTypeOf = config.isTypeOf;
@@ -894,7 +904,7 @@ export class GraphQLObjectType<TSource = any, TContext = any>
     this._interfaces = defineInterfaces.bind(undefined, config.interfaces);
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLObjectType';
   }
 
@@ -923,14 +933,6 @@ export class GraphQLObjectType<TSource = any, TContext = any>
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
     };
-  }
-
-  toString(): string {
-    return this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -1090,9 +1092,11 @@ export type GraphQLFieldNormalizedConfigMap<TSource, TContext> = ObjMap<
   GraphQLFieldNormalizedConfig<TSource, TContext>
 >;
 
-export class GraphQLField<TSource = any, TContext = any, TArgs = any>
-  implements GraphQLSchemaElement
-{
+export class GraphQLField<
+  TSource = any,
+  TContext = any,
+  TArgs = any,
+> extends GraphQLSchemaElement {
   parentType:
     | GraphQLObjectType<TSource, TContext>
     | GraphQLInterfaceType<TSource, TContext>
@@ -1115,6 +1119,8 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
     name: string,
     config: GraphQLFieldConfig<TSource, TContext, TArgs>,
   ) {
+    const coordinate = `${parentType ?? '<meta>'}.${name}`;
+    super(coordinate);
     this.parentType = parentType;
     this.name = assertName(name);
     this.description = config.description;
@@ -1135,7 +1141,7 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
     this.astNode = config.astNode;
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLField';
   }
 
@@ -1155,17 +1161,9 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
       astNode: this.astNode,
     };
   }
-
-  toString(): string {
-    return `${this.parentType ?? '<meta>'}.${this.name}`;
-  }
-
-  toJSON(): string {
-    return this.toString();
-  }
 }
 
-export class GraphQLArgument implements GraphQLSchemaElement {
+export class GraphQLArgument extends GraphQLSchemaElement {
   parent: GraphQLField | GraphQLDirective;
   name: string;
   description: Maybe<string>;
@@ -1181,6 +1179,8 @@ export class GraphQLArgument implements GraphQLSchemaElement {
     name: string,
     config: GraphQLArgumentConfig,
   ) {
+    const coordinate = `${parent}(${name}:)`;
+    super(coordinate);
     this.parent = parent;
     this.name = assertName(name);
     this.description = config.description;
@@ -1192,7 +1192,7 @@ export class GraphQLArgument implements GraphQLSchemaElement {
     this.astNode = config.astNode;
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLArgument';
   }
 
@@ -1206,14 +1206,6 @@ export class GraphQLArgument implements GraphQLSchemaElement {
       extensions: this.extensions,
       astNode: this.astNode,
     };
-  }
-
-  toString(): string {
-    return `${this.parent}(${this.name}:)`;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -1267,9 +1259,10 @@ export interface GraphQLInterfaceTypeExtensions {
  * });
  * ```
  */
-export class GraphQLInterfaceType<TSource = any, TContext = any>
-  implements GraphQLSchemaElement
-{
+export class GraphQLInterfaceType<
+  TSource = any,
+  TContext = any,
+> extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   resolveType: Maybe<GraphQLTypeResolver<TSource, TContext>>;
@@ -1281,6 +1274,8 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
   private _interfaces: ThunkReadonlyArray<GraphQLInterfaceType>;
 
   constructor(config: Readonly<GraphQLInterfaceTypeConfig<TSource, TContext>>) {
+    const coordinate = config.name;
+    super(coordinate);
     this.name = assertName(config.name);
     this.description = config.description;
     this.resolveType = config.resolveType;
@@ -1295,7 +1290,7 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
     this._interfaces = defineInterfaces.bind(undefined, config.interfaces);
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLInterfaceType';
   }
 
@@ -1324,14 +1319,6 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
     };
-  }
-
-  toString(): string {
-    return this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -1396,7 +1383,7 @@ export interface GraphQLUnionTypeExtensions {
  * });
  * ```
  */
-export class GraphQLUnionType implements GraphQLSchemaElement {
+export class GraphQLUnionType extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   resolveType: Maybe<GraphQLTypeResolver<any, any>>;
@@ -1407,6 +1394,8 @@ export class GraphQLUnionType implements GraphQLSchemaElement {
   private _types: ThunkReadonlyArray<GraphQLObjectType>;
 
   constructor(config: Readonly<GraphQLUnionTypeConfig<any, any>>) {
+    const coordinate = config.name;
+    super(coordinate);
     this.name = assertName(config.name);
     this.description = config.description;
     this.resolveType = config.resolveType;
@@ -1417,7 +1406,7 @@ export class GraphQLUnionType implements GraphQLSchemaElement {
     this._types = defineTypes.bind(undefined, config.types);
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLUnionType';
   }
 
@@ -1438,14 +1427,6 @@ export class GraphQLUnionType implements GraphQLSchemaElement {
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
     };
-  }
-
-  toString(): string {
-    return this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -1513,7 +1494,7 @@ export interface GraphQLEnumTypeExtensions {
  * Note: If a value is not provided in a definition, the name of the enum value
  * will be used as its internal value.
  */
-export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
+export class GraphQLEnumType /* <T> */ extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   extensions: Readonly<GraphQLEnumTypeExtensions>;
@@ -1528,6 +1509,8 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
   private _nameLookup: ObjMap<GraphQLEnumValue> | null;
 
   constructor(config: Readonly<GraphQLEnumTypeConfig /* <T> */>) {
+    const coordinate = config.name;
+    super(coordinate);
     this.name = assertName(config.name);
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1545,7 +1528,7 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
     this._nameLookup = null;
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLEnumType';
   }
 
@@ -1674,14 +1657,6 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
       extensionASTNodes: this.extensionASTNodes,
     };
   }
-
-  toString(): string {
-    return this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
-  }
 }
 
 function didYouMeanEnumValue(
@@ -1741,7 +1716,7 @@ export interface GraphQLEnumValueNormalizedConfig
   extensions: Readonly<GraphQLEnumValueExtensions>;
 }
 
-export class GraphQLEnumValue implements GraphQLSchemaElement {
+export class GraphQLEnumValue extends GraphQLSchemaElement {
   parentEnum: GraphQLEnumType;
   name: string;
   description: Maybe<string>;
@@ -1755,6 +1730,7 @@ export class GraphQLEnumValue implements GraphQLSchemaElement {
     name: string,
     config: GraphQLEnumValueConfig,
   ) {
+    super(`${parentEnum}.${name}`);
     this.parentEnum = parentEnum;
     this.name = assertEnumValueName(name);
     this.description = config.description;
@@ -1764,7 +1740,7 @@ export class GraphQLEnumValue implements GraphQLSchemaElement {
     this.astNode = config.astNode;
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLEnumValue';
   }
 
@@ -1776,14 +1752,6 @@ export class GraphQLEnumValue implements GraphQLSchemaElement {
       extensions: this.extensions,
       astNode: this.astNode,
     };
-  }
-
-  toString(): string {
-    return `${this.parentEnum.name}.${this.name}`;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -1821,7 +1789,7 @@ export interface GraphQLInputObjectTypeExtensions {
  * });
  * ```
  */
-export class GraphQLInputObjectType implements GraphQLSchemaElement {
+export class GraphQLInputObjectType extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   extensions: Readonly<GraphQLInputObjectTypeExtensions>;
@@ -1832,6 +1800,7 @@ export class GraphQLInputObjectType implements GraphQLSchemaElement {
   private _fields: ThunkObjMap<GraphQLInputField>;
 
   constructor(config: Readonly<GraphQLInputObjectTypeConfig>) {
+    super(config.name);
     this.name = assertName(config.name);
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1842,7 +1811,7 @@ export class GraphQLInputObjectType implements GraphQLSchemaElement {
     this._fields = defineInputFieldMap.bind(undefined, this, config.fields);
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLInputObjectType';
   }
 
@@ -1863,14 +1832,6 @@ export class GraphQLInputObjectType implements GraphQLSchemaElement {
       extensionASTNodes: this.extensionASTNodes,
       isOneOf: this.isOneOf,
     };
-  }
-
-  toString(): string {
-    return this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 
@@ -1938,7 +1899,7 @@ export interface GraphQLInputFieldNormalizedConfig
 export type GraphQLInputFieldNormalizedConfigMap =
   ObjMap<GraphQLInputFieldNormalizedConfig>;
 
-export class GraphQLInputField implements GraphQLSchemaElement {
+export class GraphQLInputField extends GraphQLSchemaElement {
   parentType: GraphQLInputObjectType;
   name: string;
   description: Maybe<string>;
@@ -1954,9 +1915,12 @@ export class GraphQLInputField implements GraphQLSchemaElement {
     name: string,
     config: GraphQLInputFieldConfig,
   ) {
+    const coordinate = `${parentType}.${name}`;
+    super(coordinate);
+
     devAssert(
       !('resolve' in config),
-      `${parentType}.${name} field has a resolve property, but Input Types cannot define resolvers.`,
+      `${coordinate} field has a resolve property, but Input Types cannot define resolvers.`,
     );
 
     this.parentType = parentType;
@@ -1970,7 +1934,7 @@ export class GraphQLInputField implements GraphQLSchemaElement {
     this.astNode = config.astNode;
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLInputField';
   }
 
@@ -1984,14 +1948,6 @@ export class GraphQLInputField implements GraphQLSchemaElement {
       extensions: this.extensions,
       astNode: this.astNode,
     };
-  }
-
-  toString(): string {
-    return `${this.parentType}.${this.name}`;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -14,9 +14,12 @@ import { assertName } from './assertName.js';
 import type {
   GraphQLArgumentConfig,
   GraphQLFieldNormalizedConfigArgumentMap,
+} from './definition.js';
+import {
+  GraphQLArgument,
+  GraphQLNonNull,
   GraphQLSchemaElement,
 } from './definition.js';
-import { GraphQLArgument, GraphQLNonNull } from './definition.js';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from './scalars.js';
 
 /**
@@ -52,7 +55,7 @@ export interface GraphQLDirectiveExtensions {
  * Directives are used by the GraphQL runtime as a way of modifying execution
  * behavior. Type system creators will usually not create these directly.
  */
-export class GraphQLDirective implements GraphQLSchemaElement {
+export class GraphQLDirective extends GraphQLSchemaElement {
   name: string;
   description: Maybe<string>;
   locations: ReadonlyArray<DirectiveLocation>;
@@ -62,6 +65,8 @@ export class GraphQLDirective implements GraphQLSchemaElement {
   astNode: Maybe<DirectiveDefinitionNode>;
 
   constructor(config: Readonly<GraphQLDirectiveConfig>) {
+    const coordinate = `@${config.name}`;
+    super(coordinate);
     this.name = assertName(config.name);
     this.description = config.description;
     this.locations = config.locations;
@@ -71,13 +76,13 @@ export class GraphQLDirective implements GraphQLSchemaElement {
 
     devAssert(
       Array.isArray(config.locations),
-      `@${this.name} locations must be an Array.`,
+      `${coordinate} locations must be an Array.`,
     );
 
     const args = config.args ?? {};
     devAssert(
       isObjectLike(args) && !Array.isArray(args),
-      `@${this.name} args must be an object with argument names as keys.`,
+      `@${coordinate} args must be an object with argument names as keys.`,
     );
 
     this.args = Object.entries(args).map(
@@ -85,7 +90,7 @@ export class GraphQLDirective implements GraphQLSchemaElement {
     );
   }
 
-  get [Symbol.toStringTag]() {
+  override get [Symbol.toStringTag]() {
     return 'GraphQLDirective';
   }
 
@@ -103,14 +108,6 @@ export class GraphQLDirective implements GraphQLSchemaElement {
       extensions: this.extensions,
       astNode: this.astNode,
     };
-  }
-
-  toString(): string {
-    return '@' + this.name;
-  }
-
-  toJSON(): string {
-    return this.toString();
   }
 }
 

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -10,12 +10,6 @@ export {
 } from './schema.js';
 export type { GraphQLSchemaConfig, GraphQLSchemaExtensions } from './schema.js';
 
-export type {
-  GraphQLField,
-  GraphQLArgument,
-  GraphQLEnumValue,
-  GraphQLInputField,
-} from './definition.js';
 export {
   resolveObjMapThunk,
   resolveReadonlyArrayThunk,
@@ -69,12 +63,17 @@ export {
   getNullableType,
   getNamedType,
   // Definitions
+  GraphQLSchemaElement,
   GraphQLScalarType,
   GraphQLObjectType,
   GraphQLInterfaceType,
   GraphQLUnionType,
   GraphQLEnumType,
   GraphQLInputObjectType,
+  GraphQLField,
+  GraphQLArgument,
+  GraphQLEnumValue,
+  GraphQLInputField,
   // Type Wrappers
   GraphQLList,
   GraphQLNonNull,

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -381,6 +381,8 @@ describe('Type System: build schema from introspection', () => {
     expect(values).to.have.lengthOf(3);
 
     expect(values[0]).to.deep.include({
+      coordinate: 'Food.VEGETABLES',
+      parentEnum: clientFoodEnum,
       name: 'VEGETABLES',
       description: 'Foods that are vegetables.',
       value: 'VEGETABLES',
@@ -390,6 +392,8 @@ describe('Type System: build schema from introspection', () => {
     });
 
     expect(values[1]).to.deep.include({
+      coordinate: 'Food.FRUITS',
+      parentEnum: clientFoodEnum,
       name: 'FRUITS',
       description: null,
       value: 'FRUITS',
@@ -399,6 +403,8 @@ describe('Type System: build schema from introspection', () => {
     });
 
     expect(values[2]).to.deep.include({
+      coordinate: 'Food.OILS',
+      parentEnum: clientFoodEnum,
       name: 'OILS',
       description: null,
       value: 'OILS',


### PR DESCRIPTION
[#3145 rebased on main](https://github.com/graphql/graphql-js/pull/3145).

depends on #3044

* Changes `GraphQLSchemaElement` interface into a base class which defines a `.coordinate` property and `toString`/`toJSON` methods.
* Uses the base class to types, fields, arguments, input fields, enum values, and directives.
* Uses this in validation error printing string templates.
* Exports the now finalized GraphQLSchemaElement, GraphQLField, GraphQLArgument, GraphQLInputField, GraphQLEnumValue classes.

This differs from the original PR [#3145](https://github.com/graphql/graphql-js/issues/3145) in that GraphQLField, GraphQLArgument, GraphQLInputField, GraphQLEnumValue constructors now take the parent type/field itself as the first argument instead of the parent coordinate. This obviates any need to validate the parent coordinate.

@leebyron comments from original PR:

> * Defines a `GraphQLSchemaElement` base class which defines a `.coordinate` property and `toString`/`toJSON` methods.
> * Adds base class to types, fields, arguments, input fields, enum values, and directives.
> * Uses this in validation error printing string templates.
> 
> Results in a net-reduction of code, minor simplification of definition.ts, and simplification/standardization of error messages