### PR TITLE
Backport "Prevent Infinite Loop in OverlappingFieldsCanBeMergedRule" to v15

### DIFF
--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.js
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.js
@@ -264,6 +264,24 @@ function collectConflictsBetweenFieldsAndFragment(
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
   for (let i = 0; i < fragmentNames2.length; i++) {
+    const referencedFragmentName = fragmentNames2[i];
+
+    // Memoize so two fragments are not compared for conflicts more than once.
+    if (
+      comparedFragmentPairs.has(
+        referencedFragmentName,
+        fragmentName,
+        areMutuallyExclusive,
+      )
+    ) {
+      continue;
+    }
+    comparedFragmentPairs.add(
+      referencedFragmentName,
+      fragmentName,
+      areMutuallyExclusive,
+    );
+
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,


### PR DESCRIPTION
Backports the fix from https://github.com/graphql/graphql-js/pull/3442 into the v15.x tree.
