### PR TITLE
BugFix: Nested List Input Coercion not matching GraphQL spec 

### DIFF
--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -395,14 +395,46 @@ describe('coerceInputValue', () => {
       expectValue(result).to.deep.equal(null);
     });
 
-    it('returns nested lists for nested non-list values', () => {
+    it('returns error for nested non-list values', () => {
       const result = coerceValue([1, 2, 3], TestNestedList);
-      expectValue(result).to.deep.equal([[1], [2], [3]]);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Expected type "[Int]" to be a list.',
+          path: [0],
+          value: 1,
+        },
+        {
+          error: 'Expected type "[Int]" to be a list.',
+          path: [1],
+          value: 2,
+        },
+        {
+          error: 'Expected type "[Int]" to be a list.',
+          path: [2],
+          value: 3,
+        },
+      ]);
+    });
+
+    it('returns errors for null values', () => {
+      const result = coerceValue([42, [null], null], TestNestedList);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Expected type "[Int]" to be a list.',
+          path: [0],
+          value: 42,
+        },
+        {
+          error: 'Expected type "[Int]" to be a list.',
+          path: [2],
+          value: null,
+        },
+      ]);
     });
 
     it('returns nested null for nested null values', () => {
-      const result = coerceValue([42, [null], null], TestNestedList);
-      expectValue(result).to.deep.equal([[42], [null], null]);
+      const result = coerceValue([[null], [null]], TestNestedList);
+      expectValue(result).to.deep.equal([[null], [null]]);
     });
   });
 

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -76,8 +76,21 @@ function coerceInputValueImpl(
   if (isListType(type)) {
     const itemType = type.ofType;
     if (isIterableObject(inputValue)) {
+      const isNestedList = Boolean(
+        isListType(itemType) && Array.from(inputValue).length > 1,
+      );
       return Array.from(inputValue, (itemValue, index) => {
         const itemPath = addPath(path, index, undefined);
+        if (isNestedList && !isIterableObject(itemValue)) {
+          // Input values should be iterable for nested list type with multiple values
+          onError(
+            pathToArray(itemPath),
+            itemValue,
+            new GraphQLError(
+              `Expected type "${inspect(itemType)}" to be a list.`,
+            ),
+          );
+        }
         return coerceInputValueImpl(itemValue, itemType, onError, itemPath);
       });
     }


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/graphql/graphql-js/issues/3858 to align input coercion of nested list with the [GraphQL spec](https://spec.graphql.org/October2021/#sel-HAHjBJLDLEBAAADFAb0le).


#### Changes (Similar to https://github.com/graphql-python/graphql-core/pull/194)
- Adds check to validate and raises error for the condition
- Updated tests to reflect the new logic, and validate error
