### PR TITLE
suggestion: alternative check for multiple graphql packages

### DIFF
--- a/integrationTests/webpack/package.json
+++ b/integrationTests/webpack/package.json
@@ -3,7 +3,7 @@
   "description": "graphql-js should be compatible with Webpack",
   "type": "module",
   "scripts": {
-    "test": "webpack && node test.js"
+    "test": "webpack && node test.js && node test-esm.js"
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz",

--- a/integrationTests/webpack/test-esm.js
+++ b/integrationTests/webpack/test-esm.js
@@ -1,14 +1,14 @@
 import assert from 'assert';
 
 /* eslint-disable n/no-missing-import */
-import cjs from './dist/main-cjs.cjs';
+import mjs from './dist/main-mjs.cjs';
 /* eslint-enable n/no-missing-import */
 
-assert.deepStrictEqual(cjs.result, {
+assert.deepStrictEqual(mjs.result, {
   data: {
     __proto__: null,
     hello: 'world',
   },
 });
 
-console.log('Test script: Got correct result from Webpack cjs bundle!');
+console.log('Test script: Got correct result from Webpack esm bundle!');

--- a/src/jsutils/__tests__/checkForMultiplePackageInstances-test.ts
+++ b/src/jsutils/__tests__/checkForMultiplePackageInstances-test.ts
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+import { expect } from 'chai';
+import { afterEach, beforeEach, describe, it } from 'mocha';
+
+import { checkForMultiplePackageInstances } from '../checkForMultiplePackageInstances.js';
+
+describe('check for different library versions', () => {
+  class OtherPackageClass {}
+  const graphqlPackageInstanceCheckSymbol = Symbol.for(
+    'graphql-js:check-multiple-package-instances',
+  );
+  const globalObject = globalThis as {
+    [graphqlPackageInstanceCheckSymbol]?: unknown;
+  };
+  const orig = globalObject[graphqlPackageInstanceCheckSymbol];
+  const origError = console.error;
+  let errors: Array<unknown> = [];
+  beforeEach(() => {
+    errors = [];
+    console.error = (...args) => {
+      errors = args;
+    };
+  });
+
+  afterEach(() => {
+    globalObject[graphqlPackageInstanceCheckSymbol] = orig;
+    console.error = origError;
+  });
+
+  it('does not log an error under normal circumstances', () => {
+    checkForMultiplePackageInstances();
+    expect(errors).to.deep.equal([]);
+    checkForMultiplePackageInstances();
+    expect(errors).to.deep.equal([]);
+    checkForMultiplePackageInstances();
+    expect(errors).to.deep.equal([]);
+  });
+
+  it('logs an error if another package has been loaded first', () => {
+    // simulate other version of this lib to have been loaded before this version
+    globalObject[graphqlPackageInstanceCheckSymbol] = new OtherPackageClass();
+
+    checkForMultiplePackageInstances();
+
+    expect(errors[0]).to.match(
+      /Multiple colliding versions of the `graphql` package detected\./m,
+    );
+  });
+});

--- a/src/jsutils/checkForMultiplePackageInstances.ts
+++ b/src/jsutils/checkForMultiplePackageInstances.ts
@@ -1,0 +1,37 @@
+const graphqlPackageInstanceCheckSymbol = Symbol.for(
+  'graphql-js:check-multiple-package-instances',
+);
+
+class Check {}
+
+/**
+ * A check which throws an error warning when multi-realm constructors are detected.
+ */
+export function checkForMultiplePackageInstances() {
+  const globalObject = globalThis as {
+    [graphqlPackageInstanceCheckSymbol]?: Check;
+  };
+  if (!globalObject[graphqlPackageInstanceCheckSymbol]) {
+    globalObject[graphqlPackageInstanceCheckSymbol] = new Check();
+    return;
+  }
+  if (!(globalObject[graphqlPackageInstanceCheckSymbol] instanceof Check)) {
+    // eslint-disable-next-line no-console
+    console.error(
+      new Error(
+        `Multiple colliding versions of the \`graphql\` package detected.
+
+Ensure that there is only one instance of "graphql" in the node_modules
+directory. If different versions of "graphql" are the dependencies of other
+relied on modules, use "resolutions" to ensure only one version is installed.
+
+https://yarnpkg.com/en/docs/selective-version-resolutions
+
+Duplicate "graphql" modules cannot be used at the same time since different
+versions may have different capabilities and behavior. The data from one
+version used in the function from another could produce confusing and
+spurious results.`,
+      ),
+    );
+  }
+}

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,4 +1,7 @@
+import { checkForMultiplePackageInstances } from './checkForMultiplePackageInstances.js';
 import { inspect } from './inspect.js';
+
+checkForMultiplePackageInstances();
 
 /**
  * A replacement for instanceof which includes an error warning when multi-realm


### PR DESCRIPTION
This could in the long term enhance early detection if users bundle multiple versions of the `graphql` package, and (in a future version of `graphql`) retire the current check that needs inside of `instanceOf` and thus needs to be restricted to development node, since it slows down the function.