### PR TITLE
Expose printDirective function to enable schema sharding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -430,6 +430,8 @@ export {
   printSchema,
   // Print a GraphQLType to GraphQL Schema language.
   printType,
+  // Print a GraphQLDirective to GraphQL Schema language.
+  printDirective,
   // Prints the built-in introspection schema in the Schema Language format.
   printIntrospectionSchema,
   // Create a GraphQLType from a GraphQL language AST.

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -49,6 +49,7 @@ export { lexicographicSortSchema } from './lexicographicSortSchema.js';
 export {
   printSchema,
   printType,
+  printDirective,
   printIntrospectionSchema,
 } from './printSchema.js';
 

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -269,7 +269,7 @@ function printInputValue(arg: GraphQLInputField): string {
   return argDecl + printDeprecated(arg.deprecationReason);
 }
 
-function printDirective(directive: GraphQLDirective): string {
+export function printDirective(directive: GraphQLDirective): string {
   return (
     printDescription(directive) +
     'directive @' +


### PR DESCRIPTION
GraphQL schemas can end up quite large. Sharding the schema into multiple files is supported by [clients like relay](https://github.com/facebook/relay/blob/main/compiler/crates/relay-compiler/src/config.rs#L966) to allow you to split a large schema into multiple smaller files. This can reduce merge conflicts, and make things easier on the file system, git's operations and your IDE's syntax highlighting.

This PR exports the `printDirective` function, which will allow you to write your own custom implementation of `printSchema` for your own sharding mechanism. `printType` is already exported