### PR TITLE
fix(esm): added export mapping to package.json for proper cjs/esm entrypoints

### DIFF
--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -105,8 +105,20 @@ function buildPackage(outDir: string, isESMOnly: boolean): void {
     packageJSON.version += '+esm';
   } else {
     delete packageJSON.type;
-    packageJSON.main = 'index';
+    packageJSON.main = 'index.js';
     packageJSON.module = 'index.mjs';
+    packageJSON.types = 'index.d.ts';
+    packageJSON.exports = {
+      '.': {
+        'import': {
+          'types': './index.d.ts',
+          'default': './index.mjs'
+        },
+        'require': {
+          'types': './index.d.ts',
+          'default': './index.js'
+        }
+    }
     emitTSFiles({ outDir, module: 'commonjs', extension: '.js' });
     emitTSFiles({ outDir, module: 'es2020', extension: '.mjs' });
   }

--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -71,7 +71,7 @@ function buildPackage(outDir: string, isESMOnly: boolean): void {
     const versionTag = splittedTag[2] ?? splittedTag[0];
     assert(
       ['alpha', 'beta', 'rc'].includes(versionTag) ||
-        versionTag.startsWith('experimental-'),
+      versionTag.startsWith('experimental-'),
       `"${versionTag}" tag is not supported.`,
     );
     assert.equal(
@@ -110,14 +110,195 @@ function buildPackage(outDir: string, isESMOnly: boolean): void {
     packageJSON.types = 'index.d.ts';
     packageJSON.exports = {
       '.': {
-        'import': {
-          'types': './index.d.ts',
-          'default': './index.mjs'
+        import: {
+          types: './index.d.ts',
+          default: './index.mjs'
         },
-        'require': {
-          'types': './index.d.ts',
-          'default': './index.js'
+        require: {
+          types: './index.d.ts',
+          default: './index.js'
         }
+      },
+      './graphql': {
+        import: {
+          types: './graphql.d.ts',
+          default: './graphql.mjs'
+        },
+        require: {
+          types: './graphql.d.ts',
+          default: './graphql.js'
+        }
+      },
+      './version': {
+        import: {
+          types: './version.d.ts',
+          default: './version.mjs'
+        },
+        require: {
+          types: './version.d.ts',
+          default: './version.js'
+        }
+      },
+      './error': {
+        import: {
+          types: './error/index.d.ts',
+          default: './error/index.mjs'
+        },
+        require: {
+          types: './error/index.d.ts',
+          default: './error/index.js'
+        }
+      },
+      './error/*': {
+        import: {
+          types: './error/*.d.ts',
+          default: './error/*.mjs'
+        },
+        require: {
+          types: './error/*.d.ts',
+          default: './error/*.js'
+        }
+      },
+      './execution': {
+        import: {
+          types: './execution/index.d.ts',
+          default: './execution/index.mjs'
+        },
+        require: {
+          types: './execution/index.d.ts',
+          default: './execution/index.js'
+        }
+      },
+      './execution/*': {
+        import: {
+          types: './execution/*.d.ts',
+          default: './execution/*.mjs'
+        },
+        require: {
+          types: './execution/*.d.ts',
+          default: './execution/*.js'
+        }
+      },
+      './jsutils': {
+        import: {
+          types: './jsutils/index.d.ts',
+          default: './jsutils/index.mjs'
+        },
+        require: {
+          types: './jsutils/index.d.ts',
+          default: './jsutils/index.js'
+        }
+      },
+      './jsutils/*': {
+        import: {
+          types: './jsutils/*.d.ts',
+          default: './jsutils/*.mjs'
+        },
+        require: {
+          types: './jsutils/*.d.ts',
+          default: './jsutils/*.js'
+        }
+      },
+      './language': {
+        import: {
+          types: './language/index.d.ts',
+          default: './language/index.mjs'
+        },
+        require: {
+          types: './language/index.d.ts',
+          default: './language/index.js'
+        }
+      },
+      './language/*': {
+        import: {
+          types: './language/*.d.ts',
+          default: './language/*.mjs'
+        },
+        require: {
+          types: './language/*.d.ts',
+          default: './language/*.js'
+        }
+      },
+      './subscription': {
+        import: {
+          types: './subscription/index.d.ts',
+          default: './subscription/index.mjs'
+        },
+        require: {
+          types: './subscription/index.d.ts',
+          default: './subscription/index.js'
+        }
+      },
+      './subscription/*': {
+        import: {
+          types: './subscription/*.d.ts',
+          default: './subscription/*.mjs'
+        },
+        require: {
+          types: './subscription/*.d.ts',
+          default: './subscription/*.js'
+        }
+      },
+      './type': {
+        import: {
+          types: './type/index.d.ts',
+          default: './type/index.mjs'
+        },
+        require: {
+          types: './type/index.d.ts',
+          default: './type/index.js'
+        }
+      },
+      './type/*': {
+        import: {
+          types: './type/*.d.ts',
+          default: './type/*.mjs'
+        },
+        require: {
+          types: './type/*.d.ts',
+          default: './type/*.js'
+        }
+      },
+      './utilities': {
+        import: {
+          types: './utilities/index.d.ts',
+          default: './utilities/index.mjs'
+        },
+        require: {
+          types: './utilities/index.d.ts',
+          default: './utilities/index.js'
+        }
+      },
+      './utilities/*': {
+        import: {
+          types: './utilities/*.d.ts',
+          default: './utilities/*.mjs'
+        },
+        require: {
+          types: './utilities/*.d.ts',
+          default: './utilities/*.js'
+        }
+      },
+      './validation': {
+        import: {
+          types: './validation/index.d.ts',
+          default: './validation/index.mjs'
+        },
+        require: {
+          types: './validation/index.d.ts',
+          default: './validation/index.js'
+        }
+      },
+      './validation/*': {
+        import: {
+          types: './validation/*.d.ts',
+          default: './validation/*.mjs'
+        },
+        require: {
+          types: './validation/*.d.ts',
+          default: './validation/*.js'
+        }
+      }
     }
     emitTSFiles({ outDir, module: 'commonjs', extension: '.js' });
     emitTSFiles({ outDir, module: 'es2020', extension: '.mjs' });

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -218,6 +218,17 @@ export function writeGeneratedFile(filepath: string, body: string): void {
   fs.writeFileSync(filepath, formatted);
 }
 
+interface PackageJsonExportMapping {
+  import: {
+    types: string;
+    default: string;
+  };
+  require: {
+    types: string;
+    default: string;
+  }
+}
+
 interface PackageJSON {
   description: string;
   version: string;
@@ -225,7 +236,7 @@ interface PackageJSON {
   repository?: { url?: string };
   scripts?: { [name: string]: string };
   type?: string;
-  exports: { [path: string]: string };
+  exports: { [path: string]: string | PackageJsonExportMapping };
   types?: string;
   typesVersions: { [ranges: string]: { [path: string]: Array<string> } };
   devDependencies?: { [name: string]: string };


### PR DESCRIPTION
With the current code that doesn't define export mapping modern tooling such as vitest v1.6.0 tries to access the CJS version of GraphQL in my project (https://github.com/favware/graphql-pokemon) because it doesn't know where to find the ESM version. This subsequently causes the error:

```
Cannot use GraphQLNonNull "Ability!" from another module or realm.

Ensure that there is only one instance of "graphql" in the node_modules
directory. If different versions of "graphql" are the dependencies of other
relied on modules, use "resolutions" to ensure only one version is installed.

https://yarnpkg.com/en/docs/selective-version-resolutions

Duplicate "graphql" modules cannot be used at the same time since different
versions may have different capabilities and behavior. The data from one
version used in the function from another could produce confusing and
spurious results.
```

By following the modern system of defining package entrypoints through the `exports` mapping this problem is solved because now vitest will properly access the ESM variant for graphql.