### PR TITLE
GraphQL*Type: bind only single property instead of entire context

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -721,8 +721,8 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
 
     // prettier-ignore
     // FIXME: blocked by https://github.com/prettier/prettier/issues/14625
-    this._fields = (defineFieldMap<TSource, TContext>).bind(undefined, config);
-    this._interfaces = defineInterfaces.bind(undefined, config);
+    this._fields = (defineFieldMap<TSource, TContext>).bind(undefined, config.fields);
+    this._interfaces = defineInterfaces.bind(undefined, config.interfaces);
   }
 
   get [Symbol.toStringTag]() {
@@ -766,20 +766,15 @@ export class GraphQLObjectType<TSource = any, TContext = any> {
 }
 
 function defineInterfaces(
-  config: Readonly<
-    GraphQLObjectTypeConfig<any, any> | GraphQLInterfaceTypeConfig<any, any>
-  >,
+  interfaces: Maybe<ThunkReadonlyArray<GraphQLInterfaceType>>,
 ): ReadonlyArray<GraphQLInterfaceType> {
-  return resolveReadonlyArrayThunk(config.interfaces ?? []);
+  return resolveReadonlyArrayThunk(interfaces ?? []);
 }
 
 function defineFieldMap<TSource, TContext>(
-  config: Readonly<
-    | GraphQLObjectTypeConfig<TSource, TContext>
-    | GraphQLInterfaceTypeConfig<TSource, TContext>
-  >,
+  fields: ThunkObjMap<GraphQLFieldConfig<TSource, TContext>>,
 ): GraphQLFieldMap<TSource, TContext> {
-  const fieldMap = resolveObjMapThunk(config.fields);
+  const fieldMap = resolveObjMapThunk(fields);
 
   return mapValue(fieldMap, (fieldConfig, fieldName) => {
     const argsConfig = fieldConfig.args ?? {};
@@ -798,9 +793,9 @@ function defineFieldMap<TSource, TContext>(
 }
 
 export function defineArguments(
-  config: GraphQLFieldConfigArgumentMap,
+  args: GraphQLFieldConfigArgumentMap,
 ): ReadonlyArray<GraphQLArgument> {
-  return Object.entries(config).map(([argName, argConfig]) => ({
+  return Object.entries(args).map(([argName, argConfig]) => ({
     name: assertName(argName),
     description: argConfig.description,
     type: argConfig.type,
@@ -1041,8 +1036,8 @@ export class GraphQLInterfaceType {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
 
-    this._fields = defineFieldMap.bind(undefined, config);
-    this._interfaces = defineInterfaces.bind(undefined, config);
+    this._fields = defineFieldMap.bind(undefined, config.fields);
+    this._interfaces = defineInterfaces.bind(undefined, config.interfaces);
   }
 
   get [Symbol.toStringTag]() {
@@ -1164,7 +1159,7 @@ export class GraphQLUnionType {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
 
-    this._types = defineTypes.bind(undefined, config);
+    this._types = defineTypes.bind(undefined, config.types);
   }
 
   get [Symbol.toStringTag]() {
@@ -1200,9 +1195,9 @@ export class GraphQLUnionType {
 }
 
 function defineTypes(
-  config: Readonly<GraphQLUnionTypeConfig<unknown, unknown>>,
+  types: ThunkReadonlyArray<GraphQLObjectType>,
 ): ReadonlyArray<GraphQLObjectType> {
-  return resolveReadonlyArrayThunk(config.types);
+  return resolveReadonlyArrayThunk(types);
 }
 
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
@@ -1503,7 +1498,7 @@ export class GraphQLInputObjectType {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
 
-    this._fields = defineInputFieldMap.bind(undefined, config);
+    this._fields = defineInputFieldMap.bind(undefined, config.fields);
   }
 
   get [Symbol.toStringTag]() {
@@ -1547,9 +1542,9 @@ export class GraphQLInputObjectType {
 }
 
 function defineInputFieldMap(
-  config: Readonly<GraphQLInputObjectTypeConfig>,
+  fields: ThunkObjMap<GraphQLInputFieldConfig>,
 ): GraphQLInputFieldMap {
-  const fieldMap = resolveObjMapThunk(config.fields);
+  const fieldMap = resolveObjMapThunk(fields);
   return mapValue(fieldMap, (fieldConfig, fieldName) => ({
     name: assertName(fieldName),
     description: fieldConfig.description,


### PR DESCRIPTION
Motivation: simplifies a code a bit and also saves some memory (measurable in bencmark) because we don't lock entire config in memory