### PR TITLE
introduce new IncrementalPublisher class

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -1,7 +1,6 @@
 import type { ObjMap } from '../jsutils/ObjMap.js';
 import type { Path } from '../jsutils/Path.js';
 import { pathToArray } from '../jsutils/Path.js';
-import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
 import { promiseWithResolvers } from '../jsutils/promiseWithResolvers.js';
 
 import type {
@@ -85,237 +84,401 @@ export type FormattedIncrementalResult<
   | FormattedIncrementalDeferResult<TData, TExtensions>
   | FormattedIncrementalStreamResult<TData, TExtensions>;
 
-export function yieldSubsequentPayloads(
-  subsequentPayloads: Set<IncrementalDataRecord>,
-): AsyncGenerator<SubsequentIncrementalExecutionResult, void, void> {
-  let isDone = false;
+/**
+ * This class is used to publish incremental results to the client, enabling semi-concurrent
+ * execution while preserving result order.
+ *
+ * The internal publishing state is manages as follows:
+ *
+ * '_released': the set of Incremental Data records that are ready to be sent to the client,
+ * i.e. their parents have completed and they have also completed.
+ *
+ * `_pending`: the set of Incremental Data records that are definitely pending, i.e. their
+ * parents have completed so that they can no longer be filtered. This includes all Incremental
+ * Data records in `released`, as well as Incremental Data records that have not yet completed.
+ *
+ * `initialResult`: a record containing the state of the initial result, as follows:
+ * `isCompleted`: indicates whether the initial result has completed.
+ * `children`: the set of Incremental Data records that can be be published when the initial
+ * result is completed.
+ *
+ * Each Incremental Data record also contains similar metadata, i.e. these records also contain
+ * similar `isCompleted` and `children` properties.
+ *
+ * @internal
+ */
+export class IncrementalPublisher {
+  initialResult: {
+    children: Set<IncrementalDataRecord>;
+    isCompleted: boolean;
+  };
 
-  async function next(): Promise<
-    IteratorResult<SubsequentIncrementalExecutionResult, void>
+  _released: Set<IncrementalDataRecord>;
+  _pending: Set<IncrementalDataRecord>;
+
+  // these are assigned within the Promise executor called synchronously within the constructor
+  _signalled!: Promise<unknown>;
+  _resolve!: () => void;
+
+  constructor() {
+    this.initialResult = {
+      children: new Set(),
+      isCompleted: false,
+    };
+    this._released = new Set();
+    this._pending = new Set();
+    this._reset();
+  }
+
+  _trigger() {
+    this._resolve();
+    this._reset();
+  }
+
+  _reset() {
+    // promiseWithResolvers uses void only as a generic type parameter
+    // see: https://typescript-eslint.io/rules/no-invalid-void-type/
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    const { promise: signalled, resolve } = promiseWithResolvers<void>();
+    this._resolve = resolve;
+    this._signalled = signalled;
+  }
+
+  hasNext(): boolean {
+    return this._pending.size > 0;
+  }
+
+  _introduce(item: IncrementalDataRecord) {
+    this._pending.add(item);
+  }
+
+  _release(item: IncrementalDataRecord): void {
+    if (this._pending.has(item)) {
+      this._released.add(item);
+      this._trigger();
+    }
+  }
+
+  _push(item: IncrementalDataRecord): void {
+    this._released.add(item);
+    this._pending.add(item);
+    this._trigger();
+  }
+
+  _delete(item: IncrementalDataRecord) {
+    this._released.delete(item);
+    this._pending.delete(item);
+    this._trigger();
+  }
+
+  subscribe(): AsyncGenerator<
+    SubsequentIncrementalExecutionResult,
+    void,
+    void
   > {
-    if (isDone) {
-      return { value: undefined, done: true };
-    }
+    let isDone = false;
 
-    await Promise.race(Array.from(subsequentPayloads).map((p) => p.promise));
+    const _next = async (): Promise<
+      IteratorResult<SubsequentIncrementalExecutionResult, void>
+    > => {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if (isDone) {
+          return { value: undefined, done: true };
+        }
 
-    if (isDone) {
-      // a different call to next has exhausted all payloads
-      return { value: undefined, done: true };
-    }
+        for (const item of this._released) {
+          this._pending.delete(item);
+        }
+        const released = this._released;
+        this._released = new Set();
 
-    const incremental = getCompletedIncrementalResults(subsequentPayloads);
-    const hasNext = subsequentPayloads.size > 0;
+        const result = this._getIncrementalResult(released);
 
-    if (!incremental.length && hasNext) {
-      return next();
-    }
+        if (!this.hasNext()) {
+          isDone = true;
+        }
 
-    if (!hasNext) {
+        if (result !== undefined) {
+          return { value: result, done: false };
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await this._signalled;
+      }
+    };
+
+    const returnStreamIterators = async (): Promise<void> => {
+      const promises: Array<Promise<IteratorResult<unknown>>> = [];
+      this._pending.forEach((incrementalDataRecord) => {
+        if (
+          isStreamItemsRecord(incrementalDataRecord) &&
+          incrementalDataRecord.asyncIterator?.return
+        ) {
+          promises.push(incrementalDataRecord.asyncIterator.return());
+        }
+      });
+      await Promise.all(promises);
+    };
+
+    const _return = async (): Promise<
+      IteratorResult<SubsequentIncrementalExecutionResult, void>
+    > => {
       isDone = true;
-    }
+      await returnStreamIterators();
+      return { value: undefined, done: true };
+    };
+
+    const _throw = async (
+      error?: unknown,
+    ): Promise<IteratorResult<SubsequentIncrementalExecutionResult, void>> => {
+      isDone = true;
+      await returnStreamIterators();
+      return Promise.reject(error);
+    };
 
     return {
-      value: incremental.length ? { incremental, hasNext } : { hasNext },
-      done: false,
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: _next,
+      return: _return,
+      throw: _throw,
     };
   }
 
-  function returnStreamIterators() {
-    const promises: Array<Promise<IteratorResult<unknown>>> = [];
-    subsequentPayloads.forEach((incrementalDataRecord) => {
-      if (
-        isStreamItemsRecord(incrementalDataRecord) &&
-        incrementalDataRecord.asyncIterator?.return
-      ) {
-        promises.push(incrementalDataRecord.asyncIterator.return());
+  _getIncrementalResult(
+    completedRecords: ReadonlySet<IncrementalDataRecord>,
+  ): SubsequentIncrementalExecutionResult | undefined {
+    const incrementalResults: Array<IncrementalResult> = [];
+    let encounteredCompletedAsyncIterator = false;
+    for (const incrementalDataRecord of completedRecords) {
+      const incrementalResult: IncrementalResult = {};
+      for (const child of incrementalDataRecord.children) {
+        this._publish(child);
       }
-    });
-    return Promise.all(promises);
+      if (isStreamItemsRecord(incrementalDataRecord)) {
+        const items = incrementalDataRecord.items;
+        if (incrementalDataRecord.isCompletedAsyncIterator) {
+          // async iterable resolver just finished but there may be pending payloads
+          encounteredCompletedAsyncIterator = true;
+          continue;
+        }
+        (incrementalResult as IncrementalStreamResult).items = items;
+      } else {
+        const data = incrementalDataRecord.data;
+        (incrementalResult as IncrementalDeferResult).data = data ?? null;
+      }
+
+      incrementalResult.path = incrementalDataRecord.path;
+      if (incrementalDataRecord.label != null) {
+        incrementalResult.label = incrementalDataRecord.label;
+      }
+      if (incrementalDataRecord.errors.length > 0) {
+        incrementalResult.errors = incrementalDataRecord.errors;
+      }
+      incrementalResults.push(incrementalResult);
+    }
+
+    return incrementalResults.length
+      ? { incremental: incrementalResults, hasNext: this.hasNext() }
+      : encounteredCompletedAsyncIterator && !this.hasNext()
+      ? { hasNext: false }
+      : undefined;
   }
 
-  return {
-    [Symbol.asyncIterator]() {
-      return this;
-    },
-    next,
-    async return(): Promise<
-      IteratorResult<SubsequentIncrementalExecutionResult, void>
-    > {
-      await returnStreamIterators();
-      isDone = true;
-      return { value: undefined, done: true };
-    },
-    async throw(
-      error?: unknown,
-    ): Promise<IteratorResult<SubsequentIncrementalExecutionResult, void>> {
-      await returnStreamIterators();
-      isDone = true;
-      return Promise.reject(error);
-    },
-  };
-}
+  prepareNewDeferredFragmentRecord(opts: {
+    label: string | undefined;
+    path: Path | undefined;
+    parentContext: IncrementalDataRecord | undefined;
+  }): DeferredFragmentRecord {
+    const deferredFragmentRecord = new DeferredFragmentRecord(opts);
 
-function getCompletedIncrementalResults(
-  subsequentPayloads: Set<IncrementalDataRecord>,
-): Array<IncrementalResult> {
-  const incrementalResults: Array<IncrementalResult> = [];
-  for (const incrementalDataRecord of subsequentPayloads) {
-    const incrementalResult: IncrementalResult = {};
-    if (!incrementalDataRecord.isCompleted) {
-      continue;
+    const parentContext = opts.parentContext;
+    if (parentContext) {
+      parentContext.children.add(deferredFragmentRecord);
+    } else {
+      this.initialResult.children.add(deferredFragmentRecord);
     }
-    subsequentPayloads.delete(incrementalDataRecord);
-    if (isStreamItemsRecord(incrementalDataRecord)) {
-      const items = incrementalDataRecord.items;
-      if (incrementalDataRecord.isCompletedAsyncIterator) {
-        // async iterable resolver just finished but there may be pending payloads
+
+    return deferredFragmentRecord;
+  }
+
+  prepareNewStreamItemsRecord(opts: {
+    label: string | undefined;
+    path: Path | undefined;
+    asyncIterator?: AsyncIterator<unknown>;
+    parentContext: IncrementalDataRecord | undefined;
+  }): StreamItemsRecord {
+    const streamItemsRecord = new StreamItemsRecord(opts);
+
+    const parentContext = opts.parentContext;
+    if (parentContext) {
+      parentContext.children.add(streamItemsRecord);
+    } else {
+      this.initialResult.children.add(streamItemsRecord);
+    }
+
+    return streamItemsRecord;
+  }
+
+  completeDeferredFragmentRecord(
+    deferredFragmentRecord: DeferredFragmentRecord,
+    data: ObjMap<unknown> | null,
+  ): void {
+    deferredFragmentRecord.data = data;
+    deferredFragmentRecord.isCompleted = true;
+    this._release(deferredFragmentRecord);
+  }
+
+  completeStreamItemsRecord(
+    streamItemsRecord: StreamItemsRecord,
+    items: Array<unknown> | null,
+  ) {
+    streamItemsRecord.items = items;
+    streamItemsRecord.isCompleted = true;
+    this._release(streamItemsRecord);
+  }
+
+  setIsCompletedAsyncIterator(streamItemsRecord: StreamItemsRecord) {
+    streamItemsRecord.isCompletedAsyncIterator = true;
+  }
+
+  addFieldError(
+    incrementalDataRecord: IncrementalDataRecord,
+    error: GraphQLError,
+  ) {
+    incrementalDataRecord.errors.push(error);
+  }
+
+  publishInitial() {
+    for (const child of this.initialResult.children) {
+      this._publish(child);
+    }
+  }
+
+  _publish(incrementalDataRecord: IncrementalDataRecord) {
+    if (incrementalDataRecord.isCompleted) {
+      this._push(incrementalDataRecord);
+    } else {
+      this._introduce(incrementalDataRecord);
+    }
+  }
+
+  filter(
+    nullPath: Path,
+    erroringIncrementalDataRecord: IncrementalDataRecord | undefined,
+  ) {
+    const nullPathArray = pathToArray(nullPath);
+
+    const asyncIterators = new Set<AsyncIterator<unknown>>();
+
+    const children =
+      erroringIncrementalDataRecord === undefined
+        ? this.initialResult.children
+        : erroringIncrementalDataRecord.children;
+
+    for (const child of this._getDescendants(children)) {
+      if (!this._matchesPath(child.path, nullPathArray)) {
         continue;
       }
-      (incrementalResult as IncrementalStreamResult).items = items;
-    } else {
-      const data = incrementalDataRecord.data;
-      (incrementalResult as IncrementalDeferResult).data = data ?? null;
-    }
 
-    incrementalResult.path = incrementalDataRecord.path;
-    if (incrementalDataRecord.label != null) {
-      incrementalResult.label = incrementalDataRecord.label;
-    }
-    if (incrementalDataRecord.errors.length > 0) {
-      incrementalResult.errors = incrementalDataRecord.errors;
-    }
-    incrementalResults.push(incrementalResult);
-  }
-  return incrementalResults;
-}
+      this._delete(child);
+      const parent =
+        child.parentContext === undefined
+          ? this.initialResult
+          : child.parentContext;
+      parent.children.delete(child);
 
-export function filterSubsequentPayloads(
-  subsequentPayloads: Set<IncrementalDataRecord>,
-  nullPath: Path,
-  currentIncrementalDataRecord: IncrementalDataRecord | undefined,
-): void {
-  const nullPathArray = pathToArray(nullPath);
-  subsequentPayloads.forEach((incrementalDataRecord) => {
-    if (incrementalDataRecord === currentIncrementalDataRecord) {
-      // don't remove payload from where error originates
-      return;
-    }
-    for (let i = 0; i < nullPathArray.length; i++) {
-      if (incrementalDataRecord.path[i] !== nullPathArray[i]) {
-        // incrementalDataRecord points to a path unaffected by this payload
-        return;
+      if (isStreamItemsRecord(child)) {
+        if (child.asyncIterator !== undefined) {
+          asyncIterators.add(child.asyncIterator);
+        }
       }
     }
-    // incrementalDataRecord path points to nulled error field
-    if (
-      isStreamItemsRecord(incrementalDataRecord) &&
-      incrementalDataRecord.asyncIterator?.return
-    ) {
-      incrementalDataRecord.asyncIterator.return().catch(() => {
+
+    asyncIterators.forEach((asyncIterator) => {
+      asyncIterator.return?.().catch(() => {
         // ignore error
       });
+    });
+  }
+
+  _getDescendants(
+    children: ReadonlySet<IncrementalDataRecord>,
+    descendants = new Set<IncrementalDataRecord>(),
+  ): ReadonlySet<IncrementalDataRecord> {
+    for (const child of children) {
+      descendants.add(child);
+      this._getDescendants(child.children, descendants);
     }
-    subsequentPayloads.delete(incrementalDataRecord);
-  });
+    return descendants;
+  }
+
+  _matchesPath(
+    testPath: Array<string | number>,
+    basePath: Array<string | number>,
+  ): boolean {
+    for (let i = 0; i < basePath.length; i++) {
+      if (basePath[i] !== testPath[i]) {
+        // testPath points to a path unaffected at basePath
+        return false;
+      }
+    }
+    return true;
+  }
 }
 
 /** @internal */
 export class DeferredFragmentRecord {
-  type: 'defer';
   errors: Array<GraphQLError>;
   label: string | undefined;
   path: Array<string | number>;
-  promise: Promise<void>;
   data: ObjMap<unknown> | null;
   parentContext: IncrementalDataRecord | undefined;
+  children: Set<IncrementalDataRecord>;
   isCompleted: boolean;
-  _subsequentPayloads: Set<IncrementalDataRecord>;
-  _resolve?: (arg: PromiseOrValue<ObjMap<unknown> | null>) => void;
   constructor(opts: {
     label: string | undefined;
     path: Path | undefined;
     parentContext: IncrementalDataRecord | undefined;
-    subsequentPayloads: Set<IncrementalDataRecord>;
   }) {
-    this.type = 'defer';
     this.label = opts.label;
     this.path = pathToArray(opts.path);
     this.parentContext = opts.parentContext;
     this.errors = [];
-    this._subsequentPayloads = opts.subsequentPayloads;
-    this._subsequentPayloads.add(this);
+    this.children = new Set();
     this.isCompleted = false;
     this.data = null;
-    const { promise, resolve } = promiseWithResolvers<ObjMap<unknown> | null>();
-    this._resolve = resolve;
-    this.promise = promise.then((data) => {
-      this.data = data;
-      this.isCompleted = true;
-    });
-  }
-
-  addData(data: PromiseOrValue<ObjMap<unknown> | null>) {
-    const parentData = this.parentContext?.promise;
-    if (parentData) {
-      this._resolve?.(parentData.then(() => data));
-      return;
-    }
-    this._resolve?.(data);
   }
 }
 
 /** @internal */
 export class StreamItemsRecord {
-  type: 'stream';
   errors: Array<GraphQLError>;
   label: string | undefined;
   path: Array<string | number>;
   items: Array<unknown> | null;
-  promise: Promise<void>;
   parentContext: IncrementalDataRecord | undefined;
+  children: Set<IncrementalDataRecord>;
   asyncIterator: AsyncIterator<unknown> | undefined;
   isCompletedAsyncIterator?: boolean;
   isCompleted: boolean;
-  _subsequentPayloads: Set<IncrementalDataRecord>;
-  _resolve?: (arg: PromiseOrValue<Array<unknown> | null>) => void;
   constructor(opts: {
     label: string | undefined;
     path: Path | undefined;
     asyncIterator?: AsyncIterator<unknown>;
     parentContext: IncrementalDataRecord | undefined;
-    subsequentPayloads: Set<IncrementalDataRecord>;
   }) {
-    this.type = 'stream';
     this.items = null;
     this.label = opts.label;
     this.path = pathToArray(opts.path);
     this.parentContext = opts.parentContext;
     this.asyncIterator = opts.asyncIterator;
     this.errors = [];
-    this._subsequentPayloads = opts.subsequentPayloads;
-    this._subsequentPayloads.add(this);
+    this.children = new Set();
     this.isCompleted = false;
     this.items = null;
-    const { promise, resolve } = promiseWithResolvers<Array<unknown> | null>();
-    this._resolve = resolve;
-    this.promise = promise.then((items) => {
-      this.items = items;
-      this.isCompleted = true;
-    });
-  }
-
-  addItems(items: PromiseOrValue<Array<unknown> | null>) {
-    const parentData = this.parentContext?.promise;
-    if (parentData) {
-      this._resolve?.(parentData.then(() => items));
-      return;
-    }
-    this._resolve?.(items);
-  }
-
-  setIsCompletedAsyncIterator() {
-    this.isCompletedAsyncIterator = true;
   }
 }
 
@@ -324,5 +487,5 @@ export type IncrementalDataRecord = DeferredFragmentRecord | StreamItemsRecord;
 function isStreamItemsRecord(
   incrementalDataRecord: IncrementalDataRecord,
 ): incrementalDataRecord is StreamItemsRecord {
-  return incrementalDataRecord.type === 'stream';
+  return incrementalDataRecord instanceof StreamItemsRecord;
 }

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -88,7 +88,7 @@ export type FormattedIncrementalResult<
  * This class is used to publish incremental results to the client, enabling semi-concurrent
  * execution while preserving result order.
  *
- * The internal publishing state is manages as follows:
+ * The internal publishing state is managed as follows:
  *
  * '_released': the set of Incremental Data records that are ready to be sent to the client,
  * i.e. their parents have completed and they have also completed.
@@ -97,7 +97,7 @@ export type FormattedIncrementalResult<
  * parents have completed so that they can no longer be filtered. This includes all Incremental
  * Data records in `released`, as well as Incremental Data records that have not yet completed.
  *
- * `initialResult`: a record containing the state of the initial result, as follows:
+ * `_initialResult`: a record containing the state of the initial result, as follows:
  * `isCompleted`: indicates whether the initial result has completed.
  * `children`: the set of Incremental Data records that can be be published when the initial
  * result is completed.

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -1165,9 +1165,6 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        hasNext: true,
-      },
-      {
         hasNext: false,
       },
     ]);
@@ -1191,25 +1188,19 @@ describe('Execute: stream directive', () => {
         } /* c8 ignore stop */,
       },
     });
-    expectJSON(result).toDeepEqual([
-      {
-        errors: [
-          {
-            message:
-              'Cannot return null for non-nullable field NestedObject.nonNullScalarField.',
-            locations: [{ line: 4, column: 11 }],
-            path: ['nestedObject', 'nonNullScalarField'],
-          },
-        ],
-        data: {
-          nestedObject: null,
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field NestedObject.nonNullScalarField.',
+          locations: [{ line: 4, column: 11 }],
+          path: ['nestedObject', 'nonNullScalarField'],
         },
-        hasNext: true,
+      ],
+      data: {
+        nestedObject: null,
       },
-      {
-        hasNext: false,
-      },
-    ]);
+    });
   });
   it('Filters payloads that are nulled by a later synchronous error', async () => {
     const document = parse(`
@@ -1293,6 +1284,9 @@ describe('Execute: stream directive', () => {
             path: ['nestedObject', 'nestedFriendList', 0],
           },
         ],
+        hasNext: true,
+      },
+      {
         hasNext: false,
       },
     ]);
@@ -1350,9 +1344,6 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        hasNext: true,
-      },
-      {
         hasNext: false,
       },
     ]);


### PR DESCRIPTION
extracted from #3886

depends on #3903

more refactors from the without-branching branch, a bit more fundamental than #3891

[set as patch release because it does have an observable effect on the number of payloads, see below]

= iterate only through completed items
= remove extra ticks by making the publisher manage changes to its state synchronously.
= use children array instead of promises to manage hierarchy
= have IncrementalPublisher instantiate new IncrementalDataRecords

= The new publisher sometimes cause an empty `{ hasNext: false }` to be emitted. In particular, because the publisher is faster than it was, it may emit a stream result before the stream's asynchronous iterator has completed.
= The new publisher may sometimes reduce the number of `{ hasNext: false }` records that are emitted. For example, when errors on the initial result filter all subsequent results, this now happens synchronously, and so the publisher knows immediately that there are no subsequent results, such that there is no need for an empty final payload.