### PR TITLE
Fixed broken source code URL in API docs

### DIFF
--- a/docs-old/APIReference-Errors.md
+++ b/docs-old/APIReference-Errors.md
@@ -2,7 +2,7 @@
 title: graphql/error
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/error/
+permalink: /graphql-js/src/error/
 sublinks: formatError,GraphQLError,locatedError,syntaxError
 next: /graphql-js/execution/
 ---

--- a/docs-old/APIReference-Execution.md
+++ b/docs-old/APIReference-Execution.md
@@ -2,7 +2,7 @@
 title: graphql/execution
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/execution/
+permalink: /graphql-js/src/execution/
 sublinks: execute
 next: /graphql-js/language/
 ---

--- a/docs-old/APIReference-GraphQL.md
+++ b/docs-old/APIReference-GraphQL.md
@@ -2,7 +2,7 @@
 title: graphql
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/graphql/
+permalink: /graphql-js/src/
 sublinks: graphql
 next: /graphql-js/error/
 ---
@@ -32,7 +32,7 @@ _Schema_
 
 <ul class="apiIndex">
   <li>
-    <a href="../type/#graphqlschema">
+    <a href="../src/type/schema.ts#graphqlschema">
       <pre>class GraphQLSchema</pre>
       A representation of the capabilities of a GraphQL Server.
     </a>
@@ -43,49 +43,49 @@ _Type Definitions_
 
 <ul class="apiIndex">
   <li>
-    <a href="../type/#graphqlscalartype">
+    <a href="../src/type/definition.ts#graphqlscalartype">
       <pre>class GraphQLScalarType</pre>
       A scalar type within GraphQL.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlobjecttype">
+    <a href="../src/type/definition.ts#graphqlobjecttype">
       <pre>class GraphQLObjectType</pre>
       An object type within GraphQL that contains fields.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlinterfacetype">
+    <a href="../src/type/definition.ts#graphqlinterfacetype">
       <pre>class GraphQLInterfaceType</pre>
       An interface type within GraphQL that defines fields implementations will contain.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqluniontype">
+    <a href="../src/type/definition.ts#graphqluniontype">
       <pre>class GraphQLUnionType</pre>
       A union type within GraphQL that defines a list of implementations.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlenumtype">
+    <a href="../src/type/definition.ts#graphqlenumtype">
       <pre>class GraphQLEnumType</pre>
       An enum type within GraphQL that defines a list of valid values.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlinputobjecttype">
+    <a href="../src/type/definition.ts#graphqlinputobjecttype">
       <pre>class GraphQLInputObjectType</pre>
       An input object type within GraphQL that represents structured inputs.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqllist">
+    <a href="../src/type/definition.ts#graphqllist">
       <pre>class GraphQLList</pre>
       A type wrapper around other types that represents a list of those types.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlnonnull">
+    <a href="../src/type/definition.ts#graphqlnonnull">
       <pre>class GraphQLNonNull</pre>
       A type wrapper around other types that represents a non-null version of those types.
     </a>
@@ -96,31 +96,31 @@ _Scalars_
 
 <ul class="apiIndex">
   <li>
-    <a href="../type/#graphqlint">
+    <a href="../src/type/scalars.ts#graphqlint">
       <pre>var GraphQLInt</pre>
       A scalar type representing integers.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlfloat">
+    <a href="../src/type/scalars.ts#graphqlfloat">
       <pre>var GraphQLFloat</pre>
       A scalar type representing floats.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlstring">
+    <a href="../src/type/scalars.ts#graphqlstring">
       <pre>var GraphQLString</pre>
       A scalar type representing strings.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlboolean">
+    <a href="../src/type/scalars.ts#graphqlboolean">
       <pre>var GraphQLBoolean</pre>
       A scalar type representing booleans.
     </a>
   </li>
   <li>
-    <a href="../type/#graphqlid">
+    <a href="../src/type/scalars.ts#graphqlid">
       <pre>var GraphQLID</pre>
       A scalar type representing IDs.
     </a>
@@ -131,7 +131,7 @@ _Errors_
 
 <ul class="apiIndex">
   <li>
-    <a href="../error/#formaterror">
+    <a href="../src/error/GraphQLError.ts#formaterror">
       <pre>function formatError</pre>
       Format an error according to the rules described by the Response Format.
     </a>
@@ -164,16 +164,16 @@ to specify which operation in `requestString` will be run, in cases where
 
 ## Schema
 
-See the [Type System API Reference](../type#schema).
+See the [Type System API Reference](../src/type/schema.ts).
 
 ## Type Definitions
 
-See the [Type System API Reference](../type#definitions).
+See the [Type System API Reference](../src/type/definition.ts).
 
 ## Scalars
 
-See the [Type System API Reference](../type#scalars).
+See the [Type System API Reference](../src/type/scalars.ts).
 
 ## Errors
 
-See the [Errors API Reference](../error)
+See the [Errors API Reference](../src/error/GraphQLError.ts)

--- a/docs-old/APIReference-Language.md
+++ b/docs-old/APIReference-Language.md
@@ -2,7 +2,7 @@
 title: graphql/language
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/language/
+permalink: /graphql-js/src/language/
 sublinks: BREAK,getLocation,Kind,lex,parse,parseValue,printSource,visit
 next: /graphql-js/type/
 ---

--- a/docs-old/APIReference-TypeSystem.md
+++ b/docs-old/APIReference-TypeSystem.md
@@ -2,7 +2,7 @@
 title: graphql/type
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/type/
+permalink: /graphql-js/src/type/
 sublinks: getNamedType,getNullableType,GraphQLBoolean,GraphQLEnumType,GraphQLFloat,GraphQLID,GraphQLInputObjectType,GraphQLInt,GraphQLInterfaceType,GraphQLList,GraphQLNonNull,GraphQLObjectType,GraphQLScalarType,GraphQLSchema,GraphQLString,GraphQLUnionType,isAbstractType,isCompositeType,isInputType,isLeafType,isOutputType
 next: /graphql-js/utilities/
 ---

--- a/docs-old/APIReference-Utilities.md
+++ b/docs-old/APIReference-Utilities.md
@@ -2,7 +2,7 @@
 title: graphql/utilities
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/utilities/
+permalink: /graphql-js/src/utilities/
 sublinks: astFromValue,buildASTSchema,buildClientSchema,buildSchema,introspectionQuery,isValidJSValue,isValidLiteralValue,printIntrospectionSchema,printSchema,typeFromAST,TypeInfo
 next: /graphql-js/validation/
 ---

--- a/docs-old/APIReference-Validation.md
+++ b/docs-old/APIReference-Validation.md
@@ -2,7 +2,7 @@
 title: graphql/validation
 layout: ../_core/GraphQLJSLayout
 category: API Reference
-permalink: /graphql-js/validation/
+permalink: /graphql-js/src/validation/
 sublinks: specifiedRules,validate
 ---
 


### PR DESCRIPTION
In reference to [bug](https://github.com/graphql/graphql-js/issues/3914). I've changed the relevant docs.