### PR TITLE
 Fix ambiguity around when schema definition may be omitted

### DIFF
--- a/src/__testUtils__/viralSDL.ts
+++ b/src/__testUtils__/viralSDL.ts
@@ -1,0 +1,19 @@
+export const viralSDL = `\
+schema {
+  query: Query
+}
+
+type Query {
+  viruses: [Virus!]
+}
+
+type Virus {
+  name: String!
+  knownMutations: [Mutation!]!
+}
+
+type Mutation {
+  name: String!
+  geneSequence: String!
+}\
+`;

--- a/src/__testUtils__/viralSchema.ts
+++ b/src/__testUtils__/viralSchema.ts
@@ -1,0 +1,44 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from '../type/definition.js';
+import { GraphQLString } from '../type/scalars.js';
+import { GraphQLSchema } from '../type/schema.js';
+
+const Mutation = new GraphQLObjectType({
+  name: 'Mutation',
+  fields: {
+    name: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    geneSequence: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+});
+
+const Virus = new GraphQLObjectType({
+  name: 'Virus',
+  fields: {
+    name: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    knownMutations: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Mutation))),
+    },
+  },
+});
+
+const Query = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    viruses: {
+      type: new GraphQLList(new GraphQLNonNull(Virus)),
+    },
+  },
+});
+
+export const viralSchema = new GraphQLSchema({
+  query: Query,
+});

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent.js';
+import { viralSDL } from '../../__testUtils__/viralSDL.js';
 
 import type { Maybe } from '../../jsutils/Maybe.js';
 
@@ -1091,5 +1092,15 @@ describe('Schema Builder', () => {
     expect(() => buildSchema(sdl, { assumeValidSDL: true })).to.throw(
       'Unknown type: "UnknownType".',
     );
+  });
+
+  it('correctly processes viral schema', () => {
+    const schema = buildSchema(viralSDL);
+    expect(schema.getQueryType()).to.contain({ name: 'Query' });
+    expect(schema.getType('Virus')).to.contain({ name: 'Virus' });
+    expect(schema.getType('Mutation')).to.contain({ name: 'Mutation' });
+    // Though the viral schema has a 'Mutation' type, it is not used for the
+    // 'mutation' operation.
+    expect(schema.getMutationType()).to.equal(undefined);
   });
 });

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { dedent, dedentString } from '../../__testUtils__/dedent.js';
+import { viralSchema } from '../../__testUtils__/viralSchema.js';
+import { viralSDL } from '../../__testUtils__/viralSDL.js';
 
 import { DirectiveLocation } from '../../language/directiveLocation.js';
 
@@ -866,5 +868,9 @@ describe('Type System Printer', () => {
         INPUT_FIELD_DEFINITION
       }
     `);
+  });
+  it('prints viral schema correctly', () => {
+    const printed = printSchema(viralSchema);
+    expect(printed).to.equal(viralSDL);
   });
 });

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -107,25 +107,23 @@ function printSchemaDefinition(schema: GraphQLSchema): Maybe<string> {
  *   }
  * ```
  *
- * When using this naming convention, the schema description can be omitted.
+ * When using this naming convention, the schema description can be omitted so
+ * long as these names are only used for operation types.
  */
 function isSchemaOfCommonNames(schema: GraphQLSchema): boolean {
-  const queryType = schema.getQueryType();
-  if (queryType && queryType.name !== 'Query') {
-    return false;
-  }
+  const queryOperationType = schema.getQueryType() ?? null;
+  const mutationOperationType = schema.getMutationType() ?? null;
+  const subscriptionOperationType = schema.getSubscriptionType() ?? null;
 
-  const mutationType = schema.getMutationType();
-  if (mutationType && mutationType.name !== 'Mutation') {
-    return false;
-  }
+  const queryType = schema.getType('Query') ?? null;
+  const mutationType = schema.getType('Mutation') ?? null;
+  const subscriptionType = schema.getType('Subscription') ?? null;
 
-  const subscriptionType = schema.getSubscriptionType();
-  if (subscriptionType && subscriptionType.name !== 'Subscription') {
-    return false;
-  }
-
-  return true;
+  return (
+    queryOperationType === queryType &&
+    mutationOperationType === mutationType &&
+    subscriptionOperationType === subscriptionType
+  );
 }
 
 export function printType(type: GraphQLNamedType): string {

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -115,6 +115,15 @@ function isSchemaOfCommonNames(schema: GraphQLSchema): boolean {
   const mutationOperationType = schema.getMutationType() ?? null;
   const subscriptionOperationType = schema.getSubscriptionType() ?? null;
 
+  // Special case for when there are no operation types
+  if (
+    !queryOperationType &&
+    !mutationOperationType &&
+    !subscriptionOperationType
+  ) {
+    return true;
+  }
+
   const queryType = schema.getType('Query') ?? null;
   const mutationType = schema.getType('Mutation') ?? null;
   const subscriptionType = schema.getType('Subscription') ?? null;


### PR DESCRIPTION
This PR implements the tests and fixes necessary for [Spec RFC #987](https://github.com/graphql/graphql-spec/pull/987).

## The main changes

This PR is made of three main commits:

1. Test printing a schema that has `Query`, `Mutation` and `Virus` types, but only supports `query` operations (via the `Query` type) and does _not_ support `mutation` operations.
2. Test parsing this same schema text, and assert that the schema does not have a mutation type.
3. Fix the printing of the schema.


## Unnecessary test?

The fourth commit addresses the following failing test that I didn't know what to do about:

https://github.com/graphql/graphql-js/blob/76e47fcd7d432f515d5bb99e95af1851148a0c54/src/utilities/__tests__/buildClientSchema-test.ts#L65-L81

I don't understand the reasoning behind this test. It seems to me that the schema output from this should instead be:

```graphql
schema {}

type Query {
  foo: String
}
```

since the schema has no operation types (but uses the default names); however this is unparseable (because `{}` is unparseable). Perhaps @IvanGoncharov or @leebyron can shed some light on the reasoning behind this test? I've worked around it by special casing it, but I'd prefer to remove the special case code and also remove the test case.