### PR TITLE
Rename `inputObjectOneOf` to `oneOf` in `getIntrospectionQuery()`

### DIFF
--- a/src/utilities/__tests__/getIntrospectionQuery-test.ts
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.ts
@@ -120,9 +120,9 @@ describe('getIntrospectionQuery', () => {
   it('include "isOneOf" field on input objects', () => {
     expectIntrospectionQuery().toNotMatch('isOneOf');
 
-    expectIntrospectionQuery({ inputObjectOneOf: true }).toMatch('isOneOf', 1);
+    expectIntrospectionQuery({ oneOf: true }).toMatch('isOneOf', 1);
 
-    expectIntrospectionQuery({ inputObjectOneOf: false }).toNotMatch('isOneOf');
+    expectIntrospectionQuery({ oneOf: false }).toNotMatch('isOneOf');
   });
 
   it('include deprecated input field and args', () => {

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -37,7 +37,7 @@ export interface IntrospectionOptions {
    * Whether target GraphQL server supports `@oneOf` input objects.
    * Default: false
    */
-  inputObjectOneOf?: boolean;
+  oneOf?: boolean;
 }
 
 /**
@@ -51,7 +51,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     directiveIsRepeatable: false,
     schemaDescription: false,
     inputValueDeprecation: false,
-    inputObjectOneOf: false,
+    oneOf: false,
     ...options,
   };
 
@@ -69,7 +69,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
   function inputDeprecation(str: string) {
     return optionsWithDefault.inputValueDeprecation ? str : '';
   }
-  const inputObjectOneOf = optionsWithDefault.inputObjectOneOf ? 'isOneOf' : '';
+  const oneOf = optionsWithDefault.oneOf ? 'isOneOf' : '';
 
   return `
     query IntrospectionQuery {
@@ -98,7 +98,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
       name
       ${descriptions}
       ${specifiedByUrl}
-      ${inputObjectOneOf}
+      ${oneOf}
       fields(includeDeprecated: true) {
         name
         ${descriptions}

--- a/src/utilities/introspectionFromSchema.ts
+++ b/src/utilities/introspectionFromSchema.ts
@@ -30,7 +30,7 @@ export function introspectionFromSchema(
     directiveIsRepeatable: true,
     schemaDescription: true,
     inputValueDeprecation: true,
-    inputObjectOneOf: true,
+    oneOf: true,
     ...options,
   };
 


### PR DESCRIPTION
The setting controls whether or not `isOneOf` is added to a selection on `__Type`; if we were to extend oneOf to output object too, the same setting could control it. Therefore, a simpler configuration variable makes sense.