### PR TITLE
getIntrospectionQuery should select kind for all types

### DIFF
--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -67,9 +67,9 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     query IntrospectionQuery {
       __schema {
         ${schemaDescription}
-        queryType { name }
-        mutationType { name }
-        subscriptionType { name }
+        queryType { name kind }
+        mutationType { name kind }
+        subscriptionType { name kind }
         types {
           ...FullType
         }


### PR DESCRIPTION
Prior to this change, the result when using the `getIntrospectionQuery` does not match the declared `IntrospectionQuery` type.

Fixes #3909

