### PR TITLE
doc: add note to `printSchema` about the missing directives

### DIFF
--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -36,6 +36,18 @@ import type { GraphQLSchema } from '../type/schema.js';
 
 import { astFromValue } from './astFromValue.js';
 
+/**
+ * Returns a string representation of the given `GraphQLSchema` in SDL format.
+ * 
+ * **Note**: This function will *not* print directives in the SDL format.
+ * If your intent is to print a schema with directives, use [`printSchemaWithDirectives`](https://the-guild.dev/graphql/tools/docs/api/modules/utils_src#printschemawithdirectives) instead.
+ *
+ * ## Example
+ * Given a schema, convert it to SDL
+ * ```
+ * const sdl = printSchema(schema);
+ * ```
+ */
 export function printSchema(schema: GraphQLSchema): string {
   return printFilteredSchema(
     schema,


### PR DESCRIPTION
This adds jsDoc to the `printSchema` to raise awareness that it won't include directives like the `@oneOf` directive.

If the user intended to have those directives then use the [`printSchemaWithDirectives`](https://the-guild.dev/graphql/tools/docs/api/modules/utils_src#printschemawithdirectives) instead.