### PR TITLE
ci: uncomment package-lock.json check for unmet dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,8 @@ jobs:
       - name: Install Dependencies
         run: npm ci --ignore-scripts
 
-      # Disabled due to https://github.com/milesj/docusaurus-plugin-typedoc-api/pull/19
-      # - name: Check that package-lock.json doesn't have conflicts
-      #  run: npm ls --depth 999
+      - name: Check that package-lock.json doesn't have conflicts
+        run: npm ls --depth 999
 
       - name: Run npm install
         run: npm install --ignore-scripts --force --package-lock-only --engine-strict --strict-peer-deps


### PR DESCRIPTION
Context: it was disabled due to bug in docusaurus plugin which was fixed a long time ago.