### PR TITLE
fix(validation): catch OverlappingFieldsCanBeMergedRule violations with nested fragments

### DIFF
--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -548,6 +548,33 @@ describe('Validate: Overlapping fields can be merged', () => {
     ]);
   });
 
+  it('reports deep conflict after nested fragments', () => {
+    expectErrors(`
+      fragment F on T {
+        ...G
+      }
+      fragment G on T {
+        ...H
+      }
+      fragment H on T {
+        x: a
+      }
+      {
+        x: b
+        ...F
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Fields "x" conflict because "b" and "a" are different fields. Use different aliases on the fields to fetch both if this was intentional.',
+        locations: [
+          { line: 12, column: 9 },
+          { line: 9, column: 9 },
+        ],
+      },
+    ]);
+  });
+
   it('ignores unknown fragments', () => {
     expectValid(`
       {

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1165,4 +1165,31 @@ describe('Validate: Overlapping fields can be merged', () => {
       },
     ]);
   });
+
+  it('does not infinite loop on recursive fragments separated by fields', () => {
+    expectValid(`
+      {
+        ...fragA
+        ...fragB
+      }
+
+      fragment fragA on T {
+        x {
+          ...fragA
+          x {
+            ...fragA
+          }
+        }
+      }
+
+      fragment fragB on T {
+        x {
+          ...fragB
+          x {
+            ...fragB
+          }
+        }
+      }
+    `);
+  });
 });

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -200,7 +200,6 @@ function findConflictsWithinSelectionSet(
         conflicts,
         cachedFieldsAndFragmentNames,
         comparedFragmentPairs,
-        null,
         false,
         fieldMap,
         fragmentNames[i],
@@ -232,15 +231,10 @@ function collectConflictsBetweenFieldsAndFragment(
   conflicts: Array<Conflict>,
   cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentNames>,
   comparedFragmentPairs: PairSet,
-  comparedFragmentsForFields: null | Set<string>,
   areMutuallyExclusive: boolean,
   fieldMap: NodeAndDefCollection,
   fragmentName: string,
 ): void {
-  if (comparedFragmentsForFields?.has(fragmentName)) {
-    return;
-  }
-
   const fragment = context.getFragment(fragmentName);
   if (!fragment) {
     return;
@@ -272,15 +266,12 @@ function collectConflictsBetweenFieldsAndFragment(
 
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
-  const newComparedFragmentsForFields =
-    comparedFragmentsForFields ?? new Set([fragmentName]);
   for (const referencedFragmentName of referencedFragmentNames) {
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
       cachedFieldsAndFragmentNames,
       comparedFragmentPairs,
-      newComparedFragmentsForFields,
       areMutuallyExclusive,
       fieldMap,
       referencedFragmentName,
@@ -423,7 +414,6 @@ function findConflictsBetweenSubSelectionSets(
       conflicts,
       cachedFieldsAndFragmentNames,
       comparedFragmentPairs,
-      null,
       areMutuallyExclusive,
       fieldMap1,
       fragmentName2,
@@ -438,7 +428,6 @@ function findConflictsBetweenSubSelectionSets(
       conflicts,
       cachedFieldsAndFragmentNames,
       comparedFragmentPairs,
-      null,
       areMutuallyExclusive,
       fieldMap2,
       fragmentName1,

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -267,22 +267,6 @@ function collectConflictsBetweenFieldsAndFragment(
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
   for (const referencedFragmentName of referencedFragmentNames) {
-    // Memoize so two fragments are not compared for conflicts more than once.
-    if (
-      comparedFragmentPairs.has(
-        referencedFragmentName,
-        fragmentName,
-        areMutuallyExclusive,
-      )
-    ) {
-      continue;
-    }
-    comparedFragmentPairs.add(
-      referencedFragmentName,
-      fragmentName,
-      areMutuallyExclusive,
-    );
-
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -200,6 +200,7 @@ function findConflictsWithinSelectionSet(
         conflicts,
         cachedFieldsAndFragmentNames,
         comparedFragmentPairs,
+        null,
         false,
         fieldMap,
         fragmentNames[i],
@@ -231,10 +232,15 @@ function collectConflictsBetweenFieldsAndFragment(
   conflicts: Array<Conflict>,
   cachedFieldsAndFragmentNames: Map<SelectionSetNode, FieldsAndFragmentNames>,
   comparedFragmentPairs: PairSet,
+  comparedFragmentsForFields: null | Set<string>,
   areMutuallyExclusive: boolean,
   fieldMap: NodeAndDefCollection,
   fragmentName: string,
 ): void {
+  if (comparedFragmentsForFields?.has(fragmentName)) {
+    return;
+  }
+
   const fragment = context.getFragment(fragmentName);
   if (!fragment) {
     return;
@@ -266,12 +272,15 @@ function collectConflictsBetweenFieldsAndFragment(
 
   // (E) Then collect any conflicts between the provided collection of fields
   // and any fragment names found in the given fragment.
+  const newComparedFragmentsForFields =
+    comparedFragmentsForFields ?? new Set([fragmentName]);
   for (const referencedFragmentName of referencedFragmentNames) {
     collectConflictsBetweenFieldsAndFragment(
       context,
       conflicts,
       cachedFieldsAndFragmentNames,
       comparedFragmentPairs,
+      newComparedFragmentsForFields,
       areMutuallyExclusive,
       fieldMap,
       referencedFragmentName,
@@ -414,6 +423,7 @@ function findConflictsBetweenSubSelectionSets(
       conflicts,
       cachedFieldsAndFragmentNames,
       comparedFragmentPairs,
+      null,
       areMutuallyExclusive,
       fieldMap1,
       fragmentName2,
@@ -428,6 +438,7 @@ function findConflictsBetweenSubSelectionSets(
       conflicts,
       cachedFieldsAndFragmentNames,
       comparedFragmentPairs,
+      null,
       areMutuallyExclusive,
       fieldMap2,
       fragmentName1,

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -66,7 +66,7 @@ export function OverlappingFieldsCanBeMergedRule(
     NodeAndDefCollection,
     string
   >();
-  const comparedFragmentPairs = new PairSet<string>((a, b) => a < b);
+  const comparedFragmentPairs = new PairSet<string>();
 
   // A cache for the "field map" and list of fragment names found in any given
   // selection set. Selection sets may be asked for this information multiple
@@ -879,21 +879,19 @@ class OrderedPairSet<T, U> {
  */
 class PairSet<T> {
   _orderedPairSet: OrderedPairSet<T, T>;
-  _comparator: (a: T, b: T) => boolean;
 
-  constructor(comparator: (a: T, b: T) => boolean) {
+  constructor() {
     this._orderedPairSet = new OrderedPairSet();
-    this._comparator = comparator;
   }
 
   has(a: T, b: T, weaklyPresent: boolean): boolean {
-    return this._comparator(a, b)
+    return a < b
       ? this._orderedPairSet.has(a, b, weaklyPresent)
       : this._orderedPairSet.has(b, a, weaklyPresent);
   }
 
   add(a: T, b: T, weaklyPresent: boolean): void {
-    if (this._comparator(a, b)) {
+    if (a < b) {
       this._orderedPairSet.add(a, b, weaklyPresent);
     } else {
       this._orderedPairSet.add(b, a, weaklyPresent);


### PR DESCRIPTION
In trying to prevent infinite loops, https://github.com/graphql/graphql-js/pull/3442 introduced a bug that causes certain violations of the [Field Selection Merging](https://spec.graphql.org/draft/#sec-Field-Selection-Merging) validation to not be caught (released in `16.3.0`, and backported to `15.9.0`). This PR fixes this bug, while continuing to prevent infinite loops.

Specifically, the code introduced in that PR misuses `comparedFragmentPairs` in the `collectConflictsBetweenFieldsAndFragment()` function. That function takes in fields/a selection set and checks whether it conflicts with the given fragment, while recursively checking those fields against nested fragments in the given fragment. The `comparedFragmentPairs` data structure is meant to store whether fragments have been checked for conflict against other fragments, but the `collectConflictsBetweenFieldsAndFragment()` does not compare fragments against nested fragments (only the selection set against fragments).

For an example of how this causes violations to be missed, see the test in the [first commit](https://github.com/graphql/graphql-js/pull/4168/commits/7abc1e73c4d4f13a45ed34d83b580fb65c1ac4b7). The first fragment causes an entry to be added to `comparedFragmentPairs` for the pair of the second and third fragments. When the query's selection set introduces a field that conflicts with a field in the third fragment, `collectConflictsBetweenFieldsAndFragment()` will then erroneously skip the third fragment due to the presence in `comparedFragmentPairs`. The [second commit](https://github.com/graphql/graphql-js/pull/4168/commits/94fd7c299f68b659c38efa3a149a6b93215db501) accordingly reverses the non-test changes of https://github.com/graphql/graphql-js/pull/3442.

The [third commit](https://github.com/graphql/graphql-js/pull/4168/commits/e444b16177e80f82f6fcfea14e90ffb0a286b781) shows a naive approach to preventing infinite loops, where we keep track of fragments seen while recursing into nested fragments in `collectConflictsBetweenFieldsAndFragment()`. This approach notably doesn't track the set of seen fragments across field boundaries, which is less memory overhead. However this unfortunately introduces a separate bug, shown by the test in the [fourth commit](https://github.com/graphql/graphql-js/pull/4168/commits/3e7e6f6591a5c0bbc229f180c19a30e39d57221b). This test creates nested fragments across field boundaries in such a way as to cause an infinite loop (`collectConflictsBetweenFieldsAndFragment()` eventually calls itself with the same arguments when it recurses into fields). The [fifth commit](https://github.com/graphql/graphql-js/pull/4168/commits/f24c570e7ee4ac4e858e8b593cfd1e6756eceb3b) accordingly reverses these changes.

The [sixth commit](https://github.com/graphql/graphql-js/pull/4168/commits/4c0a2d1d7f2d5aaf8b53d133766569a3ddd95594) introduces an actual fix. The `comparedFragmentPairs` data structure has been updated to additionally store a pair of fragment and fields/selection set instead of just two fragments. We then memoize comparisons between fields/fragments at the start of the `collectConflictsBetweenFieldsAndFragment()` function (similar to the fragment pair memoization at the start of `collectConflictsBetweenFragments()`). Note that this will increase the size of `comparedFragmentPairs` to scale with the product of the number of selection sets and the number of fragments, whereas previously it scaled with the square of the number of fragments (though I'm unsure if this extra overhead is significant in the context of full GraphQL validation).