### PR TITLE
incremental delivery: inline available payloads

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -584,10 +584,15 @@ export class IncrementalPublisher {
       }
       if (isStreamItemsRecord(subsequentResultRecord)) {
         if (subsequentResultRecord.isFinalRecord) {
-          newPendingSources.delete(subsequentResultRecord.streamRecord);
-          completedResults.push(
-            this._completedRecordToResult(subsequentResultRecord.streamRecord),
-          );
+          if (newPendingSources.has(subsequentResultRecord.streamRecord)) {
+            newPendingSources.delete(subsequentResultRecord.streamRecord);
+          } else {
+            completedResults.push(
+              this._completedRecordToResult(
+                subsequentResultRecord.streamRecord,
+              ),
+            );
+          }
         }
         if (subsequentResultRecord.isCompletedAsyncIterator) {
           // async iterable resolver just finished but there may be pending payloads
@@ -650,10 +655,13 @@ export class IncrementalPublisher {
           );
         }
       } else {
-        newPendingSources.delete(subsequentResultRecord);
-        completedResults.push(
-          this._completedRecordToResult(subsequentResultRecord),
-        );
+        if (newPendingSources.has(subsequentResultRecord)) {
+          newPendingSources.delete(subsequentResultRecord);
+        } else {
+          completedResults.push(
+            this._completedRecordToResult(subsequentResultRecord),
+          );
+        }
         if (subsequentResultRecord.errors.length > 0) {
           continue;
         }

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1191,11 +1191,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [
-          { path: ['hero'] },
-          { path: ['hero', 'nestedObject'] },
-          { path: ['hero', 'nestedObject', 'deeperObject'] },
-        ],
+        completed: [{ path: ['hero'] }],
         hasNext: false,
       },
     ]);
@@ -1260,7 +1256,6 @@ describe('Execute: defer directive', () => {
         ],
         completed: [
           { path: ['hero'] },
-          { path: ['hero', 'nestedObject', 'deeperObject'] },
           { path: ['hero', 'nestedObject', 'deeperObject'] },
         ],
         hasNext: false,
@@ -2094,12 +2089,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [
-          { path: ['hero'] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
-        ],
+        completed: [{ path: ['hero'] }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1177,35 +1177,25 @@ describe('Execute: defer directive', () => {
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero', 'nestedObject'] }],
         incremental: [
           {
             data: { bar: 'bar' },
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
-        ],
-        completed: [{ path: ['hero'] }],
-        hasNext: true,
-      },
-      {
-        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
-        incremental: [
           {
             data: { baz: 'baz' },
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
-        ],
-        hasNext: true,
-        completed: [{ path: ['hero', 'nestedObject'] }],
-      },
-      {
-        incremental: [
           {
             data: { bak: 'bak' },
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        completed: [
+          { path: ['hero'] },
+          { path: ['hero', 'nestedObject'] },
+          { path: ['hero', 'nestedObject', 'deeperObject'] },
+        ],
         hasNext: false,
       },
     ]);
@@ -1254,7 +1244,6 @@ describe('Execute: defer directive', () => {
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: {
@@ -1262,15 +1251,6 @@ describe('Execute: defer directive', () => {
             },
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
-        ],
-        completed: [
-          { path: ['hero'] },
-          { path: ['hero', 'nestedObject', 'deeperObject'] },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             data: {
               bar: 'bar',
@@ -1278,7 +1258,11 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        completed: [
+          { path: ['hero'] },
+          { path: ['hero', 'nestedObject', 'deeperObject'] },
+          { path: ['hero', 'nestedObject', 'deeperObject'] },
+        ],
         hasNext: false,
       },
     ]);
@@ -2101,27 +2085,17 @@ describe('Execute: defer directive', () => {
         hasNext: true,
       },
       {
-        pending: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
-        ],
         incremental: [
           {
             data: { name: 'slow', friends: [{}, {}, {}] },
             path: ['hero'],
           },
-        ],
-        completed: [{ path: ['hero'] }],
-        hasNext: true,
-      },
-      {
-        incremental: [
           { data: { name: 'Han' }, path: ['hero', 'friends', 0] },
           { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
           { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
         completed: [
+          { path: ['hero'] },
           { path: ['hero', 'friends', 0] },
           { path: ['hero', 'friends', 1] },
           { path: ['hero', 'friends', 2] },

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -176,6 +176,7 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -231,6 +232,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -261,6 +263,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
+        pending: [{ path: [], label: 'DeferQuery' }],
         hasNext: true,
       },
       {
@@ -302,6 +305,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
+        pending: [{ path: [], label: 'DeferQuery' }],
         hasNext: true,
       },
       {
@@ -351,6 +355,10 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
+        pending: [
+          { path: ['hero'], label: 'DeferTop' },
+          { path: ['hero'], label: 'DeferNested' },
+        ],
         hasNext: true,
       },
       {
@@ -396,6 +404,7 @@ describe('Execute: defer directive', () => {
             name: 'Luke',
           },
         },
+        pending: [{ path: ['hero'], label: 'DeferTop' }],
         hasNext: true,
       },
       {
@@ -424,6 +433,7 @@ describe('Execute: defer directive', () => {
             name: 'Luke',
           },
         },
+        pending: [{ path: ['hero'], label: 'DeferTop' }],
         hasNext: true,
       },
       {
@@ -449,6 +459,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
+        pending: [{ path: ['hero'], label: 'InlineDeferred' }],
         hasNext: true,
       },
       {
@@ -478,6 +489,7 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -506,6 +518,10 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
+        pending: [
+          { path: ['hero'], label: 'DeferID' },
+          { path: ['hero'], label: 'DeferName' },
+        ],
         hasNext: true,
       },
       {
@@ -551,6 +567,10 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
+        pending: [
+          { path: [], label: 'DeferID' },
+          { path: [], label: 'DeferName' },
+        ],
         hasNext: true,
       },
       {
@@ -601,6 +621,10 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
+        pending: [
+          { path: [], label: 'DeferID' },
+          { path: [], label: 'DeferName' },
+        ],
         hasNext: true,
       },
       {
@@ -648,6 +672,10 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
+        pending: [
+          { path: [], label: 'DeferName' },
+          { path: ['hero'], label: 'DeferID' },
+        ],
         hasNext: true,
       },
       {
@@ -691,9 +719,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
+        pending: [{ path: [], label: 'DeferName' }],
         hasNext: true,
       },
       {
+        pending: [{ path: ['hero'], label: 'DeferID' }],
         incremental: [
           {
             data: {
@@ -753,6 +783,20 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [{}, {}, {}] } },
+        pending: [
+          { path: ['hero', 'friends', 0] },
+          { path: ['hero', 'friends', 0] },
+          { path: ['hero', 'friends', 0] },
+          { path: ['hero', 'friends', 0] },
+          { path: ['hero', 'friends', 1] },
+          { path: ['hero', 'friends', 1] },
+          { path: ['hero', 'friends', 1] },
+          { path: ['hero', 'friends', 1] },
+          { path: ['hero', 'friends', 2] },
+          { path: ['hero', 'friends', 2] },
+          { path: ['hero', 'friends', 2] },
+          { path: ['hero', 'friends', 2] },
+        ],
         hasNext: true,
       },
       {
@@ -831,6 +875,7 @@ describe('Execute: defer directive', () => {
             },
           },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -872,9 +917,11 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
+        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: {
@@ -954,9 +1001,11 @@ describe('Execute: defer directive', () => {
             },
           },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
+        pending: [{ path: ['hero', 'nestedObject'] }],
         incremental: [
           {
             data: { bar: 'bar' },
@@ -967,6 +1016,7 @@ describe('Execute: defer directive', () => {
         hasNext: true,
       },
       {
+        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: { baz: 'baz' },
@@ -1025,9 +1075,14 @@ describe('Execute: defer directive', () => {
             },
           },
         },
+        pending: [
+          { path: ['hero'] },
+          { path: ['hero', 'nestedObject', 'deeperObject'] },
+        ],
         hasNext: true,
       },
       {
+        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: {
@@ -1106,6 +1161,7 @@ describe('Execute: defer directive', () => {
             },
           },
         },
+        pending: [{ path: [] }, { path: ['a', 'b'] }],
         hasNext: true,
       },
       {
@@ -1157,6 +1213,7 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
+        pending: [{ path: [] }, { path: ['a'] }],
         hasNext: true,
       },
       {
@@ -1224,6 +1281,7 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
+        pending: [{ path: [] }, { path: ['a'] }],
         hasNext: true,
       },
       {
@@ -1299,6 +1357,7 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
+        pending: [{ path: [] }, { path: ['a'] }],
         hasNext: true,
       },
       {
@@ -1388,6 +1447,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
+        pending: [{ path: [] }],
         hasNext: true,
       },
       {
@@ -1436,6 +1496,7 @@ describe('Execute: defer directive', () => {
             friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
           },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1471,6 +1532,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [{ name: 'Han' }] } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1507,6 +1569,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [] } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1539,6 +1602,7 @@ describe('Execute: defer directive', () => {
             friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
           },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1586,6 +1650,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [] } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1619,6 +1684,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { nestedObject: null } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1651,6 +1717,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { nestedObject: { name: 'foo' } } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1683,6 +1750,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1725,6 +1793,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1803,6 +1872,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1855,9 +1925,15 @@ describe('Execute: defer directive', () => {
         data: {
           hero: { id: '1' },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
+        pending: [
+          { path: ['hero', 'friends', 0] },
+          { path: ['hero', 'friends', 1] },
+          { path: ['hero', 'friends', 2] },
+        ],
         incremental: [
           {
             data: { name: 'slow', friends: [{}, {}, {}] },
@@ -1906,9 +1982,15 @@ describe('Execute: defer directive', () => {
         data: {
           hero: { id: '1' },
         },
+        pending: [{ path: ['hero'] }],
         hasNext: true,
       },
       {
+        pending: [
+          { path: ['hero', 'friends', 0] },
+          { path: ['hero', 'friends', 1] },
+          { path: ['hero', 'friends', 2] },
+        ],
         incremental: [
           {
             data: {

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -2087,12 +2087,12 @@ describe('Execute: defer directive', () => {
       {
         incremental: [
           {
-            data: { name: 'slow', friends: [{}, {}, {}] },
+            data: {
+              name: 'slow',
+              friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
+            },
             path: ['hero'],
           },
-          { data: { name: 'Han' }, path: ['hero', 'friends', 0] },
-          { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
-          { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
         completed: [
           { path: ['hero'] },

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1,13 +1,17 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
+import { isPromise } from '../../jsutils/isPromise.js';
+
 import type { DocumentNode } from '../../language/ast.js';
+import { Kind } from '../../language/kinds.js';
 import { parse } from '../../language/parser.js';
 
+import type { FieldDetails } from '../../type/definition.js';
 import {
   GraphQLList,
   GraphQLNonNull,
@@ -215,6 +219,174 @@ describe('Execute: defer directive', () => {
         },
       },
     });
+  });
+  it('Can provides correct info about deferred execution state when resolver could defer', async () => {
+    let fieldDetails: ReadonlyArray<FieldDetails> | undefined;
+    let deferPriority;
+    let published;
+    let resumed;
+
+    const SomeType = new GraphQLObjectType({
+      name: 'SomeType',
+      fields: {
+        someField: {
+          type: GraphQLString,
+          resolve: () => Promise.resolve('someField'),
+        },
+        deferredField: {
+          type: GraphQLString,
+          resolve: async (_parent, _args, _context, info) => {
+            fieldDetails = info.fieldDetails;
+            deferPriority = info.deferPriority;
+            published = info.published;
+            await published;
+            resumed = true;
+          },
+        },
+      },
+    });
+
+    const someSchema = new GraphQLSchema({ query: SomeType });
+
+    const document = parse(`
+      query {
+        someField
+        ... @defer {
+          deferredField
+        }
+      }
+    `);
+
+    const operation = document.definitions[0];
+    assert(operation.kind === Kind.OPERATION_DEFINITION);
+    const fragment = operation.selectionSet.selections[1];
+    assert(fragment.kind === Kind.INLINE_FRAGMENT);
+    const field = fragment.selectionSet.selections[0];
+
+    const result = experimentalExecuteIncrementally({
+      schema: someSchema,
+      document,
+    });
+
+    expect(fieldDetails).to.equal(undefined);
+    expect(deferPriority).to.equal(undefined);
+    expect(published).to.equal(undefined);
+    expect(resumed).to.equal(undefined);
+
+    const initialPayload = await result;
+    assert('initialResult' in initialPayload);
+    const iterator = initialPayload.subsequentResults[Symbol.asyncIterator]();
+    await iterator.next();
+
+    assert(fieldDetails !== undefined);
+    expect(fieldDetails[0].node).to.equal(field);
+    expect(fieldDetails[0].target?.deferPriority).to.equal(1);
+    expect(deferPriority).to.equal(1);
+    expect(isPromise(published)).to.equal(true);
+    expect(resumed).to.equal(true);
+  });
+  it('Can provides correct info about deferred execution state when deferred field is masked by non-deferred field', async () => {
+    let fieldDetails: ReadonlyArray<FieldDetails> | undefined;
+    let deferPriority;
+    let published;
+
+    const SomeType = new GraphQLObjectType({
+      name: 'SomeType',
+      fields: {
+        someField: {
+          type: GraphQLString,
+          resolve: (_parent, _args, _context, info) => {
+            fieldDetails = info.fieldDetails;
+            deferPriority = info.deferPriority;
+            published = info.published;
+            return 'someField';
+          },
+        },
+      },
+    });
+
+    const someSchema = new GraphQLSchema({ query: SomeType });
+
+    const document = parse(`
+      query {
+        someField
+        ... @defer {
+          someField
+        }
+      }
+    `);
+
+    const operation = document.definitions[0];
+    assert(operation.kind === Kind.OPERATION_DEFINITION);
+    const node1 = operation.selectionSet.selections[0];
+    const fragment = operation.selectionSet.selections[1];
+    assert(fragment.kind === Kind.INLINE_FRAGMENT);
+    const node2 = fragment.selectionSet.selections[0];
+
+    const result = experimentalExecuteIncrementally({
+      schema: someSchema,
+      document,
+    });
+
+    const initialPayload = await result;
+    assert('initialResult' in initialPayload);
+    expect(initialPayload.initialResult).to.deep.equal({
+      data: {
+        someField: 'someField',
+      },
+      pending: [{ path: [] }],
+      hasNext: true,
+    });
+
+    assert(fieldDetails !== undefined);
+    expect(fieldDetails[0].node).to.equal(node1);
+    expect(fieldDetails[0].target).to.equal(undefined);
+    expect(fieldDetails[1].node).to.equal(node2);
+    expect(fieldDetails[1].target?.deferPriority).to.equal(1);
+    expect(deferPriority).to.equal(0);
+    expect(published).to.equal(true);
+  });
+  it('Can provides correct info about deferred execution state when resolver need not defer', async () => {
+    let deferPriority;
+    let published;
+    const SomeType = new GraphQLObjectType({
+      name: 'SomeType',
+      fields: {
+        deferredField: {
+          type: GraphQLString,
+          resolve: (_parent, _args, _context, info) => {
+            deferPriority = info.deferPriority;
+            published = info.published;
+          },
+        },
+      },
+    });
+
+    const someSchema = new GraphQLSchema({ query: SomeType });
+
+    const document = parse(`
+      query {
+        ... @defer {
+          deferredField
+        }
+      }
+    `);
+
+    const result = experimentalExecuteIncrementally({
+      schema: someSchema,
+      document,
+    });
+
+    expect(deferPriority).to.equal(undefined);
+    expect(published).to.equal(undefined);
+
+    const initialPayload = await result;
+    assert('initialResult' in initialPayload);
+    const iterator = initialPayload.subsequentResults[Symbol.asyncIterator]();
+    await iterator.next();
+
+    expect(deferPriority).to.equal(1);
+    expect(published).to.equal(true);
   });
   it('Does not disable defer with null if argument', async () => {
     const document = parse(`

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -9,6 +9,7 @@ import { inspect } from '../../jsutils/inspect.js';
 import { Kind } from '../../language/kinds.js';
 import { parse } from '../../language/parser.js';
 
+import type { GraphQLResolveInfo } from '../../type/definition.js';
 import {
   GraphQLInterfaceType,
   GraphQLList,
@@ -191,7 +192,7 @@ describe('Execute: Handles basic execution tasks', () => {
   });
 
   it('provides info about current execution state', () => {
-    let resolvedInfo;
+    let resolvedInfo: GraphQLResolveInfo | undefined;
     const testType = new GraphQLObjectType({
       name: 'Test',
       fields: {
@@ -213,7 +214,7 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expect(resolvedInfo).to.have.all.keys(
       'fieldName',
-      'fieldNodes',
+      'fieldDetails',
       'returnType',
       'parentType',
       'path',
@@ -222,6 +223,9 @@ describe('Execute: Handles basic execution tasks', () => {
       'rootValue',
       'operation',
       'variableValues',
+      'priority',
+      'deferPriority',
+      'published',
     );
 
     const operation = document.definitions[0];
@@ -234,13 +238,23 @@ describe('Execute: Handles basic execution tasks', () => {
       schema,
       rootValue,
       operation,
+      priority: 0,
+      deferPriority: 0,
+      published: true,
     });
 
-    const field = operation.selectionSet.selections[0];
     expect(resolvedInfo).to.deep.include({
-      fieldNodes: [field],
       path: { prev: undefined, key: 'result', typename: 'Test' },
       variableValues: { var: 'abc' },
+    });
+
+    const fieldDetails = resolvedInfo?.fieldDetails;
+    assert(fieldDetails !== undefined);
+
+    const field = operation.selectionSet.selections[0];
+    expect(fieldDetails[0]).to.deep.include({
+      node: field,
+      target: undefined,
     });
   });
 

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -242,13 +242,13 @@ describe('Execute: Handles mutation execution ordering', () => {
       {
         incremental: [
           {
-            label: 'defer-label',
             path: ['first'],
             data: {
               promiseToGetTheNumber: 2,
             },
           },
         ],
+        completed: [{ path: ['first'], label: 'defer-label' }],
         hasNext: false,
       },
     ]);
@@ -317,7 +317,6 @@ describe('Execute: Handles mutation execution ordering', () => {
       {
         incremental: [
           {
-            label: 'defer-label',
             path: [],
             data: {
               first: {
@@ -326,6 +325,7 @@ describe('Execute: Handles mutation execution ordering', () => {
             },
           },
         ],
+        completed: [{ path: [], label: 'defer-label' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -237,6 +237,7 @@ describe('Execute: Handles mutation execution ordering', () => {
           first: {},
           second: { theNumber: 2 },
         },
+        pending: [{ path: ['first'], label: 'defer-label' }],
         hasNext: true,
       },
       {
@@ -312,6 +313,7 @@ describe('Execute: Handles mutation execution ordering', () => {
         data: {
           second: { theNumber: 2 },
         },
+        pending: [{ path: [], label: 'defer-label' }],
         hasNext: true,
       },
       {

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -146,11 +146,10 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList'] }],
-        hasNext: true,
-      },
-      {
-        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        incremental: [
+          { items: ['banana'], path: ['scalarList'] },
+          { items: ['coconut'], path: ['scalarList'] },
+        ],
         completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
@@ -170,15 +169,11 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['apple'], path: ['scalarList'] }],
-        hasNext: true,
-      },
-      {
-        incremental: [{ items: ['banana'], path: ['scalarList'] }],
-        hasNext: true,
-      },
-      {
-        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        incremental: [
+          { items: ['apple'], path: ['scalarList'] },
+          { items: ['banana'], path: ['scalarList'] },
+          { items: ['coconut'], path: ['scalarList'] },
+        ],
         completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
@@ -228,11 +223,6 @@ describe('Execute: stream directive', () => {
             items: ['banana'],
             path: ['scalarList'],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: ['coconut'],
             path: ['scalarList'],
@@ -297,11 +287,6 @@ describe('Execute: stream directive', () => {
             items: [['banana', 'banana', 'banana']],
             path: ['scalarListList'],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [['coconut', 'coconut', 'coconut']],
             path: ['scalarListList'],
@@ -384,20 +369,10 @@ describe('Execute: stream directive', () => {
             items: [{ name: 'Luke', id: '1' }],
             path: ['friendList'],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
             path: ['friendList'],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
             path: ['friendList'],
@@ -542,11 +517,6 @@ describe('Execute: stream directive', () => {
               },
             ],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
             path: ['friendList'],
@@ -961,11 +931,6 @@ describe('Execute: stream directive', () => {
               },
             ],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ nonNullName: 'Han' }],
             path: ['friendList'],
@@ -1012,11 +977,6 @@ describe('Execute: stream directive', () => {
               },
             ],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ nonNullName: 'Han' }],
             path: ['friendList'],
@@ -1147,11 +1107,6 @@ describe('Execute: stream directive', () => {
               },
             ],
           },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ nonNullName: 'Han' }],
             path: ['friendList'],
@@ -1475,11 +1430,10 @@ describe('Execute: stream directive', () => {
             path: ['nestedObject', 'nestedFriendList'],
           },
         ],
-        completed: [{ path: ['otherNestedObject'] }],
-        hasNext: true,
-      },
-      {
-        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        completed: [
+          { path: ['otherNestedObject'] },
+          { path: ['nestedObject', 'nestedFriendList'] },
+        ],
         hasNext: false,
       },
     ]);
@@ -1585,9 +1539,6 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        hasNext: true,
-      },
-      {
         completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
@@ -1739,9 +1690,6 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        hasNext: true,
-      },
-      {
         completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
@@ -1792,17 +1740,12 @@ describe('Execute: stream directive', () => {
             items: [{ id: '1', name: 'Luke' }],
             path: ['nestedObject', 'nestedFriendList'],
           },
-        ],
-        completed: [{ path: ['nestedObject'] }],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
             path: ['nestedObject', 'nestedFriendList'],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: true,
       },
       {
@@ -1863,6 +1806,10 @@ describe('Execute: stream directive', () => {
             data: { scalarField: 'slow', nestedFriendList: [] },
             path: ['nestedObject'],
           },
+          {
+            items: [{ name: 'Luke' }],
+            path: ['nestedObject', 'nestedFriendList'],
+          },
         ],
         completed: [{ path: ['nestedObject'] }],
         hasNext: true,
@@ -1874,7 +1821,7 @@ describe('Execute: stream directive', () => {
       value: {
         incremental: [
           {
-            items: [{ name: 'Luke' }],
+            items: [{ name: 'Han' }],
             path: ['nestedObject', 'nestedFriendList'],
           },
         ],
@@ -1885,26 +1832,13 @@ describe('Execute: stream directive', () => {
     const result4 = await iterator.next();
     expectJSON(result4).toDeepEqual({
       value: {
-        incremental: [
-          {
-            items: [{ name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList'],
-          },
-        ],
-        hasNext: true,
-      },
-      done: false,
-    });
-    const result5 = await iterator.next();
-    expectJSON(result5).toDeepEqual({
-      value: {
         completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
         hasNext: false,
       },
       done: false,
     });
-    const result6 = await iterator.next();
-    expectJSON(result6).toDeepEqual({
+    const result5 = await iterator.next();
+    expectJSON(result5).toDeepEqual({
       value: undefined,
       done: true,
     });

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -1,7 +1,8 @@
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
@@ -144,11 +145,12 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList', 1] }],
+        incremental: [{ items: ['banana'], path: ['scalarList'] }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -166,15 +168,16 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['apple'], path: ['scalarList', 0] }],
+        incremental: [{ items: ['apple'], path: ['scalarList'] }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList', 1] }],
+        incremental: [{ items: ['banana'], path: ['scalarList'] }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -220,8 +223,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: ['banana'],
-            path: ['scalarList', 1],
-            label: 'scalar-stream',
+            path: ['scalarList'],
           },
         ],
         hasNext: true,
@@ -230,10 +232,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: ['coconut'],
-            path: ['scalarList', 2],
-            label: 'scalar-stream',
+            path: ['scalarList'],
           },
         ],
+        completed: [{ path: ['scalarList'], label: 'scalar-stream' }],
         hasNext: false,
       },
     ]);
@@ -262,7 +264,8 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -287,7 +290,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [['banana', 'banana', 'banana']],
-            path: ['scalarListList', 1],
+            path: ['scalarListList'],
           },
         ],
         hasNext: true,
@@ -296,9 +299,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [['coconut', 'coconut', 'coconut']],
-            path: ['scalarListList', 2],
+            path: ['scalarListList'],
           },
         ],
+        completed: [{ path: ['scalarListList'] }],
         hasNext: false,
       },
     ]);
@@ -340,9 +344,10 @@ describe('Execute: stream directive', () => {
                 id: '3',
               },
             ],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -370,7 +375,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke', id: '1' }],
-            path: ['friendList', 0],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -379,7 +384,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
-            path: ['friendList', 1],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -388,9 +393,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -436,9 +442,10 @@ describe('Execute: stream directive', () => {
                 id: '3',
               },
             ],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -479,9 +486,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -515,7 +523,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'bad',
@@ -531,9 +539,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -565,7 +574,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke', id: '1' }],
-            path: ['friendList', 0],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -574,7 +583,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
-            path: ['friendList', 1],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -583,12 +592,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -623,12 +633,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -694,13 +705,19 @@ describe('Execute: stream directive', () => {
           incremental: [
             {
               items: [{ name: 'Leia', id: '3' }],
-              path: ['friendList', 2],
+              path: ['friendList'],
             },
           ],
           hasNext: true,
         },
       },
-      { done: false, value: { hasNext: false } },
+      {
+        done: false,
+        value: {
+          completed: [{ path: ['friendList'] }],
+          hasNext: false,
+        },
+      },
       { done: true, value: undefined },
     ]);
   });
@@ -755,10 +772,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'bad',
@@ -792,10 +808,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message:
@@ -839,10 +854,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message:
@@ -877,7 +891,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['scalarList', 1],
+            path: ['scalarList'],
             errors: [
               {
                 message: 'String cannot represent value: {}',
@@ -887,6 +901,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
+        completed: [{ path: ['scalarList'] }],
         hasNext: false,
       },
     ]);
@@ -919,7 +934,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'Oops',
@@ -935,9 +950,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -968,7 +984,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'Oops',
@@ -984,9 +1000,10 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1016,10 +1033,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1056,10 +1072,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1101,7 +1116,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 1],
+            path: ['friendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1117,12 +1132,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1154,10 +1170,9 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
+        completed: [
           {
-            items: null,
-            path: ['nonNullFriendList', 1],
+            path: ['nonNullFriendList'],
             errors: [
               {
                 message: 'Oops',
@@ -1170,6 +1185,151 @@ describe('Execute: stream directive', () => {
         hasNext: false,
       },
     ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list when the async iterable does not provide a return method) ', async () => {
+    const document = parse(`
+      query { 
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    let count = 0;
+    const result = await complete(document, {
+      nonNullFriendList: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            switch (count++) {
+              case 0:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[0].name },
+                });
+              case 1:
+                return Promise.resolve({
+                  done: false,
+                  value: {
+                    nonNullName: () => Promise.reject(new Error('Oops')),
+                  },
+                });
+              case 2:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[1].name },
+                });
+              // Not reached
+              /* c8 ignore next 5 */
+              case 3:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[2].name },
+                });
+            }
+          },
+        }),
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        completed: [
+          {
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list when the async iterable provides concurrent next/return methods and has a slow return ', async () => {
+    const document = parse(`
+      query { 
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    let count = 0;
+    let returned = false;
+    const result = await complete(document, {
+      nonNullFriendList: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            /* c8 ignore next 3 */
+            if (returned) {
+              return Promise.resolve({ done: true });
+            }
+            switch (count++) {
+              case 0:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[0].name },
+                });
+              case 1:
+                return Promise.resolve({
+                  done: false,
+                  value: {
+                    nonNullName: () => Promise.reject(new Error('Oops')),
+                  },
+                });
+              case 2:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[1].name },
+                });
+              // Not reached
+              /* c8 ignore next 5 */
+              case 3:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[2].name },
+                });
+            }
+          },
+          return: async () => {
+            await resolveOnNextTick();
+            returned = true;
+            return { done: true };
+          },
+        }),
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        completed: [
+          {
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(returned).to.equal(true);
   });
   it('Filters payloads that are nulled', async () => {
     const document = parse(`
@@ -1283,12 +1443,14 @@ describe('Execute: stream directive', () => {
           },
           {
             items: [{ name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
+        completed: [{ path: ['otherNestedObject'] }],
         hasNext: true,
       },
       {
+        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
         hasNext: false,
       },
     ]);
@@ -1346,6 +1508,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: false,
       },
     ]);
@@ -1380,7 +1543,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList', 0],
+            path: ['friendList'],
             errors: [
               {
                 message:
@@ -1394,6 +1557,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1405,10 +1569,11 @@ describe('Execute: stream directive', () => {
     const iterable = {
       [Symbol.asyncIterator]: () => ({
         next: () => {
+          /* c8 ignore start */
           if (requested) {
-            // Ignores further errors when filtered.
+            // stream is filtered, next is not called, and so this is not reached.
             return Promise.reject(new Error('Oops'));
-          }
+          } /* c8 ignore stop */
           requested = true;
           const friend = friends[0];
           return Promise.resolve({
@@ -1489,6 +1654,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: false,
       },
     });
@@ -1528,7 +1694,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            path: ['friendList', 1],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
@@ -1537,12 +1703,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '3', name: 'Leia' }],
-            path: ['friendList', 2],
+            path: ['friendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['friendList'] }],
         hasNext: false,
       },
     ]);
@@ -1585,41 +1752,24 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [{ id: '1' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
-          },
-          {
-            data: {
-              nestedFriendList: [],
-            },
-            path: ['nestedObject'],
-          },
-        ],
-        hasNext: true,
-      },
-      {
-        incremental: [
-          {
-            items: [{ id: '2' }],
-            path: ['nestedObject', 'nestedFriendList', 1],
-          },
-          {
             items: [{ id: '1', name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList', 1],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
         hasNext: true,
       },
       {
+        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
         hasNext: false,
       },
     ]);
@@ -1675,6 +1825,7 @@ describe('Execute: stream directive', () => {
             path: ['nestedObject'],
           },
         ],
+        completed: [{ path: ['nestedObject'] }],
         hasNext: true,
       },
       done: false,
@@ -1685,7 +1836,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList', 0],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
         hasNext: true,
@@ -1698,7 +1849,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList', 1],
+            path: ['nestedObject', 'nestedFriendList'],
           },
         ],
         hasNext: true,
@@ -1707,7 +1858,10 @@ describe('Execute: stream directive', () => {
     });
     const result5 = await iterator.next();
     expectJSON(result5).toDeepEqual({
-      value: { hasNext: false },
+      value: {
+        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        hasNext: false,
+      },
       done: false,
     });
     const result6 = await iterator.next();
@@ -1770,14 +1924,13 @@ describe('Execute: stream directive', () => {
           {
             data: { name: 'Luke' },
             path: ['friendList', 0],
-            label: 'DeferName',
           },
           {
             items: [{ id: '2' }],
-            path: ['friendList', 1],
-            label: 'stream-label',
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList', 0], label: 'DeferName' }],
         hasNext: true,
       },
       done: false,
@@ -1788,19 +1941,27 @@ describe('Execute: stream directive', () => {
     const result3 = await result3Promise;
     expectJSON(result3).toDeepEqual({
       value: {
-        incremental: [
-          {
-            data: { name: 'Han' },
-            path: ['friendList', 1],
-            label: 'DeferName',
-          },
-        ],
-        hasNext: false,
+        completed: [{ path: ['friendList'], label: 'stream-label' }],
+        hasNext: true,
       },
       done: false,
     });
     const result4 = await iterator.next();
     expectJSON(result4).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: { name: 'Han' },
+            path: ['friendList', 1],
+          },
+        ],
+        completed: [{ path: ['friendList', 1], label: 'DeferName' }],
+        hasNext: false,
+      },
+      done: false,
+    });
+    const result5 = await iterator.next();
+    expectJSON(result5).toDeepEqual({
       value: undefined,
       done: true,
     });
@@ -1859,14 +2020,13 @@ describe('Execute: stream directive', () => {
           {
             data: { name: 'Luke' },
             path: ['friendList', 0],
-            label: 'DeferName',
           },
           {
             items: [{ id: '2' }],
-            path: ['friendList', 1],
-            label: 'stream-label',
+            path: ['friendList'],
           },
         ],
+        completed: [{ path: ['friendList', 0], label: 'DeferName' }],
         hasNext: true,
       },
       done: false,
@@ -1879,9 +2039,9 @@ describe('Execute: stream directive', () => {
           {
             data: { name: 'Han' },
             path: ['friendList', 1],
-            label: 'DeferName',
           },
         ],
+        completed: [{ path: ['friendList', 1], label: 'DeferName' }],
         hasNext: true,
       },
       done: false,
@@ -1890,7 +2050,10 @@ describe('Execute: stream directive', () => {
     resolveIterableCompletion(null);
     const result4 = await result4Promise;
     expectJSON(result4).toDeepEqual({
-      value: { hasNext: false },
+      value: {
+        completed: [{ path: ['friendList'], label: 'stream-label' }],
+        hasNext: false,
+      },
       done: false,
     });
 

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -355,8 +355,6 @@ describe('Execute: stream directive', () => {
         completed: [
           { path: ['friendList'] },
           { path: ['friendList', 0, 'appearsIn'] },
-          { path: ['friendList', 1, 'appearsIn'] },
-          { path: ['friendList', 2, 'appearsIn'] },
         ],
         hasNext: false,
       },
@@ -404,15 +402,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList', 0],
           },
         ],
-        completed: [
-          { path: ['friendList', 0] },
-          { path: ['friendList'] },
-          { path: ['friendList', 1] },
-          { path: ['friendList', 2] },
-          { path: ['friendList', 0, 'appearsIn'] },
-          { path: ['friendList', 1, 'appearsIn'] },
-          { path: ['friendList', 2, 'appearsIn'] },
-        ],
+        completed: [{ path: ['friendList', 0] }, { path: ['friendList'] }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -142,6 +142,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: ['apple'],
         },
+        pending: [{ path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -165,6 +166,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: [],
         },
+        pending: [{ path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -217,6 +219,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: ['apple'],
         },
+        pending: [{ path: ['scalarList'], label: 'scalar-stream' }],
         hasNext: true,
       },
       {
@@ -261,6 +264,7 @@ describe('Execute: stream directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { scalarList: ['apple', 'banana'] },
+        pending: [{ path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -284,6 +288,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarListList: [['apple', 'apple', 'apple']],
         },
+        pending: [{ path: ['scalarListList'] }],
         hasNext: true,
       },
       {
@@ -333,6 +338,7 @@ describe('Execute: stream directive', () => {
             },
           ],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -369,6 +375,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -431,6 +438,7 @@ describe('Execute: stream directive', () => {
             },
           ],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -480,6 +488,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ name: 'Luke', id: '1' }, null],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -517,6 +526,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ name: 'Luke', id: '1' }],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -568,6 +578,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -627,6 +638,7 @@ describe('Execute: stream directive', () => {
             { name: 'Han', id: '2' },
           ],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -696,6 +708,7 @@ describe('Execute: stream directive', () => {
               { name: 'Han', id: '2' },
             ],
           },
+          pending: [{ path: ['friendList'] }],
           hasNext: true,
         },
       },
@@ -769,6 +782,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ name: 'Luke', id: '1' }],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -805,6 +819,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ name: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -851,6 +866,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ name: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -885,6 +901,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: ['Luke'],
         },
+        pending: [{ path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -928,6 +945,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -978,6 +996,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1030,6 +1049,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -1069,6 +1089,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -1110,6 +1131,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1167,6 +1189,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -1234,6 +1257,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -1311,6 +1335,7 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
+        pending: [{ path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
@@ -1426,6 +1451,10 @@ describe('Execute: stream directive', () => {
           otherNestedObject: {},
           nestedObject: { nestedFriendList: [] },
         },
+        pending: [
+          { path: ['otherNestedObject'] },
+          { path: ['nestedObject', 'nestedFriendList'] },
+        ],
         hasNext: true,
       },
       {
@@ -1485,6 +1514,7 @@ describe('Execute: stream directive', () => {
         data: {
           nestedObject: {},
         },
+        pending: [{ path: ['nestedObject'] }],
         hasNext: true,
       },
       {
@@ -1537,6 +1567,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1627,6 +1658,7 @@ describe('Execute: stream directive', () => {
       data: {
         nestedObject: {},
       },
+      pending: [{ path: ['nestedObject'] }],
       hasNext: true,
     });
 
@@ -1688,6 +1720,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ id: '1', name: 'Luke' }],
         },
+        pending: [{ path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1747,6 +1780,10 @@ describe('Execute: stream directive', () => {
             nestedFriendList: [],
           },
         },
+        pending: [
+          { path: ['nestedObject'] },
+          { path: ['nestedObject', 'nestedFriendList'] },
+        ],
         hasNext: true,
       },
       {
@@ -1811,6 +1848,7 @@ describe('Execute: stream directive', () => {
       data: {
         nestedObject: {},
       },
+      pending: [{ path: ['nestedObject'] }],
       hasNext: true,
     });
 
@@ -1819,6 +1857,7 @@ describe('Execute: stream directive', () => {
     const result2 = await result2Promise;
     expectJSON(result2).toDeepEqual({
       value: {
+        pending: [{ path: ['nestedObject', 'nestedFriendList'] }],
         incremental: [
           {
             data: { scalarField: 'slow', nestedFriendList: [] },
@@ -1912,6 +1951,10 @@ describe('Execute: stream directive', () => {
       data: {
         friendList: [{ id: '1' }],
       },
+      pending: [
+        { path: ['friendList', 0], label: 'DeferName' },
+        { path: ['friendList'], label: 'stream-label' },
+      ],
       hasNext: true,
     });
 
@@ -1920,6 +1963,7 @@ describe('Execute: stream directive', () => {
     const result2 = await result2Promise;
     expectJSON(result2).toDeepEqual({
       value: {
+        pending: [{ path: ['friendList', 1], label: 'DeferName' }],
         incremental: [
           {
             data: { name: 'Luke' },
@@ -2008,6 +2052,10 @@ describe('Execute: stream directive', () => {
       data: {
         friendList: [{ id: '1' }],
       },
+      pending: [
+        { path: ['friendList', 0], label: 'DeferName' },
+        { path: ['friendList'], label: 'stream-label' },
+      ],
       hasNext: true,
     });
 
@@ -2016,6 +2064,7 @@ describe('Execute: stream directive', () => {
     const result2 = await result2Promise;
     expectJSON(result2).toDeepEqual({
       value: {
+        pending: [{ path: ['friendList', 1], label: 'DeferName' }],
         incremental: [
           {
             data: { name: 'Luke' },
@@ -2111,6 +2160,7 @@ describe('Execute: stream directive', () => {
           },
         ],
       },
+      pending: [{ path: ['friendList', 0] }, { path: ['friendList'] }],
       hasNext: true,
     });
     const returnPromise = iterator.return();
@@ -2166,6 +2216,7 @@ describe('Execute: stream directive', () => {
           },
         ],
       },
+      pending: [{ path: ['friendList'] }],
       hasNext: true,
     });
 
@@ -2225,6 +2276,7 @@ describe('Execute: stream directive', () => {
           },
         ],
       },
+      pending: [{ path: ['friendList', 0] }, { path: ['friendList'] }],
       hasNext: true,
     });
 

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -15,7 +15,12 @@ import type {
 import { OperationTypeNode } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
 
-import type { GraphQLObjectType } from '../type/definition.js';
+import type {
+  DeferUsage,
+  FieldDetails,
+  GraphQLObjectType,
+  Target,
+} from '../type/definition.js';
 import { isAbstractType } from '../type/definition.js';
 import {
   GraphQLDeferDirective,
@@ -28,23 +33,12 @@ import { typeFromAST } from '../utilities/typeFromAST.js';
 
 import { getDirectiveValues } from './values.js';
 
-export interface DeferUsage {
-  label: string | undefined;
-  ancestors: ReadonlyArray<Target>;
-}
-
 export const NON_DEFERRED_TARGET_SET = new OrderedSet<Target>([
   undefined,
 ]).freeze();
 
-export type Target = DeferUsage | undefined;
 export type TargetSet = ReadonlyOrderedSet<Target>;
 export type DeferUsageSet = ReadonlyOrderedSet<DeferUsage>;
-
-export interface FieldDetails {
-  node: FieldNode;
-  target: Target;
-}
 
 export interface FieldGroup {
   fields: ReadonlyArray<FieldDetails>;
@@ -213,12 +207,19 @@ function collectFieldsImpl(
         let target: Target;
         if (!defer) {
           target = newTarget;
+        } else if (parentTarget === undefined) {
+          target = {
+            ...defer,
+            ancestors: [parentTarget],
+            deferPriority: 1,
+          };
+          newDeferUsages.push(target);
         } else {
-          const ancestors =
-            parentTarget === undefined
-              ? [parentTarget]
-              : [parentTarget, ...parentTarget.ancestors];
-          target = { ...defer, ancestors };
+          target = {
+            ...defer,
+            ancestors: [parentTarget, ...parentTarget.ancestors],
+            deferPriority: parentTarget.deferPriority + 1,
+          };
           newDeferUsages.push(target);
         }
 
@@ -255,12 +256,19 @@ function collectFieldsImpl(
         if (!defer) {
           visitedFragmentNames.add(fragName);
           target = newTarget;
+        } else if (parentTarget === undefined) {
+          target = {
+            ...defer,
+            ancestors: [parentTarget],
+            deferPriority: 1,
+          };
+          newDeferUsages.push(target);
         } else {
-          const ancestors =
-            parentTarget === undefined
-              ? [parentTarget]
-              : [parentTarget, ...parentTarget.ancestors];
-          target = { ...defer, ancestors };
+          target = {
+            ...defer,
+            ancestors: [parentTarget, ...parentTarget.ancestors],
+            deferPriority: parentTarget.deferPriority + 1,
+          };
           newDeferUsages.push(target);
         }
 

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -1,6 +1,8 @@
 import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
 import { invariant } from '../jsutils/invariant.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
+import type { ReadonlyOrderedSet } from '../jsutils/OrderedSet.js';
+import { OrderedSet } from '../jsutils/OrderedSet.js';
 
 import type {
   FieldNode,
@@ -26,18 +28,52 @@ import { typeFromAST } from '../utilities/typeFromAST.js';
 
 import { getDirectiveValues } from './values.js';
 
-export type FieldGroup = ReadonlyArray<FieldNode>;
+export interface DeferUsage {
+  label: string | undefined;
+  ancestors: ReadonlyArray<Target>;
+}
+
+export const NON_DEFERRED_TARGET_SET = new OrderedSet<Target>([
+  undefined,
+]).freeze();
+
+export type Target = DeferUsage | undefined;
+export type TargetSet = ReadonlyOrderedSet<Target>;
+export type DeferUsageSet = ReadonlyOrderedSet<DeferUsage>;
+
+export interface FieldDetails {
+  node: FieldNode;
+  target: Target;
+}
+
+export interface FieldGroup {
+  fields: ReadonlyArray<FieldDetails>;
+  targets: TargetSet;
+}
 
 export type GroupedFieldSet = Map<string, FieldGroup>;
 
-export interface PatchFields {
-  label: string | undefined;
+export interface GroupedFieldSetDetails {
   groupedFieldSet: GroupedFieldSet;
+  shouldInitiateDefer: boolean;
 }
 
-export interface FieldsAndPatches {
+export interface CollectFieldsResult {
   groupedFieldSet: GroupedFieldSet;
-  patches: Array<PatchFields>;
+  newGroupedFieldSetDetails: Map<DeferUsageSet, GroupedFieldSetDetails>;
+  newDeferUsages: ReadonlyArray<DeferUsage>;
+}
+
+interface CollectFieldsContext {
+  schema: GraphQLSchema;
+  fragments: ObjMap<FragmentDefinitionNode>;
+  variableValues: { [variable: string]: unknown };
+  operation: OperationDefinitionNode;
+  runtimeType: GraphQLObjectType;
+  targetsByKey: Map<string, Set<Target>>;
+  fieldsByTarget: Map<Target, AccumulatorMap<string, FieldNode>>;
+  newDeferUsages: Array<DeferUsage>;
+  visitedFragmentNames: Set<string>;
 }
 
 /**
@@ -55,21 +91,25 @@ export function collectFields(
   variableValues: { [variable: string]: unknown },
   runtimeType: GraphQLObjectType,
   operation: OperationDefinitionNode,
-): FieldsAndPatches {
-  const groupedFieldSet = new AccumulatorMap<string, FieldNode>();
-  const patches: Array<PatchFields> = [];
-  collectFieldsImpl(
+): CollectFieldsResult {
+  const context: CollectFieldsContext = {
     schema,
     fragments,
     variableValues,
-    operation,
     runtimeType,
-    operation.selectionSet,
-    groupedFieldSet,
-    patches,
-    new Set(),
-  );
-  return { groupedFieldSet, patches };
+    operation,
+    fieldsByTarget: new Map(),
+    targetsByKey: new Map(),
+    newDeferUsages: [],
+    visitedFragmentNames: new Set(),
+  };
+
+  collectFieldsImpl(context, operation.selectionSet);
+
+  return {
+    ...buildGroupedFieldSets(context.targetsByKey, context.fieldsByTarget),
+    newDeferUsages: context.newDeferUsages,
+  };
 }
 
 /**
@@ -90,53 +130,74 @@ export function collectSubfields(
   operation: OperationDefinitionNode,
   returnType: GraphQLObjectType,
   fieldGroup: FieldGroup,
-): FieldsAndPatches {
-  const subGroupedFieldSet = new AccumulatorMap<string, FieldNode>();
-  const visitedFragmentNames = new Set<string>();
-
-  const subPatches: Array<PatchFields> = [];
-  const subFieldsAndPatches = {
-    groupedFieldSet: subGroupedFieldSet,
-    patches: subPatches,
+): CollectFieldsResult {
+  const context: CollectFieldsContext = {
+    schema,
+    fragments,
+    variableValues,
+    runtimeType: returnType,
+    operation,
+    fieldsByTarget: new Map(),
+    targetsByKey: new Map(),
+    newDeferUsages: [],
+    visitedFragmentNames: new Set(),
   };
 
-  for (const node of fieldGroup) {
+  for (const fieldDetails of fieldGroup.fields) {
+    const node = fieldDetails.node;
     if (node.selectionSet) {
-      collectFieldsImpl(
-        schema,
-        fragments,
-        variableValues,
-        operation,
-        returnType,
-        node.selectionSet,
-        subGroupedFieldSet,
-        subPatches,
-        visitedFragmentNames,
-      );
+      collectFieldsImpl(context, node.selectionSet, fieldDetails.target);
     }
   }
-  return subFieldsAndPatches;
+
+  return {
+    ...buildGroupedFieldSets(
+      context.targetsByKey,
+      context.fieldsByTarget,
+      fieldGroup.targets,
+    ),
+    newDeferUsages: context.newDeferUsages,
+  };
 }
 
-// eslint-disable-next-line max-params
 function collectFieldsImpl(
-  schema: GraphQLSchema,
-  fragments: ObjMap<FragmentDefinitionNode>,
-  variableValues: { [variable: string]: unknown },
-  operation: OperationDefinitionNode,
-  runtimeType: GraphQLObjectType,
+  context: CollectFieldsContext,
   selectionSet: SelectionSetNode,
-  groupedFieldSet: AccumulatorMap<string, FieldNode>,
-  patches: Array<PatchFields>,
-  visitedFragmentNames: Set<string>,
+  parentTarget?: Target,
+  newTarget?: Target,
 ): void {
+  const {
+    schema,
+    fragments,
+    variableValues,
+    runtimeType,
+    operation,
+    targetsByKey,
+    fieldsByTarget,
+    newDeferUsages,
+    visitedFragmentNames,
+  } = context;
+
   for (const selection of selectionSet.selections) {
     switch (selection.kind) {
       case Kind.FIELD: {
         if (!shouldIncludeNode(variableValues, selection)) {
           continue;
         }
-        groupedFieldSet.add(getFieldEntryKey(selection), selection);
+        const key = getFieldEntryKey(selection);
+        const target = newTarget ?? parentTarget;
+        let keyTargets = targetsByKey.get(key);
+        if (keyTargets === undefined) {
+          keyTargets = new Set();
+          targetsByKey.set(key, keyTargets);
+        }
+        keyTargets.add(target);
+        let targetFields = fieldsByTarget.get(target);
+        if (targetFields === undefined) {
+          targetFields = new AccumulatorMap();
+          fieldsByTarget.set(target, targetFields);
+        }
+        targetFields.add(key, selection);
         break;
       }
       case Kind.INLINE_FRAGMENT: {
@@ -149,36 +210,25 @@ function collectFieldsImpl(
 
         const defer = getDeferValues(operation, variableValues, selection);
 
-        if (defer) {
-          const patchFields = new AccumulatorMap<string, FieldNode>();
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            selection.selectionSet,
-            patchFields,
-            patches,
-            visitedFragmentNames,
-          );
-          patches.push({
-            label: defer.label,
-            groupedFieldSet: patchFields,
-          });
+        let target: Target;
+        if (!defer) {
+          target = newTarget;
         } else {
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            selection.selectionSet,
-            groupedFieldSet,
-            patches,
-            visitedFragmentNames,
-          );
+          const ancestors =
+            parentTarget === undefined
+              ? [parentTarget]
+              : [parentTarget, ...parentTarget.ancestors];
+          target = { ...defer, ancestors };
+          newDeferUsages.push(target);
         }
+
+        collectFieldsImpl(
+          context,
+          selection.selectionSet,
+          parentTarget,
+          target,
+        );
+
         break;
       }
       case Kind.FRAGMENT_SPREAD: {
@@ -201,40 +251,20 @@ function collectFieldsImpl(
           continue;
         }
 
+        let target: Target;
         if (!defer) {
           visitedFragmentNames.add(fragName);
+          target = newTarget;
+        } else {
+          const ancestors =
+            parentTarget === undefined
+              ? [parentTarget]
+              : [parentTarget, ...parentTarget.ancestors];
+          target = { ...defer, ancestors };
+          newDeferUsages.push(target);
         }
 
-        if (defer) {
-          const patchFields = new AccumulatorMap<string, FieldNode>();
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            fragment.selectionSet,
-            patchFields,
-            patches,
-            visitedFragmentNames,
-          );
-          patches.push({
-            label: defer.label,
-            groupedFieldSet: patchFields,
-          });
-        } else {
-          collectFieldsImpl(
-            schema,
-            fragments,
-            variableValues,
-            operation,
-            runtimeType,
-            fragment.selectionSet,
-            groupedFieldSet,
-            patches,
-            visitedFragmentNames,
-          );
-        }
+        collectFieldsImpl(context, fragment.selectionSet, parentTarget, target);
         break;
       }
     }
@@ -322,4 +352,144 @@ function doesFragmentConditionMatch(
  */
 function getFieldEntryKey(node: FieldNode): string {
   return node.alias ? node.alias.value : node.name.value;
+}
+
+function buildGroupedFieldSets(
+  targetsByKey: Map<string, Set<Target>>,
+  fieldsByTarget: Map<Target, Map<string, ReadonlyArray<FieldNode>>>,
+  parentTargets = NON_DEFERRED_TARGET_SET,
+): {
+  groupedFieldSet: GroupedFieldSet;
+  newGroupedFieldSetDetails: Map<DeferUsageSet, GroupedFieldSetDetails>;
+} {
+  const { parentTargetKeys, targetSetDetailsMap } = getTargetSetDetails(
+    targetsByKey,
+    parentTargets,
+  );
+
+  const groupedFieldSet =
+    parentTargetKeys.size > 0
+      ? getOrderedGroupedFieldSet(
+          parentTargetKeys,
+          parentTargets,
+          targetsByKey,
+          fieldsByTarget,
+        )
+      : new Map();
+
+  const newGroupedFieldSetDetails = new Map<
+    DeferUsageSet,
+    GroupedFieldSetDetails
+  >();
+
+  for (const [maskingTargets, targetSetDetails] of targetSetDetailsMap) {
+    const { keys, shouldInitiateDefer } = targetSetDetails;
+
+    const newGroupedFieldSet = getOrderedGroupedFieldSet(
+      keys,
+      maskingTargets,
+      targetsByKey,
+      fieldsByTarget,
+    );
+
+    // All TargetSets that causes new grouped field sets consist only of DeferUsages
+    // and have shouldInitiateDefer defined
+    newGroupedFieldSetDetails.set(maskingTargets as DeferUsageSet, {
+      groupedFieldSet: newGroupedFieldSet,
+      shouldInitiateDefer,
+    });
+  }
+
+  return {
+    groupedFieldSet,
+    newGroupedFieldSetDetails,
+  };
+}
+
+interface TargetSetDetails {
+  keys: Set<string>;
+  shouldInitiateDefer: boolean;
+}
+
+function getTargetSetDetails(
+  targetsByKey: Map<string, Set<Target>>,
+  parentTargets: TargetSet,
+): {
+  parentTargetKeys: ReadonlySet<string>;
+  targetSetDetailsMap: Map<TargetSet, TargetSetDetails>;
+} {
+  const parentTargetKeys = new Set<string>();
+  const targetSetDetailsMap = new Map<TargetSet, TargetSetDetails>();
+
+  for (const [responseKey, targets] of targetsByKey) {
+    const maskingTargetList: Array<Target> = [];
+    for (const target of targets) {
+      if (
+        target === undefined ||
+        target.ancestors.every((ancestor) => !targets.has(ancestor))
+      ) {
+        maskingTargetList.push(target);
+      }
+    }
+
+    const maskingTargets = new OrderedSet(maskingTargetList).freeze();
+    if (maskingTargets === parentTargets) {
+      parentTargetKeys.add(responseKey);
+      continue;
+    }
+
+    let targetSetDetails = targetSetDetailsMap.get(maskingTargets);
+    if (targetSetDetails === undefined) {
+      targetSetDetails = {
+        keys: new Set(),
+        shouldInitiateDefer: maskingTargetList.some(
+          (deferUsage) => !parentTargets.has(deferUsage),
+        ),
+      };
+      targetSetDetailsMap.set(maskingTargets, targetSetDetails);
+    }
+    targetSetDetails.keys.add(responseKey);
+  }
+
+  return {
+    parentTargetKeys,
+    targetSetDetailsMap,
+  };
+}
+
+function getOrderedGroupedFieldSet(
+  keys: ReadonlySet<string>,
+  maskingTargets: TargetSet,
+  targetsByKey: Map<string, Set<Target>>,
+  fieldsByTarget: Map<Target, Map<string, ReadonlyArray<FieldNode>>>,
+): GroupedFieldSet {
+  const groupedFieldSet = new Map<
+    string,
+    { fields: Array<FieldDetails>; targets: TargetSet }
+  >();
+
+  const firstTarget = maskingTargets.values().next().value as Target;
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const firstFields = fieldsByTarget.get(firstTarget)!;
+  for (const [key] of firstFields) {
+    if (keys.has(key)) {
+      let fieldGroup = groupedFieldSet.get(key);
+      if (fieldGroup === undefined) {
+        fieldGroup = { fields: [], targets: maskingTargets };
+        groupedFieldSet.set(key, fieldGroup);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      for (const target of targetsByKey.get(key)!) {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const fieldsForTarget = fieldsByTarget.get(target)!;
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const nodes = fieldsForTarget.get(key)!;
+        // the following line is an optional minor optimization
+        fieldsForTarget.delete(key);
+        fieldGroup.fields.push(...nodes.map((node) => ({ node, target })));
+      }
+    }
+  }
+
+  return groupedFieldSet;
 }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -26,6 +26,7 @@ import { OperationTypeNode } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
 
 import type {
+  DeferUsage,
   GraphQLAbstractType,
   GraphQLField,
   GraphQLFieldResolver,
@@ -48,7 +49,6 @@ import type { GraphQLSchema } from '../type/schema.js';
 import { assertValidSchema } from '../type/validate.js';
 
 import type {
-  DeferUsage,
   DeferUsageSet,
   FieldGroup,
   GroupedFieldSet,
@@ -419,6 +419,7 @@ function executeOperation(
   const newDeferredGroupedFieldSetRecords = addNewDeferredGroupedFieldSets(
     incrementalPublisher,
     newGroupedFieldSetDetails,
+    initialResultRecord,
     newDeferMap,
     path,
   );
@@ -606,6 +607,7 @@ function executeField(
     fieldGroup,
     parentType,
     path,
+    incrementalDataRecord,
   );
 
   // Get the resolve function, regardless of if its result is normal or abrupt (error).
@@ -691,12 +693,31 @@ export function buildResolveInfo(
   fieldGroup: FieldGroup,
   parentType: GraphQLObjectType,
   path: Path,
+  incrementalDataRecord?: IncrementalDataRecord | undefined,
 ): GraphQLResolveInfo {
   // The resolve function's optional fourth argument is a collection of
   // information about the current execution state.
+  if (incrementalDataRecord === undefined) {
+    return {
+      fieldName: fieldDef.name,
+      fieldDetails: fieldGroup.fields,
+      returnType: fieldDef.type,
+      parentType,
+      path,
+      schema: exeContext.schema,
+      fragments: exeContext.fragments,
+      rootValue: exeContext.rootValue,
+      operation: exeContext.operation,
+      variableValues: exeContext.variableValues,
+      priority: 0,
+      deferPriority: 0,
+      published: true,
+    };
+  }
+
   return {
     fieldName: fieldDef.name,
-    fieldNodes: toNodes(fieldGroup),
+    fieldDetails: fieldGroup.fields,
     returnType: fieldDef.type,
     parentType,
     path,
@@ -705,6 +726,12 @@ export function buildResolveInfo(
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
     variableValues: exeContext.variableValues,
+    priority: incrementalDataRecord.priority,
+    deferPriority: incrementalDataRecord.deferPriority,
+    published:
+      incrementalDataRecord.published === true
+        ? true
+        : incrementalDataRecord.published,
   };
 }
 
@@ -1469,6 +1496,7 @@ function deferredFragmentRecordFromDeferUsage(
 function addNewDeferredGroupedFieldSets(
   incrementalPublisher: IncrementalPublisher,
   newGroupedFieldSetDetails: Map<DeferUsageSet, GroupedFieldSetDetails>,
+  incrementalDataRecord: IncrementalDataRecord,
   deferMap: ReadonlyMap<DeferUsage, DeferredFragmentRecord>,
   path?: Path | undefined,
 ): ReadonlyArray<DeferredGroupedFieldSetRecord> {
@@ -1483,12 +1511,23 @@ function addNewDeferredGroupedFieldSets(
       newGroupedFieldSetDeferUsages,
       deferMap,
     );
-    const deferredGroupedFieldSetRecord = new DeferredGroupedFieldSetRecord({
-      path,
-      deferredFragmentRecords,
-      groupedFieldSet,
-      shouldInitiateDefer,
-    });
+    const deferredGroupedFieldSetRecord = shouldInitiateDefer
+      ? new DeferredGroupedFieldSetRecord({
+          path,
+          priority: incrementalDataRecord.priority + 1,
+          deferPriority: incrementalDataRecord.deferPriority + 1,
+          deferredFragmentRecords,
+          groupedFieldSet,
+          shouldInitiateDefer: true,
+        })
+      : new DeferredGroupedFieldSetRecord({
+          path,
+          priority: incrementalDataRecord.priority,
+          deferPriority: incrementalDataRecord.deferPriority,
+          deferredFragmentRecords,
+          groupedFieldSet,
+          shouldInitiateDefer: false,
+        });
     incrementalPublisher.reportNewDeferredGroupedFieldSetRecord(
       deferredGroupedFieldSetRecord,
     );
@@ -1533,6 +1572,7 @@ function collectAndExecuteSubfields(
   const newDeferredGroupedFieldSetRecords = addNewDeferredGroupedFieldSets(
     incrementalPublisher,
     newGroupedFieldSetDetails,
+    incrementalDataRecord,
     newDeferMap,
     path,
   );
@@ -1951,6 +1991,7 @@ function executeStreamField(
   const streamItemsRecord = new StreamItemsRecord({
     streamRecord,
     path: itemPath,
+    priority: incrementalDataRecord.priority + 1,
   });
   incrementalPublisher.reportNewStreamItemsRecord(
     streamItemsRecord,
@@ -2143,6 +2184,7 @@ async function executeStreamAsyncIterator(
     const streamItemsRecord = new StreamItemsRecord({
       streamRecord,
       path: itemPath,
+      priority: incrementalDataRecord.priority + 1,
     });
     incrementalPublisher.reportNewStreamItemsRecord(
       streamItemsRecord,

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1475,6 +1475,7 @@ function addNewDeferredFragments(
 
       incrementalPublisher.reportNewDeferFragmentRecord(
         deferredFragmentRecord,
+        incrementalDataRecord,
         parent,
       );
 

--- a/src/jsutils/OrderedSet.ts
+++ b/src/jsutils/OrderedSet.ts
@@ -1,0 +1,93 @@
+const setContainingUndefined = new Set([undefined]);
+const setsContainingOneItem = new WeakMap<object, Set<object | undefined>>();
+const setsAppendedByUndefined = new WeakMap<
+  ReadonlySet<object | undefined>,
+  Set<object | undefined>
+>();
+const setsAppendedByDefined = new WeakMap<
+  ReadonlySet<object | undefined>,
+  WeakMap<object, Set<object | undefined>>
+>();
+
+function createOrderedSet<T extends object | undefined>(
+  item: T,
+): ReadonlySet<T | undefined> {
+  if (item === undefined) {
+    return setContainingUndefined;
+  }
+
+  let set = setsContainingOneItem.get(item);
+  if (set === undefined) {
+    set = new Set([item]);
+    set.add(item);
+    setsContainingOneItem.set(item, set);
+  }
+  return set as ReadonlyOrderedSet<T | undefined>;
+}
+
+function appendToOrderedSet<T extends object | undefined>(
+  set: ReadonlySet<T | undefined>,
+  item: T | undefined,
+): ReadonlySet<T | undefined> {
+  if (set.has(item)) {
+    return set;
+  }
+
+  if (item === undefined) {
+    let appendedSet = setsAppendedByUndefined.get(set);
+    if (appendedSet === undefined) {
+      appendedSet = new Set(set);
+      appendedSet.add(undefined);
+      setsAppendedByUndefined.set(set, appendedSet);
+    }
+    return appendedSet as ReadonlySet<T | undefined>;
+  }
+
+  let appendedSets = setsAppendedByDefined.get(set);
+  if (appendedSets === undefined) {
+    appendedSets = new WeakMap();
+    setsAppendedByDefined.set(set, appendedSets);
+    const appendedSet = new Set(set);
+    appendedSet.add(item);
+    appendedSets.set(item, appendedSet);
+    return appendedSet as ReadonlySet<T | undefined>;
+  }
+
+  let appendedSet: Set<object | undefined> | undefined = appendedSets.get(item);
+  if (appendedSet === undefined) {
+    appendedSet = new Set<object | undefined>(set);
+    appendedSet.add(item);
+    appendedSets.set(item, appendedSet);
+  }
+
+  return appendedSet as ReadonlySet<T | undefined>;
+}
+
+export type ReadonlyOrderedSet<T> = ReadonlySet<T>;
+
+const emptySet = new Set();
+
+/**
+ * A set that when frozen can be directly compared for equality.
+ *
+ * Sets are limited to JSON serializable values.
+ *
+ * @internal
+ */
+export class OrderedSet<T extends object | undefined> {
+  _set: ReadonlySet<T | undefined> = emptySet as ReadonlySet<T>;
+  constructor(items: Iterable<T>) {
+    for (const item of items) {
+      if (this._set === emptySet) {
+        this._set = createOrderedSet(item);
+        continue;
+      }
+
+      this._set = appendToOrderedSet(this._set, item);
+    }
+  }
+
+  freeze(): ReadonlyOrderedSet<T> {
+    return this._set as ReadonlyOrderedSet<T>;
+  }
+}

--- a/src/jsutils/__tests__/OrderedSet-test.ts
+++ b/src/jsutils/__tests__/OrderedSet-test.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { OrderedSet } from '../OrderedSet.js';
+
+describe('OrderedSet', () => {
+  it('empty sets are equal', () => {
+    const orderedSetA = new OrderedSet([]).freeze();
+    const orderedSetB = new OrderedSet([]).freeze();
+
+    expect(orderedSetA).to.equal(orderedSetB);
+  });
+
+  it('sets with members in different orders or numbers are equal', () => {
+    const a = { a: 'a' };
+    const b = { b: 'b' };
+    const c = { c: 'c' };
+    const orderedSetA = new OrderedSet([a, b, c, a, undefined]).freeze();
+    const orderedSetB = new OrderedSet([undefined, b, a, b, c]).freeze();
+
+    expect(orderedSetA).to.not.equal(orderedSetB);
+  });
+
+  it('sets with members in different orders or numbers are equal', () => {
+    const a = { a: 'a' };
+    const b = { b: 'b' };
+    const c = { c: 'c' };
+    const d = { c: 'd' };
+    const orderedSetA = new OrderedSet([a, b, c, a, undefined]).freeze();
+    const orderedSetB = new OrderedSet([undefined, b, a, b, d]).freeze();
+
+    expect(orderedSetA).to.not.equal(orderedSetB);
+  });
+});

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -885,9 +885,22 @@ export type GraphQLFieldResolver<
   info: GraphQLResolveInfo,
 ) => TResult;
 
+export interface DeferUsage {
+  label: string | undefined;
+  ancestors: ReadonlyArray<Target>;
+  deferPriority: number;
+}
+
+export type Target = DeferUsage | undefined;
+
+export interface FieldDetails {
+  node: FieldNode;
+  target: Target;
+}
+
 export interface GraphQLResolveInfo {
   readonly fieldName: string;
-  readonly fieldNodes: ReadonlyArray<FieldNode>;
+  readonly fieldDetails: ReadonlyArray<FieldDetails>;
   readonly returnType: GraphQLOutputType;
   readonly parentType: GraphQLObjectType;
   readonly path: Path;
@@ -896,6 +909,9 @@ export interface GraphQLResolveInfo {
   readonly rootValue: unknown;
   readonly operation: OperationDefinitionNode;
   readonly variableValues: { [variable: string]: unknown };
+  readonly priority: number;
+  readonly deferPriority: number;
+  readonly published: true | Promise<void>;
 }
 
 /**


### PR DESCRIPTION
depends on #3911

emit all completed payloads in a dependency tree within the same batch, by including subsequent deferred grouped field sets and stream items into their parents.

results that are ready are not only batched, they are wholly consolidated/inlined

as a notable excepetion, the initial result still does not include any defers, even if they are completed! although early execution still does kick off.  this may need revisiting!