### PR TITLE
incremental: lazily create DeferredFragments

### DIFF
--- a/src/execution/DeferredFragments.ts
+++ b/src/execution/DeferredFragments.ts
@@ -1,0 +1,108 @@
+import type { Path } from '../jsutils/Path.js';
+
+import type { DeferUsage } from './collectFields.js';
+import type {
+  PendingExecutionGroup,
+  StreamRecord,
+  SuccessfulExecutionGroup,
+} from './types.js';
+
+export type DeliveryGroup = DeferredFragmentRecord | StreamRecord;
+
+/** @internal */
+export class DeferredFragmentRecord {
+  path: Path | undefined;
+  label: string | undefined;
+  parentDeferUsage: DeferUsage | undefined;
+  id?: string | undefined;
+  pendingExecutionGroups: Set<PendingExecutionGroup>;
+  successfulExecutionGroups: Set<SuccessfulExecutionGroup>;
+  children: Set<DeliveryGroup>;
+
+  constructor(
+    path: Path | undefined,
+    label: string | undefined,
+    parentDeferUsage: DeferUsage | undefined,
+  ) {
+    this.path = path;
+    this.label = label;
+    this.parentDeferUsage = parentDeferUsage;
+    this.pendingExecutionGroups = new Set();
+    this.successfulExecutionGroups = new Set();
+    this.children = new Set();
+  }
+}
+
+export function isDeferredFragmentRecord(
+  deliveryGroup: DeliveryGroup,
+): deliveryGroup is DeferredFragmentRecord {
+  return deliveryGroup instanceof DeferredFragmentRecord;
+}
+
+/**
+ * @internal
+ */
+export class DeferredFragmentFactory {
+  private _rootDeferredFragments = new Map<
+    DeferUsage,
+    DeferredFragmentRecord
+  >();
+
+  get(deferUsage: DeferUsage, path: Path | undefined): DeferredFragmentRecord {
+    const deferUsagePath = this._pathAtDepth(path, deferUsage.depth);
+    let deferredFragmentRecords:
+      | Map<DeferUsage, DeferredFragmentRecord>
+      | undefined;
+    if (deferUsagePath === undefined) {
+      deferredFragmentRecords = this._rootDeferredFragments;
+    } else {
+      // A doubly nested Map<Path, Map<DeferUsage, DeferredFragmentRecord>>
+      // could be used, but could leak memory in long running operations.
+      // A WeakMap could be used instead. The below implementation is
+      // WeakMap-Like, saving the Map on the Path object directly.
+      // Alternatively, memory could be reclaimed manually, taking care to
+      // also reclaim memory for nested DeferredFragmentRecords if the parent
+      // is removed secondary to an error.
+      deferredFragmentRecords = (
+        deferUsagePath as unknown as {
+          deferredFragmentRecords: Map<DeferUsage, DeferredFragmentRecord>;
+        }
+      ).deferredFragmentRecords;
+      if (deferredFragmentRecords === undefined) {
+        deferredFragmentRecords = new Map();
+        (
+          deferUsagePath as unknown as {
+            deferredFragmentRecords: Map<DeferUsage, DeferredFragmentRecord>;
+          }
+        ).deferredFragmentRecords = deferredFragmentRecords;
+      }
+    }
+    let deferredFragmentRecord = deferredFragmentRecords.get(deferUsage);
+    if (deferredFragmentRecord === undefined) {
+      const { label, parentDeferUsage } = deferUsage;
+      deferredFragmentRecord = new DeferredFragmentRecord(
+        deferUsagePath,
+        label,
+        parentDeferUsage,
+      );
+      deferredFragmentRecords.set(deferUsage, deferredFragmentRecord);
+    }
+    return deferredFragmentRecord;
+  }
+
+  private _pathAtDepth(
+    path: Path | undefined,
+    depth: number,
+  ): Path | undefined {
+    if (depth === 0) {
+      return;
+    }
+    const stack: Array<Path> = [];
+    let currentPath = path;
+    while (currentPath !== undefined) {
+      stack.unshift(currentPath);
+      currentPath = currentPath.prev;
+    }
+    return stack[depth - 1];
+  }
+}

--- a/src/jsutils/memoize3.ts
+++ b/src/jsutils/memoize3.ts
@@ -1,15 +1,18 @@
 /**
- * Memoizes the provided three-argument function.
+ * Memoizes the provided three-argument or more function based on the first three arguments.
  */
 export function memoize3<
   A1 extends object,
   A2 extends object,
   A3 extends object,
+  V extends Array<any>,
   R,
->(fn: (a1: A1, a2: A2, a3: A3) => R): (a1: A1, a2: A2, a3: A3) => R {
+>(
+  fn: (a1: A1, a2: A2, a3: A3, ...rest: V) => R,
+): (a1: A1, a2: A2, a3: A3, ...rest: V) => R {
   let cache0: WeakMap<A1, WeakMap<A2, WeakMap<A3, R>>>;
 
-  return function memoized(a1, a2, a3) {
+  return function memoized(a1, a2, a3, ...rest) {
     if (cache0 === undefined) {
       cache0 = new WeakMap();
     }
@@ -28,7 +31,7 @@ export function memoize3<
 
     let fnResult = cache2.get(a3);
     if (fnResult === undefined) {
-      fnResult = fn(a1, a2, a3);
+      fnResult = fn(a1, a2, a3, ...rest);
       cache2.set(a3, fnResult);
     }
 

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -47,7 +47,7 @@ export function SingleFieldSubscriptionsRule(
               fragments[definition.name.value] = definition;
             }
           }
-          const { groupedFieldSet } = collectFields(
+          const groupedFieldSet = collectFields(
             schema,
             fragments,
             variableValues,


### PR DESCRIPTION
depends on #4152

goal:

avoid creating or passing around the deferMap

methodology:

- each `DeferredFragmentRecord` will be unique for a given `DeferUsage` and creation `Path`.
- we annotate the `DeferUsage` with a `depth` property representing the path `depth` in the response for wherever this `DeferUsage` is used.
- from a given `ExecutionGroup`, we can derive the `path` for its `DeferredFragmentRecord` from the `DeferUsage` and the `ExecutionGroup` `path` by "rewinding" the `ExecutionGroup` `path` to the depth annotated on the corresponding `DeferUsage`.

~~note:~~

~~for performance, we now save the depth of the path on the path elements themselves. this could always be replaced by a call to `pathToArray` as `path.depth === pathToArray(path).length)`~~