### PR TITLE
Add fragment variables to parseLiteral

### DIFF
--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -167,7 +167,10 @@ export function valueFromAST(
     // no value is returned.
     let result;
     try {
-      result = type.parseLiteral(valueNode, variables);
+      result = type.parseLiteral(
+        valueNode,
+        fragmentVariables ? { ...variables, ...fragmentVariables } : variables,
+      );
     } catch (_error) {
       return; // Invalid: intentionally return no value.
     }


### PR DESCRIPTION
This adds in support for parsing literals that are encapsulated within a fragment, this allows us to leverage any shadowed operation variable or newly introduced fragment-variable.