### PR TITLE
refactor(incremental): set pending result id during execution

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -15,32 +15,16 @@ import type {
   StreamRecord,
   SubsequentResultRecord,
 } from './types.js';
-import { isDeferredGroupedFieldSetRecord } from './types.js';
-
-interface DeferredFragmentNode {
-  deferredFragmentRecord: DeferredFragmentRecord;
-  deferredGroupedFieldSetRecords: Set<DeferredGroupedFieldSetRecord>;
-  reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
-  children: Set<SubsequentResultNode>;
-}
-
-function isDeferredFragmentNode(
-  node: SubsequentResultNode | undefined,
-): node is DeferredFragmentNode {
-  return node !== undefined && 'deferredFragmentRecord' in node;
-}
-
-type SubsequentResultNode = DeferredFragmentNode | StreamRecord;
+import {
+  isDeferredFragmentRecord,
+  isDeferredGroupedFieldSetRecord,
+} from './types.js';
 
 /**
  * @internal
  */
 export class IncrementalGraph {
-  private _rootNodes: Set<SubsequentResultNode>;
-  private _deferredFragmentNodes: Map<
-    DeferredFragmentRecord,
-    DeferredFragmentNode
-  >;
+  private _rootNodes: Set<SubsequentResultRecord>;
 
   private _completedQueue: Array<IncrementalDataRecordResult>;
   private _nextQueue: Array<
@@ -49,7 +33,6 @@ export class IncrementalGraph {
 
   constructor() {
     this._rootNodes = new Set();
-    this._deferredFragmentNodes = new Map();
     this._completedQueue = [];
     this._nextQueue = [];
   }
@@ -57,7 +40,7 @@ export class IncrementalGraph {
   getNewRootNodes(
     incrementalDataRecords: ReadonlyArray<IncrementalDataRecord>,
   ): ReadonlyArray<SubsequentResultRecord> {
-    const initialResultChildren = new Set<SubsequentResultNode>();
+    const initialResultChildren = new Set<SubsequentResultRecord>();
     this._addIncrementalDataRecords(
       incrementalDataRecords,
       undefined,
@@ -69,13 +52,12 @@ export class IncrementalGraph {
   addCompletedReconcilableDeferredGroupedFieldSet(
     reconcilableResult: ReconcilableDeferredGroupedFieldSetResult,
   ): void {
-    for (const deferredFragmentNode of this._fragmentsToNodes(
-      reconcilableResult.deferredGroupedFieldSetRecord.deferredFragmentRecords,
-    )) {
-      deferredFragmentNode.deferredGroupedFieldSetRecords.delete(
+    for (const deferredFragmentRecord of reconcilableResult
+      .deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+      deferredFragmentRecord.deferredGroupedFieldSetRecords.delete(
         reconcilableResult.deferredGroupedFieldSetRecord,
       );
-      deferredFragmentNode.reconcilableResults.add(reconcilableResult);
+      deferredFragmentRecord.reconcilableResults.add(reconcilableResult);
     }
 
     const incrementalDataRecords = reconcilableResult.incrementalDataRecords;
@@ -131,33 +113,28 @@ export class IncrementalGraph {
         reconcilableResults: ReadonlyArray<ReconcilableDeferredGroupedFieldSetResult>;
       }
     | undefined {
-    const deferredFragmentNode = this._deferredFragmentNodes.get(
-      deferredFragmentRecord,
-    );
     // TODO: add test case?
     /* c8 ignore next 3 */
-    if (deferredFragmentNode === undefined) {
+    if (!this._rootNodes.has(deferredFragmentRecord)) {
       return;
     }
-    if (deferredFragmentNode.deferredGroupedFieldSetRecords.size > 0) {
+    if (deferredFragmentRecord.deferredGroupedFieldSetRecords.size > 0) {
       return;
     }
     const reconcilableResults = Array.from(
-      deferredFragmentNode.reconcilableResults,
+      deferredFragmentRecord.reconcilableResults,
     );
-    this._removeRootNode(deferredFragmentNode);
+    this._removeRootNode(deferredFragmentRecord);
     for (const reconcilableResult of reconcilableResults) {
-      for (const otherDeferredFragmentNode of this._fragmentsToNodes(
-        reconcilableResult.deferredGroupedFieldSetRecord
-          .deferredFragmentRecords,
-      )) {
-        otherDeferredFragmentNode.reconcilableResults.delete(
+      for (const otherDeferredFragmentRecord of reconcilableResult
+        .deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+        otherDeferredFragmentRecord.reconcilableResults.delete(
           reconcilableResult,
         );
       }
     }
     const newRootNodes = this._promoteNonEmptyToRoot(
-      deferredFragmentNode.children,
+      deferredFragmentRecord.children,
     );
     return { newRootNodes, reconcilableResults };
   }
@@ -165,21 +142,10 @@ export class IncrementalGraph {
   removeDeferredFragment(
     deferredFragmentRecord: DeferredFragmentRecord,
   ): boolean {
-    const deferredFragmentNode = this._deferredFragmentNodes.get(
-      deferredFragmentRecord,
-    );
-    if (deferredFragmentNode === undefined) {
+    if (!this._rootNodes.has(deferredFragmentRecord)) {
       return false;
     }
-    this._removeRootNode(deferredFragmentNode);
-    this._deferredFragmentNodes.delete(deferredFragmentRecord);
-    // TODO: add test case for an erroring deferred fragment with child defers
-    /* c8 ignore next 5 */
-    for (const child of deferredFragmentNode.children) {
-      if (isDeferredFragmentNode(child)) {
-        this.removeDeferredFragment(child.deferredFragmentRecord);
-      }
-    }
+    this._removeRootNode(deferredFragmentRecord);
     return true;
   }
 
@@ -187,8 +153,10 @@ export class IncrementalGraph {
     this._removeRootNode(streamRecord);
   }
 
-  private _removeRootNode(subsequentResultNode: SubsequentResultNode): void {
-    this._rootNodes.delete(subsequentResultNode);
+  private _removeRootNode(
+    subsequentResultRecord: SubsequentResultRecord,
+  ): void {
+    this._rootNodes.delete(subsequentResultRecord);
     if (this._rootNodes.size === 0) {
       for (const resolve of this._nextQueue) {
         resolve({ value: undefined, done: true });
@@ -199,16 +167,16 @@ export class IncrementalGraph {
   private _addIncrementalDataRecords(
     incrementalDataRecords: ReadonlyArray<IncrementalDataRecord>,
     parents: ReadonlyArray<DeferredFragmentRecord> | undefined,
-    initialResultChildren?: Set<SubsequentResultNode> | undefined,
+    initialResultChildren?: Set<SubsequentResultRecord> | undefined,
   ): void {
     for (const incrementalDataRecord of incrementalDataRecords) {
       if (isDeferredGroupedFieldSetRecord(incrementalDataRecord)) {
         for (const deferredFragmentRecord of incrementalDataRecord.deferredFragmentRecords) {
-          const deferredFragmentNode = this._addDeferredFragmentNode(
+          this._addDeferredFragment(
             deferredFragmentRecord,
             initialResultChildren,
           );
-          deferredFragmentNode.deferredGroupedFieldSetRecords.add(
+          deferredFragmentRecord.deferredGroupedFieldSetRecords.add(
             incrementalDataRecord,
           );
         }
@@ -220,22 +188,19 @@ export class IncrementalGraph {
         initialResultChildren.add(incrementalDataRecord);
       } else {
         for (const parent of parents) {
-          const deferredFragmentNode = this._addDeferredFragmentNode(
-            parent,
-            initialResultChildren,
-          );
-          deferredFragmentNode.children.add(incrementalDataRecord);
+          this._addDeferredFragment(parent, initialResultChildren);
+          parent.children.add(incrementalDataRecord);
         }
       }
     }
   }
 
   private _promoteNonEmptyToRoot(
-    maybeEmptyNewRootNodes: Set<SubsequentResultNode>,
+    maybeEmptyNewRootNodes: Set<SubsequentResultRecord>,
   ): ReadonlyArray<SubsequentResultRecord> {
     const newRootNodes: Array<SubsequentResultRecord> = [];
     for (const node of maybeEmptyNewRootNodes) {
-      if (isDeferredFragmentNode(node)) {
+      if (isDeferredFragmentRecord(node)) {
         if (node.deferredGroupedFieldSetRecords.size > 0) {
           for (const deferredGroupedFieldSetRecord of node.deferredGroupedFieldSetRecords) {
             if (!this._completesRootNode(deferredGroupedFieldSetRecord)) {
@@ -243,10 +208,9 @@ export class IncrementalGraph {
             }
           }
           this._rootNodes.add(node);
-          newRootNodes.push(node.deferredFragmentRecord);
+          newRootNodes.push(node);
           continue;
         }
-        this._deferredFragmentNodes.delete(node.deferredFragmentRecord);
         for (const child of node.children) {
           maybeEmptyNewRootNodes.add(child);
         }
@@ -264,53 +228,26 @@ export class IncrementalGraph {
   private _completesRootNode(
     deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
   ): boolean {
-    return this._fragmentsToNodes(
-      deferredGroupedFieldSetRecord.deferredFragmentRecords,
-    ).some((node) => this._rootNodes.has(node));
+    return deferredGroupedFieldSetRecord.deferredFragmentRecords.some(
+      (deferredFragmentRecord) => this._rootNodes.has(deferredFragmentRecord),
+    );
   }
 
-  private _fragmentsToNodes(
-    deferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord>,
-  ): Array<DeferredFragmentNode> {
-    return deferredFragmentRecords
-      .map((deferredFragmentRecord) =>
-        this._deferredFragmentNodes.get(deferredFragmentRecord),
-      )
-      .filter<DeferredFragmentNode>(isDeferredFragmentNode);
-  }
-
-  private _addDeferredFragmentNode(
+  private _addDeferredFragment(
     deferredFragmentRecord: DeferredFragmentRecord,
-    initialResultChildren: Set<SubsequentResultNode> | undefined,
-  ): DeferredFragmentNode {
-    let deferredFragmentNode = this._deferredFragmentNodes.get(
-      deferredFragmentRecord,
-    );
-    if (deferredFragmentNode !== undefined) {
-      return deferredFragmentNode;
+    subsequentResultRecords: Set<SubsequentResultRecord> | undefined,
+  ): void {
+    if (this._rootNodes.has(deferredFragmentRecord)) {
+      return;
     }
-    deferredFragmentNode = {
-      deferredFragmentRecord,
-      deferredGroupedFieldSetRecords: new Set(),
-      reconcilableResults: new Set(),
-      children: new Set(),
-    };
-    this._deferredFragmentNodes.set(
-      deferredFragmentRecord,
-      deferredFragmentNode,
-    );
     const parent = deferredFragmentRecord.parent;
     if (parent === undefined) {
-      invariant(initialResultChildren !== undefined);
-      initialResultChildren.add(deferredFragmentNode);
-      return deferredFragmentNode;
+      invariant(subsequentResultRecords !== undefined);
+      subsequentResultRecords.add(deferredFragmentRecord);
+      return;
     }
-    const parentNode = this._addDeferredFragmentNode(
-      parent,
-      initialResultChildren,
-    );
-    parentNode.children.add(deferredFragmentNode);
-    return deferredFragmentNode;
+    parent.children.add(deferredFragmentRecord);
+    this._addDeferredFragment(parent, subsequentResultRecords);
   }
 
   private _onDeferredGroupedFieldSet(

--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -54,7 +54,7 @@ export class IncrementalGraph {
     this._nextQueue = [];
   }
 
-  getNewPending(
+  getNewRootNodes(
     incrementalDataRecords: ReadonlyArray<IncrementalDataRecord>,
   ): ReadonlyArray<SubsequentResultRecord> {
     const initialResultChildren = new Set<SubsequentResultNode>();
@@ -127,7 +127,7 @@ export class IncrementalGraph {
 
   completeDeferredFragment(deferredFragmentRecord: DeferredFragmentRecord):
     | {
-        newPending: ReadonlyArray<SubsequentResultRecord>;
+        newRootNodes: ReadonlyArray<SubsequentResultRecord>;
         reconcilableResults: ReadonlyArray<ReconcilableDeferredGroupedFieldSetResult>;
       }
     | undefined {
@@ -156,10 +156,10 @@ export class IncrementalGraph {
         );
       }
     }
-    const newPending = this._promoteNonEmptyToRoot(
+    const newRootNodes = this._promoteNonEmptyToRoot(
       deferredFragmentNode.children,
     );
-    return { newPending, reconcilableResults };
+    return { newRootNodes, reconcilableResults };
   }
 
   removeDeferredFragment(

--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -231,10 +231,10 @@ export class IncrementalGraph {
   }
 
   private _promoteNonEmptyToRoot(
-    newRootNodes: Set<SubsequentResultNode>,
+    maybeEmptyNewRootNodes: Set<SubsequentResultNode>,
   ): ReadonlyArray<SubsequentResultRecord> {
-    const newPending: Array<SubsequentResultRecord> = [];
-    for (const node of newRootNodes) {
+    const newRootNodes: Array<SubsequentResultRecord> = [];
+    for (const node of maybeEmptyNewRootNodes) {
       if (isDeferredFragmentNode(node)) {
         if (node.deferredGroupedFieldSetRecords.size > 0) {
           for (const deferredGroupedFieldSetRecord of node.deferredGroupedFieldSetRecords) {
@@ -243,22 +243,22 @@ export class IncrementalGraph {
             }
           }
           this._rootNodes.add(node);
-          newPending.push(node.deferredFragmentRecord);
+          newRootNodes.push(node.deferredFragmentRecord);
           continue;
         }
         this._deferredFragmentNodes.delete(node.deferredFragmentRecord);
         for (const child of node.children) {
-          newRootNodes.add(child);
+          maybeEmptyNewRootNodes.add(child);
         }
       } else {
         this._rootNodes.add(node);
-        newPending.push(node);
+        newRootNodes.push(node);
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this._onStreamItems(node);
       }
     }
-    return newPending;
+    return newRootNodes;
   }
 
   private _completesRootNode(

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -607,12 +607,12 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [{ id: '0', path: ['hero'] }],
+        pending: [{ id: '1', path: ['hero'] }],
         hasNext: true,
       },
       {
-        incremental: [{ data: { name: 'Luke' }, id: '0' }],
-        completed: [{ id: '0' }],
+        incremental: [{ data: { name: 'Luke' }, id: '1' }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
     ]);
@@ -787,8 +787,8 @@ describe('Execute: defer directive', () => {
           hero: {},
         },
         pending: [
-          { id: '0', path: ['hero'], label: 'DeferID' },
-          { id: '1', path: [], label: 'DeferName' },
+          { id: '1', path: ['hero'], label: 'DeferID' },
+          { id: '0', path: [], label: 'DeferName' },
         ],
         hasNext: true,
       },
@@ -798,17 +798,17 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            id: '0',
+            id: '1',
           },
           {
             data: {
               name: 'Luke',
             },
-            id: '1',
+            id: '0',
             subPath: ['hero'],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
+        completed: [{ id: '1' }, { id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1019,18 +1019,18 @@ describe('Execute: defer directive', () => {
         data: { hero: { friends: [{}, {}, {}] } },
         pending: [
           { id: '0', path: ['hero', 'friends', 0] },
-          { id: '1', path: ['hero', 'friends', 1] },
-          { id: '2', path: ['hero', 'friends', 2] },
+          { id: '4', path: ['hero', 'friends', 1] },
+          { id: '8', path: ['hero', 'friends', 2] },
         ],
         hasNext: true,
       },
       {
         incremental: [
           { data: { id: '2', name: 'Han' }, id: '0' },
-          { data: { id: '3', name: 'Leia' }, id: '1' },
-          { data: { id: '4', name: 'C-3PO' }, id: '2' },
+          { data: { id: '3', name: 'Leia' }, id: '4' },
+          { data: { id: '4', name: 'C-3PO' }, id: '8' },
         ],
-        completed: [{ id: '0' }, { id: '1' }, { id: '2' }],
+        completed: [{ id: '0' }, { id: '4' }, { id: '8' }],
         hasNext: false,
       },
     ]);
@@ -1275,8 +1275,8 @@ describe('Execute: defer directive', () => {
           },
         },
         pending: [
-          { id: '0', path: ['hero', 'nestedObject', 'deeperObject'] },
           { id: '1', path: ['hero', 'nestedObject', 'deeperObject'] },
+          { id: '2', path: ['hero', 'nestedObject', 'deeperObject'] },
         ],
         hasNext: true,
       },
@@ -1286,16 +1286,16 @@ describe('Execute: defer directive', () => {
             data: {
               foo: 'foo',
             },
-            id: '0',
+            id: '1',
           },
           {
             data: {
               bar: 'bar',
             },
-            id: '1',
+            id: '2',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
+        completed: [{ id: '1' }, { id: '2' }],
         hasNext: false,
       },
     ]);
@@ -1351,8 +1351,8 @@ describe('Execute: defer directive', () => {
           },
         },
         pending: [
-          { id: '0', path: ['a', 'b'] },
-          { id: '1', path: [] },
+          { id: '1', path: ['a', 'b'] },
+          { id: '0', path: [] },
         ],
         hasNext: true,
       },
@@ -1360,14 +1360,14 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { e: { f: 'f' } },
-            id: '0',
+            id: '1',
           },
           {
             data: { g: { h: 'h' } },
-            id: '1',
+            id: '0',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
+        completed: [{ id: '1' }, { id: '0' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1,9 +1,11 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
 
 import type { DocumentNode } from '../../language/ast.js';
 import { parse } from '../../language/parser.js';
@@ -854,6 +856,134 @@ describe('Execute: defer directive', () => {
         hasNext: false,
       },
     ]);
+  });
+
+  it('Initiates all deferred grouped field sets immediately if and only if they have been released as pending', async () => {
+    const document = parse(`
+      query {
+        ... @defer {
+          a {
+            ... @defer {
+              b {
+                c { d }
+              }
+            }
+          }
+        }
+        ... @defer {
+          a {
+            someField
+            ... @defer {
+              b {
+                e { f }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const { promise: slowFieldPromise, resolve: resolveSlowField } =
+      promiseWithResolvers();
+    let cResolverCalled = false;
+    let eResolverCalled = false;
+    const executeResult = experimentalExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        a: {
+          someField: slowFieldPromise,
+          b: {
+            c: () => {
+              cResolverCalled = true;
+              return { d: 'd' };
+            },
+            e: () => {
+              eResolverCalled = true;
+              return { f: 'f' };
+            },
+          },
+        },
+      },
+      enableEarlyExecution: false,
+    });
+
+    assert('initialResult' in executeResult);
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {},
+      pending: [
+        { id: '0', path: [] },
+        { id: '1', path: [] },
+      ],
+      hasNext: true,
+    });
+
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    expect(cResolverCalled).to.equal(false);
+    expect(eResolverCalled).to.equal(false);
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      value: {
+        pending: [{ id: '2', path: ['a'] }],
+        incremental: [
+          {
+            data: { a: {} },
+            id: '0',
+          },
+          {
+            data: { b: {} },
+            id: '2',
+          },
+          {
+            data: { c: { d: 'd' } },
+            id: '2',
+            subPath: ['b'],
+          },
+        ],
+        completed: [{ id: '0' }, { id: '2' }],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    expect(cResolverCalled).to.equal(true);
+    expect(eResolverCalled).to.equal(false);
+
+    resolveSlowField('someField');
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({
+      value: {
+        pending: [{ id: '3', path: ['a'] }],
+        incremental: [
+          {
+            data: { someField: 'someField' },
+            id: '1',
+            subPath: ['a'],
+          },
+          {
+            data: { e: { f: 'f' } },
+            id: '3',
+            subPath: ['b'],
+          },
+        ],
+        completed: [{ id: '1' }, { id: '3' }],
+        hasNext: false,
+      },
+      done: false,
+    });
+
+    expect(eResolverCalled).to.equal(true);
+
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('Can deduplicate multiple defers on the same object', async () => {

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -1978,14 +1978,14 @@ describe('Execute: stream directive', () => {
             nestedFriendList: [],
           },
         },
-        pending: [{ id: '0', path: ['nestedObject', 'nestedFriendList'] }],
+        pending: [{ id: '1', path: ['nestedObject', 'nestedFriendList'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
             items: [{ id: '1', name: 'Luke' }],
-            id: '0',
+            id: '1',
           },
         ],
         hasNext: true,
@@ -1994,13 +1994,13 @@ describe('Execute: stream directive', () => {
         incremental: [
           {
             items: [{ id: '2', name: 'Han' }],
-            id: '0',
+            id: '1',
           },
         ],
         hasNext: true,
       },
       {
-        completed: [{ id: '0' }],
+        completed: [{ id: '1' }],
         hasNext: false,
       },
     ]);

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -63,7 +63,6 @@ import { buildIncrementalResponse } from './IncrementalPublisher.js';
 import { mapAsyncIterable } from './mapAsyncIterable.js';
 import type {
   CancellableStreamRecord,
-  DeferredFragmentRecord,
   DeferredGroupedFieldSetRecord,
   DeferredGroupedFieldSetResult,
   ExecutionResult,
@@ -73,6 +72,7 @@ import type {
   StreamItemResult,
   StreamRecord,
 } from './types.js';
+import { DeferredFragmentRecord } from './types.js';
 import {
   getArgumentValues,
   getDirectiveValues,
@@ -1676,11 +1676,11 @@ function addNewDeferredFragments(
         : deferredFragmentRecordFromDeferUsage(parentDeferUsage, newDeferMap);
 
     // Instantiate the new record.
-    const deferredFragmentRecord: DeferredFragmentRecord = {
+    const deferredFragmentRecord = new DeferredFragmentRecord(
       path,
-      label: newDeferUsage.label,
+      newDeferUsage.label,
       parent,
-    };
+    );
 
     // Update the map.
     newDeferMap.set(newDeferUsage, deferredFragmentRecord);

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -214,11 +214,34 @@ export interface DeferredGroupedFieldSetRecord {
 
 export type SubsequentResultRecord = DeferredFragmentRecord | StreamRecord;
 
-export interface DeferredFragmentRecord {
+/** @internal */
+export class DeferredFragmentRecord {
   path: Path | undefined;
   label: string | undefined;
   id?: string | undefined;
   parent: DeferredFragmentRecord | undefined;
+  deferredGroupedFieldSetRecords: Set<DeferredGroupedFieldSetRecord>;
+  reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
+  children: Set<SubsequentResultRecord>;
+
+  constructor(
+    path: Path | undefined,
+    label: string | undefined,
+    parent: DeferredFragmentRecord | undefined,
+  ) {
+    this.path = path;
+    this.label = label;
+    this.parent = parent;
+    this.deferredGroupedFieldSetRecords = new Set();
+    this.reconcilableResults = new Set();
+    this.children = new Set();
+  }
+}
+
+export function isDeferredFragmentRecord(
+  subsequentResultRecord: SubsequentResultRecord,
+): subsequentResultRecord is DeferredFragmentRecord {
+  return subsequentResultRecord instanceof DeferredFragmentRecord;
 }
 
 export interface StreamItemResult {

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -224,6 +224,9 @@ export class DeferredFragmentRecord {
   reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
   children: Set<SubsequentResultRecord>;
 
+  private pending: boolean;
+  private fns: Array<() => void>;
+
   constructor(
     path: Path | undefined,
     label: string | undefined,
@@ -235,6 +238,24 @@ export class DeferredFragmentRecord {
     this.deferredGroupedFieldSetRecords = new Set();
     this.reconcilableResults = new Set();
     this.children = new Set();
+    this.pending = false;
+    this.fns = [];
+  }
+
+  onPending(fn: () => void): void {
+    if (this.pending) {
+      fn();
+    } else {
+      this.fns.push(fn);
+    }
+  }
+
+  setAsPending(): void {
+    this.pending = true;
+    let fn;
+    while ((fn = this.fns.shift()) !== undefined) {
+      fn();
+    }
   }
 }
 

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -218,7 +218,7 @@ export type SubsequentResultRecord = DeferredFragmentRecord | StreamRecord;
 export class DeferredFragmentRecord {
   path: Path | undefined;
   label: string | undefined;
-  id?: string | undefined;
+  id: string;
   parent: DeferredFragmentRecord | undefined;
   deferredGroupedFieldSetRecords: Set<DeferredGroupedFieldSetRecord>;
   reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
@@ -230,10 +230,12 @@ export class DeferredFragmentRecord {
   constructor(
     path: Path | undefined,
     label: string | undefined,
+    id: string,
     parent: DeferredFragmentRecord | undefined,
   ) {
     this.path = path;
     this.label = label;
+    this.id = id;
     this.parent = parent;
     this.deferredGroupedFieldSetRecords = new Set();
     this.reconcilableResults = new Set();
@@ -276,7 +278,7 @@ export type StreamItemRecord = ThunkIncrementalResult<StreamItemResult>;
 export interface StreamRecord {
   path: Path;
   label: string | undefined;
-  id?: string | undefined;
+  id: string;
   streamItemQueue: Array<StreamItemRecord>;
 }
 


### PR DESCRIPTION
This makes id an immutable property of each pending result, reducing the need to track these ids / lazily create them within the publisher.

## Spec changes

This would change the language in the specification around creating a pending result to be something like:

> Let {id} be a unique identifier for this new Deferred Fragment.
> Let {path} and {label} be the path and label....
> Let {newDeferredFragment} be an unordered map containing {id}, {path} and {label}

And retrieving the {id} to be as simple as:

> Let {id} be the corresponding entry on {deferredFragment}.

As opposed to the current way of doing things, where we kind of hand-wave and just write when retrieving the {id} for the first time (i.e. when preparing the entry within the `pending` list to send to the client:

> Let {id} be a unique identifier for this new Deferred Fragment.

And then when using it later within `incremental` and `completed`:

> Let {id} be the unique identifier for this Deferred Fragment.

## Implementation Differences

With this change, empty and filtered deferred fragments will lead to "missing" ids and id ordering will now depend on timing/early execution. The id by the specification are opaque strings so that this is not a specification concern. It's not a practical concern either -- in fact, one could argue that this wierdness is actually beneficial, in that if the ids were always sequential, clients might think that the spec says they should be, but the spec actually says they are opaque strings.

A practical concern, however, is that every future change to internals which results in a different execution ordering (presumably rare, but possible) may result in a change to these identifiers, which could end up breaking library users who have hardcoded their tests utilizing graphql-js with specific identifiers. This seems bad.

Along a  very minor similar vein, it is unclear what to label this change. It's just polish, really, but it unfortunately does have an observable difference. Presumably we would have to bump it up to patch-release worthy, which would translate to the bug-fix label.[^1]

### My Conclusion

I am leaning against this change.

[^1]: Of course, the actual release type doesn't matter, as we are on alpha and have breaking changes already within our alpha, as one might expect. It's the ambiguity of what to label this change that is parallel to the practical concern above, the theoretical question of how to release if this was the only change in the queue, not actually how we would perform the next release.