### PR TITLE
Package lock update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8130,8 +8130,13 @@
       "dev": true
     },
     "node_modules/eslint-plugin-internal-rules": {
-      "resolved": "resources/eslint-internal-rules",
-      "link": true
+      "name": "eslint-plugin-graphql-internal",
+      "version": "0.0.0",
+      "resolved": "file:resources/eslint-internal-rules",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -17991,14 +17996,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "resources/eslint-internal-rules": {
-      "name": "eslint-plugin-graphql-internal",
-      "version": "0.0.0",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.0.0"
-      }
     }
   },
   "dependencies": {
@@ -24175,7 +24172,8 @@
       }
     },
     "eslint-plugin-internal-rules": {
-      "version": "file:resources/eslint-internal-rules"
+      "version": "npm:eslint-plugin-graphql-internal@0.0.0",
+      "dev": true
     },
     "eslint-plugin-node": {
       "version": "11.1.0",


### PR DESCRIPTION
Every time I run `npm install` on a new `graphql-js` repo, across multiple computer setups, I'm seeing a `package-lock.json` update that I need to ignore within my ocmmit.

I suspect other people are seeing this too, so let's just upgrade it.