### PR TITLE
printSchema: correctly print empty description

### DIFF
--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -601,16 +601,133 @@ describe('Type System Printer', () => {
     `);
   });
 
-  it('Prints an empty description', () => {
-    const schema = buildSingleFieldSchema({
-      type: GraphQLString,
+  it('Prints an empty descriptions', () => {
+    const args = {
+      someArg: { description: '', type: GraphQLString },
+      anotherArg: { description: '', type: GraphQLString },
+    };
+
+    const fields = {
+      someField: { description: '', type: GraphQLString, args },
+      anotherField: { description: '', type: GraphQLString, args },
+    };
+
+    const queryType = new GraphQLObjectType({
+      name: 'Query',
+      description: '',
+      fields,
+    });
+
+    const scalarType = new GraphQLScalarType({
+      name: 'SomeScalar',
       description: '',
     });
 
+    const interfaceType = new GraphQLInterfaceType({
+      name: 'SomeInterface',
+      description: '',
+      fields,
+    });
+
+    const unionType = new GraphQLUnionType({
+      name: 'SomeUnion',
+      description: '',
+      types: [queryType],
+    });
+
+    const enumType = new GraphQLEnumType({
+      name: 'SomeEnum',
+      description: '',
+      values: {
+        SOME_VALUE: { description: '' },
+        ANOTHER_VALUE: { description: '' },
+      },
+    });
+
+    const someDirective = new GraphQLDirective({
+      name: 'someDirective',
+      description: '',
+      args,
+      locations: [DirectiveLocation.QUERY],
+    });
+
+    const schema = new GraphQLSchema({
+      description: '',
+      query: queryType,
+      types: [scalarType, interfaceType, unionType, enumType],
+      directives: [someDirective],
+    });
+
     expectPrintedSchema(schema).to.equal(dedent`
+      """"""
+      schema {
+        query: Query
+      }
+      
+      """"""
+      directive @someDirective(
+        """"""
+        someArg: String
+
+        """"""
+        anotherArg: String
+      ) on QUERY
+
+      """"""
+      scalar SomeScalar
+
+      """"""
+      interface SomeInterface {
+        """"""
+        someField(
+          """"""
+          someArg: String
+
+          """"""
+          anotherArg: String
+        ): String
+
+        """"""
+        anotherField(
+          """"""
+          someArg: String
+
+          """"""
+          anotherArg: String
+        ): String
+      }
+
+      """"""
+      union SomeUnion = Query
+
+      """"""
       type Query {
         """"""
-        singleField: String
+        someField(
+          """"""
+          someArg: String
+
+          """"""
+          anotherArg: String
+        ): String
+
+        """"""
+        anotherField(
+          """"""
+          someArg: String
+
+          """"""
+          anotherArg: String
+        ): String
+      }
+
+      """"""
+      enum SomeEnum {
+        """"""
+        SOME_VALUE
+
+        """"""
+        ANOTHER_VALUE
       }
     `);
   });

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -82,7 +82,7 @@ function printSchemaDefinition(schema: GraphQLSchema): Maybe<string> {
 
   // Only print a schema definition if there is a description or if it should
   // not be omitted because of having default type names.
-  if (schema.description || !hasDefaultRootOperationTypes(schema)) {
+  if (schema.description != null || !hasDefaultRootOperationTypes(schema)) {
     return (
       printDescription(schema) +
       'schema {\n' +
@@ -234,7 +234,7 @@ function printArgs(
   }
 
   // If every arg does not have a description, print them on one line.
-  if (args.every((arg) => !arg.description)) {
+  if (args.every((arg) => arg.description == null)) {
     return '(' + args.map(printInputValue).join(', ') + ')';
   }
 


### PR DESCRIPTION
Motivation: empty description is definetly a corner case but spec allow them so we should correctly print them