### PR TITLE
Add Developer best practices in starWarsSchema.ts

### DIFF
--- a/src/__tests__/starWarsSchema.ts
+++ b/src/__tests__/starWarsSchema.ts
@@ -134,6 +134,8 @@ const characterInterface: GraphQLInterfaceType = new GraphQLInterfaceType({
         return humanType.name;
       case 'Droid':
         return droidType.name;
+      default:
+        return humanType.name;
     }
   },
 });


### PR DESCRIPTION
Added Developer best practices in starWarsSchema.ts

Ideally, the switch-case statement should have default keyword at the end. 

In example, there was no default keyword. So as a part of developer best practices, added the default keyword and return the first switch-case value. So that if anyone enters the wrong value in the switch case, the code will not break.