### PR TITLE
Fix/optimize value coercion check for OneOf type

### DIFF
--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -153,16 +153,16 @@ function coerceInputValueImpl(
             `Exactly one key must be specified for OneOf type "${type}".`,
           ),
         );
-      }
-
-      const key = keys[0];
-      const value = coercedValue[key];
-      if (value === null) {
-        onError(
-          pathToArray(path).concat(key),
-          value,
-          new GraphQLError(`Field "${key}" must be non-null.`),
-        );
+      } else {
+        const key = keys[0];
+        const value = coercedValue[key];
+        if (value === null) {
+          onError(
+            pathToArray(path).concat(key),
+            value,
+            new GraphQLError(`Field "${key}" must be non-null.`),
+          );
+        }
       }
     }
 


### PR DESCRIPTION
Where a JavaScript value is coerced to a GraphQL OneOf Input Type, a null value should only be reported when the "one of" condition is satisfied. The code block starting at line 158 [here](https://github.com/graphql/graphql-js/blob/1dbdadc6f46d2c97c71c7a4f5c61a2c75d1536ae/src/utilities/coerceInputValue.ts#L158) that accesses `keys[0]` should not be executed if `keys` is empty or contains more than one item.

The PR fixes this by adding an else statement. Alternatively, the "if/else" branches could be reversed, and the `keys.length !== 1` check should become a `keys.length === 1` check.