### PR TITLE
fix(jsutils): use optional chaining to prevent crash in browser

### DIFF
--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -9,7 +9,7 @@ import { inspect } from './inspect.js';
 export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  globalThis.process != null && globalThis.process.env.NODE_ENV === 'production'
+  globalThis?.process?.env?.NODE_ENV === 'production'
     ? function instanceOf(value: unknown, constructor: Constructor): boolean {
         return value instanceof constructor;
       }


### PR DESCRIPTION
## Context

We use [contentful/live-preview](https://github.com/contentful/live-preview). The library has `graphql-js` as a dependency. 

## Problem

If the DOM has an element with `id="process"` eg. `<div id="process"></div>` than the current implementation of `utils/instanceOf` would fail.

### Current implementation:
```js
globalThis.process != null && globalThis.process.env.NODE_ENV === 'production'
```
with this implementation `globalThis.process` will return the DOM element:
<img width="952" alt="image" src="https://github.com/graphql/graphql-js/assets/24622/b4d77006-2d55-4c54-b849-ef98d9f58a4b">

Because `globalThis.process is true`, the condition `globalThis.process.env.NODE_ENV === 'production'` gets executed and will result with an javascript error:
<img width="640" alt="image" src="https://github.com/graphql/graphql-js/assets/24622/5c560efa-4aee-44b4-9c8d-eabc4a241070">