### PR TITLE
fix: invalid originalError propagation in custom scalars

### DIFF
--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -32,9 +32,9 @@ const TestFaultyScalarGraphQLError = new GraphQLError(
   'FaultyScalarErrorMessage',
   {
     extensions: {
-      code: 'FaultyScalarErrorExtensionCode'
-    }
-  }
+      code: 'FaultyScalarErrorExtensionCode',
+    },
+  },
 );
 
 const TestFaultyScalar = new GraphQLScalarType({
@@ -66,7 +66,7 @@ const TestInputObject = new GraphQLInputObjectType({
     b: { type: new GraphQLList(GraphQLString) },
     c: { type: new GraphQLNonNull(GraphQLString) },
     d: { type: TestComplexScalar },
-    e: { type: TestFaultyScalar }
+    e: { type: TestFaultyScalar },
   },
 });
 
@@ -268,7 +268,6 @@ describe('Execute: Handles inputs', () => {
             },
           ],
         });
-
       });
     });
 
@@ -415,15 +414,15 @@ describe('Execute: Handles inputs', () => {
         const params = { input: { c: 'foo', e: 'SerializedValue' } };
         const result = executeQuery(doc, params);
 
-        expect(result.errors?.at(0)?.originalError).to.equal(TestFaultyScalarGraphQLError);
         expectJSON(result).toDeepEqual({
           errors: [
             {
-              message: 'Variable "$input" got invalid value "SerializedValue" at "input.e"; FaultyScalarErrorMessage',
+              message:
+                'Variable "$input" got invalid value "SerializedValue" at "input.e"; FaultyScalarErrorMessage',
               locations: [{ line: 2, column: 16 }],
-              extensions: { code: 'FaultyScalarErrorExtensionCode' }
-            }
-          ]
+              extensions: { code: 'FaultyScalarErrorExtensionCode' },
+            },
+          ],
         });
       });
 

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -32,7 +32,7 @@ const TestFaultyScalarGraphQLError = new GraphQLError(
   'FaultyScalarErrorMessage',
   {
     extensions: {
-      code: 'FaultyScalarErrorMessageExtensionCode'
+      code: 'FaultyScalarErrorExtensionCode'
     }
   }
 );
@@ -421,7 +421,7 @@ describe('Execute: Handles inputs', () => {
             {
               message: 'Variable "$input" got invalid value "SerializedValue" at "input.e"; FaultyScalarErrorMessage',
               locations: [{ line: 2, column: 16 }],
-              extensions: { code: 'FaultyScalarErrorMessageExtensionCode' }
+              extensions: { code: 'FaultyScalarErrorExtensionCode' }
             }
           ]
         });

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -131,7 +131,7 @@ function coerceVariableValues(
         onError(
           new GraphQLError(prefix + '; ' + error.message, {
             nodes: varDefNode,
-            originalError: error.originalError,
+            originalError: error,
           }),
         );
       },


### PR DESCRIPTION
Errors thrown in the `parseValue` function for custom scalars are not propagated correctly using the `originalError` variable of the GraphQLError on invalid input. As a result, error codes from the `extensions.code` are not propagated correctly.

The fix is simple: Replace `error.orginalError` with `error`, since `error.orginalError` does not exist yet.
see:
https://github.com/graphql/graphql-js/blob/8be83d8d528991aed04ca17434b7e26e56f649cf/src/execution/values.ts#L134

I have added test-cases to avoid this problem in the future.