### PR TITLE
Enable passing values configuration to GraphQLEnumType as a thunk

### DIFF
--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -31,6 +31,14 @@ const ComplexEnum = new GraphQLEnumType({
   },
 });
 
+const ThunkValuesEnum = new GraphQLEnumType({
+  name: 'ThunkValues',
+  values: () => ({
+    A: { value: 'a' },
+    B: { value: 'b' },
+  }),
+});
+
 const QueryType = new GraphQLObjectType({
   name: 'Query',
   fields: {
@@ -81,6 +89,15 @@ const QueryType = new GraphQLObjectType({
           // as Complex2 above. Enum internal values require === equality.
           return { someRandomValue: 123 };
         }
+        return fromEnum;
+      },
+    },
+    thunkValuesString: {
+      type: GraphQLString,
+      args: {
+        fromEnum: { type: ThunkValuesEnum },
+      },
+      resolve(_source, { fromEnum }) {
         return fromEnum;
       },
     },
@@ -397,6 +414,14 @@ describe('Type System: Enum Values', () => {
           path: ['bad'],
         },
       ],
+    });
+  });
+
+  it('may have values specified via a callback', () => {
+    const result = executeQuery('{ thunkValuesString(fromEnum: B) }');
+
+    expect(result).to.deep.equal({
+      data: { thunkValuesString: 'b' },
     });
   });
 

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1430,6 +1430,7 @@ export interface GraphQLEnumTypeConfig {
 }
 
 interface GraphQLEnumTypeNormalizedConfig extends GraphQLEnumTypeConfig {
+  values: ObjMap<GraphQLEnumValueConfig /* <T> */>;
   extensions: Readonly<GraphQLEnumTypeExtensions>;
   extensionASTNodes: ReadonlyArray<EnumTypeExtensionNode>;
 }

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1237,6 +1237,17 @@ export interface GraphQLEnumTypeExtensions {
   [attributeName: string]: unknown;
 }
 
+function enumValuesFromConfig(values: GraphQLEnumValueConfigMap) {
+  return Object.entries(values).map(([valueName, valueConfig]) => ({
+    name: assertEnumValueName(valueName),
+    description: valueConfig.description,
+    value: valueConfig.value !== undefined ? valueConfig.value : valueName,
+    deprecationReason: valueConfig.deprecationReason,
+    extensions: toObjMap(valueConfig.extensions),
+    astNode: valueConfig.astNode,
+  }));
+}
+
 /**
  * Enum Type Definition
  *
@@ -1267,9 +1278,12 @@ export class GraphQLEnumType /* <T> */ {
   astNode: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<EnumTypeExtensionNode>;
 
-  private _values: ReadonlyArray<GraphQLEnumValue /* <T> */>;
-  private _valueLookup: ReadonlyMap<any /* T */, GraphQLEnumValue>;
-  private _nameLookup: ObjMap<GraphQLEnumValue>;
+  private _values:
+    | ReadonlyArray<GraphQLEnumValue /* <T> */>
+    | (() => GraphQLEnumValueConfigMap);
+
+  private _valueLookup: ReadonlyMap<any /* T */, GraphQLEnumValue> | null;
+  private _nameLookup: ObjMap<GraphQLEnumValue> | null;
 
   constructor(config: Readonly<GraphQLEnumTypeConfig /* <T> */>) {
     this.name = assertName(config.name);
@@ -1278,20 +1292,12 @@ export class GraphQLEnumType /* <T> */ {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
 
-    this._values = Object.entries(config.values).map(
-      ([valueName, valueConfig]) => ({
-        name: assertEnumValueName(valueName),
-        description: valueConfig.description,
-        value: valueConfig.value !== undefined ? valueConfig.value : valueName,
-        deprecationReason: valueConfig.deprecationReason,
-        extensions: toObjMap(valueConfig.extensions),
-        astNode: valueConfig.astNode,
-      }),
-    );
-    this._valueLookup = new Map(
-      this._values.map((enumValue) => [enumValue.value, enumValue]),
-    );
-    this._nameLookup = keyMap(this._values, (value) => value.name);
+    this._values =
+      typeof config.values === 'function'
+        ? config.values
+        : enumValuesFromConfig(config.values);
+    this._valueLookup = null;
+    this._nameLookup = null;
   }
 
   get [Symbol.toStringTag]() {
@@ -1299,14 +1305,25 @@ export class GraphQLEnumType /* <T> */ {
   }
 
   getValues(): ReadonlyArray<GraphQLEnumValue /* <T> */> {
+    if (typeof this._values === 'function') {
+      this._values = enumValuesFromConfig(this._values());
+    }
     return this._values;
   }
 
   getValue(name: string): Maybe<GraphQLEnumValue> {
+    if (this._nameLookup === null) {
+      this._nameLookup = keyMap(this.getValues(), (value) => value.name);
+    }
     return this._nameLookup[name];
   }
 
   serialize(outputValue: unknown /* T */): Maybe<string> {
+    if (this._valueLookup === null) {
+      this._valueLookup = new Map(
+        this.getValues().map((enumValue) => [enumValue.value, enumValue]),
+      );
+    }
     const enumValue = this._valueLookup.get(outputValue);
     if (enumValue === undefined) {
       throw new GraphQLError(
@@ -1406,7 +1423,7 @@ function didYouMeanEnumValue(
 export interface GraphQLEnumTypeConfig {
   name: string;
   description?: Maybe<string>;
-  values: GraphQLEnumValueConfigMap /* <T> */;
+  values: ThunkObjMap<GraphQLEnumValueConfig /* <T> */>;
   extensions?: Maybe<Readonly<GraphQLEnumTypeExtensions>>;
   astNode?: Maybe<EnumTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;


### PR DESCRIPTION
Many of the type configuration objects in GraphQL-js have properties that accept thunks:

- GraphQLObjectTypeConfig.fields
- GraphQLObjectTypeConfig.interfaces
- GraphQLInterfaceTypeConfig.fields
- GraphQLInterfaceTypeConfig.interfaces
- GraphQLInputObjectTypeConfig.fields
- GraphQLUnionTypeConfig.types

These are because their definitions may contain references to other types which may form cycles, and thus a thunk is required to enable their definition.

This PR allows setting `GraphQLEnumTypeConfig.values` to be a thunk. At first, this might seem unnecessary (and, well, it has been this way for 9 years so you can be forgiven for thinking that) but it can be quite useful when building enums that reference types. For example: you might have a field that returns a union (`Person.pets`), and you might want to add an argument that allows you to limit the returned types to only certain types (`Person.pets(only:)`):

```graphql
type Person {
  name: String
  pets(only: [AnimalType!]): [Animal]
}
enum AnimalType {
  Cat
  Dog
  Hamster
  Mouse
}
union AnimalType = Cat | Dog | Hamster | Mouse
type Cat { name: String, owner: Person, numberOfLives: Int }
type Dog implements Animal { name: String, owner: Person, wagsTail: Booean }
type Hamster implements Animal { ... }
type Mouse implements Animal { ... }
type Query {
  currentPerson: Person
}
```

```graphql
query {
  currentPerson {
    pets(only: [Cat, Dog]) {
      ... on Cat {
        name
        numberOfLives
      }
      ... on Dog {
        name
        wagsTail
      }
    }
  }
}
```

For this it can be useful for the `AnimalType` type to enumerate the types in the `Animal` union, but those types contain references back to `AnimalType` -> there's a cycle.

The thunk approach outlined in this PR would solve the cycle. There are workarounds (i.e. manually listing out the types) but they're not as ergonomic as (and are more error-prone than) resolving the values directly from the union.