### PR TITLE
backport[v16]: Implement OneOf Input Objects via `@oneOf` directive

### DIFF
--- a/src/__testUtils__/kitchenSinkSDL.ts
+++ b/src/__testUtils__/kitchenSinkSDL.ts
@@ -27,6 +27,7 @@ type Foo implements Bar & Baz & Two {
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
   seven(argument: Int = null): Type
+  eight(argument: OneOfInputType): Type
 }
 
 type AnnotatedObject @onObject(arg: "value") {
@@ -114,6 +115,11 @@ extend enum Site @onEnum
 input InputType {
   key: String!
   answer: Int = 42
+}
+
+input OneOfInputType @oneOf {
+  string: String
+  int: Int
 }
 
 input AnnotatedInput @onInputObject {

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from 'mocha';
 
-import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { expectJSON } from '../../__testUtils__/expectJSON';
 
-import { parse } from '../../language/parser.js';
+import { parse } from '../../language/parser';
 
-import { buildSchema } from '../../utilities/buildASTSchema.js';
+import { buildSchema } from '../../utilities/buildASTSchema';
 
-import type { ExecutionResult } from '../execute.js';
-import { execute } from '../execute.js';
+import type { ExecutionResult } from '../execute';
+import { execute } from '../execute';
 
 const schema = buildSchema(`
   type Query {

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -1,0 +1,185 @@
+import { describe, it } from 'mocha';
+
+import { expectJSON } from '../../__testUtils__/expectJSON.js';
+
+import { parse } from '../../language/parser.js';
+
+import { buildSchema } from '../../utilities/buildASTSchema.js';
+
+import type { ExecutionResult } from '../execute.js';
+import { execute } from '../execute.js';
+
+const schema = buildSchema(`
+  type Query {
+    test(input: TestInputObject!): TestObject
+  }
+
+  input TestInputObject @oneOf {
+    a: String
+    b: Int
+  }
+
+  type TestObject {
+    a: String
+    b: Int
+  }
+`);
+
+function executeQuery(
+  query: string,
+  rootValue: unknown,
+  variableValues?: { [variable: string]: unknown },
+): ExecutionResult | Promise<ExecutionResult> {
+  return execute({ schema, document: parse(query), rootValue, variableValues });
+}
+
+describe('Execute: Handles OneOf Input Objects', () => {
+  describe('OneOf Input Objects', () => {
+    const rootValue = {
+      test({ input }: { input: { a?: string; b?: number } }) {
+        return input;
+      },
+    };
+
+    it('accepts a good default value', () => {
+      const query = `
+        query ($input: TestInputObject! = {a: "abc"}) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: 'abc',
+            b: null,
+          },
+        },
+      });
+    });
+
+    it('rejects a bad default value', () => {
+      const query = `
+        query ($input: TestInputObject! = {a: "abc", b: 123}) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: null,
+        },
+        errors: [
+          {
+            locations: [{ column: 23, line: 3 }],
+            message:
+              // This type of error would be caught at validation-time
+              // hence the vague error message here.
+              'Argument "input" of non-null type "TestInputObject!" must not be null.',
+            path: ['test'],
+          },
+        ],
+      });
+    });
+
+    it('accepts a good variable', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, { input: { a: 'abc' } });
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: 'abc',
+            b: null,
+          },
+        },
+      });
+    });
+
+    it('accepts a good variable with an undefined key', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, {
+        input: { a: 'abc', b: undefined },
+      });
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          test: {
+            a: 'abc',
+            b: null,
+          },
+        },
+      });
+    });
+
+    it('rejects a variable with multiple non-null keys', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, {
+        input: { a: 'abc', b: 123 },
+      });
+
+      expectJSON(result).toDeepEqual({
+        errors: [
+          {
+            locations: [{ column: 16, line: 2 }],
+            message:
+              'Variable "$input" got invalid value { a: "abc", b: 123 }; Exactly one key must be specified for OneOf type "TestInputObject".',
+          },
+        ],
+      });
+    });
+
+    it('rejects a variable with multiple nullable keys', () => {
+      const query = `
+        query ($input: TestInputObject!) {
+          test(input: $input) {
+            a
+            b
+          }
+        }
+      `;
+      const result = executeQuery(query, rootValue, {
+        input: { a: 'abc', b: null },
+      });
+
+      expectJSON(result).toDeepEqual({
+        errors: [
+          {
+            locations: [{ column: 16, line: 2 }],
+            message:
+              'Variable "$input" got invalid value { a: "abc", b: null }; Exactly one key must be specified for OneOf type "TestInputObject".',
+          },
+        ],
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,7 @@ export {
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
+  GraphQLOneOfDirective,
   // "Enum" of Type Kinds
   TypeKind,
   // Constant Deprecation Reason

--- a/src/language/__tests__/schema-printer-test.ts
+++ b/src/language/__tests__/schema-printer-test.ts
@@ -61,6 +61,7 @@ describe('Printer: SDL document', () => {
         five(argument: [String] = ["string", "string"]): String
         six(argument: InputType = {key: "value"}): Type
         seven(argument: Int = null): Type
+        eight(argument: OneOfInputType): Type
       }
 
       type AnnotatedObject @onObject(arg: "value") {
@@ -141,6 +142,11 @@ describe('Printer: SDL document', () => {
       input InputType {
         key: String!
         answer: Int = 42
+      }
+
+      input OneOfInputType @oneOf {
+        string: String
+        int: Int
       }
 
       input AnnotatedInput @onInputObject {

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -336,7 +336,7 @@ describe('Type System: A Schema must have Object root types', () => {
     ]);
   });
 
-  it('rejects a schema extended with invalid root types', () => {
+  it('rejects a Schema extended with invalid root types', () => {
     let schema = buildSchema(`
       input SomeInputObject {
         test: String
@@ -1658,6 +1658,47 @@ describe('Type System: Input Object fields must have input types', () => {
         message:
           'The type of SomeInputObject.foo must be Input Type but got: SomeObject.',
         locations: [{ line: 7, column: 14 }],
+      },
+    ]);
+  });
+});
+
+describe('Type System: OneOf Input Object fields must be nullable', () => {
+  it('rejects non-nullable fields', () => {
+    const schema = buildSchema(`
+      type Query {
+        test(arg: SomeInputObject): String
+      }
+
+      input SomeInputObject @oneOf {
+        a: String
+        b: String!
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message: 'OneOf input field SomeInputObject.b must be nullable.',
+        locations: [{ line: 8, column: 12 }],
+      },
+    ]);
+  });
+
+  it('rejects fields with default values', () => {
+    const schema = buildSchema(`
+      type Query {
+        test(arg: SomeInputObject): String
+      }
+
+      input SomeInputObject @oneOf {
+        a: String
+        b: String = "foo"
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'OneOf input field SomeInputObject.b cannot have a default value.',
+        locations: [{ line: 8, column: 9 }],
       },
     ]);
   });

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1611,6 +1611,7 @@ export class GraphQLInputObjectType {
   extensions: Readonly<GraphQLInputObjectTypeExtensions>;
   astNode: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
+  isOneOf: boolean;
 
   private _fields: ThunkObjMap<GraphQLInputField>;
 
@@ -1620,6 +1621,7 @@ export class GraphQLInputObjectType {
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
+    this.isOneOf = config.isOneOf ?? false;
 
     this._fields = defineInputFieldMap.bind(undefined, config);
   }
@@ -1652,6 +1654,7 @@ export class GraphQLInputObjectType {
       extensions: this.extensions,
       astNode: this.astNode,
       extensionASTNodes: this.extensionASTNodes,
+      isOneOf: this.isOneOf,
     };
   }
 
@@ -1697,6 +1700,7 @@ export interface GraphQLInputObjectTypeConfig {
   extensions?: Maybe<Readonly<GraphQLInputObjectTypeExtensions>>;
   astNode?: Maybe<InputObjectTypeDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<InputObjectTypeExtensionNode>>;
+  isOneOf?: boolean;
 }
 
 interface GraphQLInputObjectTypeNormalizedConfig

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -210,11 +210,12 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
   });
 
 /**
- * Used to declare an Input Object as a OneOf Input Objects.
+ * Used to indicate an Input Object is a OneOf Input Object.
  */
 export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
   name: 'oneOf',
-  description: 'Indicates an Input Object is a OneOf Input Object.',
+  description:
+    'Indicates exactly one field must be supplied and this field must not be `null`.',
   locations: [DirectiveLocation.INPUT_OBJECT],
   args: {},
 });

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -210,6 +210,16 @@ export const GraphQLSpecifiedByDirective: GraphQLDirective =
   });
 
 /**
+ * Used to declare an Input Object as a OneOf Input Objects.
+ */
+export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
+  name: 'oneOf',
+  description: 'Indicates an Input Object is a OneOf Input Object.',
+  locations: [DirectiveLocation.INPUT_OBJECT],
+  args: {},
+});
+
+/**
  * The full list of specified directives.
  */
 export const specifiedDirectives: ReadonlyArray<GraphQLDirective> =
@@ -218,6 +228,7 @@ export const specifiedDirectives: ReadonlyArray<GraphQLDirective> =
     GraphQLSkipDirective,
     GraphQLDeprecatedDirective,
     GraphQLSpecifiedByDirective,
+    GraphQLOneOfDirective,
   ]);
 
 export function isSpecifiedDirective(directive: GraphQLDirective): boolean {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -133,6 +133,7 @@ export {
   GraphQLSkipDirective,
   GraphQLDeprecatedDirective,
   GraphQLSpecifiedByDirective,
+  GraphQLOneOfDirective,
   // Constant Deprecation Reason
   DEFAULT_DEPRECATION_REASON,
 } from './directives';

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -323,6 +323,14 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
         type: __Type,
         resolve: (type) => ('ofType' in type ? type.ofType : undefined),
       },
+      isOneOf: {
+        type: GraphQLBoolean,
+        resolve: (type) => {
+          if (isInputObjectType(type)) {
+            return type.isOneOf;
+          }
+        },
+      },
     } as GraphQLFieldConfigMap<GraphQLType, unknown>),
 });
 

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -531,6 +531,30 @@ function validateInputFields(
         [getDeprecatedDirectiveNode(field.astNode), field.astNode?.type],
       );
     }
+
+    if (inputObj.isOneOf) {
+      validateOneOfInputObjectField(inputObj, field, context);
+    }
+  }
+}
+
+function validateOneOfInputObjectField(
+  type: GraphQLInputObjectType,
+  field: GraphQLInputField,
+  context: SchemaValidationContext,
+): void {
+  if (isNonNullType(field.type)) {
+    context.reportError(
+      `OneOf input field ${type.name}.${field.name} must be nullable.`,
+      field.astNode?.type,
+    );
+  }
+
+  if (field.defaultValue !== undefined) {
+    context.reportError(
+      `OneOf input field ${type.name}.${field.name} cannot have a default value.`,
+      field.astNode,
+    );
   }
 }
 

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -23,6 +23,7 @@ import {
   assertDirective,
   GraphQLDeprecatedDirective,
   GraphQLIncludeDirective,
+  GraphQLOneOfDirective,
   GraphQLSkipDirective,
   GraphQLSpecifiedByDirective,
 } from '../../type/directives';
@@ -222,7 +223,7 @@ describe('Schema Builder', () => {
   it('Maintains @include, @skip & @specifiedBy', () => {
     const schema = buildSchema('type Query');
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
     expect(schema.getDirective('deprecated')).to.equal(
@@ -231,6 +232,7 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('oneOf')).to.equal(GraphQLOneOfDirective);
   });
 
   it('Overriding directives excludes specified', () => {
@@ -239,9 +241,10 @@ describe('Schema Builder', () => {
       directive @include on FIELD
       directive @deprecated on FIELD_DEFINITION
       directive @specifiedBy on FIELD_DEFINITION
+      directive @oneOf on OBJECT
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(4);
+    expect(schema.getDirectives()).to.have.lengthOf(5);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
@@ -252,18 +255,20 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.not.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('oneOf')).to.not.equal(GraphQLOneOfDirective);
   });
 
-  it('Adding directives maintains @include, @skip & @specifiedBy', () => {
+  it('Adding directives maintains @include, @skip, @deprecated, @specifiedBy, and @oneOf', () => {
     const schema = buildSchema(`
       directive @foo(arg: Int) on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
     expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
+    expect(schema.getDirective('oneOf')).to.not.equal(undefined);
   });
 
   it('Type modifiers', () => {

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -573,6 +573,21 @@ describe('Type System: build schema from introspection', () => {
     expect(cycleIntrospection(sdl)).to.equal(sdl);
   });
 
+  it('builds a schema with @oneOf directive', () => {
+    const sdl = dedent`
+      type Query {
+        someField(someArg: SomeInputObject): String
+      }
+
+      input SomeInputObject @oneOf {
+        someInputField1: String
+        someInputField2: String
+      }
+    `;
+
+    expect(cycleIntrospection(sdl)).to.equal(sdl);
+  });
+
   it('can use client schema for limited execution', () => {
     const schema = buildSchema(`
       scalar CustomScalar

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -273,6 +273,111 @@ describe('coerceInputValue', () => {
     });
   });
 
+  describe('for GraphQLInputObject that isOneOf', () => {
+    const TestInputObject = new GraphQLInputObjectType({
+      name: 'TestInputObject',
+      fields: {
+        foo: { type: GraphQLInt },
+        bar: { type: GraphQLInt },
+      },
+      isOneOf: true,
+    });
+
+    it('returns no error for a valid input', () => {
+      const result = coerceValue({ foo: 123 }, TestInputObject);
+      expectValue(result).to.deep.equal({ foo: 123 });
+    });
+
+    it('returns an error if more than one field is specified', () => {
+      const result = coerceValue({ foo: 123, bar: null }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error:
+            'Exactly one key must be specified for OneOf type "TestInputObject".',
+          path: [],
+          value: { foo: 123, bar: null },
+        },
+      ]);
+    });
+
+    it('returns an error the one field is null', () => {
+      const result = coerceValue({ bar: null }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Field "bar" must be non-null.',
+          path: ['bar'],
+          value: null,
+        },
+      ]);
+    });
+
+    it('returns an error for an invalid field', () => {
+      const result = coerceValue({ foo: NaN }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Int cannot represent non-integer value: NaN',
+          path: ['foo'],
+          value: NaN,
+        },
+      ]);
+    });
+
+    it('returns multiple errors for multiple invalid fields', () => {
+      const result = coerceValue({ foo: 'abc', bar: 'def' }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Int cannot represent non-integer value: "abc"',
+          path: ['foo'],
+          value: 'abc',
+        },
+        {
+          error: 'Int cannot represent non-integer value: "def"',
+          path: ['bar'],
+          value: 'def',
+        },
+        {
+          error:
+            'Exactly one key must be specified for OneOf type "TestInputObject".',
+          path: [],
+          value: { foo: 'abc', bar: 'def' },
+        },
+      ]);
+    });
+
+    it('returns error for an unknown field', () => {
+      const result = coerceValue(
+        { foo: 123, unknownField: 123 },
+        TestInputObject,
+      );
+      expectErrors(result).to.deep.equal([
+        {
+          error:
+            'Field "unknownField" is not defined by type "TestInputObject".',
+          path: [],
+          value: { foo: 123, unknownField: 123 },
+        },
+      ]);
+    });
+
+    it('returns error for a misspelled field', () => {
+      const result = coerceValue({ bart: 123 }, TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error:
+            'Field "bart" is not defined by type "TestInputObject". Did you mean "bar"?',
+          path: [],
+          value: { bart: 123 },
+        },
+        {
+          error:
+            'Exactly one key must be specified for OneOf type "TestInputObject".',
+          path: [],
+          value: { bart: 123 },
+        },
+      ]);
+    });
+  });
+
   describe('for GraphQLInputObject with default value', () => {
     const makeTestInputObject = (defaultValue: any) =>
       new GraphQLInputObjectType({

--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import {
   GraphQLDeprecatedDirective,
   GraphQLIncludeDirective,
+  GraphQLOneOfDirective,
   GraphQLSkipDirective,
   GraphQLSpecifiedByDirective,
 } from '../../type/directives';
@@ -802,6 +803,7 @@ describe('findBreakingChanges', () => {
         GraphQLSkipDirective,
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
+        GraphQLOneOfDirective,
       ],
     });
 

--- a/src/utilities/__tests__/getIntrospectionQuery-test.ts
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.ts
@@ -117,6 +117,14 @@ describe('getIntrospectionQuery', () => {
     );
   });
 
+  it('include "isOneOf" field on input objects', () => {
+    expectIntrospectionQuery().toNotMatch('isOneOf');
+
+    expectIntrospectionQuery({ inputObjectOneOf: true }).toMatch('isOneOf', 1);
+
+    expectIntrospectionQuery({ inputObjectOneOf: false }).toNotMatch('isOneOf');
+  });
+
   it('include deprecated input field and args', () => {
     expectIntrospectionQuery().toMatch('includeDeprecated: true', 2);
 

--- a/src/utilities/__tests__/getIntrospectionQuery-test.ts
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.ts
@@ -120,9 +120,9 @@ describe('getIntrospectionQuery', () => {
   it('include "isOneOf" field on input objects', () => {
     expectIntrospectionQuery().toNotMatch('isOneOf');
 
-    expectIntrospectionQuery({ inputObjectOneOf: true }).toMatch('isOneOf', 1);
+    expectIntrospectionQuery({ oneOf: true }).toMatch('isOneOf', 1);
 
-    expectIntrospectionQuery({ inputObjectOneOf: false }).toNotMatch('isOneOf');
+    expectIntrospectionQuery({ oneOf: false }).toNotMatch('isOneOf');
   });
 
   it('include deprecated input field and args', () => {

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -672,6 +672,9 @@ describe('Type System Printer', () => {
         url: String!
       ) on SCALAR
 
+      """Indicates an Input Object is a OneOf Input Object."""
+      directive @oneOf on INPUT_OBJECT
+
       """
       A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
       """
@@ -714,6 +717,7 @@ describe('Type System Printer', () => {
         enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
         inputFields(includeDeprecated: Boolean = false): [__InputValue!]
         ofType: __Type
+        isOneOf: Boolean
       }
 
       """An enum describing what kind of type a given \`__Type\` is."""

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -503,6 +503,23 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('Print Input Type with @oneOf directive', () => {
+    const InputType = new GraphQLInputObjectType({
+      name: 'InputType',
+      isOneOf: true,
+      fields: {
+        int: { type: GraphQLInt },
+      },
+    });
+
+    const schema = new GraphQLSchema({ types: [InputType] });
+    expectPrintedSchema(schema).to.equal(dedent`
+      input InputType @oneOf {
+        int: Int
+      }
+    `);
+  });
+
   it('Custom Scalar', () => {
     const OddType = new GraphQLScalarType({ name: 'Odd' });
 

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -672,7 +672,9 @@ describe('Type System Printer', () => {
         url: String!
       ) on SCALAR
 
-      """Indicates an Input Object is a OneOf Input Object."""
+      """
+      Indicates exactly one field must be supplied and this field must not be \`null\`.
+      """
       directive @oneOf on INPUT_OBJECT
 
       """

--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -196,6 +196,14 @@ describe('valueFromAST', () => {
       requiredBool: { type: nonNullBool },
     },
   });
+  const testOneOfInputObj = new GraphQLInputObjectType({
+    name: 'TestOneOfInput',
+    fields: {
+      a: { type: GraphQLString },
+      b: { type: GraphQLString },
+    },
+    isOneOf: true,
+  });
 
   it('coerces input objects according to input coercion rules', () => {
     expectValueFrom('null', testInputObj).to.equal(null);
@@ -221,6 +229,22 @@ describe('valueFromAST', () => {
     );
     expectValueFrom('{ requiredBool: null }', testInputObj).to.equal(undefined);
     expectValueFrom('{ bool: true }', testInputObj).to.equal(undefined);
+    expectValueFrom('{ a: "abc" }', testOneOfInputObj).to.deep.equal({
+      a: 'abc',
+    });
+    expectValueFrom('{ b: "def" }', testOneOfInputObj).to.deep.equal({
+      b: 'def',
+    });
+    expectValueFrom('{ a: "abc", b: null }', testOneOfInputObj).to.deep.equal(
+      undefined,
+    );
+    expectValueFrom('{ a: null }', testOneOfInputObj).to.equal(undefined);
+    expectValueFrom('{ a: 1 }', testOneOfInputObj).to.equal(undefined);
+    expectValueFrom('{ a: "abc", b: "def" }', testOneOfInputObj).to.equal(
+      undefined,
+    );
+    expectValueFrom('{}', testOneOfInputObj).to.equal(undefined);
+    expectValueFrom('{ c: "abc" }', testOneOfInputObj).to.equal(undefined);
   });
 
   it('accepts variable values assuming already coerced', () => {

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -304,6 +304,7 @@ export function buildClientSchema(
       name: inputObjectIntrospection.name,
       description: inputObjectIntrospection.description,
       fields: () => buildInputValueDefMap(inputObjectIntrospection.inputFields),
+      isOneOf: inputObjectIntrospection.isOneOf,
     });
   }
 

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -142,6 +142,30 @@ function coerceInputValueImpl(
         );
       }
     }
+
+    if (type.isOneOf) {
+      const keys = Object.keys(coercedValue);
+      if (keys.length !== 1) {
+        onError(
+          pathToArray(path),
+          inputValue,
+          new GraphQLError(
+            `Exactly one key must be specified for OneOf type "${type.name}".`,
+          ),
+        );
+      }
+
+      const key = keys[0];
+      const value = coercedValue[key];
+      if (value === null) {
+        onError(
+          pathToArray(path).concat(key),
+          value,
+          new GraphQLError(`Field "${key}" must be non-null.`),
+        );
+      }
+    }
+
     return coercedValue;
   }
 

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -66,6 +66,7 @@ import {
 import {
   GraphQLDeprecatedDirective,
   GraphQLDirective,
+  GraphQLOneOfDirective,
   GraphQLSpecifiedByDirective,
 } from '../type/directives';
 import { introspectionTypes, isIntrospectionType } from '../type/introspection';
@@ -646,6 +647,7 @@ export function extendSchemaImpl(
           fields: () => buildInputFieldMap(allNodes),
           astNode,
           extensionASTNodes,
+          isOneOf: isOneOf(astNode),
         });
       }
     }
@@ -681,4 +683,11 @@ function getSpecifiedByURL(
   const specifiedBy = getDirectiveValues(GraphQLSpecifiedByDirective, node);
   // @ts-expect-error validated by `getDirectiveValues`
   return specifiedBy?.url;
+}
+
+/**
+ * Given an input object node, returns if the node should be OneOf.
+ */
+function isOneOf(node: InputObjectTypeDefinitionNode): boolean {
+  return Boolean(getDirectiveValues(GraphQLOneOfDirective, node));
 }

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -37,7 +37,7 @@ export interface IntrospectionOptions {
    * Whether target GraphQL server supports `@oneOf` input objects.
    * Default: false
    */
-  inputObjectOneOf?: boolean;
+  oneOf?: boolean;
 }
 
 /**
@@ -51,7 +51,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     directiveIsRepeatable: false,
     schemaDescription: false,
     inputValueDeprecation: false,
-    inputObjectOneOf: false,
+    oneOf: false,
     ...options,
   };
 
@@ -69,7 +69,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   function inputDeprecation(str: string) {
     return optionsWithDefault.inputValueDeprecation ? str : '';
   }
-  const inputObjectOneOf = optionsWithDefault.inputObjectOneOf ? 'isOneOf' : '';
+  const oneOf = optionsWithDefault.oneOf ? 'isOneOf' : '';
 
   return `
     query IntrospectionQuery {
@@ -98,7 +98,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
       name
       ${descriptions}
       ${specifiedByUrl}
-      ${inputObjectOneOf}
+      ${oneOf}
       fields(includeDeprecated: true) {
         name
         ${descriptions}

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -32,6 +32,12 @@ export interface IntrospectionOptions {
    * Default: false
    */
   inputValueDeprecation?: boolean;
+
+  /**
+   * Whether target GraphQL server supports `@oneOf` input objects.
+   * Default: false
+   */
+  inputObjectOneOf?: boolean;
 }
 
 /**
@@ -45,6 +51,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     directiveIsRepeatable: false,
     schemaDescription: false,
     inputValueDeprecation: false,
+    inputObjectOneOf: false,
     ...options,
   };
 
@@ -62,6 +69,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   function inputDeprecation(str: string) {
     return optionsWithDefault.inputValueDeprecation ? str : '';
   }
+  const inputObjectOneOf = optionsWithDefault.inputObjectOneOf ? 'isOneOf' : '';
 
   return `
     query IntrospectionQuery {
@@ -90,6 +98,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
       name
       ${descriptions}
       ${specifiedByUrl}
+      ${inputObjectOneOf}
       fields(includeDeprecated: true) {
         name
         ${descriptions}
@@ -259,6 +268,7 @@ export interface IntrospectionInputObjectType {
   readonly name: string;
   readonly description?: Maybe<string>;
   readonly inputFields: ReadonlyArray<IntrospectionInputValue>;
+  readonly isOneOf: boolean;
 }
 
 export interface IntrospectionListTypeRef<

--- a/src/utilities/introspectionFromSchema.ts
+++ b/src/utilities/introspectionFromSchema.ts
@@ -30,6 +30,7 @@ export function introspectionFromSchema(
     directiveIsRepeatable: true,
     schemaDescription: true,
     inputValueDeprecation: true,
+    inputObjectOneOf: true,
     ...options,
   };
 

--- a/src/utilities/introspectionFromSchema.ts
+++ b/src/utilities/introspectionFromSchema.ts
@@ -30,7 +30,7 @@ export function introspectionFromSchema(
     directiveIsRepeatable: true,
     schemaDescription: true,
     inputValueDeprecation: true,
-    inputObjectOneOf: true,
+    oneOf: true,
     ...options,
   };
 

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -209,7 +209,12 @@ function printInputObject(type: GraphQLInputObjectType): string {
   const fields = Object.values(type.getFields()).map(
     (f, i) => printDescription(f, '  ', !i) + '  ' + printInputValue(f),
   );
-  return printDescription(type) + `input ${type.name}` + printBlock(fields);
+  return (
+    printDescription(type) +
+    `input ${type.name}` +
+    (type.isOneOf ? ' @oneOf' : '') +
+    printBlock(fields)
+  );
 }
 
 function printFields(type: GraphQLObjectType | GraphQLInterfaceType): string {

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -125,6 +125,18 @@ export function valueFromAST(
       }
       coercedObj[field.name] = fieldValue;
     }
+
+    if (type.isOneOf) {
+      const keys = Object.keys(coercedObj);
+      if (keys.length !== 1) {
+        return; // Invalid: not exactly one key, intentionally return no value.
+      }
+
+      if (coercedObj[keys[0]] === null) {
+        return; // Invalid: value not non-null, intentionally return no value.
+      }
+    }
+
     return coercedObj;
   }
 

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -874,6 +874,28 @@ describe('Validate: Values of correct type', () => {
     });
   });
 
+  describe('Valid oneOf input object value', () => {
+    it('Exactly one field', () => {
+      expectValid(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: "abc" })
+          }
+        }
+      `);
+    });
+
+    it('Exactly one non-nullable variable', () => {
+      expectValid(`
+        query ($string: String!) {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: $string })
+          }
+        }
+      `);
+    });
+  });
+
   describe('Invalid input object value', () => {
     it('Partial object, missing required', () => {
       expectErrors(`
@@ -1038,6 +1060,70 @@ describe('Validate: Values of correct type', () => {
           }
         `,
       );
+    });
+  });
+
+  describe('Invalid oneOf input object value', () => {
+    it('Invalid field type', () => {
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: 2 })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message: 'String cannot represent a non string value: 2',
+          locations: [{ line: 4, column: 52 }],
+        },
+      ]);
+    });
+
+    it('Exactly one null field', () => {
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: null })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message: 'Field "OneOfInput.stringField" must be non-null.',
+          locations: [{ line: 4, column: 37 }],
+        },
+      ]);
+    });
+
+    it('Exactly one nullable variable', () => {
+      expectErrors(`
+        query ($string: String) {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: $string })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message:
+            'Variable "string" must be non-nullable to be used for OneOf Input Object "OneOfInput".',
+          locations: [{ line: 4, column: 37 }],
+        },
+      ]);
+    });
+
+    it('More than one field', () => {
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: "abc", intField: 123 })
+          }
+        }
+      `).toDeepEqual([
+        {
+          message:
+            'OneOf Input Object "OneOfInput" must specify exactly one key.',
+          locations: [{ line: 4, column: 37 }],
+        },
+      ]);
     });
   });
 

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -79,6 +79,11 @@ export const testSchema: GraphQLSchema = buildSchema(`
     stringListField: [String]
   }
 
+  input OneOfInput @oneOf {
+    stringField: String
+    intField: Int
+  }
+
   type ComplicatedArgs {
     # TODO List
     # TODO Coercion
@@ -93,6 +98,7 @@ export const testSchema: GraphQLSchema = buildSchema(`
     stringListArgField(stringListArg: [String]): String
     stringListNonNullArgField(stringListNonNullArg: [String!]): String
     complexArgField(complexArg: ComplexInput): String
+    oneOfArgField(oneOfArg: OneOfInput): String
     multipleReqs(req1: Int!, req2: Int!): String
     nonNullFieldWithDefault(arg: Int! = 0): String
     multipleOpts(opt1: Int = 0, opt2: Int = 0): String

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -15,7 +15,7 @@ import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
 import type { ASTVisitor } from '../../language/visitor';
 
-import type { GraphQLInputObjectType } from '../../type/definition.js';
+import type { GraphQLInputObjectType } from '../../type/definition';
 import {
   getNamedType,
   getNullableType,

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -5,10 +5,17 @@ import { suggestionList } from '../../jsutils/suggestionList';
 
 import { GraphQLError } from '../../error/GraphQLError';
 
-import type { ValueNode } from '../../language/ast';
+import type {
+  ObjectFieldNode,
+  ObjectValueNode,
+  ValueNode,
+  VariableDefinitionNode,
+} from '../../language/ast';
+import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
 import type { ASTVisitor } from '../../language/visitor';
 
+import type { GraphQLInputObjectType } from '../../type/definition.js';
 import {
   getNamedType,
   getNullableType,
@@ -32,7 +39,17 @@ import type { ValidationContext } from '../ValidationContext';
 export function ValuesOfCorrectTypeRule(
   context: ValidationContext,
 ): ASTVisitor {
+  let variableDefinitions: { [key: string]: VariableDefinitionNode } = {};
+
   return {
+    OperationDefinition: {
+      enter() {
+        variableDefinitions = {};
+      },
+    },
+    VariableDefinition(definition) {
+      variableDefinitions[definition.variable.name.value] = definition;
+    },
     ListValue(node) {
       // Note: TypeInfo will traverse into a list's item type, so look to the
       // parent input type to check if it is a list.
@@ -61,6 +78,16 @@ export function ValuesOfCorrectTypeRule(
             ),
           );
         }
+      }
+
+      if (type.isOneOf) {
+        validateOneOfInputObject(
+          context,
+          node,
+          type,
+          fieldNodeMap,
+          variableDefinitions,
+        );
       }
     },
     ObjectField(node) {
@@ -146,6 +173,55 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
           `Expected value of type "${typeStr}", found ${print(node)}; ` +
             error.message,
           { nodes: node, originalError: error },
+        ),
+      );
+    }
+  }
+}
+
+function validateOneOfInputObject(
+  context: ValidationContext,
+  node: ObjectValueNode,
+  type: GraphQLInputObjectType,
+  fieldNodeMap: Map<string, ObjectFieldNode>,
+  variableDefinitions: { [key: string]: VariableDefinitionNode },
+): void {
+  const keys = Array.from(fieldNodeMap.keys());
+  const isNotExactlyOneField = keys.length !== 1;
+
+  if (isNotExactlyOneField) {
+    context.reportError(
+      new GraphQLError(
+        `OneOf Input Object "${type.name}" must specify exactly one key.`,
+        { nodes: [node] },
+      ),
+    );
+    return;
+  }
+
+  const value = fieldNodeMap.get(keys[0])?.value;
+  const isNullLiteral = !value || value.kind === Kind.NULL;
+  const isVariable = value?.kind === Kind.VARIABLE;
+
+  if (isNullLiteral) {
+    context.reportError(
+      new GraphQLError(`Field "${type.name}.${keys[0]}" must be non-null.`, {
+        nodes: [node],
+      }),
+    );
+    return;
+  }
+
+  if (isVariable) {
+    const variableName = value.name.value;
+    const definition = variableDefinitions[variableName];
+    const isNullableVariable = definition.type.kind !== Kind.NON_NULL_TYPE;
+
+    if (isNullableVariable) {
+      context.reportError(
+        new GraphQLError(
+          `Variable "${variableName}" must be non-nullable to be used for OneOf Input Object "${type.name}".`,
+          { nodes: [node] },
         ),
       );
     }

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -1,6 +1,7 @@
 import { didYouMean } from '../../jsutils/didYouMean';
 import { inspect } from '../../jsutils/inspect';
 import { keyMap } from '../../jsutils/keyMap';
+import type { ObjMap } from '../../jsutils/ObjMap';
 import { suggestionList } from '../../jsutils/suggestionList';
 
 import { GraphQLError } from '../../error/GraphQLError';
@@ -183,10 +184,10 @@ function validateOneOfInputObject(
   context: ValidationContext,
   node: ObjectValueNode,
   type: GraphQLInputObjectType,
-  fieldNodeMap: Map<string, ObjectFieldNode>,
+  fieldNodeMap: ObjMap<ObjectFieldNode>,
   variableDefinitions: { [key: string]: VariableDefinitionNode },
 ): void {
-  const keys = Array.from(fieldNodeMap.keys());
+  const keys = Object.keys(fieldNodeMap);
   const isNotExactlyOneField = keys.length !== 1;
 
   if (isNotExactlyOneField) {
@@ -199,7 +200,7 @@ function validateOneOfInputObject(
     return;
   }
 
-  const value = fieldNodeMap.get(keys[0])?.value;
+  const value = fieldNodeMap[keys[0]]?.value;
   const isNullLiteral = !value || value.kind === Kind.NULL;
   const isVariable = value?.kind === Kind.VARIABLE;
 


### PR DESCRIPTION
See:

- #3513
- #3937 
- #3969
- #4078

Relates to the oneOf RFC: https://github.com/graphql/graphql-spec/pull/825