### PR TITLE
Preserve sources of variable values

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -240,7 +240,19 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(resolvedInfo).to.deep.include({
       fieldNodes: [field],
       path: { prev: undefined, key: 'result', typename: 'Test' },
-      variableValues: { var: 'abc' },
+      variableValues: {
+        sources: {
+          var: {
+            signature: {
+              name: 'var',
+              type: GraphQLString,
+              defaultValue: undefined,
+            },
+            value: 'abc',
+          },
+        },
+        coerced: { var: 'abc' },
+      },
     });
   });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -843,7 +843,7 @@ export function buildResolveInfo(
     ),
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
-    variableValues: exeContext.variableValues.coerced,
+    variableValues: exeContext.variableValues,
   };
 }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1092,7 +1092,7 @@ function getStreamUsage(
   const streamedFieldGroup: FieldGroup = fieldGroup.map((fieldDetails) => ({
     node: fieldDetails.node,
     deferUsage: undefined,
-    fragmentVariables: fieldDetails.fragmentVariableValues,
+    fragmentVariablesValues: fieldDetails.fragmentVariableValues,
   }));
 
   const streamUsage = {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -75,6 +75,7 @@ import type {
   StreamRecord,
 } from './types.js';
 import { DeferredFragmentRecord } from './types.js';
+import type { VariableValues } from './values.js';
 import {
   experimentalGetArgumentValues,
   getArgumentValues,
@@ -139,7 +140,7 @@ export interface ExecutionContext {
   rootValue: unknown;
   contextValue: unknown;
   operation: OperationDefinitionNode;
-  variableValues: { [variable: string]: unknown };
+  variableValues: VariableValues;
   fieldResolver: GraphQLFieldResolver<any, any>;
   typeResolver: GraphQLTypeResolver<any, any>;
   subscribeFieldResolver: GraphQLFieldResolver<any, any>;
@@ -510,15 +511,15 @@ export function buildExecutionContext(
   /* c8 ignore next */
   const variableDefinitions = operation.variableDefinitions ?? [];
 
-  const coercedVariableValues = getVariableValues(
+  const variableValuesOrErrors = getVariableValues(
     schema,
     variableDefinitions,
     rawVariableValues ?? {},
     { maxErrors: 50 },
   );
 
-  if (coercedVariableValues.errors) {
-    return coercedVariableValues.errors;
+  if (variableValuesOrErrors.errors) {
+    return variableValuesOrErrors.errors;
   }
 
   return {
@@ -527,7 +528,7 @@ export function buildExecutionContext(
     rootValue,
     contextValue,
     operation,
-    variableValues: coercedVariableValues.coerced,
+    variableValues: variableValuesOrErrors.variableValues,
     fieldResolver: fieldResolver ?? defaultFieldResolver,
     typeResolver: typeResolver ?? defaultTypeResolver,
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
@@ -753,7 +754,7 @@ function executeField(
       fieldGroup[0].node,
       fieldDef.args,
       exeContext.variableValues,
-      fieldGroup[0].fragmentVariables,
+      fieldGroup[0].fragmentVariableValues,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -842,7 +843,7 @@ export function buildResolveInfo(
     ),
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
-    variableValues: exeContext.variableValues,
+    variableValues: exeContext.variableValues.coerced,
   };
 }
 
@@ -1062,7 +1063,7 @@ function getStreamUsage(
     GraphQLStreamDirective,
     fieldGroup[0].node,
     exeContext.variableValues,
-    fieldGroup[0].fragmentVariables,
+    fieldGroup[0].fragmentVariableValues,
   );
 
   if (!stream) {
@@ -1091,7 +1092,7 @@ function getStreamUsage(
   const streamedFieldGroup: FieldGroup = fieldGroup.map((fieldDetails) => ({
     node: fieldDetails.node,
     deferUsage: undefined,
-    fragmentVariables: fieldDetails.fragmentVariables,
+    fragmentVariables: fieldDetails.fragmentVariableValues,
   }));
 
   const streamUsage = {

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -1,6 +1,6 @@
 import { inspect } from '../jsutils/inspect.js';
 import type { Maybe } from '../jsutils/Maybe.js';
-import type { ObjMap } from '../jsutils/ObjMap.js';
+import type { ObjMap, ReadOnlyObjMap } from '../jsutils/ObjMap.js';
 import { printPathArray } from '../jsutils/printPathArray.js';
 
 import { GraphQLError } from '../error/GraphQLError.js';
@@ -25,13 +25,22 @@ import {
   coerceInputValue,
 } from '../utilities/coerceInputValue.js';
 
-import type { FragmentVariables } from './collectFields.js';
 import type { GraphQLVariableSignature } from './getVariableSignature.js';
 import { getVariableSignature } from './getVariableSignature.js';
 
-type CoercedVariableValues =
-  | { errors: ReadonlyArray<GraphQLError>; coerced?: never }
-  | { coerced: { [variable: string]: unknown }; errors?: never };
+export interface VariableValues {
+  readonly sources: ReadOnlyObjMap<VariableValueSource>;
+  readonly coerced: ReadOnlyObjMap<unknown>;
+}
+
+interface VariableValueSource {
+  readonly signature: GraphQLVariableSignature;
+  readonly value: unknown;
+}
+
+type VariableValuesOrErrors =
+  | { variableValues: VariableValues; errors?: never }
+  | { errors: ReadonlyArray<GraphQLError>; variableValues?: never };
 
 /**
  * Prepares an object map of variableValues of the correct type based on the
@@ -47,11 +56,11 @@ export function getVariableValues(
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
   inputs: { readonly [variable: string]: unknown },
   options?: { maxErrors?: number },
-): CoercedVariableValues {
-  const errors = [];
+): VariableValuesOrErrors {
+  const errors: Array<GraphQLError> = [];
   const maxErrors = options?.maxErrors;
   try {
-    const coerced = coerceVariableValues(
+    const variableValues = coerceVariableValues(
       schema,
       varDefNodes,
       inputs,
@@ -66,7 +75,7 @@ export function getVariableValues(
     );
 
     if (errors.length === 0) {
-      return { coerced };
+      return { variableValues };
     }
   } catch (error) {
     errors.push(error);
@@ -80,10 +89,12 @@ function coerceVariableValues(
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
   inputs: { readonly [variable: string]: unknown },
   onError: (error: GraphQLError) => void,
-): { [variable: string]: unknown } {
-  const coercedValues: { [variable: string]: unknown } = {};
+): VariableValues {
+  const sources: ObjMap<VariableValueSource> = Object.create(null);
+  const coerced: ObjMap<unknown> = Object.create(null);
   for (const varDefNode of varDefNodes) {
     const varSignature = getVariableSignature(schema, varDefNode);
+
     if (varSignature instanceof GraphQLError) {
       onError(varSignature);
       continue;
@@ -91,11 +102,13 @@ function coerceVariableValues(
 
     const { name: varName, type: varType } = varSignature;
     if (!Object.hasOwn(inputs, varName)) {
-      if (varSignature.defaultValue) {
-        coercedValues[varName] = coerceDefaultValue(
-          varSignature.defaultValue,
-          varType,
-        );
+      const defaultValue = varSignature.defaultValue;
+      if (defaultValue) {
+        sources[varName] = {
+          signature: varSignature,
+          value: undefined,
+        };
+        coerced[varName] = coerceDefaultValue(defaultValue, varType);
       } else if (isNonNullType(varType)) {
         const varTypeStr = inspect(varType);
         onError(
@@ -104,6 +117,11 @@ function coerceVariableValues(
             { nodes: varDefNode },
           ),
         );
+      } else {
+        sources[varName] = {
+          signature: varSignature,
+          value: undefined,
+        };
       }
       continue;
     }
@@ -120,7 +138,8 @@ function coerceVariableValues(
       continue;
     }
 
-    coercedValues[varName] = coerceInputValue(
+    sources[varName] = { signature: varSignature, value };
+    coerced[varName] = coerceInputValue(
       value,
       varType,
       (path, invalidValue, error) => {
@@ -139,7 +158,35 @@ function coerceVariableValues(
     );
   }
 
-  return coercedValues;
+  return { sources, coerced };
+}
+
+export function getFragmentVariableValues(
+  fragmentSpreadNode: FragmentSpreadNode,
+  fragmentSignatures: ReadOnlyObjMap<GraphQLVariableSignature>,
+  variableValues: VariableValues,
+  fragmentVariableValues?: Maybe<VariableValues>,
+): VariableValues {
+  const varSignatures: Array<GraphQLVariableSignature> = [];
+  const sources = Object.create(null);
+  for (const [varName, varSignature] of Object.entries(fragmentSignatures)) {
+    varSignatures.push(varSignature);
+    sources[varName] = {
+      signature: varSignature,
+      value:
+        fragmentVariableValues?.sources[varName]?.value ??
+        variableValues.sources[varName]?.value,
+    };
+  }
+
+  const coerced = experimentalGetArgumentValues(
+    fragmentSpreadNode,
+    varSignatures,
+    variableValues,
+    fragmentVariableValues,
+  );
+
+  return { sources, coerced };
 }
 
 /**
@@ -153,7 +200,7 @@ function coerceVariableValues(
 export function getArgumentValues(
   def: GraphQLField<unknown, unknown> | GraphQLDirective,
   node: FieldNode | DirectiveNode,
-  variableValues?: Maybe<ObjMap<unknown>>,
+  variableValues?: Maybe<VariableValues>,
 ): { [argument: string]: unknown } {
   return experimentalGetArgumentValues(node, def.args, variableValues);
 }
@@ -161,8 +208,8 @@ export function getArgumentValues(
 export function experimentalGetArgumentValues(
   node: FieldNode | DirectiveNode | FragmentSpreadNode,
   argDefs: ReadonlyArray<GraphQLArgument | GraphQLVariableSignature>,
-  variableValues: Maybe<ObjMap<unknown>>,
-  fragmentVariables?: Maybe<FragmentVariables>,
+  variableValues: Maybe<VariableValues>,
+  fragmentVariables?: Maybe<VariableValues>,
 ): { [argument: string]: unknown } {
   const coercedValues: { [argument: string]: unknown } = {};
 
@@ -197,12 +244,12 @@ export function experimentalGetArgumentValues(
 
     if (valueNode.kind === Kind.VARIABLE) {
       const variableName = valueNode.name.value;
-      const scopedVariableValues = fragmentVariables?.signatures[variableName]
-        ? fragmentVariables.values
+      const scopedVariableValues = fragmentVariables?.sources[variableName]
+        ? fragmentVariables
         : variableValues;
       if (
         scopedVariableValues == null ||
-        !Object.hasOwn(scopedVariableValues, variableName)
+        !Object.hasOwn(scopedVariableValues.coerced, variableName)
       ) {
         if (argDef.defaultValue) {
           coercedValues[name] = coerceDefaultValue(
@@ -218,7 +265,7 @@ export function experimentalGetArgumentValues(
         }
         continue;
       }
-      isNull = scopedVariableValues[variableName] == null;
+      isNull = scopedVariableValues.coerced[variableName] == null;
     }
 
     if (isNull && isNonNullType(argType)) {
@@ -265,8 +312,8 @@ export function experimentalGetArgumentValues(
 export function getDirectiveValues(
   directiveDef: GraphQLDirective,
   node: { readonly directives?: ReadonlyArray<DirectiveNode> | undefined },
-  variableValues?: Maybe<ObjMap<unknown>>,
-  fragmentVariables?: Maybe<FragmentVariables>,
+  variableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<VariableValues>,
 ): undefined | { [argument: string]: unknown } {
   const directiveNode = node.directives?.find(
     (directive) => directive.name.value === directiveDef.name,
@@ -277,7 +324,7 @@ export function getDirectiveValues(
       directiveNode,
       directiveDef.args,
       variableValues,
-      fragmentVariables,
+      fragmentVariableValues,
     );
   }
 }

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -35,7 +35,7 @@ export interface VariableValues {
 
 interface VariableValueSource {
   readonly signature: GraphQLVariableSignature;
-  readonly value: unknown;
+  readonly value?: unknown;
 }
 
 type VariableValuesOrErrors =
@@ -104,10 +104,7 @@ function coerceVariableValues(
     if (!Object.hasOwn(inputs, varName)) {
       const defaultValue = varSignature.defaultValue;
       if (defaultValue) {
-        sources[varName] = {
-          signature: varSignature,
-          value: undefined,
-        };
+        sources[varName] = { signature: varSignature };
         coerced[varName] = coerceDefaultValue(defaultValue, varType);
       } else if (isNonNullType(varType)) {
         const varTypeStr = inspect(varType);
@@ -118,10 +115,7 @@ function coerceVariableValues(
           ),
         );
       } else {
-        sources[varName] = {
-          signature: varSignature,
-          value: undefined,
-        };
+        sources[varName] = { signature: varSignature };
       }
       continue;
     }
@@ -244,7 +238,9 @@ export function experimentalGetArgumentValues(
 
     if (valueNode.kind === Kind.VARIABLE) {
       const variableName = valueNode.name.value;
-      const scopedVariableValues = fragmentVariablesValues?.sources[variableName]
+      const scopedVariableValues = fragmentVariablesValues?.sources[
+        variableName
+      ]
         ? fragmentVariablesValues
         : variableValues;
       if (

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -209,7 +209,7 @@ export function experimentalGetArgumentValues(
   node: FieldNode | DirectiveNode | FragmentSpreadNode,
   argDefs: ReadonlyArray<GraphQLArgument | GraphQLVariableSignature>,
   variableValues: Maybe<VariableValues>,
-  fragmentVariables?: Maybe<VariableValues>,
+  fragmentVariablesValues?: Maybe<VariableValues>,
 ): { [argument: string]: unknown } {
   const coercedValues: { [argument: string]: unknown } = {};
 
@@ -244,8 +244,8 @@ export function experimentalGetArgumentValues(
 
     if (valueNode.kind === Kind.VARIABLE) {
       const variableName = valueNode.name.value;
-      const scopedVariableValues = fragmentVariables?.sources[variableName]
-        ? fragmentVariables
+      const scopedVariableValues = fragmentVariablesValues?.sources[variableName]
+        ? fragmentVariablesValues
         : variableValues;
       if (
         scopedVariableValues == null ||
@@ -280,7 +280,7 @@ export function experimentalGetArgumentValues(
       valueNode,
       argType,
       variableValues,
-      fragmentVariables,
+      fragmentVariablesValues,
     );
     if (coercedValue === undefined) {
       // Note: ValuesOfCorrectTypeRule validation should catch this before

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -40,6 +40,8 @@ import type {
 import { Kind } from '../language/kinds.js';
 import { print } from '../language/printer.js';
 
+import type { VariableValues } from '../execution/values.js';
+
 import { valueFromASTUntyped } from '../utilities/valueFromASTUntyped.js';
 
 import { assertEnumValueName, assertName } from './assertName.js';
@@ -897,7 +899,7 @@ export interface GraphQLResolveInfo {
   readonly fragments: ObjMap<FragmentDefinitionNode>;
   readonly rootValue: unknown;
   readonly operation: OperationDefinitionNode;
-  readonly variableValues: { [variable: string]: unknown };
+  readonly variableValues: VariableValues;
 }
 
 /**

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -3,11 +3,12 @@ import { describe, it } from 'mocha';
 
 import { identityFunc } from '../../jsutils/identityFunc.js';
 import { invariant } from '../../jsutils/invariant.js';
-import type { ObjMap } from '../../jsutils/ObjMap.js';
+import type { ReadOnlyObjMap } from '../../jsutils/ObjMap.js';
 
 import { Kind } from '../../language/kinds.js';
-import { parseValue } from '../../language/parser.js';
+import { Parser, parseValue } from '../../language/parser.js';
 import { print } from '../../language/printer.js';
+import { TokenKind } from '../../language/tokenKind.js';
 
 import type { GraphQLInputType } from '../../type/definition.js';
 import {
@@ -24,6 +25,10 @@ import {
   GraphQLInt,
   GraphQLString,
 } from '../../type/scalars.js';
+import { GraphQLSchema } from '../../type/schema.js';
+
+import type { VariableValues } from '../../execution/values.js';
+import { getVariableValues } from '../../execution/values.js';
 
 import {
   coerceDefaultValue,
@@ -557,20 +562,29 @@ describe('coerceInputLiteral', () => {
     valueText: string,
     type: GraphQLInputType,
     expected: unknown,
-    variables?: ObjMap<unknown>,
+    variableValues?: VariableValues,
   ) {
     const ast = parseValue(valueText);
-    const value = coerceInputLiteral(ast, type, variables);
+    const value = coerceInputLiteral(ast, type, variableValues);
     expect(value).to.deep.equal(expected);
   }
 
   function testWithVariables(
-    variables: ObjMap<unknown>,
+    variableDefs: string,
+    inputs: ReadOnlyObjMap<unknown>,
     valueText: string,
     type: GraphQLInputType,
     expected: unknown,
   ) {
-    test(valueText, type, expected, variables);
+    const parser = new Parser(variableDefs);
+    parser.expectToken(TokenKind.SOF);
+    const variableValuesOrErrors = getVariableValues(
+      new GraphQLSchema({}),
+      parser.parseVariableDefinitions(),
+      inputs,
+    );
+    invariant(variableValuesOrErrors.variableValues !== undefined);
+    test(valueText, type, expected, variableValuesOrErrors.variableValues);
   }
 
   it('converts according to input coercion rules', () => {
@@ -789,19 +803,55 @@ describe('coerceInputLiteral', () => {
 
   it('accepts variable values assuming already coerced', () => {
     test('$var', GraphQLBoolean, undefined);
-    testWithVariables({ var: true }, '$var', GraphQLBoolean, true);
-    testWithVariables({ var: null }, '$var', GraphQLBoolean, null);
-    testWithVariables({ var: null }, '$var', nonNullBool, undefined);
+    testWithVariables(
+      '($var: Boolean)',
+      { var: true },
+      '$var',
+      GraphQLBoolean,
+      true,
+    );
+    testWithVariables(
+      '($var: Boolean)',
+      { var: null },
+      '$var',
+      GraphQLBoolean,
+      null,
+    );
+    testWithVariables(
+      '($var: Boolean)',
+      { var: null },
+      '$var',
+      nonNullBool,
+      undefined,
+    );
   });
 
   it('asserts variables are provided as items in lists', () => {
     test('[ $foo ]', listOfBool, [null]);
     test('[ $foo ]', listOfNonNullBool, undefined);
-    testWithVariables({ foo: true }, '[ $foo ]', listOfNonNullBool, [true]);
+    testWithVariables(
+      '($foo: Boolean)',
+      { foo: true },
+      '[ $foo ]',
+      listOfNonNullBool,
+      [true],
+    );
     // Note: variables are expected to have already been coerced, so we
     // do not expect the singleton wrapping behavior for variables.
-    testWithVariables({ foo: true }, '$foo', listOfNonNullBool, true);
-    testWithVariables({ foo: [true] }, '$foo', listOfNonNullBool, [true]);
+    testWithVariables(
+      '($foo: Boolean)',
+      { foo: true },
+      '$foo',
+      listOfNonNullBool,
+      true,
+    );
+    testWithVariables(
+      '($foo: [Boolean])',
+      { foo: [true] },
+      '$foo',
+      listOfNonNullBool,
+      [true],
+    );
   });
 
   it('omits input object fields for unprovided variables', () => {
@@ -810,10 +860,13 @@ describe('coerceInputLiteral', () => {
       requiredBool: true,
     });
     test('{ requiredBool: $foo }', testInputObj, undefined);
-    testWithVariables({ foo: true }, '{ requiredBool: $foo }', testInputObj, {
-      int: 42,
-      requiredBool: true,
-    });
+    testWithVariables(
+      '($foo: Boolean)',
+      { foo: true },
+      '{ requiredBool: $foo }',
+      testInputObj,
+      { int: 42, requiredBool: true },
+    );
   });
 });
 

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -11,6 +11,7 @@ import type {
   FragmentDetails,
 } from '../../execution/collectFields.js';
 import { collectFields } from '../../execution/collectFields.js';
+import type { VariableValues } from '../../execution/values.js';
 
 import type { ValidationContext } from '../ValidationContext.js';
 
@@ -36,9 +37,7 @@ export function SingleFieldSubscriptionsRule(
         const subscriptionType = schema.getSubscriptionType();
         if (subscriptionType) {
           const operationName = node.name ? node.name.value : null;
-          const variableValues: {
-            [variable: string]: any;
-          } = Object.create(null);
+          const variableValues: VariableValues = Object.create(null);
           const document = context.getDocument();
           const fragments: ObjMap<FragmentDetails> = Object.create(null);
           for (const definition of document.definitions) {


### PR DESCRIPTION
[#3077 rebased on main](https://github.com/graphql/graphql-js/pull/3077).

Depends on #3810

@leebyron comments from original PR:

> By way of introducing type `VariableValues`, allows `getVariableValues` to return both the coerced values as well as the original sources, which are then made available in `ExecutionContext`.
> 
> While variable sources are not used directly here, they're used directly in #3065. This PR is pulled out as a pre-req to aid review 