### PR TITLE
implement bundling changes suggested in #4062

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -29,6 +29,8 @@ words:
   - graphiql
   - sublinks
   - instanceof
+  - vitest
+  - vite
 
   # Different names used inside tests
   - Skywalker

--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -6,18 +6,13 @@
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz",
-    "typescript-4.2": "npm:typescript@4.2.x",
-    "typescript-4.3": "npm:typescript@4.3.x",
-    "typescript-4.4": "npm:typescript@4.4.x",
-    "typescript-4.5": "npm:typescript@4.5.x",
-    "typescript-4.6": "npm:typescript@4.6.x",
-    "typescript-4.7": "npm:typescript@4.7.x",
     "typescript-4.8": "npm:typescript@4.8.x",
     "typescript-4.9": "npm:typescript@4.9.x",
     "typescript-5.0": "npm:typescript@5.0.x",
     "typescript-5.1": "npm:typescript@5.1.x",
     "typescript-5.2": "npm:typescript@5.2.x",
     "typescript-5.3": "npm:typescript@5.3.x",
-    "typescript-5.4": "npm:typescript@5.4.x"
+    "typescript-5.4": "npm:typescript@5.4.x",
+    "typescript-5.5": "npm:typescript@5.5.x"
   }
 }

--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -6,11 +6,18 @@
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz",
-    "typescript-4.1": "npm:typescript@4.1.x",
     "typescript-4.2": "npm:typescript@4.2.x",
     "typescript-4.3": "npm:typescript@4.3.x",
     "typescript-4.4": "npm:typescript@4.4.x",
     "typescript-4.5": "npm:typescript@4.5.x",
-    "typescript-4.6": "npm:typescript@4.6.x"
+    "typescript-4.6": "npm:typescript@4.6.x",
+    "typescript-4.7": "npm:typescript@4.7.x",
+    "typescript-4.8": "npm:typescript@4.8.x",
+    "typescript-4.9": "npm:typescript@4.9.x",
+    "typescript-5.0": "npm:typescript@5.0.x",
+    "typescript-5.1": "npm:typescript@5.1.x",
+    "typescript-5.2": "npm:typescript@5.2.x",
+    "typescript-5.3": "npm:typescript@5.3.x",
+    "typescript-5.4": "npm:typescript@5.4.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,15 +7,6 @@
   "main": "index.js",
   "module": "index.mjs",
   "exports": {
-    ".": {
-      "types": {
-        "import": "./index.js.d.mts",
-        "default": "./index.d.ts"
-      },
-      "module": "./index.mjs",
-      "import": "./index.js.mjs",
-      "default": "./index.js"
-    },
     "./execution/execute.js": {
       "types": {
         "import": "./execution/execute.js.d.mts",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,12 @@
         "import": "./execution/execute.js.d.mts",
         "default": "./execution/execute.d.ts"
       },
-      "import": "./execution/execute.js.mjs",
+      "vitest": {
+        "import": "./execution/execute.js.mjs",
+        "default": "./execution/execute.js"
+      },
       "module": "./execution/execute.mjs",
+      "import": "./execution/execute.js.mjs",
       "default": "./execution/execute.js"
     },
     "./jsutils/instanceOf.js": {
@@ -21,8 +25,12 @@
         "import": "./jsutils/instanceOf.js.d.mts",
         "default": "./jsutils/instanceOf.d.ts"
       },
-      "import": "./jsutils/instanceOf.js.mjs",
+      "vitest": {
+        "import": "./jsutils/instanceOf.js.mjs",
+        "default": "./jsutils/instanceOf.js"
+      },
       "module": "./jsutils/instanceOf.mjs",
+      "import": "./jsutils/instanceOf.js.mjs",
       "default": "./jsutils/instanceOf.js"
     },
     "./language/parser.js": {
@@ -30,8 +38,12 @@
         "import": "./language/parser.js.d.mts",
         "default": "./language/parser.d.ts"
       },
-      "import": "./language/parser.js.mjs",
+      "vitest": {
+        "import": "./language/parser.js.mjs",
+        "default": "./language/parser.js"
+      },
       "module": "./language/parser.mjs",
+      "import": "./language/parser.js.mjs",
       "default": "./language/parser.js"
     },
     "./language/ast.js": {
@@ -39,8 +51,12 @@
         "import": "./language/ast.js.d.mts",
         "default": "./language/ast.d.ts"
       },
-      "import": "./language/ast.js.mjs",
+      "vitest": {
+        "import": "./language/ast.js.mjs",
+        "default": "./language/ast.js"
+      },
       "module": "./language/ast.mjs",
+      "import": "./language/ast.js.mjs",
       "default": "./language/ast.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -7,59 +7,7 @@
   "main": "index.js",
   "module": "index.mjs",
   "exports": {
-    "./package.json": "./package.json",
-    "./execution/execute.js": {
-      "types": {
-        "import": "./execution/execute.js.d.mts",
-        "default": "./execution/execute.d.ts"
-      },
-      "vitest": {
-        "import": "./execution/execute.js.mjs",
-        "default": "./execution/execute.js"
-      },
-      "module": "./execution/execute.mjs",
-      "import": "./execution/execute.js.mjs",
-      "default": "./execution/execute.js"
-    },
-    "./jsutils/instanceOf.js": {
-      "types": {
-        "import": "./jsutils/instanceOf.js.d.mts",
-        "default": "./jsutils/instanceOf.d.ts"
-      },
-      "vitest": {
-        "import": "./jsutils/instanceOf.js.mjs",
-        "default": "./jsutils/instanceOf.js"
-      },
-      "module": "./jsutils/instanceOf.mjs",
-      "import": "./jsutils/instanceOf.js.mjs",
-      "default": "./jsutils/instanceOf.js"
-    },
-    "./language/parser.js": {
-      "types": {
-        "import": "./language/parser.js.d.mts",
-        "default": "./language/parser.d.ts"
-      },
-      "vitest": {
-        "import": "./language/parser.js.mjs",
-        "default": "./language/parser.js"
-      },
-      "module": "./language/parser.mjs",
-      "import": "./language/parser.js.mjs",
-      "default": "./language/parser.js"
-    },
-    "./language/ast.js": {
-      "types": {
-        "import": "./language/ast.js.d.mts",
-        "default": "./language/ast.d.ts"
-      },
-      "vitest": {
-        "import": "./language/ast.js.mjs",
-        "default": "./language/ast.js"
-      },
-      "module": "./language/ast.mjs",
-      "import": "./language/ast.js.mjs",
-      "default": "./language/ast.js"
-    }
+    "./package.json": "./package.json"
   },
   "typesVersions": {
     ">=4.1.0": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,55 @@
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,
-  "main": "index",
+  "main": "index.js",
   "module": "index.mjs",
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./index.js.d.mts",
+        "default": "./index.d.ts"
+      },
+      "module": "./index.mjs",
+      "import": "./index.js.mjs",
+      "default": "./index.js"
+    },
+    "./execution/execute.js": {
+      "types": {
+        "import": "./execution/execute.js.d.mts",
+        "default": "./execution/execute.d.ts"
+      },
+      "module": "./execution/execute.mjs",
+      "import": "./execution/execute.js.mjs",
+      "default": "./execution/execute.js"
+    },
+    "./jsutils/instanceOf.js": {
+      "types": {
+        "import": "./jsutils/instanceOf.js.d.mts",
+        "default": "./jsutils/instanceOf.d.ts"
+      },
+      "module": "./jsutils/instanceOf.mjs",
+      "import": "./jsutils/instanceOf.js.mjs",
+      "default": "./jsutils/instanceOf.js"
+    },
+    "./language/parser.js": {
+      "types": {
+        "import": "./language/parser.js.d.mts",
+        "default": "./language/parser.d.ts"
+      },
+      "module": "./language/parser.mjs",
+      "import": "./language/parser.js.mjs",
+      "default": "./language/parser.js"
+    },
+    "./language/ast.js": {
+      "types": {
+        "import": "./language/ast.js.d.mts",
+        "default": "./language/ast.d.ts"
+      },
+      "module": "./language/ast.mjs",
+      "import": "./language/ast.js.mjs",
+      "default": "./language/ast.js"
+    }
+  },
   "typesVersions": {
     ">=4.1.0": {
       "*": [

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "import": "./execution/execute.js.d.mts",
         "default": "./execution/execute.d.ts"
       },
-      "module": "./execution/execute.mjs",
       "import": "./execution/execute.js.mjs",
+      "module": "./execution/execute.mjs",
       "default": "./execution/execute.js"
     },
     "./jsutils/instanceOf.js": {
@@ -21,8 +21,8 @@
         "import": "./jsutils/instanceOf.js.d.mts",
         "default": "./jsutils/instanceOf.d.ts"
       },
-      "module": "./jsutils/instanceOf.mjs",
       "import": "./jsutils/instanceOf.js.mjs",
+      "module": "./jsutils/instanceOf.mjs",
       "default": "./jsutils/instanceOf.js"
     },
     "./language/parser.js": {
@@ -30,8 +30,8 @@
         "import": "./language/parser.js.d.mts",
         "default": "./language/parser.d.ts"
       },
-      "module": "./language/parser.mjs",
       "import": "./language/parser.js.mjs",
+      "module": "./language/parser.mjs",
       "default": "./language/parser.js"
     },
     "./language/ast.js": {
@@ -39,8 +39,8 @@
         "import": "./language/ast.js.d.mts",
         "default": "./language/ast.d.ts"
       },
-      "module": "./language/ast.mjs",
       "import": "./language/ast.js.mjs",
+      "module": "./language/ast.mjs",
       "default": "./language/ast.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "module": "index.mjs",
   "exports": {
+    "./package.json": "./package.json",
     "./execution/execute.js": {
       "types": {
         "import": "./execution/execute.js.d.mts",

--- a/resources/build-npm.js
+++ b/resources/build-npm.js
@@ -125,6 +125,8 @@ function buildPackageJSON() {
   delete packageJSON.scripts;
   delete packageJSON.devDependencies;
 
+  packageJSON.type = 'commonjs';
+
   // TODO: move to integration tests
   const publishTag = packageJSON.publishConfig?.tag;
   assert(publishTag != null, 'Should have packageJSON.publishConfig defined!');

--- a/resources/build-npm.js
+++ b/resources/build-npm.js
@@ -142,8 +142,23 @@ function buildPackageJSON() {
         import: base + '/index.js.d.mts',
         default: base + '/index.d.ts',
       },
-      import: base + '/index.js.mjs',
+      /*
+       this is not automatically picked up by vitest, but we can instruct users to add it to their vitest config:
+      ```js title="vite.config.ts"
+      import { defineConfig } from 'vite';
+      export default defineConfig(async ({ mode }) => {
+        return {
+          resolve: mode === 'test' ? { conditions: ['vitest'] } : undefined,
+        };
+      });
+      ```
+       */
+      vitest: {
+        import: base + '/index.js.mjs',
+        default: base + '/index.js',
+      },
       module: base + '/index.mjs',
+      import: base + '/index.js.mjs',
       default: base + '/index.js',
     };
     packageJSON.exports = {

--- a/resources/build-npm.js
+++ b/resources/build-npm.js
@@ -148,12 +148,12 @@ function buildPackageJSON() {
       import { defineConfig } from 'vite';
       export default defineConfig(async ({ mode }) => {
         return {
-          resolve: mode === 'test' ? { conditions: ['vitest'] } : undefined,
+          resolve: mode === 'test' ? { conditions: ['dual-module-hazard-workaround'] } : undefined,
         };
       });
       ```
        */
-      vitest: {
+      'dual-module-hazard-workaround': {
         import: base + '/index.js.mjs',
         default: base + '/index.js',
       },

--- a/resources/build-npm.js
+++ b/resources/build-npm.js
@@ -142,8 +142,8 @@ function buildPackageJSON() {
         import: base + '/index.js.d.mts',
         default: base + '/index.d.ts',
       },
-      module: base + '/index.mjs',
       import: base + '/index.js.mjs',
+      module: base + '/index.mjs',
       default: base + '/index.js',
     };
     packageJSON.exports = {

--- a/resources/build-npm.js
+++ b/resources/build-npm.js
@@ -132,15 +132,13 @@ function buildPackageJSON() {
   packageJSON.type = 'commonjs';
 
   for (const entryPoint of entryPoints) {
-    if (!entryPoint.endsWith('index.ts')) {
-      continue;
-    }
     const base = ('./' + path.dirname(entryPoint)).replace(/\/.?$/, '');
+    const filename = path.basename(entryPoint, '.ts');
     const generated = {};
-    generated[base] = {
+    generated[filename === 'index' ? base : `${base}/${filename}.js`] = {
       types: {
-        import: base + '/index.js.d.mts',
-        default: base + '/index.d.ts',
+        import: `${base}/${filename}.js.d.mts`,
+        default: `${base}/${filename}.d.ts`,
       },
       /*
        this is not automatically picked up by vitest, but we can instruct users to add it to their vitest config:
@@ -154,12 +152,12 @@ function buildPackageJSON() {
       ```
        */
       'dual-module-hazard-workaround': {
-        import: base + '/index.js.mjs',
-        default: base + '/index.js',
+        import: `${base}/${filename}.js.mjs`,
+        default: `${base}/${filename}.js`,
       },
-      module: base + '/index.mjs',
-      import: base + '/index.js.mjs',
-      default: base + '/index.js',
+      module: `${base}/${filename}.mjs`,
+      import: `${base}/${filename}.js.mjs`,
+      default: `${base}/${filename}.js`,
     };
     packageJSON.exports = {
       ...generated,

--- a/resources/build-npm.js
+++ b/resources/build-npm.js
@@ -13,6 +13,14 @@ const {
   showDirStats,
 } = require('./utils.js');
 
+const entryPoints = [
+  'index.ts',
+  'execution/execute.ts',
+  'jsutils/instanceOf.ts',
+  'language/parser.ts',
+  'language/ast.ts',
+];
+
 if (require.main === module) {
   fs.rmSync('./npmDist', { recursive: true, force: true });
   fs.mkdirSync('./npmDist');
@@ -57,10 +65,20 @@ if (require.main === module) {
 
   const tsProgram = ts.createProgram(['src/index.ts'], tsOptions, tsHost);
   const tsResult = tsProgram.emit();
+
   assert(
     !tsResult.emitSkipped,
     'Fail to generate `*.d.ts` files, please run `npm run check`',
   );
+
+  for (const [filename, contents] of Object.entries(
+    buildCjsEsmWrapper(
+      entryPoints.map((e) => './src/' + e),
+      tsProgram,
+    ),
+  )) {
+    writeGeneratedFile(filename, contents);
+  }
 
   assert(packageJSON.types === undefined, 'Unexpected "types" in package.json');
   const supportedTSVersions = Object.keys(packageJSON.typesVersions);
@@ -136,4 +154,131 @@ function buildPackageJSON() {
   }
 
   return packageJSON;
+}
+
+/**
+ *
+ * @param {string[]} files
+ * @param {ts.Program} tsProgram
+ * @returns
+ */
+function buildCjsEsmWrapper(files, tsProgram) {
+  /**
+   * @type {Record<string, string>} inputFiles
+   */
+  const inputFiles = {};
+  for (const file of files) {
+    const sourceFile = tsProgram.getSourceFile(file);
+    assert(sourceFile, `No source file found for ${file}`);
+
+    const generatedFileName = path.relative(
+      path.dirname(tsProgram.getRootFileNames()[0]),
+      file.replace(/\.ts$/, '.js.mts'),
+    );
+    const exportFrom = ts.factory.createStringLiteral(
+      './' + path.basename(file, '.ts') + '.js',
+    );
+
+    /**
+     * @type {ts.Statement[]}
+     */
+    const statements = [];
+
+    /** @type {string[]} */
+    const exports = [];
+
+    /** @type {string[]} */
+    const typeExports = [];
+
+    sourceFile.forEachChild((node) => {
+      if (ts.isExportDeclaration(node)) {
+        if (node.exportClause && ts.isNamedExports(node.exportClause)) {
+          for (const element of node.exportClause.elements) {
+            if (node.isTypeOnly || element.isTypeOnly) {
+              typeExports.push(element.name.text);
+            } else {
+              exports.push(element.name.text);
+            }
+          }
+        }
+      } else if (
+        node.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+        )
+      ) {
+        if (ts.isVariableStatement(node)) {
+          for (const declaration of node.declarationList.declarations) {
+            if (declaration.name && ts.isIdentifier(declaration.name)) {
+              exports.push(declaration.name.text);
+            }
+          }
+        } else if (
+          ts.isFunctionDeclaration(node) ||
+          ts.isClassDeclaration(node)
+        ) {
+          exports.push(node.name.text);
+        } else if (ts.isTypeAliasDeclaration(node)) {
+          typeExports.push(node.name.text);
+        }
+      }
+    });
+    if (exports.length > 0) {
+      statements.push(
+        ts.factory.createExportDeclaration(
+          undefined,
+          undefined,
+          false,
+          ts.factory.createNamedExports(
+            exports.map((name) =>
+              ts.factory.createExportSpecifier(false, undefined, name),
+            ),
+          ),
+          exportFrom,
+        ),
+      );
+    }
+    if (typeExports.length > 0) {
+      statements.push(
+        ts.factory.createExportDeclaration(
+          undefined,
+          undefined,
+          true,
+          ts.factory.createNamedExports(
+            typeExports.map((name) =>
+              ts.factory.createExportSpecifier(false, undefined, name),
+            ),
+          ),
+          exportFrom,
+        ),
+      );
+    }
+    const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+    inputFiles[generatedFileName] = printer.printFile(
+      ts.factory.createSourceFile(
+        statements,
+        ts.factory.createToken(ts.SyntaxKind.EndOfFileToken),
+        ts.NodeFlags.None,
+      ),
+    );
+  }
+  /**
+   * @type {ts.CompilerOptions} options
+   */
+  const options = {
+    ...tsProgram.getCompilerOptions(),
+    declaration: true,
+    emitDeclarationOnly: false,
+    isolatedModules: true,
+    module: ts.ModuleKind.ESNext,
+  };
+  options.outDir = options.declarationDir;
+  const results = {};
+  const host = ts.createCompilerHost(options);
+  host.writeFile = (fileName, contents) => (results[fileName] = contents);
+  host.readFile = (fileName) => inputFiles[fileName];
+
+  const program = ts.createProgram(Object.keys(inputFiles), options, host);
+  program.emit();
+
+  return results;
 }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1,3 +1,14 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * ExecutionContext
+ * * assertValidExecutionArguments @internal
+ * * buildExecutionContext @internal
+ * * buildResolveInfo @internal
+ * * getFieldDef @internal
+ * Should we still expose this file?
+ */
+
 import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { invariant } from '../jsutils/invariant';

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -1,3 +1,9 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`: none
+ * Should we still expose this file?
+ */
+
 import { inspect } from '../jsutils/inspect';
 import { keyMap } from '../jsutils/keyMap';
 import type { Maybe } from '../jsutils/Maybe';

--- a/src/jsutils/Maybe.ts
+++ b/src/jsutils/Maybe.ts
@@ -1,2 +1,6 @@
+/**
+ * Quoted as "used by external libraries".
+ * Should we still expose these?
+ */
 /** Conveniently represents flow's "Maybe" type https://flow.org/en/docs/types/maybe/ */
 export type Maybe<T> = null | undefined | T;

--- a/src/jsutils/ObjMap.ts
+++ b/src/jsutils/ObjMap.ts
@@ -1,6 +1,6 @@
 /**
  * Quoted as "used by external libraries".
- * All of these could be replaced by Record<string, T> or Readonly<Record<string, T>>
+ * All of these could be replaced by Record\<string, T\> or Readonly\<Record\<string, T\>\>
  * Should we still expose these?
  */
 

--- a/src/jsutils/ObjMap.ts
+++ b/src/jsutils/ObjMap.ts
@@ -1,3 +1,9 @@
+/**
+ * Quoted as "used by external libraries".
+ * All of these could be replaced by Record<string, T> or Readonly<Record<string, T>>
+ * Should we still expose these?
+ */
+
 export interface ObjMap<T> {
   [key: string]: T;
 }

--- a/src/jsutils/PromiseOrValue.ts
+++ b/src/jsutils/PromiseOrValue.ts
@@ -1,1 +1,5 @@
+/**
+ * Quoted as "used by external libraries".
+ * Should we still expose these?
+ */
 export type PromiseOrValue<T> = Promise<T> | T;

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -1,3 +1,10 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * isNode @internal
+ * * QueryDocumentKeys @internal
+ * Should we still expose this file?
+ */
 import type { Kind } from './kinds';
 import type { Source } from './source';
 import type { TokenKind } from './tokenKind';

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -1,3 +1,10 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * isPunctuatorTokenKind @internal
+ * Should we still expose this file?
+ */
+
 import { syntaxError } from '../error/syntaxError';
 
 import { Token } from './ast';

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -1,3 +1,10 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * Parser @internal
+ * Should we still expose this file?
+ */
+
 import type { Maybe } from '../jsutils/Maybe';
 
 import type { GraphQLError } from '../error/GraphQLError';

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -1,3 +1,10 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * GraphQLSchemaNormalizedConfig @internal
+ * * GraphQLSchemaValidationOptions
+ * Should we still expose this file?
+ */
 import { devAssert } from '../jsutils/devAssert';
 import { inspect } from '../jsutils/inspect';
 import { instanceOf } from '../jsutils/instanceOf';

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -1,3 +1,13 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * ASTValidationContext
+ * * ASTValidationRule
+ * * SDLValidationContext
+ * * SDLValidationRule
+ * Should we still expose this file?
+ */
+
 import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
 

--- a/src/validation/specifiedRules.ts
+++ b/src/validation/specifiedRules.ts
@@ -1,3 +1,10 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * specifiedSDLRules @internal
+ * Should we still expose this file?
+ */
+
 // Spec Section: "Executable Definitions"
 import { ExecutableDefinitionsRule } from './rules/ExecutableDefinitionsRule';
 // Spec Section: "Field Selections on Objects, Interfaces, and Unions Types"

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -1,3 +1,12 @@
+/**
+ * Quoted as "used by external libraries".
+ * Missing exports from `graphql`:
+ * * assertValidSDL @internal
+ * * assertValidSDLExtension @internal
+ * * validateSDL @internal
+ * Should we still expose this file?
+ */
+
 import { devAssert } from '../jsutils/devAssert';
 import type { Maybe } from '../jsutils/Maybe';
 


### PR DESCRIPTION
This is now ready for review.


Current AreTheTypesWrong output:

```sh
 graphql v16.7.0

 No problems found 🌟


"graphql/language/ast.js"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/language/parser.js"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/jsutils/instanceOf.js"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/execution/execute.js"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/error"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/execution"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/language"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/subscription"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/type"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/utilities"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/validation"

node10: 🟢 
node16 (from CJS): 🟢 (CJS)
node16 (from ESM): 🟢 (ESM)
bundler: 🟢 

***********************************

"graphql/package.json"

node10: 🟢 (JSON)
node16 (from CJS): 🟢 (JSON)
node16 (from ESM): 🟢 (JSON)
bundler: 🟢 (JSON)

***********************************


```


Running `publint` also is successful.