### PR TITLE
Input Value Validation

### DIFF
--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -647,7 +647,7 @@ describe('Execute: handles non-nullable types', () => {
         errors: [
           {
             message:
-              'Argument "cannotBeNull" of non-null type "String!" must not be null.',
+              'Argument "cannotBeNull" has invalid value: Expected value of non-null type "String!" not to be null.',
             locations: [{ line: 3, column: 42 }],
             path: ['withNonNullArg'],
           },
@@ -677,7 +677,7 @@ describe('Execute: handles non-nullable types', () => {
         errors: [
           {
             message:
-              'Argument "cannotBeNull" of required type "String!" was provided the variable "$testVar" which was not provided a runtime value.',
+              'Argument "cannotBeNull" has invalid value: Expected variable "$testVar" provided to type "String!" to provide a runtime value.',
             locations: [{ line: 3, column: 42 }],
             path: ['withNonNullArg'],
           },
@@ -705,7 +705,7 @@ describe('Execute: handles non-nullable types', () => {
         errors: [
           {
             message:
-              'Argument "cannotBeNull" of non-null type "String!" must not be null.',
+              'Argument "cannotBeNull" has invalid value: Expected variable "$testVar" provided to non-null type "String!" not to be null.',
             locations: [{ line: 3, column: 43 }],
             path: ['withNonNullArg'],
           },

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -30,7 +30,12 @@ function executeQuery(
   rootValue: unknown,
   variableValues?: { [variable: string]: unknown },
 ): ExecutionResult | Promise<ExecutionResult> {
-  return execute({ schema, document: parse(query), rootValue, variableValues });
+  return execute({
+    schema,
+    document: parse(query, { experimentalFragmentArguments: true }),
+    rootValue,
+    variableValues,
+  });
 }
 
 describe('Execute: Handles OneOf Input Objects', () => {
@@ -83,7 +88,7 @@ describe('Execute: Handles OneOf Input Objects', () => {
             message:
               // This type of error would be caught at validation-time
               // hence the vague error message here.
-              'Argument "input" of non-null type "TestInputObject!" must not be null.',
+              'Argument "input" has invalid value: Expected variable "$input" provided to type "TestInputObject!" to provide a runtime value.',
             path: ['test'],
           },
         ],
@@ -134,6 +139,28 @@ describe('Execute: Handles OneOf Input Objects', () => {
       });
     });
 
+    it('rejects a variable with a nulled key', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, { input: { a: null } });
+
+      expectJSON(result).toDeepEqual({
+        errors: [
+          {
+            message:
+              'Variable "$input" has invalid value: Field "a" for OneOf type "TestInputObject" must be non-null.',
+            locations: [{ line: 2, column: 16 }],
+          },
+        ],
+      });
+    });
+
     it('rejects a variable with multiple non-null keys', () => {
       const query = `
         query ($input: TestInputObject!) {
@@ -152,7 +179,7 @@ describe('Execute: Handles OneOf Input Objects', () => {
           {
             locations: [{ column: 16, line: 2 }],
             message:
-              'Variable "$input" got invalid value { a: "abc", b: 123 }; Exactly one key must be specified for OneOf type "TestInputObject".',
+              'Variable "$input" has invalid value: Exactly one key must be specified for OneOf type "TestInputObject".',
           },
         ],
       });
@@ -176,7 +203,125 @@ describe('Execute: Handles OneOf Input Objects', () => {
           {
             locations: [{ column: 16, line: 2 }],
             message:
-              'Variable "$input" got invalid value { a: "abc", b: null }; Exactly one key must be specified for OneOf type "TestInputObject".',
+              'Variable "$input" has invalid value: Exactly one key must be specified for OneOf type "TestInputObject".',
+          },
+        ],
+      });
+    });
+
+    it('errors with nulled variable for field', () => {
+      const query = `
+        query ($a: String) {
+          test(input: { a: $a }) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, { a: null });
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: null,
+        },
+        errors: [
+          {
+            // A nullable variable in a oneOf field position would be caught at validation-time
+            // hence the vague error message here.
+            message:
+              'Argument "input" has invalid value: Expected variable "$a" provided to field "a" for OneOf Input Object type "TestInputObject" not to be null.',
+            locations: [{ line: 3, column: 23 }],
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('errors with missing variable for field', () => {
+      const query = `
+        query ($a: String) {
+          test(input: { a: $a }) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: null,
+        },
+        errors: [
+          {
+            // A nullable variable in a oneOf field position would be caught at validation-time
+            // hence the vague error message here.
+            message:
+              'Argument "input" has invalid value: Expected variable "$a" provided to field "a" for OneOf Input Object type "TestInputObject" to provide a runtime value.',
+            locations: [{ line: 3, column: 23 }],
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('errors with nulled fragment variable for field', () => {
+      const query = `
+        query {
+          ...TestFragment(a: null)
+        }
+        fragment TestFragment($a: String) on Query {
+          test(input: { a: $a }) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, { a: null });
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: null,
+        },
+        errors: [
+          {
+            // A nullable variable in a oneOf field position would be caught at validation-time
+            // hence the vague error message here.
+            message:
+              'Argument "input" has invalid value: Expected variable "$a" provided to field "a" for OneOf Input Object type "TestInputObject" not to be null.',
+            locations: [{ line: 6, column: 23 }],
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('errors with missing fragment variable for field', () => {
+      const query = `
+        query {
+          ...TestFragment
+        }
+        fragment TestFragment($a: String) on Query {
+          test(input: { a: $a }) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: null,
+        },
+        errors: [
+          {
+            // A nullable variable in a oneOf field position would be caught at validation-time
+            // hence the vague error message here.
+            message:
+              'Argument "input" has invalid value: Expected variable "$a" provided to field "a" for OneOf Input Object type "TestInputObject" to provide a runtime value.',
+            locations: [{ line: 6, column: 23 }],
+            path: ['test'],
           },
         ],
       });

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -567,7 +567,7 @@ describe('Subscription Initialization Phase', () => {
       errors: [
         {
           message:
-            'Variable "$arg" got invalid value "meow"; Int cannot represent non-integer value: "meow"',
+            'Variable "$arg" has invalid value: Int cannot represent non-integer value: "meow"',
           locations: [{ line: 2, column: 21 }],
         },
       ],

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -82,6 +82,15 @@ const TestInputObject = new GraphQLInputObjectType({
   },
 });
 
+const TestOneOfInputObject = new GraphQLInputObjectType({
+  name: 'TestOneOfInputObject',
+  fields: {
+    a: { type: GraphQLString },
+    b: { type: GraphQLString },
+  },
+  isOneOf: true,
+});
+
 const TestNestedInputObject = new GraphQLInputObjectType({
   name: 'TestNestedInputObject',
   fields: {
@@ -124,6 +133,9 @@ const TestType = new GraphQLObjectType({
       type: new GraphQLNonNull(TestEnum),
     }),
     fieldWithObjectInput: fieldWithInputArg({ type: TestInputObject }),
+    fieldWithOneOfObjectInput: fieldWithInputArg({
+      type: TestOneOfInputObject,
+    }),
     fieldWithNullableStringInput: fieldWithInputArg({ type: GraphQLString }),
     fieldWithNonNullableStringInput: fieldWithInputArg({
       type: new GraphQLNonNull(GraphQLString),
@@ -273,7 +285,7 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Argument "input" of type "TestInputObject" has invalid value ["foo", "bar", "baz"].',
+                'Argument "input" has invalid value: Expected value of type "TestInputObject" to be an object, found: ["foo", "bar", "baz"].',
               path: ['fieldWithObjectInput'],
               locations: [{ line: 3, column: 41 }],
             },
@@ -309,9 +321,10 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Argument "input" of type "TestInputObject" has invalid value { c: "foo", e: "bar" }.',
+                'Argument "input" has invalid value at .e: FaultyScalarErrorMessage',
               path: ['fieldWithObjectInput'],
-              locations: [{ line: 3, column: 41 }],
+              locations: [{ line: 3, column: 13 }],
+              extensions: { code: 'FaultyScalarErrorExtensionCode' },
             },
           ],
         });
@@ -465,7 +478,7 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Variable "$input" got invalid value "ExternalValue" at "input.e"; FaultyScalarErrorMessage',
+                'Variable "$input" has invalid value at .e: Argument "input" has invalid value at .e: FaultyScalarErrorMessage',
               locations: [{ line: 2, column: 16 }],
               extensions: { code: 'FaultyScalarErrorExtensionCode' },
             },
@@ -481,7 +494,7 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Variable "$input" got invalid value null at "input.c"; Expected non-nullable type "String!" not to be null.',
+                'Variable "$input" has invalid value at .c: Expected value of non-null type "String!" not to be null.',
               locations: [{ line: 2, column: 16 }],
             },
           ],
@@ -495,7 +508,7 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Variable "$input" got invalid value "foo bar"; Expected type "TestInputObject" to be an object.',
+                'Variable "$input" has invalid value: Expected value of type "TestInputObject" to be an object, found: "foo bar".',
               locations: [{ line: 2, column: 16 }],
             },
           ],
@@ -509,7 +522,7 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Variable "$input" got invalid value { a: "foo", b: "bar" }; Field "TestInputObject.c" of required type "String!" was not provided.',
+                'Variable "$input" has invalid value: Expected value of type "TestInputObject" to include required field "c", found: { a: "foo", b: "bar" }.',
               locations: [{ line: 2, column: 16 }],
             },
           ],
@@ -528,12 +541,12 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Variable "$input" got invalid value { a: "foo" } at "input.na"; Field "TestInputObject.c" of required type "String!" was not provided.',
+                'Variable "$input" has invalid value at .na: Expected value of type "TestInputObject" to include required field "c", found: { a: "foo" }.',
               locations: [{ line: 2, column: 18 }],
             },
             {
               message:
-                'Variable "$input" got invalid value { na: { a: "foo" } }; Field "TestNestedInputObject.nb" of required type "String!" was not provided.',
+                'Variable "$input" has invalid value: Expected value of type "TestNestedInputObject" to include required field "nb", found: { na: { a: "foo" } }.',
               locations: [{ line: 2, column: 18 }],
             },
           ],
@@ -550,7 +563,7 @@ describe('Execute: Handles inputs', () => {
           errors: [
             {
               message:
-                'Variable "$input" got invalid value { a: "foo", b: "bar", c: "baz", extra: "dog" }; Field "extra" is not defined by type "TestInputObject".',
+                'Variable "$input" has invalid value: Expected value of type "TestInputObject" not to include unknown field "extra", found: { a: "foo", b: "bar", c: "baz", extra: "dog" }.',
               locations: [{ line: 2, column: 16 }],
             },
           ],
@@ -725,7 +738,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$value" of required type "String!" was not provided.',
+              'Variable "$value" has invalid value: Expected a value of non-null type "String!" to be provided.',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -744,7 +757,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$value" of non-null type "String!" must not be null.',
+              'Variable "$value" has invalid value: Expected value of non-null type "String!" not to be null.',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -810,7 +823,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$value" got invalid value [1, 2, 3]; String cannot represent a non string value: [1, 2, 3]',
+              'Variable "$value" has invalid value: String cannot represent a non string value: [1, 2, 3]',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -838,7 +851,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Argument "input" of required type "String!" was provided the variable "$foo" which was not provided a runtime value.',
+              'Argument "input" has invalid value: Expected variable "$foo" provided to type "String!" to provide a runtime value.',
             locations: [{ line: 3, column: 50 }],
             path: ['fieldWithNonNullableStringInput'],
           },
@@ -893,7 +906,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$input" of non-null type "[String]!" must not be null.',
+              'Variable "$input" has invalid value: Expected value of non-null type "[String]!" not to be null.',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -956,7 +969,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$input" got invalid value null at "input[1]"; Expected non-nullable type "String!" not to be null.',
+              'Variable "$input" has invalid value at [1]: Expected value of non-null type "String!" not to be null.',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -975,7 +988,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$input" of non-null type "[String!]!" must not be null.',
+              'Variable "$input" has invalid value: Expected value of non-null type "[String!]!" not to be null.',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -1005,7 +1018,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Variable "$input" got invalid value null at "input[1]"; Expected non-nullable type "String!" not to be null.',
+              'Variable "$input" has invalid value at [1]: Expected value of non-null type "String!" not to be null.',
             locations: [{ line: 2, column: 16 }],
           },
         ],
@@ -1090,7 +1103,7 @@ describe('Execute: Handles inputs', () => {
         errors: [
           {
             message:
-              'Argument "input" of type "String" has invalid value WRONG_TYPE.',
+              'Argument "input" has invalid value: String cannot represent a non string value: WRONG_TYPE',
             locations: [{ line: 3, column: 48 }],
             path: ['fieldWithDefaultArgumentValue'],
           },
@@ -1130,7 +1143,7 @@ describe('Execute: Handles inputs', () => {
 
     function invalidValueError(value: number, index: number) {
       return {
-        message: `Variable "$input" got invalid value ${value} at "input[${index}]"; String cannot represent a non string value: ${value}`,
+        message: `Variable "$input" has invalid value at [${index}]: String cannot represent a non string value: ${value}`,
         locations: [{ line: 2, column: 14 }],
       };
     }
@@ -1299,7 +1312,7 @@ describe('Execute: Handles inputs', () => {
       expect(result).to.have.property('errors');
       expect(result.errors).to.have.length(1);
       expect(result.errors?.at(0)?.message).to.match(
-        /Argument "value" of non-null type "String!"/,
+        /Argument "value" has invalid value: Expected value of non-null type "String!" not to be null./,
       );
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -456,10 +456,14 @@ export {
   replaceVariables,
   // Create a GraphQL literal (AST) from a JavaScript input value.
   valueToLiteral,
-  // Coerces a JavaScript value to a GraphQL type, or produces errors.
+  // Coerces a JavaScript value to a GraphQL type, or returns undefined.
   coerceInputValue,
   // Coerces a GraphQL literal (AST) to a GraphQL type, or returns undefined.
   coerceInputLiteral,
+  // Validate a JavaScript value with a GraphQL type, collecting all errors.
+  validateInputValue,
+  // Validate a GraphQL literal (AST) with a GraphQL type, collecting all errors.
+  validateInputLiteral,
   // Concatenates multiple AST together.
   concatAST,
   // Separates an AST into an AST per Operation.

--- a/src/jsutils/printPathArray.ts
+++ b/src/jsutils/printPathArray.ts
@@ -2,9 +2,10 @@
  * Build a string describing the path.
  */
 export function printPathArray(path: ReadonlyArray<string | number>): string {
-  return path
-    .map((key) =>
-      typeof key === 'number' ? '[' + key.toString() + ']' : '.' + key,
-    )
-    .join('');
+  if (path.length === 0) {
+    return '';
+  }
+  return ` at ${path
+    .map((key) => (typeof key === 'number' ? `[${key}]` : `.${key}`))
+    .join('')}`;
 }

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -306,7 +306,7 @@ describe('Type System: Enum Values', () => {
       errors: [
         {
           message:
-            'Variable "$color" got invalid value 2; Enum "Color" cannot represent non-string value: 2.',
+            'Variable "$color" has invalid value: Enum "Color" cannot represent non-string value: 2.',
           locations: [{ line: 1, column: 8 }],
         },
       ],

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -40,6 +40,7 @@ import type {
 import { Kind } from '../language/kinds.js';
 import { print } from '../language/printer.js';
 
+import type { GraphQLVariableSignature } from '../execution/getVariableSignature.js';
 import type { VariableValues } from '../execution/values.js';
 
 import { valueFromASTUntyped } from '../utilities/valueFromASTUntyped.js';
@@ -1084,7 +1085,9 @@ export interface GraphQLArgument {
   astNode: Maybe<InputValueDefinitionNode>;
 }
 
-export function isRequiredArgument(arg: GraphQLArgument): boolean {
+export function isRequiredArgument(
+  arg: GraphQLArgument | GraphQLVariableSignature,
+): boolean {
   return isNonNullType(arg.type) && arg.defaultValue === undefined;
 }
 

--- a/src/utilities/__tests__/validateInputValue-test.ts
+++ b/src/utilities/__tests__/validateInputValue-test.ts
@@ -1,0 +1,921 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { invariant } from '../../jsutils/invariant.js';
+import type { ReadOnlyObjMap } from '../../jsutils/ObjMap.js';
+
+import { Parser, parseValue } from '../../language/parser.js';
+import { TokenKind } from '../../language/tokenKind.js';
+
+import type { GraphQLInputType } from '../../type/definition.js';
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLScalarType,
+} from '../../type/definition.js';
+import { GraphQLInt } from '../../type/scalars.js';
+import { GraphQLSchema } from '../../type/schema.js';
+
+import type { VariableValues } from '../../execution/values.js';
+import { getVariableValues } from '../../execution/values.js';
+
+import {
+  validateInputLiteral,
+  validateInputValue,
+} from '../validateInputValue.js';
+
+describe('validateInputValue', () => {
+  function test(
+    inputValue: unknown,
+    type: GraphQLInputType,
+    expected: unknown,
+    hideSuggestions = false,
+  ) {
+    const errors: any = [];
+    validateInputValue(
+      inputValue,
+      type,
+      (error, path) => {
+        errors.push({ error: error.message, path });
+      },
+      hideSuggestions,
+    );
+    expect(errors).to.deep.equal(expected);
+  }
+
+  describe('for GraphQLNonNull', () => {
+    const TestNonNull = new GraphQLNonNull(GraphQLInt);
+
+    it('returns no error for non-null value', () => {
+      test(1, TestNonNull, []);
+    });
+
+    it('returns an error for undefined value', () => {
+      test(undefined, TestNonNull, [
+        {
+          error: 'Expected a value of non-null type "Int!" to be provided.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for null value', () => {
+      test(null, TestNonNull, [
+        {
+          error: 'Expected value of non-null type "Int!" not to be null.',
+          path: [],
+        },
+      ]);
+    });
+  });
+
+  describe('for GraphQLScalar', () => {
+    const TestScalar = new GraphQLScalarType({
+      name: 'TestScalar',
+      parseValue(input: any) {
+        invariant(typeof input === 'object' && input !== null);
+        if (input.error != null) {
+          throw new Error(input.error);
+        }
+        return input.value;
+      },
+    });
+
+    it('returns no error for valid input', () => {
+      test({ value: 1 }, TestScalar, []);
+    });
+
+    it('returns no error for null result', () => {
+      test({ value: null }, TestScalar, []);
+    });
+
+    it('returns no error for NaN result', () => {
+      test({ value: NaN }, TestScalar, []);
+    });
+
+    it('returns an error for undefined result', () => {
+      test({ value: undefined }, TestScalar, [
+        {
+          error:
+            'Expected value of type "TestScalar", found: { value: undefined }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for undefined result', () => {
+      const inputValue = { error: 'Some error message.' };
+      test(inputValue, TestScalar, [
+        {
+          error:
+            'Expected value of type "TestScalar", but encountered error "Some error message."; found: { error: "Some error message." }.',
+          path: [],
+        },
+      ]);
+    });
+  });
+
+  describe('for GraphQLEnum', () => {
+    const TestEnum = new GraphQLEnumType({
+      name: 'TestEnum',
+      values: {
+        FOO: { value: 'InternalFoo' },
+        BAR: { value: 123456789 },
+      },
+    });
+
+    it('returns no error for a known enum name', () => {
+      test('FOO', TestEnum, []);
+
+      test('BAR', TestEnum, []);
+    });
+
+    it('returns an error for unknown enum value', () => {
+      test('UNKNOWN', TestEnum, [
+        {
+          error: 'Value "UNKNOWN" does not exist in "TestEnum" enum.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for misspelled enum value', () => {
+      test('foo', TestEnum, [
+        {
+          error:
+            'Value "foo" does not exist in "TestEnum" enum. Did you mean the enum value "FOO"?',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for misspelled enum value (no suggestions)', () => {
+      test(
+        'foo',
+        TestEnum,
+        [
+          {
+            error: 'Value "foo" does not exist in "TestEnum" enum.',
+            path: [],
+          },
+        ],
+        true,
+      );
+    });
+
+    it('returns an error for incorrect value type', () => {
+      class Foo {
+        toJSON() {
+          return 'FOO';
+        }
+      }
+
+      test(new Foo(), TestEnum, [
+        {
+          error:
+            'Enum "TestEnum" cannot represent non-string value: FOO. Did you mean the enum value "FOO"?',
+          path: [],
+        },
+      ]);
+
+      test(
+        new Foo(),
+        TestEnum,
+        [
+          {
+            error: 'Enum "TestEnum" cannot represent non-string value: FOO.',
+            path: [],
+          },
+        ],
+        true,
+      );
+
+      test(123, TestEnum, [
+        {
+          error: 'Enum "TestEnum" cannot represent non-string value: 123.',
+          path: [],
+        },
+      ]);
+
+      test({ field: 'value' }, TestEnum, [
+        {
+          error:
+            'Enum "TestEnum" cannot represent non-string value: { field: "value" }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('reports thrown non-error', () => {
+      const TestThrowScalar = new GraphQLScalarType({
+        name: 'TestScalar',
+        parseValue() {
+          // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error
+          throw 'Not an error object.';
+        },
+      });
+
+      test({}, TestThrowScalar, [
+        {
+          error:
+            'Expected value of type "TestScalar", but encountered error "Not an error object."; found: {}.',
+          path: [],
+        },
+      ]);
+    });
+  });
+
+  describe('for GraphQLInputObject', () => {
+    const TestInputObject = new GraphQLInputObjectType({
+      name: 'TestInputObject',
+      fields: {
+        foo: { type: new GraphQLNonNull(GraphQLInt) },
+        bar: { type: GraphQLInt },
+      },
+    });
+
+    it('returns no error for a valid input', () => {
+      test({ foo: 123 }, TestInputObject, []);
+    });
+
+    it('returns an error for a non-object type', () => {
+      test(123, TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" to be an object, found: 123.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for an invalid field', () => {
+      test({ foo: NaN }, TestInputObject, [
+        {
+          error: 'Int cannot represent non-integer value: NaN',
+          path: ['foo'],
+        },
+      ]);
+    });
+
+    it('returns multiple errors for multiple invalid fields', () => {
+      test({ foo: 'abc', bar: 'def' }, TestInputObject, [
+        {
+          error: 'Int cannot represent non-integer value: "abc"',
+          path: ['foo'],
+        },
+        {
+          error: 'Int cannot represent non-integer value: "def"',
+          path: ['bar'],
+        },
+      ]);
+    });
+
+    it('returns error for a missing required field', () => {
+      test({ bar: 123 }, TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" to include required field "foo", found: { bar: 123 }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns error for an unknown field', () => {
+      test({ foo: 123, unknownField: 123 }, TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" not to include unknown field "unknownField", found: { foo: 123, unknownField: 123 }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns error for a misspelled field', () => {
+      test({ foo: 123, bart: 123 }, TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" not to include unknown field "bart". Did you mean "bar"? Found: { foo: 123, bart: 123 }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns error for a misspelled field (no suggestions)', () => {
+      test(
+        { foo: 123, bart: 123 },
+        TestInputObject,
+        [
+          {
+            error:
+              'Expected value of type "TestInputObject" not to include unknown field "bart", found: { foo: 123, bart: 123 }.',
+            path: [],
+          },
+        ],
+        true,
+      );
+    });
+  });
+
+  describe('for GraphQLInputObject with default value', () => {
+    function makeTestInputObject(defaultValue: unknown) {
+      return new GraphQLInputObjectType({
+        name: 'TestInputObject',
+        fields: {
+          foo: {
+            type: new GraphQLScalarType({ name: 'TestScalar' }),
+            defaultValue,
+          },
+        },
+      });
+    }
+
+    it('no error for no errors for valid input value', () => {
+      test({ foo: 5 }, makeTestInputObject(7), []);
+    });
+
+    it('no error for object with default value', () => {
+      test({}, makeTestInputObject(7), []);
+    });
+
+    it('no error for null as value', () => {
+      test({}, makeTestInputObject(null), []);
+    });
+
+    it('no error for NaN as value', () => {
+      test({}, makeTestInputObject(NaN), []);
+    });
+  });
+
+  describe('for GraphQLList', () => {
+    const TestList = new GraphQLList(GraphQLInt);
+
+    it('returns no error for a valid input', () => {
+      test([1, 2, 3], TestList, []);
+    });
+
+    it('returns no error for a valid iterable input', () => {
+      // TODO: put an error in this list and show it appears
+      function* listGenerator() {
+        yield 1;
+        yield 2;
+        yield 3;
+      }
+
+      test(listGenerator(), TestList, []);
+    });
+
+    it('returns an error for an invalid input', () => {
+      test([1, 'b', true, 4], TestList, [
+        {
+          error: 'Int cannot represent non-integer value: "b"',
+          path: [1],
+        },
+        {
+          error: 'Int cannot represent non-integer value: true',
+          path: [2],
+        },
+      ]);
+    });
+
+    it('no error for a list for a non-list value', () => {
+      test(42, TestList, []);
+    });
+
+    it('returns an error for a non-list invalid value', () => {
+      test('INVALID', TestList, [
+        {
+          error: 'Int cannot represent non-integer value: "INVALID"',
+          path: [],
+        },
+      ]);
+    });
+
+    it('no error for null for a null value', () => {
+      test(null, TestList, []);
+    });
+  });
+
+  describe('for nested GraphQLList', () => {
+    const TestNestedList = new GraphQLList(new GraphQLList(GraphQLInt));
+
+    it('no error for a valid input', () => {
+      test([[1], [2, 3]], TestNestedList, []);
+    });
+
+    it('no error for a list for a non-list value', () => {
+      test(42, TestNestedList, []);
+    });
+
+    it('no error for null for a null value', () => {
+      test(null, TestNestedList, []);
+    });
+
+    it('no error for nested lists for nested non-list values', () => {
+      test([1, 2, 3], TestNestedList, []);
+    });
+
+    it('no error for nested null for nested null values', () => {
+      test([42, [null], null], TestNestedList, []);
+    });
+  });
+});
+
+describe('validateInputLiteral', () => {
+  function test(
+    inputValue: string,
+    type: GraphQLInputType,
+    expected: unknown,
+    variableValues?: VariableValues,
+    hideSuggestions = false,
+  ) {
+    const errors: any = [];
+    validateInputLiteral(
+      parseValue(inputValue),
+      type,
+      (error, path) => {
+        errors.push({ error: error.message, path });
+      },
+      variableValues,
+      undefined,
+      hideSuggestions,
+    );
+    expect(errors).to.deep.equal(expected);
+  }
+
+  function testWithVariables(
+    variableDefs: string,
+    values: ReadOnlyObjMap<unknown>,
+    inputValue: string,
+    type: GraphQLInputType,
+    expected: unknown,
+  ) {
+    const parser = new Parser(variableDefs);
+    parser.expectToken(TokenKind.SOF);
+    const variableValuesOrErrors = getVariableValues(
+      new GraphQLSchema({ types: [GraphQLInt] }),
+      parser.parseVariableDefinitions() ?? [],
+      values,
+    );
+    invariant(variableValuesOrErrors.variableValues != null);
+    test(inputValue, type, expected, variableValuesOrErrors.variableValues);
+  }
+
+  it('ignores variables statically', () => {
+    const TestNonNull = new GraphQLNonNull(GraphQLInt);
+    test('$var', TestNonNull, []);
+  });
+
+  it('returns an error for null variables for non-nullable types', () => {
+    const TestNonNull = new GraphQLNonNull(GraphQLInt);
+    testWithVariables('($var: Int)', { var: null }, '$var', TestNonNull, [
+      {
+        error:
+          'Expected variable "$var" provided to non-null type "Int!" not to be null.',
+        path: [],
+      },
+    ]);
+  });
+
+  describe('for GraphQLNonNull', () => {
+    const TestNonNull = new GraphQLNonNull(GraphQLInt);
+
+    it('returns no error for non-null value', () => {
+      test('1', TestNonNull, []);
+    });
+
+    it('returns an error for null value', () => {
+      test('null', TestNonNull, [
+        {
+          error: 'Expected value of non-null type "Int!" not to be null.',
+          path: [],
+        },
+      ]);
+    });
+  });
+
+  describe('for GraphQLScalar', () => {
+    const TestScalar = new GraphQLScalarType({
+      name: 'TestScalar',
+      parseValue(input: any) {
+        invariant(typeof input === 'object' && input !== null);
+        if (input.error != null) {
+          throw new Error(input.error);
+        }
+        return input.value;
+      },
+    });
+
+    it('returns no error for valid input', () => {
+      test('{ value: 1 }', TestScalar, []);
+    });
+
+    it('returns no error for null result', () => {
+      test('{ value: null }', TestScalar, []);
+    });
+
+    it('returns no error for NaN result', () => {
+      test('{ value: NaN }', TestScalar, []);
+    });
+
+    it('returns an error for undefined result', () => {
+      test('{}', TestScalar, [
+        {
+          error: 'Expected value of type "TestScalar", found: {  }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for undefined result', () => {
+      const inputValue = '{ error: "Some error message." }';
+      test(inputValue, TestScalar, [
+        {
+          error:
+            'Expected value of type "TestScalar", but encountered error "Some error message."; found: { error: "Some error message." }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('reports thrown non-error', () => {
+      const TestThrowScalar = new GraphQLScalarType({
+        name: 'TestScalar',
+        parseValue() {
+          // eslint-disable-next-line no-throw-literal, @typescript-eslint/only-throw-error
+          throw 'Not an error object.';
+        },
+      });
+
+      test('{}', TestThrowScalar, [
+        {
+          error:
+            'Expected value of type "TestScalar", but encountered error "Not an error object."; found: {  }.',
+          path: [],
+        },
+      ]);
+    });
+  });
+
+  describe('for GraphQLEnum', () => {
+    const TestEnum = new GraphQLEnumType({
+      name: 'TestEnum',
+      values: {
+        FOO: { value: 'InternalFoo' },
+        BAR: { value: 123456789 },
+      },
+    });
+
+    it('returns no error for a known enum name', () => {
+      test('FOO', TestEnum, []);
+
+      test('BAR', TestEnum, []);
+    });
+
+    it('returns an error for unknown enum value', () => {
+      test('UNKNOWN', TestEnum, [
+        {
+          error: 'Value "UNKNOWN" does not exist in "TestEnum" enum.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for misspelled enum value', () => {
+      test('foo', TestEnum, [
+        {
+          error:
+            'Value "foo" does not exist in "TestEnum" enum. Did you mean the enum value "FOO"?',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for misspelled enum value (no suggestions)', () => {
+      test(
+        'foo',
+        TestEnum,
+        [
+          {
+            error: 'Value "foo" does not exist in "TestEnum" enum.',
+            path: [],
+          },
+        ],
+        undefined,
+        true,
+      );
+    });
+
+    it('returns an error for incorrect value type', () => {
+      test('"FOO"', TestEnum, [
+        {
+          error:
+            'Enum "TestEnum" cannot represent non-enum value: "FOO". Did you mean the enum value "FOO"?',
+          path: [],
+        },
+      ]);
+
+      test(
+        '"FOO"',
+        TestEnum,
+        [
+          {
+            error: 'Enum "TestEnum" cannot represent non-enum value: "FOO".',
+            path: [],
+          },
+        ],
+        undefined,
+        true,
+      );
+
+      test('"UNKNOWN"', TestEnum, [
+        {
+          error: 'Enum "TestEnum" cannot represent non-enum value: "UNKNOWN".',
+          path: [],
+        },
+      ]);
+
+      test('123', TestEnum, [
+        {
+          error: 'Enum "TestEnum" cannot represent non-enum value: 123.',
+          path: [],
+        },
+      ]);
+
+      test('{ field: "value" }', TestEnum, [
+        {
+          error:
+            'Enum "TestEnum" cannot represent non-enum value: { field: "value" }.',
+          path: [],
+        },
+      ]);
+    });
+  });
+
+  describe('for GraphQLInputObject', () => {
+    const TestInputObject = new GraphQLInputObjectType({
+      name: 'TestInputObject',
+      fields: {
+        foo: { type: new GraphQLNonNull(GraphQLInt) },
+        bar: { type: GraphQLInt },
+        optional: { type: new GraphQLNonNull(GraphQLInt), defaultValue: 42 },
+      },
+    });
+
+    it('returns no error for a valid input', () => {
+      test('{ foo: 123 }', TestInputObject, []);
+    });
+
+    it('returns an error for a non-object type', () => {
+      test('123', TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" to be an object, found: 123.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns an error for an invalid field', () => {
+      test('{ foo: 1.5 }', TestInputObject, [
+        {
+          error: 'Int cannot represent non-integer value: 1.5',
+          path: ['foo'],
+        },
+      ]);
+    });
+
+    it('returns multiple errors for multiple invalid fields', () => {
+      test('{ foo: "abc", bar: "def" }', TestInputObject, [
+        {
+          error: 'Int cannot represent non-integer value: "abc"',
+          path: ['foo'],
+        },
+        {
+          error: 'Int cannot represent non-integer value: "def"',
+          path: ['bar'],
+        },
+      ]);
+    });
+
+    it('returns error for a missing required field', () => {
+      test('{ bar: 123 }', TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" to include required field "foo", found: { bar: 123 }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns error for an unknown field', () => {
+      test('{ foo: 123, unknownField: 123 }', TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" not to include unknown field "unknownField", found: { foo: 123, unknownField: 123 }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('returns error for a misspelled field', () => {
+      test('{ foo: 123, bart: 123 }', TestInputObject, [
+        {
+          error:
+            'Expected value of type "TestInputObject" not to include unknown field "bart". Did you mean "bar"? Found: { foo: 123, bart: 123 }.',
+          path: [],
+        },
+      ]);
+    });
+
+    it('allows variables in an object, statically', () => {
+      test('{ foo: $var }', TestInputObject, []);
+    });
+
+    it('allows correct use of variables', () => {
+      testWithVariables(
+        '($var: Int)',
+        { var: 123 },
+        '{ foo: $var }',
+        TestInputObject,
+        [],
+      );
+    });
+
+    it('allows missing variables in an nullable field', () => {
+      testWithVariables('', {}, '{ foo: 123, bar: $var }', TestInputObject, []);
+      testWithVariables(
+        '($var: Int)',
+        {},
+        '{ foo: 123, bar: $var }',
+        TestInputObject,
+        [],
+      );
+    });
+
+    it('allows missing variables in an optional field', () => {
+      testWithVariables(
+        '($var: Int)',
+        {},
+        '{ foo: 123, optional: $var }',
+        TestInputObject,
+        [],
+      );
+    });
+
+    it('errors on missing variable in an required field', () => {
+      testWithVariables('($var: Int)', {}, '{ foo: $var }', TestInputObject, [
+        {
+          error:
+            'Expected variable "$var" provided to type "Int!" to provide a runtime value.',
+          path: ['foo'],
+        },
+      ]);
+    });
+
+    it('errors on null variable in an non-null field', () => {
+      testWithVariables(
+        '($var: Int)',
+        { var: null },
+        '{ foo: 123, optional: $var }',
+        TestInputObject,
+        [
+          {
+            error:
+              'Expected variable "$var" provided to non-null type "Int!" not to be null.',
+            path: ['optional'],
+          },
+        ],
+      );
+    });
+  });
+
+  describe('for GraphQLInputObject with default value', () => {
+    function makeTestInputObject(defaultValue: unknown) {
+      return new GraphQLInputObjectType({
+        name: 'TestInputObject',
+        fields: {
+          foo: {
+            type: new GraphQLScalarType({ name: 'TestScalar' }),
+            defaultValue,
+          },
+        },
+      });
+    }
+
+    it('no error for no errors for valid input value', () => {
+      test('{ foo: 5 }', makeTestInputObject(7), []);
+    });
+
+    it('no error for object with default value', () => {
+      test('{}', makeTestInputObject(7), []);
+    });
+
+    it('no error for null as value', () => {
+      test('{}', makeTestInputObject(null), []);
+    });
+
+    it('no error for NaN as value', () => {
+      test('{}', makeTestInputObject(NaN), []);
+    });
+  });
+
+  describe('for GraphQLList', () => {
+    const TestList = new GraphQLList(GraphQLInt);
+
+    it('returns no error for a valid input', () => {
+      test('[1, 2, 3]', TestList, []);
+    });
+
+    it('returns an error for an invalid input', () => {
+      test('[1, "b", true, 4]', TestList, [
+        {
+          error: 'Int cannot represent non-integer value: "b"',
+          path: [1],
+        },
+        {
+          error: 'Int cannot represent non-integer value: true',
+          path: [2],
+        },
+      ]);
+    });
+
+    it('no error for a list for a non-list value', () => {
+      test('42', TestList, []);
+    });
+
+    it('returns an error for a non-list invalid value', () => {
+      test('"INVALID"', TestList, [
+        {
+          error: 'Int cannot represent non-integer value: "INVALID"',
+          path: [],
+        },
+      ]);
+    });
+
+    it('no error for null for a null value', () => {
+      test('null', TestList, []);
+    });
+
+    it('allows variables in a list, statically', () => {
+      test('[1, $var, 3]', TestList, []);
+    });
+
+    it('allows missing variables in a list (which coerce to null)', () => {
+      testWithVariables('($var: Int)', {}, '[1, $var, 3]', TestList, []);
+    });
+
+    it('errors on missing variables in a list of non-null', () => {
+      const TestListNonNull = new GraphQLList(new GraphQLNonNull(GraphQLInt));
+      testWithVariables('($var: Int)', {}, '[1, $var, 3]', TestListNonNull, [
+        {
+          error:
+            'Expected variable "$var" provided to type "Int!" to provide a runtime value.',
+          path: [1],
+        },
+      ]);
+    });
+
+    it('errors on null variables in a list of non-null', () => {
+      const TestListNonNull = new GraphQLList(new GraphQLNonNull(GraphQLInt));
+      testWithVariables(
+        '($var: Int)',
+        { var: null },
+        '[1, $var, 3]',
+        TestListNonNull,
+        [
+          {
+            error:
+              'Expected variable "$var" provided to non-null type "Int!" not to be null.',
+            path: [1],
+          },
+        ],
+      );
+    });
+  });
+
+  describe('for nested GraphQLList', () => {
+    const TestNestedList = new GraphQLList(new GraphQLList(GraphQLInt));
+
+    it('no error for a valid input', () => {
+      test('[[1], [2, 3]]', TestNestedList, []);
+    });
+
+    it('no error for a list for a non-list value', () => {
+      test('42', TestNestedList, []);
+    });
+
+    it('no error for null for a null value', () => {
+      test('null', TestNestedList, []);
+    });
+
+    it('no error for nested lists for nested non-list values', () => {
+      test('[1, 2, 3]', TestNestedList, []);
+    });
+
+    it('no error for nested null for nested null values', () => {
+      test('[42, [null], null]', TestNestedList, []);
+    });
+  });
+});

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -78,11 +78,18 @@ export { replaceVariables } from './replaceVariables.js';
 export { valueToLiteral } from './valueToLiteral.js';
 
 export {
-  // Coerces a JavaScript value to a GraphQL type, or produces errors.
+  // Coerces a JavaScript value to a GraphQL type, or returns undefined.
   coerceInputValue,
   // Coerces a GraphQL literal (AST) to a GraphQL type, or returns undefined.
   coerceInputLiteral,
 } from './coerceInputValue.js';
+
+export {
+  // Validate a JavaScript value with a GraphQL type, collecting all errors.
+  validateInputValue,
+  // Validate a GraphQL literal (AST) with a GraphQL type, collecting all errors.
+  validateInputLiteral,
+} from './validateInputValue.js';
 
 // Concatenates multiple AST together.
 export { concatAST } from './concatAST.js';

--- a/src/utilities/validateInputValue.ts
+++ b/src/utilities/validateInputValue.ts
@@ -1,0 +1,507 @@
+import { didYouMean } from '../jsutils/didYouMean.js';
+import { inspect } from '../jsutils/inspect.js';
+import { isIterableObject } from '../jsutils/isIterableObject.js';
+import { isObjectLike } from '../jsutils/isObjectLike.js';
+import { keyMap } from '../jsutils/keyMap.js';
+import type { Maybe } from '../jsutils/Maybe.js';
+import type { Path } from '../jsutils/Path.js';
+import { addPath, pathToArray } from '../jsutils/Path.js';
+import { suggestionList } from '../jsutils/suggestionList.js';
+
+import { GraphQLError } from '../error/GraphQLError.js';
+
+import type { ASTNode, ValueNode, VariableNode } from '../language/ast.js';
+import { Kind } from '../language/kinds.js';
+import { print } from '../language/printer.js';
+
+import type { GraphQLInputType } from '../type/definition.js';
+import {
+  assertLeafType,
+  isInputObjectType,
+  isListType,
+  isNonNullType,
+  isRequiredInputField,
+} from '../type/definition.js';
+
+import type { VariableValues } from '../execution/values.js';
+
+import { replaceVariables } from './replaceVariables.js';
+
+/**
+ * Validate that the provided input value is allowed for this type, collecting
+ * all errors via a callback function.
+ */
+export function validateInputValue(
+  inputValue: unknown,
+  type: GraphQLInputType,
+  onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void,
+  hideSuggestions?: Maybe<boolean>,
+): void {
+  return validateInputValueImpl(
+    inputValue,
+    type,
+    onError,
+    hideSuggestions,
+    undefined,
+  );
+}
+
+function validateInputValueImpl(
+  inputValue: unknown,
+  type: GraphQLInputType,
+  onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void,
+  hideSuggestions: Maybe<boolean>,
+  path: Path | undefined,
+): void {
+  if (isNonNullType(type)) {
+    if (inputValue === undefined) {
+      reportInvalidValue(
+        onError,
+        `Expected a value of non-null type "${type}" to be provided.`,
+        path,
+      );
+      return;
+    }
+    if (inputValue === null) {
+      reportInvalidValue(
+        onError,
+        `Expected value of non-null type "${type}" not to be null.`,
+        path,
+      );
+      return;
+    }
+    return validateInputValueImpl(
+      inputValue,
+      type.ofType,
+      onError,
+      hideSuggestions,
+      path,
+    );
+  }
+
+  if (inputValue == null) {
+    return;
+  }
+
+  if (isListType(type)) {
+    if (!isIterableObject(inputValue)) {
+      // Lists accept a non-list value as a list of one.
+      validateInputValueImpl(
+        inputValue,
+        type.ofType,
+        onError,
+        hideSuggestions,
+        path,
+      );
+    } else {
+      let index = 0;
+      for (const itemValue of inputValue) {
+        validateInputValueImpl(
+          itemValue,
+          type.ofType,
+          onError,
+          hideSuggestions,
+          addPath(path, index++, undefined),
+        );
+      }
+    }
+  } else if (isInputObjectType(type)) {
+    if (!isObjectLike(inputValue)) {
+      reportInvalidValue(
+        onError,
+        `Expected value of type "${type}" to be an object, found: ${inspect(
+          inputValue,
+        )}.`,
+        path,
+      );
+      return;
+    }
+
+    const fieldDefs = type.getFields();
+
+    for (const field of Object.values(fieldDefs)) {
+      const fieldValue = inputValue[field.name];
+      if (fieldValue === undefined) {
+        if (isRequiredInputField(field)) {
+          reportInvalidValue(
+            onError,
+            `Expected value of type "${type}" to include required field "${
+              field.name
+            }", found: ${inspect(inputValue)}.`,
+            path,
+          );
+        }
+      } else {
+        validateInputValueImpl(
+          fieldValue,
+          field.type,
+          onError,
+          hideSuggestions,
+          addPath(path, field.name, type.name),
+        );
+      }
+    }
+
+    const fields = Object.keys(inputValue);
+    // Ensure every provided field is defined.
+    for (const fieldName of fields) {
+      if (!Object.hasOwn(fieldDefs, fieldName)) {
+        const suggestion = hideSuggestions
+          ? ''
+          : didYouMean(suggestionList(fieldName, Object.keys(fieldDefs)));
+        reportInvalidValue(
+          onError,
+          `Expected value of type "${type}" not to include unknown field "${fieldName}"${
+            suggestion ? `.${suggestion} Found` : ', found'
+          }: ${inspect(inputValue)}.`,
+          path,
+        );
+      }
+    }
+
+    if (type.isOneOf) {
+      if (fields.length !== 1) {
+        reportInvalidValue(
+          onError,
+          `Exactly one key must be specified for OneOf type "${type}".`,
+          path,
+        );
+      }
+
+      const field = fields[0];
+      const value = inputValue[field];
+      if (value === null) {
+        reportInvalidValue(
+          onError,
+          `Field "${field}" for OneOf type "${type}" must be non-null.`,
+          path,
+        );
+      }
+    }
+  } else {
+    assertLeafType(type);
+
+    let result;
+    let caughtError;
+
+    try {
+      result = type.parseValue(inputValue, hideSuggestions);
+    } catch (error) {
+      if (error instanceof GraphQLError) {
+        onError(error, pathToArray(path));
+        return;
+      }
+      caughtError = error;
+    }
+
+    if (result === undefined) {
+      reportInvalidValue(
+        onError,
+        `Expected value of type "${type}"${
+          caughtError != null
+            ? `, but encountered error "${caughtError.message != null && caughtError.message !== '' ? caughtError.message : caughtError}"; found`
+            : ', found'
+        }: ${inspect(inputValue)}.`,
+        path,
+        caughtError,
+      );
+    }
+  }
+}
+
+function reportInvalidValue(
+  onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void,
+  message: string,
+  path: Path | undefined,
+  originalError?: GraphQLError | undefined,
+): void {
+  onError(new GraphQLError(message, { originalError }), pathToArray(path));
+}
+
+/**
+ * Validate that the provided input literal is allowed for this type, collecting
+ * all errors via a callback function.
+ *
+ * If variable values are not provided, the literal is validated statically
+ * (not assuming that those variables are missing runtime values).
+ */
+// eslint-disable-next-line @typescript-eslint/max-params
+export function validateInputLiteral(
+  valueNode: ValueNode,
+  type: GraphQLInputType,
+  onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void,
+  variables?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<VariableValues>,
+  hideSuggestions?: Maybe<boolean>,
+): void {
+  const context: ValidationContext = {
+    static: !variables && !fragmentVariableValues,
+    onError,
+    variables,
+    fragmentVariableValues,
+  };
+  return validateInputLiteralImpl(
+    context,
+    valueNode,
+    type,
+    hideSuggestions,
+    undefined,
+  );
+}
+
+interface ValidationContext {
+  static: boolean;
+  onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void;
+  variables?: Maybe<VariableValues>;
+  fragmentVariableValues?: Maybe<VariableValues>;
+}
+
+function validateInputLiteralImpl(
+  context: ValidationContext,
+  valueNode: ValueNode,
+  type: GraphQLInputType,
+  hideSuggestions: Maybe<boolean>,
+  path: Path | undefined,
+): void {
+  if (valueNode.kind === Kind.VARIABLE) {
+    if (context.static) {
+      // If no variable values are provided, this is being validated statically,
+      // and cannot yet produce any validation errors for variables.
+      return;
+    }
+    const scopedVariableValues = getScopedVariableValues(context, valueNode);
+    const value = scopedVariableValues?.coerced[valueNode.name.value];
+    if (isNonNullType(type)) {
+      if (value === undefined) {
+        reportInvalidLiteral(
+          context.onError,
+          `Expected variable "$${valueNode.name.value}" provided to type "${type}" to provide a runtime value.`,
+          valueNode,
+          path,
+        );
+      } else if (value === null) {
+        reportInvalidLiteral(
+          context.onError,
+          `Expected variable "$${valueNode.name.value}" provided to non-null type "${type}" not to be null.`,
+          valueNode,
+          path,
+        );
+      }
+    }
+    // Note: This does no further checking that this variable is correct.
+    // This assumes this variable usage has already been validated.
+    return;
+  }
+
+  if (isNonNullType(type)) {
+    if (valueNode.kind === Kind.NULL) {
+      reportInvalidLiteral(
+        context.onError,
+        `Expected value of non-null type "${type}" not to be null.`,
+        valueNode,
+        path,
+      );
+      return;
+    }
+    return validateInputLiteralImpl(
+      context,
+      valueNode,
+      type.ofType,
+      hideSuggestions,
+      path,
+    );
+  }
+
+  if (valueNode.kind === Kind.NULL) {
+    return;
+  }
+
+  if (isListType(type)) {
+    if (valueNode.kind !== Kind.LIST) {
+      // Lists accept a non-list value as a list of one.
+      validateInputLiteralImpl(
+        context,
+        valueNode,
+        type.ofType,
+        hideSuggestions,
+        path,
+      );
+    } else {
+      let index = 0;
+      for (const itemNode of valueNode.values) {
+        validateInputLiteralImpl(
+          context,
+          itemNode,
+          type.ofType,
+          hideSuggestions,
+          addPath(path, index++, undefined),
+        );
+      }
+    }
+  } else if (isInputObjectType(type)) {
+    if (valueNode.kind !== Kind.OBJECT) {
+      reportInvalidLiteral(
+        context.onError,
+        `Expected value of type "${type}" to be an object, found: ${print(
+          valueNode,
+        )}.`,
+        valueNode,
+        path,
+      );
+      return;
+    }
+
+    const fieldDefs = type.getFields();
+    const fieldNodes = keyMap(valueNode.fields, (field) => field.name.value);
+
+    for (const field of Object.values(fieldDefs)) {
+      const fieldNode = fieldNodes[field.name];
+      if (fieldNode === undefined) {
+        if (isRequiredInputField(field)) {
+          reportInvalidLiteral(
+            context.onError,
+            `Expected value of type "${type}" to include required field "${
+              field.name
+            }", found: ${print(valueNode)}.`,
+            valueNode,
+            path,
+          );
+        }
+      } else {
+        const fieldValueNode = fieldNode.value;
+        if (fieldValueNode.kind === Kind.VARIABLE && !context.static) {
+          const scopedVariableValues = getScopedVariableValues(
+            context,
+            fieldValueNode,
+          );
+          const variableName = fieldValueNode.name.value;
+          const value = scopedVariableValues?.coerced[variableName];
+          if (type.isOneOf) {
+            if (value === undefined) {
+              reportInvalidLiteral(
+                context.onError,
+                `Expected variable "$${variableName}" provided to field "${field.name}" for OneOf Input Object type "${type}" to provide a runtime value.`,
+                valueNode,
+                path,
+              );
+            } else if (value === null) {
+              reportInvalidLiteral(
+                context.onError,
+                `Expected variable "$${variableName}" provided to field "${field.name}" for OneOf Input Object type "${type}" not to be null.`,
+                valueNode,
+                path,
+              );
+            }
+          } else if (value === undefined && !isRequiredInputField(field)) {
+            continue;
+          }
+        }
+
+        validateInputLiteralImpl(
+          context,
+          fieldValueNode,
+          field.type,
+          hideSuggestions,
+          addPath(path, field.name, type.name),
+        );
+      }
+    }
+
+    const fields = valueNode.fields;
+    // Ensure every provided field is defined.
+    for (const fieldNode of fields) {
+      const fieldName = fieldNode.name.value;
+      if (!Object.hasOwn(fieldDefs, fieldName)) {
+        const suggestion = hideSuggestions
+          ? ''
+          : didYouMean(suggestionList(fieldName, Object.keys(fieldDefs)));
+        reportInvalidLiteral(
+          context.onError,
+          `Expected value of type "${type}" not to include unknown field "${fieldName}"${
+            suggestion ? `.${suggestion} Found` : ', found'
+          }: ${print(valueNode)}.`,
+          fieldNode,
+          path,
+        );
+      }
+    }
+
+    if (type.isOneOf) {
+      const isNotExactlyOneField = fields.length !== 1;
+      if (isNotExactlyOneField) {
+        reportInvalidLiteral(
+          context.onError,
+          `OneOf Input Object "${type}" must specify exactly one key.`,
+          valueNode,
+          path,
+        );
+        return;
+      }
+
+      const fieldValueNode = fields[0].value;
+      if (fieldValueNode.kind === Kind.NULL) {
+        const fieldName = fields[0].name.value;
+        reportInvalidLiteral(
+          context.onError,
+          `Field "${type}.${fieldName}" used for OneOf Input Object must be non-null.`,
+          valueNode,
+          addPath(path, fieldName, undefined),
+        );
+      }
+    }
+  } else {
+    assertLeafType(type);
+
+    let result;
+    let caughtError;
+    try {
+      result = type.coerceInputLiteral
+        ? type.coerceInputLiteral(replaceVariables(valueNode), hideSuggestions)
+        : type.parseLiteral(valueNode, undefined, hideSuggestions);
+    } catch (error) {
+      if (error instanceof GraphQLError) {
+        context.onError(error, pathToArray(path));
+        return;
+      }
+      caughtError = error;
+    }
+
+    if (result === undefined) {
+      reportInvalidLiteral(
+        context.onError,
+        `Expected value of type "${type}"${
+          caughtError != null
+            ? `, but encountered error "${caughtError.message != null && caughtError.message !== '' ? caughtError.message : caughtError}"; found`
+            : ', found'
+        }: ${print(valueNode)}.`,
+        valueNode,
+        path,
+        caughtError,
+      );
+    }
+  }
+}
+
+function getScopedVariableValues(
+  context: ValidationContext,
+  valueNode: VariableNode,
+): Maybe<VariableValues> {
+  const variableName = valueNode.name.value;
+  const { fragmentVariableValues, variables } = context;
+  return fragmentVariableValues?.sources[variableName]
+    ? fragmentVariableValues
+    : variables;
+}
+
+function reportInvalidLiteral(
+  onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void,
+  message: string,
+  valueNode: ASTNode,
+  path: Path | undefined,
+  originalError?: GraphQLError | undefined,
+): void {
+  onError(
+    new GraphQLError(message, { nodes: valueNode, originalError }),
+    pathToArray(path),
+  );
+}

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -3,8 +3,6 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
-import { inspect } from '../../jsutils/inspect.js';
-
 import { parse } from '../../language/parser.js';
 
 import { GraphQLObjectType, GraphQLScalarType } from '../../type/definition.js';
@@ -833,7 +831,7 @@ describe('Validate: Values of correct type', () => {
         }
       `).toDeepEqual([
         {
-          message: 'Expected value of type "Int!", found null.',
+          message: 'Expected value of non-null type "Int!" not to be null.',
           locations: [{ line: 4, column: 32 }],
         },
       ]);
@@ -947,7 +945,7 @@ describe('Validate: Values of correct type', () => {
       `).toDeepEqual([
         {
           message:
-            'Field "ComplexInput.requiredField" of required type "Boolean!" was not provided.',
+            'Expected value of type "ComplexInput" to include required field "requiredField", found: { intField: 4 }.',
           locations: [{ line: 4, column: 41 }],
         },
       ]);
@@ -983,7 +981,7 @@ describe('Validate: Values of correct type', () => {
         }
       `).toDeepEqual([
         {
-          message: 'Expected value of type "Boolean!", found null.',
+          message: 'Expected value of non-null type "Boolean!" not to be null.',
           locations: [{ line: 6, column: 29 }],
         },
       ]);
@@ -1002,7 +1000,7 @@ describe('Validate: Values of correct type', () => {
       `).toDeepEqual([
         {
           message:
-            'Field "invalidField" is not defined by type "ComplexInput". Did you mean "intField"?',
+            'Expected value of type "ComplexInput" not to include unknown field "invalidField". Did you mean "intField"? Found: { requiredField: true, invalidField: "value" }.',
           locations: [{ line: 6, column: 15 }],
         },
       ]);
@@ -1024,7 +1022,7 @@ describe('Validate: Values of correct type', () => {
       ).toDeepEqual([
         {
           message:
-            'Field "invalidField" is not defined by type "ComplexInput".',
+            'Expected value of type "ComplexInput" not to include unknown field "invalidField", found: { requiredField: true, invalidField: "value" }.',
           locations: [{ line: 6, column: 15 }],
         },
       ]);
@@ -1033,10 +1031,8 @@ describe('Validate: Values of correct type', () => {
     it('reports original error for custom scalar which throws', () => {
       const customScalar = new GraphQLScalarType({
         name: 'Invalid',
-        coerceInputValue(value) {
-          throw new Error(
-            `Invalid scalar is always invalid: ${inspect(value)}`,
-          );
+        coerceInputValue() {
+          throw new Error('Invalid scalar is always invalid.');
         },
       });
 
@@ -1058,14 +1054,14 @@ describe('Validate: Values of correct type', () => {
       expectJSON(errors).toDeepEqual([
         {
           message:
-            'Expected value of type "Invalid", found 123; Invalid scalar is always invalid: 123',
+            'Expected value of type "Invalid", but encountered error "Invalid scalar is always invalid."; found: 123.',
           locations: [{ line: 1, column: 19 }],
         },
       ]);
 
       expect(errors[0]).to.have.nested.property(
         'originalError.message',
-        'Invalid scalar is always invalid: 123',
+        'Invalid scalar is always invalid.',
       );
     });
 
@@ -1091,7 +1087,7 @@ describe('Validate: Values of correct type', () => {
 
       expectErrorsWithSchema(schema, '{ invalidArg(arg: 123) }').toDeepEqual([
         {
-          message: 'Expected value of type "CustomScalar", found 123.',
+          message: 'Expected value of type "CustomScalar", found: 123.',
           locations: [{ line: 1, column: 19 }],
         },
       ]);
@@ -1150,7 +1146,8 @@ describe('Validate: Values of correct type', () => {
         }
       `).toDeepEqual([
         {
-          message: 'Field "OneOfInput.stringField" must be non-null.',
+          message:
+            'Field "OneOfInput.stringField" used for OneOf Input Object must be non-null.',
           locations: [{ line: 4, column: 37 }],
         },
       ]);
@@ -1244,15 +1241,15 @@ describe('Validate: Values of correct type', () => {
         }
       `).toDeepEqual([
         {
-          message: 'Expected value of type "Int!", found null.',
+          message: 'Expected value of non-null type "Int!" not to be null.',
           locations: [{ line: 3, column: 22 }],
         },
         {
-          message: 'Expected value of type "String!", found null.',
+          message: 'Expected value of non-null type "String!" not to be null.',
           locations: [{ line: 4, column: 25 }],
         },
         {
-          message: 'Expected value of type "Boolean!", found null.',
+          message: 'Expected value of non-null type "Boolean!" not to be null.',
           locations: [{ line: 5, column: 47 }],
         },
       ]);
@@ -1278,7 +1275,7 @@ describe('Validate: Values of correct type', () => {
         },
         {
           message:
-            'Expected value of type "ComplexInput", found "NotVeryComplex".',
+            'Expected value of type "ComplexInput" to be an object, found: "NotVeryComplex".',
           locations: [{ line: 5, column: 30 }],
         },
       ]);
@@ -1311,7 +1308,7 @@ describe('Validate: Values of correct type', () => {
       `).toDeepEqual([
         {
           message:
-            'Field "ComplexInput.requiredField" of required type "Boolean!" was not provided.',
+            'Expected value of type "ComplexInput" to include required field "requiredField", found: { intField: 3 }.',
           locations: [{ line: 2, column: 55 }],
         },
       ]);

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -1,30 +1,11 @@
-import { didYouMean } from '../../jsutils/didYouMean.js';
-import { inspect } from '../../jsutils/inspect.js';
-import { suggestionList } from '../../jsutils/suggestionList.js';
+import type { Maybe } from '../../jsutils/Maybe.js';
 
-import { GraphQLError } from '../../error/GraphQLError.js';
-
-import type {
-  ObjectFieldNode,
-  ObjectValueNode,
-  ValueNode,
-} from '../../language/ast.js';
-import { Kind } from '../../language/kinds.js';
-import { print } from '../../language/printer.js';
+import type { ValueNode } from '../../language/ast.js';
 import type { ASTVisitor } from '../../language/visitor.js';
 
-import type { GraphQLInputObjectType } from '../../type/definition.js';
-import {
-  getNamedType,
-  getNullableType,
-  isInputObjectType,
-  isLeafType,
-  isListType,
-  isNonNullType,
-  isRequiredInputField,
-} from '../../type/definition.js';
+import type { GraphQLInputType } from '../../type/index.js';
 
-import { replaceVariables } from '../../utilities/replaceVariables.js';
+import { validateInputLiteral } from '../../utilities/validateInputValue.js';
 
 import type { ValidationContext } from '../ValidationContext.js';
 
@@ -40,77 +21,23 @@ export function ValuesOfCorrectTypeRule(
   context: ValidationContext,
 ): ASTVisitor {
   return {
-    ListValue(node) {
+    NullValue: (node) =>
+      isValidValueNode(context, node, context.getInputType()),
+    ListValue: (node) =>
       // Note: TypeInfo will traverse into a list's item type, so look to the
       // parent input type to check if it is a list.
-      const type = getNullableType(context.getParentInputType());
-      if (!isListType(type)) {
-        isValidValueNode(context, node);
-        return false; // Don't traverse further.
-      }
-    },
-    ObjectValue(node) {
-      const type = getNamedType(context.getInputType());
-      if (!isInputObjectType(type)) {
-        isValidValueNode(context, node);
-        return false; // Don't traverse further.
-      }
-      // Ensure every required field exists.
-      const fieldNodeMap = new Map(
-        node.fields.map((field) => [field.name.value, field]),
-      );
-      for (const fieldDef of Object.values(type.getFields())) {
-        const fieldNode = fieldNodeMap.get(fieldDef.name);
-        if (!fieldNode && isRequiredInputField(fieldDef)) {
-          const typeStr = inspect(fieldDef.type);
-          context.reportError(
-            new GraphQLError(
-              `Field "${type}.${fieldDef.name}" of required type "${typeStr}" was not provided.`,
-              { nodes: node },
-            ),
-          );
-        }
-      }
-
-      if (type.isOneOf) {
-        validateOneOfInputObject(context, node, type, fieldNodeMap);
-      }
-    },
-    ObjectField(node) {
-      const parentType = getNamedType(context.getParentInputType());
-      const fieldType = context.getInputType();
-      if (!fieldType && isInputObjectType(parentType)) {
-        const suggestions = context.hideSuggestions
-          ? []
-          : suggestionList(
-              node.name.value,
-              Object.keys(parentType.getFields()),
-            );
-        context.reportError(
-          new GraphQLError(
-            `Field "${node.name.value}" is not defined by type "${parentType}".` +
-              didYouMean(suggestions),
-            { nodes: node },
-          ),
-        );
-      }
-    },
-    NullValue(node) {
-      const type = context.getInputType();
-      if (isNonNullType(type)) {
-        context.reportError(
-          new GraphQLError(
-            `Expected value of type "${inspect(type)}", found ${print(node)}.`,
-            { nodes: node },
-          ),
-        );
-      }
-    },
-    EnumValue: (node) => isValidValueNode(context, node),
-    IntValue: (node) => isValidValueNode(context, node),
-    FloatValue: (node) => isValidValueNode(context, node),
-    StringValue: (node) => isValidValueNode(context, node),
-    BooleanValue: (node) => isValidValueNode(context, node),
+      isValidValueNode(context, node, context.getParentInputType()),
+    ObjectValue: (node) =>
+      isValidValueNode(context, node, context.getInputType()),
+    EnumValue: (node) =>
+      isValidValueNode(context, node, context.getInputType()),
+    IntValue: (node) => isValidValueNode(context, node, context.getInputType()),
+    FloatValue: (node) =>
+      isValidValueNode(context, node, context.getInputType()),
+    StringValue: (node) =>
+      isValidValueNode(context, node, context.getInputType()),
+    BooleanValue: (node) =>
+      isValidValueNode(context, node, context.getInputType()),
   };
 }
 
@@ -118,84 +45,22 @@ export function ValuesOfCorrectTypeRule(
  * Any value literal may be a valid representation of a Scalar, depending on
  * that scalar type.
  */
-function isValidValueNode(context: ValidationContext, node: ValueNode): void {
-  // Report any error at the full type expected by the location.
-  const locationType = context.getInputType();
-  if (!locationType) {
-    return;
-  }
-
-  const type = getNamedType(locationType);
-
-  if (!isLeafType(type)) {
-    const typeStr = inspect(locationType);
-    context.reportError(
-      new GraphQLError(
-        `Expected value of type "${typeStr}", found ${print(node)}.`,
-        { nodes: node },
-      ),
-    );
-    return;
-  }
-
-  // Scalars and Enums determine if a literal value is valid via coerceInputLiteral(),
-  // which may throw or return undefined to indicate an invalid value.
-  try {
-    const parseResult = type.coerceInputLiteral
-      ? type.coerceInputLiteral(replaceVariables(node), context.hideSuggestions)
-      : type.parseLiteral(node, undefined, context.hideSuggestions);
-    if (parseResult === undefined) {
-      const typeStr = inspect(locationType);
-      context.reportError(
-        new GraphQLError(
-          `Expected value of type "${typeStr}", found ${print(node)}.`,
-          { nodes: node },
-        ),
-      );
-    }
-  } catch (error) {
-    const typeStr = inspect(locationType);
-    if (error instanceof GraphQLError) {
-      context.reportError(error);
-    } else {
-      context.reportError(
-        new GraphQLError(
-          `Expected value of type "${typeStr}", found ${print(node)}; ` +
-            error.message,
-          { nodes: node, originalError: error },
-        ),
-      );
-    }
-  }
-}
-
-function validateOneOfInputObject(
+function isValidValueNode(
   context: ValidationContext,
-  node: ObjectValueNode,
-  type: GraphQLInputObjectType,
-  fieldNodeMap: Map<string, ObjectFieldNode>,
-): void {
-  const keys = Array.from(fieldNodeMap.keys());
-  const isNotExactlyOneField = keys.length !== 1;
-
-  if (isNotExactlyOneField) {
-    context.reportError(
-      new GraphQLError(
-        `OneOf Input Object "${type}" must specify exactly one key.`,
-        { nodes: [node] },
-      ),
-    );
-    return;
-  }
-
-  const value = fieldNodeMap.get(keys[0])?.value;
-  const isNullLiteral = !value || value.kind === Kind.NULL;
-
-  if (isNullLiteral) {
-    context.reportError(
-      new GraphQLError(`Field "${type}.${keys[0]}" must be non-null.`, {
-        nodes: [node],
-      }),
+  node: ValueNode,
+  inputType: Maybe<GraphQLInputType>,
+): false {
+  if (inputType) {
+    validateInputLiteral(
+      node,
+      inputType,
+      (error) => {
+        context.reportError(error);
+      },
+      undefined,
+      undefined,
+      context.hideSuggestions,
     );
   }
+  return false;
 }


### PR DESCRIPTION
[#3086 rebased on main](https://github.com/graphql/graphql-js/pull/3086).

Depends on #3812 

@leebyron comments from original PR:

> Factors out input validation to reusable functions:
> 
> * Introduces `validateInputLiteral` by extracting this behavior from `ValuesOfCorrectTypeRule`.
> * Introduces `validateInputValue` by extracting this behavior from `coerceInputValue`
> * Simplifies `coerceInputValue` to return early on validation error
> * Unifies error reporting between `validateInputValue` and `validateInputLiteral`, causing some error message strings to change, but error data (eg locations) are preserved.
> 
> These two parallel functions will be used to validate default values
> 
> Potentially breaking if you rely on the existing behavior of `coerceInputValue` to call a callback function, as the call signature has changed. GraphQL behavior should not change, though error messages are now slightly different.

Note: also breaking if you rely on the default callback function to throw. Grossly similar behavior is available with `validateInputValue()`.