### PR TITLE
Add reference types

### DIFF
--- a/src/__tests__/starWarsData.ts
+++ b/src/__tests__/starWarsData.ts
@@ -27,6 +27,22 @@ export interface Droid {
   primaryFunction: string;
 }
 
+export interface Jedi {
+  type: 'Jedi';
+  id: string;
+  human: string;
+  lightsaberColor: string;
+  enemies: ReadonlyArray<string>;
+}
+
+export interface Sith {
+  type: 'Sith';
+  id: string;
+  human: string;
+  darkSidePower: string;
+  enemies: ReadonlyArray<string>;
+}
+
 /**
  * This defines a basic set of data for our Star Wars Schema.
  *
@@ -109,6 +125,30 @@ const droidData: { [id: string]: Droid } = {
   [artoo.id]: artoo,
 };
 
+const jediLuke: Jedi = {
+  type: 'Jedi',
+  id: '3000',
+  human: '1000',
+  lightsaberColor: 'Blue',
+  enemies: ['4000'],
+};
+
+const jediData: { [id: string]: Jedi } = {
+  [jediLuke.id]: jediLuke,
+};
+
+const sithVader: Sith = {
+  type: 'Sith',
+  id: '4000',
+  human: '1001',
+  darkSidePower: 'Force Choke',
+  enemies: ['3000'],
+};
+
+const sithData: { [id: string]: Sith } = {
+  [sithVader.id]: sithVader,
+};
+
 /**
  * Helper function to get a character by ID.
  */
@@ -151,4 +191,25 @@ export function getHuman(id: string): Human | null {
  */
 export function getDroid(id: string): Droid | null {
   return droidData[id];
+}
+
+/**
+ * Allows us to query for the jedi with the given id
+ */
+export function getJedi(id: string): Jedi | null {
+  return jediData[id];
+}
+
+/**
+ * Allows us to query for the enimies.
+ */
+export function getEnemies(character: Jedi | Sith): Array<Jedi | Sith | null> {
+  return character.enemies.map((id) => getJedi(id) ?? getSith(id));
+}
+
+/**
+ * Allows us to query for the sith with the given id
+ */
+export function getSith(id: string): Sith | null {
+  return sithData[id];
 }

--- a/src/__tests__/starWarsIntrospection-test.ts
+++ b/src/__tests__/starWarsIntrospection-test.ts
@@ -35,6 +35,8 @@ describe('Star Wars Introspection Tests', () => {
             { name: 'String' },
             { name: 'Episode' },
             { name: 'Droid' },
+            { name: 'Jedi' },
+            { name: 'Sith' },
             { name: 'Query' },
             { name: 'Boolean' },
             { name: '__Schema' },
@@ -327,6 +329,42 @@ describe('Star Wars Introspection Tests', () => {
                   {
                     name: 'id',
                     description: 'id of the droid',
+                    type: {
+                      kind: 'NON_NULL',
+                      name: null,
+                      ofType: {
+                        kind: 'SCALAR',
+                        name: 'String',
+                      },
+                    },
+                    defaultValue: null,
+                  },
+                ],
+              },
+              {
+                name: 'jedi',
+                args: [
+                  {
+                    name: 'id',
+                    description: 'id of the jedi',
+                    type: {
+                      kind: 'NON_NULL',
+                      name: null,
+                      ofType: {
+                        kind: 'SCALAR',
+                        name: 'String',
+                      },
+                    },
+                    defaultValue: null,
+                  },
+                ],
+              },
+              {
+                name: 'sith',
+                args: [
+                  {
+                    name: 'id',
+                    description: 'id of the sith',
                     type: {
                       kind: 'NON_NULL',
                       name: null,

--- a/src/__tests__/starWarsQuery-test.ts
+++ b/src/__tests__/starWarsQuery-test.ts
@@ -494,4 +494,60 @@ describe('Star Wars Query Tests', () => {
       });
     });
   });
+
+  describe('Using types with Ref types', () => {
+    it('Allows us to query jedi enemies', async () => {
+      const source = `
+        query FetchJediEnemies {
+          jedi(id: "3000") {
+            enemies {
+              id
+              darkSidePower
+            }
+          }
+        }
+      `;
+
+      const result = await graphql({ schema, source });
+      expect(result).to.deep.equal({
+        data: {
+          jedi: {
+            enemies: [
+              {
+                id: '4000',
+                darkSidePower: 'Force Choke',
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    it('Allows us to query sith enemies', async () => {
+      const source = `
+        query FetchSithEnemies {
+          sith(id: "4000") {
+            enemies {
+              id
+              lightsaberColor
+            }
+          }
+        }
+      `;
+
+      const result = await graphql({ schema, source });
+      expect(result).to.deep.equal({
+        data: {
+          sith: {
+            enemies: [
+              {
+                id: '3000',
+                lightsaberColor: 'Blue',
+              },
+            ],
+          },
+        },
+      });
+    });
+  });
 });

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -60,7 +60,8 @@ export function isType(type: unknown): type is GraphQLType {
     isEnumType(type) ||
     isInputObjectType(type) ||
     isListType(type) ||
-    isNonNullType(type)
+    isNonNullType(type) ||
+    isRefType(type)
   );
 }
 
@@ -233,7 +234,8 @@ export function isOutputType(type: unknown): type is GraphQLOutputType {
     isInterfaceType(type) ||
     isUnionType(type) ||
     isEnumType(type) ||
-    (isWrappingType(type) && isOutputType(type.ofType))
+    (isWrappingType(type) && isOutputType(type.ofType)) ||
+    isRefType(type)
   );
 }
 
@@ -442,7 +444,8 @@ export type GraphQLNamedOutputType =
   | GraphQLObjectType
   | GraphQLInterfaceType
   | GraphQLUnionType
-  | GraphQLEnumType;
+  | GraphQLEnumType
+  | string;
 
 export function isNamedType(type: unknown): type is GraphQLNamedType {
   return (
@@ -479,6 +482,10 @@ export function getNamedType(
     }
     return unwrappedType;
   }
+}
+
+export function isRefType(type: unknown): type is string {
+  return typeof type === 'string';
 }
 
 /**

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -26,6 +26,7 @@ import {
   isInputObjectType,
   isInterfaceType,
   isObjectType,
+  isRefType,
   isUnionType,
 } from './definition.js';
 import type { GraphQLDirective } from './directives.js';
@@ -212,6 +213,10 @@ export class GraphQLSchema {
 
     for (const namedType of allReferencedTypes) {
       if (namedType == null) {
+        continue;
+      }
+
+      if (isRefType(namedType)) {
         continue;
       }
 


### PR DESCRIPTION
This pull request introduces string references for GraphQL types, which aims to solve the problem with circular dependency between types in multiple files. Here's an usage example:

```ts
type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull('User')))
```

This PR has only the implementation for output types for now.

I've also made a RFC repository with a patch and pratical examples for testing: https://github.com/fersilva16/graphql-refs-rfc

Contributions and feedback are welcome.
