### PR TITLE
eslint: replace unmaintained 'node' plugin with it's fork

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,11 +7,8 @@ module.exports = {
     'shared-node-browser': true,
   },
   reportUnusedDisableDirectives: true,
-  plugins: ['node', 'import', 'simple-import-sort'],
+  plugins: ['n', 'import', 'simple-import-sort'],
   settings: {
-    node: {
-      tryExtensions: ['.js', '.ts', '.jsx', '.json', '.node', '.d.ts'],
-    },
     // eslint-plugin-import tries to parse all imported files included huge ones (e.g. 'typescript')
     // that leads to very poor perfomance so to fix that we disable all checks on external files.
     'import/ignore': '/node_modules/',
@@ -26,57 +23,54 @@ module.exports = {
     'require-to-string-tag': 'off',
 
     //////////////////////////////////////////////////////////////////////////////
-    // `eslint-plugin-node` rule list based on `v11.1.x`
+    // `eslint-plugin-n` rule list based on `v15.7.x`
     //////////////////////////////////////////////////////////////////////////////
 
     // Possible Errors
-    // https://github.com/mysticatea/eslint-plugin-node#possible-errors
-    'node/handle-callback-err': ['error', 'error'],
-    'node/no-callback-literal': 'error',
-    'node/no-exports-assign': 'error',
-    'node/no-extraneous-import': 'error',
-    'node/no-extraneous-require': 'error',
-    'node/no-missing-import': 'off', // TODO: Blocked by https://github.com/mysticatea/eslint-plugin-node/issues/248
-    'node/no-missing-require': 'error',
-    'node/no-new-require': 'error',
-    'node/no-path-concat': 'error',
-    'node/no-process-exit': 'off',
-    'node/no-unpublished-bin': 'error',
-    'node/no-unpublished-import': 'error',
-    'node/no-unpublished-require': 'error',
-    'node/no-unsupported-features/es-builtins': 'error',
-    'node/no-unsupported-features/es-syntax': [
-      'error',
-      { ignores: ['modules'] },
-    ],
-    'node/no-unsupported-features/node-builtins': 'error',
-    'node/process-exit-as-throw': 'error',
-    'node/shebang': 'error',
+    // https://github.com/eslint-community/eslint-plugin-n#possible-errors
+    'n/handle-callback-err': ['error', 'error'],
+    'n/no-callback-literal': 'error',
+    'n/no-exports-assign': 'error',
+    'n/no-extraneous-import': 'error',
+    'n/no-extraneous-require': 'error',
+    'n/no-missing-import': 'error',
+    'n/no-missing-require': 'error',
+    'n/no-new-require': 'error',
+    'n/no-path-concat': 'error',
+    'n/no-process-exit': 'off',
+    'n/no-unpublished-bin': 'error',
+    'n/no-unpublished-import': 'error',
+    'n/no-unpublished-require': 'error',
+    'n/no-unsupported-features/es-builtins': 'error',
+    'n/no-unsupported-features/es-syntax': ['error', { ignores: ['modules'] }],
+    'n/no-unsupported-features/node-builtins': 'error',
+    'n/process-exit-as-throw': 'error',
+    'n/shebang': 'error',
 
     // Best Practices
-    // https://github.com/mysticatea/eslint-plugin-node#best-practices
-    'node/no-deprecated-api': 'error',
+    // https://github.com/eslint-community/eslint-plugin-n#best-practices
+    'n/no-deprecated-api': 'error',
 
     // Stylistic Issues
-    // https://github.com/mysticatea/eslint-plugin-node#stylistic-issues
-    'node/callback-return': 'error',
-    'node/exports-style': 'off', // TODO: consider
-    'node/file-extension-in-import': 'off', // TODO: consider
-    'node/global-require': 'error',
-    'node/no-mixed-requires': 'error',
-    'node/no-process-env': 'off',
-    'node/no-restricted-import': 'off',
-    'node/no-restricted-require': 'off',
-    'node/no-sync': 'error',
-    'node/prefer-global/buffer': 'error',
-    'node/prefer-global/console': 'error',
-    'node/prefer-global/process': 'error',
-    'node/prefer-global/text-decoder': 'error',
-    'node/prefer-global/text-encoder': 'error',
-    'node/prefer-global/url-search-params': 'error',
-    'node/prefer-global/url': 'error',
-    'node/prefer-promises/dns': 'off',
-    'node/prefer-promises/fs': 'off',
+    // https://github.com/eslint-community/eslint-plugin-n#stylistic-issues
+    'n/callback-return': 'error',
+    'n/exports-style': 'off', // TODO: consider
+    'n/file-extension-in-import': 'error',
+    'n/global-require': 'error',
+    'n/no-mixed-requires': 'error',
+    'n/no-process-env': 'off',
+    'n/no-restricted-import': 'off',
+    'n/no-restricted-require': 'off',
+    'n/no-sync': 'error',
+    'n/prefer-global/buffer': 'error',
+    'n/prefer-global/console': 'error',
+    'n/prefer-global/process': 'error',
+    'n/prefer-global/text-decoder': 'error',
+    'n/prefer-global/text-encoder': 'error',
+    'n/prefer-global/url-search-params': 'error',
+    'n/prefer-global/url': 'error',
+    'n/prefer-promises/dns': 'off',
+    'n/prefer-promises/fs': 'off',
 
     //////////////////////////////////////////////////////////////////////////////
     // `eslint-plugin-import` rule list based on `v2.27.x`
@@ -705,7 +699,7 @@ module.exports = {
       files: 'src/**/__*__/**',
       rules: {
         'require-to-string-tag': 'off',
-        'node/no-unpublished-import': [
+        'n/no-unpublished-import': [
           'error',
           { allowModules: ['chai', 'mocha'] },
         ],
@@ -723,8 +717,8 @@ module.exports = {
         node: true,
       },
       rules: {
-        'node/no-sync': 'off',
-        'node/no-unpublished-import': ['error', { allowModules: ['mocha'] }],
+        'n/no-sync': 'off',
+        'n/no-unpublished-import': ['error', { allowModules: ['mocha'] }],
         'import/no-extraneous-dependencies': [
           'error',
           { devDependencies: true },
@@ -742,9 +736,10 @@ module.exports = {
         node: true,
       },
       rules: {
-        'node/no-sync': 'off',
+        'n/no-sync': 'off',
         'import/no-nodejs-modules': 'off',
         'no-console': 'off',
+        'n/no-missing-import': ['error', { allowModules: ['graphql'] }],
       },
     },
     {
@@ -756,8 +751,9 @@ module.exports = {
         node: true,
       },
       rules: {
-        'node/no-sync': 'off',
-        'node/no-extraneous-import': ['error', { allowModules: ['graphql'] }],
+        'n/no-sync': 'off',
+        'n/no-missing-import': ['error', { allowModules: ['graphql'] }],
+        'n/no-extraneous-import': ['error', { allowModules: ['graphql'] }],
         'import/no-unresolved': 'off',
         'import/no-namespace': 'off',
         'import/no-nodejs-modules': 'off',
@@ -771,8 +767,8 @@ module.exports = {
       },
       rules: {
         'only-ascii': ['error', { allowEmoji: true }],
-        'node/no-unpublished-import': 'off',
-        'node/no-sync': 'off',
+        'n/no-unpublished-import': 'off',
+        'n/no-sync': 'off',
         'import/no-namespace': 'off',
         'import/no-extraneous-dependencies': [
           'error',
@@ -800,7 +796,7 @@ module.exports = {
         },
       },
       rules: {
-        'node/no-unpublished-import': 'off',
+        'n/no-unpublished-import': 'off',
         'import/no-default-export': 'off',
       },
     },
@@ -818,12 +814,13 @@ module.exports = {
       },
       rules: {
         'no-restricted-exports': 'off',
-        'node/no-unpublished-require': 'off',
+        'n/no-unpublished-require': 'off',
         'import/no-default-export': 'off',
         'import/no-commonjs': 'off',
         'import/no-nodejs-modules': 'off',
         'import/no-extraneous-dependencies': 'off',
         // Ignore docusarus related webpack aliases
+        'n/no-missing-import': 'off',
         'import/no-unresolved': [
           'error',
           { ignore: ['^@theme', '^@docusaurus', '^@generated'] },

--- a/integrationTests/webpack/test.js
+++ b/integrationTests/webpack/test.js
@@ -1,7 +1,9 @@
 import assert from 'assert';
 
+/* eslint-disable n/no-missing-import */
 import cjs from './dist/main-cjs.cjs';
 import mjs from './dist/main-mjs.cjs';
+/* eslint-enable n/no-missing-import */
 
 assert.deepStrictEqual(cjs.result, {
   data: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "docusaurus-plugin-typedoc-api": "2.5.1",
         "eslint": "8.34.0",
         "eslint-plugin-import": "2.27.5",
-        "eslint-plugin-node": "11.1.0",
+        "eslint-plugin-n": "15.7.0",
         "eslint-plugin-react": "7.32.2",
         "eslint-plugin-react-hooks": "4.6.0",
         "eslint-plugin-simple-import-sort": "10.0.0",
@@ -5886,6 +5886,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -8197,49 +8206,6 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
-      "dev": true,
-      "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=4.19.1"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/eslint-plugin-import": {
       "version": "2.27.5",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.27.5.tgz",
@@ -8321,27 +8287,32 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
+      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es": "^4.1.0",
+        "eslint-utils": "^3.0.0",
         "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
+        "is-core-module": "^2.11.0",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.1",
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       },
       "peerDependencies": {
-        "eslint": ">=5.16.0"
+        "eslint": ">=7.0.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/brace-expansion": {
+    "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
@@ -8351,7 +8322,26 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
+    "node_modules/eslint-plugin-n/node_modules/eslint-plugin-es": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
+      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/eslint-plugin-es/node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
@@ -8366,7 +8356,7 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-plugin-n/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
@@ -8375,7 +8365,7 @@
         "node": ">=4"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/minimatch": {
+    "node_modules/eslint-plugin-n/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
@@ -8385,15 +8375,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "docusaurus-plugin-typedoc-api": "2.5.1",
     "eslint": "8.34.0",
     "eslint-plugin-import": "2.27.5",
-    "eslint-plugin-node": "11.1.0",
+    "eslint-plugin-n": "15.7.0",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-simple-import-sort": "10.0.0",


### PR DESCRIPTION
Motivation: 'node' is in unmaintained state for year but recently ESLint community started to maintain it's fork