### PR TITLE
polish(fragmentArgs): simplify fragment args execution

### DIFF
--- a/benchmark/fragment-arguments-benchmark.js
+++ b/benchmark/fragment-arguments-benchmark.js
@@ -1,0 +1,48 @@
+import { execute } from 'graphql/execution/execute.js';
+import { parse } from 'graphql/language/parser.js';
+import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
+
+const schema = buildSchema('type Query { field(echo: String!): [String] }');
+
+const integers = Array.from({ length: 100 }, (_, i) => i + 1);
+
+const document = parse(
+  `
+    query WithManyFragmentArguments(${integers
+      .map((i) => `$echo${i}: String`)
+      .join(', ')}) {
+      ${integers.map((i) => `echo${i}: field(echo: $echo${i})`).join('\n')}
+      ${integers.map((i) => `...EchoFragment${i}(echo: $echo${i})`).join('\n')}
+    }
+
+    ${integers
+      .map(
+        (i) =>
+          `fragment EchoFragment${i}($echo: String) on Query { echoFragment${i}: field(echo: $echo) }`,
+      )
+      .join('\n')}
+  `,
+  { experimentalFragmentArguments: true },
+);
+
+const variableValues = Object.create(null);
+for (const i of integers) {
+  variableValues[`echo${i}`] = `Echo ${i}`;
+}
+
+function field(_, args) {
+  return args.echo;
+}
+
+export const benchmark = {
+  name: 'Execute Operation with Fragment Arguments',
+  count: 10,
+  async measure() {
+    await execute({
+      schema,
+      document,
+      rootValue: { field },
+      variableValues,
+    });
+  },
+};

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -380,6 +380,7 @@ function getScopedVariableValues(
       scopedVariableValues[variableName] = value;
     }
   }
+  return scopedVariableValues;
 }
 
 /**

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -752,7 +752,7 @@ function executeField(
     const args = experimentalGetArgumentValues(
       fieldGroup[0].node,
       fieldDef.args,
-      fieldGroup[0].fragmentVariableValues ?? exeContext.variableValues,
+      fieldGroup[0].scopedVariableValues ?? exeContext.variableValues,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -1060,7 +1060,7 @@ function getStreamUsage(
   const stream = getDirectiveValues(
     GraphQLStreamDirective,
     fieldGroup[0].node,
-    fieldGroup[0].fragmentVariableValues ?? exeContext.variableValues,
+    fieldGroup[0].scopedVariableValues ?? exeContext.variableValues,
   );
 
   if (!stream) {
@@ -1089,7 +1089,7 @@ function getStreamUsage(
   const streamedFieldGroup: FieldGroup = fieldGroup.map((fieldDetails) => ({
     node: fieldDetails.node,
     deferUsage: undefined,
-    fragmentVariableValues: fieldDetails.fragmentVariableValues,
+    scopedVariableValues: fieldDetails.scopedVariableValues,
   }));
 
   const streamUsage = {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -752,8 +752,7 @@ function executeField(
     const args = experimentalGetArgumentValues(
       fieldGroup[0].node,
       fieldDef.args,
-      exeContext.variableValues,
-      fieldGroup[0].fragmentVariables,
+      fieldGroup[0].fragmentVariableValues ?? exeContext.variableValues,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -1061,8 +1060,7 @@ function getStreamUsage(
   const stream = getDirectiveValues(
     GraphQLStreamDirective,
     fieldGroup[0].node,
-    exeContext.variableValues,
-    fieldGroup[0].fragmentVariables,
+    fieldGroup[0].fragmentVariableValues ?? exeContext.variableValues,
   );
 
   if (!stream) {
@@ -1091,7 +1089,7 @@ function getStreamUsage(
   const streamedFieldGroup: FieldGroup = fieldGroup.map((fieldDetails) => ({
     node: fieldDetails.node,
     deferUsage: undefined,
-    fragmentVariables: fieldDetails.fragmentVariables,
+    fragmentVariableValues: fieldDetails.fragmentVariableValues,
   }));
 
   const streamUsage = {

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -38,7 +38,6 @@ export function valueFromAST(
   valueNode: Maybe<ValueNode>,
   type: GraphQLInputType,
   variables?: Maybe<ObjMap<unknown>>,
-  fragmentVariables?: Maybe<ObjMap<unknown>>,
 ): unknown {
   if (!valueNode) {
     // When there is no node, then there is also no value.
@@ -48,8 +47,7 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    const variableValue =
-      fragmentVariables?.[variableName] ?? variables?.[variableName];
+    const variableValue = variables?.[variableName];
     if (variableValue === undefined) {
       // No valid return value.
       return;
@@ -67,7 +65,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.NULL) {
       return; // Invalid: intentionally return no value.
     }
-    return valueFromAST(valueNode, type.ofType, variables, fragmentVariables);
+    return valueFromAST(valueNode, type.ofType, variables);
   }
 
   if (valueNode.kind === Kind.NULL) {
@@ -80,7 +78,7 @@ export function valueFromAST(
     if (valueNode.kind === Kind.LIST) {
       const coercedValues = [];
       for (const itemNode of valueNode.values) {
-        if (isMissingVariable(itemNode, variables, fragmentVariables)) {
+        if (isMissingVariable(itemNode, variables)) {
           // If an array contains a missing variable, it is either coerced to
           // null or if the item type is non-null, it considered invalid.
           if (isNonNullType(itemType)) {
@@ -88,12 +86,7 @@ export function valueFromAST(
           }
           coercedValues.push(null);
         } else {
-          const itemValue = valueFromAST(
-            itemNode,
-            itemType,
-            variables,
-            fragmentVariables,
-          );
+          const itemValue = valueFromAST(itemNode, itemType, variables);
           if (itemValue === undefined) {
             return; // Invalid: intentionally return no value.
           }
@@ -102,12 +95,7 @@ export function valueFromAST(
       }
       return coercedValues;
     }
-    const coercedValue = valueFromAST(
-      valueNode,
-      itemType,
-      variables,
-      fragmentVariables,
-    );
+    const coercedValue = valueFromAST(valueNode, itemType, variables);
     if (coercedValue === undefined) {
       return; // Invalid: intentionally return no value.
     }
@@ -124,10 +112,7 @@ export function valueFromAST(
     );
     for (const field of Object.values(type.getFields())) {
       const fieldNode = fieldNodes.get(field.name);
-      if (
-        fieldNode == null ||
-        isMissingVariable(fieldNode.value, variables, fragmentVariables)
-      ) {
+      if (fieldNode == null || isMissingVariable(fieldNode.value, variables)) {
         if (field.defaultValue !== undefined) {
           coercedObj[field.name] = field.defaultValue;
         } else if (isNonNullType(field.type)) {
@@ -135,12 +120,7 @@ export function valueFromAST(
         }
         continue;
       }
-      const fieldValue = valueFromAST(
-        fieldNode.value,
-        field.type,
-        variables,
-        fragmentVariables,
-      );
+      const fieldValue = valueFromAST(fieldNode.value, field.type, variables);
       if (fieldValue === undefined) {
         return; // Invalid: intentionally return no value.
       }
@@ -186,12 +166,9 @@ export function valueFromAST(
 function isMissingVariable(
   valueNode: ValueNode,
   variables: Maybe<ObjMap<unknown>>,
-  fragmentVariables: Maybe<ObjMap<unknown>>,
 ): boolean {
   return (
     valueNode.kind === Kind.VARIABLE &&
-    (fragmentVariables == null ||
-      fragmentVariables[valueNode.name.value] === undefined) &&
     (variables == null || variables[valueNode.name.value] === undefined)
   );
 }


### PR DESCRIPTION
...by creating a map for each fragment with fragment variables with the combined local and global variables

background: this was in the original version PR #4015, was taken out -- by me -- when i misunderstood and thought that when a fragment variable shadows an operation variable, the operation variable could still leak through if the fragment variable had no default, and I thought it was necessary within getArgumentValues to still have the signatures. that was fixed, but the original method of coalescing local and global variables within a map was not restored, in favor of just retaining both maps

advantage to the original approach, which this PR restores => does not change the signature of getVariableValues, getDirectiveValues, valueFromAST. the lazy method retains both maps and requires passing the local fragment variables to those functions

disadvantage to the original approach => creating a combined variable map of local and global variables may be a waste if the global variables are not actually used in that fragment

I am not sure which way is better! Just raising this for discussion.