### PR TITLE
introduce promiseWithResolvers helper

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -12,6 +12,7 @@ import { addPath, pathToArray } from '../jsutils/Path.js';
 import { promiseForObject } from '../jsutils/promiseForObject.js';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
 import { promiseReduce } from '../jsutils/promiseReduce.js';
+import { promiseWithResolvers } from '../jsutils/promiseWithResolvers.js';
 
 import type { GraphQLFormattedError } from '../error/GraphQLError.js';
 import { GraphQLError } from '../error/GraphQLError.js';
@@ -2239,11 +2240,9 @@ class DeferredFragmentRecord {
     this._exeContext.subsequentPayloads.add(this);
     this.isCompleted = false;
     this.data = null;
-    this.promise = new Promise<ObjMap<unknown> | null>((resolve) => {
-      this._resolve = (promiseOrValue) => {
-        resolve(promiseOrValue);
-      };
-    }).then((data) => {
+    const { promise, resolve } = promiseWithResolvers<ObjMap<unknown> | null>();
+    this._resolve = resolve;
+    this.promise = promise.then((data) => {
       this.data = data;
       this.isCompleted = true;
     });
@@ -2290,11 +2289,9 @@ class StreamItemsRecord {
     this._exeContext.subsequentPayloads.add(this);
     this.isCompleted = false;
     this.items = null;
-    this.promise = new Promise<Array<unknown> | null>((resolve) => {
-      this._resolve = (promiseOrValue) => {
-        resolve(promiseOrValue);
-      };
-    }).then((items) => {
+    const { promise, resolve } = promiseWithResolvers<Array<unknown> | null>();
+    this._resolve = resolve;
+    this.promise = promise.then((items) => {
       this.items = items;
       this.isCompleted = true;
     });

--- a/src/jsutils/__tests__/promiseWithResolvers-test.ts
+++ b/src/jsutils/__tests__/promiseWithResolvers-test.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectPromise } from '../../__testUtils__/expectPromise.js';
+
+import { promiseWithResolvers } from '../promiseWithResolvers.js';
+
+describe('promiseWithResolvers', () => {
+  it('resolves values', async () => {
+    const { promise, resolve } = promiseWithResolvers();
+    resolve('foo');
+    expect(await expectPromise(promise).toResolve()).to.equal('foo');
+  });
+
+  it('rejects values', async () => {
+    const { promise, reject } = promiseWithResolvers();
+    const error = new Error('rejected');
+    reject(error);
+    await expectPromise(promise).toRejectWith('rejected');
+  });
+});

--- a/src/jsutils/promiseWithResolvers.ts
+++ b/src/jsutils/promiseWithResolvers.ts
@@ -1,0 +1,20 @@
+import type { PromiseOrValue } from './PromiseOrValue.js';
+
+/**
+ * Based on Promise.withResolvers proposal
+ * https://github.com/tc39/proposal-promise-with-resolvers
+ */
+export function promiseWithResolvers<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseOrValue<T>) => void;
+  reject: (reason?: any) => void;
+} {
+  // these are assigned synchronously within the Promise constructor
+  let resolve!: (value: T | PromiseOrValue<T>) => void;
+  let reject!: (reason?: any) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}


### PR DESCRIPTION
Promise.withResolvers is currently a [stage 2 proposal for JS](https://github.com/tc39/proposal-promise-with-resolvers). This adds an equivalent jsutil to standardize usage.