### PR TITLE
internal: fix inlineInvariant for cjs builds that require filenames with explicit extensions

### DIFF
--- a/integrationTests/node/index.cjs
+++ b/integrationTests/node/index.cjs
@@ -29,6 +29,13 @@ assert.deepStrictEqual(result, {
   },
 });
 
+/**
+ * The below test triggers a call `invariant` method during execution (by
+ * passing a negative number to the `initialCount` parameter on the `@stream`
+ * directive). This ensures that the `inlineInvariant` method called by our
+ * build script works correctly.
+ **/
+
 const experimentalSchema = buildSchema(`
   directive @stream(initialCount: Int!) on FIELD
 

--- a/integrationTests/node/index.mjs
+++ b/integrationTests/node/index.mjs
@@ -30,6 +30,13 @@ assert.deepStrictEqual(result, {
   },
 });
 
+/**
+ * The below test triggers a call `invariant` method during execution (by
+ * passing a negative number to the `initialCount` parameter on the `@stream`
+ * directive). This ensures that the `inlineInvariant` method called by our
+ * build script works correctly.
+ **/
+
 const experimentalSchema = buildSchema(`
   directive @stream(initialCount: Int!) on FIELD
 

--- a/integrationTests/node/index.mjs
+++ b/integrationTests/node/index.mjs
@@ -2,7 +2,11 @@
 import assert from 'assert';
 import { readFileSync } from 'fs';
 
-import { graphqlSync } from 'graphql-esm';
+import {
+  experimentalExecuteIncrementally,
+  graphqlSync,
+  parse,
+} from 'graphql-esm';
 import { buildSchema } from 'graphql-esm/utilities';
 import { version } from 'graphql-esm/version';
 
@@ -13,7 +17,7 @@ assert.deepStrictEqual(
 
 const schema = buildSchema('type Query { hello: String }');
 
-const result = graphqlSync({
+let result = graphqlSync({
   schema,
   source: '{ hello }',
   rootValue: { hello: 'world' },
@@ -25,3 +29,20 @@ assert.deepStrictEqual(result, {
     hello: 'world',
   },
 });
+
+const experimentalSchema = buildSchema(`
+  directive @stream(initialCount: Int!) on FIELD
+
+  type Query {
+    greetings: [String]
+  }
+`);
+
+result = experimentalExecuteIncrementally({
+  schema: experimentalSchema,
+  document: parse('{ greetings @stream(initialCount: -1) }'),
+  rootValue: { greetings: ['hi', 'hello'] },
+});
+
+assert(result.errors?.[0] !== undefined);
+assert(!result.errors[0].message.includes('is not defined'));

--- a/resources/inline-invariant.ts
+++ b/resources/inline-invariant.ts
@@ -32,11 +32,10 @@ export function inlineInvariant(context: ts.TransformationContext) {
           return factory.createBinaryExpression(
             factory.createParenthesizedExpression(condition),
             ts.SyntaxKind.BarBarToken,
-            factory.createCallExpression(
-              factory.createIdentifier(funcName),
-              undefined,
-              [factory.createFalse(), ...otherArgs],
-            ),
+            factory.createCallExpression(expression, undefined, [
+              factory.createFalse(),
+              ...otherArgs,
+            ]),
           );
         }
       }


### PR DESCRIPTION
Current build script rewrites invariant to avoid function call if invariant true.

However, the rewriting should take into account the import name as rewritten (by TS?):

Current output for cjs is:

https://github.com/graphql/graphql-js/blob/ba59ddd4afbe1129616ddb1ccbc79d2cd8dbf615/execution/execute.js#L14

while the call is still:

https://github.com/graphql/graphql-js/blob/ba59ddd4afbe1129616ddb1ccbc79d2cd8dbf615/execution/execute.js#L723-L724
yielding an error of the sort: `invariant is not defined`