### PR TITLE
incremental: remove extra ticks

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -339,14 +339,17 @@ class IncrementalPublisher {
   private _enqueueCompletedDeferredGroupedFieldSet(
     result: DeferredGroupedFieldSetResult,
   ): void {
-    let hasPendingParent = false;
+    let readyToPublish = false;
     for (const deferredFragmentRecord of result.deferredFragmentRecords) {
-      if (deferredFragmentRecord.id !== undefined) {
-        hasPendingParent = true;
+      if (
+        this._pending.has(deferredFragmentRecord) ||
+        this._newPending.has(deferredFragmentRecord)
+      ) {
+        readyToPublish = true;
       }
       deferredFragmentRecord.results.push(result);
     }
-    if (hasPendingParent) {
+    if (readyToPublish) {
       this._completedResultQueue.push(result);
       this._trigger();
     }

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -726,12 +726,6 @@ describe('Execute: defer directive', () => {
             },
             id: '0',
           },
-        ],
-        completed: [{ id: '0' }],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             data: {
               id: '1',
@@ -739,7 +733,7 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         ],
-        completed: [{ id: '1' }],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -903,12 +897,6 @@ describe('Execute: defer directive', () => {
             },
             id: '0',
           },
-        ],
-        completed: [{ id: '0' }],
-        hasNext: true,
-      },
-      {
-        incremental: [
           {
             data: {
               bar: 'bar',
@@ -916,7 +904,7 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         ],
-        completed: [{ id: '1' }],
+        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -1918,17 +1906,11 @@ describe('Execute: defer directive', () => {
             data: { name: 'slow', friends: [{}, {}, {}] },
             id: '0',
           },
-        ],
-        completed: [{ id: '0' }],
-        hasNext: true,
-      },
-      {
-        incremental: [
           { data: { name: 'Han' }, id: '1' },
           { data: { name: 'Leia' }, id: '2' },
           { data: { name: 'C-3PO' }, id: '3' },
         ],
-        completed: [{ id: '1' }, { id: '2' }, { id: '3' }],
+        completed: [{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
       },
     ]);
@@ -1974,17 +1956,11 @@ describe('Execute: defer directive', () => {
             },
             id: '0',
           },
-        ],
-        completed: [{ id: '0' }],
-        hasNext: true,
-      },
-      {
-        incremental: [
           { data: { name: 'Han' }, id: '1' },
           { data: { name: 'Leia' }, id: '2' },
           { data: { name: 'C-3PO' }, id: '3' },
         ],
-        completed: [{ id: '1' }, { id: '2' }, { id: '3' }],
+        completed: [{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -2106,12 +2106,22 @@ function executeDeferredGroupedFieldSets(
         deferMap,
       );
 
+    const result = shouldDefer(parentDeferUsages, deferUsageSet)
+      ? Promise.resolve().then(executor)
+      : executor();
+
     const deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord = {
       deferredFragmentRecords,
-      result: shouldDefer(parentDeferUsages, deferUsageSet)
-        ? Promise.resolve().then(executor)
-        : executor(),
+      result,
     };
+
+    if (isPromise(result)) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      result.then((resolved) => {
+        deferredGroupedFieldSetRecord.result = resolved;
+        return resolved;
+      });
+    }
 
     newDeferredGroupedFieldSetRecords.push(deferredGroupedFieldSetRecord);
   }


### PR DESCRIPTION
consolidates some defer payloads

This is accomplished by replacing a promised result within a `DeferredGroupedFieldSetRecord` with the actual result as soon as possible, so that IncrementalPublisher doesn't wait an extra tick if it doesn't need to.

This same optimization can also be employed with `StreamItemsRecord`s, but it is possible that the stream logic should be overall reworked.