### PR TITLE
Update release instructions in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -93,17 +93,21 @@ then use `npm version patch|minor|major` in order to increment the version in
 package.json and tag and commit a release. Then `git push && git push --tags`
 to sync this change with source control. Then `npm publish npmDist` to actually
 publish the release to NPM.
-Once published, add [release notes](https://github.com/graphql/graphql-js/tags).
+Once published, add [release notes](https://github.com/graphql/graphql-js/releases).
 Use [semver](https://semver.org/) to determine which version part to increment.
 
 Example for a patch release:
 
 ```sh
+npm ci
 npm test
 npm version patch
 git push --follow-tags
-npm publish npmDist
+cd npmDist && npm publish
+npm run changelog
 ```
+
+Then upload the changelog to [https://github.com/graphql/graphql-js/releases](https://github.com/graphql/graphql-js/releases).
 
 ## License
 


### PR DESCRIPTION
`npm publish npmDist` fails:

```
$ npm publish npmDist                  
npm ERR! code E404                                                            
npm ERR! 404 Not Found - GET https://registry.npmjs.org/npmDist - Not found                                                                                                                    
npm ERR! 404                                                                  
npm ERR! 404  'npmDist@*' is not in this registry.                            
npm ERR! 404 This package name is not valid, because                                                                                                                                           
npm ERR! 404  1. name can no longer contain capital letters                   
npm ERR! 404                                                                  
npm ERR! 404 Note that you can also install from a                            
npm ERR! 404 tarball, folder, http url, or git url.  
```

However `cd npmDist && npm publish` works.

I've also fixed the releases URL, and added the `npm run changelog` command with final instruction.