### PR TITLE
introduce new execute exports

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -270,7 +270,9 @@ export function experimentalExecuteIncrementally(
     return { errors: validatedExecutionArgs };
   }
 
-  return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
+  return experimentalExecuteQueryOrMutationOrSubscriptionEvent(
+    validatedExecutionArgs,
+  );
 }
 
 /**
@@ -288,7 +290,16 @@ export function experimentalExecuteIncrementally(
  * at which point we still log the error and null the parent field, which
  * in this case is the entire response.
  */
-function executeQueryOrMutationOrSubscriptionEvent(
+export function executeQueryOrMutationOrSubscriptionEvent(
+  validatedExecutionArgs: ValidatedExecutionArgs,
+): PromiseOrValue<ExecutionResult> {
+  const result = experimentalExecuteQueryOrMutationOrSubscriptionEvent(
+    validatedExecutionArgs,
+  );
+  return ensureSinglePayload(result);
+}
+
+export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
   const exeContext: ExecutionContext = {
@@ -1971,10 +1982,7 @@ function mapSourceToResponse(
 export function executeSubscriptionEvent(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<ExecutionResult> {
-  const result = executeQueryOrMutationOrSubscriptionEvent(
-    validatedExecutionArgs,
-  );
-  return ensureSinglePayload(result);
+  return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
 }
 
 /**

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3,8 +3,10 @@ export { pathToArray as responsePathAsArray } from '../jsutils/Path.js';
 export {
   createSourceEventStream,
   execute,
+  executeQueryOrMutationOrSubscriptionEvent,
   executeSubscriptionEvent,
   experimentalExecuteIncrementally,
+  experimentalExecuteQueryOrMutationOrSubscriptionEvent,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,

--- a/src/index.ts
+++ b/src/index.ts
@@ -317,8 +317,10 @@ export type {
 // Execute GraphQL queries.
 export {
   execute,
+  executeQueryOrMutationOrSubscriptionEvent,
   executeSubscriptionEvent,
   experimentalExecuteIncrementally,
+  experimentalExecuteQueryOrMutationOrSubscriptionEvent,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,


### PR DESCRIPTION
operating on `ValidatedExecutionArguments`:

`executeQueryOrMutationOrSubscriptionEvent()` and
`experimentalExecuteQueryOrMutationOrSubscriptionEvent()`

motivation: allows library users/servers to make sure that documents contain necessary operation and that variables coerce, and then allow them to call an executor on those already validated arguments

motivation: missing piece necessary for really closing #3679 