### PR TITLE
Fix/invalid error propagation custom scalars (backport for 16.x.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7712,13 +7712,8 @@
       "dev": true
     },
     "node_modules/eslint-plugin-internal-rules": {
-      "name": "eslint-plugin-graphql-internal",
-      "version": "0.0.0",
-      "resolved": "file:resources/eslint-internal-rules",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.0.0"
-      }
+      "resolved": "resources/eslint-internal-rules",
+      "link": true
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -17116,6 +17111,14 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "resources/eslint-internal-rules": {
+      "name": "eslint-plugin-graphql-internal",
+      "version": "0.0.0",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     }
   },
   "dependencies": {
@@ -23042,8 +23045,7 @@
       }
     },
     "eslint-plugin-internal-rules": {
-      "version": "npm:eslint-plugin-graphql-internal@0.0.0",
-      "dev": true
+      "version": "file:resources/eslint-internal-rules"
     },
     "eslint-plugin-node": {
       "version": "11.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7712,8 +7712,13 @@
       "dev": true
     },
     "node_modules/eslint-plugin-internal-rules": {
-      "resolved": "resources/eslint-internal-rules",
-      "link": true
+      "name": "eslint-plugin-graphql-internal",
+      "version": "0.0.0",
+      "resolved": "file:resources/eslint-internal-rules",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/eslint-plugin-node": {
       "version": "11.1.0",
@@ -17111,14 +17116,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "resources/eslint-internal-rules": {
-      "name": "eslint-plugin-graphql-internal",
-      "version": "0.0.0",
-      "dev": true,
-      "engines": {
-        "node": ">= 14.0.0"
-      }
     }
   },
   "dependencies": {
@@ -23045,7 +23042,8 @@
       }
     },
     "eslint-plugin-internal-rules": {
-      "version": "file:resources/eslint-internal-rules"
+      "version": "npm:eslint-plugin-graphql-internal@0.0.0",
+      "dev": true
     },
     "eslint-plugin-node": {
       "version": "11.1.0",

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -131,7 +131,7 @@ function coerceVariableValues(
         onError(
           new GraphQLError(prefix + '; ' + error.message, {
             nodes: varDefNode,
-            originalError: error.originalError,
+            originalError: error,
           }),
         );
       },


### PR DESCRIPTION
This is the same fix for invalid error propagation on custom scalars, but now backported for 16.x.x

see:
https://github.com/graphql/graphql-js/pull/3837