### PR TITLE
Ignore meta-files from Sapling SCM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /.eslintcache
 /.cspellcache
 /.docusaurus
+/.sl
 /.stryker-tmp
 /node_modules
 /reports

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 /diff-npm-package.html
 /.eslintcache
 /.docusaurus
+/.sl
 /.stryker-tmp
 /node_modules
 /reports


### PR DESCRIPTION
[Sapling](https://sapling-scm.com/) is a new incantation of Mercurial, designed to work with git repositories, while supporting Mercurial's preference for stacked commits and stacked rebases as a first-class operation.

This ensures our tooling ignores `/.sl` directories produced from people who make PRs using Sapling.