### PR TITLE
fix(16.x.x.): avoid stack size limit in overlapping field rules as well as execute

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -22,7 +22,6 @@ import { GraphQLBoolean, GraphQLInt, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
 import { execute, executeSync } from '../execute';
-import { print } from '../../language';
 
 describe('Execute: Handles basic execution tasks', () => {
   it('throws if no document is provided', () => {
@@ -81,7 +80,6 @@ describe('Execute: Handles basic execution tasks', () => {
       }),
     });
 
-
     const n = 10000;
     const fragments = Array.from(Array(n).keys()).reduce(
       (acc, next) =>
@@ -96,7 +94,6 @@ describe('Execute: Handles basic execution tasks', () => {
     const document = parse(`
       query {
         ...X${n}
-        __typename
       }
       ${fragments}
       fragment X0 on Query {

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1138,4 +1138,28 @@ describe('Validate: Overlapping fields can be merged', () => {
       },
     ]);
   });
+
+  it('does not hit stack size limits', () => {
+    const n = 10000;
+    const fragments = Array.from(Array(n).keys()).reduce(
+      (acc, next) =>
+        acc.concat(`\n
+        fragment X${next + 1} on Query {
+          ...X${next}
+        }
+      `),
+      '',
+    );
+
+    const query = `
+      query Test {
+        ...X${n}
+      }
+      ${fragments}
+      fragment X0 on Query {
+        __typename
+      }
+    `;
+    expectErrors(query).toDeepEqual([]);
+  });
 });

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1160,6 +1160,7 @@ describe('Validate: Overlapping fields can be merged', () => {
         __typename
       }
     `;
+
     expectErrors(query).toDeepEqual([]);
   });
 });

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -485,7 +485,7 @@ function findConflictsBetweenSubSelectionSets(
 
 // (E) Then collect any conflicts between the provided collection of fields
 // and any fragment names found in the given fragment.
-const processDiscoveredFragments = (
+function processDiscoveredFragments(
   context: ValidationContext,
   conflicts: Array<Conflict>,
   cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentNames>,
@@ -493,16 +493,19 @@ const processDiscoveredFragments = (
   areMutuallyExclusive: boolean,
   fieldMap: NodeAndDefCollection,
   discoveredFragments: Array<Array<string>>,
-) => {
-  while (discoveredFragments.length !== 0) {
-    const item = discoveredFragments.pop();
+) {
+  let item;
+  while ((item = discoveredFragments.pop()) !== undefined) {
+    const [fragmentName, referencedFragmentName] = item;
     if (
-      !item ||
-      comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)
+      comparedFragmentPairs.has(
+        referencedFragmentName,
+        fragmentName,
+        areMutuallyExclusive,
+      )
     ) {
       continue;
     }
-    const [fragmentName, referencedFragmentName] = item;
     comparedFragmentPairs.add(
       referencedFragmentName,
       fragmentName,
@@ -519,7 +522,7 @@ const processDiscoveredFragments = (
       discoveredFragments,
     );
   }
-};
+}
 
 // Collect all Conflicts "within" one collection of fields.
 function collectConflictsWithin(

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -207,26 +207,15 @@ function findConflictsWithinSelectionSet(
         discoveredFragments,
       );
 
-      // (E) Then collect any conflicts between the provided collection of fields
-      // and any fragment names found in the given fragment.
-      while (discoveredFragments.length !== 0) {
-        const item = discoveredFragments.pop();
-        if (!item || comparedFragmentPairs.has(item[1], item[0], false)) {
-          continue;
-        }
-        const [fragmentName, referencedFragmentName] = item;
-        comparedFragmentPairs.add(referencedFragmentName, fragmentName, false);
-        collectConflictsBetweenFieldsAndFragment(
-          context,
-          conflicts,
-          cachedFieldsAndFragmentNames,
-          comparedFragmentPairs,
-          false,
-          fieldMap,
-          referencedFragmentName,
-          discoveredFragments,
-        );
-      }
+      processDiscoveredFragments(
+        context,
+        conflicts,
+        cachedFieldsAndFragmentNames,
+        comparedFragmentPairs,
+        false,
+        fieldMap,
+        discoveredFragments,
+      );
       // (C) Then compare this fragment with all other fragments found in this
       // selection set to collect conflicts between fragments spread together.
       // This compares each item in the list of fragment names to every other
@@ -439,33 +428,15 @@ function findConflictsBetweenSubSelectionSets(
     );
   }
 
-  // (E) Then collect any conflicts between the provided collection of fields
-  // and any fragment names found in the given fragment.
-  while (discoveredFragments.length !== 0) {
-    const item = discoveredFragments.pop();
-    if (
-      !item ||
-      comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)
-    ) {
-      continue;
-    }
-    const [fragmentName, referencedFragmentName] = item;
-    comparedFragmentPairs.add(
-      referencedFragmentName,
-      fragmentName,
-      areMutuallyExclusive,
-    );
-    collectConflictsBetweenFieldsAndFragment(
-      context,
-      conflicts,
-      cachedFieldsAndFragmentNames,
-      comparedFragmentPairs,
-      areMutuallyExclusive,
-      fieldMap1,
-      referencedFragmentName,
-      discoveredFragments,
-    );
-  }
+  processDiscoveredFragments(
+    context,
+    conflicts,
+    cachedFieldsAndFragmentNames,
+    comparedFragmentPairs,
+    areMutuallyExclusive,
+    fieldMap1,
+    discoveredFragments,
+  );
 
   // (I) Then collect conflicts between the second collection of fields and
   // those referenced by each fragment name associated with the first.
@@ -482,33 +453,15 @@ function findConflictsBetweenSubSelectionSets(
     );
   }
 
-  // (E) Then collect any conflicts between the provided collection of fields
-  // and any fragment names found in the given fragment.
-  while (discoveredFragments.length !== 0) {
-    const item = discoveredFragments.pop();
-    if (
-      !item ||
-      comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)
-    ) {
-      continue;
-    }
-    const [fragmentName, referencedFragmentName] = item;
-    comparedFragmentPairs.add(
-      referencedFragmentName,
-      fragmentName,
-      areMutuallyExclusive,
-    );
-    collectConflictsBetweenFieldsAndFragment(
-      context,
-      conflicts,
-      cachedFieldsAndFragmentNames,
-      comparedFragmentPairs,
-      areMutuallyExclusive,
-      fieldMap2,
-      referencedFragmentName,
-      discoveredFragments,
-    );
-  }
+  processDiscoveredFragments(
+    context,
+    conflicts,
+    cachedFieldsAndFragmentNames,
+    comparedFragmentPairs,
+    areMutuallyExclusive,
+    fieldMap2,
+    discoveredFragments,
+  );
 
   // (J) Also collect conflicts between any fragment names by the first and
   // fragment names by the second. This compares each item in the first set of
@@ -528,6 +481,44 @@ function findConflictsBetweenSubSelectionSets(
   }
   return conflicts;
 }
+
+// (E) Then collect any conflicts between the provided collection of fields
+// and any fragment names found in the given fragment.
+const processDiscoveredFragments = (
+  context: ValidationContext,
+  conflicts: Array<Conflict>,
+  cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentNames>,
+  comparedFragmentPairs: PairSet,
+  areMutuallyExclusive: boolean,
+  fieldMap: NodeAndDefCollection,
+  discoveredFragments: Array<Array<string>>,
+) => {
+  while (discoveredFragments.length !== 0) {
+    const item = discoveredFragments.pop();
+    if (
+      !item ||
+      comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)
+    ) {
+      continue;
+    }
+    const [fragmentName, referencedFragmentName] = item;
+    comparedFragmentPairs.add(
+      referencedFragmentName,
+      fragmentName,
+      areMutuallyExclusive,
+    );
+    collectConflictsBetweenFieldsAndFragment(
+      context,
+      conflicts,
+      cachedFieldsAndFragmentNames,
+      comparedFragmentPairs,
+      areMutuallyExclusive,
+      fieldMap,
+      referencedFragmentName,
+      discoveredFragments,
+    );
+  }
+};
 
 // Collect all Conflicts "within" one collection of fields.
 function collectConflictsWithin(

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -425,6 +425,7 @@ function findConflictsBetweenSubSelectionSets(
 
   // (I) Then collect conflicts between the first collection of fields and
   // those referenced by each fragment name associated with the second.
+  const discoveredFragments: Array<Array<string>> = [];
   for (const fragmentName2 of fragmentNames2) {
     collectConflictsBetweenFieldsAndFragment(
       context,
@@ -434,7 +435,28 @@ function findConflictsBetweenSubSelectionSets(
       areMutuallyExclusive,
       fieldMap1,
       fragmentName2,
-      [],
+      discoveredFragments,
+    );
+  }
+
+  // (E) Then collect any conflicts between the provided collection of fields
+  // and any fragment names found in the given fragment.
+  while (discoveredFragments.length !== 0) {
+    const item = discoveredFragments.pop();
+    if (!item || comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)) {
+      continue;
+    }
+    const [fragmentName, referencedFragmentName] = item;
+    comparedFragmentPairs.add(referencedFragmentName, fragmentName, areMutuallyExclusive);
+    collectConflictsBetweenFieldsAndFragment(
+      context,
+      conflicts,
+      cachedFieldsAndFragmentNames,
+      comparedFragmentPairs,
+      areMutuallyExclusive,
+      fieldMap1,
+      fragmentName,
+      discoveredFragments,
     );
   }
 
@@ -449,7 +471,28 @@ function findConflictsBetweenSubSelectionSets(
       areMutuallyExclusive,
       fieldMap2,
       fragmentName1,
-      [],
+      discoveredFragments,
+    );
+  }
+
+  // (E) Then collect any conflicts between the provided collection of fields
+  // and any fragment names found in the given fragment.
+  while (discoveredFragments.length !== 0) {
+    const item = discoveredFragments.pop();
+    if (!item || comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)) {
+      continue;
+    }
+    const [fragmentName, referencedFragmentName] = item;
+    comparedFragmentPairs.add(referencedFragmentName, fragmentName, areMutuallyExclusive);
+    collectConflictsBetweenFieldsAndFragment(
+      context,
+      conflicts,
+      cachedFieldsAndFragmentNames,
+      comparedFragmentPairs,
+      areMutuallyExclusive,
+      fieldMap2,
+      fragmentName,
+      discoveredFragments,
     );
   }
 

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -223,7 +223,7 @@ function findConflictsWithinSelectionSet(
           comparedFragmentPairs,
           false,
           fieldMap,
-          fragmentName,
+          referencedFragmentName,
           discoveredFragments,
         );
       }
@@ -443,11 +443,18 @@ function findConflictsBetweenSubSelectionSets(
   // and any fragment names found in the given fragment.
   while (discoveredFragments.length !== 0) {
     const item = discoveredFragments.pop();
-    if (!item || comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)) {
+    if (
+      !item ||
+      comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)
+    ) {
       continue;
     }
     const [fragmentName, referencedFragmentName] = item;
-    comparedFragmentPairs.add(referencedFragmentName, fragmentName, areMutuallyExclusive);
+    comparedFragmentPairs.add(
+      referencedFragmentName,
+      fragmentName,
+      areMutuallyExclusive,
+    );
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
@@ -455,7 +462,7 @@ function findConflictsBetweenSubSelectionSets(
       comparedFragmentPairs,
       areMutuallyExclusive,
       fieldMap1,
-      fragmentName,
+      referencedFragmentName,
       discoveredFragments,
     );
   }
@@ -479,11 +486,18 @@ function findConflictsBetweenSubSelectionSets(
   // and any fragment names found in the given fragment.
   while (discoveredFragments.length !== 0) {
     const item = discoveredFragments.pop();
-    if (!item || comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)) {
+    if (
+      !item ||
+      comparedFragmentPairs.has(item[1], item[0], areMutuallyExclusive)
+    ) {
       continue;
     }
     const [fragmentName, referencedFragmentName] = item;
-    comparedFragmentPairs.add(referencedFragmentName, fragmentName, areMutuallyExclusive);
+    comparedFragmentPairs.add(
+      referencedFragmentName,
+      fragmentName,
+      areMutuallyExclusive,
+    );
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
@@ -491,7 +505,7 @@ function findConflictsBetweenSubSelectionSets(
       comparedFragmentPairs,
       areMutuallyExclusive,
       fieldMap2,
-      fragmentName,
+      referencedFragmentName,
       discoveredFragments,
     );
   }

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -191,8 +191,8 @@ function findConflictsWithinSelectionSet(
     fieldMap,
   );
 
+  const discoveredFragments: Array<[string, string]> = [];
   if (fragmentNames.length !== 0) {
-    const discoveredFragments: Array<[string, string]> = [];
     // (B) Then collect conflicts between these fields and those represented by
     // each spread fragment name found.
     for (let i = 0; i < fragmentNames.length; i++) {

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -207,15 +207,6 @@ function findConflictsWithinSelectionSet(
         discoveredFragments,
       );
 
-      processDiscoveredFragments(
-        context,
-        conflicts,
-        cachedFieldsAndFragmentNames,
-        comparedFragmentPairs,
-        false,
-        fieldMap,
-        discoveredFragments,
-      );
       // (C) Then compare this fragment with all other fragments found in this
       // selection set to collect conflicts between fragments spread together.
       // This compares each item in the list of fragment names to every other
@@ -232,6 +223,16 @@ function findConflictsWithinSelectionSet(
         );
       }
     }
+
+    processDiscoveredFragments(
+      context,
+      conflicts,
+      cachedFieldsAndFragmentNames,
+      comparedFragmentPairs,
+      false,
+      fieldMap,
+      discoveredFragments,
+    );
   }
   return conflicts;
 }


### PR DESCRIPTION
Fixes https://github.com/graphql/graphql-js/issues/3938

This moves us from our recursion when we are in a fragment to discovering more referenced fragments to a stack-iterator based approach. The memory consumption might be slightly higher during validation now but this will stop us from crashing which is less desired I presume.

EDIT: found some bugs, working on it (fixed in https://github.com/graphql/graphql-js/pull/4116/commits/18f81bd5af0c9a45b11a27380c156db4e16f7b60)