### PR TITLE
require non-empty directive locations

### DIFF
--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -431,6 +431,23 @@ describe('Type System: A Schema must have Object root types', () => {
       },
     ]);
   });
+
+  it('rejects a Schema whose directives have empty locations', () => {
+    const badDirective = new GraphQLDirective({
+      name: 'BadDirective',
+      args: {},
+      locations: [],
+    });
+    const schema = new GraphQLSchema({
+      query: SomeObjectType,
+      directives: [badDirective],
+    });
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message: 'Directive @BadDirective must include 1 or more locations.',
+      },
+    ]);
+  });
 });
 
 describe('Type System: Root types must all be different if provided', () => {

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -183,7 +183,12 @@ function validateDirectives(context: SchemaValidationContext): void {
     // Ensure they are named correctly.
     validateName(context, directive);
 
-    // TODO: Ensure proper locations.
+    if (directive.locations.length === 0) {
+      context.reportError(
+        `Directive @${directive.name} must include 1 or more locations.`,
+        directive.astNode,
+      );
+    }
 
     // Ensure the arguments are valid.
     for (const arg of directive.args) {


### PR DESCRIPTION
A [proposed spec edit](https://github.com/graphql/graphql-spec/pull/1089) clarifies a requirement that was always true but was slightly buried: _directive definitions must include 1 or more locations_.

This PR adds explicit validation to graphql-js around non-empty directive locations. [Similar work](https://github.com/graphql-java/graphql-java/pull/3552) was landed in graphql-java