### PR TITLE
benchmark: update v8 flag

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -404,7 +404,7 @@ function sampleModule(modulePath: string): BenchmarkSample {
       // V8 flags
       '--predictable',
       '--no-concurrent-sweeping',
-      '--no-scavenge-task',
+      '--no-minor-gc-task',
       '--min-semi-space-size=1024', // 1GB
       '--max-semi-space-size=1024', // 1GB
       '--trace-gc', // no gc calls should happen during benchmark, so trace them


### PR DESCRIPTION
changed in v8 11.3 / node 20

see: https://chromium.googlesource.com/v8/v8/+/73c45833472086ca1c6ab4140cdb058d1890e930%5E%21/src/flags/flag-definitions.h

fixes benchmarking, see https://github.com/graphql/graphql-js/actions/runs/8314729475/job/22752257524#step:6:142