### PR TITLE
Add coerceInputLiteral()

### DIFF
--- a/src/execution/getVariableSignature.ts
+++ b/src/execution/getVariableSignature.ts
@@ -6,8 +6,8 @@ import { print } from '../language/printer.js';
 import { isInputType } from '../type/definition.js';
 import type { GraphQLInputType, GraphQLSchema } from '../type/index.js';
 
+import { coerceInputLiteral } from '../utilities/coerceInputValue.js';
 import { typeFromAST } from '../utilities/typeFromAST.js';
-import { valueFromAST } from '../utilities/valueFromAST.js';
 
 /**
  * A GraphQLVariableSignature is required to coerce a variable value.
@@ -38,9 +38,13 @@ export function getVariableSignature(
     );
   }
 
+  const defaultValue = varDefNode.defaultValue;
+
   return {
     name: varName,
     type: varType,
-    defaultValue: valueFromAST(varDefNode.defaultValue, varType),
+    defaultValue: defaultValue
+      ? coerceInputLiteral(varDefNode.defaultValue, varType)
+      : undefined,
   };
 }

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -19,8 +19,10 @@ import { isNonNullType } from '../type/definition.js';
 import type { GraphQLDirective } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
-import { coerceInputValue } from '../utilities/coerceInputValue.js';
-import { valueFromAST } from '../utilities/valueFromAST.js';
+import {
+  coerceInputLiteral,
+  coerceInputValue,
+} from '../utilities/coerceInputValue.js';
 
 import type { FragmentVariables } from './collectFields.js';
 import type { GraphQLVariableSignature } from './getVariableSignature.js';
@@ -217,11 +219,11 @@ export function experimentalGetArgumentValues(
       );
     }
 
-    const coercedValue = valueFromAST(
+    const coercedValue = coerceInputLiteral(
       valueNode,
       argType,
       variableValues,
-      fragmentVariables?.values,
+      fragmentVariables,
     );
     if (coercedValue === undefined) {
       // Note: ValuesOfCorrectTypeRule validation should catch this before

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,6 +440,7 @@ export {
   // Create a GraphQLType from a GraphQL language AST.
   typeFromAST,
   // Create a JavaScript value from a GraphQL language AST with a Type.
+  /** @deprecated use `coerceInputLiteral()` instead - will be removed in v18 */
   valueFromAST,
   // Create a JavaScript value from a GraphQL language AST without a Type.
   valueFromASTUntyped,
@@ -450,6 +451,8 @@ export {
   visitWithTypeInfo,
   // Coerces a JavaScript value to a GraphQL type, or produces errors.
   coerceInputValue,
+  // Coerces a GraphQL literal (AST) to a GraphQL type, or returns undefined.
+  coerceInputLiteral,
   // Concatenates multiple AST together.
   concatAST,
   // Separates an AST into an AST per Operation.

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -156,8 +156,6 @@ export function parse(
  *
  * This is useful within tools that operate upon GraphQL Values directly and
  * in isolation of complete GraphQL documents.
- *
- * Consider providing the results to the utility function: valueFromAST().
  */
 export function parseValue(
   source: string | Source,

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -1,6 +1,13 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { identityFunc } from '../../jsutils/identityFunc.js';
+import { invariant } from '../../jsutils/invariant.js';
+import type { ObjMap } from '../../jsutils/ObjMap.js';
+
+import { parseValue } from '../../language/parser.js';
+import { print } from '../../language/printer.js';
+
 import type { GraphQLInputType } from '../../type/definition.js';
 import {
   GraphQLEnumType,
@@ -9,9 +16,15 @@ import {
   GraphQLNonNull,
   GraphQLScalarType,
 } from '../../type/definition.js';
-import { GraphQLInt } from '../../type/scalars.js';
+import {
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLInt,
+  GraphQLString,
+} from '../../type/scalars.js';
 
-import { coerceInputValue } from '../coerceInputValue.js';
+import { coerceInputLiteral, coerceInputValue } from '../coerceInputValue.js';
 
 interface CoerceResult {
   value: unknown;
@@ -530,6 +543,267 @@ describe('coerceInputValue', () => {
       ).to.throw(
         'Invalid value null at "value[0]": Expected non-nullable type "Int!" not to be null.',
       );
+    });
+  });
+});
+
+describe('coerceInputLiteral', () => {
+  function test(
+    valueText: string,
+    type: GraphQLInputType,
+    expected: unknown,
+    variables?: ObjMap<unknown>,
+  ) {
+    const ast = parseValue(valueText);
+    const value = coerceInputLiteral(ast, type, variables);
+    expect(value).to.deep.equal(expected);
+  }
+
+  function testWithVariables(
+    variables: ObjMap<unknown>,
+    valueText: string,
+    type: GraphQLInputType,
+    expected: unknown,
+  ) {
+    test(valueText, type, expected, variables);
+  }
+
+  it('converts according to input coercion rules', () => {
+    test('true', GraphQLBoolean, true);
+    test('false', GraphQLBoolean, false);
+    test('123', GraphQLInt, 123);
+    test('123', GraphQLFloat, 123);
+    test('123.456', GraphQLFloat, 123.456);
+    test('"abc123"', GraphQLString, 'abc123');
+    test('123456', GraphQLID, '123456');
+    test('"123456"', GraphQLID, '123456');
+  });
+
+  it('does not convert when input coercion rules reject a value', () => {
+    test('123', GraphQLBoolean, undefined);
+    test('123.456', GraphQLInt, undefined);
+    test('true', GraphQLInt, undefined);
+    test('"123"', GraphQLInt, undefined);
+    test('"123"', GraphQLFloat, undefined);
+    test('123', GraphQLString, undefined);
+    test('true', GraphQLString, undefined);
+    test('123.456', GraphQLString, undefined);
+    test('123.456', GraphQLID, undefined);
+  });
+
+  it('convert using parseLiteral from a custom scalar type', () => {
+    const passthroughScalar = new GraphQLScalarType({
+      name: 'PassthroughScalar',
+      parseLiteral(node) {
+        invariant(node.kind === 'StringValue');
+        return node.value;
+      },
+      parseValue: identityFunc,
+    });
+
+    test('"value"', passthroughScalar, 'value');
+
+    const printScalar = new GraphQLScalarType({
+      name: 'PrintScalar',
+      parseLiteral(node) {
+        return `~~~${print(node)}~~~`;
+      },
+      parseValue: identityFunc,
+    });
+
+    test('"value"', printScalar, '~~~"value"~~~');
+
+    const throwScalar = new GraphQLScalarType({
+      name: 'ThrowScalar',
+      parseLiteral() {
+        throw new Error('Test');
+      },
+      parseValue: identityFunc,
+    });
+
+    test('value', throwScalar, undefined);
+
+    const returnUndefinedScalar = new GraphQLScalarType({
+      name: 'ReturnUndefinedScalar',
+      parseLiteral() {
+        return undefined;
+      },
+      parseValue: identityFunc,
+    });
+
+    test('value', returnUndefinedScalar, undefined);
+  });
+
+  it('converts enum values according to input coercion rules', () => {
+    const testEnum = new GraphQLEnumType({
+      name: 'TestColor',
+      values: {
+        RED: { value: 1 },
+        GREEN: { value: 2 },
+        BLUE: { value: 3 },
+        NULL: { value: null },
+        NAN: { value: NaN },
+        NO_CUSTOM_VALUE: { value: undefined },
+      },
+    });
+
+    test('RED', testEnum, 1);
+    test('BLUE', testEnum, 3);
+    test('3', testEnum, undefined);
+    test('"BLUE"', testEnum, undefined);
+    test('null', testEnum, null);
+    test('NULL', testEnum, null);
+    test('NULL', new GraphQLNonNull(testEnum), null);
+    test('NAN', testEnum, NaN);
+    test('NO_CUSTOM_VALUE', testEnum, 'NO_CUSTOM_VALUE');
+  });
+
+  // Boolean!
+  const nonNullBool = new GraphQLNonNull(GraphQLBoolean);
+  // [Boolean]
+  const listOfBool = new GraphQLList(GraphQLBoolean);
+  // [Boolean!]
+  const listOfNonNullBool = new GraphQLList(nonNullBool);
+  // [Boolean]!
+  const nonNullListOfBool = new GraphQLNonNull(listOfBool);
+  // [Boolean!]!
+  const nonNullListOfNonNullBool = new GraphQLNonNull(listOfNonNullBool);
+
+  it('coerces to null unless non-null', () => {
+    test('null', GraphQLBoolean, null);
+    test('null', nonNullBool, undefined);
+  });
+
+  it('coerces lists of values', () => {
+    test('true', listOfBool, [true]);
+    test('123', listOfBool, undefined);
+    test('null', listOfBool, null);
+    test('[true, false]', listOfBool, [true, false]);
+    test('[true, 123]', listOfBool, undefined);
+    test('[true, null]', listOfBool, [true, null]);
+    test('{ true: true }', listOfBool, undefined);
+  });
+
+  it('coerces non-null lists of values', () => {
+    test('true', nonNullListOfBool, [true]);
+    test('123', nonNullListOfBool, undefined);
+    test('null', nonNullListOfBool, undefined);
+    test('[true, false]', nonNullListOfBool, [true, false]);
+    test('[true, 123]', nonNullListOfBool, undefined);
+    test('[true, null]', nonNullListOfBool, [true, null]);
+  });
+
+  it('coerces lists of non-null values', () => {
+    test('true', listOfNonNullBool, [true]);
+    test('123', listOfNonNullBool, undefined);
+    test('null', listOfNonNullBool, null);
+    test('[true, false]', listOfNonNullBool, [true, false]);
+    test('[true, 123]', listOfNonNullBool, undefined);
+    test('[true, null]', listOfNonNullBool, undefined);
+  });
+
+  it('coerces non-null lists of non-null values', () => {
+    test('true', nonNullListOfNonNullBool, [true]);
+    test('123', nonNullListOfNonNullBool, undefined);
+    test('null', nonNullListOfNonNullBool, undefined);
+    test('[true, false]', nonNullListOfNonNullBool, [true, false]);
+    test('[true, 123]', nonNullListOfNonNullBool, undefined);
+    test('[true, null]', nonNullListOfNonNullBool, undefined);
+  });
+
+  it('uses default values for unprovided fields', () => {
+    const type = new GraphQLInputObjectType({
+      name: 'TestInput',
+      fields: {
+        int: { type: GraphQLInt, defaultValue: 42 },
+      },
+    });
+
+    test('{}', type, { int: 42 });
+  });
+
+  const testInputObj = new GraphQLInputObjectType({
+    name: 'TestInput',
+    fields: {
+      int: { type: GraphQLInt, defaultValue: 42 },
+      bool: { type: GraphQLBoolean },
+      requiredBool: { type: nonNullBool },
+    },
+  });
+  const testOneOfInputObj = new GraphQLInputObjectType({
+    name: 'TestOneOfInput',
+    fields: {
+      a: { type: GraphQLString },
+      b: { type: GraphQLString },
+    },
+    isOneOf: true,
+  });
+
+  it('coerces input objects according to input coercion rules', () => {
+    test('null', testInputObj, null);
+    test('123', testInputObj, undefined);
+    test('[]', testInputObj, undefined);
+    test('{ requiredBool: true }', testInputObj, {
+      int: 42,
+      requiredBool: true,
+    });
+    test('{ int: null, requiredBool: true }', testInputObj, {
+      int: null,
+      requiredBool: true,
+    });
+    test('{ int: 123, requiredBool: false }', testInputObj, {
+      int: 123,
+      requiredBool: false,
+    });
+    test('{ bool: true, requiredBool: false }', testInputObj, {
+      int: 42,
+      bool: true,
+      requiredBool: false,
+    });
+    test('{ int: true, requiredBool: true }', testInputObj, undefined);
+    test('{ requiredBool: null }', testInputObj, undefined);
+    test('{ bool: true }', testInputObj, undefined);
+    test('{ requiredBool: true, unknown: 123 }', testInputObj, undefined);
+    test('{ a: "abc" }', testOneOfInputObj, {
+      a: 'abc',
+    });
+    test('{ b: "def" }', testOneOfInputObj, {
+      b: 'def',
+    });
+    test('{ a: "abc", b: null }', testOneOfInputObj, undefined);
+    test('{ a: null }', testOneOfInputObj, undefined);
+    test('{ a: 1 }', testOneOfInputObj, undefined);
+    test('{ a: "abc", b: "def" }', testOneOfInputObj, undefined);
+    test('{}', testOneOfInputObj, undefined);
+    test('{ c: "abc" }', testOneOfInputObj, undefined);
+  });
+
+  it('accepts variable values assuming already coerced', () => {
+    test('$var', GraphQLBoolean, undefined);
+    testWithVariables({ var: true }, '$var', GraphQLBoolean, true);
+    testWithVariables({ var: null }, '$var', GraphQLBoolean, null);
+    testWithVariables({ var: null }, '$var', nonNullBool, undefined);
+  });
+
+  it('asserts variables are provided as items in lists', () => {
+    test('[ $foo ]', listOfBool, [null]);
+    test('[ $foo ]', listOfNonNullBool, undefined);
+    testWithVariables({ foo: true }, '[ $foo ]', listOfNonNullBool, [true]);
+    // Note: variables are expected to have already been coerced, so we
+    // do not expect the singleton wrapping behavior for variables.
+    testWithVariables({ foo: true }, '$foo', listOfNonNullBool, true);
+    testWithVariables({ foo: [true] }, '$foo', listOfNonNullBool, [true]);
+  });
+
+  it('omits input object fields for unprovided variables', () => {
+    test('{ int: $foo, bool: $foo, requiredBool: true }', testInputObj, {
+      int: 42,
+      requiredBool: true,
+    });
+    test('{ requiredBool: $foo }', testInputObj, undefined);
+    testWithVariables({ foo: true }, '{ requiredBool: $foo }', testInputObj, {
+      int: 42,
+      requiredBool: true,
     });
   });
 });

--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -24,6 +24,7 @@ import {
 
 import { valueFromAST } from '../valueFromAST.js';
 
+/** @deprecated use `coerceInputLiteral()` instead - will be removed in v18 */
 describe('valueFromAST', () => {
   function expectValueFrom(
     valueText: string,

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -3,7 +3,7 @@ import { inspect } from '../jsutils/inspect.js';
 import { isObjectLike } from '../jsutils/isObjectLike.js';
 import { keyValMap } from '../jsutils/keyValMap.js';
 
-import { parseValue } from '../language/parser.js';
+import { parseConstValue } from '../language/parser.js';
 
 import type {
   GraphQLFieldConfig,
@@ -32,6 +32,7 @@ import { specifiedScalarTypes } from '../type/scalars.js';
 import type { GraphQLSchemaValidationOptions } from '../type/schema.js';
 import { GraphQLSchema } from '../type/schema.js';
 
+import { coerceInputLiteral } from './coerceInputValue.js';
 import type {
   IntrospectionDirective,
   IntrospectionEnumType,
@@ -47,7 +48,6 @@ import type {
   IntrospectionTypeRef,
   IntrospectionUnionType,
 } from './getIntrospectionQuery.js';
-import { valueFromAST } from './valueFromAST.js';
 
 /**
  * Build a GraphQLSchema for use by client tools.
@@ -376,7 +376,10 @@ export function buildClientSchema(
 
     const defaultValue =
       inputValueIntrospection.defaultValue != null
-        ? valueFromAST(parseValue(inputValueIntrospection.defaultValue), type)
+        ? coerceInputLiteral(
+            parseConstValue(inputValueIntrospection.defaultValue),
+            type,
+          )
         : undefined;
     return {
       description: inputValueIntrospection.description,

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -83,7 +83,7 @@ import { assertValidSDLExtension } from '../validation/validate.js';
 
 import { getDirectiveValues } from '../execution/values.js';
 
-import { valueFromAST } from './valueFromAST.js';
+import { coerceInputLiteral } from './coerceInputValue.js';
 
 interface Options extends GraphQLSchemaValidationOptions {
   /**
@@ -535,7 +535,9 @@ export function extendSchemaImpl(
       argConfigMap[arg.name.value] = {
         type,
         description: arg.description?.value,
-        defaultValue: valueFromAST(arg.defaultValue, type),
+        defaultValue: arg.defaultValue
+          ? coerceInputLiteral(arg.defaultValue, type)
+          : undefined,
         deprecationReason: getDeprecationReason(arg),
         astNode: arg,
       };
@@ -562,7 +564,9 @@ export function extendSchemaImpl(
         inputFieldMap[field.name.value] = {
           type,
           description: field.description?.value,
-          defaultValue: valueFromAST(field.defaultValue, type),
+          defaultValue: field.defaultValue
+            ? coerceInputLiteral(field.defaultValue, type)
+            : undefined,
           deprecationReason: getDeprecationReason(field),
           astNode: field,
         };

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -57,7 +57,10 @@ export {
 export { typeFromAST } from './typeFromAST.js';
 
 // Create a JavaScript value from a GraphQL language AST with a type.
-export { valueFromAST } from './valueFromAST.js';
+export {
+  /** @deprecated use `coerceInputLiteral()` instead - will be removed in v18 */
+  valueFromAST,
+} from './valueFromAST.js';
 
 // Create a JavaScript value from a GraphQL language AST without a type.
 export { valueFromASTUntyped } from './valueFromASTUntyped.js';
@@ -68,8 +71,12 @@ export { astFromValue } from './astFromValue.js';
 // A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system.
 export { TypeInfo, visitWithTypeInfo } from './TypeInfo.js';
 
-// Coerces a JavaScript value to a GraphQL type, or produces errors.
-export { coerceInputValue } from './coerceInputValue.js';
+export {
+  // Coerces a JavaScript value to a GraphQL type, or produces errors.
+  coerceInputValue,
+  // Coerces a GraphQL literal (AST) to a GraphQL type, or returns undefined.
+  coerceInputLiteral,
+} from './coerceInputValue.js';
 
 // Concatenates multiple AST together.
 export { concatAST } from './concatAST.js';

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -33,12 +33,12 @@ import {
  * | Enum Value           | Unknown       |
  * | NullValue            | null          |
  *
+ * @deprecated use `coerceInputLiteral()` instead - will be removed in v18
  */
 export function valueFromAST(
   valueNode: Maybe<ValueNode>,
   type: GraphQLInputType,
   variables?: Maybe<ObjMap<unknown>>,
-  fragmentVariables?: Maybe<ObjMap<unknown>>,
 ): unknown {
   if (!valueNode) {
     // When there is no node, then there is also no value.
@@ -48,8 +48,7 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    const variableValue =
-      fragmentVariables?.[variableName] ?? variables?.[variableName];
+    const variableValue = variables?.[variableName];
     if (variableValue === undefined) {
       // No valid return value.
       return;
@@ -67,7 +66,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.NULL) {
       return; // Invalid: intentionally return no value.
     }
-    return valueFromAST(valueNode, type.ofType, variables, fragmentVariables);
+    return valueFromAST(valueNode, type.ofType, variables);
   }
 
   if (valueNode.kind === Kind.NULL) {
@@ -80,7 +79,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.LIST) {
       const coercedValues = [];
       for (const itemNode of valueNode.values) {
-        if (isMissingVariable(itemNode, variables, fragmentVariables)) {
+        if (isMissingVariable(itemNode, variables)) {
           // If an array contains a missing variable, it is either coerced to
           // null or if the item type is non-null, it considered invalid.
           if (isNonNullType(itemType)) {
@@ -88,12 +87,7 @@ export function valueFromAST(
           }
           coercedValues.push(null);
         } else {
-          const itemValue = valueFromAST(
-            itemNode,
-            itemType,
-            variables,
-            fragmentVariables,
-          );
+          const itemValue = valueFromAST(itemNode, itemType, variables);
           if (itemValue === undefined) {
             return; // Invalid: intentionally return no value.
           }
@@ -102,12 +96,7 @@ export function valueFromAST(
       }
       return coercedValues;
     }
-    const coercedValue = valueFromAST(
-      valueNode,
-      itemType,
-      variables,
-      fragmentVariables,
-    );
+    const coercedValue = valueFromAST(valueNode, itemType, variables);
     if (coercedValue === undefined) {
       return; // Invalid: intentionally return no value.
     }
@@ -124,10 +113,7 @@ export function valueFromAST(
     );
     for (const field of Object.values(type.getFields())) {
       const fieldNode = fieldNodes.get(field.name);
-      if (
-        fieldNode == null ||
-        isMissingVariable(fieldNode.value, variables, fragmentVariables)
-      ) {
+      if (fieldNode == null || isMissingVariable(fieldNode.value, variables)) {
         if (field.defaultValue !== undefined) {
           coercedObj[field.name] = field.defaultValue;
         } else if (isNonNullType(field.type)) {
@@ -135,12 +121,7 @@ export function valueFromAST(
         }
         continue;
       }
-      const fieldValue = valueFromAST(
-        fieldNode.value,
-        field.type,
-        variables,
-        fragmentVariables,
-      );
+      const fieldValue = valueFromAST(fieldNode.value, field.type, variables);
       if (fieldValue === undefined) {
         return; // Invalid: intentionally return no value.
       }
@@ -186,12 +167,9 @@ export function valueFromAST(
 function isMissingVariable(
   valueNode: ValueNode,
   variables: Maybe<ObjMap<unknown>>,
-  fragmentVariables: Maybe<ObjMap<unknown>>,
 ): boolean {
   return (
     valueNode.kind === Kind.VARIABLE &&
-    (fragmentVariables == null ||
-      fragmentVariables[valueNode.name.value] === undefined) &&
     (variables == null || variables[valueNode.name.value] === undefined)
   );
 }

--- a/src/utilities/valueFromASTUntyped.ts
+++ b/src/utilities/valueFromASTUntyped.ts
@@ -8,8 +8,8 @@ import { Kind } from '../language/kinds.js';
 /**
  * Produces a JavaScript value given a GraphQL Value AST.
  *
- * Unlike `valueFromAST()`, no type is provided. The resulting JavaScript value
- * will reflect the provided GraphQL value AST.
+ * No type is provided. The resulting JavaScript value will reflect the
+ * provided GraphQL value AST.
  *
  * | GraphQL Value        | JavaScript Value |
  * | -------------------- | ---------------- |


### PR DESCRIPTION
[#3092 rebased on main](https://github.com/graphql/graphql-js/pull/3092).

~~Depends on #3808~~

@leebyron comments from original PR:
> Removes `valueFromAST()` and adds `coerceInputLiteral()` as an additional export from `coerceInputValue`.
> 
> The implementation is almost exactly the same as `valueFromAST()` with a slightly more strict type signature and refactored tests to improve coverage (the file unit test has 100% coverage)
> 
> While this does not change any behavior, it could be breaking if you rely directly on the `valueFromAST()` method. Use `coerceInputLiteral()` as a direct replacement.

Changes from the original:

1. Deprecation rather than removal of `valueFromAST()`.
2. `coerceInputLiteral()` and only `coerceInputLiteral()` supports fragment variables in addition to operation variables.
