### PR TITLE
draft: add support for fine grained aborting promises on error

### DIFF
--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -14,6 +14,6 @@
     "typescript-4.7": "npm:typescript@4.7.x",
     "typescript-4.8": "npm:typescript@4.8.x",
     "typescript-4.9": "npm:typescript@4.9.x",
-    "typescript-4.9": "npm:typescript@5.0.x"
+    "typescript-5.0": "npm:typescript@5.0.x"
   }
 }

--- a/integrationTests/ts/tsconfig.json
+++ b/integrationTests/ts/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "lib": [
+      "es2019",
+      "es2020.promise",
+      "es2020.bigint",
+      "es2020.string",
+      "dom" // Workaround for missing web-compatible globals in `@types/node`
+    ],
     "noEmit": true,
     "types": [],
     "strict": true,

--- a/src/jsutils/addAbortListener.ts
+++ b/src/jsutils/addAbortListener.ts
@@ -1,0 +1,64 @@
+type Callback = () => void;
+interface AbortInfo {
+  listeners: Set<Callback>;
+  dispose: Callback;
+}
+type Cache = WeakMap<AbortSignal, AbortInfo>;
+
+let maybeCache: Cache | undefined;
+
+/**
+ * Helper function to add a callback to be triggered when the abort signal fires.
+ * Returns a function that will remove the callback when called.
+ *
+ * This helper function also avoids hitting the max listener limit on AbortSignals,
+ * which could be a common occurrence when setting up multiple contingent
+ * abort signals.
+ */
+export function addAbortListener(
+  abortSignal: AbortSignal,
+  callback: Callback,
+): Callback {
+  if (abortSignal.aborted) {
+    callback();
+    return () => {
+      /* noop */
+    };
+  }
+
+  const cache = (maybeCache ??= new WeakMap());
+
+  const abortInfo = cache.get(abortSignal);
+
+  if (abortInfo !== undefined) {
+    abortInfo.listeners.add(callback);
+    return () => removeAbortListener(abortInfo, callback);
+  }
+
+  const listeners = new Set<Callback>([callback]);
+  const onAbort = () => triggerCallbacks(listeners);
+  const dispose = () => {
+    abortSignal.removeEventListener('abort', onAbort);
+  };
+  const newAbortInfo = { listeners, dispose };
+  cache.set(abortSignal, newAbortInfo);
+  abortSignal.addEventListener('abort', onAbort);
+
+  return () => removeAbortListener(newAbortInfo, callback);
+}
+
+function triggerCallbacks(listeners: Set<Callback>): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function removeAbortListener(abortInfo: AbortInfo, callback: Callback): void {
+  const listeners = abortInfo.listeners;
+
+  listeners.delete(callback);
+
+  if (listeners.size === 0) {
+    abortInfo.dispose();
+  }
+}

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -883,6 +883,7 @@ export type GraphQLFieldResolver<
   args: TArgs,
   context: TContext,
   info: GraphQLResolveInfo,
+  abortSignal: AbortSignal | undefined,
 ) => TResult;
 
 export interface GraphQLResolveInfo {


### PR DESCRIPTION
abort async resolvers on errors

TODO: connect return() and throw() events on returned iterators to abortion of resolvers for subscriptions/incremental delivery