### PR TITLE
incremental publisher should handle all response building

### DIFF
--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -16,9 +16,11 @@ import {
 import { GraphQLID, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import type { InitialIncrementalExecutionResult } from '../execute.js';
 import { execute, experimentalExecuteIncrementally } from '../execute.js';
-import type { SubsequentIncrementalExecutionResult } from '../IncrementalPublisher.js';
+import type {
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
+} from '../IncrementalPublisher.js';
 
 const friendType = new GraphQLObjectType({
   fields: {

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -18,8 +18,8 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import type { ExecutionResult } from '../execute.js';
 import { execute, executeSync } from '../execute.js';
+import type { ExecutionResult } from '../IncrementalPublisher.js';
 
 describe('Execute: Accepts any iterable as list value', () => {
   function complete(rootValue: unknown) {

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -13,8 +13,8 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import type { ExecutionResult } from '../execute.js';
 import { execute, executeSync } from '../execute.js';
+import type { ExecutionResult } from '../IncrementalPublisher.js';
 
 const syncError = new Error('sync');
 const syncNonNullError = new Error('syncNonNull');

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -6,8 +6,8 @@ import { parse } from '../../language/parser.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import type { ExecutionResult } from '../execute.js';
 import { execute } from '../execute.js';
+import type { ExecutionResult } from '../IncrementalPublisher.js';
 
 const schema = buildSchema(`
   type Query {

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -17,9 +17,11 @@ import {
 import { GraphQLID, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import type { InitialIncrementalExecutionResult } from '../execute.js';
 import { experimentalExecuteIncrementally } from '../execute.js';
-import type { SubsequentIncrementalExecutionResult } from '../IncrementalPublisher.js';
+import type {
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
+} from '../IncrementalPublisher.js';
 
 const friendType = new GraphQLObjectType({
   fields: {

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -20,8 +20,9 @@ import {
 } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import type { ExecutionArgs, ExecutionResult } from '../execute.js';
+import type { ExecutionArgs } from '../execute.js';
 import { createSourceEventStream, subscribe } from '../execute.js';
+import type { ExecutionResult } from '../IncrementalPublisher.js';
 
 import { SimplePubSub } from './simplePubSub.js';
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -10,20 +10,18 @@ export {
   subscribe,
 } from './execute.js';
 
+export type { ExecutionArgs } from './execute.js';
+
 export type {
-  ExecutionArgs,
   ExecutionResult,
   ExperimentalIncrementalExecutionResults,
   InitialIncrementalExecutionResult,
-  FormattedExecutionResult,
-  FormattedInitialIncrementalExecutionResult,
-} from './execute.js';
-
-export type {
   SubsequentIncrementalExecutionResult,
   IncrementalDeferResult,
   IncrementalStreamResult,
   IncrementalResult,
+  FormattedExecutionResult,
+  FormattedInitialIncrementalExecutionResult,
   FormattedSubsequentIncrementalExecutionResult,
   FormattedIncrementalDeferResult,
   FormattedIncrementalStreamResult,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -14,8 +14,8 @@ import { validateSchema } from './type/validate.js';
 
 import { validate } from './validation/validate.js';
 
-import type { ExecutionResult } from './execution/execute.js';
 import { execute } from './execution/execute.js';
+import type { ExecutionResult } from './execution/IncrementalPublisher.js';
 
 /**
  * This is the primary entry point function for fulfilling GraphQL operations


### PR DESCRIPTION
extracted from #3929

the publisher itself can determine whether to return a single result or the initial result + stream

the only desired change is to replace the following code block with the below:

[FROM:](https://github.com/graphql/graphql-js/blob/fae5da500bad94c39a7ecd77a4c4361b58d6d2da/src/execution/execute.ts#L293-L340)

```ts
  const incrementalPublisher = exeContext.incrementalPublisher;
  const initialResultRecord = incrementalPublisher.prepareInitialResultRecord();
  try {
    const result = executeOperation(exeContext, initialResultRecord);
    if (isPromise(result)) {
      return result.then(
        (data) => {
          const errors =
            incrementalPublisher.getInitialErrors(initialResultRecord);
          const initialResult = buildResponse(data, errors);
          incrementalPublisher.publishInitial(initialResultRecord);
          if (incrementalPublisher.hasNext()) {
            return {
              initialResult: {
                ...initialResult,
                hasNext: true,
              },
              subsequentResults: incrementalPublisher.subscribe(),
            };
          }
          return initialResult;
        },
        (error) => {
          incrementalPublisher.addFieldError(initialResultRecord, error);
          const errors =
            incrementalPublisher.getInitialErrors(initialResultRecord);
          return buildResponse(null, errors);
        },
      );
    }
    const initialResult = buildResponse(result, initialResultRecord.errors);
    incrementalPublisher.publishInitial(initialResultRecord);
    if (incrementalPublisher.hasNext()) {
      return {
        initialResult: {
          ...initialResult,
          hasNext: true,
        },
        subsequentResults: incrementalPublisher.subscribe(),
      };
    }
    return initialResult;
  } catch (error) {
    incrementalPublisher.addFieldError(initialResultRecord, error);
    const errors = incrementalPublisher.getInitialErrors(initialResultRecord);
    return buildResponse(null, errors);
  }
}
```

[TO:](https://github.com/yaacovCR/graphql-executor/blob/598608e8d8b23bc527dd73283b477997305afd58/src/execution/execute.ts#L234-L250):

```ts
  const incrementalPublisher = exeContext.incrementalPublisher;
  const initialResultRecord = incrementalPublisher.prepareInitialResultRecord();
  try {
    const data = executeOperation(exeContext, initialResultRecord);
    if (isPromise(data)) {
      return data.then(
        (resolved) =>
          incrementalPublisher.buildDataResponse(initialResultRecord, resolved),
        (error) =>
          incrementalPublisher.buildErrorResponse(initialResultRecord, error),
      );
    }
    return incrementalPublisher.buildDataResponse(initialResultRecord, data);
  } catch (error) {
    return incrementalPublisher.buildErrorResponse(initialResultRecord, error);
  }
```

Supporting changes are required:
1. some existing public methods no longer are required to be public and so are made private (or removed entirely!), with lint rules forcing the reordering of existing methods
2. to prevent cyclic type dependencies (not strictly necessary, but still!), types are moved from `execute.ts` to `IncrementalPublisher.ts`