### PR TITLE
Preserve defaultValue literals

### DIFF
--- a/src/execution/getVariableSignature.ts
+++ b/src/execution/getVariableSignature.ts
@@ -4,9 +4,12 @@ import type { VariableDefinitionNode } from '../language/ast.js';
 import { print } from '../language/printer.js';
 
 import { isInputType } from '../type/definition.js';
-import type { GraphQLInputType, GraphQLSchema } from '../type/index.js';
+import type {
+  GraphQLDefaultValueUsage,
+  GraphQLInputType,
+  GraphQLSchema,
+} from '../type/index.js';
 
-import { coerceInputLiteral } from '../utilities/coerceInputValue.js';
 import { typeFromAST } from '../utilities/typeFromAST.js';
 
 /**
@@ -18,7 +21,7 @@ import { typeFromAST } from '../utilities/typeFromAST.js';
 export interface GraphQLVariableSignature {
   name: string;
   type: GraphQLInputType;
-  defaultValue: unknown;
+  defaultValue: GraphQLDefaultValueUsage | undefined;
 }
 
 export function getVariableSignature(
@@ -43,8 +46,6 @@ export function getVariableSignature(
   return {
     name: varName,
     type: varType,
-    defaultValue: defaultValue
-      ? coerceInputLiteral(varDefNode.defaultValue, varType)
-      : undefined,
+    defaultValue: defaultValue ? { literal: defaultValue } : undefined,
   };
 }

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -20,6 +20,7 @@ import type { GraphQLDirective } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
 import {
+  coerceDefaultValue,
   coerceInputLiteral,
   coerceInputValue,
 } from '../utilities/coerceInputValue.js';
@@ -90,8 +91,11 @@ function coerceVariableValues(
 
     const { name: varName, type: varType } = varSignature;
     if (!Object.hasOwn(inputs, varName)) {
-      if (varDefNode.defaultValue) {
-        coercedValues[varName] = varSignature.defaultValue;
+      if (varSignature.defaultValue) {
+        coercedValues[varName] = coerceDefaultValue(
+          varSignature.defaultValue,
+          varType,
+        );
       } else if (isNonNullType(varType)) {
         const varTypeStr = inspect(varType);
         onError(
@@ -173,8 +177,11 @@ export function experimentalGetArgumentValues(
     const argumentNode = argNodeMap.get(name);
 
     if (argumentNode == null) {
-      if (argDef.defaultValue !== undefined) {
-        coercedValues[name] = argDef.defaultValue;
+      if (argDef.defaultValue) {
+        coercedValues[name] = coerceDefaultValue(
+          argDef.defaultValue,
+          argDef.type,
+        );
       } else if (isNonNullType(argType)) {
         throw new GraphQLError(
           `Argument "${name}" of required type "${inspect(argType)}" ` +
@@ -197,8 +204,11 @@ export function experimentalGetArgumentValues(
         scopedVariableValues == null ||
         !Object.hasOwn(scopedVariableValues, variableName)
       ) {
-        if (argDef.defaultValue !== undefined) {
-          coercedValues[name] = argDef.defaultValue;
+        if (argDef.defaultValue) {
+          coercedValues[name] = coerceDefaultValue(
+            argDef.defaultValue,
+            argDef.type,
+          );
         } else if (isNonNullType(argType)) {
           throw new GraphQLError(
             `Argument "${name}" of required type "${inspect(argType)}" ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,7 @@ export type {
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
+  GraphQLDefaultValueUsage,
 } from './type/index.js';
 
 // Parse and operate on GraphQL language source files.

--- a/src/type/__tests__/predicate-test.ts
+++ b/src/type/__tests__/predicate-test.ts
@@ -574,7 +574,10 @@ describe('Type predicates', () => {
         name: 'someArg',
         type: config.type,
         description: undefined,
-        defaultValue: config.defaultValue,
+        defaultValue:
+          config.defaultValue !== undefined
+            ? { value: config.defaultValue }
+            : undefined,
         deprecationReason: null,
         extensions: Object.create(null),
         astNode: undefined,
@@ -622,7 +625,10 @@ describe('Type predicates', () => {
         name: 'someInputField',
         type: config.type,
         description: undefined,
-        defaultValue: config.defaultValue,
+        defaultValue:
+          config.defaultValue !== undefined
+            ? { value: config.defaultValue }
+            : undefined,
         deprecationReason: null,
         extensions: Object.create(null),
         astNode: undefined,

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -16,6 +16,7 @@ import { toObjMap } from '../jsutils/toObjMap.js';
 import { GraphQLError } from '../error/GraphQLError.js';
 
 import type {
+  ConstValueNode,
   EnumTypeDefinitionNode,
   EnumTypeExtensionNode,
   EnumValueDefinitionNode,
@@ -799,7 +800,7 @@ export function defineArguments(
     name: assertName(argName),
     description: argConfig.description,
     type: argConfig.type,
-    defaultValue: argConfig.defaultValue,
+    defaultValue: defineDefaultValue(argName, argConfig),
     deprecationReason: argConfig.deprecationReason,
     extensions: toObjMap(argConfig.extensions),
     astNode: argConfig.astNode,
@@ -833,7 +834,8 @@ export function argsToArgsConfig(
     (arg) => ({
       description: arg.description,
       type: arg.type,
-      defaultValue: arg.defaultValue,
+      defaultValue: arg.defaultValue?.value,
+      defaultValueLiteral: arg.defaultValue?.literal,
       deprecationReason: arg.deprecationReason,
       extensions: arg.extensions,
       astNode: arg.astNode,
@@ -946,6 +948,7 @@ export interface GraphQLArgumentConfig {
   description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: unknown;
+  defaultValueLiteral?: ConstValueNode | undefined;
   deprecationReason?: Maybe<string>;
   extensions?: Maybe<Readonly<GraphQLArgumentExtensions>>;
   astNode?: Maybe<InputValueDefinitionNode>;
@@ -971,7 +974,7 @@ export interface GraphQLArgument {
   name: string;
   description: Maybe<string>;
   type: GraphQLInputType;
-  defaultValue: unknown;
+  defaultValue: GraphQLDefaultValueUsage | undefined;
   deprecationReason: Maybe<string>;
   extensions: Readonly<GraphQLArgumentExtensions>;
   astNode: Maybe<InputValueDefinitionNode>;
@@ -984,6 +987,26 @@ export function isRequiredArgument(arg: GraphQLArgument): boolean {
 export type GraphQLFieldMap<TSource, TContext> = ObjMap<
   GraphQLField<TSource, TContext>
 >;
+
+export type GraphQLDefaultValueUsage =
+  | { value: unknown; literal?: never }
+  | { literal: ConstValueNode; value?: never };
+
+export function defineDefaultValue(
+  argName: string,
+  config: GraphQLArgumentConfig | GraphQLInputFieldConfig,
+): GraphQLDefaultValueUsage | undefined {
+  if (config.defaultValue === undefined && !config.defaultValueLiteral) {
+    return;
+  }
+  devAssert(
+    !(config.defaultValue !== undefined && config.defaultValueLiteral),
+    `Argument "${argName}" has both a defaultValue and a defaultValueLiteral property, but only one must be provided.`,
+  );
+  return config.defaultValueLiteral
+    ? { literal: config.defaultValueLiteral }
+    : { value: config.defaultValue };
+}
 
 /**
  * Custom extensions
@@ -1538,7 +1561,8 @@ export class GraphQLInputObjectType {
     const fields = mapValue(this.getFields(), (field) => ({
       description: field.description,
       type: field.type,
-      defaultValue: field.defaultValue,
+      defaultValue: field.defaultValue?.value,
+      defaultValueLiteral: field.defaultValue?.literal,
       deprecationReason: field.deprecationReason,
       extensions: field.extensions,
       astNode: field.astNode,
@@ -1572,7 +1596,7 @@ function defineInputFieldMap(
     name: assertName(fieldName),
     description: fieldConfig.description,
     type: fieldConfig.type,
-    defaultValue: fieldConfig.defaultValue,
+    defaultValue: defineDefaultValue(fieldName, fieldConfig),
     deprecationReason: fieldConfig.deprecationReason,
     extensions: toObjMap(fieldConfig.extensions),
     astNode: fieldConfig.astNode,
@@ -1613,6 +1637,7 @@ export interface GraphQLInputFieldConfig {
   description?: Maybe<string>;
   type: GraphQLInputType;
   defaultValue?: unknown;
+  defaultValueLiteral?: ConstValueNode | undefined;
   deprecationReason?: Maybe<string>;
   extensions?: Maybe<Readonly<GraphQLInputFieldExtensions>>;
   astNode?: Maybe<InputValueDefinitionNode>;
@@ -1624,7 +1649,7 @@ export interface GraphQLInputField {
   name: string;
   description: Maybe<string>;
   type: GraphQLInputType;
-  defaultValue: unknown;
+  defaultValue: GraphQLDefaultValueUsage | undefined;
   deprecationReason: Maybe<string>;
   extensions: Readonly<GraphQLInputFieldExtensions>;
   astNode: Maybe<InputValueDefinitionNode>;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -119,6 +119,7 @@ export type {
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
   GraphQLScalarLiteralParser,
+  GraphQLDefaultValueUsage,
 } from './definition.js';
 
 export {

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -407,8 +407,13 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
           'A GraphQL-formatted string representing the default value for this input value.',
         resolve(inputValue) {
           const { type, defaultValue } = inputValue;
-          const valueAST = astFromValue(defaultValue, type);
-          return valueAST ? print(valueAST) : null;
+          if (!defaultValue) {
+            return null;
+          }
+          const literal =
+            defaultValue.literal ?? astFromValue(defaultValue.value, type);
+          invariant(literal != null, 'Invalid default value');
+          return print(literal);
         },
       },
       isDeprecated: {

--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -14,6 +14,7 @@ import { getEnterLeaveForKind } from '../language/visitor.js';
 import type {
   GraphQLArgument,
   GraphQLCompositeType,
+  GraphQLDefaultValueUsage,
   GraphQLEnumValue,
   GraphQLField,
   GraphQLInputField,
@@ -53,7 +54,7 @@ export class TypeInfo {
   private _parentTypeStack: Array<Maybe<GraphQLCompositeType>>;
   private _inputTypeStack: Array<Maybe<GraphQLInputType>>;
   private _fieldDefStack: Array<Maybe<GraphQLField<unknown, unknown>>>;
-  private _defaultValueStack: Array<Maybe<unknown>>;
+  private _defaultValueStack: Array<GraphQLDefaultValueUsage | undefined>;
   private _directive: Maybe<GraphQLDirective>;
   private _argument: Maybe<GraphQLArgument>;
   private _enumValue: Maybe<GraphQLEnumValue>;
@@ -124,7 +125,7 @@ export class TypeInfo {
     return this._fieldDefStack.at(-1);
   }
 
-  getDefaultValue(): Maybe<unknown> {
+  getDefaultValue(): GraphQLDefaultValueUsage | undefined {
     return this._defaultValueStack.at(-1);
   }
 

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -439,6 +439,7 @@ describe('Type System: build schema from introspection', () => {
       }
 
       type Query {
+        defaultID(intArg: ID = "123"): String
         defaultInt(intArg: Int = 30): String
         defaultList(listArg: [Int] = [1, 2, 3]): String
         defaultObject(objArg: Geo = { lat: 37.485, lon: -122.148 }): String
@@ -607,6 +608,28 @@ describe('Type System: build schema from introspection', () => {
     });
 
     expect(result.data).to.deep.equal({ foo: 'bar' });
+  });
+
+  it('can use client schema for execution if resolvers are added', () => {
+    const schema = buildSchema(`
+      type Query {
+        foo(bar: String = "abc"): String
+      }
+    `);
+
+    const introspection = introspectionFromSchema(schema);
+    const clientSchema = buildClientSchema(introspection);
+
+    const QueryType: GraphQLObjectType = clientSchema.getType('Query') as any;
+    QueryType.getFields().foo.resolve = (_value, args) => args.bar;
+
+    const result = graphqlSync({
+      schema: clientSchema,
+      source: '{ foo }',
+    });
+
+    expect(result.data).to.deep.equal({ foo: 'abc' });
+    expect(result.data).to.deep.equal({ foo: 'abc' });
   });
 
   it('can build invalid schema', () => {

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -32,7 +32,6 @@ import { specifiedScalarTypes } from '../type/scalars.js';
 import type { GraphQLSchemaValidationOptions } from '../type/schema.js';
 import { GraphQLSchema } from '../type/schema.js';
 
-import { coerceInputLiteral } from './coerceInputValue.js';
 import type {
   IntrospectionDirective,
   IntrospectionEnumType,
@@ -374,17 +373,13 @@ export function buildClientSchema(
       );
     }
 
-    const defaultValue =
-      inputValueIntrospection.defaultValue != null
-        ? coerceInputLiteral(
-            parseConstValue(inputValueIntrospection.defaultValue),
-            type,
-          )
-        : undefined;
     return {
       description: inputValueIntrospection.description,
       type,
-      defaultValue,
+      defaultValueLiteral:
+        inputValueIntrospection.defaultValue != null
+          ? parseConstValue(inputValueIntrospection.defaultValue)
+          : undefined,
       deprecationReason: inputValueIntrospection.deprecationReason,
     };
   }

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -83,8 +83,6 @@ import { assertValidSDLExtension } from '../validation/validate.js';
 
 import { getDirectiveValues } from '../execution/values.js';
 
-import { coerceInputLiteral } from './coerceInputValue.js';
-
 interface Options extends GraphQLSchemaValidationOptions {
   /**
    * Set to true to assume the SDL is valid.
@@ -535,9 +533,7 @@ export function extendSchemaImpl(
       argConfigMap[arg.name.value] = {
         type,
         description: arg.description?.value,
-        defaultValue: arg.defaultValue
-          ? coerceInputLiteral(arg.defaultValue, type)
-          : undefined,
+        defaultValueLiteral: arg.defaultValue,
         deprecationReason: getDeprecationReason(arg),
         astNode: arg,
       };
@@ -564,9 +560,7 @@ export function extendSchemaImpl(
         inputFieldMap[field.name.value] = {
           type,
           description: field.description?.value,
-          defaultValue: field.defaultValue
-            ? coerceInputLiteral(field.defaultValue, type)
-            : undefined,
+          defaultValueLiteral: field.defaultValue,
           deprecationReason: getDeprecationReason(field),
           astNode: field,
         };

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -5,6 +5,7 @@ import { keyMap } from '../jsutils/keyMap.js';
 import { print } from '../language/printer.js';
 
 import type {
+  GraphQLDefaultValueUsage,
   GraphQLEnumType,
   GraphQLField,
   GraphQLInputObjectType,
@@ -534,8 +535,11 @@ function typeKindName(type: GraphQLNamedType): string {
   invariant(false, 'Unexpected type: ' + inspect(type));
 }
 
-function stringifyValue(value: unknown, type: GraphQLInputType): string {
-  const ast = astFromValue(value, type);
+function stringifyValue(
+  defaultValue: GraphQLDefaultValueUsage,
+  type: GraphQLInputType,
+): string {
+  const ast = defaultValue.literal ?? astFromValue(defaultValue.value, type);
   invariant(ast != null);
   return print(sortValueNode(ast));
 }

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -259,10 +259,13 @@ function printArgs(
 }
 
 function printInputValue(arg: GraphQLInputField): string {
-  const defaultAST = astFromValue(arg.defaultValue, arg.type);
   let argDecl = arg.name + ': ' + String(arg.type);
-  if (defaultAST) {
-    argDecl += ` = ${print(defaultAST)}`;
+  if (arg.defaultValue) {
+    const literal =
+      arg.defaultValue.literal ??
+      astFromValue(arg.defaultValue.value, arg.type);
+    invariant(literal != null, 'Invalid default value');
+    argDecl += ` = ${print(literal)}`;
   }
   return argDecl + printDeprecated(arg.deprecationReason);
 }

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -115,7 +115,7 @@ export function valueFromAST(
       const fieldNode = fieldNodes.get(field.name);
       if (fieldNode == null || isMissingVariable(fieldNode.value, variables)) {
         if (field.defaultValue !== undefined) {
-          coercedObj[field.name] = field.defaultValue;
+          coercedObj[field.name] = field.defaultValue.value;
         } else if (isNonNullType(field.type)) {
           return; // Invalid: intentionally return no value.
         }

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -19,6 +19,7 @@ import { visit } from '../language/visitor.js';
 import type {
   GraphQLArgument,
   GraphQLCompositeType,
+  GraphQLDefaultValueUsage,
   GraphQLEnumValue,
   GraphQLField,
   GraphQLInputType,
@@ -34,7 +35,7 @@ type NodeWithSelectionSet = OperationDefinitionNode | FragmentDefinitionNode;
 interface VariableUsage {
   readonly node: VariableNode;
   readonly type: Maybe<GraphQLInputType>;
-  readonly defaultValue: Maybe<unknown>;
+  readonly defaultValue: GraphQLDefaultValueUsage | undefined;
   readonly fragmentVariableDefinition: Maybe<VariableDefinitionNode>;
 }
 

--- a/src/validation/rules/VariablesInAllowedPositionRule.ts
+++ b/src/validation/rules/VariablesInAllowedPositionRule.ts
@@ -7,7 +7,10 @@ import type { ValueNode, VariableDefinitionNode } from '../../language/ast.js';
 import { Kind } from '../../language/kinds.js';
 import type { ASTVisitor } from '../../language/visitor.js';
 
-import type { GraphQLType } from '../../type/definition.js';
+import type {
+  GraphQLDefaultValueUsage,
+  GraphQLType,
+} from '../../type/definition.js';
 import { isNonNullType } from '../../type/definition.js';
 import type { GraphQLSchema } from '../../type/schema.js';
 
@@ -95,7 +98,7 @@ function allowedVariableUsage(
   varType: GraphQLType,
   varDefaultValue: Maybe<ValueNode>,
   locationType: GraphQLType,
-  locationDefaultValue: Maybe<unknown>,
+  locationDefaultValue: GraphQLDefaultValueUsage | undefined,
 ): boolean {
   if (isNonNullType(locationType) && !isNonNullType(varType)) {
     const hasNonNullVariableDefaultValue =


### PR DESCRIPTION
[#3074 rebased on main](https://github.com/graphql/graphql-js/pull/3074).

Depends on #3809

@leebyron comments from original PR (edited, hopefully correctly):

> Fixes #3051
> 
> This change solves the problem of default values defined via SDL not always resolving correctly through introspection by preserving the original GraphQL literal in the schema definition. This changes argument and input field definitions `defaultValue` field from just the "value" to a new `GraphQLDefaultValueUsage` type which contains either (EDIT: but not both!) "value" and "literal" fields.
> 
> Here is the flow for how a default value defined in an SDL would be converted into a functional schema and back to an SDL:
> 
> **Before this change:**
> 
> ```
> (SDL) --parse-> (AST) --coerceInputLiteral--> (defaultValue config) --valueToAST--> (AST) --print --> (SDL)
> ```
> 
> `coerceInputLiteral` performs coercion which is a one-way function, and `valueToAST` is unsafe and set to be deprecated in #3049.
> 
> **After this change:**
> 
> ```
> (SDL) --parse-> (defaultValue literal config) --print --> (SDL)
> ```