### PR TITLE
Release 16.8.1 to address resource exhaustion vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "16.8.0",
+  "version": "16.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "16.8.0",
+      "version": "16.8.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "16.8.0",
+  "version": "16.8.1",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '16.8.0' as string;
+export const version = '16.8.1' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -12,6 +12,6 @@ export const version = '16.8.0' as string;
 export const versionInfo = Object.freeze({
   major: 16 as number,
   minor: 8 as number,
-  patch: 0 as number,
+  patch: 1 as number,
   preReleaseTag: null as string | null,
 });


### PR DESCRIPTION
As per https://github.com/graphql/graphql-js/issues/3955#issuecomment-1719209803 & https://github.com/graphql/graphql-js/pull/3967#issuecomment-1713484642 it would be great to get this addressed and released. 