### PR TITLE
Fix edit URL in documentation

### DIFF
--- a/website/docusaurus.config.cjs
+++ b/website/docusaurus.config.cjs
@@ -25,7 +25,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.cjs'),
           editUrl:
-            'https://github.com/graphql/graphql-js/edit/main/website/docs/',
+            'https://github.com/graphql/graphql-js/edit/main/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/website/docusaurus.config.cjs
+++ b/website/docusaurus.config.cjs
@@ -24,8 +24,7 @@ module.exports = {
       ({
         docs: {
           sidebarPath: require.resolve('./sidebars.cjs'),
-          editUrl:
-            'https://github.com/graphql/graphql-js/edit/main/website/',
+          editUrl: 'https://github.com/graphql/graphql-js/edit/main/website/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
If you go to https://graphql-js.org/docs/tutorials/authentication-and-express-middleware and click `Edit this page` you'll be taken to `https://github.com/graphql/graphql-js/edit/main/website/docs/docs/tutorials/authentication-and-express-middleware.md`.
Instead you should be taken to `https://github.com/graphql/graphql-js/edit/main/website/docs/tutorials/authentication-and-express-middleware.md` - the `docs/` in the edit URL is incorrect since Docusaurus already adds that for you.

