### PR TITLE
GraphQLObjectType: partial revert of #3143, due to perf regression

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -719,8 +719,10 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
 
-    this._fields = () => defineFieldMap(config);
-    this._interfaces = () => defineInterfaces(config);
+    // prettier-ignore
+    // FIXME: blocked by https://github.com/prettier/prettier/issues/14625
+    this._fields = (defineFieldMap<TSource, TContext>).bind(undefined, config);
+    this._interfaces = defineInterfaces.bind(undefined, config);
   }
 
   get [Symbol.toStringTag]() {


### PR DESCRIPTION
Context: revert back to use bind since it way faster
Reverts: https://github.com/graphql/graphql-js/commit/ac7098505ac3f5485ad3ac79351f0e64175bde23#diff-abcb97c7918631025353ea7ae5c1913946f00eb9d5d7ea9fe6060b6cfd92d480L761

<img width="536" alt="image" src="https://user-images.githubusercontent.com/8336157/229523268-d00e2df1-691c-4f79-b878-a2b98ec725ec.png">
