### PR TITLE
incremental: handle Stream as stream rather than linked list

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -1,13 +1,15 @@
 import { isPromise } from '../jsutils/isPromise.js';
 import { promiseWithResolvers } from '../jsutils/promiseWithResolvers.js';
 
+import type { GraphQLError } from '../error/GraphQLError.js';
+
 import type {
   DeferredFragmentRecord,
   DeferredGroupedFieldSetRecord,
   IncrementalDataRecord,
   IncrementalDataRecordResult,
   ReconcilableDeferredGroupedFieldSetResult,
-  StreamItemsRecord,
+  StreamItemRecord,
   StreamRecord,
   SubsequentResultRecord,
 } from './types.js';
@@ -27,9 +29,9 @@ function isDeferredFragmentNode(
 }
 
 function isStreamNode(
-  subsequentResultNode: SubsequentResultNode,
-): subsequentResultNode is StreamRecord {
-  return 'path' in subsequentResultNode;
+  record: SubsequentResultNode | IncrementalDataRecord,
+): record is StreamRecord {
+  return 'streamItemQueue' in record;
 }
 
 type SubsequentResultNode = DeferredFragmentNode | StreamRecord;
@@ -67,7 +69,7 @@ export class IncrementalGraph {
       if (isDeferredGroupedFieldSetRecord(incrementalDataRecord)) {
         this._addDeferredGroupedFieldSetRecord(incrementalDataRecord);
       } else {
-        this._addStreamItemsRecord(incrementalDataRecord);
+        this._addStreamRecord(incrementalDataRecord);
       }
     }
   }
@@ -95,6 +97,7 @@ export class IncrementalGraph {
       if (isStreamNode(node)) {
         this._pending.add(node);
         newPending.push(node);
+        this._newIncrementalDataRecords.add(node);
       } else if (node.deferredGroupedFieldSetRecords.size > 0) {
         for (const deferredGroupedFieldSetNode of node.deferredGroupedFieldSetRecords) {
           this._newIncrementalDataRecords.add(deferredGroupedFieldSetNode);
@@ -110,12 +113,20 @@ export class IncrementalGraph {
     this._newPending.clear();
 
     for (const incrementalDataRecord of this._newIncrementalDataRecords) {
-      const result = incrementalDataRecord.result.value;
-      if (isPromise(result)) {
+      if (isStreamNode(incrementalDataRecord)) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        result.then((resolved) => this._enqueue(resolved));
+        this._onStreamItems(
+          incrementalDataRecord,
+          incrementalDataRecord.streamItemQueue,
+        );
       } else {
-        this._enqueue(result);
+        const result = incrementalDataRecord.result.value;
+        if (isPromise(result)) {
+          // eslint-disable-next-line @typescript-eslint/no-floating-promises
+          result.then((resolved) => this._enqueue(resolved));
+        } else {
+          this._enqueue(result);
+        }
       }
     }
     this._newIncrementalDataRecords.clear();
@@ -246,12 +257,8 @@ export class IncrementalGraph {
     }
   }
 
-  private _addStreamItemsRecord(streamItemsRecord: StreamItemsRecord): void {
-    const streamRecord = streamItemsRecord.streamRecord;
-    if (!this._pending.has(streamRecord)) {
-      this._newPending.add(streamRecord);
-    }
-    this._newIncrementalDataRecords.add(streamItemsRecord);
+  private _addStreamRecord(streamRecord: StreamRecord): void {
+    this._newPending.add(streamRecord);
   }
 
   private _addDeferredFragmentNode(
@@ -281,6 +288,66 @@ export class IncrementalGraph {
     const parentNode = this._addDeferredFragmentNode(parent);
     parentNode.children.push(deferredFragmentNode);
     return deferredFragmentNode;
+  }
+
+  private async _onStreamItems(
+    streamRecord: StreamRecord,
+    streamItemQueue: Array<StreamItemRecord>,
+  ): Promise<void> {
+    let items: Array<unknown> = [];
+    let errors: Array<GraphQLError> = [];
+    let incrementalDataRecords: Array<IncrementalDataRecord> = [];
+    let streamItemRecord: StreamItemRecord | undefined;
+    while ((streamItemRecord = streamItemQueue.shift()) !== undefined) {
+      let result = streamItemRecord.value;
+      if (isPromise(result)) {
+        if (items.length > 0) {
+          this._enqueue({
+            streamRecord,
+            result:
+              // TODO add additional test case or rework for coverage
+              errors.length > 0 /* c8 ignore start */
+                ? { items, errors } /* c8 ignore stop */
+                : { items },
+            incrementalDataRecords,
+          });
+          items = [];
+          errors = [];
+          incrementalDataRecords = [];
+        }
+        // eslint-disable-next-line no-await-in-loop
+        result = await result;
+        // wait an additional tick to coalesce resolving additional promises
+        // within the queue
+        // eslint-disable-next-line no-await-in-loop
+        await Promise.resolve();
+      }
+      if (result.item === undefined) {
+        if (items.length > 0) {
+          this._enqueue({
+            streamRecord,
+            result: errors.length > 0 ? { items, errors } : { items },
+            incrementalDataRecords,
+          });
+        }
+        this._enqueue(
+          result.errors === undefined
+            ? { streamRecord }
+            : {
+                streamRecord,
+                errors: result.errors,
+              },
+        );
+        return;
+      }
+      items.push(result.item);
+      if (result.errors !== undefined) {
+        errors.push(...result.errors);
+      }
+      if (result.incrementalDataRecords !== undefined) {
+        incrementalDataRecords.push(...result.incrementalDataRecords);
+      }
+    }
   }
 
   private *_yieldCurrentCompletedIncrementalData(

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -146,10 +146,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
-          { items: ['banana'], id: '0' },
-          { items: ['coconut'], id: '0' },
-        ],
+        incremental: [{ items: ['banana', 'coconut'], id: '0' }],
         completed: [{ id: '0' }],
         hasNext: false,
       },
@@ -169,11 +166,7 @@ describe('Execute: stream directive', () => {
         hasNext: true,
       },
       {
-        incremental: [
-          { items: ['apple'], id: '0' },
-          { items: ['banana'], id: '0' },
-          { items: ['coconut'], id: '0' },
-        ],
+        incremental: [{ items: ['apple', 'banana', 'coconut'], id: '0' }],
         completed: [{ id: '0' }],
         hasNext: false,
       },
@@ -220,11 +213,7 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: ['banana'],
-            id: '0',
-          },
-          {
-            items: ['coconut'],
+            items: ['banana', 'coconut'],
             id: '0',
           },
         ],
@@ -284,11 +273,10 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [['banana', 'banana', 'banana']],
-            id: '0',
-          },
-          {
-            items: [['coconut', 'coconut', 'coconut']],
+            items: [
+              ['banana', 'banana', 'banana'],
+              ['coconut', 'coconut', 'coconut'],
+            ],
             id: '0',
           },
         ],
@@ -366,15 +354,11 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [{ name: 'Luke', id: '1' }],
-            id: '0',
-          },
-          {
-            items: [{ name: 'Han', id: '2' }],
-            id: '0',
-          },
-          {
-            items: [{ name: 'Leia', id: '3' }],
+            items: [
+              { name: 'Luke', id: '1' },
+              { name: 'Han', id: '2' },
+              { name: 'Leia', id: '3' },
+            ],
             id: '0',
           },
         ],
@@ -507,7 +491,7 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [null],
+            items: [null, { name: 'Leia', id: '3' }],
             id: '0',
             errors: [
               {
@@ -516,10 +500,6 @@ describe('Execute: stream directive', () => {
                 path: ['friendList', 1],
               },
             ],
-          },
-          {
-            items: [{ name: 'Leia', id: '3' }],
-            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -557,6 +537,11 @@ describe('Execute: stream directive', () => {
             items: [{ name: 'Luke', id: '1' }],
             id: '0',
           },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
           {
             items: [{ name: 'Han', id: '2' }],
             id: '0',
@@ -910,7 +895,7 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [null],
+            items: [null, { nonNullName: 'Han' }],
             id: '0',
             errors: [
               {
@@ -919,10 +904,6 @@ describe('Execute: stream directive', () => {
                 path: ['friendList', 1, 'nonNullName'],
               },
             ],
-          },
-          {
-            items: [{ nonNullName: 'Han' }],
-            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -956,7 +937,7 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [null],
+            items: [null, { nonNullName: 'Han' }],
             id: '0',
             errors: [
               {
@@ -965,10 +946,6 @@ describe('Execute: stream directive', () => {
                 path: ['friendList', 1, 'nonNullName'],
               },
             ],
-          },
-          {
-            items: [{ nonNullName: 'Han' }],
-            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1086,7 +1063,7 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [null],
+            items: [null, { nonNullName: 'Han' }],
             id: '0',
             errors: [
               {
@@ -1095,10 +1072,6 @@ describe('Execute: stream directive', () => {
                 path: ['friendList', 1, 'nonNullName'],
               },
             ],
-          },
-          {
-            items: [{ nonNullName: 'Han' }],
-            id: '0',
           },
         ],
         completed: [{ id: '0' }],
@@ -1401,10 +1374,6 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [{ name: 'Luke' }],
-            id: '1',
-          },
-          {
             data: { scalarField: null },
             id: '0',
             errors: [
@@ -1414,6 +1383,10 @@ describe('Execute: stream directive', () => {
                 path: ['otherNestedObject', 'scalarField'],
               },
             ],
+          },
+          {
+            items: [{ name: 'Luke' }],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }, { id: '1' }],
@@ -1717,11 +1690,10 @@ describe('Execute: stream directive', () => {
       {
         incremental: [
           {
-            items: [{ id: '1', name: 'Luke' }],
-            id: '0',
-          },
-          {
-            items: [{ id: '2', name: 'Han' }],
+            items: [
+              { id: '1', name: 'Luke' },
+              { id: '2', name: 'Han' },
+            ],
             id: '0',
           },
         ],
@@ -1783,11 +1755,7 @@ describe('Execute: stream directive', () => {
             id: '0',
           },
           {
-            items: [{ name: 'Luke' }],
-            id: '1',
-          },
-          {
-            items: [{ name: 'Han' }],
+            items: [{ name: 'Luke' }, { name: 'Han' }],
             id: '1',
           },
         ],
@@ -1859,12 +1827,12 @@ describe('Execute: stream directive', () => {
         pending: [{ id: '2', path: ['friendList', 1], label: 'DeferName' }],
         incremental: [
           {
-            items: [{ id: '2' }],
-            id: '1',
-          },
-          {
             data: { name: 'Luke' },
             id: '0',
+          },
+          {
+            items: [{ id: '2' }],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }],
@@ -1960,12 +1928,12 @@ describe('Execute: stream directive', () => {
         pending: [{ id: '2', path: ['friendList', 1], label: 'DeferName' }],
         incremental: [
           {
-            items: [{ id: '2' }],
-            id: '1',
-          },
-          {
             data: { name: 'Luke' },
             id: '0',
+          },
+          {
+            items: [{ id: '2' }],
+            id: '1',
           },
         ],
         completed: [{ id: '0' }],

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -217,10 +217,26 @@ export interface DeferredFragmentRecord {
   parent: DeferredFragmentRecord | undefined;
 }
 
+export interface StreamItemResult {
+  item?: unknown;
+  incrementalDataRecords?: ReadonlyArray<IncrementalDataRecord> | undefined;
+  errors?: ReadonlyArray<GraphQLError> | undefined;
+}
+
+export type StreamItemRecord = BoxedPromiseOrValue<StreamItemResult>;
+
 export interface StreamRecord {
   path: Path;
   label: string | undefined;
   id?: string | undefined;
+  streamItemQueue: Array<StreamItemRecord>;
+}
+
+export interface StreamItemsResult {
+  streamRecord: StreamRecord;
+  result?: BareStreamItemsResult | undefined;
+  incrementalDataRecords?: ReadonlyArray<IncrementalDataRecord> | undefined;
+  errors?: ReadonlyArray<GraphQLError> | undefined;
 }
 
 export interface CancellableStreamRecord extends StreamRecord {
@@ -233,45 +249,9 @@ export function isCancellableStreamRecord(
   return 'earlyReturn' in subsequentResultRecord;
 }
 
-interface ReconcilableStreamItemsResult {
-  streamRecord: StreamRecord;
-  result: BareStreamItemsResult;
-  incrementalDataRecords: ReadonlyArray<IncrementalDataRecord> | undefined;
-  errors?: never;
-}
-
-export function isReconcilableStreamItemsResult(
-  streamItemsResult: StreamItemsResult,
-): streamItemsResult is ReconcilableStreamItemsResult {
-  return streamItemsResult.result !== undefined;
-}
-
-interface TerminatingStreamItemsResult {
-  streamRecord: StreamRecord;
-  result?: never;
-  incrementalDataRecords?: never;
-  errors?: never;
-}
-
-interface NonReconcilableStreamItemsResult {
-  streamRecord: StreamRecord;
-  errors: ReadonlyArray<GraphQLError>;
-  result?: never;
-}
-
-export type StreamItemsResult =
-  | ReconcilableStreamItemsResult
-  | TerminatingStreamItemsResult
-  | NonReconcilableStreamItemsResult;
-
-export interface StreamItemsRecord {
-  streamRecord: StreamRecord;
-  result: BoxedPromiseOrValue<StreamItemsResult>;
-}
-
 export type IncrementalDataRecord =
   | DeferredGroupedFieldSetRecord
-  | StreamItemsRecord;
+  | StreamRecord;
 
 export type IncrementalDataRecordResult =
   | DeferredGroupedFieldSetResult


### PR DESCRIPTION
The incremental graph can handle a stream as a stream, rather than creating a linked list where each incremental data record also includes the next record in addition to any new defers and/or streams.

Enables easily batching all available stream items within the same incremental entry.

Depends on #4094