### PR TITLE
polish: clarify filtering test semantics

### DIFF
--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { assert } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
@@ -1422,9 +1422,8 @@ describe('Execute: stream directive', () => {
       [Symbol.asyncIterator]: () => ({
         next: () => {
           if (requested) {
-            /* c8 ignore next 3 */
-            // Not reached, iterator should end immediately.
-            expect.fail('Not reached');
+            // Ignores further errors when filtered.
+            return Promise.reject(new Error('Oops'));
           }
           requested = true;
           const friend = friends[0];
@@ -1438,6 +1437,7 @@ describe('Execute: stream directive', () => {
         },
         return: () => {
           returned = true;
+          // Ignores errors from return.
           return Promise.reject(new Error('Oops'));
         },
       }),


### PR DESCRIPTION
expect.fail() was mistakenly introduced in #3760 under the assumption that expect.fail() will always cause the test to fail, and that `.next()` should be called at most once.

Actually, thought, expect.fail() just throws an error, `.next()` is called more than once, the error is produced and wrapped by GraphQL, but then, it is filtered, so the test passes.

Fortunately, that's actually the desired behavior! It's ok if the number of calls to next() is more than 1 (in our case it is 2). The exact number of calls to next() depends on the # of ticks that it takes for the deferred fragment to resolve, which should be as low as possible, but that is a separate objective (with other PRs in the mix already aimed at reducing).

So the test as written is intending to be overly strict, but is broken and so functions as desires. This commit makes no change to the test semantics, but changes the comment, the coverage ignore statement, and removes the confusing use of expect.fail, so that the test semantics are more clearly apparent.