### PR TITLE
Improve description for `@oneOf` directive

### DIFF
--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -253,7 +253,7 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
 export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
   name: 'oneOf',
   description:
-    'Indicates that exactly one field must be supplied and that field must not be `null`.',
+    'Indicates that exactly one field must be supplied and not `null`.',
   locations: [DirectiveLocation.INPUT_OBJECT],
   args: {},
 });

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -253,7 +253,7 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
 export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
   name: 'oneOf',
   description:
-    'Indicates that exactly one field must be supplied and not `null`.',
+    'Indicates exactly one field must be supplied and this field must not be `null`.',
   locations: [DirectiveLocation.INPUT_OBJECT],
   args: {},
 });

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -252,7 +252,8 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
  */
 export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
   name: 'oneOf',
-  description: 'Indicates that exactly one field must be supplied and that field must not be `null`.',
+  description:
+    'Indicates that exactly one field must be supplied and that field must not be `null`.',
   locations: [DirectiveLocation.INPUT_OBJECT],
   args: {},
 });

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -248,11 +248,11 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
   });
 
 /**
- * Used to declare an Input Object as a OneOf Input Objects.
+ * Used to indicate an Input Object is a OneOf Input Object.
  */
 export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
   name: 'oneOf',
-  description: 'Indicates an Input Object is a OneOf Input Object.',
+  description: 'Indicates that exactly one field must be supplied and that field must not be `null`.',
   locations: [DirectiveLocation.INPUT_OBJECT],
   args: {},
 });

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -795,9 +795,7 @@ describe('Type System Printer', () => {
         url: String!
       ) on SCALAR
 
-      """
-      Indicates that exactly one field must be supplied and not \`null\`.
-      """
+      """Indicates that exactly one field must be supplied and not \`null\`."""
       directive @oneOf on INPUT_OBJECT
 
       """

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -795,7 +795,9 @@ describe('Type System Printer', () => {
         url: String!
       ) on SCALAR
 
-      """Indicates that exactly one field must be supplied and that field must not be \`null\`."""
+      """
+      Indicates that exactly one field must be supplied and that field must not be \`null\`.
+      """
       directive @oneOf on INPUT_OBJECT
 
       """

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -795,7 +795,7 @@ describe('Type System Printer', () => {
         url: String!
       ) on SCALAR
 
-      """Indicates an Input Object is a OneOf Input Object."""
+      """Indicates that exactly one field must be supplied and that field must not be \`null\`."""
       directive @oneOf on INPUT_OBJECT
 
       """

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -796,7 +796,7 @@ describe('Type System Printer', () => {
       ) on SCALAR
 
       """
-      Indicates that exactly one field must be supplied and that field must not be \`null\`.
+      Indicates that exactly one field must be supplied and not \`null\`.
       """
       directive @oneOf on INPUT_OBJECT
 

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -795,7 +795,9 @@ describe('Type System Printer', () => {
         url: String!
       ) on SCALAR
 
-      """Indicates that exactly one field must be supplied and not \`null\`."""
+      """
+      Indicates exactly one field must be supplied and this field must not be \`null\`.
+      """
       directive @oneOf on INPUT_OBJECT
 
       """


### PR DESCRIPTION
Follow up from https://github.com/graphql/graphql-js/pull/3513.

I think it is fine for the spec text in https://github.com/graphql/graphql-spec/pull/825 to refer to `OneOf Input Object`, as the spec explains what that is in another section. In a directive definition, that explanation by itself does not make much sense without prior knowledge.

Channeling the RFC champion @benjie.