### PR TITLE
fix: remove `globalThis` check and align with what bundlers can accept

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -19,6 +19,10 @@ overrides:
       - clsx
       - infima
       - noopener
+      - Vite
+      - craco
+      - esbuild
+      - swcrc
       - noreferrer
       - xlink
 

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -2,7 +2,6 @@ import { inspect } from './inspect';
 
 /* c8 ignore next 3 */
 const isProduction =
-  // eslint-disable-next-line no-undef
   typeof process !== 'undefined' &&
   // eslint-disable-next-line no-undef
   process.env.NODE_ENV === 'production';

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -2,7 +2,7 @@ import { inspect } from './inspect';
 
 /* c8 ignore next 3 */
 const isProduction =
-  typeof process !== 'undefined' &&
+  globalThis.process &&
   // eslint-disable-next-line no-undef
   process.env.NODE_ENV === 'production';
 

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,6 +1,13 @@
 import { inspect } from './inspect';
 
-const isProduction = typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production';
+/* c8 ignore next 4 */
+const isProduction =
+  // eslint-disable-next-line no-undef
+  typeof process !== 'undefined' &&
+  // eslint-disable-next-line no-undef
+  process.env &&
+  // eslint-disable-next-line no-undef
+  process.env.NODE_ENV === 'production';
 
 /**
  * A replacement for instanceof which includes an error warning when multi-realm

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,11 +1,9 @@
 import { inspect } from './inspect';
 
-/* c8 ignore next 4 */
+/* c8 ignore next 3 */
 const isProduction =
   // eslint-disable-next-line no-undef
   typeof process !== 'undefined' &&
-  // eslint-disable-next-line no-undef
-  process.env &&
   // eslint-disable-next-line no-undef
   process.env.NODE_ENV === 'production';
 

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,5 +1,7 @@
 import { inspect } from './inspect';
 
+const isProduction = typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'production';
+
 /**
  * A replacement for instanceof which includes an error warning when multi-realm
  * constructors are detected.
@@ -9,7 +11,7 @@ import { inspect } from './inspect';
 export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  globalThis.process && globalThis.process.env.NODE_ENV === 'production'
+  isProduction
     ? function instanceOf(value: unknown, constructor: Constructor): boolean {
         return value instanceof constructor;
       }

--- a/website/docs/tutorials/going-to-production.md
+++ b/website/docs/tutorials/going-to-production.md
@@ -9,7 +9,7 @@ out the most popular ones.
 
 ## Bundler-specific configuration
 
-Here are some bundler-specific suggestions for configuring your bundler to remove `globalThis.process` and `proces.env.NODE_ENV` on build time.
+Here are some bundler-specific suggestions for configuring your bundler to remove `globalThis.process` and `process.env.NODE_ENV` on build time.
 
 ### Vite
 

--- a/website/docs/tutorials/going-to-production.md
+++ b/website/docs/tutorials/going-to-production.md
@@ -17,8 +17,8 @@ Here are some bundler-specific suggestions for configuring your bundler to remov
 export default defineConfig({
   // ...
   define: {
-    "globalThis.process": JSON.stringify(true),
-    "process.env.NODE_ENV": JSON.stringify("production"),
+    'globalThis.process': JSON.stringify(true),
+    'process.env.NODE_ENV': JSON.stringify('production'),
   },
 });
 ```
@@ -32,9 +32,9 @@ const nextConfig = {
   webpack(config, { webpack }) {
     config.plugins.push(
       new webpack.DefinePlugin({
-        "globalThis.process": JSON.stringify(true),
-        "process.env.NODE_ENV": JSON.stringify("production"),
-      })
+        'globalThis.process': JSON.stringify(true),
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
     );
     return config;
   },
@@ -48,13 +48,13 @@ module.exports = nextConfig;
 With `create-react-app`, you need to use a third-party package like [`craco`](https://craco.js.org/) to modify the bundler configuration.
 
 ```js
-const webpack = require("webpack");
+const webpack = require('webpack');
 module.exports = {
   webpack: {
     plugins: [
       new webpack.DefinePlugin({
-        "globalThis.process": JSON.stringify(true),
-        "process.env.NODE_ENV": JSON.stringify("production"),
+        'globalThis.process': JSON.stringify(true),
+        'process.env.NODE_ENV': JSON.stringify('production'),
       }),
     ],
   },
@@ -77,9 +77,9 @@ module.exports = {
 ```js
 config.plugins.push(
   new webpack.DefinePlugin({
-    "globalThis.process": JSON.stringify(true),
-    "process.env.NODE_ENV": JSON.stringify("production"),
-  })
+    'globalThis.process': JSON.stringify(true),
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  }),
 );
 ```
 
@@ -97,8 +97,8 @@ export default [
         compress: {
           toplevel: true,
           global_defs: {
-            "@globalThis.process": JSON.stringify(true),
-            "@process.env.NODE_ENV": JSON.stringify("production"),
+            '@globalThis.process': JSON.stringify(true),
+            '@process.env.NODE_ENV': JSON.stringify('production'),
           },
         },
       }),
@@ -125,4 +125,3 @@ export default [
   }
 }
 ```
-

--- a/website/docs/tutorials/going-to-production.md
+++ b/website/docs/tutorials/going-to-production.md
@@ -1,0 +1,128 @@
+---
+title: Going to production
+category: FAQ
+---
+
+GraphQL.JS contains a few development checks which in production will cause slower performance and
+an increase in bundle-size. Every bundler goes about these changes different, in here we'll list
+out the most popular ones.
+
+## Bundler-specific configuration
+
+Here are some bundler-specific suggestions for configuring your bundler to remove `globalThis.process` and `proces.env.NODE_ENV` on build time.
+
+### Vite
+
+```js
+export default defineConfig({
+  // ...
+  define: {
+    "globalThis.process": JSON.stringify(true),
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+});
+```
+
+### Next.js
+
+```js
+// ...
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  webpack(config, { webpack }) {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        "globalThis.process": JSON.stringify(true),
+        "process.env.NODE_ENV": JSON.stringify("production"),
+      })
+    );
+    return config;
+  },
+};
+
+module.exports = nextConfig;
+```
+
+### create-react-app
+
+With `create-react-app`, you need to use a third-party package like [`craco`](https://craco.js.org/) to modify the bundler configuration.
+
+```js
+const webpack = require("webpack");
+module.exports = {
+  webpack: {
+    plugins: [
+      new webpack.DefinePlugin({
+        "globalThis.process": JSON.stringify(true),
+        "process.env.NODE_ENV": JSON.stringify("production"),
+      }),
+    ],
+  },
+};
+```
+
+### esbuild
+
+```json
+{
+  "define": {
+    "globalThis.process": true,
+    "process.env.NODE_ENV": "production"
+  }
+}
+```
+
+### Webpack
+
+```js
+config.plugins.push(
+  new webpack.DefinePlugin({
+    "globalThis.process": JSON.stringify(true),
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  })
+);
+```
+
+### Rollup
+
+```js
+export default [
+  {
+    // ... input, output, etc.
+    plugins: [
+      minify({
+        mangle: {
+          toplevel: true,
+        },
+        compress: {
+          toplevel: true,
+          global_defs: {
+            "@globalThis.process": JSON.stringify(true),
+            "@process.env.NODE_ENV": JSON.stringify("production"),
+          },
+        },
+      }),
+    ],
+  },
+];
+```
+
+### SWC
+
+```json title=".swcrc"
+{
+  "jsc": {
+    "transform": {
+      "optimizer": {
+        "globals": {
+          "vars": {
+            "globalThis.process": true,
+            "process.env.NODE_ENV": "production"
+          }
+        }
+      }
+    }
+  }
+}
+```
+

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -15,6 +15,11 @@ module.exports = {
       label: 'Advanced',
       items: ['tutorials/constructing-types'],
     },
+    {
+      type: 'category',
+      label: 'FAQ',
+      items: ['tutorials/going-to-production'],
+    },
     'tutorials/express-graphql',
   ],
 };


### PR DESCRIPTION
As surfaced in [Discord](https://discord.com/channels/625400653321076807/862957336082645006/1206980831915282532) this currently is a breaking change in the 16.x.x release line which is preventing folks from upgrading towards a security fix. This PR should result in a patch release on the 16 release line.

This change was originally introduced to support CFW and browser environments which should still be supported with the `typeof` check CC @n1ru4l

This also adds a check whether `.env` is present as in the DOM using `id="process"` defines that as a global which we don't want to access on accident. as shown in https://github.com/graphql/graphql-js/pull/4017

Bundles also target `process.env.NODE_ENV` specifically which fails when it replaces `globalThis.process.env.NODE_ENV` as this becomes `globalThis."production"` which is invalid syntax.

Fixes https://github.com/graphql/graphql-js/issues/3978
Fixes https://github.com/graphql/graphql-js/issues/3918
Fixes https://github.com/graphql/graphql-js/issues/3928
Fixes https://github.com/graphql/graphql-js/issues/3758
Fixes https://github.com/graphql/graphql-js/issues/3934

This purposefully does not account for https://github.com/graphql/graphql-js/issues/3925 as we can't address this without breaking CF/plain browsers so the small byte-size increase will be expected for bundled browser environments. As a middle ground we did optimise the performance here. We can revisit this for v17.

Most bundlers will be able to tree-shake this with a little help, in https://github.com/graphql/graphql-js/issues/4075#issuecomment-2094052098 you can find a conclusion with a repo where we discuss a few.

- Next.JS by default replaces [`process.env.NODE_ENV`](https://github.com/vercel/next.js/blob/b0ab0fe85fe8c93792051b058e060724ff373cc2/packages/next/webpack.config.js#L182) you can add `typeof process` linearly
- Vite allows you to specify [`config.define`](https://vitejs.dev/config/shared-options.html#define)
- ESBuild by default will replace `process.env.NODE_ENV` but does not support replacing `typeof process`
- Rollup has a plugin for this https://www.npmjs.com/package/@rollup/plugin-replace

Supersedes https://github.com/graphql/graphql-js/pull/4021
Supersedes https://github.com/graphql/graphql-js/pull/4019
Supersedes https://github.com/graphql/graphql-js/pull/3927

> This now also adds a documentation page on how to remove all of these