### PR TITLE
GraphQLInputObjectType: remove check that duplicate TS types

### DIFF
--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -566,34 +566,6 @@ describe('Type System: Input Objects', () => {
     });
   });
 
-  describe('Input Object fields must not have resolvers', () => {
-    it('rejects an Input Object type with resolvers', () => {
-      const inputObjType = new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          // @ts-expect-error (Input fields cannot have resolvers)
-          f: { type: ScalarType, resolve: dummyFunc },
-        },
-      });
-      expect(() => inputObjType.getFields()).to.throw(
-        'SomeInputObject.f field has a resolve property, but Input Types cannot define resolvers.',
-      );
-    });
-
-    it('rejects an Input Object type with resolver constant', () => {
-      const inputObjType = new GraphQLInputObjectType({
-        name: 'SomeInputObject',
-        fields: {
-          // @ts-expect-error (Input fields cannot have resolvers)
-          f: { type: ScalarType, resolve: {} },
-        },
-      });
-      expect(() => inputObjType.getFields()).to.throw(
-        'SomeInputObject.f field has a resolve property, but Input Types cannot define resolvers.',
-      );
-    });
-  });
-
   it('Deprecation reason is preserved on fields', () => {
     const inputObjType = new GraphQLInputObjectType({
       name: 'SomeInputObject',

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1550,22 +1550,15 @@ function defineInputFieldMap(
   config: Readonly<GraphQLInputObjectTypeConfig>,
 ): GraphQLInputFieldMap {
   const fieldMap = resolveObjMapThunk(config.fields);
-  return mapValue(fieldMap, (fieldConfig, fieldName) => {
-    devAssert(
-      !('resolve' in fieldConfig),
-      `${config.name}.${fieldName} field has a resolve property, but Input Types cannot define resolvers.`,
-    );
-
-    return {
-      name: assertName(fieldName),
-      description: fieldConfig.description,
-      type: fieldConfig.type,
-      defaultValue: fieldConfig.defaultValue,
-      deprecationReason: fieldConfig.deprecationReason,
-      extensions: toObjMap(fieldConfig.extensions),
-      astNode: fieldConfig.astNode,
-    };
-  });
+  return mapValue(fieldMap, (fieldConfig, fieldName) => ({
+    name: assertName(fieldName),
+    description: fieldConfig.description,
+    type: fieldConfig.type,
+    defaultValue: fieldConfig.defaultValue,
+    deprecationReason: fieldConfig.deprecationReason,
+    extensions: toObjMap(fieldConfig.extensions),
+    astNode: fieldConfig.astNode,
+  }));
 }
 
 export interface GraphQLInputObjectTypeConfig {


### PR DESCRIPTION
Context: Continuation of #3642
Some discussion here: https://github.com/graphql/graphql-js/pull/3642#issuecomment-1154255542