### PR TITLE
ASTReducer: correctly type scalar values

### DIFF
--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -143,7 +143,6 @@ const printDocASTReducer: ASTReducer<string> = {
   FloatValue: { leave: ({ value }) => value },
   StringValue: {
     leave: ({ value, block: isBlockString }) =>
-      // @ts-expect-error FIXME: it's a problem with ASTReducer, will be fixed in separate PR
       isBlockString === true ? printBlockString(value) : printString(value),
   },
   BooleanValue: { leave: ({ value }) => (value ? 'true' : 'false') },

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -71,11 +71,11 @@ type ASTReducerFn<TReducedNode extends ASTNode, R> = (
   ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>,
 ) => R;
 
-type ReducedField<T, R> = T extends null | undefined
-  ? T
-  : T extends ReadonlyArray<any>
+type ReducedField<T, R> = T extends ASTNode
+  ? R
+  : T extends ReadonlyArray<ASTNode>
   ? ReadonlyArray<R>
-  : R;
+  : T;
 
 /**
  * A KeyMap describes each the traversable properties of each kind of node.


### PR DESCRIPTION
Context: only nodes are mapped in reducer and leafs inside nodes stays as is.