### PR TITLE
feat: Allow skipping suggestions

### DIFF
--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -55,7 +55,7 @@ interface CollectFieldsContext {
   operation: OperationDefinitionNode;
   runtimeType: GraphQLObjectType;
   visitedFragmentNames: Set<string>;
-  maskSuggestions: boolean;
+  hideSuggestions: boolean;
 }
 
 /**
@@ -74,7 +74,7 @@ export function collectFields(
   variableValues: VariableValues,
   runtimeType: GraphQLObjectType,
   operation: OperationDefinitionNode,
-  maskSuggestions: boolean,
+  hideSuggestions: boolean,
 ): {
   groupedFieldSet: GroupedFieldSet;
   newDeferUsages: ReadonlyArray<DeferUsage>;
@@ -88,7 +88,7 @@ export function collectFields(
     runtimeType,
     operation,
     visitedFragmentNames: new Set(),
-    maskSuggestions,
+    hideSuggestions,
   };
 
   collectFieldsImpl(
@@ -118,7 +118,7 @@ export function collectSubfields(
   operation: OperationDefinitionNode,
   returnType: GraphQLObjectType,
   fieldDetailsList: FieldDetailsList,
-  maskSuggestions: boolean,
+  hideSuggestions: boolean,
 ): {
   groupedFieldSet: GroupedFieldSet;
   newDeferUsages: ReadonlyArray<DeferUsage>;
@@ -130,7 +130,7 @@ export function collectSubfields(
     runtimeType: returnType,
     operation,
     visitedFragmentNames: new Set(),
-    maskSuggestions,
+    hideSuggestions,
   };
   const subGroupedFieldSet = new AccumulatorMap<string, FieldDetails>();
   const newDeferUsages: Array<DeferUsage> = [];
@@ -172,7 +172,7 @@ function collectFieldsImpl(
     runtimeType,
     operation,
     visitedFragmentNames,
-    maskSuggestions,
+    hideSuggestions,
   } = context;
 
   for (const selection of selectionSet.selections) {
@@ -272,7 +272,7 @@ function collectFieldsImpl(
             fragmentVariableSignatures,
             variableValues,
             fragmentVariableValues,
-            maskSuggestions,
+            hideSuggestions,
           );
         }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -98,13 +98,8 @@ const collectSubfields = memoize3(
     returnType: GraphQLObjectType,
     fieldDetailsList: FieldDetailsList,
   ) => {
-    const {
-      schema,
-      fragments,
-      operation,
-      variableValues,
-      shouldProvideSuggestions,
-    } = validatedExecutionArgs;
+    const { schema, fragments, operation, variableValues, maskSuggestions } =
+      validatedExecutionArgs;
     return _collectSubfields(
       schema,
       fragments,
@@ -112,7 +107,7 @@ const collectSubfields = memoize3(
       operation,
       returnType,
       fieldDetailsList,
-      shouldProvideSuggestions,
+      maskSuggestions,
     );
   },
 );
@@ -161,7 +156,7 @@ export interface ValidatedExecutionArgs {
     validatedExecutionArgs: ValidatedExecutionArgs,
   ) => PromiseOrValue<ExecutionResult>;
   enableEarlyExecution: boolean;
-  shouldProvideSuggestions: boolean;
+  maskSuggestions: boolean;
 }
 
 export interface ExecutionContext {
@@ -191,7 +186,7 @@ export interface ExecutionArgs {
     ) => PromiseOrValue<ExecutionResult>
   >;
   enableEarlyExecution?: Maybe<boolean>;
-  shouldProvideSuggestions?: Maybe<boolean>;
+  maskSuggestions?: Maybe<boolean>;
 }
 
 export interface StreamUsage {
@@ -322,7 +317,7 @@ export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
       rootValue,
       operation,
       variableValues,
-      shouldProvideSuggestions,
+      maskSuggestions,
     } = validatedExecutionArgs;
     const rootType = schema.getRootType(operation.operation);
     if (rootType == null) {
@@ -338,7 +333,7 @@ export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
       variableValues,
       rootType,
       operation,
-      shouldProvideSuggestions,
+      maskSuggestions,
     );
 
     const { groupedFieldSet, newDeferUsages } = collectedFields;
@@ -516,7 +511,6 @@ export function validateExecutionArgs(
     subscribeFieldResolver,
     perEventExecutor,
     enableEarlyExecution,
-    shouldProvideSuggestions,
   } = args;
 
   // If the schema used for execution is invalid, throw an error.
@@ -570,6 +564,7 @@ export function validateExecutionArgs(
   // FIXME: https://github.com/graphql/graphql-js/issues/2203
   /* c8 ignore next */
   const variableDefinitions = operation.variableDefinitions ?? [];
+  const maskSuggestions = args.maskSuggestions ?? false;
 
   const variableValuesOrErrors = getVariableValues(
     schema,
@@ -577,7 +572,7 @@ export function validateExecutionArgs(
     rawVariableValues ?? {},
     {
       maxErrors: 50,
-      shouldProvideSuggestions: shouldProvideSuggestions ?? true,
+      maskSuggestions,
     },
   );
 
@@ -598,7 +593,7 @@ export function validateExecutionArgs(
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
     perEventExecutor: perEventExecutor ?? executeSubscriptionEvent,
     enableEarlyExecution: enableEarlyExecution === true,
-    shouldProvideSuggestions: shouldProvideSuggestions ?? true,
+    maskSuggestions,
   };
 }
 
@@ -782,7 +777,8 @@ function executeField(
   deferMap: ReadonlyMap<DeferUsage, DeferredFragmentRecord> | undefined,
 ): PromiseOrValue<GraphQLWrappedResult<unknown>> | undefined {
   const validatedExecutionArgs = exeContext.validatedExecutionArgs;
-  const { schema, contextValue, variableValues, shouldProvideSuggestions } = validatedExecutionArgs;
+  const { schema, contextValue, variableValues, maskSuggestions } =
+    validatedExecutionArgs;
   const fieldName = fieldDetailsList[0].node.name.value;
   const fieldDef = schema.getField(parentType, fieldName);
   if (!fieldDef) {
@@ -809,8 +805,8 @@ function executeField(
       fieldDetailsList[0].node,
       fieldDef.args,
       variableValues,
-      shouldProvideSuggestions,
       fieldDetailsList[0].fragmentVariableValues,
+      maskSuggestions,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -1114,14 +1110,12 @@ function getStreamUsage(
       ._streamUsage;
   }
 
-  const { operation, variableValues, shouldProvideSuggestions } =
-    validatedExecutionArgs;
+  const { operation, variableValues } = validatedExecutionArgs;
   // validation only allows equivalent streams on multiple fields, so it is
   // safe to only check the first fieldNode for the stream directive
   const stream = getDirectiveValues(
     GraphQLStreamDirective,
     fieldDetailsList[0].node,
-    shouldProvideSuggestions,
     variableValues,
     fieldDetailsList[0].fragmentVariableValues,
   );
@@ -2088,7 +2082,7 @@ function executeSubscription(
     contextValue,
     operation,
     variableValues,
-    shouldProvideSuggestions,
+    maskSuggestions,
   } = validatedExecutionArgs;
 
   const rootType = schema.getSubscriptionType();
@@ -2105,7 +2099,7 @@ function executeSubscription(
     variableValues,
     rootType,
     operation,
-    shouldProvideSuggestions,
+    maskSuggestions,
   );
 
   const firstRootField = groupedFieldSet.entries().next().value as [
@@ -2142,8 +2136,8 @@ function executeSubscription(
     const args = getArgumentValues(
       fieldDef,
       fieldNodes[0],
-      validatedExecutionArgs.shouldProvideSuggestions,
       variableValues,
+      maskSuggestions,
     );
 
     // Call the `subscribe()` resolver or the default resolver to produce an

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -98,7 +98,7 @@ const collectSubfields = memoize3(
     returnType: GraphQLObjectType,
     fieldDetailsList: FieldDetailsList,
   ) => {
-    const { schema, fragments, operation, variableValues, maskSuggestions } =
+    const { schema, fragments, operation, variableValues, hideSuggestions } =
       validatedExecutionArgs;
     return _collectSubfields(
       schema,
@@ -107,7 +107,7 @@ const collectSubfields = memoize3(
       operation,
       returnType,
       fieldDetailsList,
-      maskSuggestions,
+      hideSuggestions,
     );
   },
 );
@@ -156,7 +156,7 @@ export interface ValidatedExecutionArgs {
     validatedExecutionArgs: ValidatedExecutionArgs,
   ) => PromiseOrValue<ExecutionResult>;
   enableEarlyExecution: boolean;
-  maskSuggestions: boolean;
+  hideSuggestions: boolean;
 }
 
 export interface ExecutionContext {
@@ -186,7 +186,7 @@ export interface ExecutionArgs {
     ) => PromiseOrValue<ExecutionResult>
   >;
   enableEarlyExecution?: Maybe<boolean>;
-  maskSuggestions?: Maybe<boolean>;
+  hideSuggestions?: Maybe<boolean>;
 }
 
 export interface StreamUsage {
@@ -317,7 +317,7 @@ export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
       rootValue,
       operation,
       variableValues,
-      maskSuggestions,
+      hideSuggestions,
     } = validatedExecutionArgs;
     const rootType = schema.getRootType(operation.operation);
     if (rootType == null) {
@@ -333,7 +333,7 @@ export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
       variableValues,
       rootType,
       operation,
-      maskSuggestions,
+      hideSuggestions,
     );
 
     const { groupedFieldSet, newDeferUsages } = collectedFields;
@@ -564,7 +564,7 @@ export function validateExecutionArgs(
   // FIXME: https://github.com/graphql/graphql-js/issues/2203
   /* c8 ignore next */
   const variableDefinitions = operation.variableDefinitions ?? [];
-  const maskSuggestions = args.maskSuggestions ?? false;
+  const hideSuggestions = args.hideSuggestions ?? false;
 
   const variableValuesOrErrors = getVariableValues(
     schema,
@@ -572,7 +572,7 @@ export function validateExecutionArgs(
     rawVariableValues ?? {},
     {
       maxErrors: 50,
-      maskSuggestions,
+      hideSuggestions,
     },
   );
 
@@ -593,7 +593,7 @@ export function validateExecutionArgs(
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
     perEventExecutor: perEventExecutor ?? executeSubscriptionEvent,
     enableEarlyExecution: enableEarlyExecution === true,
-    maskSuggestions,
+    hideSuggestions,
   };
 }
 
@@ -777,7 +777,7 @@ function executeField(
   deferMap: ReadonlyMap<DeferUsage, DeferredFragmentRecord> | undefined,
 ): PromiseOrValue<GraphQLWrappedResult<unknown>> | undefined {
   const validatedExecutionArgs = exeContext.validatedExecutionArgs;
-  const { schema, contextValue, variableValues, maskSuggestions } =
+  const { schema, contextValue, variableValues, hideSuggestions } =
     validatedExecutionArgs;
   const fieldName = fieldDetailsList[0].node.name.value;
   const fieldDef = schema.getField(parentType, fieldName);
@@ -806,7 +806,7 @@ function executeField(
       fieldDef.args,
       variableValues,
       fieldDetailsList[0].fragmentVariableValues,
-      maskSuggestions,
+      hideSuggestions,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -2082,7 +2082,7 @@ function executeSubscription(
     contextValue,
     operation,
     variableValues,
-    maskSuggestions,
+    hideSuggestions,
   } = validatedExecutionArgs;
 
   const rootType = schema.getSubscriptionType();
@@ -2099,7 +2099,7 @@ function executeSubscription(
     variableValues,
     rootType,
     operation,
-    maskSuggestions,
+    hideSuggestions,
   );
 
   const firstRootField = groupedFieldSet.entries().next().value as [
@@ -2137,7 +2137,7 @@ function executeSubscription(
       fieldDef,
       fieldNodes[0],
       variableValues,
-      maskSuggestions,
+      hideSuggestions,
     );
 
     // Call the `subscribe()` resolver or the default resolver to produce an

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -55,7 +55,7 @@ export function getVariableValues(
   schema: GraphQLSchema,
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
   inputs: { readonly [variable: string]: unknown },
-  options?: { maxErrors?: number; maskSuggestions?: boolean },
+  options?: { maxErrors?: number; hideSuggestions?: boolean },
 ): VariableValuesOrErrors {
   const errors: Array<GraphQLError> = [];
   const maxErrors = options?.maxErrors;
@@ -72,7 +72,7 @@ export function getVariableValues(
         }
         errors.push(error);
       },
-      options?.maskSuggestions,
+      options?.hideSuggestions,
     );
 
     if (errors.length === 0) {
@@ -90,7 +90,7 @@ function coerceVariableValues(
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
   inputs: { readonly [variable: string]: unknown },
   onError: (error: GraphQLError) => void,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): VariableValues {
   const sources: ObjMap<VariableValueSource> = Object.create(null);
   const coerced: ObjMap<unknown> = Object.create(null);
@@ -110,7 +110,7 @@ function coerceVariableValues(
         coerced[varName] = coerceDefaultValue(
           defaultValue,
           varType,
-          maskSuggestions,
+          hideSuggestions,
         );
       } else if (isNonNullType(varType)) {
         const varTypeStr = inspect(varType);
@@ -155,7 +155,7 @@ function coerceVariableValues(
           }),
         );
       },
-      maskSuggestions,
+      hideSuggestions,
     );
   }
 
@@ -167,7 +167,7 @@ export function getFragmentVariableValues(
   fragmentSignatures: ReadOnlyObjMap<GraphQLVariableSignature>,
   variableValues: VariableValues,
   fragmentVariableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): VariableValues {
   const varSignatures: Array<GraphQLVariableSignature> = [];
   const sources = Object.create(null);
@@ -186,7 +186,7 @@ export function getFragmentVariableValues(
     varSignatures,
     variableValues,
     fragmentVariableValues,
-    maskSuggestions,
+    hideSuggestions,
   );
 
   return { sources, coerced };
@@ -204,14 +204,14 @@ export function getArgumentValues(
   def: GraphQLField<unknown, unknown> | GraphQLDirective,
   node: FieldNode | DirectiveNode,
   variableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): { [argument: string]: unknown } {
   return experimentalGetArgumentValues(
     node,
     def.args,
     variableValues,
     undefined,
-    maskSuggestions,
+    hideSuggestions,
   );
 }
 
@@ -220,7 +220,7 @@ export function experimentalGetArgumentValues(
   argDefs: ReadonlyArray<GraphQLArgument | GraphQLVariableSignature>,
   variableValues: Maybe<VariableValues>,
   fragmentVariablesValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): { [argument: string]: unknown } {
   const coercedValues: { [argument: string]: unknown } = {};
 
@@ -239,7 +239,7 @@ export function experimentalGetArgumentValues(
         coercedValues[name] = coerceDefaultValue(
           argDef.defaultValue,
           argDef.type,
-          maskSuggestions,
+          hideSuggestions,
         );
       } else if (isNonNullType(argType)) {
         throw new GraphQLError(
@@ -269,7 +269,7 @@ export function experimentalGetArgumentValues(
           coercedValues[name] = coerceDefaultValue(
             argDef.defaultValue,
             argDef.type,
-            maskSuggestions,
+            hideSuggestions,
           );
         } else if (isNonNullType(argType)) {
           throw new GraphQLError(
@@ -296,7 +296,7 @@ export function experimentalGetArgumentValues(
       argType,
       variableValues,
       fragmentVariablesValues,
-      maskSuggestions,
+      hideSuggestions,
     );
     if (coercedValue === undefined) {
       // Note: ValuesOfCorrectTypeRule validation should catch this before
@@ -330,7 +330,7 @@ export function getDirectiveValues(
   node: { readonly directives?: ReadonlyArray<DirectiveNode> | undefined },
   variableValues?: Maybe<VariableValues>,
   fragmentVariableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): undefined | { [argument: string]: unknown } {
   const directiveNode = node.directives?.find(
     (directive) => directive.name.value === directiveDef.name,
@@ -342,7 +342,7 @@ export function getDirectiveValues(
       directiveDef.args,
       variableValues,
       fragmentVariableValues,
-      maskSuggestions,
+      hideSuggestions,
     );
   }
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -61,6 +61,7 @@ import type { ExecutionResult } from './execution/types.js';
 export interface GraphQLArgs {
   schema: GraphQLSchema;
   source: string | Source;
+  maskSuggestions?: boolean;
   rootValue?: unknown;
   contextValue?: unknown;
   variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
@@ -101,6 +102,7 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
+    maskSuggestions,
   } = args;
 
   // Validate Schema
@@ -118,7 +120,9 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
   }
 
   // Validate
-  const validationErrors = validate(schema, document);
+  const validationErrors = validate(schema, document, undefined, {
+    maskSuggestions,
+  });
   if (validationErrors.length > 0) {
     return { errors: validationErrors };
   }
@@ -133,5 +137,6 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
+    maskSuggestions,
   });
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -61,7 +61,7 @@ import type { ExecutionResult } from './execution/types.js';
 export interface GraphQLArgs {
   schema: GraphQLSchema;
   source: string | Source;
-  maskSuggestions?: boolean;
+  hideSuggestions?: Maybe<boolean>;
   rootValue?: unknown;
   contextValue?: unknown;
   variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
@@ -102,7 +102,7 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
-    maskSuggestions,
+    hideSuggestions,
   } = args;
 
   // Validate Schema
@@ -121,7 +121,7 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
 
   // Validate
   const validationErrors = validate(schema, document, undefined, {
-    maskSuggestions,
+    hideSuggestions,
   });
   if (validationErrors.length > 0) {
     return { errors: validationErrors };
@@ -137,6 +137,6 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
-    maskSuggestions,
+    hideSuggestions,
   });
 }

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -135,13 +135,13 @@ const schema = new GraphQLSchema({
 function executeQuery(
   source: string,
   variableValues?: { readonly [variable: string]: unknown },
-  maskSuggestions = false,
+  hideSuggestions = false,
 ) {
   return graphqlSync({
     schema,
     source,
     variableValues,
-    maskSuggestions,
+    hideSuggestions,
   });
 }
 

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -135,8 +135,14 @@ const schema = new GraphQLSchema({
 function executeQuery(
   source: string,
   variableValues?: { readonly [variable: string]: unknown },
+  maskSuggestions = false,
 ) {
-  return graphqlSync({ schema, source, variableValues });
+  return graphqlSync({
+    schema,
+    source,
+    variableValues,
+    maskSuggestions,
+  });
 }
 
 describe('Type System: Enum Values', () => {
@@ -186,6 +192,23 @@ describe('Type System: Enum Values', () => {
         {
           message:
             'Value "GREENISH" does not exist in "Color" enum. Did you mean the enum value "GREEN"?',
+          locations: [{ line: 1, column: 23 }],
+        },
+      ],
+    });
+  });
+
+  it('does not accept values not in the enum (no suggestions)', () => {
+    const result = executeQuery(
+      '{ colorEnum(fromEnum: GREENISH) }',
+      undefined,
+      true,
+    );
+
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'Value "GREENISH" does not exist in "Color" enum.',
           locations: [{ line: 1, column: 23 }],
         },
       ],

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1424,13 +1424,13 @@ export class GraphQLEnumType /* <T> */ {
 
   parseValue(
     inputValue: unknown,
-    maskSuggestions?: Maybe<boolean>,
+    hideSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     if (typeof inputValue !== 'string') {
       const valueStr = inspect(inputValue);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-string value: ${valueStr}.` +
-          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
+          (hideSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
       );
     }
 
@@ -1438,7 +1438,7 @@ export class GraphQLEnumType /* <T> */ {
     if (enumValue == null) {
       throw new GraphQLError(
         `Value "${inputValue}" does not exist in "${this.name}" enum.` +
-          (maskSuggestions ? '' : didYouMeanEnumValue(this, inputValue)),
+          (hideSuggestions ? '' : didYouMeanEnumValue(this, inputValue)),
       );
     }
     return enumValue.value;
@@ -1448,21 +1448,21 @@ export class GraphQLEnumType /* <T> */ {
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
-    maskSuggestions?: Maybe<boolean>,
+    hideSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
-    return this.parseConstLiteral(valueNode as ConstValueNode, maskSuggestions);
+    return this.parseConstLiteral(valueNode as ConstValueNode, hideSuggestions);
   }
 
   parseConstLiteral(
     valueNode: ConstValueNode,
-    maskSuggestions?: Maybe<boolean>,
+    hideSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     if (valueNode.kind !== Kind.ENUM) {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-enum value: ${valueStr}.` +
-          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
+          (hideSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
         { nodes: valueNode },
       );
     }
@@ -1472,7 +1472,7 @@ export class GraphQLEnumType /* <T> */ {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Value "${valueStr}" does not exist in "${this.name}" enum.` +
-          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
+          (hideSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
         { nodes: valueNode },
       );
     }

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1422,12 +1422,15 @@ export class GraphQLEnumType /* <T> */ {
     return enumValue.name;
   }
 
-  parseValue(inputValue: unknown): Maybe<any> /* T */ {
+  parseValue(
+    inputValue: unknown,
+    shouldProvideSuggestions: boolean,
+  ): Maybe<any> /* T */ {
     if (typeof inputValue !== 'string') {
       const valueStr = inspect(inputValue);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-string value: ${valueStr}.` +
-          didYouMeanEnumValue(this, valueStr),
+          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
       );
     }
 
@@ -1435,7 +1438,9 @@ export class GraphQLEnumType /* <T> */ {
     if (enumValue == null) {
       throw new GraphQLError(
         `Value "${inputValue}" does not exist in "${this.name}" enum.` +
-          didYouMeanEnumValue(this, inputValue),
+          (shouldProvideSuggestions
+            ? didYouMeanEnumValue(this, inputValue)
+            : ''),
       );
     }
     return enumValue.value;
@@ -1445,17 +1450,24 @@ export class GraphQLEnumType /* <T> */ {
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
+    shouldProvideSuggestions: boolean,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
-    return this.parseConstLiteral(valueNode as ConstValueNode);
+    return this.parseConstLiteral(
+      valueNode as ConstValueNode,
+      shouldProvideSuggestions,
+    );
   }
 
-  parseConstLiteral(valueNode: ConstValueNode): Maybe<any> /* T */ {
+  parseConstLiteral(
+    valueNode: ConstValueNode,
+    shouldProvideSuggestions: boolean,
+  ): Maybe<any> /* T */ {
     if (valueNode.kind !== Kind.ENUM) {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-enum value: ${valueStr}.` +
-          didYouMeanEnumValue(this, valueStr),
+          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
         { nodes: valueNode },
       );
     }
@@ -1465,7 +1477,7 @@ export class GraphQLEnumType /* <T> */ {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Value "${valueStr}" does not exist in "${this.name}" enum.` +
-          didYouMeanEnumValue(this, valueStr),
+          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
         { nodes: valueNode },
       );
     }

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1424,13 +1424,13 @@ export class GraphQLEnumType /* <T> */ {
 
   parseValue(
     inputValue: unknown,
-    shouldProvideSuggestions: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     if (typeof inputValue !== 'string') {
       const valueStr = inspect(inputValue);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-string value: ${valueStr}.` +
-          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
       );
     }
 
@@ -1438,9 +1438,7 @@ export class GraphQLEnumType /* <T> */ {
     if (enumValue == null) {
       throw new GraphQLError(
         `Value "${inputValue}" does not exist in "${this.name}" enum.` +
-          (shouldProvideSuggestions
-            ? didYouMeanEnumValue(this, inputValue)
-            : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, inputValue)),
       );
     }
     return enumValue.value;
@@ -1450,24 +1448,21 @@ export class GraphQLEnumType /* <T> */ {
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
-    shouldProvideSuggestions: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
-    return this.parseConstLiteral(
-      valueNode as ConstValueNode,
-      shouldProvideSuggestions,
-    );
+    return this.parseConstLiteral(valueNode as ConstValueNode, maskSuggestions);
   }
 
   parseConstLiteral(
     valueNode: ConstValueNode,
-    shouldProvideSuggestions: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     if (valueNode.kind !== Kind.ENUM) {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-enum value: ${valueStr}.` +
-          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
         { nodes: valueNode },
       );
     }
@@ -1477,7 +1472,7 @@ export class GraphQLEnumType /* <T> */ {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Value "${valueStr}" does not exist in "${this.name}" enum.` +
-          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
         { nodes: valueNode },
       );
     }

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -55,6 +55,7 @@ function coerceValue(
   const value = coerceInputValue(
     inputValue,
     type,
+    true,
     (path, invalidValue, error) => {
       errors.push({ path, value: invalidValue, error: error.message });
     },
@@ -538,7 +539,7 @@ describe('coerceInputValue', () => {
   describe('with default onError', () => {
     it('throw error without path', () => {
       expect(() =>
-        coerceInputValue(null, new GraphQLNonNull(GraphQLInt)),
+        coerceInputValue(null, new GraphQLNonNull(GraphQLInt), true),
       ).to.throw(
         'Invalid value null: Expected non-nullable type "Int!" not to be null.',
       );
@@ -549,6 +550,7 @@ describe('coerceInputValue', () => {
         coerceInputValue(
           [null],
           new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          true,
         ),
       ).to.throw(
         'Invalid value null at "value[0]": Expected non-nullable type "Int!" not to be null.',
@@ -565,7 +567,7 @@ describe('coerceInputLiteral', () => {
     variableValues?: VariableValues,
   ) {
     const ast = parseValue(valueText);
-    const value = coerceInputLiteral(ast, type, variableValues);
+    const value = coerceInputLiteral(ast, type, true, variableValues);
     expect(value).to.deep.equal(expected);
   }
 
@@ -892,10 +894,14 @@ describe('coerceDefaultValue', () => {
     const defaultValueUsage = {
       literal: { kind: Kind.STRING, value: 'hello' },
     } as const;
-    expect(coerceDefaultValue(defaultValueUsage, spyScalar)).to.equal('hello');
+    expect(coerceDefaultValue(defaultValueUsage, spyScalar, true)).to.equal(
+      'hello',
+    );
 
     // Call a second time
-    expect(coerceDefaultValue(defaultValueUsage, spyScalar)).to.equal('hello');
+    expect(coerceDefaultValue(defaultValueUsage, spyScalar, true)).to.equal(
+      'hello',
+    );
     expect(parseValueCalls).to.deep.equal(['hello']);
   });
 });

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -50,7 +50,7 @@ interface CoerceError {
 function coerceValue(
   inputValue: unknown,
   type: GraphQLInputType,
-  maskSuggestions = false,
+  hideSuggestions = false,
 ): CoerceResult {
   const errors: Array<CoerceError> = [];
   const value = coerceInputValue(
@@ -59,7 +59,7 @@ function coerceValue(
     (path, invalidValue, error) => {
       errors.push({ path, value: invalidValue, error: error.message });
     },
-    maskSuggestions,
+    hideSuggestions,
   );
 
   return { errors, value };

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -50,15 +50,16 @@ interface CoerceError {
 function coerceValue(
   inputValue: unknown,
   type: GraphQLInputType,
+  maskSuggestions = false,
 ): CoerceResult {
   const errors: Array<CoerceError> = [];
   const value = coerceInputValue(
     inputValue,
     type,
-    true,
     (path, invalidValue, error) => {
       errors.push({ path, value: invalidValue, error: error.message });
     },
+    maskSuggestions,
   );
 
   return { errors, value };
@@ -184,6 +185,17 @@ describe('coerceInputValue', () => {
       ]);
     });
 
+    it('returns an error for misspelled enum value (no suggestions)', () => {
+      const result = coerceValue('foo', TestEnum, true);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Value "foo" does not exist in "TestEnum" enum.',
+          path: [],
+          value: 'foo',
+        },
+      ]);
+    });
+
     it('returns an error for incorrect value type', () => {
       const result1 = coerceValue(123, TestEnum);
       expectErrors(result1).to.deep.equal([
@@ -195,6 +207,27 @@ describe('coerceInputValue', () => {
       ]);
 
       const result2 = coerceValue({ field: 'value' }, TestEnum);
+      expectErrors(result2).to.deep.equal([
+        {
+          error:
+            'Enum "TestEnum" cannot represent non-string value: { field: "value" }.',
+          path: [],
+          value: { field: 'value' },
+        },
+      ]);
+    });
+
+    it('returns an error for incorrect value type (no suggestions)', () => {
+      const result1 = coerceValue(123, TestEnum, true);
+      expectErrors(result1).to.deep.equal([
+        {
+          error: 'Enum "TestEnum" cannot represent non-string value: 123.',
+          path: [],
+          value: 123,
+        },
+      ]);
+
+      const result2 = coerceValue({ field: 'value' }, TestEnum, false);
       expectErrors(result2).to.deep.equal([
         {
           error:
@@ -401,6 +434,23 @@ describe('coerceInputValue', () => {
         },
       ]);
     });
+
+    it('returns error for a misspelled field without suggestions', () => {
+      const result = coerceValue({ bart: 123 }, TestInputObject, true);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Field "bart" is not defined by type "TestInputObject".',
+          path: [],
+          value: { bart: 123 },
+        },
+        {
+          error:
+            'Exactly one key must be specified for OneOf type "TestInputObject".',
+          path: [],
+          value: { bart: 123 },
+        },
+      ]);
+    });
   });
 
   describe('for GraphQLInputObject with default value', () => {
@@ -539,7 +589,7 @@ describe('coerceInputValue', () => {
   describe('with default onError', () => {
     it('throw error without path', () => {
       expect(() =>
-        coerceInputValue(null, new GraphQLNonNull(GraphQLInt), true),
+        coerceInputValue(null, new GraphQLNonNull(GraphQLInt), undefined, true),
       ).to.throw(
         'Invalid value null: Expected non-nullable type "Int!" not to be null.',
       );
@@ -550,6 +600,7 @@ describe('coerceInputValue', () => {
         coerceInputValue(
           [null],
           new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          undefined,
           true,
         ),
       ).to.throw(
@@ -567,7 +618,13 @@ describe('coerceInputLiteral', () => {
     variableValues?: VariableValues,
   ) {
     const ast = parseValue(valueText);
-    const value = coerceInputLiteral(ast, type, true, variableValues);
+    const value = coerceInputLiteral(
+      ast,
+      type,
+      variableValues,
+      undefined,
+      true,
+    );
     expect(value).to.deep.equal(expected);
   }
 

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -44,14 +44,14 @@ export function coerceInputValue(
   inputValue: unknown,
   type: GraphQLInputType,
   onError: OnErrorCB = defaultOnError,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): unknown {
   return coerceInputValueImpl(
     inputValue,
     type,
     onError,
     undefined,
-    maskSuggestions,
+    hideSuggestions,
   );
 }
 
@@ -73,7 +73,7 @@ function coerceInputValueImpl(
   type: GraphQLInputType,
   onError: OnErrorCB,
   path: Path | undefined,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): unknown {
   if (isNonNullType(type)) {
     if (inputValue != null) {
@@ -82,7 +82,7 @@ function coerceInputValueImpl(
         type.ofType,
         onError,
         path,
-        maskSuggestions,
+        hideSuggestions,
       );
     }
     onError(
@@ -110,7 +110,7 @@ function coerceInputValueImpl(
           itemType,
           onError,
           itemPath,
-          maskSuggestions,
+          hideSuggestions,
         );
       });
     }
@@ -121,7 +121,7 @@ function coerceInputValueImpl(
         itemType,
         onError,
         path,
-        maskSuggestions,
+        hideSuggestions,
       ),
     ];
   }
@@ -147,7 +147,7 @@ function coerceInputValueImpl(
           coercedValue[field.name] = coerceDefaultValue(
             field.defaultValue,
             field.type,
-            maskSuggestions,
+            hideSuggestions,
           );
         } else if (isNonNullType(field.type)) {
           const typeStr = inspect(field.type);
@@ -167,7 +167,7 @@ function coerceInputValueImpl(
         field.type,
         onError,
         addPath(path, field.name, type.name),
-        maskSuggestions,
+        hideSuggestions,
       );
     }
 
@@ -183,7 +183,7 @@ function coerceInputValueImpl(
           inputValue,
           new GraphQLError(
             `Field "${fieldName}" is not defined by type "${type}".` +
-              (maskSuggestions ? '' : didYouMean(suggestions)),
+              (hideSuggestions ? '' : didYouMean(suggestions)),
           ),
         );
       }
@@ -222,7 +222,7 @@ function coerceInputValueImpl(
     // which can throw to indicate failure. If it throws, maintain a reference
     // to the original error.
     try {
-      parseResult = type.parseValue(inputValue, maskSuggestions);
+      parseResult = type.parseValue(inputValue, hideSuggestions);
     } catch (error) {
       if (error instanceof GraphQLError) {
         onError(pathToArray(path), inputValue, error);
@@ -262,7 +262,7 @@ export function coerceInputLiteral(
   type: GraphQLInputType,
   variableValues?: Maybe<VariableValues>,
   fragmentVariableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): unknown {
   if (valueNode.kind === Kind.VARIABLE) {
     const coercedVariableValue = getCoercedVariableValue(
@@ -287,7 +287,7 @@ export function coerceInputLiteral(
       type.ofType,
       variableValues,
       fragmentVariableValues,
-      maskSuggestions,
+      hideSuggestions,
     );
   }
 
@@ -303,7 +303,7 @@ export function coerceInputLiteral(
         type.ofType,
         variableValues,
         fragmentVariableValues,
-        maskSuggestions,
+        hideSuggestions,
       );
       if (itemValue === undefined) {
         return; // Invalid: intentionally return no value.
@@ -317,7 +317,7 @@ export function coerceInputLiteral(
         type.ofType,
         variableValues,
         fragmentVariableValues,
-        maskSuggestions,
+        hideSuggestions,
       );
       if (itemValue === undefined) {
         if (
@@ -374,7 +374,7 @@ export function coerceInputLiteral(
           coercedValue[field.name] = coerceDefaultValue(
             field.defaultValue,
             field.type,
-            maskSuggestions,
+            hideSuggestions,
           );
         }
       } else {
@@ -383,7 +383,7 @@ export function coerceInputLiteral(
           field.type,
           variableValues,
           fragmentVariableValues,
-          maskSuggestions,
+          hideSuggestions,
         );
         if (fieldValue === undefined) {
           return; // Invalid: intentionally return no value.
@@ -411,12 +411,12 @@ export function coerceInputLiteral(
     return leafType.parseConstLiteral
       ? leafType.parseConstLiteral(
           replaceVariables(valueNode, variableValues, fragmentVariableValues),
-          maskSuggestions,
+          hideSuggestions,
         )
       : leafType.parseLiteral(
           valueNode,
           variableValues?.coerced,
-          maskSuggestions,
+          hideSuggestions,
         );
   } catch (_error) {
     // Invalid: ignore error and intentionally return no value.
@@ -443,7 +443,7 @@ function getCoercedVariableValue(
 export function coerceDefaultValue(
   defaultValue: GraphQLDefaultValueUsage,
   type: GraphQLInputType,
-  maskSuggestions?: Maybe<boolean>,
+  hideSuggestions?: Maybe<boolean>,
 ): unknown {
   // Memoize the result of coercing the default value in a hidden field.
   let coercedValue = (defaultValue as any)._memoizedCoercedValue;
@@ -454,7 +454,7 @@ export function coerceDefaultValue(
           type,
           undefined,
           undefined,
-          maskSuggestions,
+          hideSuggestions,
         )
       : defaultValue.value;
     (defaultValue as any)._memoizedCoercedValue = coercedValue;

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -148,7 +148,7 @@ export function valueFromAST(
     // no value is returned.
     let result;
     try {
-      result = type.parseLiteral(valueNode, variables);
+      result = type.parseLiteral(valueNode, variables, true);
     } catch (_error) {
       return; // Invalid: intentionally return no value.
     }

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -148,7 +148,7 @@ export function valueFromAST(
     // no value is returned.
     let result;
     try {
-      result = type.parseLiteral(valueNode, variables, true);
+      result = type.parseLiteral(valueNode, variables);
     } catch (_error) {
       return; // Invalid: intentionally return no value.
     }

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -154,7 +154,7 @@ export class SDLValidationContext extends ASTValidationContext {
     this._schema = schema;
   }
 
-  get maskSuggestions() {
+  get hideSuggestions() {
     return false;
   }
 
@@ -181,29 +181,29 @@ export class ValidationContext extends ASTValidationContext {
     OperationDefinitionNode,
     ReadonlyArray<VariableUsage>
   >;
-  private _maskSuggestions: boolean;
+  private _hideSuggestions: boolean;
 
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
-    maskSuggestions?: Maybe<boolean>,
+    hideSuggestions?: Maybe<boolean>,
   ) {
     super(ast, onError);
     this._schema = schema;
     this._typeInfo = typeInfo;
     this._variableUsages = new Map();
     this._recursiveVariableUsages = new Map();
-    this._maskSuggestions = maskSuggestions ?? false;
+    this._hideSuggestions = hideSuggestions ?? false;
   }
 
   get [Symbol.toStringTag]() {
     return 'ValidationContext';
   }
 
-  get maskSuggestions() {
-    return this._maskSuggestions;
+  get hideSuggestions() {
+    return this._hideSuggestions;
   }
 
   getSchema(): GraphQLSchema {

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -154,8 +154,8 @@ export class SDLValidationContext extends ASTValidationContext {
     this._schema = schema;
   }
 
-  get shouldProvideSuggestions() {
-    return true;
+  get maskSuggestions() {
+    return false;
   }
 
   get [Symbol.toStringTag]() {
@@ -181,29 +181,29 @@ export class ValidationContext extends ASTValidationContext {
     OperationDefinitionNode,
     ReadonlyArray<VariableUsage>
   >;
-  private _shouldProvideSuggestions: boolean;
+  private _maskSuggestions: boolean;
 
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
-    shouldProvideSuggestions?: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ) {
     super(ast, onError);
     this._schema = schema;
     this._typeInfo = typeInfo;
     this._variableUsages = new Map();
     this._recursiveVariableUsages = new Map();
-    this._shouldProvideSuggestions = shouldProvideSuggestions ?? true;
+    this._maskSuggestions = maskSuggestions ?? false;
   }
 
   get [Symbol.toStringTag]() {
     return 'ValidationContext';
   }
 
-  get shouldProvideSuggestions() {
-    return this._shouldProvideSuggestions;
+  get maskSuggestions() {
+    return this._maskSuggestions;
   }
 
   getSchema(): GraphQLSchema {

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -154,6 +154,10 @@ export class SDLValidationContext extends ASTValidationContext {
     this._schema = schema;
   }
 
+  get shouldProvideSuggestions() {
+    return true;
+  }
+
   get [Symbol.toStringTag]() {
     return 'SDLValidationContext';
   }
@@ -177,22 +181,29 @@ export class ValidationContext extends ASTValidationContext {
     OperationDefinitionNode,
     ReadonlyArray<VariableUsage>
   >;
+  private _shouldProvideSuggestions: boolean;
 
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
+    shouldProvideSuggestions?: boolean,
   ) {
     super(ast, onError);
     this._schema = schema;
     this._typeInfo = typeInfo;
     this._variableUsages = new Map();
     this._recursiveVariableUsages = new Map();
+    this._shouldProvideSuggestions = shouldProvideSuggestions ?? true;
   }
 
   get [Symbol.toStringTag]() {
     return 'ValidationContext';
+  }
+
+  get shouldProvideSuggestions() {
+    return this._shouldProvideSuggestions;
   }
 
   getSchema(): GraphQLSchema {

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
@@ -12,11 +12,12 @@ import { validate } from '../validate.js';
 
 import { expectValidationErrorsWithSchema } from './harness.js';
 
-function expectErrors(queryStr: string) {
+function expectErrors(queryStr: string, maskSuggestions = false) {
   return expectValidationErrorsWithSchema(
     testSchema,
     FieldsOnCorrectTypeRule,
     queryStr,
+    maskSuggestions,
   );
 }
 
@@ -135,6 +136,22 @@ describe('Validate: Fields on correct type', () => {
       {
         message:
           'Cannot query field "meowVolume" on type "Dog". Did you mean "barkVolume"?',
+        locations: [{ line: 3, column: 9 }],
+      },
+    ]);
+  });
+
+  it('Field not defined on fragment (no suggestions)', () => {
+    expectErrors(
+      `
+      fragment fieldNotDefined on Dog {
+        meowVolume
+      }
+    `,
+      true,
+    ).toDeepEqual([
+      {
+        message: 'Cannot query field "meowVolume" on type "Dog".',
         locations: [{ line: 3, column: 9 }],
       },
     ]);

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
@@ -12,12 +12,12 @@ import { validate } from '../validate.js';
 
 import { expectValidationErrorsWithSchema } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, hideSuggestions = false) {
   return expectValidationErrorsWithSchema(
     testSchema,
     FieldsOnCorrectTypeRule,
     queryStr,
-    maskSuggestions,
+    hideSuggestions,
   );
 }
 

--- a/src/validation/__tests__/KnownArgumentNamesRule-test.ts
+++ b/src/validation/__tests__/KnownArgumentNamesRule-test.ts
@@ -14,11 +14,11 @@ import {
   expectValidationErrors,
 } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, hideSuggestions = false) {
   return expectValidationErrors(
     KnownArgumentNamesRule,
     queryStr,
-    maskSuggestions,
+    hideSuggestions,
   );
 }
 

--- a/src/validation/__tests__/KnownTypeNamesRule-test.ts
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.ts
@@ -12,8 +12,8 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string) {
-  return expectValidationErrors(KnownTypeNamesRule, queryStr);
+function expectErrors(queryStr: string, maskSuggestions = false) {
+  return expectValidationErrors(KnownTypeNamesRule, queryStr, maskSuggestions);
 }
 
 function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
@@ -73,6 +73,36 @@ describe('Validate: Known type names', () => {
       },
       {
         message: 'Unknown type "Peat". Did you mean "Pet" or "Cat"?',
+        locations: [{ line: 8, column: 29 }],
+      },
+    ]);
+  });
+
+  it('unknown type names are invalid (no suggestions)', () => {
+    expectErrors(
+      `
+      query Foo($var: [JumbledUpLetters!]!) {
+        user(id: 4) {
+          name
+          pets { ... on Badger { name }, ...PetFields }
+        }
+      }
+      fragment PetFields on Peat {
+        name
+      }
+    `,
+      true,
+    ).toDeepEqual([
+      {
+        message: 'Unknown type "JumbledUpLetters".',
+        locations: [{ line: 2, column: 24 }],
+      },
+      {
+        message: 'Unknown type "Badger".',
+        locations: [{ line: 5, column: 25 }],
+      },
+      {
+        message: 'Unknown type "Peat".',
         locations: [{ line: 8, column: 29 }],
       },
     ]);

--- a/src/validation/__tests__/KnownTypeNamesRule-test.ts
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.ts
@@ -12,8 +12,8 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
-  return expectValidationErrors(KnownTypeNamesRule, queryStr, maskSuggestions);
+function expectErrors(queryStr: string, hideSuggestions = false) {
+  return expectValidationErrors(KnownTypeNamesRule, queryStr, hideSuggestions);
 }
 
 function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -19,11 +19,11 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, hideSuggestions = false) {
   return expectValidationErrors(
     ValuesOfCorrectTypeRule,
     queryStr,
-    maskSuggestions,
+    hideSuggestions,
   );
 }
 

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -19,8 +19,12 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string) {
-  return expectValidationErrors(ValuesOfCorrectTypeRule, queryStr);
+function expectErrors(queryStr: string, maskSuggestions = false) {
+  return expectValidationErrors(
+    ValuesOfCorrectTypeRule,
+    queryStr,
+    maskSuggestions,
+  );
 }
 
 function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
@@ -526,6 +530,24 @@ describe('Validate: Values of correct type', () => {
       ]);
     });
 
+    it('String into Enum (no suggestion)', () => {
+      expectErrors(
+        `
+        {
+          dog {
+            doesKnowCommand(dogCommand: "SIT")
+          }
+        }
+      `,
+        true,
+      ).toDeepEqual([
+        {
+          message: 'Enum "DogCommand" cannot represent non-enum value: "SIT".',
+          locations: [{ line: 4, column: 41 }],
+        },
+      ]);
+    });
+
     it('Boolean into Enum', () => {
       expectErrors(`
         {
@@ -567,6 +589,24 @@ describe('Validate: Values of correct type', () => {
         {
           message:
             'Value "sit" does not exist in "DogCommand" enum. Did you mean the enum value "SIT"?',
+          locations: [{ line: 4, column: 41 }],
+        },
+      ]);
+    });
+
+    it('Different case Enum Value into Enum (no suggestion)', () => {
+      expectErrors(
+        `
+        {
+          dog {
+            doesKnowCommand(dogCommand: sit)
+          }
+        }
+      `,
+        true,
+      ).toDeepEqual([
+        {
+          message: 'Value "sit" does not exist in "DogCommand" enum.',
           locations: [{ line: 4, column: 41 }],
         },
       ]);
@@ -963,6 +1003,28 @@ describe('Validate: Values of correct type', () => {
         {
           message:
             'Field "invalidField" is not defined by type "ComplexInput". Did you mean "intField"?',
+          locations: [{ line: 6, column: 15 }],
+        },
+      ]);
+    });
+
+    it('Partial object, unknown field arg (no suggestions)', () => {
+      expectErrors(
+        `
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              requiredField: true,
+              invalidField: "value"
+            })
+          }
+        }
+      `,
+        true,
+      ).toDeepEqual([
+        {
+          message:
+            'Field "invalidField" is not defined by type "ComplexInput".',
           locations: [{ line: 6, column: 15 }],
         },
       ]);

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -128,17 +128,24 @@ export function expectValidationErrorsWithSchema(
   schema: GraphQLSchema,
   rule: ValidationRule,
   queryStr: string,
+  maskSuggestions = false,
 ): any {
   const doc = parse(queryStr, { experimentalFragmentArguments: true });
-  const errors = validate(schema, doc, [rule]);
+  const errors = validate(schema, doc, [rule], { maskSuggestions });
   return expectJSON(errors);
 }
 
 export function expectValidationErrors(
   rule: ValidationRule,
   queryStr: string,
+  maskSuggestions = false,
 ): any {
-  return expectValidationErrorsWithSchema(testSchema, rule, queryStr);
+  return expectValidationErrorsWithSchema(
+    testSchema,
+    rule,
+    queryStr,
+    maskSuggestions,
+  );
 }
 
 export function expectSDLValidationErrors(

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -128,23 +128,23 @@ export function expectValidationErrorsWithSchema(
   schema: GraphQLSchema,
   rule: ValidationRule,
   queryStr: string,
-  maskSuggestions = false,
+  hideSuggestions = false,
 ): any {
   const doc = parse(queryStr, { experimentalFragmentArguments: true });
-  const errors = validate(schema, doc, [rule], { maskSuggestions });
+  const errors = validate(schema, doc, [rule], { hideSuggestions });
   return expectJSON(errors);
 }
 
 export function expectValidationErrors(
   rule: ValidationRule,
   queryStr: string,
-  maskSuggestions = false,
+  hideSuggestions = false,
 ): any {
   return expectValidationErrorsWithSchema(
     testSchema,
     rule,
     queryStr,
-    maskSuggestions,
+    hideSuggestions,
   );
 }
 

--- a/src/validation/rules/FieldsOnCorrectTypeRule.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.ts
@@ -45,17 +45,17 @@ export function FieldsOnCorrectTypeRule(
           // First determine if there are any suggested types to condition on.
           let suggestion = didYouMean(
             'to use an inline fragment on',
-            context.shouldProvideSuggestions
-              ? getSuggestedTypeNames(schema, type, fieldName)
-              : [],
+            context.maskSuggestions
+              ? []
+              : getSuggestedTypeNames(schema, type, fieldName),
           );
 
           // If there are no suggested types, then perhaps this was a typo?
           if (suggestion === '') {
             suggestion = didYouMean(
-              context.shouldProvideSuggestions
-                ? getSuggestedFieldNames(type, fieldName)
-                : [],
+              context.maskSuggestions
+                ? []
+                : getSuggestedFieldNames(type, fieldName),
             );
           }
 

--- a/src/validation/rules/FieldsOnCorrectTypeRule.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.ts
@@ -45,7 +45,7 @@ export function FieldsOnCorrectTypeRule(
           // First determine if there are any suggested types to condition on.
           let suggestion = didYouMean(
             'to use an inline fragment on',
-            context.maskSuggestions
+            context.hideSuggestions
               ? []
               : getSuggestedTypeNames(schema, type, fieldName),
           );
@@ -53,7 +53,7 @@ export function FieldsOnCorrectTypeRule(
           // If there are no suggested types, then perhaps this was a typo?
           if (suggestion === '') {
             suggestion = didYouMean(
-              context.maskSuggestions
+              context.hideSuggestions
                 ? []
                 : getSuggestedFieldNames(type, fieldName),
             );

--- a/src/validation/rules/FieldsOnCorrectTypeRule.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.ts
@@ -45,12 +45,18 @@ export function FieldsOnCorrectTypeRule(
           // First determine if there are any suggested types to condition on.
           let suggestion = didYouMean(
             'to use an inline fragment on',
-            getSuggestedTypeNames(schema, type, fieldName),
+            context.shouldProvideSuggestions
+              ? getSuggestedTypeNames(schema, type, fieldName)
+              : [],
           );
 
           // If there are no suggested types, then perhaps this was a typo?
           if (suggestion === '') {
-            suggestion = didYouMean(getSuggestedFieldNames(type, fieldName));
+            suggestion = didYouMean(
+              context.shouldProvideSuggestions
+                ? getSuggestedFieldNames(type, fieldName)
+                : [],
+            );
           }
 
           // Report an error, including helpful suggestions.

--- a/src/validation/rules/KnownArgumentNamesRule.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.ts
@@ -34,7 +34,7 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
         );
         if (!varDef) {
           const argName = argNode.name.value;
-          const suggestions = context.maskSuggestions
+          const suggestions = context.hideSuggestions
             ? []
             : suggestionList(
                 argName,
@@ -59,7 +59,7 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
 
       if (!argDef && fieldDef && parentType) {
         const argName = argNode.name.value;
-        const suggestions = context.maskSuggestions
+        const suggestions = context.hideSuggestions
           ? []
           : suggestionList(
               argName,
@@ -123,7 +123,7 @@ export function KnownArgumentNamesOnDirectivesRule(
             context.reportError(
               new GraphQLError(
                 `Unknown argument "${argName}" on directive "@${directiveName}".` +
-                  (context.maskSuggestions ? '' : didYouMean(suggestions)),
+                  (context.hideSuggestions ? '' : didYouMean(suggestions)),
                 { nodes: argNode },
               ),
             );

--- a/src/validation/rules/KnownArgumentNamesRule.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.ts
@@ -34,12 +34,14 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
         );
         if (!varDef) {
           const argName = argNode.name.value;
-          const suggestions = suggestionList(
-            argName,
-            Array.from(fragmentSignature.variableDefinitions.values()).map(
-              (varSignature) => varSignature.variable.name.value,
-            ),
-          );
+          const suggestions = context.shouldProvideSuggestions
+            ? suggestionList(
+                argName,
+                Array.from(fragmentSignature.variableDefinitions.values()).map(
+                  (varSignature) => varSignature.variable.name.value,
+                ),
+              )
+            : [];
           context.reportError(
             new GraphQLError(
               `Unknown argument "${argName}" on fragment "${fragmentSignature.definition.name.value}".` +
@@ -57,10 +59,12 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
 
       if (!argDef && fieldDef && parentType) {
         const argName = argNode.name.value;
-        const suggestions = suggestionList(
-          argName,
-          fieldDef.args.map((arg) => arg.name),
-        );
+        const suggestions = context.shouldProvideSuggestions
+          ? suggestionList(
+              argName,
+              fieldDef.args.map((arg) => arg.name),
+            )
+          : [];
         context.reportError(
           new GraphQLError(
             `Unknown argument "${argName}" on field "${parentType}.${fieldDef.name}".` +

--- a/src/validation/rules/KnownArgumentNamesRule.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.ts
@@ -34,14 +34,14 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
         );
         if (!varDef) {
           const argName = argNode.name.value;
-          const suggestions = context.shouldProvideSuggestions
-            ? suggestionList(
+          const suggestions = context.maskSuggestions
+            ? []
+            : suggestionList(
                 argName,
                 Array.from(fragmentSignature.variableDefinitions.values()).map(
                   (varSignature) => varSignature.variable.name.value,
                 ),
-              )
-            : [];
+              );
           context.reportError(
             new GraphQLError(
               `Unknown argument "${argName}" on fragment "${fragmentSignature.definition.name.value}".` +
@@ -59,12 +59,12 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
 
       if (!argDef && fieldDef && parentType) {
         const argName = argNode.name.value;
-        const suggestions = context.shouldProvideSuggestions
-          ? suggestionList(
+        const suggestions = context.maskSuggestions
+          ? []
+          : suggestionList(
               argName,
               fieldDef.args.map((arg) => arg.name),
-            )
-          : [];
+            );
         context.reportError(
           new GraphQLError(
             `Unknown argument "${argName}" on field "${parentType}.${fieldDef.name}".` +
@@ -123,7 +123,7 @@ export function KnownArgumentNamesOnDirectivesRule(
             context.reportError(
               new GraphQLError(
                 `Unknown argument "${argName}" on directive "@${directiveName}".` +
-                  didYouMean(suggestions),
+                  (context.maskSuggestions ? '' : didYouMean(suggestions)),
                 { nodes: argNode },
               ),
             );

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -48,10 +48,12 @@ export function KnownTypeNamesRule(
           return;
         }
 
-        const suggestedTypes = suggestionList(
-          typeName,
-          isSDL ? [...standardTypeNames, ...typeNames] : [...typeNames],
-        );
+        const suggestedTypes = context.shouldProvideSuggestions
+          ? suggestionList(
+              typeName,
+              isSDL ? [...standardTypeNames, ...typeNames] : [...typeNames],
+            )
+          : [];
         context.reportError(
           new GraphQLError(
             `Unknown type "${typeName}".` + didYouMean(suggestedTypes),

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -48,7 +48,7 @@ export function KnownTypeNamesRule(
           return;
         }
 
-        const suggestedTypes = context.maskSuggestions
+        const suggestedTypes = context.hideSuggestions
           ? []
           : suggestionList(
               typeName,

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -48,12 +48,12 @@ export function KnownTypeNamesRule(
           return;
         }
 
-        const suggestedTypes = context.shouldProvideSuggestions
-          ? suggestionList(
+        const suggestedTypes = context.maskSuggestions
+          ? []
+          : suggestionList(
               typeName,
               isSDL ? [...standardTypeNames, ...typeNames] : [...typeNames],
-            )
-          : [];
+            );
         context.reportError(
           new GraphQLError(
             `Unknown type "${typeName}".` + didYouMean(suggestedTypes),

--- a/src/validation/rules/PossibleTypeExtensionsRule.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.ts
@@ -78,13 +78,10 @@ export function PossibleTypeExtensionsRule(
         ...Object.keys(schema?.getTypeMap() ?? {}),
       ];
 
-      const suggestedTypes = context.shouldProvideSuggestions
-        ? suggestionList(typeName, allTypeNames)
-        : [];
       context.reportError(
         new GraphQLError(
           `Cannot extend type "${typeName}" because it is not defined.` +
-            didYouMean(suggestedTypes),
+            didYouMean(suggestionList(typeName, allTypeNames)),
           { nodes: node.name },
         ),
       );

--- a/src/validation/rules/PossibleTypeExtensionsRule.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.ts
@@ -78,7 +78,9 @@ export function PossibleTypeExtensionsRule(
         ...Object.keys(schema?.getTypeMap() ?? {}),
       ];
 
-      const suggestedTypes = suggestionList(typeName, allTypeNames);
+      const suggestedTypes = context.shouldProvideSuggestions
+        ? suggestionList(typeName, allTypeNames)
+        : [];
       context.reportError(
         new GraphQLError(
           `Cannot extend type "${typeName}" because it is not defined.` +

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -51,7 +51,7 @@ export function SingleFieldSubscriptionsRule(
             variableValues,
             subscriptionType,
             node,
-            context.maskSuggestions,
+            context.hideSuggestions,
           );
           if (groupedFieldSet.size > 1) {
             const fieldDetailsLists = [...groupedFieldSet.values()];

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -51,6 +51,7 @@ export function SingleFieldSubscriptionsRule(
             variableValues,
             subscriptionType,
             node,
+            context.maskSuggestions,
           );
           if (groupedFieldSet.size > 1) {
             const fieldDetailsLists = [...groupedFieldSet.values()];

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -97,10 +97,9 @@ export function ValuesOfCorrectTypeRule(
       const parentType = getNamedType(context.getParentInputType());
       const fieldType = context.getInputType();
       if (!fieldType && isInputObjectType(parentType)) {
-        const suggestions = suggestionList(
-          node.name.value,
-          Object.keys(parentType.getFields()),
-        );
+        const suggestions = context.shouldProvideSuggestions
+          ? suggestionList(node.name.value, Object.keys(parentType.getFields()))
+          : [];
         context.reportError(
           new GraphQLError(
             `Field "${node.name.value}" is not defined by type "${parentType}".` +
@@ -157,8 +156,11 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // which may throw or return undefined to indicate an invalid value.
   try {
     const parseResult = type.parseConstLiteral
-      ? type.parseConstLiteral(replaceVariables(node))
-      : type.parseLiteral(node, undefined);
+      ? type.parseConstLiteral(
+          replaceVariables(node),
+          context.shouldProvideSuggestions,
+        )
+      : type.parseLiteral(node, undefined, context.shouldProvideSuggestions);
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -97,9 +97,12 @@ export function ValuesOfCorrectTypeRule(
       const parentType = getNamedType(context.getParentInputType());
       const fieldType = context.getInputType();
       if (!fieldType && isInputObjectType(parentType)) {
-        const suggestions = context.shouldProvideSuggestions
-          ? suggestionList(node.name.value, Object.keys(parentType.getFields()))
-          : [];
+        const suggestions = context.maskSuggestions
+          ? []
+          : suggestionList(
+              node.name.value,
+              Object.keys(parentType.getFields()),
+            );
         context.reportError(
           new GraphQLError(
             `Field "${node.name.value}" is not defined by type "${parentType}".` +
@@ -156,11 +159,8 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // which may throw or return undefined to indicate an invalid value.
   try {
     const parseResult = type.parseConstLiteral
-      ? type.parseConstLiteral(
-          replaceVariables(node),
-          context.shouldProvideSuggestions,
-        )
-      : type.parseLiteral(node, undefined, context.shouldProvideSuggestions);
+      ? type.parseConstLiteral(replaceVariables(node), context.maskSuggestions)
+      : type.parseLiteral(node, undefined, context.maskSuggestions);
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -97,7 +97,7 @@ export function ValuesOfCorrectTypeRule(
       const parentType = getNamedType(context.getParentInputType());
       const fieldType = context.getInputType();
       if (!fieldType && isInputObjectType(parentType)) {
-        const suggestions = context.maskSuggestions
+        const suggestions = context.hideSuggestions
           ? []
           : suggestionList(
               node.name.value,
@@ -159,8 +159,8 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // which may throw or return undefined to indicate an invalid value.
   try {
     const parseResult = type.parseConstLiteral
-      ? type.parseConstLiteral(replaceVariables(node), context.maskSuggestions)
-      : type.parseLiteral(node, undefined, context.maskSuggestions);
+      ? type.parseConstLiteral(replaceVariables(node), context.hideSuggestions)
+      : type.parseLiteral(node, undefined, context.hideSuggestions);
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -41,10 +41,10 @@ export function validate(
   schema: GraphQLSchema,
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
-  options?: { maxErrors?: number; shouldProvideSuggestions?: boolean },
+  options?: { maxErrors?: number; maskSuggestions?: Maybe<boolean> },
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
-  const shouldProvideSuggestions = options?.shouldProvideSuggestions ?? true;
+  const maskSuggestions = options?.maskSuggestions ?? false;
 
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
@@ -64,7 +64,7 @@ export function validate(
       }
       errors.push(error);
     },
-    shouldProvideSuggestions,
+    maskSuggestions,
   );
 
   // This uses a specialized visitor which runs multiple visitors in parallel,

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -41,10 +41,10 @@ export function validate(
   schema: GraphQLSchema,
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
-  options?: { maxErrors?: number; maskSuggestions?: Maybe<boolean> },
+  options?: { maxErrors?: number; hideSuggestions?: Maybe<boolean> },
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
-  const maskSuggestions = options?.maskSuggestions ?? false;
+  const hideSuggestions = options?.hideSuggestions ?? false;
 
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
@@ -64,7 +64,7 @@ export function validate(
       }
       errors.push(error);
     },
-    maskSuggestions,
+    hideSuggestions,
   );
 
   // This uses a specialized visitor which runs multiple visitors in parallel,

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -41,9 +41,10 @@ export function validate(
   schema: GraphQLSchema,
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
-  options?: { maxErrors?: number },
+  options?: { maxErrors?: number; shouldProvideSuggestions?: boolean },
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
+  const shouldProvideSuggestions = options?.shouldProvideSuggestions ?? true;
 
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
@@ -63,6 +64,7 @@ export function validate(
       }
       errors.push(error);
     },
+    shouldProvideSuggestions,
   );
 
   // This uses a specialized visitor which runs multiple visitors in parallel,


### PR DESCRIPTION
Resolves https://github.com/graphql/graphql-js/issues/4190
Resolves https://github.com/graphql/graphql-js/issues/2247
Supersedes https://github.com/graphql/graphql-js/pull/3467

This is a best practice already in production however GraphQL JS does not provide an out of the box solution. In the community we have solutions like https://escape.tech/graphql-armor/docs/plugins/block-field-suggestions/ however in v17 it would be worth considering providing a built-in.

The recommendation here would be to do `validate(schema, doc, rules, { hideSuggestions: process.env.NODE_ENV === 'production' })`