### PR TITLE
[#4169] `UniqueInputFieldNamesRule` incorrectly identifies field names as duplicates within and/or array

### DIFF
--- a/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
@@ -61,7 +61,7 @@ describe('Validate: Unique input field names', () => {
     `);
     expectValid(`
       {
-        field(arg: { or: [{ f: true }, { f: {f1: true} }] })
+        field(arg: { or: [{ f: { f1: "value1" } }, { f: { f1: "value2" } }] })
       }
     `);
     expectValid(`

--- a/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
@@ -56,7 +56,7 @@ describe('Validate: Unique input field names', () => {
   it('allow and/or with duplicate fields in array', () => {
     expectValid(`
       {
-        field(arg: { and: [{ f: true }, { f: true }] })
+        field(arg: { and: [{ f: "value1" }, { f: "value2" }] })
       }
     `);
     expectValid(`

--- a/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
@@ -69,19 +69,40 @@ describe('Validate: Unique input field names', () => {
         field(arg: { or: [{ f: true }, { f1: {f: true} }] })
       }
     `);
+    expectValid(`
+      {
+        field(arg: { 
+          or: [
+            { field: true },
+            { 
+              deep1: { 
+                deep2: {
+                  and: [{ field: false }, { field: true }]
+                }
+              } 
+            }
+            {
+              deep1: {
+                field: true
+              }
+            }
+          ]
+        })
+      }
+    `);
   });
 
   it('duplicate input object fields in objects of array', () => {
     expectErrors(`
       {
-        field(arg: { or: [{ f: true, f: true }] })
+        field(arg: { or: [{ f: "value1", f: "value2" }] })
       }
     `).toDeepEqual([
       {
         message: 'There can be only one input field named "f".',
         locations: [
           { line: 3, column: 29 },
-          { line: 3, column: 38 },
+          { line: 3, column: 42 },
         ],
       },
     ]);
@@ -90,19 +111,19 @@ describe('Validate: Unique input field names', () => {
   it('nested input object fields in objects of array', () => {
     expectErrors(`
       {
-        field(arg: { or: [{f2: true}, { f1: {f2: "value", f2: "value" }}] })
+        field(arg: { or: [ { f2: "value1" }, { f1: { f2: "value2", f2: "value3" } } ] })
       }
     `).toDeepEqual([
       {
         message: 'There can be only one input field named "f2".',
         locations: [
-          { line: 3, column: 46 },
-          { line: 3, column: 59 },
+          { line: 3, column: 54 },
+          { line: 3, column: 68 },
         ],
       },
     ]);
   });
-  
+
   it('duplicate input object fields', () => {
     expectErrors(`
       {

--- a/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
+++ b/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts
@@ -53,6 +53,56 @@ describe('Validate: Unique input field names', () => {
     `);
   });
 
+  it('allow and/or with duplicate fields in array', () => {
+    expectValid(`
+      {
+        field(arg: { and: [{ f: true }, { f: true }] })
+      }
+    `);
+    expectValid(`
+      {
+        field(arg: { or: [{ f: true }, { f: {f1: true} }] })
+      }
+    `);
+    expectValid(`
+      {
+        field(arg: { or: [{ f: true }, { f1: {f: true} }] })
+      }
+    `);
+  });
+
+  it('duplicate input object fields in objects of array', () => {
+    expectErrors(`
+      {
+        field(arg: { or: [{ f: true, f: true }] })
+      }
+    `).toDeepEqual([
+      {
+        message: 'There can be only one input field named "f".',
+        locations: [
+          { line: 3, column: 29 },
+          { line: 3, column: 38 },
+        ],
+      },
+    ]);
+  });
+
+  it('nested input object fields in objects of array', () => {
+    expectErrors(`
+      {
+        field(arg: { or: [{f2: true}, { f1: {f2: "value", f2: "value" }}] })
+      }
+    `).toDeepEqual([
+      {
+        message: 'There can be only one input field named "f2".',
+        locations: [
+          { line: 3, column: 46 },
+          { line: 3, column: 59 },
+        ],
+      },
+    ]);
+  });
+  
   it('duplicate input object fields', () => {
     expectErrors(`
       {

--- a/src/validation/rules/UniqueInputFieldNamesRule.ts
+++ b/src/validation/rules/UniqueInputFieldNamesRule.ts
@@ -64,7 +64,7 @@ export function UniqueInputFieldNamesRule(
             );
 
             // expecting only one field with the same name, if there is more than one, report error. if there is no field with the same name, mean it is in the nested object instead list value, report error.
-            if (nestedFields.length !== 1) {            
+            if (!isError && nestedFields.length !== 1) {            
               isError = true;
             }
           }

--- a/src/validation/rules/UniqueInputFieldNamesRule.ts
+++ b/src/validation/rules/UniqueInputFieldNamesRule.ts
@@ -22,7 +22,8 @@ export function UniqueInputFieldNamesRule(
   const knownNameStack: Array<ObjMap<NameNode>> = [];
   let knownNames: ObjMap<NameNode> = Object.create(null);
 
-  let knownNamesInList: (readonly ObjectFieldNode[])[] = Object.create([]);
+  let knownNamesInList: Array<ReadonlyArray<ObjectFieldNode>> =
+    Object.create([]);
 
   return {
     ObjectValue: {
@@ -61,7 +62,7 @@ export function UniqueInputFieldNamesRule(
             const nestedFields = fields.filter(
               (field) => field.name.value === fieldName,
             );
-            
+
             // expecting only one field with the same name, if there is more than one, report error. if there is no field with the same name, mean it is in the nested object instead list value, report error.
             if (nestedFields.length !== 1) {            
               isError = true;
@@ -76,7 +77,7 @@ export function UniqueInputFieldNamesRule(
         context.reportError(
           new GraphQLError(
             `There can be only one input field named "${fieldName}".`,
-            [knownNames[fieldName], node.name],
+            { nodes: [knownNames[fieldName], node.name] },
           ),
         );
       }


### PR DESCRIPTION
Fixed: #4169

To address the issue, use additional variables to store `ListValue` nodes and check if the duplicate field is present in the `ListValue`