### PR TITLE
Fix publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
   },
   "scripts": {
-    "preversion": ". ./resources/checkgit.sh && npm ci --ignore-scripts",
+    "preversion": "bash -c '. ./resources/checkgit.sh && npm ci --ignore-scripts'",
     "version": "node resources/gen-version.js && npm test && git add src/version.ts",
     "fuzzonly": "mocha --full-trace src/**/__tests__/**/*-fuzz.ts",
     "changelog": "node resources/gen-changelog.js",

--- a/resources/checkgit.sh
+++ b/resources/checkgit.sh
@@ -1,4 +1,5 @@
 # Exit immediately if any subcommand terminated
+set -e
 trap "exit 1" ERR
 
 #


### PR DESCRIPTION
The publish scripts require the shell to be `bash`, which despite being the shell I use is not the one that `npm version` seems to use currently. Fixed by forcing the script to run through `bash -c`

This will NOT work on Windows. Probably it already didn't.