### PR TITLE
Expose GraphQLErrorOptions type (#3554) (#3565)

### DIFF
--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -9,7 +9,7 @@ import { inspect } from './inspect';
 export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  globalThis.process?.env.NODE_ENV === 'production'
+  globalThis.process && globalThis.process.env.NODE_ENV === 'production'
     ? function instanceOf(value: unknown, constructor: Constructor): boolean {
         return value instanceof constructor;
       }


### PR DESCRIPTION
…tional arguments (#3645)

BACKPORT OF #3634

Deprecates the positional arguments to createSourceEventStream, to be removed in the next major version, in favor of named arguments.

Motivation:

1. aligns createSourceEventStream with the other exported entrypoints graphql, execute, and subscribe
2. allows simplification of mapSourceToResponse

suggested by @IvanGoncharov