### PR TITLE
Upgrade deprecated actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: npm run build:npm
 
       - name: Upload npmDist package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: npmDist
           path: ./npmDist
@@ -229,7 +229,7 @@ jobs:
         run: npm run build:deno
 
       - name: Upload denoDist package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: denoDist
           path: ./denoDist
@@ -256,7 +256,7 @@ jobs:
         run: npm run build:website
 
       - name: Upload denoDist package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: websiteDist
           path: ./websiteDist

--- a/.github/workflows/cmd-publish-pr-on-npm.yml
+++ b/.github/workflows/cmd-publish-pr-on-npm.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build:npm
 
       - name: Upload npmDist package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: npmDist
           path: ./npmDist
@@ -55,7 +55,7 @@ jobs:
           # 'registry-url' is required for 'npm publish'
           registry-url: 'https://registry.npmjs.org'
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: npmDist
           path: npmDist
@@ -63,7 +63,7 @@ jobs:
       - name: Modify NPM package to be canary release
         env:
           PULL_REQUEST_JSON: ${{ inputs.pullRequestJSON }}
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -110,7 +110,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_CANARY_PR_PUBLISH_TOKEN }}
 
       - name: Upload replyMessage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: replyMessage
           path: ./replyMessage.txt

--- a/.github/workflows/cmd-run-benchmark.yml
+++ b/.github/workflows/cmd-run-benchmark.yml
@@ -42,7 +42,7 @@ jobs:
           EOF
 
       - name: Upload replyMessage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: replyMessage
           path: ./replyMessage.txt

--- a/.github/workflows/deploy-artifact-as-branch.yml
+++ b/.github/workflows/deploy-artifact-as-branch.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Remove existing files first
         run: git rm -r .
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/github-actions-bot.yml
+++ b/.github/workflows/github-actions-bot.yml
@@ -34,7 +34,7 @@ jobs:
           WORKFLOW_ID: ${{github.event.workflow_run.id}}
 
       - name: Add comment on PR
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -58,7 +58,7 @@ jobs:
       cmd: ${{ steps.parse-cmd.outputs.cmd }}
       pullRequestJSON: ${{ steps.parse-cmd.outputs.pullRequestJSON }}
     steps:
-      - uses: actions/github-script@v5
+      - uses: actions/github-script@v7
         with:
           script: |
             github.rest.reactions.createForIssueComment({
@@ -68,7 +68,7 @@ jobs:
             });
 
       - id: parse-cmd
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             const comment = context.payload.comment.body;
@@ -102,12 +102,12 @@ jobs:
     if: needs.accept-cmd.result != 'skipped' && always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: replyMessage
 
       - if: failure()
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -131,7 +131,7 @@ jobs:
           RUN_URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
 
       - if: always()
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,7 +33,7 @@ jobs:
         run: 'node resources/diff-npm-package.js BASE HEAD'
 
       - name: Upload generated report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: npm-dist-diff.html
           path: ./npm-dist-diff.html

--- a/.github/workflows/pull_request_opened.yml
+++ b/.github/workflows/pull_request_opened.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Upload event.json
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: event.json
           path: ${{ github.event_path }}


### PR DESCRIPTION
In response to some of our actions starting to fail deprecate all of the actions that don't work anymore due to using Node 10/12

- [Looks like upload artefact is safe to upgrade](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) we don't seem to overwrite files
- [Same for download](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md)