### PR TITLE
fix for development on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "testonly:mutate": "stryker run",
     "prettier": "prettier --cache --cache-strategy metadata --write --list-different .",
     "prettier:check": "prettier --cache --cache-strategy metadata --check .",
-    "check:spelling": "cspell --cache --no-progress '**/*'",
+    "check:spelling": "cspell --cache --no-progress \"**/*\"",
     "check:integrations": "mocha --full-trace resources/integration-test.ts",
     "serve": "docusaurus serve --dir websiteDist/ --config website/docusaurus.config.cjs",
     "start": "npm run build:website && npm run serve",

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -3,12 +3,14 @@ import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import url from 'node:url';
 
 import prettier from 'prettier';
 import ts from 'typescript';
 
 export function localRepoPath(...paths: ReadonlyArray<string>): string {
-  const repoDir = new URL('..', import.meta.url).pathname;
+  const resourcesDir = path.dirname(url.fileURLToPath(import.meta.url));
+  const repoDir = path.join(resourcesDir, '..');
   return path.join(repoDir, ...paths);
 }
 


### PR DESCRIPTION
- use url.fileURLToPath instead of URL.pathname
- use double quote instead on single quote for shell command