### PR TITLE
instanceOf: workaround bundler issue with `process.env`

### DIFF
--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -9,7 +9,7 @@ import { inspect } from './inspect';
 export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  globalThis.process?.env.NODE_ENV === 'production'
+  globalThis.process && globalThis.process.env.NODE_ENV === 'production'
     ? function instanceOf(value: unknown, constructor: Constructor): boolean {
         return value instanceof constructor;
       }


### PR DESCRIPTION
Big shout out to @phryneas, who managed to reproduce this issue and come up with this fix.

Fixes: #3919 #3920 #3921
Context: #3887 changed code and introced optinal chaining. `globalThis.process?.env.NODE_ENV` is transpiled into
```
(_globalThis$process = globalThis.process) === null ||
_globalThis$process === void 0
  ? void 0
  : _globalThis$process.env.NODE_ENV;
```
Bundlers incorrectly replace (probably RegExp) `process.env.NODE_ENV` with `"development"` resulting in:
```
(_globalThis$process = globalThis.process) === null ||
_globalThis$process === void 0
  ? void 0
  : _globalThis$"development";
```

Technically it's not a graphql issue but an issue with bundler but since it caused so much pain in comutinity this is an attempt to fix it within our codebase.