### PR TITLE
RFC: Default value validation & coercion

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -34,6 +34,8 @@ ignoreRegExpList:
 
 words:
   - graphiql
+  - uncoerce
+  - uncoerced
 
   # Different names used inside tests
   - Skywalker

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -150,7 +150,6 @@ const TestType = new GraphQLObjectType({
     }),
     fieldWithNestedInputObject: fieldWithInputArg({
       type: TestNestedInputObject,
-      defaultValue: 'Hello World',
     }),
     list: fieldWithInputArg({ type: new GraphQLList(GraphQLString) }),
     nested: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -448,6 +448,7 @@ export {
   // Create a JavaScript value from a GraphQL language AST without a Type.
   valueFromASTUntyped,
   // Create a GraphQL language AST from a JavaScript value.
+  /** @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18 */
   astFromValue,
   // A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system.
   TypeInfo,

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -71,9 +71,7 @@ const QueryType = new GraphQLObjectType({
       args: {
         fromEnum: {
           type: ComplexEnum,
-          // Note: defaultValue is provided an *internal* representation for
-          // Enums, rather than the string name.
-          defaultValue: Complex1,
+          defaultValue: 'ONE',
         },
         provideGoodValue: { type: GraphQLBoolean },
         provideBadValue: { type: GraphQLBoolean },

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -4,7 +4,7 @@ import { invariant } from '../jsutils/invariant.js';
 import { DirectiveLocation } from '../language/directiveLocation.js';
 import { print } from '../language/printer.js';
 
-import { astFromValue } from '../utilities/astFromValue.js';
+import { valueToLiteral } from '../utilities/valueToLiteral.js';
 
 import type {
   GraphQLEnumValue,
@@ -411,7 +411,7 @@ export const __InputValue: GraphQLObjectType = new GraphQLObjectType({
             return null;
           }
           const literal =
-            defaultValue.literal ?? astFromValue(defaultValue.value, type);
+            defaultValue.literal ?? valueToLiteral(defaultValue.value, type);
           invariant(literal != null, 'Invalid default value');
           return print(literal);
         },

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -342,11 +342,11 @@ function uncoerceDefaultValue(value: unknown, type: GraphQLInputType): unknown {
 
   assertLeafType(type);
 
-  // For most leaf types (Scalars, Enums), result coercion ("serialize") is
+  // For most leaf types (Scalars, Enums), output value coercion ("serialize") is
   // the inverse of input coercion ("parseValue") and will produce an
   // "external" value. Historically, this method was also used as part of the
-  // now-removed "astFromValue" to perform the same behavior.
-  return type.serialize(value);
+  // now-deprecated "astFromValue" to perform the same behavior.
+  return type.coerceOutputValue(value);
 }
 
 function validateName(

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -2,12 +2,20 @@ import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
 import { capitalize } from '../jsutils/capitalize.js';
 import { andList } from '../jsutils/formatList.js';
 import { inspect } from '../jsutils/inspect.js';
+import { invariant } from '../jsutils/invariant.js';
+import { isIterableObject } from '../jsutils/isIterableObject.js';
+import { isObjectLike } from '../jsutils/isObjectLike.js';
+import { keyMap } from '../jsutils/keyMap.js';
+import { mapValue } from '../jsutils/mapValue.js';
 import type { Maybe } from '../jsutils/Maybe.js';
+import type { ObjMap } from '../jsutils/ObjMap.js';
+import { printPathArray } from '../jsutils/printPathArray.js';
 
 import { GraphQLError } from '../error/GraphQLError.js';
 
 import type {
   ASTNode,
+  ConstValueNode,
   DirectiveNode,
   InterfaceTypeDefinitionNode,
   InterfaceTypeExtensionNode,
@@ -18,22 +26,32 @@ import type {
   UnionTypeExtensionNode,
 } from '../language/ast.js';
 import { OperationTypeNode } from '../language/ast.js';
+import { Kind } from '../language/kinds.js';
 
 import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators.js';
+import {
+  validateInputLiteral,
+  validateInputValue,
+} from '../utilities/validateInputValue.js';
 
 import type {
+  GraphQLArgument,
   GraphQLEnumType,
   GraphQLInputField,
   GraphQLInputObjectType,
+  GraphQLInputType,
   GraphQLInterfaceType,
   GraphQLObjectType,
   GraphQLUnionType,
 } from './definition.js';
 import {
+  assertLeafType,
+  getNamedType,
   isEnumType,
   isInputObjectType,
   isInputType,
   isInterfaceType,
+  isListType,
   isNamedType,
   isNonNullType,
   isObjectType,
@@ -192,10 +210,12 @@ function validateDirectives(context: SchemaValidationContext): void {
       // Ensure they are named correctly.
       validateName(context, arg);
 
+      const argStr = `${directive}(${arg.name}:)`;
+
       // Ensure the type is an input type.
       if (!isInputType(arg.type)) {
         context.reportError(
-          `The type of ${directive}(${arg.name}:) must be Input Type ` +
+          `The type of ${argStr} must be Input Type ` +
             `but got: ${inspect(arg.type)}.`,
           arg.astNode,
         );
@@ -203,12 +223,130 @@ function validateDirectives(context: SchemaValidationContext): void {
 
       if (isRequiredArgument(arg) && arg.deprecationReason != null) {
         context.reportError(
-          `Required argument ${directive}(${arg.name}:) cannot be deprecated.`,
+          `Required argument ${argStr} cannot be deprecated.`,
           [getDeprecatedDirectiveNode(arg.astNode), arg.astNode?.type],
         );
       }
+
+      validateDefaultValue(context, arg, argStr);
     }
   }
+}
+
+function validateDefaultValue(
+  context: SchemaValidationContext,
+  inputValue: GraphQLArgument | GraphQLInputField,
+  argStr: string,
+): void {
+  const defaultValue = inputValue.defaultValue;
+
+  if (!defaultValue) {
+    return;
+  }
+
+  if (defaultValue.literal) {
+    validateInputLiteral(
+      defaultValue.literal,
+      inputValue.type,
+      (error, path) => {
+        context.reportError(
+          `${argStr} has invalid default value${printPathArray(path)}: ${
+            error.message
+          }`,
+          error.nodes,
+        );
+      },
+    );
+  } else {
+    const errors: Array<[GraphQLError, ReadonlyArray<string | number>]> = [];
+    validateInputValue(defaultValue.value, inputValue.type, (error, path) => {
+      errors.push([error, path]);
+    });
+
+    // If there were validation errors, check to see if it can be "uncoerced"
+    // and then correctly validated. If so, report a clear error with a path
+    // to resolution.
+    if (errors.length > 0) {
+      try {
+        const uncoercedValue = uncoerceDefaultValue(
+          defaultValue.value,
+          inputValue.type,
+        );
+
+        const uncoercedErrors = [];
+        validateInputValue(uncoercedValue, inputValue.type, (error, path) => {
+          uncoercedErrors.push([error, path]);
+        });
+
+        if (uncoercedErrors.length === 0) {
+          context.reportError(
+            `${argStr} has invalid default value: ${inspect(
+              defaultValue.value,
+            )}. Did you mean: ${inspect(uncoercedValue)}?`,
+            inputValue.astNode?.defaultValue,
+          );
+          return;
+        }
+      } catch (_error) {
+        // ignore
+      }
+    }
+
+    // Otherwise report the original set of errors.
+    for (const [error, path] of errors) {
+      context.reportError(
+        `${argStr} has invalid default value${printPathArray(path)}: ${
+          error.message
+        }`,
+        inputValue.astNode?.defaultValue,
+      );
+    }
+  }
+}
+
+/**
+ * Historically GraphQL.js allowed default values to be provided as
+ * assumed-coerced "internal" values, however default values should be provided
+ * as "external" pre-coerced values. `uncoerceDefaultValue()` will convert such
+ * "internal" values to "external" values to display as part of validation.
+ *
+ * This performs the "opposite" of `coerceInputValue()`. Given an "internal"
+ * coerced value, reverse the process to provide an "external" uncoerced value.
+ */
+function uncoerceDefaultValue(value: unknown, type: GraphQLInputType): unknown {
+  if (isNonNullType(type)) {
+    return uncoerceDefaultValue(value, type.ofType);
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  if (isListType(type)) {
+    if (isIterableObject(value)) {
+      return Array.from(value, (itemValue) =>
+        uncoerceDefaultValue(itemValue, type.ofType),
+      );
+    }
+    return [uncoerceDefaultValue(value, type.ofType)];
+  }
+
+  if (isInputObjectType(type)) {
+    invariant(isObjectLike(value));
+    const fieldDefs = type.getFields();
+    return mapValue(value, (fieldValue, fieldName) => {
+      invariant(fieldName in fieldDefs);
+      return uncoerceDefaultValue(fieldValue, fieldDefs[fieldName].type);
+    });
+  }
+
+  assertLeafType(type);
+
+  // For most leaf types (Scalars, Enums), result coercion ("serialize") is
+  // the inverse of input coercion ("parseValue") and will produce an
+  // "external" value. Historically, this method was also used as part of the
+  // now-removed "astFromValue" to perform the same behavior.
+  return type.serialize(value);
 }
 
 function validateName(
@@ -225,8 +363,11 @@ function validateName(
 }
 
 function validateTypes(context: SchemaValidationContext): void {
-  const validateInputObjectCircularRefs =
-    createInputObjectCircularRefsValidator(context);
+  // Ensure Input Objects do not contain non-nullable circular references.
+  const validateInputObjectNonNullCircularRefs =
+    createInputObjectNonNullCircularRefsValidator(context);
+  const validateInputObjectDefaultValueCircularRefs =
+    createInputObjectDefaultValueCircularRefsValidator(context);
   const typeMap = context.schema.getTypeMap();
   for (const type of Object.values(typeMap)) {
     // Ensure all provided types are in fact GraphQL type.
@@ -265,8 +406,12 @@ function validateTypes(context: SchemaValidationContext): void {
       // Ensure Input Object fields are valid.
       validateInputFields(context, type);
 
-      // Ensure Input Objects do not contain non-nullable circular references
-      validateInputObjectCircularRefs(type);
+      // Ensure Input Objects do not contain invalid field circular references.
+      // Ensure Input Objects do not contain non-nullable circular references.
+      validateInputObjectNonNullCircularRefs(type);
+
+      // Ensure Input Objects do not contain invalid default value circular references.
+      validateInputObjectDefaultValueCircularRefs(type);
     }
   }
 }
@@ -305,11 +450,12 @@ function validateFields(
       // Ensure they are named correctly.
       validateName(context, arg);
 
+      const argStr = `${type}.${field.name}(${argName}:)`;
+
       // Ensure the type is an input type
       if (!isInputType(arg.type)) {
         context.reportError(
-          `The type of ${type}.${field.name}(${argName}:) must be Input ` +
-            `Type but got: ${inspect(arg.type)}.`,
+          `The type of ${argStr} must be Input Type but got: ${inspect(arg.type)}.`,
           arg.astNode?.type,
         );
       }
@@ -320,6 +466,8 @@ function validateFields(
           [getDeprecatedDirectiveNode(arg.astNode), arg.astNode?.type],
         );
       }
+
+      validateDefaultValue(context, arg, argStr);
     }
   }
 }
@@ -420,8 +568,6 @@ function validateTypeImplementsInterface(
           [ifaceArg.astNode?.type, typeArg.astNode?.type],
         );
       }
-
-      // TODO: validate default values?
     }
 
     // Assert additional arguments must not be required.
@@ -528,7 +674,7 @@ function validateInputFields(
     );
   }
 
-  // Ensure the arguments are valid
+  // Ensure the input fields are valid
   for (const field of fields) {
     // Ensure they are named correctly.
     validateName(context, field);
@@ -542,12 +688,16 @@ function validateInputFields(
       );
     }
 
+    const fieldStr = `${inputObj.name}.${field.name}`;
+
     if (isRequiredInputField(field) && field.deprecationReason != null) {
       context.reportError(
-        `Required input field ${inputObj.name}.${field.name} cannot be deprecated.`,
+        `Required input field ${fieldStr} cannot be deprecated.`,
         [getDeprecatedDirectiveNode(field.astNode), field.astNode?.type],
       );
     }
+
+    validateDefaultValue(context, field, fieldStr);
 
     if (inputObj.isOneOf) {
       validateOneOfInputObjectField(inputObj, field, context);
@@ -575,7 +725,7 @@ function validateOneOfInputObjectField(
   }
 }
 
-function createInputObjectCircularRefsValidator(
+function createInputObjectNonNullCircularRefsValidator(
   context: SchemaValidationContext,
 ): (inputObj: GraphQLInputObjectType) => void {
   // Modified copy of algorithm from 'src/validation/rules/NoFragmentCycles.js'.
@@ -584,10 +734,11 @@ function createInputObjectCircularRefsValidator(
   const visitedTypes = new Set<GraphQLInputObjectType>();
 
   // Array of types nodes used to produce meaningful errors
-  const fieldPath: Array<GraphQLInputField> = [];
+  const fieldPath: Array<{ fieldStr: string; astNode: Maybe<ASTNode> }> = [];
 
   // Position in the type path
-  const fieldPathIndexByTypeName = Object.create(null);
+  const fieldPathIndexByTypeName: ObjMap<number | undefined> =
+    Object.create(null);
 
   return detectCycleRecursive;
 
@@ -608,14 +759,23 @@ function createInputObjectCircularRefsValidator(
         const fieldType = field.type.ofType;
         const cycleIndex = fieldPathIndexByTypeName[fieldType.name];
 
-        fieldPath.push(field);
+        fieldPath.push({
+          fieldStr: `${inputObj}.${field.name}`,
+          astNode: field.astNode,
+        });
         if (cycleIndex === undefined) {
           detectCycleRecursive(fieldType);
         } else {
           const cyclePath = fieldPath.slice(cycleIndex);
-          const pathStr = cyclePath.map((fieldObj) => fieldObj.name).join('.');
+          const pathStr = cyclePath
+            .map((fieldObj) => fieldObj.fieldStr)
+            .join(', ');
           context.reportError(
-            `Cannot reference Input Object "${fieldType}" within itself through a series of non-null fields: "${pathStr}".`,
+            `Invalid circular reference. The Input Object ${fieldType} references itself ${
+              cyclePath.length > 1
+                ? 'via the non-null fields:'
+                : 'in the non-null field'
+            } ${pathStr}.`,
             cyclePath.map((fieldObj) => fieldObj.astNode),
           );
         }
@@ -624,6 +784,161 @@ function createInputObjectCircularRefsValidator(
     }
 
     fieldPathIndexByTypeName[inputObj.name] = undefined;
+  }
+}
+
+function createInputObjectDefaultValueCircularRefsValidator(
+  context: SchemaValidationContext,
+): (inputObj: GraphQLInputObjectType) => void {
+  // Modified copy of algorithm from 'src/validation/rules/NoFragmentCycles.js'.
+  // Tracks already visited types to maintain O(N) and to ensure that cycles
+  // are not redundantly reported.
+  const visitedFields = Object.create(null);
+
+  // Array of keys for fields and default values used to produce meaningful errors.
+  const fieldPath: Array<
+    [fieldStr: string, defaultValue: ConstValueNode | undefined]
+  > = [];
+
+  // Position in the path
+  const fieldPathIndex: ObjMap<number | undefined> = Object.create(null);
+
+  // This does a straight-forward DFS to find cycles.
+  // It does not terminate when a cycle was found but continues to explore
+  // the graph to find all possible cycles.
+  return function validateInputObjectDefaultValueCircularRefs(
+    inputObj: GraphQLInputObjectType,
+  ): void {
+    // Start with an empty object as a way to visit every field in this input
+    // object type and apply every default value.
+    return detectValueDefaultValueCycle(inputObj, {});
+  };
+
+  function detectValueDefaultValueCycle(
+    inputObj: GraphQLInputObjectType,
+    defaultValue: unknown,
+  ): void {
+    // If the value is a List, recursively check each entry for a cycle.
+    // Otherwise, only object values can contain a cycle.
+    if (isIterableObject(defaultValue)) {
+      for (const itemValue of defaultValue) {
+        detectValueDefaultValueCycle(inputObj, itemValue);
+      }
+      return;
+    } else if (!isObjectLike(defaultValue)) {
+      return;
+    }
+
+    // Check each defined field for a cycle.
+    for (const field of Object.values(inputObj.getFields())) {
+      const namedFieldType = getNamedType(field.type);
+
+      // Only input object type fields can result in a cycle.
+      if (!isInputObjectType(namedFieldType)) {
+        continue;
+      }
+
+      if (Object.hasOwn(defaultValue, field.name)) {
+        // If the provided value has this field defined, recursively check it
+        // for cycles.
+        detectValueDefaultValueCycle(namedFieldType, defaultValue[field.name]);
+      } else {
+        // Otherwise check this field's default value for cycles.
+        detectFieldDefaultValueCycle(
+          field,
+          namedFieldType,
+          `${inputObj}.${field.name}`,
+        );
+      }
+    }
+  }
+
+  function detectLiteralDefaultValueCycle(
+    inputObj: GraphQLInputObjectType,
+    defaultValue: ConstValueNode,
+  ): void {
+    // If the value is a List, recursively check each entry for a cycle.
+    // Otherwise, only object values can contain a cycle.
+    if (defaultValue.kind === Kind.LIST) {
+      for (const itemLiteral of defaultValue.values) {
+        detectLiteralDefaultValueCycle(inputObj, itemLiteral);
+      }
+      return;
+    } else if (defaultValue.kind !== Kind.OBJECT) {
+      return;
+    }
+
+    // Check each defined field for a cycle.
+    const fieldNodes = keyMap(defaultValue.fields, (field) => field.name.value);
+    for (const field of Object.values(inputObj.getFields())) {
+      const namedFieldType = getNamedType(field.type);
+
+      // Only input object type fields can result in a cycle.
+      if (!isInputObjectType(namedFieldType)) {
+        continue;
+      }
+
+      if (Object.hasOwn(fieldNodes, field.name)) {
+        // If the provided value has this field defined, recursively check it
+        // for cycles.
+        detectLiteralDefaultValueCycle(
+          namedFieldType,
+          fieldNodes[field.name].value,
+        );
+      } else {
+        // Otherwise check this field's default value for cycles.
+        detectFieldDefaultValueCycle(
+          field,
+          namedFieldType,
+          `${inputObj}.${field.name}`,
+        );
+      }
+    }
+  }
+
+  function detectFieldDefaultValueCycle(
+    field: GraphQLInputField,
+    fieldType: GraphQLInputObjectType,
+    fieldStr: string,
+  ): void {
+    // Only a field with a default value can result in a cycle.
+    const defaultValue = field.defaultValue;
+    if (defaultValue === undefined) {
+      return;
+    }
+
+    // Check to see if there is cycle.
+    const cycleIndex = fieldPathIndex[fieldStr];
+    if (cycleIndex !== undefined && cycleIndex > 0) {
+      context.reportError(
+        `Invalid circular reference. The default value of Input Object field ${fieldStr} references itself${
+          cycleIndex < fieldPath.length
+            ? ` via the default values of: ${fieldPath
+                .slice(cycleIndex)
+                .map(([stringForMessage]) => stringForMessage)
+                .join(', ')}`
+            : ''
+        }.`,
+        fieldPath.slice(cycleIndex - 1).map(([, node]) => node),
+      );
+      return;
+    }
+
+    // Recurse into this field's default value once, tracking the path.
+    if (visitedFields[fieldStr] === undefined) {
+      visitedFields[fieldStr] = true;
+      fieldPathIndex[fieldStr] = fieldPath.push([
+        fieldStr,
+        field.astNode?.defaultValue,
+      ]);
+      if (defaultValue.literal) {
+        detectLiteralDefaultValueCycle(fieldType, defaultValue.literal);
+      } else {
+        detectValueDefaultValueCycle(fieldType, defaultValue.value);
+      }
+      fieldPath.pop();
+      fieldPathIndex[fieldStr] = undefined;
+    }
   }
 }
 

--- a/src/utilities/__tests__/astFromValue-test.ts
+++ b/src/utilities/__tests__/astFromValue-test.ts
@@ -18,6 +18,7 @@ import {
 
 import { astFromValue } from '../astFromValue.js';
 
+/** @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18 */
 describe('astFromValue', () => {
   it('converts boolean values to ASTs', () => {
     expect(astFromValue(true, GraphQLBoolean)).to.deep.equal({

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -37,6 +37,7 @@ import { GraphQLID } from '../type/scalars.js';
  * | Unknown       | Enum Value           |
  * | null          | NullValue            |
  *
+ * @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18
  */
 export function astFromValue(
   value: unknown,

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -1,3 +1,4 @@
+import { invariant } from '../jsutils/invariant.js';
 import { isIterableObject } from '../jsutils/isIterableObject.js';
 import { isObjectLike } from '../jsutils/isObjectLike.js';
 import type { Maybe } from '../jsutils/Maybe.js';
@@ -308,7 +309,8 @@ export function coerceDefaultValue(
   if (coercedValue === undefined) {
     coercedValue = defaultValue.literal
       ? coerceInputLiteral(defaultValue.literal, type)
-      : defaultValue.value;
+      : coerceInputValue(defaultValue.value, type);
+    invariant(coercedValue !== undefined);
     (defaultValue as any)._memoizedCoercedValue = coercedValue;
   }
   return coercedValue;

--- a/src/utilities/findSchemaChanges.ts
+++ b/src/utilities/findSchemaChanges.ts
@@ -32,8 +32,8 @@ import {
 import { isSpecifiedScalarType } from '../type/scalars.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
-import { astFromValue } from './astFromValue.js';
 import { sortValueNode } from './sortValueNode.js';
+import { valueToLiteral } from './valueToLiteral.js';
 
 enum BreakingChangeType {
   TYPE_REMOVED = 'TYPE_REMOVED',
@@ -635,7 +635,7 @@ function stringifyValue(
   defaultValue: GraphQLDefaultValueUsage,
   type: GraphQLInputType,
 ): string {
-  const ast = defaultValue.literal ?? astFromValue(defaultValue.value, type);
+  const ast = defaultValue.literal ?? valueToLiteral(defaultValue.value, type);
   invariant(ast != null);
   return print(sortValueNode(ast));
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -66,7 +66,10 @@ export {
 export { valueFromASTUntyped } from './valueFromASTUntyped.js';
 
 // Create a GraphQL language AST from a JavaScript value.
-export { astFromValue } from './astFromValue.js';
+export {
+  /** @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18 */
+  astFromValue,
+} from './astFromValue.js';
 
 // A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system.
 export { TypeInfo, visitWithTypeInfo } from './TypeInfo.js';

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -34,7 +34,7 @@ import { isIntrospectionType } from '../type/introspection.js';
 import { isSpecifiedScalarType } from '../type/scalars.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
-import { astFromValue } from './astFromValue.js';
+import { valueToLiteral } from './valueToLiteral.js';
 
 export function printSchema(schema: GraphQLSchema): string {
   return printFilteredSchema(
@@ -263,7 +263,7 @@ function printInputValue(arg: GraphQLInputField): string {
   if (arg.defaultValue) {
     const literal =
       arg.defaultValue.literal ??
-      astFromValue(arg.defaultValue.value, arg.type);
+      valueToLiteral(arg.defaultValue.value, arg.type);
     invariant(literal != null, 'Invalid default value');
     argDecl += ` = ${print(literal)}`;
   }


### PR DESCRIPTION
[#3049 rebased on main](https://github.com/graphql/graphql-js/pull/3049).

This is the last rebased PR from the original PR stack concluding with #3049.

* Rebased: #3809 [Original: #3092]
* Rebased: #3810 [Original: #3074]
* Rebased: #3811 [Original: #3077]
* Rebased: #3812 [Original: #3065]
* Rebased: #3813 [Original: #3086]
* Rebased: #3814 (this PR) [Original: #3049]

Update: #3044 and #3145 have been separated from this stack.

Changes from original PR:
1. `astFromValue()` is deprecated instead of being removed.

@leebyron comments from #3049, the original PR:
> Implements [graphql/graphql-spec#793](https://github.com/graphql/graphql-spec/pull/793)
> 
> * BREAKING: Changes default values from being represented as an assumed-coerced "internal input value" to a pre-coerced "external input value" (See chart below).
>   This allows programmatically provided default values to be represented in the same domain as values sent to the service via variable values, and allows it to have well defined methods for both transforming into a printed GraphQL literal string for introspection / schema printing (via `valueToLiteral()`) or coercing into an "internal input value" for use at runtime (via `coerceInputValue()`)
>   To support this change in value type, this PR adds two related behavioral changes:
>   
>   * Adds coercion of default values from external to internal at runtime (within `coerceInputValue()`)
>   * Removes `astFromValue()`, replacing it with `valueToLiteral()` for use in introspection and schema printing. `astFromValue()` performed unsafe "uncoercion" to convert an "Internal input value" directly to a "GraphQL Literal AST", where `valueToLiteral()` performs a well defined transform from "External input value" to "GraphQL Literal AST".
> * Adds validation of default values during schema validation.
>   Since assumed-coerced "internal" values may not pass "external" validation (for example, Enum values), an additional validation error has been included which attempts to detect this case and report a strategy for resolution.
> 
> Here's a broad overview of the intended end state:
> 
> ![GraphQL Value Flow](https://user-images.githubusercontent.com/50130/118379946-51ac5300-b593-11eb-839f-c483ecfbc875.png)
