### PR TITLE
chore(performance): optimize regressed for..of and array destructuring performance

### DIFF
--- a/.babelrc-deno.json
+++ b/.babelrc-deno.json
@@ -1,6 +1,8 @@
 {
   "plugins": [
     "@babel/plugin-syntax-typescript",
+    "@babel/plugin-transform-for-of",
+    "@babel/plugin-transform-destructuring",
     ["./resources/add-extension-to-import-paths", { "extension": "ts" }],
     "./resources/inline-invariant"
   ]

--- a/.babelrc-deno.json
+++ b/.babelrc-deno.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@babel/plugin-syntax-typescript",
-    "@babel/plugin-transform-for-of",
+    ["@babel/plugin-transform-for-of", { "assumeArray": true }],
     "@babel/plugin-transform-destructuring",
     ["./resources/add-extension-to-import-paths", { "extension": "ts" }],
     "./resources/inline-invariant"

--- a/.babelrc-npm.json
+++ b/.babelrc-npm.json
@@ -1,6 +1,8 @@
 {
   "plugins": [
     "@babel/plugin-transform-typescript",
+    "@babel/plugin-transform-for-of",
+    "@babel/plugin-transform-destructuring",
     "./resources/inline-invariant"
   ],
   "env": {

--- a/.babelrc-npm.json
+++ b/.babelrc-npm.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@babel/plugin-transform-typescript",
-    "@babel/plugin-transform-for-of",
+    ["@babel/plugin-transform-for-of", { "assumeArray": true }],
     "@babel/plugin-transform-destructuring",
     "./resources/inline-invariant"
   ],

--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,5 +1,9 @@
 {
-  "plugins": ["@babel/plugin-transform-typescript"],
+  "plugins": [
+    "@babel/plugin-transform-typescript",
+    "@babel/plugin-transform-for-of",
+    "@babel/plugin-transform-destructuring"
+  ],
   "presets": [
     [
       "@babel/preset-env",

--- a/.babelrc.json
+++ b/.babelrc.json
@@ -1,7 +1,7 @@
 {
   "plugins": [
     "@babel/plugin-transform-typescript",
-    "@babel/plugin-transform-for-of",
+    ["@babel/plugin-transform-for-of", { "assumeArray": true }],
     "@babel/plugin-transform-destructuring"
   ],
   "presets": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "devDependencies": {
         "@babel/core": "7.17.9",
         "@babel/plugin-syntax-typescript": "7.16.7",
+        "@babel/plugin-transform-destructuring": "^7.24.5",
+        "@babel/plugin-transform-for-of": "^7.24.1",
         "@babel/plugin-transform-typescript": "7.16.8",
         "@babel/preset-env": "7.16.11",
         "@babel/register": "7.17.7",
@@ -494,9 +496,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -545,12 +547,12 @@
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -568,10 +570,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -1228,12 +1239,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz",
-      "integrity": "sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
+      "integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.24.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1290,12 +1301,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
-      "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
+      "integrity": "sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1972,12 +1984,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -17492,9 +17505,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
-      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
+      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -17531,12 +17544,12 @@
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.22.5"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -17548,10 +17561,16 @@
         "@babel/types": "^7.16.7"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz",
+      "integrity": "sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==",
+      "dev": true
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz",
+      "integrity": "sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -17986,12 +18005,12 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz",
-      "integrity": "sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.5.tgz",
+      "integrity": "sha512-SZuuLyfxvsm+Ah57I/i1HVjveBENYK9ue8MJ7qkc7ndoNjqquJiElzA7f5yaAXjyW2hKojosOTAQQRX50bPSVg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.24.5"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -18024,12 +18043,13 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
-      "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.1.tgz",
+      "integrity": "sha512-OxBdcnF04bpdQdR3i4giHZNZQn7cm8RQKcSwA17wAAqEELo1ZOwp5FFgeptWUQXFyT9kwHo10aqqauYkRZPCAg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.24.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
       }
     },
     "@babel/plugin-transform-function-name": {
@@ -18493,12 +18513,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.5.tgz",
+      "integrity": "sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-string-parser": "^7.24.1",
+        "@babel/helper-validator-identifier": "^7.24.5",
         "to-fast-properties": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
   "devDependencies": {
     "@babel/core": "7.17.9",
     "@babel/plugin-syntax-typescript": "7.16.7",
+    "@babel/plugin-transform-destructuring": "^7.24.5",
+    "@babel/plugin-transform-for-of": "^7.24.1",
     "@babel/plugin-transform-typescript": "7.16.8",
     "@babel/preset-env": "7.16.11",
     "@babel/register": "7.17.7",

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -405,7 +405,7 @@ function executeFieldsSerially(
   fields: Map<string, ReadonlyArray<FieldNode>>,
 ): PromiseOrValue<ObjMap<unknown>> {
   return promiseReduce(
-    fields.entries(),
+    Array.from(fields.entries()),
     (results, [responseName, fieldNodes]) => {
       const fieldPath = addPath(path, responseName, parentType.name);
       const result = executeField(
@@ -446,7 +446,8 @@ function executeFields(
   let containsPromise = false;
 
   try {
-    for (const [responseName, fieldNodes] of fields.entries()) {
+    const fieldsEntries = Array.from(fields.entries());
+    for (const [responseName, fieldNodes] of fieldsEntries) {
       const fieldPath = addPath(path, responseName, parentType.name);
       const result = executeField(
         exeContext,

--- a/src/jsutils/promiseForObject.ts
+++ b/src/jsutils/promiseForObject.ts
@@ -12,7 +12,8 @@ export function promiseForObject<T>(
 ): Promise<ObjMap<T>> {
   return Promise.all(Object.values(object)).then((resolvedValues) => {
     const resolvedObject = Object.create(null);
-    for (const [i, key] of Object.keys(object).entries()) {
+    const entries = Array.from(Object.keys(object).entries());
+    for (const [i, key] of entries) {
       resolvedObject[key] = resolvedValues[i];
     }
     return resolvedObject;

--- a/src/jsutils/promiseReduce.ts
+++ b/src/jsutils/promiseReduce.ts
@@ -9,7 +9,7 @@ import type { PromiseOrValue } from './PromiseOrValue';
  * return a Promise.
  */
 export function promiseReduce<T, U>(
-  values: Iterable<T>,
+  values: Array<T>,
   callbackFn: (accumulator: U, currentValue: T) => PromiseOrValue<U>,
   initialValue: PromiseOrValue<U>,
 ): PromiseOrValue<U> {

--- a/src/language/location.ts
+++ b/src/language/location.ts
@@ -20,7 +20,8 @@ export function getLocation(source: Source, position: number): SourceLocation {
   let lastLineStart = 0;
   let line = 1;
 
-  for (const match of source.body.matchAll(LineRegExp)) {
+  const matches = Array.from(source.body.matchAll(LineRegExp))
+  for (const match of matches) {
     invariant(typeof match.index === 'number');
     if (match.index >= position) {
       break;

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -213,7 +213,7 @@ export class GraphQLSchema {
     // Keep track of all implementations by interface name.
     this._implementationsMap = Object.create(null);
 
-    for (const namedType of allReferencedTypes) {
+    for (const namedType of Array.from(allReferencedTypes)) {
       if (namedType == null) {
         continue;
       }


### PR DESCRIPTION
One of the issues we uncovered in https://github.com/graphql/graphql-js/issues/3648 is that upgrading to ES6 output maintained the `for..of` and array destructuring in our bundles which leads to a pretty considerable performance regression. This changes our build step to account for these less performant syntaxes and transforms them.

There is more low hanging fruit that can be optimised like the custom accumulatormap/... however starting with a quick win. The babel plugin also still leverages the iterator spec for non-array for loops, [it optimises what it can](https://babeljs.io/docs/babel-plugin-transform-for-of#optimization)

Fixes https://github.com/graphql/graphql-js/issues/3648

The performance implication would be higher if we did something akin to https://github.com/graphql/graphql-js/pull/3687