### PR TITLE
fix(incremental): do not initiate non-pending execution groups

### DIFF
--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -986,7 +986,7 @@ describe('Execute: defer directive', () => {
     });
   });
 
-  it('Initiates all deferred grouped field sets immediately once they have been released as pending', async () => {
+  it('Initiates unique deferred grouped field sets after those that are common to sibling defers', async () => {
     const document = parse(`
       query {
         ... @defer {
@@ -1076,7 +1076,7 @@ describe('Execute: defer directive', () => {
     resolveC();
 
     expect(cResolverCalled).to.equal(true);
-    expect(eResolverCalled).to.equal(true);
+    expect(eResolverCalled).to.equal(false);
 
     const result3 = await iterator.next();
     expectJSON(result3).toDeepEqual({

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1,9 +1,11 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
 
 import type { DocumentNode } from '../../language/ast.js';
 import { parse } from '../../language/parser.js';
@@ -854,6 +856,134 @@ describe('Execute: defer directive', () => {
         hasNext: false,
       },
     ]);
+  });
+
+  it('Initiates all deferred grouped field sets immediately if and only if they have been released as pending', async () => {
+    const document = parse(`
+      query {
+        ... @defer {
+          a {
+            ... @defer {
+              b {
+                c { d }
+              }
+            }
+          }
+        }
+        ... @defer {
+          a {
+            someField
+            ... @defer {
+              b {
+                e { f }
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const { promise: slowFieldPromise, resolve: resolveSlowField } =
+      promiseWithResolvers();
+    let cResolverCalled = false;
+    let eResolverCalled = false;
+    const executeResult = experimentalExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        a: {
+          someField: slowFieldPromise,
+          b: {
+            c: () => {
+              cResolverCalled = true;
+              return { d: 'd' };
+            },
+            e: () => {
+              eResolverCalled = true;
+              return { f: 'f' };
+            },
+          },
+        },
+      },
+      enableEarlyExecution: false,
+    });
+
+    assert('initialResult' in executeResult);
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {},
+      pending: [
+        { id: '0', path: [] },
+        { id: '1', path: [] },
+      ],
+      hasNext: true,
+    });
+
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    expect(cResolverCalled).to.equal(false);
+    expect(eResolverCalled).to.equal(false);
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      value: {
+        pending: [{ id: '2', path: ['a'] }],
+        incremental: [
+          {
+            data: { a: {} },
+            id: '0',
+          },
+          {
+            data: { b: {} },
+            id: '2',
+          },
+          {
+            data: { c: { d: 'd' } },
+            id: '2',
+            subPath: ['b'],
+          },
+        ],
+        completed: [{ id: '0' }, { id: '2' }],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    expect(cResolverCalled).to.equal(true);
+    expect(eResolverCalled).to.equal(false);
+
+    resolveSlowField('someField');
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({
+      value: {
+        pending: [{ id: '3', path: ['a'] }],
+        incremental: [
+          {
+            data: { someField: 'someField' },
+            id: '1',
+            subPath: ['a'],
+          },
+          {
+            data: { e: { f: 'f' } },
+            id: '3',
+            subPath: ['b'],
+          },
+        ],
+        completed: [{ id: '1' }, { id: '3' }],
+        hasNext: false,
+      },
+      done: false,
+    });
+
+    expect(eResolverCalled).to.equal(true);
+
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('Can deduplicate multiple defers on the same object', async () => {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -2123,15 +2123,6 @@ function executeDeferredGroupedFieldSets(
     } else {
       deferredGroupedFieldSetRecord.result = () =>
         new BoxedPromiseOrValue(executor());
-      const resolveThunk = () => {
-        const maybeThunk = deferredGroupedFieldSetRecord.result;
-        if (!(maybeThunk instanceof BoxedPromiseOrValue)) {
-          deferredGroupedFieldSetRecord.result = maybeThunk();
-        }
-      };
-      for (const deferredFragmentRecord of deferredFragmentRecords) {
-        deferredFragmentRecord.onPending(resolveThunk);
-      }
     }
 
     newDeferredGroupedFieldSetRecords.push(deferredGroupedFieldSetRecord);

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -224,6 +224,9 @@ export class DeferredFragmentRecord {
   reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
   children: Set<SubsequentResultRecord>;
 
+  private pending: boolean;
+  private fns: Array<() => void>;
+
   constructor(
     path: Path | undefined,
     label: string | undefined,
@@ -235,6 +238,24 @@ export class DeferredFragmentRecord {
     this.deferredGroupedFieldSetRecords = new Set();
     this.reconcilableResults = new Set();
     this.children = new Set();
+    this.pending = false;
+    this.fns = [];
+  }
+
+  onPending(fn: () => void): void {
+    if (this.pending) {
+      fn();
+    } else {
+      this.fns.push(fn);
+    }
+  }
+
+  setAsPending(): void {
+    this.pending = true;
+    let fn;
+    while ((fn = this.fns.shift()) !== undefined) {
+      fn();
+    }
   }
 }
 

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -224,9 +224,6 @@ export class DeferredFragmentRecord {
   reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
   children: Set<SubsequentResultRecord>;
 
-  private pending: boolean;
-  private fns: Array<() => void>;
-
   constructor(
     path: Path | undefined,
     label: string | undefined,
@@ -238,24 +235,6 @@ export class DeferredFragmentRecord {
     this.deferredGroupedFieldSetRecords = new Set();
     this.reconcilableResults = new Set();
     this.children = new Set();
-    this.pending = false;
-    this.fns = [];
-  }
-
-  onPending(fn: () => void): void {
-    if (this.pending) {
-      fn();
-    } else {
-      this.fns.push(fn);
-    }
-  }
-
-  setAsPending(): void {
-    this.pending = true;
-    let fn;
-    while ((fn = this.fns.shift()) !== undefined) {
-      fn();
-    }
   }
 }
 


### PR DESCRIPTION
Currently, when early execution is disabled, we still use the early execution logic to initiate execution groups, which may cause early initiation of non-pending execution groups.

alternative to #4109, causes potentially stacking delays when combinations of shared and non-shared keys between sibling defers cause separate deferred grouped field sets for the same deferred fragment.