### PR TITLE
Speedup sorting & building/extending schema

### DIFF
--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -1,7 +1,6 @@
 import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
 import { inspect } from '../jsutils/inspect.js';
 import { invariant } from '../jsutils/invariant.js';
-import { keyMap } from '../jsutils/keyMap.js';
 import { mapValue } from '../jsutils/mapValue.js';
 import type { Maybe } from '../jsutils/Maybe.js';
 
@@ -217,14 +216,13 @@ export function extendSchemaImpl(
     return schemaConfig;
   }
 
-  const typeMap = Object.create(null);
-  for (const existingType of schemaConfig.types) {
-    typeMap[existingType.name] = extendNamedType(existingType);
-  }
+  const typeMap = new Map<string, GraphQLNamedType>(
+    schemaConfig.types.map((type) => [type.name, extendNamedType(type)]),
+  );
 
   for (const typeNode of typeDefs) {
     const name = typeNode.name.value;
-    typeMap[name] = stdTypeMap[name] ?? buildType(typeNode);
+    typeMap.set(name, stdTypeMap.get(name) ?? buildType(typeNode));
   }
 
   const operationTypes = {
@@ -242,7 +240,7 @@ export function extendSchemaImpl(
   return {
     description: schemaDef?.description?.value ?? schemaConfig.description,
     ...operationTypes,
-    types: Object.values(typeMap),
+    types: Array.from(typeMap.values()),
     directives: [
       ...schemaConfig.directives.map(replaceDirective),
       ...directiveDefs.map(buildDirective),
@@ -273,7 +271,7 @@ export function extendSchemaImpl(
     // Note: While this could make early assertions to get the correctly
     // typed values, that would throw immediately while type system
     // validation with validateSchema() will produce more actionable results.
-    return typeMap[type.name];
+    return typeMap.get(type.name) as T;
   }
 
   function replaceDirective(directive: GraphQLDirective): GraphQLDirective {
@@ -462,7 +460,7 @@ export function extendSchemaImpl(
 
   function getNamedType(node: NamedTypeNode): GraphQLNamedType {
     const name = node.name.value;
-    const type = stdTypeMap[name] ?? typeMap[name];
+    const type = stdTypeMap.get(name) ?? typeMap.get(name);
 
     if (type === undefined) {
       throw new Error(`Unknown type: "${name}".`);
@@ -704,9 +702,11 @@ export function extendSchemaImpl(
   }
 }
 
-const stdTypeMap = keyMap(
-  [...specifiedScalarTypes, ...introspectionTypes],
-  (type) => type.name,
+const stdTypeMap = new Map(
+  [...specifiedScalarTypes, ...introspectionTypes].map((type) => [
+    type.name,
+    type,
+  ]),
 );
 
 /**


### PR DESCRIPTION
Switch from using JS object as a map to use proper ES6 Map It gave ~30% speedup in benchmark tests.

```
Build Schema from AST
  2 tests completed.

  local x 93.98 ops/sec ±0.38% x 3.74 MB/op (9 runs sampled)
  HEAD  x   123 ops/sec ±0.91% x 3.78 MB/op (9 runs sampled)
```