### PR TITLE
incremental: utilize `id` and `subPath` rather than `path` and `label`

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -566,6 +566,7 @@ export class IncrementalPublisher {
         }
         const incrementalResult: IncrementalStreamResult = {
           items: subsequentResultRecord.items,
+          // safe because `id` is defined once the stream has been released as pending
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           id: subsequentResultRecord.streamRecord.id!,
         };
@@ -625,6 +626,7 @@ export class IncrementalPublisher {
     const incrementalDeferResult: IncrementalDeferResult = {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       data: data!,
+      // safe because `id` is defined once the fragment has been released as pending
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       id: id!,
     };
@@ -640,6 +642,7 @@ export class IncrementalPublisher {
     completedRecord: DeferredFragmentRecord | StreamRecord,
   ): CompletedResult {
     const result: CompletedResult = {
+      // safe because `id` is defined once the stream has been released as pending
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       id: completedRecord.id!,
     };

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -176,7 +176,7 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -188,7 +188,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -232,7 +232,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -242,7 +242,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -263,7 +263,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ path: [], label: 'DeferQuery' }],
+        pending: [{ id: '0', path: [], label: 'DeferQuery' }],
         hasNext: true,
       },
       {
@@ -277,7 +277,7 @@ describe('Execute: defer directive', () => {
             path: [],
           },
         ],
-        completed: [{ path: [], label: 'DeferQuery' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -305,7 +305,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ path: [], label: 'DeferQuery' }],
+        pending: [{ id: '0', path: [], label: 'DeferQuery' }],
         hasNext: true,
       },
       {
@@ -326,7 +326,7 @@ describe('Execute: defer directive', () => {
             path: [],
           },
         ],
-        completed: [{ path: [], label: 'DeferQuery' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -356,8 +356,8 @@ describe('Execute: defer directive', () => {
           hero: {},
         },
         pending: [
-          { path: ['hero'], label: 'DeferTop' },
-          { path: ['hero'], label: 'DeferNested' },
+          { id: '0', path: ['hero'], label: 'DeferTop' },
+          { id: '1', path: ['hero'], label: 'DeferNested' },
         ],
         hasNext: true,
       },
@@ -376,10 +376,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [
-          { path: ['hero'], label: 'DeferTop' },
-          { path: ['hero'], label: 'DeferNested' },
-        ],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -404,11 +401,11 @@ describe('Execute: defer directive', () => {
             name: 'Luke',
           },
         },
-        pending: [{ path: ['hero'], label: 'DeferTop' }],
+        pending: [{ id: '0', path: ['hero'], label: 'DeferTop' }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'], label: 'DeferTop' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -433,11 +430,11 @@ describe('Execute: defer directive', () => {
             name: 'Luke',
           },
         },
-        pending: [{ path: ['hero'], label: 'DeferTop' }],
+        pending: [{ id: '0', path: ['hero'], label: 'DeferTop' }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'], label: 'DeferTop' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -459,12 +456,12 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ path: ['hero'], label: 'InlineDeferred' }],
+        pending: [{ id: '0', path: ['hero'], label: 'InlineDeferred' }],
         hasNext: true,
       },
       {
         incremental: [{ data: { name: 'Luke' }, path: ['hero'] }],
-        completed: [{ path: ['hero'], label: 'InlineDeferred' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -489,11 +486,11 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -519,8 +516,8 @@ describe('Execute: defer directive', () => {
           hero: {},
         },
         pending: [
-          { path: ['hero'], label: 'DeferID' },
-          { path: ['hero'], label: 'DeferName' },
+          { id: '0', path: ['hero'], label: 'DeferID' },
+          { id: '1', path: ['hero'], label: 'DeferName' },
         ],
         hasNext: true,
       },
@@ -539,10 +536,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [
-          { path: ['hero'], label: 'DeferID' },
-          { path: ['hero'], label: 'DeferName' },
-        ],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -568,8 +562,8 @@ describe('Execute: defer directive', () => {
       {
         data: {},
         pending: [
-          { path: [], label: 'DeferID' },
-          { path: [], label: 'DeferName' },
+          { id: '0', path: [], label: 'DeferID' },
+          { id: '1', path: [], label: 'DeferName' },
         ],
         hasNext: true,
       },
@@ -588,10 +582,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [
-          { path: [], label: 'DeferID' },
-          { path: [], label: 'DeferName' },
-        ],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -622,8 +613,8 @@ describe('Execute: defer directive', () => {
       {
         data: {},
         pending: [
-          { path: [], label: 'DeferID' },
-          { path: [], label: 'DeferName' },
+          { id: '0', path: [], label: 'DeferID' },
+          { id: '1', path: [], label: 'DeferName' },
         ],
         hasNext: true,
       },
@@ -642,10 +633,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [
-          { path: [], label: 'DeferID' },
-          { path: [], label: 'DeferName' },
-        ],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -673,8 +661,8 @@ describe('Execute: defer directive', () => {
           hero: {},
         },
         pending: [
-          { path: [], label: 'DeferName' },
-          { path: ['hero'], label: 'DeferID' },
+          { id: '0', path: [], label: 'DeferName' },
+          { id: '1', path: ['hero'], label: 'DeferID' },
         ],
         hasNext: true,
       },
@@ -693,10 +681,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [
-          { path: ['hero'], label: 'DeferID' },
-          { path: [], label: 'DeferName' },
-        ],
+        completed: [{ id: '1' }, { id: '0' }],
         hasNext: false,
       },
     ]);
@@ -719,11 +704,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ path: [], label: 'DeferName' }],
+        pending: [{ id: '0', path: [], label: 'DeferName' }],
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero'], label: 'DeferID' }],
+        pending: [{ id: '1', path: ['hero'], label: 'DeferID' }],
         incremental: [
           {
             data: {
@@ -734,7 +719,7 @@ describe('Execute: defer directive', () => {
             path: [],
           },
         ],
-        completed: [{ path: [], label: 'DeferName' }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
@@ -746,7 +731,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [{ path: ['hero'], label: 'DeferID' }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
     ]);
@@ -784,18 +769,18 @@ describe('Execute: defer directive', () => {
       {
         data: { hero: { friends: [{}, {}, {}] } },
         pending: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
-          { path: ['hero', 'friends', 2] },
-          { path: ['hero', 'friends', 2] },
-          { path: ['hero', 'friends', 2] },
+          { id: '0', path: ['hero', 'friends', 0] },
+          { id: '1', path: ['hero', 'friends', 0] },
+          { id: '2', path: ['hero', 'friends', 0] },
+          { id: '3', path: ['hero', 'friends', 0] },
+          { id: '4', path: ['hero', 'friends', 1] },
+          { id: '5', path: ['hero', 'friends', 1] },
+          { id: '6', path: ['hero', 'friends', 1] },
+          { id: '7', path: ['hero', 'friends', 1] },
+          { id: '8', path: ['hero', 'friends', 2] },
+          { id: '9', path: ['hero', 'friends', 2] },
+          { id: '10', path: ['hero', 'friends', 2] },
+          { id: '11', path: ['hero', 'friends', 2] },
         ],
         hasNext: true,
       },
@@ -806,18 +791,18 @@ describe('Execute: defer directive', () => {
           { data: { id: '4', name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
         completed: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
-          { path: ['hero', 'friends', 2] },
-          { path: ['hero', 'friends', 2] },
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
+          { id: '1' },
+          { id: '2' },
+          { id: '3' },
+          { id: '5' },
+          { id: '6' },
+          { id: '7' },
+          { id: '9' },
+          { id: '10' },
+          { id: '11' },
+          { id: '0' },
+          { id: '4' },
+          { id: '8' },
         ],
         hasNext: false,
       },
@@ -875,7 +860,7 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -885,7 +870,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -917,11 +902,11 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        pending: [{ id: '1', path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: {
@@ -932,7 +917,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
@@ -944,7 +929,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
     ]);
@@ -1001,22 +986,22 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero', 'nestedObject'] }],
+        pending: [{ id: '1', path: ['hero', 'nestedObject'] }],
         incremental: [
           {
             data: { bar: 'bar' },
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        pending: [{ id: '2', path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: { baz: 'baz' },
@@ -1024,7 +1009,7 @@ describe('Execute: defer directive', () => {
           },
         ],
         hasNext: true,
-        completed: [{ path: ['hero', 'nestedObject'] }],
+        completed: [{ id: '1' }],
       },
       {
         incremental: [
@@ -1033,7 +1018,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        completed: [{ id: '2' }],
         hasNext: false,
       },
     ]);
@@ -1076,13 +1061,13 @@ describe('Execute: defer directive', () => {
           },
         },
         pending: [
-          { path: ['hero'] },
-          { path: ['hero', 'nestedObject', 'deeperObject'] },
+          { id: '0', path: ['hero'] },
+          { id: '1', path: ['hero', 'nestedObject', 'deeperObject'] },
         ],
         hasNext: true,
       },
       {
-        pending: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        pending: [{ id: '2', path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: {
@@ -1091,10 +1076,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [
-          { path: ['hero'] },
-          { path: ['hero', 'nestedObject', 'deeperObject'] },
-        ],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: true,
       },
       {
@@ -1106,7 +1088,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ path: ['hero', 'nestedObject', 'deeperObject'] }],
+        completed: [{ id: '2' }],
         hasNext: false,
       },
     ]);
@@ -1161,7 +1143,10 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [{ path: [] }, { path: ['a', 'b'] }],
+        pending: [
+          { id: '0', path: [] },
+          { id: '1', path: ['a', 'b'] },
+        ],
         hasNext: true,
       },
       {
@@ -1175,7 +1160,7 @@ describe('Execute: defer directive', () => {
             path: [],
           },
         ],
-        completed: [{ path: ['a', 'b'] }, { path: [] }],
+        completed: [{ id: '1' }, { id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1213,7 +1198,10 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [{ path: [] }, { path: ['a'] }],
+        pending: [
+          { id: '0', path: [] },
+          { id: '1', path: ['a'] },
+        ],
         hasNext: true,
       },
       {
@@ -1229,7 +1217,7 @@ describe('Execute: defer directive', () => {
         ],
         completed: [
           {
-            path: [],
+            id: '0',
             errors: [
               {
                 message:
@@ -1239,7 +1227,7 @@ describe('Execute: defer directive', () => {
               },
             ],
           },
-          { path: ['a'] },
+          { id: '1' },
         ],
         hasNext: false,
       },
@@ -1281,7 +1269,10 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [{ path: [] }, { path: ['a'] }],
+        pending: [
+          { id: '0', path: [] },
+          { id: '1', path: ['a'] },
+        ],
         hasNext: true,
       },
       {
@@ -1297,7 +1288,7 @@ describe('Execute: defer directive', () => {
         ],
         completed: [
           {
-            path: ['a'],
+            id: '1',
             errors: [
               {
                 message:
@@ -1307,7 +1298,7 @@ describe('Execute: defer directive', () => {
               },
             ],
           },
-          { path: [] },
+          { id: '0' },
         ],
         hasNext: false,
       },
@@ -1357,7 +1348,10 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [{ path: [] }, { path: ['a'] }],
+        pending: [
+          { id: '0', path: [] },
+          { id: '1', path: ['a'] },
+        ],
         hasNext: true,
       },
       {
@@ -1371,13 +1365,13 @@ describe('Execute: defer directive', () => {
             path: ['a', 'b', 'c'],
           },
         ],
-        completed: [{ path: ['a'] }],
+        completed: [{ id: '1' }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: [],
+            id: '0',
             errors: [
               {
                 message:
@@ -1447,7 +1441,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ path: [] }],
+        pending: [{ id: '0', path: [] }],
         hasNext: true,
       },
       {
@@ -1467,7 +1461,7 @@ describe('Execute: defer directive', () => {
             path: [],
           },
         ],
-        completed: [{ path: [] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1496,11 +1490,11 @@ describe('Execute: defer directive', () => {
             friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
           },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1532,11 +1526,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [{ name: 'Han' }] } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1569,11 +1563,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [] } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1602,7 +1596,7 @@ describe('Execute: defer directive', () => {
             friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
           },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1620,7 +1614,7 @@ describe('Execute: defer directive', () => {
             path: ['hero', 'friends', 2],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1650,11 +1644,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [] } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1684,11 +1678,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { nestedObject: null } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1717,11 +1711,11 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { nestedObject: { name: 'foo' } } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1750,7 +1744,7 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -1767,7 +1761,7 @@ describe('Execute: defer directive', () => {
             ],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1793,13 +1787,13 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['hero'],
+            id: '0',
             errors: [
               {
                 message:
@@ -1872,13 +1866,13 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['hero'],
+            id: '0',
             errors: [
               {
                 message:
@@ -1925,14 +1919,14 @@ describe('Execute: defer directive', () => {
         data: {
           hero: { id: '1' },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         pending: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
+          { id: '1', path: ['hero', 'friends', 0] },
+          { id: '2', path: ['hero', 'friends', 1] },
+          { id: '3', path: ['hero', 'friends', 2] },
         ],
         incremental: [
           {
@@ -1940,7 +1934,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
@@ -1949,11 +1943,7 @@ describe('Execute: defer directive', () => {
           { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
           { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
-        completed: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
-        ],
+        completed: [{ id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
       },
     ]);
@@ -1982,14 +1972,14 @@ describe('Execute: defer directive', () => {
         data: {
           hero: { id: '1' },
         },
-        pending: [{ path: ['hero'] }],
+        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         pending: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
+          { id: '1', path: ['hero', 'friends', 0] },
+          { id: '2', path: ['hero', 'friends', 1] },
+          { id: '3', path: ['hero', 'friends', 2] },
         ],
         incremental: [
           {
@@ -2000,7 +1990,7 @@ describe('Execute: defer directive', () => {
             path: ['hero'],
           },
         ],
-        completed: [{ path: ['hero'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
@@ -2009,11 +1999,7 @@ describe('Execute: defer directive', () => {
           { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
           { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
-        completed: [
-          { path: ['hero', 'friends', 0] },
-          { path: ['hero', 'friends', 1] },
-          { path: ['hero', 'friends', 2] },
-        ],
+        completed: [{ id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -185,7 +185,7 @@ describe('Execute: defer directive', () => {
             data: {
               name: 'Luke',
             },
-            path: ['hero'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -239,7 +239,7 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { name: 'Luke' },
-            path: ['hero'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -274,7 +274,7 @@ describe('Execute: defer directive', () => {
                 id: '1',
               },
             },
-            path: [],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -323,7 +323,7 @@ describe('Execute: defer directive', () => {
                 path: ['hero', 'name'],
               },
             ],
-            path: [],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -367,13 +367,13 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            path: ['hero'],
+            id: '0',
           },
           {
             data: {
               friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
             },
-            path: ['hero'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }, { id: '1' }],
@@ -460,7 +460,7 @@ describe('Execute: defer directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ data: { name: 'Luke' }, path: ['hero'] }],
+        incremental: [{ data: { name: 'Luke' }, id: '0' }],
         completed: [{ id: '0' }],
         hasNext: false,
       },
@@ -527,13 +527,13 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            path: ['hero'],
+            id: '0',
           },
           {
             data: {
               name: 'Luke',
             },
-            path: ['hero'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }, { id: '1' }],
@@ -571,15 +571,17 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { hero: {} },
-            path: [],
+            id: '0',
           },
           {
             data: { id: '1' },
-            path: ['hero'],
+            id: '0',
+            subPath: ['hero'],
           },
           {
             data: { name: 'Luke' },
-            path: ['hero'],
+            id: '1',
+            subPath: ['hero'],
           },
         ],
         completed: [{ id: '0' }, { id: '1' }],
@@ -622,15 +624,17 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { hero: {} },
-            path: [],
+            id: '0',
           },
           {
             data: { id: '1' },
-            path: ['hero'],
+            id: '0',
+            subPath: ['hero'],
           },
           {
             data: { name: 'Luke' },
-            path: ['hero'],
+            id: '1',
+            subPath: ['hero'],
           },
         ],
         completed: [{ id: '0' }, { id: '1' }],
@@ -672,13 +676,14 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            path: ['hero'],
+            id: '1',
           },
           {
             data: {
               name: 'Luke',
             },
-            path: ['hero'],
+            id: '0',
+            subPath: ['hero'],
           },
         ],
         completed: [{ id: '1' }, { id: '0' }],
@@ -716,7 +721,7 @@ describe('Execute: defer directive', () => {
                 name: 'Luke',
               },
             },
-            path: [],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -728,7 +733,7 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            path: ['hero'],
+            id: '1',
           },
         ],
         completed: [{ id: '1' }],
@@ -786,9 +791,9 @@ describe('Execute: defer directive', () => {
       },
       {
         incremental: [
-          { data: { id: '2', name: 'Han' }, path: ['hero', 'friends', 0] },
-          { data: { id: '3', name: 'Leia' }, path: ['hero', 'friends', 1] },
-          { data: { id: '4', name: 'C-3PO' }, path: ['hero', 'friends', 2] },
+          { data: { id: '2', name: 'Han' }, id: '0' },
+          { data: { id: '3', name: 'Leia' }, id: '4' },
+          { data: { id: '4', name: 'C-3PO' }, id: '8' },
         ],
         completed: [
           { id: '1' },
@@ -867,7 +872,8 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { bar: 'bar' },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '0',
+            subPath: ['nestedObject', 'deeperObject'],
           },
         ],
         completed: [{ id: '0' }],
@@ -914,7 +920,7 @@ describe('Execute: defer directive', () => {
                 deeperObject: { foo: 'foo' },
               },
             },
-            path: ['hero'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -926,7 +932,7 @@ describe('Execute: defer directive', () => {
             data: {
               bar: 'bar',
             },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '1',
           },
         ],
         completed: [{ id: '1' }],
@@ -994,7 +1000,8 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { bar: 'bar' },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '0',
+            subPath: ['nestedObject', 'deeperObject'],
           },
         ],
         completed: [{ id: '0' }],
@@ -1005,7 +1012,8 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { baz: 'baz' },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '1',
+            subPath: ['deeperObject'],
           },
         ],
         hasNext: true,
@@ -1015,7 +1023,7 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { bak: 'bak' },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '2',
           },
         ],
         completed: [{ id: '2' }],
@@ -1073,7 +1081,7 @@ describe('Execute: defer directive', () => {
             data: {
               foo: 'foo',
             },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }, { id: '1' }],
@@ -1085,7 +1093,7 @@ describe('Execute: defer directive', () => {
             data: {
               bar: 'bar',
             },
-            path: ['hero', 'nestedObject', 'deeperObject'],
+            id: '2',
           },
         ],
         completed: [{ id: '2' }],
@@ -1153,11 +1161,11 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { e: { f: 'f' } },
-            path: ['a', 'b'],
+            id: '1',
           },
           {
             data: { g: { h: 'h' } },
-            path: [],
+            id: '0',
           },
         ],
         completed: [{ id: '1' }, { id: '0' }],
@@ -1208,11 +1216,12 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: {} } },
-            path: ['a'],
+            id: '1',
           },
           {
             data: { d: 'd' },
-            path: ['a', 'b', 'c'],
+            id: '1',
+            subPath: ['b', 'c'],
           },
         ],
         completed: [
@@ -1279,11 +1288,12 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: {} } },
-            path: ['a'],
+            id: '1',
           },
           {
             data: { d: 'd' },
-            path: ['a', 'b', 'c'],
+            id: '0',
+            subPath: ['a', 'b', 'c'],
           },
         ],
         completed: [
@@ -1358,11 +1368,12 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: {} } },
-            path: ['a'],
+            id: '1',
           },
           {
             data: { d: 'd' },
-            path: ['a', 'b', 'c'],
+            id: '1',
+            subPath: ['b', 'c'],
           },
         ],
         completed: [{ id: '1' }],
@@ -1458,7 +1469,7 @@ describe('Execute: defer directive', () => {
                 path: ['hero', 'nonNullName'],
               },
             ],
-            path: [],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1603,15 +1614,18 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { id: '2' },
-            path: ['hero', 'friends', 0],
+            id: '0',
+            subPath: ['friends', 0],
           },
           {
             data: { id: '3' },
-            path: ['hero', 'friends', 1],
+            id: '0',
+            subPath: ['friends', 1],
           },
           {
             data: { id: '4' },
-            path: ['hero', 'friends', 2],
+            id: '0',
+            subPath: ['friends', 2],
           },
         ],
         completed: [{ id: '0' }],
@@ -1751,7 +1765,7 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { name: null },
-            path: ['hero'],
+            id: '0',
             errors: [
               {
                 message: 'bad',
@@ -1931,7 +1945,7 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { name: 'slow', friends: [{}, {}, {}] },
-            path: ['hero'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1939,9 +1953,9 @@ describe('Execute: defer directive', () => {
       },
       {
         incremental: [
-          { data: { name: 'Han' }, path: ['hero', 'friends', 0] },
-          { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
-          { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
+          { data: { name: 'Han' }, id: '1' },
+          { data: { name: 'Leia' }, id: '2' },
+          { data: { name: 'C-3PO' }, id: '3' },
         ],
         completed: [{ id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
@@ -1987,7 +2001,7 @@ describe('Execute: defer directive', () => {
               name: 'Luke',
               friends: [{}, {}, {}],
             },
-            path: ['hero'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1995,9 +2009,9 @@ describe('Execute: defer directive', () => {
       },
       {
         incremental: [
-          { data: { name: 'Han' }, path: ['hero', 'friends', 0] },
-          { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
-          { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
+          { data: { name: 'Han' }, id: '1' },
+          { data: { name: 'Leia' }, id: '2' },
+          { data: { name: 'C-3PO' }, id: '3' },
         ],
         completed: [{ id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -243,7 +243,7 @@ describe('Execute: Handles mutation execution ordering', () => {
       {
         incremental: [
           {
-            path: ['first'],
+            id: '0',
             data: {
               promiseToGetTheNumber: 2,
             },
@@ -319,7 +319,7 @@ describe('Execute: Handles mutation execution ordering', () => {
       {
         incremental: [
           {
-            path: [],
+            id: '0',
             data: {
               first: {
                 theNumber: 1,

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -237,7 +237,7 @@ describe('Execute: Handles mutation execution ordering', () => {
           first: {},
           second: { theNumber: 2 },
         },
-        pending: [{ path: ['first'], label: 'defer-label' }],
+        pending: [{ id: '0', path: ['first'], label: 'defer-label' }],
         hasNext: true,
       },
       {
@@ -249,7 +249,7 @@ describe('Execute: Handles mutation execution ordering', () => {
             },
           },
         ],
-        completed: [{ path: ['first'], label: 'defer-label' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -313,7 +313,7 @@ describe('Execute: Handles mutation execution ordering', () => {
         data: {
           second: { theNumber: 2 },
         },
-        pending: [{ path: [], label: 'defer-label' }],
+        pending: [{ id: '0', path: [], label: 'defer-label' }],
         hasNext: true,
       },
       {
@@ -327,7 +327,7 @@ describe('Execute: Handles mutation execution ordering', () => {
             },
           },
         ],
-        completed: [{ path: [], label: 'defer-label' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -146,11 +146,11 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList'] }],
+        incremental: [{ items: ['banana'], id: '0' }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        incremental: [{ items: ['coconut'], id: '0' }],
         completed: [{ id: '0' }],
         hasNext: false,
       },
@@ -170,15 +170,15 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['apple'], path: ['scalarList'] }],
+        incremental: [{ items: ['apple'], id: '0' }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['banana'], path: ['scalarList'] }],
+        incremental: [{ items: ['banana'], id: '0' }],
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        incremental: [{ items: ['coconut'], id: '0' }],
         completed: [{ id: '0' }],
         hasNext: false,
       },
@@ -226,7 +226,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: ['banana'],
-            path: ['scalarList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -235,7 +235,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: ['coconut'],
-            path: ['scalarList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -268,7 +268,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [{ items: ['coconut'], path: ['scalarList'] }],
+        incremental: [{ items: ['coconut'], id: '0' }],
         completed: [{ id: '0' }],
         hasNext: false,
       },
@@ -295,7 +295,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [['banana', 'banana', 'banana']],
-            path: ['scalarListList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -304,7 +304,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [['coconut', 'coconut', 'coconut']],
-            path: ['scalarListList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -350,7 +350,7 @@ describe('Execute: stream directive', () => {
                 id: '3',
               },
             ],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -382,7 +382,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke', id: '1' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -391,7 +391,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -400,7 +400,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -450,7 +450,7 @@ describe('Execute: stream directive', () => {
                 id: '3',
               },
             ],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -495,7 +495,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -533,7 +533,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList'],
+            id: '0',
             errors: [
               {
                 message: 'bad',
@@ -549,7 +549,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -585,7 +585,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke', id: '1' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -594,7 +594,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -603,7 +603,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -645,7 +645,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Leia', id: '3' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -718,7 +718,7 @@ describe('Execute: stream directive', () => {
           incremental: [
             {
               items: [{ name: 'Leia', id: '3' }],
-              path: ['friendList'],
+              id: '0',
             },
           ],
           hasNext: true,
@@ -908,7 +908,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['scalarList'],
+            id: '0',
             errors: [
               {
                 message: 'String cannot represent value: {}',
@@ -952,7 +952,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -968,7 +968,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1003,7 +1003,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1019,7 +1019,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1138,7 +1138,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1154,7 +1154,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ nonNullName: 'Han' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -1461,7 +1461,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             data: { scalarField: null },
-            path: ['otherNestedObject'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1472,7 +1472,7 @@ describe('Execute: stream directive', () => {
           },
           {
             items: [{ name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }],
@@ -1523,7 +1523,7 @@ describe('Execute: stream directive', () => {
             data: {
               deeperNestedObject: null,
             },
-            path: ['nestedObject'],
+            id: '0',
             errors: [
               {
                 message:
@@ -1574,7 +1574,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [null],
-            path: ['friendList'],
+            id: '0',
             errors: [
               {
                 message:
@@ -1671,7 +1671,7 @@ describe('Execute: stream directive', () => {
             data: {
               deeperNestedObject: null,
             },
-            path: ['nestedObject'],
+            id: '0',
             errors: [
               {
                 message:
@@ -1727,7 +1727,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -1736,7 +1736,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '3', name: 'Leia' }],
-            path: ['friendList'],
+            id: '0',
           },
         ],
         hasNext: true,
@@ -1790,7 +1790,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '1', name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }],
@@ -1800,7 +1800,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList'],
+            id: '1',
           },
         ],
         hasNext: true,
@@ -1861,7 +1861,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             data: { scalarField: 'slow', nestedFriendList: [] },
-            path: ['nestedObject'],
+            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1875,7 +1875,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Luke' }],
-            path: ['nestedObject', 'nestedFriendList'],
+            id: '1',
           },
         ],
         hasNext: true,
@@ -1888,7 +1888,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ name: 'Han' }],
-            path: ['nestedObject', 'nestedFriendList'],
+            id: '1',
           },
         ],
         hasNext: true,
@@ -1967,11 +1967,11 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             data: { name: 'Luke' },
-            path: ['friendList', 0],
+            id: '0',
           },
           {
             items: [{ id: '2' }],
-            path: ['friendList'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }],
@@ -1996,7 +1996,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             data: { name: 'Han' },
-            path: ['friendList', 1],
+            id: '2',
           },
         ],
         completed: [{ id: '2' }],
@@ -2068,11 +2068,11 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             data: { name: 'Luke' },
-            path: ['friendList', 0],
+            id: '0',
           },
           {
             items: [{ id: '2' }],
-            path: ['friendList'],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }],
@@ -2087,7 +2087,7 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             data: { name: 'Han' },
-            path: ['friendList', 1],
+            id: '2',
           },
         ],
         completed: [{ id: '2' }],

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -142,7 +142,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: ['apple'],
         },
-        pending: [{ path: ['scalarList'] }],
+        pending: [{ id: '0', path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -151,7 +151,7 @@ describe('Execute: stream directive', () => {
       },
       {
         incremental: [{ items: ['coconut'], path: ['scalarList'] }],
-        completed: [{ path: ['scalarList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -166,7 +166,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: [],
         },
-        pending: [{ path: ['scalarList'] }],
+        pending: [{ id: '0', path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -179,7 +179,7 @@ describe('Execute: stream directive', () => {
       },
       {
         incremental: [{ items: ['coconut'], path: ['scalarList'] }],
-        completed: [{ path: ['scalarList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -219,7 +219,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: ['apple'],
         },
-        pending: [{ path: ['scalarList'], label: 'scalar-stream' }],
+        pending: [{ id: '0', path: ['scalarList'], label: 'scalar-stream' }],
         hasNext: true,
       },
       {
@@ -238,7 +238,7 @@ describe('Execute: stream directive', () => {
             path: ['scalarList'],
           },
         ],
-        completed: [{ path: ['scalarList'], label: 'scalar-stream' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -264,12 +264,12 @@ describe('Execute: stream directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { scalarList: ['apple', 'banana'] },
-        pending: [{ path: ['scalarList'] }],
+        pending: [{ id: '0', path: ['scalarList'] }],
         hasNext: true,
       },
       {
         incremental: [{ items: ['coconut'], path: ['scalarList'] }],
-        completed: [{ path: ['scalarList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -288,7 +288,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarListList: [['apple', 'apple', 'apple']],
         },
-        pending: [{ path: ['scalarListList'] }],
+        pending: [{ id: '0', path: ['scalarListList'] }],
         hasNext: true,
       },
       {
@@ -307,7 +307,7 @@ describe('Execute: stream directive', () => {
             path: ['scalarListList'],
           },
         ],
-        completed: [{ path: ['scalarListList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -338,7 +338,7 @@ describe('Execute: stream directive', () => {
             },
           ],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -353,7 +353,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -375,7 +375,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -403,7 +403,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -438,7 +438,7 @@ describe('Execute: stream directive', () => {
             },
           ],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -453,7 +453,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -488,7 +488,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ name: 'Luke', id: '1' }, null],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -498,7 +498,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -526,7 +526,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ name: 'Luke', id: '1' }],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -552,7 +552,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -578,7 +578,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -609,7 +609,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -638,7 +638,7 @@ describe('Execute: stream directive', () => {
             { name: 'Han', id: '2' },
           ],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -651,7 +651,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -708,7 +708,7 @@ describe('Execute: stream directive', () => {
               { name: 'Han', id: '2' },
             ],
           },
-          pending: [{ path: ['friendList'] }],
+          pending: [{ id: '0', path: ['friendList'] }],
           hasNext: true,
         },
       },
@@ -727,7 +727,7 @@ describe('Execute: stream directive', () => {
       {
         done: false,
         value: {
-          completed: [{ path: ['friendList'] }],
+          completed: [{ id: '0' }],
           hasNext: false,
         },
       },
@@ -782,13 +782,13 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ name: 'Luke', id: '1' }],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['friendList'],
+            id: '0',
             errors: [
               {
                 message: 'bad',
@@ -819,13 +819,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ name: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message:
@@ -866,13 +866,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ name: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message:
@@ -901,7 +901,7 @@ describe('Execute: stream directive', () => {
         data: {
           scalarList: ['Luke'],
         },
-        pending: [{ path: ['scalarList'] }],
+        pending: [{ id: '0', path: ['scalarList'] }],
         hasNext: true,
       },
       {
@@ -918,7 +918,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        completed: [{ path: ['scalarList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -945,7 +945,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -971,7 +971,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -996,7 +996,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1022,7 +1022,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1049,13 +1049,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1089,13 +1089,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1131,7 +1131,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1160,7 +1160,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1189,13 +1189,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1257,13 +1257,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1335,13 +1335,13 @@ describe('Execute: stream directive', () => {
         data: {
           nonNullFriendList: [{ nonNullName: 'Luke' }],
         },
-        pending: [{ path: ['nonNullFriendList'] }],
+        pending: [{ id: '0', path: ['nonNullFriendList'] }],
         hasNext: true,
       },
       {
         completed: [
           {
-            path: ['nonNullFriendList'],
+            id: '0',
             errors: [
               {
                 message: 'Oops',
@@ -1452,8 +1452,8 @@ describe('Execute: stream directive', () => {
           nestedObject: { nestedFriendList: [] },
         },
         pending: [
-          { path: ['otherNestedObject'] },
-          { path: ['nestedObject', 'nestedFriendList'] },
+          { id: '0', path: ['otherNestedObject'] },
+          { id: '1', path: ['nestedObject', 'nestedFriendList'] },
         ],
         hasNext: true,
       },
@@ -1475,11 +1475,11 @@ describe('Execute: stream directive', () => {
             path: ['nestedObject', 'nestedFriendList'],
           },
         ],
-        completed: [{ path: ['otherNestedObject'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
-        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
     ]);
@@ -1514,7 +1514,7 @@ describe('Execute: stream directive', () => {
         data: {
           nestedObject: {},
         },
-        pending: [{ path: ['nestedObject'] }],
+        pending: [{ id: '0', path: ['nestedObject'] }],
         hasNext: true,
       },
       {
@@ -1538,7 +1538,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        completed: [{ path: ['nestedObject'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1567,7 +1567,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1588,7 +1588,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1658,7 +1658,7 @@ describe('Execute: stream directive', () => {
       data: {
         nestedObject: {},
       },
-      pending: [{ path: ['nestedObject'] }],
+      pending: [{ id: '0', path: ['nestedObject'] }],
       hasNext: true,
     });
 
@@ -1686,7 +1686,7 @@ describe('Execute: stream directive', () => {
             ],
           },
         ],
-        completed: [{ path: ['nestedObject'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     });
@@ -1720,7 +1720,7 @@ describe('Execute: stream directive', () => {
         data: {
           friendList: [{ id: '1', name: 'Luke' }],
         },
-        pending: [{ path: ['friendList'] }],
+        pending: [{ id: '0', path: ['friendList'] }],
         hasNext: true,
       },
       {
@@ -1742,7 +1742,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        completed: [{ path: ['friendList'] }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1781,8 +1781,8 @@ describe('Execute: stream directive', () => {
           },
         },
         pending: [
-          { path: ['nestedObject'] },
-          { path: ['nestedObject', 'nestedFriendList'] },
+          { id: '0', path: ['nestedObject'] },
+          { id: '1', path: ['nestedObject', 'nestedFriendList'] },
         ],
         hasNext: true,
       },
@@ -1793,7 +1793,7 @@ describe('Execute: stream directive', () => {
             path: ['nestedObject', 'nestedFriendList'],
           },
         ],
-        completed: [{ path: ['nestedObject'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
@@ -1806,7 +1806,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
     ]);
@@ -1848,7 +1848,7 @@ describe('Execute: stream directive', () => {
       data: {
         nestedObject: {},
       },
-      pending: [{ path: ['nestedObject'] }],
+      pending: [{ id: '0', path: ['nestedObject'] }],
       hasNext: true,
     });
 
@@ -1857,14 +1857,14 @@ describe('Execute: stream directive', () => {
     const result2 = await result2Promise;
     expectJSON(result2).toDeepEqual({
       value: {
-        pending: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        pending: [{ id: '1', path: ['nestedObject', 'nestedFriendList'] }],
         incremental: [
           {
             data: { scalarField: 'slow', nestedFriendList: [] },
             path: ['nestedObject'],
           },
         ],
-        completed: [{ path: ['nestedObject'] }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       done: false,
@@ -1898,7 +1898,7 @@ describe('Execute: stream directive', () => {
     const result5 = await iterator.next();
     expectJSON(result5).toDeepEqual({
       value: {
-        completed: [{ path: ['nestedObject', 'nestedFriendList'] }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
       done: false,
@@ -1952,8 +1952,8 @@ describe('Execute: stream directive', () => {
         friendList: [{ id: '1' }],
       },
       pending: [
-        { path: ['friendList', 0], label: 'DeferName' },
-        { path: ['friendList'], label: 'stream-label' },
+        { id: '0', path: ['friendList', 0], label: 'DeferName' },
+        { id: '1', path: ['friendList'], label: 'stream-label' },
       ],
       hasNext: true,
     });
@@ -1963,7 +1963,7 @@ describe('Execute: stream directive', () => {
     const result2 = await result2Promise;
     expectJSON(result2).toDeepEqual({
       value: {
-        pending: [{ path: ['friendList', 1], label: 'DeferName' }],
+        pending: [{ id: '2', path: ['friendList', 1], label: 'DeferName' }],
         incremental: [
           {
             data: { name: 'Luke' },
@@ -1974,7 +1974,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList', 0], label: 'DeferName' }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       done: false,
@@ -1985,7 +1985,7 @@ describe('Execute: stream directive', () => {
     const result3 = await result3Promise;
     expectJSON(result3).toDeepEqual({
       value: {
-        completed: [{ path: ['friendList'], label: 'stream-label' }],
+        completed: [{ id: '1' }],
         hasNext: true,
       },
       done: false,
@@ -1999,7 +1999,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList', 1],
           },
         ],
-        completed: [{ path: ['friendList', 1], label: 'DeferName' }],
+        completed: [{ id: '2' }],
         hasNext: false,
       },
       done: false,
@@ -2053,8 +2053,8 @@ describe('Execute: stream directive', () => {
         friendList: [{ id: '1' }],
       },
       pending: [
-        { path: ['friendList', 0], label: 'DeferName' },
-        { path: ['friendList'], label: 'stream-label' },
+        { id: '0', path: ['friendList', 0], label: 'DeferName' },
+        { id: '1', path: ['friendList'], label: 'stream-label' },
       ],
       hasNext: true,
     });
@@ -2064,7 +2064,7 @@ describe('Execute: stream directive', () => {
     const result2 = await result2Promise;
     expectJSON(result2).toDeepEqual({
       value: {
-        pending: [{ path: ['friendList', 1], label: 'DeferName' }],
+        pending: [{ id: '2', path: ['friendList', 1], label: 'DeferName' }],
         incremental: [
           {
             data: { name: 'Luke' },
@@ -2075,7 +2075,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList'],
           },
         ],
-        completed: [{ path: ['friendList', 0], label: 'DeferName' }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       done: false,
@@ -2090,7 +2090,7 @@ describe('Execute: stream directive', () => {
             path: ['friendList', 1],
           },
         ],
-        completed: [{ path: ['friendList', 1], label: 'DeferName' }],
+        completed: [{ id: '2' }],
         hasNext: true,
       },
       done: false,
@@ -2100,7 +2100,7 @@ describe('Execute: stream directive', () => {
     const result4 = await result4Promise;
     expectJSON(result4).toDeepEqual({
       value: {
-        completed: [{ path: ['friendList'], label: 'stream-label' }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
       done: false,
@@ -2160,7 +2160,10 @@ describe('Execute: stream directive', () => {
           },
         ],
       },
-      pending: [{ path: ['friendList', 0] }, { path: ['friendList'] }],
+      pending: [
+        { id: '0', path: ['friendList', 0] },
+        { id: '1', path: ['friendList'] },
+      ],
       hasNext: true,
     });
     const returnPromise = iterator.return();
@@ -2216,7 +2219,7 @@ describe('Execute: stream directive', () => {
           },
         ],
       },
-      pending: [{ path: ['friendList'] }],
+      pending: [{ id: '0', path: ['friendList'] }],
       hasNext: true,
     });
 
@@ -2276,7 +2279,10 @@ describe('Execute: stream directive', () => {
           },
         ],
       },
-      pending: [{ path: ['friendList', 0] }, { path: ['friendList'] }],
+      pending: [
+        { id: '0', path: ['friendList', 0] },
+        { id: '1', path: ['friendList'] },
+      ],
       hasNext: true,
     });
 


### PR DESCRIPTION
to match new format at https://github.com/graphql/defer-stream-wg/discussions/69