### PR TITLE
experiment: lazily create DeferredFragments

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -56,10 +56,11 @@ class DeferredFragmentFactory {
     }
     let deferredFragmentRecord = deferredFragmentRecords.get(deferUsage);
     if (deferredFragmentRecord === undefined) {
+      const { label, parentDeferUsage } = deferUsage;
       deferredFragmentRecord = new DeferredFragmentRecord(
-        deferUsage,
         deferUsagePath,
-        deferUsage.label,
+        label,
+        parentDeferUsage,
       );
       deferredFragmentRecords.set(deferUsage, deferredFragmentRecord);
     }
@@ -333,7 +334,7 @@ export class IncrementalGraph {
     if (this._rootNodes.has(deferredFragmentRecord)) {
       return;
     }
-    const parentDeferUsage = deferredFragmentRecord.deferUsage.parentDeferUsage;
+    const parentDeferUsage = deferredFragmentRecord.parentDeferUsage;
     if (parentDeferUsage === undefined) {
       invariant(initialResultChildren !== undefined);
       initialResultChildren.add(deferredFragmentRecord);

--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -337,9 +337,16 @@ export class IncrementalGraph {
     deferredGroupedFieldSetRecord: DeferredGroupedFieldSetRecord,
   ): boolean {
     const { deferUsages, path } = deferredGroupedFieldSetRecord;
-    return Array.from(deferUsages).some((deferUsage) =>
-      this._rootNodes.has(this._getDeferredFragmentRecord(deferUsage, path)),
-    );
+    for (const deferUsage of deferUsages) {
+      const deferredFragmentRecord = this._getDeferredFragmentRecord(
+        deferUsage,
+        path,
+      );
+      if (this._rootNodes.has(deferredFragmentRecord)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private _addDeferredFragment(

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -256,12 +256,10 @@ class IncrementalPublisher {
       if (completion === undefined) {
         continue;
       }
-      const incremental = context.incremental;
       const { deferredFragmentRecord, newRootNodes, reconcilableResults } =
         completion;
-      const id = deferredFragmentRecord.id;
-      invariant(id !== undefined);
       context.pending.push(...this._toPendingResults(newRootNodes));
+      const incremental = context.incremental;
       for (const reconcilableResult of reconcilableResults) {
         const { deferUsages: resultDeferUsages, path: resultPath } =
           reconcilableResult.deferredGroupedFieldSetRecord;
@@ -285,6 +283,8 @@ class IncrementalPublisher {
         }
         incremental.push(incrementalEntry);
       }
+      const id = deferredFragmentRecord.id;
+      invariant(id !== undefined);
       context.completed.push({ id });
     }
   }

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -257,7 +257,7 @@ class IncrementalPublisher {
         continue;
       }
       const incremental = context.incremental;
-      const { newRootNodes, reconcilableResults } = completion;
+      const { id, newRootNodes, reconcilableResults } = completion;
       context.pending.push(...this._toPendingResults(newRootNodes));
       for (const reconcilableResult of reconcilableResults) {
         const { bestId, subPath } = this._incrementalGraph.getBestIdAndSubPath(
@@ -273,8 +273,6 @@ class IncrementalPublisher {
         }
         incremental.push(incrementalEntry);
       }
-      const id = completion.id;
-      invariant(id !== undefined);
       context.completed.push({ id });
     }
   }

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -226,8 +226,11 @@ class IncrementalPublisher {
         deferredGroupedFieldSetResult,
       )
     ) {
-      for (const deferredFragmentRecord of deferredGroupedFieldSetResult
-        .deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+      const deferredFragmentRecords =
+        this._incrementalGraph.getDeferredFragmentRecords(
+          deferredGroupedFieldSetResult.deferredGroupedFieldSetRecord,
+        );
+      for (const deferredFragmentRecord of deferredFragmentRecords) {
         const id = deferredFragmentRecord.id;
         if (
           !this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord)
@@ -248,8 +251,11 @@ class IncrementalPublisher {
       deferredGroupedFieldSetResult,
     );
 
-    for (const deferredFragmentRecord of deferredGroupedFieldSetResult
-      .deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+    const deferredFragmentRecords =
+      this._incrementalGraph.getDeferredFragmentRecords(
+        deferredGroupedFieldSetResult.deferredGroupedFieldSetRecord,
+      );
+    for (const deferredFragmentRecord of deferredFragmentRecords) {
       const completion = this._incrementalGraph.completeDeferredFragment(
         deferredFragmentRecord,
       );
@@ -334,8 +340,11 @@ class IncrementalPublisher {
     let maxLength = pathToArray(initialDeferredFragmentRecord.path).length;
     let bestId = initialId;
 
-    for (const deferredFragmentRecord of deferredGroupedFieldSetResult
-      .deferredGroupedFieldSetRecord.deferredFragmentRecords) {
+    const deferredFragmentRecords =
+      this._incrementalGraph.getDeferredFragmentRecords(
+        deferredGroupedFieldSetResult.deferredGroupedFieldSetRecord,
+      );
+    for (const deferredFragmentRecord of deferredFragmentRecords) {
       if (deferredFragmentRecord === initialDeferredFragmentRecord) {
         continue;
       }

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -239,7 +239,7 @@ describe('Execute: Handles basic execution tasks', () => {
     const field = operation.selectionSet.selections[0];
     expect(resolvedInfo).to.deep.include({
       fieldNodes: [field],
-      path: { prev: undefined, key: 'result', typename: 'Test' },
+      path: { prev: undefined, key: 'result', typename: 'Test', fieldDepth: 1 },
       variableValues: { var: 'abc' },
     });
   });
@@ -291,12 +291,15 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(path).to.deep.equal({
       key: 'l2',
       typename: 'SomeObject',
+      fieldDepth: 2,
       prev: {
         key: 0,
         typename: undefined,
+        fieldDepth: 1,
         prev: {
           key: 'l1',
           typename: 'SomeQuery',
+          fieldDepth: 1,
           prev: undefined,
         },
       },

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -7,6 +7,8 @@ import type {
   GraphQLFormattedError,
 } from '../error/GraphQLError.js';
 
+import type { DeferUsage } from './collectFields.js';
+
 /**
  * The result of GraphQL execution.
  *
@@ -169,7 +171,7 @@ export interface FormattedCompletedResult {
 export function isDeferredGroupedFieldSetRecord(
   incrementalDataRecord: IncrementalDataRecord,
 ): incrementalDataRecord is DeferredGroupedFieldSetRecord {
-  return 'deferredFragmentRecords' in incrementalDataRecord;
+  return 'deferUsages' in incrementalDataRecord;
 }
 
 export type DeferredGroupedFieldSetResult =
@@ -208,7 +210,8 @@ type ThunkIncrementalResult<T> =
   | (() => BoxedPromiseOrValue<T>);
 
 export interface DeferredGroupedFieldSetRecord {
-  deferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord>;
+  deferUsages: ReadonlySet<DeferUsage>;
+  path: Path | undefined;
   result: ThunkIncrementalResult<DeferredGroupedFieldSetResult>;
 }
 

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -219,22 +219,22 @@ export type SubsequentResultRecord = DeferredFragmentRecord | StreamRecord;
 
 /** @internal */
 export class DeferredFragmentRecord {
+  deferUsage: DeferUsage;
   path: Path | undefined;
   label: string | undefined;
   id?: string | undefined;
-  parent: DeferredFragmentRecord | undefined;
   deferredGroupedFieldSetRecords: Set<DeferredGroupedFieldSetRecord>;
   reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
   children: Set<SubsequentResultRecord>;
 
   constructor(
+    deferUsage: DeferUsage,
     path: Path | undefined,
     label: string | undefined,
-    parent: DeferredFragmentRecord | undefined,
   ) {
+    this.deferUsage = deferUsage;
     this.path = path;
     this.label = label;
-    this.parent = parent;
     this.deferredGroupedFieldSetRecords = new Set();
     this.reconcilableResults = new Set();
     this.children = new Set();

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -219,22 +219,22 @@ export type SubsequentResultRecord = DeferredFragmentRecord | StreamRecord;
 
 /** @internal */
 export class DeferredFragmentRecord {
-  deferUsage: DeferUsage;
   path: Path | undefined;
   label: string | undefined;
+  parentDeferUsage: DeferUsage | undefined;
   id?: string | undefined;
   deferredGroupedFieldSetRecords: Set<DeferredGroupedFieldSetRecord>;
   reconcilableResults: Set<ReconcilableDeferredGroupedFieldSetResult>;
   children: Set<SubsequentResultRecord>;
 
   constructor(
-    deferUsage: DeferUsage,
     path: Path | undefined,
     label: string | undefined,
+    parentDeferUsage: DeferUsage | undefined,
   ) {
-    this.deferUsage = deferUsage;
     this.path = path;
     this.label = label;
+    this.parentDeferUsage = parentDeferUsage;
     this.deferredGroupedFieldSetRecords = new Set();
     this.reconcilableResults = new Set();
     this.children = new Set();

--- a/src/jsutils/Path.ts
+++ b/src/jsutils/Path.ts
@@ -4,6 +4,7 @@ export interface Path {
   readonly prev: Path | undefined;
   readonly key: string | number;
   readonly typename: string | undefined;
+  readonly fieldDepth: number;
 }
 
 /**
@@ -14,7 +15,12 @@ export function addPath(
   key: string | number,
   typename: string | undefined,
 ): Path {
-  return { prev, key, typename };
+  const fieldDepth = prev
+    ? typeof key === 'number'
+      ? prev.fieldDepth
+      : prev.fieldDepth + 1
+    : 1;
+  return { prev, key, typename, fieldDepth };
 }
 
 /**
@@ -30,4 +36,26 @@ export function pathToArray(
     curr = curr.prev;
   }
   return flattened.reverse();
+}
+
+export function pathAtFieldDepth(
+  path: Path | undefined,
+  fieldDepth: number,
+): Path | undefined {
+  if (fieldDepth === 0) {
+    return undefined;
+  }
+  let currentPath = path;
+  while (currentPath !== undefined) {
+    if (currentPath.fieldDepth === fieldDepth) {
+      return currentPath;
+    }
+    currentPath = currentPath.prev;
+  }
+  /* c8 ignore next 5 */
+  throw new Error(
+    `Path is of fieldDepth ${
+      path === undefined ? 0 : path.fieldDepth
+    }, but fieldDepth ${fieldDepth} requested.`,
+  );
 }

--- a/src/jsutils/__tests__/Path-test.ts
+++ b/src/jsutils/__tests__/Path-test.ts
@@ -11,6 +11,7 @@ describe('Path', () => {
       prev: undefined,
       key: 1,
       typename: 'First',
+      fieldDepth: 1,
     });
   });
 
@@ -22,6 +23,7 @@ describe('Path', () => {
       prev: first,
       key: 'two',
       typename: 'Second',
+      fieldDepth: 2,
     });
   });
 

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -47,7 +47,7 @@ export function SingleFieldSubscriptionsRule(
               fragments[definition.name.value] = definition;
             }
           }
-          const { groupedFieldSet } = collectFields(
+          const groupedFieldSet = collectFields(
             schema,
             fragments,
             variableValues,


### PR DESCRIPTION
goal:

avoid creating or passing around the deferMap

methodology:

- each DeferredFragmentRecord will be unique for a given deferUsage and creationPath
- we annotate the path and deferUsage with a "fieldDepth" property representing the number of nested fields in the operation corresponding to the current execution path and the defer directive.
- from a path for a deferredGroupedFieldSet, we can derive the path for the deferredFragment from a given deferUsage by "rewinding" the deferredGroupedFieldSet path to the depth of the given deferUsage
- we also add a "fieldDepth" property to the FieldDetails structure as well so as to not require an additional depth argument to collectFields which would complicate memoization