### PR TITLE
fix: lint errors from PR prior to latest checks

### DIFF
--- a/src/validation/__tests__/KnownDirectivesRule-test.ts
+++ b/src/validation/__tests__/KnownDirectivesRule-test.ts
@@ -356,8 +356,8 @@ describe('Validate: Known directives', () => {
             query: MyQuery
           }
 
-          directive @myDirective(arg:String) on ARGUMENT_DEFINITION 
-          directive @myDirective2(arg:String @myDirective) on FIELD 
+          directive @myDirective(arg:String) on ARGUMENT_DEFINITION
+          directive @myDirective2(arg:String @myDirective) on FIELD
 
           extend schema @onSchema
         `,


### PR DESCRIPTION
This was my mistake, git can help GitHub merge even old PRs automatically when there are no conflicts, but it does not rerun checks/actions if they have changed.

Not sure if there is a separate flow to ensure that the checks are up to date, worth investigating.