### PR TITLE
polish(IncrementalPublisher): remove unnecessary check and method call

### DIFF
--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -244,7 +244,6 @@ class IncrementalPublisher {
           id,
           errors: deferredGroupedFieldSetResult.errors,
         });
-        this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord);
       }
       return;
     }
@@ -261,19 +260,13 @@ class IncrementalPublisher {
 
     for (const deferredFragmentRecord of deferredGroupedFieldSetResult
       .deferredGroupedFieldSetRecord.deferredFragmentRecords) {
-      const id = deferredFragmentRecord.id;
-      // TODO: add test case for this.
-      // Presumably, this can occur if an error causes a fragment to be completed early,
-      // while an asynchronous deferred grouped field set result is enqueued.
-      /* c8 ignore next 3 */
-      if (id === undefined) {
-        continue;
-      }
       const reconcilableResults =
         this._incrementalGraph.completeDeferredFragment(deferredFragmentRecord);
       if (reconcilableResults === undefined) {
         continue;
       }
+      const id = deferredFragmentRecord.id;
+      invariant(id !== undefined);
       const incremental = context.incremental;
       for (const reconcilableResult of reconcilableResults) {
         const { bestId, subPath } = this._getBestIdAndSubPath(


### PR DESCRIPTION
polished IncrementalPublisher:

= completeDeferredFragment will always return undefined if the deferredFragmentRecord has already been removed from the graph
= removeDeferredFragment need not be called twice