### PR TITLE
incremental: subsequent result records should not store parent references

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -285,7 +285,6 @@ export class IncrementalPublisher {
         continue;
       }
 
-      this._delete(child);
       child.filtered = true;
 
       if (isStreamItemsRecord(child)) {
@@ -330,12 +329,6 @@ export class IncrementalPublisher {
   private _push(item: SubsequentDataRecord): void {
     this._released.add(item);
     this._pending.add(item);
-    this._trigger();
-  }
-
-  private _delete(item: SubsequentDataRecord) {
-    this._released.delete(item);
-    this._pending.delete(item);
     this._trigger();
   }
 


### PR DESCRIPTION
as memory then cannot be freed

This affects both the existing branching executor on main as well as the non-branching, deduplicated version in #3886

We want to ensure that after an incremental result is sent to the client, no subsequent results reference this result so that garbage collection can free the memory associated with the result.  To effect this, two changes are required:

1. Prior to this change, we performed filtering by modifying the children stored on a parent; now we add a flag on the filtered item itself, so that we no longer need a backreference from child to parent.
2. We no longer store a permanent reference on the ExecutionContext to the children of the initial result. Rather, we have the IncrementalPublisher provide a new InitialResultRecord that carries its own errors and children properties.