### PR TITLE
asyncIterable: locate async iterator errors to the collection

### DIFF
--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -141,12 +141,12 @@ describe('Execute: Accepts async iterables as list value', () => {
     }
 
     expectJSON(await complete({ listField })).toDeepEqual({
-      data: { listField: ['two', '4', null] },
+      data: { listField: null },
       errors: [
         {
           message: 'bad',
           locations: [{ line: 1, column: 3 }],
-          path: ['listField', 2],
+          path: ['listField'],
         },
       ],
     });

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -731,11 +731,11 @@ describe('Execute: stream directive', () => {
         {
           message: 'bad',
           locations: [{ line: 3, column: 9 }],
-          path: ['friendList', 1],
+          path: ['friendList'],
         },
       ],
       data: {
-        friendList: [{ name: 'Luke', id: '1' }, null],
+        friendList: null,
       },
     });
   });
@@ -764,13 +764,13 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [null],
+            items: null,
             path: ['friendList', 1],
             errors: [
               {
                 message: 'bad',
                 locations: [{ line: 3, column: 9 }],
-                path: ['friendList', 1],
+                path: ['friendList'],
               },
             ],
           },

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1093,16 +1093,7 @@ async function completeAsyncIteratorValue(
         break;
       }
     } catch (rawError) {
-      handleFieldError(
-        rawError,
-        exeContext,
-        itemType,
-        fieldGroup,
-        itemPath,
-        incrementalDataRecord,
-      );
-      completedResults.push(null);
-      break;
+      throw locatedError(rawError, fieldGroup, pathToArray(path));
     }
 
     if (
@@ -1954,6 +1945,7 @@ async function executeStreamAsyncIteratorItem(
   info: GraphQLResolveInfo,
   itemType: GraphQLOutputType,
   incrementalDataRecord: StreamItemsRecord,
+  path: Path,
   itemPath: Path,
 ): Promise<IteratorResult<unknown>> {
   let item;
@@ -1965,16 +1957,7 @@ async function executeStreamAsyncIteratorItem(
     }
     item = value;
   } catch (rawError) {
-    handleFieldError(
-      rawError,
-      exeContext,
-      itemType,
-      fieldGroup,
-      itemPath,
-      incrementalDataRecord,
-    );
-    // don't continue if async iterator throws
-    return { done: true, value: null };
+    throw locatedError(rawError, fieldGroup, pathToArray(path));
   }
   let completedItem;
   try {
@@ -2051,6 +2034,7 @@ async function executeStreamAsyncIterator(
         info,
         itemType,
         incrementalDataRecord,
+        path,
         itemPath,
       );
     } catch (error) {


### PR DESCRIPTION
Currently, they are presented as errors in the next pending item.

Of course, there may or not be a next pending item; there may not be a way to definitively know the reason for the error, such that the error is a function of a problem with the collection itself.

As discussed in a prior incremental delivery WG meeting, this must be changed for both the non-streaming and streaming cases; this PR makes the minor adjustments addressing both cases.