### PR TITLE
fix(incremental): fix logic around selecting id/subPath

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -609,27 +609,31 @@ export class IncrementalPublisher {
     deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
   ): IncrementalDeferResult {
     const { data, deferredFragmentRecords } = deferredGroupedFieldSetRecord;
-    let maxLength = deferredFragmentRecords[0].path.length;
-    let maxIndex = 0;
-    for (let i = 1; i < deferredFragmentRecords.length; i++) {
-      const deferredFragmentRecord = deferredFragmentRecords[i];
+    let maxLength: number | undefined;
+    let recordWithLongestPath: DeferredFragmentRecord | undefined;
+    for (const deferredFragmentRecord of deferredFragmentRecords) {
+      if (deferredFragmentRecord.id === undefined) {
+        continue;
+      }
       const length = deferredFragmentRecord.path.length;
-      if (length > maxLength) {
+      if (maxLength === undefined || length > maxLength) {
         maxLength = length;
-        maxIndex = i;
+        recordWithLongestPath = deferredFragmentRecord;
       }
     }
-    const recordWithLongestPath = deferredFragmentRecords[maxIndex];
-    const longestPath = recordWithLongestPath.path;
-    const subPath = deferredGroupedFieldSetRecord.path.slice(
-      longestPath.length,
-    );
-    const id = recordWithLongestPath.id;
+    const subPath = deferredGroupedFieldSetRecord.path.slice(maxLength);
+    // safe because `id` is always defined once the fragment has been released
+    // as pending and at least one fragment has been completed, so must have been
+    // released as pending
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const id = recordWithLongestPath!.id;
     const incrementalDeferResult: IncrementalDeferResult = {
       // safe because `data``is always defined when the record is completed
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       data: data!,
-      // safe because `id` is defined once the fragment has been released as pending
+      // safe because `id` is always defined once the fragment has been released
+      // as pending and at least one fragment has been completed, so must have been
+      // released as pending
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       id: id!,
     };

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -610,23 +610,19 @@ export class IncrementalPublisher {
   ): IncrementalDeferResult {
     const { data, deferredFragmentRecords } = deferredGroupedFieldSetRecord;
     let maxLength: number | undefined;
-    let recordWithLongestPath: DeferredFragmentRecord | undefined;
+    let idWithLongestPath: string | undefined;
     for (const deferredFragmentRecord of deferredFragmentRecords) {
-      if (deferredFragmentRecord.id === undefined) {
+      const id = deferredFragmentRecord.id;
+      if (id === undefined) {
         continue;
       }
       const length = deferredFragmentRecord.path.length;
       if (maxLength === undefined || length > maxLength) {
         maxLength = length;
-        recordWithLongestPath = deferredFragmentRecord;
+        idWithLongestPath = id;
       }
     }
     const subPath = deferredGroupedFieldSetRecord.path.slice(maxLength);
-    // safe because `id` is always defined once the fragment has been released
-    // as pending and at least one fragment has been completed, so must have been
-    // released as pending
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const id = recordWithLongestPath!.id;
     const incrementalDeferResult: IncrementalDeferResult = {
       // safe because `data``is always defined when the record is completed
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -635,7 +631,7 @@ export class IncrementalPublisher {
       // as pending and at least one fragment has been completed, so must have been
       // released as pending
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      id: id!,
+      id: idWithLongestPath!,
     };
 
     if (subPath.length > 0) {


### PR DESCRIPTION
current loop assumes that the first analyzed DeferredFragmentRecord has been released as pending and thereofre has an `id`, which happens to be the case in this scenario, but is not reliable, uncovered by #3982.

Demonstrates the peril of `!` which might point to requiring additional types, but we can leave that for a different PR.