### PR TITLE
chore: update main with outstanding fixes on v16.x.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GraphQLConf 2024 Banner: September 10-12, San Francisco. Hosted by the GraphQL Foundation](https://github.com/user-attachments/assets/2d048502-e5b2-4e9d-a02a-50b841824de6)](https://graphql.org/conf/2024/?utm_source=github&utm_medium=graphql_js&utm_campaign=readme)
+
 # GraphQL.js
 
 The JavaScript reference implementation for GraphQL, a query language for APIs created by Facebook.

--- a/cspell.yml
+++ b/cspell.yml
@@ -20,6 +20,13 @@ overrides:
     words:
       - clsx
       - infima
+      - noopener
+      - Vite
+      - craco
+      - esbuild
+      - swcrc
+      - noreferrer
+      - xlink
 
 validateDirectives: true
 ignoreRegExpList:

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,5 +1,11 @@
 import { inspect } from './inspect.js';
 
+/* c8 ignore next 3 */
+const isProduction =
+  globalThis.process != null &&
+  // eslint-disable-next-line no-undef
+  process.env.NODE_ENV === 'production';
+
 /**
  * A replacement for instanceof which includes an error warning when multi-realm
  * constructors are detected.
@@ -9,7 +15,7 @@ import { inspect } from './inspect.js';
 export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
   /* c8 ignore next 6 */
   // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  globalThis.process != null && globalThis.process.env.NODE_ENV === 'production'
+  isProduction
     ? function instanceOf(value: unknown, constructor: Constructor): boolean {
         return value instanceof constructor;
       }

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -343,11 +343,12 @@ export interface OperationDefinitionNode {
   readonly selectionSet: SelectionSetNode;
 }
 
-export enum OperationTypeNode {
+enum OperationTypeNode {
   QUERY = 'query',
   MUTATION = 'mutation',
   SUBSCRIPTION = 'subscription',
 }
+export { OperationTypeNode };
 
 export interface VariableDefinitionNode {
   readonly kind: Kind.VARIABLE_DEFINITION;

--- a/src/language/directiveLocation.ts
+++ b/src/language/directiveLocation.ts
@@ -1,7 +1,7 @@
 /**
  * The set of allowed directive location values.
  */
-export enum DirectiveLocation {
+enum DirectiveLocation {
   /** Request Definitions */
   QUERY = 'QUERY',
   MUTATION = 'MUTATION',
@@ -24,3 +24,5 @@ export enum DirectiveLocation {
   INPUT_OBJECT = 'INPUT_OBJECT',
   INPUT_FIELD_DEFINITION = 'INPUT_FIELD_DEFINITION',
 }
+
+export { DirectiveLocation };

--- a/src/language/kinds.ts
+++ b/src/language/kinds.ts
@@ -1,7 +1,7 @@
 /**
  * The set of allowed kind values for AST nodes.
  */
-export enum Kind {
+enum Kind {
   /** Name */
   NAME = 'Name',
 
@@ -72,3 +72,5 @@ export enum Kind {
   ENUM_TYPE_EXTENSION = 'EnumTypeExtension',
   INPUT_OBJECT_TYPE_EXTENSION = 'InputObjectTypeExtension',
 }
+
+export { Kind };

--- a/src/language/tokenKind.ts
+++ b/src/language/tokenKind.ts
@@ -2,7 +2,7 @@
  * An exported enum describing the different kinds of tokens that the
  * lexer emits.
  */
-export enum TokenKind {
+enum TokenKind {
   SOF = '<SOF>',
   EOF = '<EOF>',
   BANG = '!',
@@ -27,3 +27,5 @@ export enum TokenKind {
   BLOCK_STRING = 'BlockString',
   COMMENT = 'Comment',
 }
+
+export { TokenKind };

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -443,7 +443,7 @@ export const __EnumValue: GraphQLObjectType = new GraphQLObjectType({
     } as GraphQLFieldConfigMap<GraphQLEnumValue, unknown>),
 });
 
-export enum TypeKind {
+enum TypeKind {
   SCALAR = 'SCALAR',
   OBJECT = 'OBJECT',
   INTERFACE = 'INTERFACE',
@@ -453,6 +453,7 @@ export enum TypeKind {
   LIST = 'LIST',
   NON_NULL = 'NON_NULL',
 }
+export { TypeKind };
 
 export const __TypeKind: GraphQLEnumType = new GraphQLEnumType({
   name: '__TypeKind',

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -34,7 +34,7 @@ import type { GraphQLSchema } from '../type/schema.js';
 import { astFromValue } from './astFromValue.js';
 import { sortValueNode } from './sortValueNode.js';
 
-export enum BreakingChangeType {
+enum BreakingChangeType {
   TYPE_REMOVED = 'TYPE_REMOVED',
   TYPE_CHANGED_KIND = 'TYPE_CHANGED_KIND',
   TYPE_REMOVED_FROM_UNION = 'TYPE_REMOVED_FROM_UNION',
@@ -52,8 +52,9 @@ export enum BreakingChangeType {
   DIRECTIVE_REPEATABLE_REMOVED = 'DIRECTIVE_REPEATABLE_REMOVED',
   DIRECTIVE_LOCATION_REMOVED = 'DIRECTIVE_LOCATION_REMOVED',
 }
+export { BreakingChangeType };
 
-export enum DangerousChangeType {
+enum DangerousChangeType {
   VALUE_ADDED_TO_ENUM = 'VALUE_ADDED_TO_ENUM',
   TYPE_ADDED_TO_UNION = 'TYPE_ADDED_TO_UNION',
   OPTIONAL_INPUT_FIELD_ADDED = 'OPTIONAL_INPUT_FIELD_ADDED',
@@ -61,6 +62,7 @@ export enum DangerousChangeType {
   IMPLEMENTED_INTERFACE_ADDED = 'IMPLEMENTED_INTERFACE_ADDED',
   ARG_DEFAULT_VALUE_CHANGE = 'ARG_DEFAULT_VALUE_CHANGE',
 }
+export { DangerousChangeType };
 
 export interface BreakingChange {
   type: BreakingChangeType;

--- a/website/docs/tutorials/going-to-production.md
+++ b/website/docs/tutorials/going-to-production.md
@@ -1,0 +1,127 @@
+---
+title: Going to production
+category: FAQ
+---
+
+GraphQL.JS contains a few development checks which in production will cause slower performance and
+an increase in bundle-size. Every bundler goes about these changes different, in here we'll list
+out the most popular ones.
+
+## Bundler-specific configuration
+
+Here are some bundler-specific suggestions for configuring your bundler to remove `globalThis.process` and `process.env.NODE_ENV` on build time.
+
+### Vite
+
+```js
+export default defineConfig({
+  // ...
+  define: {
+    'globalThis.process': JSON.stringify(true),
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  },
+});
+```
+
+### Next.js
+
+```js
+// ...
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  webpack(config, { webpack }) {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        'globalThis.process': JSON.stringify(true),
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
+    );
+    return config;
+  },
+};
+
+module.exports = nextConfig;
+```
+
+### create-react-app
+
+With `create-react-app`, you need to use a third-party package like [`craco`](https://craco.js.org/) to modify the bundler configuration.
+
+```js
+const webpack = require('webpack');
+module.exports = {
+  webpack: {
+    plugins: [
+      new webpack.DefinePlugin({
+        'globalThis.process': JSON.stringify(true),
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
+    ],
+  },
+};
+```
+
+### esbuild
+
+```json
+{
+  "define": {
+    "globalThis.process": true,
+    "process.env.NODE_ENV": "production"
+  }
+}
+```
+
+### Webpack
+
+```js
+config.plugins.push(
+  new webpack.DefinePlugin({
+    'globalThis.process': JSON.stringify(true),
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  }),
+);
+```
+
+### Rollup
+
+```js
+export default [
+  {
+    // ... input, output, etc.
+    plugins: [
+      minify({
+        mangle: {
+          toplevel: true,
+        },
+        compress: {
+          toplevel: true,
+          global_defs: {
+            '@globalThis.process': JSON.stringify(true),
+            '@process.env.NODE_ENV': JSON.stringify('production'),
+          },
+        },
+      }),
+    ],
+  },
+];
+```
+
+### SWC
+
+```json title=".swcrc"
+{
+  "jsc": {
+    "transform": {
+      "optimizer": {
+        "globals": {
+          "vars": {
+            "globalThis.process": true,
+            "process.env.NODE_ENV": "production"
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/website/sidebars.cjs
+++ b/website/sidebars.cjs
@@ -15,6 +15,11 @@ module.exports = {
       label: 'Advanced',
       items: ['tutorials/constructing-types'],
     },
+    {
+      type: 'category',
+      label: 'FAQ',
+      items: ['tutorials/going-to-production'],
+    },
     'tutorials/express-graphql',
     'tutorials/defer-stream',
   ],


### PR DESCRIPTION
@JoviDeCroock @robrichard @benjie 

In this PR, the outstanding v16.x.x changes highlighted by the work in #4165 have been cherry-picked and include the following PRs:

#3686 [Workaround for codesandbox having bug with TS enums](https://github.com/graphql/graphql-js/pull/3686)
#3923 [instanceOf: workaround bundler issue with process.env #3923](https://github.com/graphql/graphql-js/pull/3923)
#4157 [Add GraphQLConf 2024 banner #4157](https://github.com/graphql/graphql-js/pull/4157)

Why were these 3 PRs not developed on main like all the authors? Well, for the first two, it was thought at the time of the original work that a different strategy would be pursued in v17. See the individual links for more information, but, in short, for #3686 it was thought that in v17 TS enums would be entirely deprecated and for #3923 there were a number of proposals, including removing `instanceof` checks entirely. For #4157, the README change is only meant for the current 16.x.x default branch so that the GraphQL Conf banner can be shown on the publicly seen README and would be most appropriate on main if that became the default branch, although it would not cause any direct harm.

1. In terms of code changes, this PR exactly matches the alternative merge commit strategy to align 16.x.x with main in https://github.com/graphql/graphql-js/pull/4165. See: https://github.com/graphql/graphql-js/compare/backport-16.x.x..yaacovcr:cherry-pick
2. If this PR is merged to main using the "rebase" strategy instead of the "squash" strategy, (A) we will get 3 separate commits on main with just like every other (recent?) change on main, (B), the original author information and the link to the original PR will be retained, (C) the git blame will point to the commit on main with the link to the original PR.
3. If we choose the "rebase" strategy as I am suggesting, The gen-changelog script will list only this PR, i.e. a chore, so that readers of the changelog will not be aware that only v17 alpha 8 will have the exact same `instanceof` changes as the latest v16 version. This could be felt to be appropriate: this PR "fixes" the v17 alpha to be up to date with the latest changes in v16.x.x. Alternatively, we could split this PR into 2 or 3 separate PRs, which is a very straightforward task that I would be happy to do, each of which could be merged with the rebase strategy.

A more divergent alternative strategy would be to merge neither this PR nor #4165 => and just directly make the above planned changes, i.e. deprecate the use of TS enums and deal with the desired `instanceof` behavior, and ignore the GraphQLConf banner, presuming that the conference will precede the v17 release. This was the original plan, but I see the benefit in doing something as the shared memory of promised work "to be done later" is a bit tricky, especially considering the change in the maintainer cohort and the long time frame of the v17 alpha work.

Finally, an additional option to consider is to merge this PR so that the git blame will be more "directed" and STILL do the merge commit a la #4165 after this PR if we want to -- if that provides some additional benefit.

Either way, I think for v17 we should definitely include a migration guide, which would definitely aid developers directly to understand what has changed between v17 and the latest version of v16. We have gotten feedback after the last major release that a migration guide would be quite helpful.