### PR TITLE
OverlappingFieldsCanBeMergedRule: Fix performance degradation

### DIFF
--- a/benchmark/repeated-fields-benchmark.js
+++ b/benchmark/repeated-fields-benchmark.js
@@ -1,0 +1,18 @@
+import { graphqlSync } from 'graphql/graphql.js';
+import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
+
+import { bigSchemaSDL } from './fixtures.js';
+
+const schema = buildSchema(bigSchemaSDL, { assumeValid: true });
+const query = `{ ${'__typename '.repeat(2000)}}`;
+
+export const benchmark = {
+  name: 'Many repeated fields',
+  count: 50,
+  measure() {
+    graphqlSync({
+      schema,
+      source: query,
+    });
+  },
+};

--- a/benchmark/repeated-fields-benchmark.js
+++ b/benchmark/repeated-fields-benchmark.js
@@ -1,18 +1,13 @@
 import { graphqlSync } from 'graphql/graphql.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 
-import { bigSchemaSDL } from './fixtures.js';
-
-const schema = buildSchema(bigSchemaSDL, { assumeValid: true });
-const query = `{ ${'__typename '.repeat(2000)}}`;
+const schema = buildSchema('type Query { hello: String! }');
+const source = `{ ${'hello '.repeat(250)}}`;
 
 export const benchmark = {
   name: 'Many repeated fields',
-  count: 50,
+  count: 5,
   measure() {
-    graphqlSync({
-      schema,
-      source: query,
-    });
+    graphqlSync({ schema, source });
   },
 };

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -179,6 +179,24 @@ describe('Validate: Overlapping fields can be merged', () => {
     ]);
   });
 
+  it('different stream directive extra argument', () => {
+    expectErrors(`
+      fragment conflictingArgs on Dog {
+        name @stream(label: "streamLabel", initialCount: 1)
+        name @stream(label: "streamLabel", initialCount: 1, extraArg: true)
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Fields "name" conflict because they have differing stream directives. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 3, column: 9 },
+          { line: 4, column: 9 },
+        ],
+      },
+    ]);
+  });
+
   it('mix of stream and no stream', () => {
     expectErrors(`
       fragment conflictingArgs on Dog {


### PR DESCRIPTION
Update(from @IvanGoncharov): In addition to reversing #3457 this PR improves performance further, see below discussion.

Resolves https://github.com/graphql/graphql-js/issues/3955 (at least greatly mitigates it) 

Effectively reverts https://github.com/graphql/graphql-js/pull/3457 which introduces a performance degradation found in https://github.com/graphql/graphql-js/issues/3955. This pull request was identified in a git bisect. The performance issue results in the potential for DOS attacks. 

I think there are potential performance increases still available in this file, but this is a simple enough fix for the immediate problem. 

The following query:

```
const maliciousQuery = `{ ${'hello '.repeat(2000)}}`;
```

now takes 564ms on my machine, and on main takes 12s. 