### PR TITLE
polish(incremental): refactor getNewPending functionality

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -54,7 +54,7 @@ export class IncrementalGraph {
     this._nextQueue = [];
   }
 
-  getNewPending(
+  getNewRootNodes(
     incrementalDataRecords: ReadonlyArray<IncrementalDataRecord>,
   ): ReadonlyArray<SubsequentResultRecord> {
     const initialResultChildren = new Set<SubsequentResultNode>();
@@ -127,7 +127,7 @@ export class IncrementalGraph {
 
   completeDeferredFragment(deferredFragmentRecord: DeferredFragmentRecord):
     | {
-        newPending: ReadonlyArray<SubsequentResultRecord>;
+        newRootNodes: ReadonlyArray<SubsequentResultRecord>;
         reconcilableResults: ReadonlyArray<ReconcilableDeferredGroupedFieldSetResult>;
       }
     | undefined {
@@ -156,10 +156,10 @@ export class IncrementalGraph {
         );
       }
     }
-    const newPending = this._promoteNonEmptyToRoot(
+    const newRootNodes = this._promoteNonEmptyToRoot(
       deferredFragmentNode.children,
     );
-    return { newPending, reconcilableResults };
+    return { newRootNodes, reconcilableResults };
   }
 
   removeDeferredFragment(

--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -231,10 +231,10 @@ export class IncrementalGraph {
   }
 
   private _promoteNonEmptyToRoot(
-    newRootNodes: Set<SubsequentResultNode>,
+    maybeEmptyNewRootNodes: Set<SubsequentResultNode>,
   ): ReadonlyArray<SubsequentResultRecord> {
-    const newPending: Array<SubsequentResultRecord> = [];
-    for (const node of newRootNodes) {
+    const newRootNodes: Array<SubsequentResultRecord> = [];
+    for (const node of maybeEmptyNewRootNodes) {
       if (isDeferredFragmentNode(node)) {
         if (node.deferredGroupedFieldSetRecords.size > 0) {
           for (const deferredGroupedFieldSetRecord of node.deferredGroupedFieldSetRecords) {
@@ -243,22 +243,22 @@ export class IncrementalGraph {
             }
           }
           this._rootNodes.add(node);
-          newPending.push(node.deferredFragmentRecord);
+          newRootNodes.push(node.deferredFragmentRecord);
           continue;
         }
         this._deferredFragmentNodes.delete(node.deferredFragmentRecord);
         for (const child of node.children) {
-          newRootNodes.add(child);
+          maybeEmptyNewRootNodes.add(child);
         }
       } else {
         this._rootNodes.add(node);
-        newPending.push(node);
+        newRootNodes.push(node);
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this._onStreamItems(node);
       }
     }
-    return newPending;
+    return newRootNodes;
   }
 
   private _completesRootNode(


### PR DESCRIPTION
return newPending alongside incremental results when completing a fragment

= removes need to track `newPending` and `newIncrementalDataRecords` as part of the class
= unifies handling of retrieving new pending for initial result, completed fragments, and stream items incremental entries