### PR TITLE
RFC: incremental delivery: without branching, with deduplication

### DIFF
--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -242,13 +242,13 @@ describe('Execute: Handles mutation execution ordering', () => {
       {
         incremental: [
           {
-            label: 'defer-label',
             path: ['first'],
             data: {
               promiseToGetTheNumber: 2,
             },
           },
         ],
+        completed: [{ path: ['first'], label: 'defer-label' }],
         hasNext: false,
       },
     ]);
@@ -317,7 +317,6 @@ describe('Execute: Handles mutation execution ordering', () => {
       {
         incremental: [
           {
-            label: 'defer-label',
             path: [],
             data: {
               first: {
@@ -326,6 +325,7 @@ describe('Execute: Handles mutation execution ordering', () => {
             },
           },
         ],
+        completed: [{ path: [], label: 'defer-label' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -1,7 +1,8 @@
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
@@ -144,11 +145,12 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList', 1] }],
+        incremental: [{ items: ['banana'], path: ['scalarList'] }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -166,15 +168,16 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['apple'], path: ['scalarList', 0] }],
+        incremental: [{ items: ['apple'], path: ['scalarList'] }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList', 1] }],
+        incremental: [{ items: ['banana'], path: ['scalarList'] }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -220,8 +223,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: ['banana'],
-            path: ['scalarList', 1],
-            label: 'scalar-stream',
+            path: ['scalarList'],
           },
         ],
         hasNext: true,
@@ -230,10 +232,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: ['coconut'],
-            path: ['scalarList', 2],
-            label: 'scalar-stream',
+            path: ['scalarList'],
           },
         ],
+        completed: [{ path: ['scalarList'], label: 'scalar-stream' }],
         hasNext: false,
       },
     ]);
@@ -262,7 +264,8 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -287,7 +290,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [['banana', 'banana', 'banana']],
-            path: ['scalarListList', 1],
+            path: ['scalarListList'],
           },
         ],
         hasNext: true,
@@ -296,9 +299,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [['coconut', 'coconut', 'coconut']],
-            path: ['scalarListList', 2],
+            path: ['scalarListList'],
           },
         ],
+        completed: [{ path: ['scalarListList'] }],
         hasNext: false,
       },
     ]);
@@ -340,9 +344,10 @@ describe('Execute: stream directive', () => {
                 id: '3',
               },
             ],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -370,7 +375,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke', id: '1' }],
-            path: ['friendList', 0],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -379,7 +384,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
-            path: ['friendList', 1],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -388,9 +393,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -436,9 +442,10 @@ describe('Execute: stream directive', () => {
                 id: '3',
               },
             ],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -479,9 +486,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -515,7 +523,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'bad',
@@ -531,9 +539,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -565,7 +574,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke', id: '1' }],
-            path: ['friendList', 0],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -574,7 +583,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
-            path: ['friendList', 1],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -583,12 +592,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -623,12 +633,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -694,13 +705,19 @@ describe('Execute: stream directive', () => {
           incremental: [
             {
               items: [{ name: 'Leia', id: '3' }],
-              path: ['friendList', 2],
+              path: ['friendList'],
             },
           ],
           hasNext: true,
         },
       },
-      { done: false, value: { hasNext: false } },
+      {
+        done: false,
+        value: {
+          completed: [{ path: ['friendList'] }],
+          hasNext: false,
+        },
+      },
       { done: true, value: undefined },
     ]);
   });
@@ -755,10 +772,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'bad',
@@ -792,10 +808,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message:
@@ -839,10 +854,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message:
@@ -877,7 +891,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['scalarList', 1],
+            path: ['scalarList'],
             errors: [
               {
                 message: 'String cannot represent value: {}',
@@ -887,6 +901,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -919,7 +934,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'Oops',
@@ -935,9 +950,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -968,7 +984,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'Oops',
@@ -984,9 +1000,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1016,10 +1033,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1056,10 +1072,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1101,7 +1116,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1117,12 +1132,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1154,10 +1170,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1170,6 +1185,151 @@ describe('Execute: stream directive', () => {
         hasNext: false,
       },
     ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list when the async iterable does not provide a return method) ', async () => {
+    const document = parse(`
+      query { 
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    let count = 0;
+    const result = await complete(document, {
+      nonNullFriendList: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            switch (count++) {
+              case 0:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[0].name },
+                });
+              case 1:
+                return Promise.resolve({
+                  done: false,
+                  value: {
+                    nonNullName: () => Promise.reject(new Error('Oops')),
+                  },
+                });
+              case 2:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[1].name },
+                });
+              // Not reached
+              /* c8 ignore next 5 */
+              case 3:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[2].name },
+                });
+            }
+          },
+        }),
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        completed: [
+          {
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list when the async iterable provides concurrent next/return methods and has a slow return ', async () => {
+    const document = parse(`
+      query { 
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    let count = 0;
+    let returned = false;
+    const result = await complete(document, {
+      nonNullFriendList: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            /* c8 ignore next 3 */
+            if (returned) {
+              return Promise.resolve({ done: true });
+            }
+            switch (count++) {
+              case 0:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[0].name },
+                });
+              case 1:
+                return Promise.resolve({
+                  done: false,
+                  value: {
+                    nonNullName: () => Promise.reject(new Error('Oops')),
+                  },
+                });
+              case 2:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[1].name },
+                });
+              // Not reached
+              /* c8 ignore next 5 */
+              case 3:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[2].name },
+                });
+            }
+          },
+          return: async () => {
+            await resolveOnNextTick();
+            returned = true;
+            return { done: true };
+          },
+        }),
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        completed: [
+          {
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(returned).to.equal(true);
   });
   it('Filters payloads that are nulled', async () => {
     const document = parse(`
@@ -1283,12 +1443,14 @@ describe('Execute: stream directive', () => {
           },
           {
             items: [{ name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
+        completed: [{ path: ['otherNestedObject'] }],
         hasNext: true,
       },
       {
+        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
         hasNext: false,
       },
     ]);
@@ -1346,6 +1508,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: false,
       },
     ]);
@@ -1380,7 +1543,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 0],
+            path: ['friendList'],
             errors: [
               {
                 message:
@@ -1394,6 +1557,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1405,10 +1569,11 @@ describe('Execute: stream directive', () => {
     const iterable = {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          /* c8 ignore start */
           if (requested) {
-            // Ignores further errors when filtered.
+            // stream is filtered, next is not called, and so this is not reached.
             return Promise.reject(new Error('Oops'));
-          }
+          } /* c8 ignore stop */
           requested = true;
           const friend = friends[0];
           return Promise.resolve({
@@ -1489,6 +1654,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: false,
       },
     });
@@ -1528,7 +1694,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            path: ['friendList', 1],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -1537,12 +1703,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '3', name: 'Leia' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1585,41 +1752,24 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [{ id: '1' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
-          },
-          {
-            data: {
-              nestedFriendList: [],
-            },
-            path: ['nestedObject'],
-          },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
-          {
-            items: [{ id: '2' }],
-            path: ['nestedObject', 'nestedFriendList', 1],
-          },
-          {
             items: [{ id: '1', name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList', 1],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
         hasNext: false,
       },
     ]);
@@ -1675,6 +1825,7 @@ describe('Execute: stream directive', () => {
             path: ['nestedObject'],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: true,
       },
       done: false,
@@ -1685,7 +1836,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
         hasNext: true,
@@ -1698,7 +1849,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList', 1],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
         hasNext: true,
@@ -1707,7 +1858,10 @@ describe('Execute: stream directive', () => {
     });
     const result5 = await iterator.next();
     expectJSON(result5).toDeepEqual({
-      value: { hasNext: false },
+      value: {
+        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        hasNext: false,
+      },
       done: false,
     });
     const result6 = await iterator.next();
@@ -1770,14 +1924,13 @@ describe('Execute: stream directive', () => {
           {
             data: { name: 'Luke' },
             path: ['friendList', 0],
-            label: 'DeferName',
           },
           {
             items: [{ id: '2' }],
-            path: ['friendList', 1],
-            label: 'stream-label',
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList', 0], label: 'DeferName' }],
         hasNext: true,
       },
       done: false,
@@ -1788,19 +1941,27 @@ describe('Execute: stream directive', () => {
     const result3 = await result3Promise;
     expectJSON(result3).toDeepEqual({
       value: {
-        incremental: [
-          {
-            data: { name: 'Han' },
-            path: ['friendList', 1],
-            label: 'DeferName',
-          },
-        ],
-        hasNext: false,
+        completed: [{ path: ['friendList'], label: 'stream-label' }],
+        hasNext: true,
       },
       done: false,
     });
     const result4 = await iterator.next();
     expectJSON(result4).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: { name: 'Han' },
+            path: ['friendList', 1],
+          },
+        ],
+        completed: [{ path: ['friendList', 1], label: 'DeferName' }],
+        hasNext: false,
+      },
+      done: false,
+    });
+    const result5 = await iterator.next();
+    expectJSON(result5).toDeepEqual({
       value: undefined,
       done: true,
     });
@@ -1859,14 +2020,13 @@ describe('Execute: stream directive', () => {
           {
             data: { name: 'Luke' },
             path: ['friendList', 0],
-            label: 'DeferName',
           },
           {
             items: [{ id: '2' }],
-            path: ['friendList', 1],
-            label: 'stream-label',
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList', 0], label: 'DeferName' }],
         hasNext: true,
       },
       done: false,
@@ -1879,9 +2039,9 @@ describe('Execute: stream directive', () => {
           {
             data: { name: 'Han' },
             path: ['friendList', 1],
-            label: 'DeferName',
           },
         ],
+        completed: [{ path: ['friendList', 1], label: 'DeferName' }],
         hasNext: true,
       },
       done: false,
@@ -1890,7 +2050,10 @@ describe('Execute: stream directive', () => {
     resolveIterableCompletion(null);
     const result4 = await result4Promise;
     expectJSON(result4).toDeepEqual({
-      value: { hasNext: false },
+      value: {
+        completed: [{ path: ['friendList'], label: 'stream-label' }],
+        hasNext: false,
+      },
       done: false,
     });
 

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -1,5 +1,7 @@
 import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
+import { getBySet } from '../jsutils/getBySet.js';
 import { invariant } from '../jsutils/invariant.js';
+import { isSameSet } from '../jsutils/isSameSet.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
 
 import type {
@@ -26,18 +28,50 @@ import { typeFromAST } from '../utilities/typeFromAST.js';
 
 import { getDirectiveValues } from './values.js';
 
-export type FieldGroup = ReadonlyArray<FieldNode>;
+export interface DeferUsage {
+  label: string | undefined;
+  ancestors: ReadonlyArray<Target>;
+}
+
+export const NON_DEFERRED_TARGET_SET: TargetSet = new Set<Target>([undefined]);
+
+export type Target = DeferUsage | undefined;
+export type TargetSet = ReadonlySet<Target>;
+export type DeferUsageSet = ReadonlySet<DeferUsage>;
+
+export interface FieldDetails {
+  node: FieldNode;
+  target: Target;
+}
+
+export interface FieldGroup {
+  fields: ReadonlyArray<FieldDetails>;
+  targets: TargetSet;
+}
 
 export type GroupedFieldSet = Map<string, FieldGroup>;
 
-export interface PatchFields {
-  label: string | undefined;
+export interface GroupedFieldSetDetails {
   groupedFieldSet: GroupedFieldSet;
+  shouldInitiateDefer: boolean;
 }
 
-export interface FieldsAndPatches {
+export interface CollectFieldsResult {
   groupedFieldSet: GroupedFieldSet;
-  patches: Array<PatchFields>;
+  newGroupedFieldSetDetails: Map<DeferUsageSet, GroupedFieldSetDetails>;
+  newDeferUsages: ReadonlyArray<DeferUsage>;
+}
+
+interface CollectFieldsContext {
+  schema: GraphQLSchema;
+  fragments: ObjMap<FragmentDefinitionNode>;
+  variableValues: { [variable: string]: unknown };
+  operation: OperationDefinitionNode;
+  runtimeType: GraphQLObjectType;
+  targetsByKey: Map<string, Set<Target>>;
+  fieldsByTarget: Map<Target, AccumulatorMap<string, FieldNode>>;
+  newDeferUsages: Array<DeferUsage>;
+  visitedFragmentNames: Set<string>;
 }
 
 /**
@@ -55,21 +89,25 @@ export function collectFields(
   variableValues: { [variable: string]: unknown },
   runtimeType: GraphQLObjectType,
   operation: OperationDefinitionNode,
-): FieldsAndPatches {
-  const groupedFieldSet = new AccumulatorMap<string, FieldNode>();
-  const patches: Array<PatchFields> = [];
-  collectFieldsImpl(
+): CollectFieldsResult {
+  const context: CollectFieldsContext = {
     schema,
     fragments,
     variableValues,
-    operation,
     runtimeType,
-    operation.selectionSet,
-    groupedFieldSet,
-    patches,
-    new Set(),
-  );
-  return { groupedFieldSet, patches };
+    operation,
+    fieldsByTarget: new Map(),
+    targetsByKey: new Map(),
+    newDeferUsages: [],
+    visitedFragmentNames: new Set(),
+  };
+
+  collectFieldsImpl(context, operation.selectionSet);
+
+  return {
+    ...buildGroupedFieldSets(context.targetsByKey, context.fieldsByTarget),
+    newDeferUsages: context.newDeferUsages,
+  };
 }
 
 /**
@@ -90,53 +128,74 @@ export function collectSubfields(
   operation: OperationDefinitionNode,
   returnType: GraphQLObjectType,
   fieldGroup: FieldGroup,
-): FieldsAndPatches {
-  const subGroupedFieldSet = new AccumulatorMap<string, FieldNode>();
-  const visitedFragmentNames = new Set<string>();
-
-  const subPatches: Array<PatchFields> = [];
-  const subFieldsAndPatches = {
-    groupedFieldSet: subGroupedFieldSet,
-    patches: subPatches,
+): CollectFieldsResult {
+  const context: CollectFieldsContext = {
+    schema,
+    fragments,
+    variableValues,
+    runtimeType: returnType,
+    operation,
+    fieldsByTarget: new Map(),
+    targetsByKey: new Map(),
+    newDeferUsages: [],
+    visitedFragmentNames: new Set(),
   };
 
-  for (const node of fieldGroup) {
+  for (const fieldDetails of fieldGroup.fields) {
+    const node = fieldDetails.node;
     if (node.selectionSet) {
-      collectFieldsImpl(
-        schema,
-        fragments,
-        variableValues,
-        operation,
-        returnType,
-        node.selectionSet,
-        subGroupedFieldSet,
-        subPatches,
-        visitedFragmentNames,
-      );
+      collectFieldsImpl(context, node.selectionSet, fieldDetails.target);
     }
   }
-  return subFieldsAndPatches;
+
+  return {
+    ...buildGroupedFieldSets(
+      context.targetsByKey,
+      context.fieldsByTarget,
+      fieldGroup.targets,
+    ),
+    newDeferUsages: context.newDeferUsages,
+  };
 }
 
-// eslint-disable-next-line max-params
 function collectFieldsImpl(
-  schema: GraphQLSchema,
-  fragments: ObjMap<FragmentDefinitionNode>,
-  variableValues: { [variable: string]: unknown },
-  operation: OperationDefinitionNode,
-  runtimeType: GraphQLObjectType,
+  context: CollectFieldsContext,
   selectionSet: SelectionSetNode,
-  groupedFieldSet: AccumulatorMap<string, FieldNode>,
-  patches: Array<PatchFields>,
-  visitedFragmentNames: Set<string>,
+  parentTarget?: Target,
+  newTarget?: Target,
 ): void {
+  const {
+    schema,
+    fragments,
+    variableValues,
+    runtimeType,
+    operation,
+    targetsByKey,
+    fieldsByTarget,
+    newDeferUsages,
+    visitedFragmentNames,
+  } = context;
+
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {
       case Kind.FIELD: {
         if (!shouldIncludeNode(variableValues, selection)) {
           continue;
         }
-        groupedFieldSet.add(getFieldEntryKey(selection), selection);
+        const key = getFieldEntryKey(selection);
+        const target = newTarget ?? parentTarget;
+        let keyTargets = targetsByKey.get(key);
+        if (keyTargets === undefined) {
+          keyTargets = new Set();
+          targetsByKey.set(key, keyTargets);
+        }
+        keyTargets.add(target);
+        let targetFields = fieldsByTarget.get(target);
+        if (targetFields === undefined) {
+          targetFields = new AccumulatorMap();
+          fieldsByTarget.set(target, targetFields);
+        }
+        targetFields.add(key, selection);
         break;
       }
       case Kind.INLINE_FRAGMENT: {
@@ -149,36 +208,25 @@ function collectFieldsImpl(
 
         const defer = getDeferValues(operation, variableValues, selection);
 
-        if (defer) {
-          const patchFields = new AccumulatorMap<string, FieldNode>();
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            selection.selectionSet,
-            patchFields,
-            patches,
-            visitedFragmentNames,
-          );
-          patches.push({
-            label: defer.label,
-            groupedFieldSet: patchFields,
-          });
+        let target: Target;
+        if (!defer) {
+          target = newTarget;
         } else {
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            selection.selectionSet,
-            groupedFieldSet,
-            patches,
-            visitedFragmentNames,
-          );
+          const ancestors =
+            parentTarget === undefined
+              ? [parentTarget]
+              : [parentTarget, ...parentTarget.ancestors];
+          target = { ...defer, ancestors };
+          newDeferUsages.push(target);
         }
+
+        collectFieldsImpl(
+          context,
+          selection.selectionSet,
+          parentTarget,
+          target,
+        );
+
         break;
       }
       case Kind.FRAGMENT_SPREAD: {
@@ -201,40 +249,20 @@ function collectFieldsImpl(
           continue;
         }
 
+        let target: Target;
         if (!defer) {
           visitedFragmentNames.add(fragName);
+          target = newTarget;
+        } else {
+          const ancestors =
+            parentTarget === undefined
+              ? [parentTarget]
+              : [parentTarget, ...parentTarget.ancestors];
+          target = { ...defer, ancestors };
+          newDeferUsages.push(target);
         }
 
-        if (defer) {
-          const patchFields = new AccumulatorMap<string, FieldNode>();
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            fragment.selectionSet,
-            patchFields,
-            patches,
-            visitedFragmentNames,
-          );
-          patches.push({
-            label: defer.label,
-            groupedFieldSet: patchFields,
-          });
-        } else {
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            fragment.selectionSet,
-            groupedFieldSet,
-            patches,
-            visitedFragmentNames,
-          );
-        }
+        collectFieldsImpl(context, fragment.selectionSet, parentTarget, target);
         break;
       }
     }
@@ -322,4 +350,144 @@ function doesFragmentConditionMatch(
  */
 function getFieldEntryKey(node: FieldNode): string {
   return node.alias ? node.alias.value : node.name.value;
+}
+
+function buildGroupedFieldSets(
+  targetsByKey: Map<string, Set<Target>>,
+  fieldsByTarget: Map<Target, Map<string, ReadonlyArray<FieldNode>>>,
+  parentTargets = NON_DEFERRED_TARGET_SET,
+): {
+  groupedFieldSet: GroupedFieldSet;
+  newGroupedFieldSetDetails: Map<DeferUsageSet, GroupedFieldSetDetails>;
+} {
+  const { parentTargetKeys, targetSetDetailsMap } = getTargetSetDetails(
+    targetsByKey,
+    parentTargets,
+  );
+
+  const groupedFieldSet =
+    parentTargetKeys.size > 0
+      ? getOrderedGroupedFieldSet(
+          parentTargetKeys,
+          parentTargets,
+          targetsByKey,
+          fieldsByTarget,
+        )
+      : new Map();
+
+  const newGroupedFieldSetDetails = new Map<
+    DeferUsageSet,
+    GroupedFieldSetDetails
+  >();
+
+  for (const [maskingTargets, targetSetDetails] of targetSetDetailsMap) {
+    const { keys, shouldInitiateDefer } = targetSetDetails;
+
+    const newGroupedFieldSet = getOrderedGroupedFieldSet(
+      keys,
+      maskingTargets,
+      targetsByKey,
+      fieldsByTarget,
+    );
+
+    // All TargetSets that causes new grouped field sets consist only of DeferUsages
+    // and have shouldInitiateDefer defined
+    newGroupedFieldSetDetails.set(maskingTargets as DeferUsageSet, {
+      groupedFieldSet: newGroupedFieldSet,
+      shouldInitiateDefer,
+    });
+  }
+
+  return {
+    groupedFieldSet,
+    newGroupedFieldSetDetails,
+  };
+}
+
+interface TargetSetDetails {
+  keys: Set<string>;
+  shouldInitiateDefer: boolean;
+}
+
+function getTargetSetDetails(
+  targetsByKey: Map<string, Set<Target>>,
+  parentTargets: TargetSet,
+): {
+  parentTargetKeys: ReadonlySet<string>;
+  targetSetDetailsMap: Map<TargetSet, TargetSetDetails>;
+} {
+  const parentTargetKeys = new Set<string>();
+  const targetSetDetailsMap = new Map<TargetSet, TargetSetDetails>();
+
+  for (const [responseKey, targets] of targetsByKey) {
+    const maskingTargetList: Array<Target> = [];
+    for (const target of targets) {
+      if (
+        target === undefined ||
+        target.ancestors.every((ancestor) => !targets.has(ancestor))
+      ) {
+        maskingTargetList.push(target);
+      }
+    }
+
+    const maskingTargets: TargetSet = new Set<Target>(maskingTargetList);
+    if (isSameSet(maskingTargets, parentTargets)) {
+      parentTargetKeys.add(responseKey);
+      continue;
+    }
+
+    let targetSetDetails = getBySet(targetSetDetailsMap, maskingTargets);
+    if (targetSetDetails === undefined) {
+      targetSetDetails = {
+        keys: new Set(),
+        shouldInitiateDefer: maskingTargetList.some(
+          (deferUsage) => !parentTargets.has(deferUsage),
+        ),
+      };
+      targetSetDetailsMap.set(maskingTargets, targetSetDetails);
+    }
+    targetSetDetails.keys.add(responseKey);
+  }
+
+  return {
+    parentTargetKeys,
+    targetSetDetailsMap,
+  };
+}
+
+function getOrderedGroupedFieldSet(
+  keys: ReadonlySet<string>,
+  maskingTargets: TargetSet,
+  targetsByKey: Map<string, Set<Target>>,
+  fieldsByTarget: Map<Target, Map<string, ReadonlyArray<FieldNode>>>,
+): GroupedFieldSet {
+  const groupedFieldSet = new Map<
+    string,
+    { fields: Array<FieldDetails>; targets: TargetSet }
+  >();
+
+  const firstTarget = maskingTargets.values().next().value as Target;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const firstFields = fieldsByTarget.get(firstTarget)!;
+  for (const [key] of firstFields) {
+    if (keys.has(key)) {
+      let fieldGroup = groupedFieldSet.get(key);
+      if (fieldGroup === undefined) {
+        fieldGroup = { fields: [], targets: maskingTargets };
+        groupedFieldSet.set(key, fieldGroup);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      for (const target of targetsByKey.get(key)!) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const fieldsForTarget = fieldsByTarget.get(target)!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const nodes = fieldsForTarget.get(key)!;
+        // the following line is an optional minor optimization
+        fieldsForTarget.delete(key);
+        fieldGroup.fields.push(...nodes.map((node) => ({ node, target })));
+      }
+    }
+  }
+
+  return groupedFieldSet;
 }

--- a/src/jsutils/getBySet.ts
+++ b/src/jsutils/getBySet.ts
@@ -1,0 +1,13 @@
+import { isSameSet } from './isSameSet.js';
+
+export function getBySet<T, U>(
+  map: ReadonlyMap<ReadonlySet<T>, U>,
+  setToMatch: ReadonlySet<T>,
+): U | undefined {
+  for (const set of map.keys()) {
+    if (isSameSet(set, setToMatch)) {
+      return map.get(set);
+    }
+  }
+  return undefined;
+}

--- a/src/jsutils/isSameSet.ts
+++ b/src/jsutils/isSameSet.ts
@@ -1,0 +1,14 @@
+export function isSameSet<T>(
+  setA: ReadonlySet<T>,
+  setB: ReadonlySet<T>,
+): boolean {
+  if (setA.size !== setB.size) {
+    return false;
+  }
+  for (const item of setA) {
+    if (!setB.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
This in the main PR implements the major ideas from the latest incremental delivery proposal, https://github.com/graphql/defer-stream-wg/discussions/69 which is centered around the idea of deduplication of execution and delivery.

This PR is part of the following stack:

#3886 = main PR (this PR!) switching to deduplication of execution/delivery
#3897 = adds pending
#3911 = adds helpers to resolvers to further delay execution of deferred fields or manage concurrency
#3895 = consolidates payloads

TODO:
[x] convert existing tests
[x] error handling
[x] filter late nulls correctly
[x] defer/streams interactions
[x] completed
[x] pending
[ ] ids and subpaths instead of paths
[ ] even more tests?