### PR TITLE
improve new leaf type `parseConstLiteral()` method

### DIFF
--- a/integrationTests/ts/kitchenSink-test.ts
+++ b/integrationTests/ts/kitchenSink-test.ts
@@ -8,7 +8,7 @@ new GraphQLScalarType({
   name: 'SomeScalar',
   serialize: undefined,
   parseValue: undefined,
-  parseConstLiteral: undefined,
+  coerceInputLiteral: undefined,
 });
 
 new GraphQLError('test', { nodes: undefined });

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -47,7 +47,7 @@ const TestFaultyScalar = new GraphQLScalarType({
   parseValue() {
     throw TestFaultyScalarGraphQLError;
   },
-  parseConstLiteral() {
+  coerceInputLiteral() {
     throw TestFaultyScalarGraphQLError;
   },
 });
@@ -58,7 +58,7 @@ const TestComplexScalar = new GraphQLScalarType({
     expect(value).to.equal('SerializedValue');
     return 'DeserializedValue';
   },
-  parseConstLiteral(ast) {
+  coerceInputLiteral(ast) {
     expect(ast).to.include({ kind: 'StringValue', value: 'SerializedValue' });
     return 'DeserializedValue';
   },
@@ -281,7 +281,7 @@ describe('Execute: Handles inputs', () => {
         });
       });
 
-      it('properly runs parseConstLiteral on complex scalar types', () => {
+      it('properly runs coerceInputLiteral on complex scalar types', () => {
         const result = executeQuery(`
           {
             fieldWithObjectInput(input: {c: "foo", d: "SerializedValue"})

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,9 @@ export type {
   GraphQLUnionTypeExtensions,
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
+  /* @deprecated in favor of GraphQLScalarInputLiteralCoercer, will be removed in v18 */
   GraphQLScalarLiteralParser,
+  GraphQLScalarInputLiteralCoercer,
   GraphQLDefaultValueUsage,
 } from './type/index.js';
 

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -60,7 +60,7 @@ describe('Type System: Scalars', () => {
       serialize: someScalar.serialize,
       parseValue: someScalar.parseValue,
       parseLiteral: someScalar.parseLiteral,
-      parseConstLiteral: undefined,
+      coerceInputLiteral: undefined,
       valueToLiteral: undefined,
       extensions: {},
       astNode: undefined,
@@ -76,7 +76,7 @@ describe('Type System: Scalars', () => {
       serialize: passThroughFunc,
       parseValue: passThroughFunc,
       parseLiteral: passThroughFunc,
-      parseConstLiteral: passThroughFunc,
+      coerceInputLiteral: passThroughFunc,
       valueToLiteral: passThroughFunc,
       extensions: { someExtension: 'extension' },
       astNode: dummyAny,
@@ -93,7 +93,7 @@ describe('Type System: Scalars', () => {
     expect(scalar.parseValue).to.equal(identityFunc);
     expect(scalar.parseLiteral).to.be.a('function');
     /* default will be provided in v18 when parseLiteral is removed */
-    // expect(scalar.parseConstLiteral).to.be.a('function');
+    // expect(scalar.coerceInputLiteral).to.be.a('function');
   });
 
   it('use parseValue for parsing literals if parseLiteral omitted', () => {
@@ -124,15 +124,15 @@ describe('Type System: Scalars', () => {
     );
   });
 
-  it('rejects a Scalar type defining parseConstLiteral but not parseValue', () => {
+  it('rejects a Scalar type defining coerceInputLiteral but not parseValue', () => {
     expect(
       () =>
         new GraphQLScalarType({
           name: 'SomeScalar',
-          parseConstLiteral: passThroughFunc,
+          coerceInputLiteral: passThroughFunc,
         }),
     ).to.throw(
-      'SomeScalar must provide both "parseValue" and "parseConstLiteral" functions.',
+      'SomeScalar must provide both "parseValue" and "coerceInputLiteral" functions.',
     );
   });
 });

--- a/src/type/__tests__/scalars-test.ts
+++ b/src/type/__tests__/scalars-test.ts
@@ -64,45 +64,45 @@ describe('Type System: Specified scalar types', () => {
       );
     });
 
-    it('parseConstLiteral', () => {
-      function parseConstLiteral(str: string) {
+    it('coerceInputLiteral', () => {
+      function coerceInputLiteral(str: string) {
         /* @ts-expect-error to be removed in v18 when all custom scalars will have default method */
-        return GraphQLInt.parseConstLiteral(parseConstValue(str));
+        return GraphQLInt.coerceInputLiteral(parseConstValue(str));
       }
 
-      expect(parseConstLiteral('1')).to.equal(1);
-      expect(parseConstLiteral('0')).to.equal(0);
-      expect(parseConstLiteral('-1')).to.equal(-1);
+      expect(coerceInputLiteral('1')).to.equal(1);
+      expect(coerceInputLiteral('0')).to.equal(0);
+      expect(coerceInputLiteral('-1')).to.equal(-1);
 
-      expect(() => parseConstLiteral('9876504321')).to.throw(
+      expect(() => coerceInputLiteral('9876504321')).to.throw(
         'Int cannot represent non 32-bit signed integer value: 9876504321',
       );
-      expect(() => parseConstLiteral('-9876504321')).to.throw(
+      expect(() => coerceInputLiteral('-9876504321')).to.throw(
         'Int cannot represent non 32-bit signed integer value: -9876504321',
       );
 
-      expect(() => parseConstLiteral('1.0')).to.throw(
+      expect(() => coerceInputLiteral('1.0')).to.throw(
         'Int cannot represent non-integer value: 1.0',
       );
-      expect(() => parseConstLiteral('null')).to.throw(
+      expect(() => coerceInputLiteral('null')).to.throw(
         'Int cannot represent non-integer value: null',
       );
-      expect(() => parseConstLiteral('""')).to.throw(
+      expect(() => coerceInputLiteral('""')).to.throw(
         'Int cannot represent non-integer value: ""',
       );
-      expect(() => parseConstLiteral('"123"')).to.throw(
+      expect(() => coerceInputLiteral('"123"')).to.throw(
         'Int cannot represent non-integer value: "123"',
       );
-      expect(() => parseConstLiteral('false')).to.throw(
+      expect(() => coerceInputLiteral('false')).to.throw(
         'Int cannot represent non-integer value: false',
       );
-      expect(() => parseConstLiteral('[1]')).to.throw(
+      expect(() => coerceInputLiteral('[1]')).to.throw(
         'Int cannot represent non-integer value: [1]',
       );
-      expect(() => parseConstLiteral('{ value: 1 }')).to.throw(
+      expect(() => coerceInputLiteral('{ value: 1 }')).to.throw(
         'Int cannot represent non-integer value: { value: 1 }',
       );
-      expect(() => parseConstLiteral('ENUM_VALUE')).to.throw(
+      expect(() => coerceInputLiteral('ENUM_VALUE')).to.throw(
         'Int cannot represent non-integer value: ENUM_VALUE',
       );
     });
@@ -227,40 +227,40 @@ describe('Type System: Specified scalar types', () => {
       );
     });
 
-    it('parseConstLiteral', () => {
-      function parseConstLiteral(str: string) {
+    it('coerceInputLiteral', () => {
+      function coerceInputLiteral(str: string) {
         /* @ts-expect-error to be removed in v18 when all custom scalars will have default method */
-        return GraphQLFloat.parseConstLiteral(parseConstValue(str));
+        return GraphQLFloat.coerceInputLiteral(parseConstValue(str));
       }
 
-      expect(parseConstLiteral('1')).to.equal(1);
-      expect(parseConstLiteral('0')).to.equal(0);
-      expect(parseConstLiteral('-1')).to.equal(-1);
-      expect(parseConstLiteral('0.1')).to.equal(0.1);
-      expect(parseConstLiteral(Math.PI.toString())).to.equal(Math.PI);
+      expect(coerceInputLiteral('1')).to.equal(1);
+      expect(coerceInputLiteral('0')).to.equal(0);
+      expect(coerceInputLiteral('-1')).to.equal(-1);
+      expect(coerceInputLiteral('0.1')).to.equal(0.1);
+      expect(coerceInputLiteral(Math.PI.toString())).to.equal(Math.PI);
 
-      expect(() => parseConstLiteral('null')).to.throw(
+      expect(() => coerceInputLiteral('null')).to.throw(
         'Float cannot represent non numeric value: null',
       );
-      expect(() => parseConstLiteral('""')).to.throw(
+      expect(() => coerceInputLiteral('""')).to.throw(
         'Float cannot represent non numeric value: ""',
       );
-      expect(() => parseConstLiteral('"123"')).to.throw(
+      expect(() => coerceInputLiteral('"123"')).to.throw(
         'Float cannot represent non numeric value: "123"',
       );
-      expect(() => parseConstLiteral('"123.5"')).to.throw(
+      expect(() => coerceInputLiteral('"123.5"')).to.throw(
         'Float cannot represent non numeric value: "123.5"',
       );
-      expect(() => parseConstLiteral('false')).to.throw(
+      expect(() => coerceInputLiteral('false')).to.throw(
         'Float cannot represent non numeric value: false',
       );
-      expect(() => parseConstLiteral('[0.1]')).to.throw(
+      expect(() => coerceInputLiteral('[0.1]')).to.throw(
         'Float cannot represent non numeric value: [0.1]',
       );
-      expect(() => parseConstLiteral('{ value: 0.1 }')).to.throw(
+      expect(() => coerceInputLiteral('{ value: 0.1 }')).to.throw(
         'Float cannot represent non numeric value: { value: 0.1 }',
       );
-      expect(() => parseConstLiteral('ENUM_VALUE')).to.throw(
+      expect(() => coerceInputLiteral('ENUM_VALUE')).to.throw(
         'Float cannot represent non numeric value: ENUM_VALUE',
       );
     });
@@ -338,34 +338,34 @@ describe('Type System: Specified scalar types', () => {
       );
     });
 
-    it('parseConstLiteral', () => {
-      function parseConstLiteral(str: string) {
+    it('coerceInputLiteral', () => {
+      function coerceInputLiteral(str: string) {
         /* @ts-expect-error to be removed in v18 when all custom scalars will have default method */
-        return GraphQLString.parseConstLiteral(parseConstValue(str));
+        return GraphQLString.coerceInputLiteral(parseConstValue(str));
       }
 
-      expect(parseConstLiteral('"foo"')).to.equal('foo');
-      expect(parseConstLiteral('"""bar"""')).to.equal('bar');
+      expect(coerceInputLiteral('"foo"')).to.equal('foo');
+      expect(coerceInputLiteral('"""bar"""')).to.equal('bar');
 
-      expect(() => parseConstLiteral('null')).to.throw(
+      expect(() => coerceInputLiteral('null')).to.throw(
         'String cannot represent a non string value: null',
       );
-      expect(() => parseConstLiteral('1')).to.throw(
+      expect(() => coerceInputLiteral('1')).to.throw(
         'String cannot represent a non string value: 1',
       );
-      expect(() => parseConstLiteral('0.1')).to.throw(
+      expect(() => coerceInputLiteral('0.1')).to.throw(
         'String cannot represent a non string value: 0.1',
       );
-      expect(() => parseConstLiteral('false')).to.throw(
+      expect(() => coerceInputLiteral('false')).to.throw(
         'String cannot represent a non string value: false',
       );
-      expect(() => parseConstLiteral('["foo"]')).to.throw(
+      expect(() => coerceInputLiteral('["foo"]')).to.throw(
         'String cannot represent a non string value: ["foo"]',
       );
-      expect(() => parseConstLiteral('{ value: "foo" }')).to.throw(
+      expect(() => coerceInputLiteral('{ value: "foo" }')).to.throw(
         'String cannot represent a non string value: { value: "foo" }',
       );
-      expect(() => parseConstLiteral('ENUM_VALUE')).to.throw(
+      expect(() => coerceInputLiteral('ENUM_VALUE')).to.throw(
         'String cannot represent a non string value: ENUM_VALUE',
       );
     });
@@ -448,40 +448,40 @@ describe('Type System: Specified scalar types', () => {
       );
     });
 
-    it('parseConstLiteral', () => {
-      function parseConstLiteral(str: string) {
+    it('coerceInputLiteral', () => {
+      function coerceInputLiteral(str: string) {
         /* @ts-expect-error to be removed in v18 when all custom scalars will have default method */
-        return GraphQLBoolean.parseConstLiteral(parseConstValue(str));
+        return GraphQLBoolean.coerceInputLiteral(parseConstValue(str));
       }
 
-      expect(parseConstLiteral('true')).to.equal(true);
-      expect(parseConstLiteral('false')).to.equal(false);
+      expect(coerceInputLiteral('true')).to.equal(true);
+      expect(coerceInputLiteral('false')).to.equal(false);
 
-      expect(() => parseConstLiteral('null')).to.throw(
+      expect(() => coerceInputLiteral('null')).to.throw(
         'Boolean cannot represent a non boolean value: null',
       );
-      expect(() => parseConstLiteral('0')).to.throw(
+      expect(() => coerceInputLiteral('0')).to.throw(
         'Boolean cannot represent a non boolean value: 0',
       );
-      expect(() => parseConstLiteral('1')).to.throw(
+      expect(() => coerceInputLiteral('1')).to.throw(
         'Boolean cannot represent a non boolean value: 1',
       );
-      expect(() => parseConstLiteral('0.1')).to.throw(
+      expect(() => coerceInputLiteral('0.1')).to.throw(
         'Boolean cannot represent a non boolean value: 0.1',
       );
-      expect(() => parseConstLiteral('""')).to.throw(
+      expect(() => coerceInputLiteral('""')).to.throw(
         'Boolean cannot represent a non boolean value: ""',
       );
-      expect(() => parseConstLiteral('"false"')).to.throw(
+      expect(() => coerceInputLiteral('"false"')).to.throw(
         'Boolean cannot represent a non boolean value: "false"',
       );
-      expect(() => parseConstLiteral('[false]')).to.throw(
+      expect(() => coerceInputLiteral('[false]')).to.throw(
         'Boolean cannot represent a non boolean value: [false]',
       );
-      expect(() => parseConstLiteral('{ value: false }')).to.throw(
+      expect(() => coerceInputLiteral('{ value: false }')).to.throw(
         'Boolean cannot represent a non boolean value: { value: false }',
       );
-      expect(() => parseConstLiteral('ENUM_VALUE')).to.throw(
+      expect(() => coerceInputLiteral('ENUM_VALUE')).to.throw(
         'Boolean cannot represent a non boolean value: ENUM_VALUE',
       );
     });
@@ -561,44 +561,44 @@ describe('Type System: Specified scalar types', () => {
       );
     });
 
-    it('parseConstLiteral', () => {
-      function parseConstLiteral(str: string) {
+    it('coerceInputLiteral', () => {
+      function coerceInputLiteral(str: string) {
         /* @ts-expect-error to be removed in v18 when all custom scalars will have default method */
-        return GraphQLID.parseConstLiteral(parseConstValue(str));
+        return GraphQLID.coerceInputLiteral(parseConstValue(str));
       }
 
-      expect(parseConstLiteral('""')).to.equal('');
-      expect(parseConstLiteral('"1"')).to.equal('1');
-      expect(parseConstLiteral('"foo"')).to.equal('foo');
-      expect(parseConstLiteral('"""foo"""')).to.equal('foo');
-      expect(parseConstLiteral('1')).to.equal('1');
-      expect(parseConstLiteral('0')).to.equal('0');
-      expect(parseConstLiteral('-1')).to.equal('-1');
+      expect(coerceInputLiteral('""')).to.equal('');
+      expect(coerceInputLiteral('"1"')).to.equal('1');
+      expect(coerceInputLiteral('"foo"')).to.equal('foo');
+      expect(coerceInputLiteral('"""foo"""')).to.equal('foo');
+      expect(coerceInputLiteral('1')).to.equal('1');
+      expect(coerceInputLiteral('0')).to.equal('0');
+      expect(coerceInputLiteral('-1')).to.equal('-1');
 
       // Support arbitrary long numbers even if they can't be represented in JS
-      expect(parseConstLiteral('90071992547409910')).to.equal(
+      expect(coerceInputLiteral('90071992547409910')).to.equal(
         '90071992547409910',
       );
-      expect(parseConstLiteral('-90071992547409910')).to.equal(
+      expect(coerceInputLiteral('-90071992547409910')).to.equal(
         '-90071992547409910',
       );
 
-      expect(() => parseConstLiteral('null')).to.throw(
+      expect(() => coerceInputLiteral('null')).to.throw(
         'ID cannot represent a non-string and non-integer value: null',
       );
-      expect(() => parseConstLiteral('0.1')).to.throw(
+      expect(() => coerceInputLiteral('0.1')).to.throw(
         'ID cannot represent a non-string and non-integer value: 0.1',
       );
-      expect(() => parseConstLiteral('false')).to.throw(
+      expect(() => coerceInputLiteral('false')).to.throw(
         'ID cannot represent a non-string and non-integer value: false',
       );
-      expect(() => parseConstLiteral('["1"]')).to.throw(
+      expect(() => coerceInputLiteral('["1"]')).to.throw(
         'ID cannot represent a non-string and non-integer value: ["1"]',
       );
-      expect(() => parseConstLiteral('{ value: "1" }')).to.throw(
+      expect(() => coerceInputLiteral('{ value: "1" }')).to.throw(
         'ID cannot represent a non-string and non-integer value: { value: "1" }',
       );
-      expect(() => parseConstLiteral('ENUM_VALUE')).to.throw(
+      expect(() => coerceInputLiteral('ENUM_VALUE')).to.throw(
         'ID cannot represent a non-string and non-integer value: ENUM_VALUE',
       );
     });

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -568,9 +568,9 @@ export interface GraphQLScalarTypeExtensions {
  *  - parseLiteral(ast): Implements "Input Coercion" for literals including
  *    non-specified replacement of variables embedded within complex scalars.
  *    This method will be removed in v18 favor of the combination of the
- *    `replaceVariables()` utility and the `parseConstLiteral()` method.
+ *    `replaceVariables()` utility and the `coerceInputLiteral()` method.
  *
- *  - parseConstLiteral(ast): Implements "Input Coercion" for constant literals.
+ *  - coerceInputLiteral(ast): Implements "Input Coercion" for constant literals.
  *    Given an GraphQL literal (AST) (for example, an argument value), produces
  *    an internal value valid for this type. Returns undefined or throws an
  *    error to indicate invalid values.
@@ -586,9 +586,9 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal> {
   specifiedByURL: Maybe<string>;
   serialize: GraphQLScalarSerializer<TExternal>;
   parseValue: GraphQLScalarValueParser<TInternal>;
-  /** @deprecated use `replaceVariables()` and `parseConstLiteral()` instead, `parseLiteral()` will be deprecated in v18 */
+  /** @deprecated use `replaceVariables()` and `coerceInputLiteral()` instead, `parseLiteral()` will be deprecated in v18 */
   parseLiteral: GraphQLScalarLiteralParser<TInternal>;
-  parseConstLiteral: GraphQLScalarConstLiteralParser<TInternal> | undefined;
+  coerceInputLiteral: GraphQLScalarInputLiteralCoercer<TInternal> | undefined;
   valueToLiteral: GraphQLScalarValueToLiteral | undefined;
   extensions: Readonly<GraphQLScalarTypeExtensions>;
   astNode: Maybe<ScalarTypeDefinitionNode>;
@@ -608,7 +608,7 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal> {
     this.parseLiteral =
       config.parseLiteral ??
       ((node, variables) => parseValue(valueFromASTUntyped(node, variables)));
-    this.parseConstLiteral = config.parseConstLiteral;
+    this.coerceInputLiteral = config.coerceInputLiteral;
     this.valueToLiteral = config.valueToLiteral;
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
@@ -622,11 +622,11 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal> {
       );
     }
 
-    if (config.parseConstLiteral) {
+    if (config.coerceInputLiteral) {
       devAssert(
         typeof config.parseValue === 'function' &&
-          typeof config.parseConstLiteral === 'function',
-        `${this.name} must provide both "parseValue" and "parseConstLiteral" functions.`,
+          typeof config.coerceInputLiteral === 'function',
+        `${this.name} must provide both "parseValue" and "coerceInputLiteral" functions.`,
       );
     }
   }
@@ -643,7 +643,7 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal> {
       serialize: this.serialize,
       parseValue: this.parseValue,
       parseLiteral: this.parseLiteral,
-      parseConstLiteral: this.parseConstLiteral,
+      coerceInputLiteral: this.coerceInputLiteral,
       valueToLiteral: this.valueToLiteral,
       extensions: this.extensions,
       astNode: this.astNode,
@@ -668,12 +668,13 @@ export type GraphQLScalarValueParser<TInternal> = (
   inputValue: unknown,
 ) => TInternal;
 
+/* @deprecated in favor of GraphQLScalarInputLiteralCoercer, will be removed in v18 */
 export type GraphQLScalarLiteralParser<TInternal> = (
   valueNode: ValueNode,
   variables: Maybe<ObjMap<unknown>>,
 ) => Maybe<TInternal>;
 
-export type GraphQLScalarConstLiteralParser<TInternal> = (
+export type GraphQLScalarInputLiteralCoercer<TInternal> = (
   valueNode: ConstValueNode,
 ) => Maybe<TInternal>;
 
@@ -690,10 +691,10 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   /** Parses an externally provided value to use as an input. */
   parseValue?: GraphQLScalarValueParser<TInternal> | undefined;
   /** Parses an externally provided literal value to use as an input. */
-  /** @deprecated use `replaceVariables()` and `parseConstLiteral()` instead, `parseLiteral()` will be deprecated in v18 */
+  /** @deprecated use `replaceVariables()` and `coerceInputLiteral()` instead, `parseLiteral()` will be deprecated in v18 */
   parseLiteral?: GraphQLScalarLiteralParser<TInternal> | undefined;
   /** Parses an externally provided const literal value to use as an input. */
-  parseConstLiteral?: GraphQLScalarConstLiteralParser<TInternal> | undefined;
+  coerceInputLiteral?: GraphQLScalarInputLiteralCoercer<TInternal> | undefined;
   /** Translates an externally provided value to a literal (AST). */
   valueToLiteral?: GraphQLScalarValueToLiteral | undefined;
   extensions?: Maybe<Readonly<GraphQLScalarTypeExtensions>>;
@@ -706,7 +707,7 @@ interface GraphQLScalarTypeNormalizedConfig<TInternal, TExternal>
   serialize: GraphQLScalarSerializer<TExternal>;
   parseValue: GraphQLScalarValueParser<TInternal>;
   parseLiteral: GraphQLScalarLiteralParser<TInternal>;
-  parseConstLiteral: GraphQLScalarConstLiteralParser<TInternal> | undefined;
+  coerceInputLiteral: GraphQLScalarInputLiteralCoercer<TInternal> | undefined;
   extensions: Readonly<GraphQLScalarTypeExtensions>;
   extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
 }
@@ -1444,17 +1445,20 @@ export class GraphQLEnumType /* <T> */ {
     return enumValue.value;
   }
 
-  /** @deprecated use `parseConstLiteral()` instead, `parseLiteral()` will be deprecated in v18 */
+  /** @deprecated use `coerceInputLiteral()` instead, `parseLiteral()` will be deprecated in v18 */
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
     hideSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
-    return this.parseConstLiteral(valueNode as ConstValueNode, hideSuggestions);
+    return this.coerceInputLiteral(
+      valueNode as ConstValueNode,
+      hideSuggestions,
+    );
   }
 
-  parseConstLiteral(
+  coerceInputLiteral(
     valueNode: ConstValueNode,
     hideSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -118,7 +118,9 @@ export type {
   GraphQLUnionTypeExtensions,
   GraphQLScalarSerializer,
   GraphQLScalarValueParser,
+  /* @deprecated in favor of GraphQLScalarInputLiteralCoercer, will be removed in v18 */
   GraphQLScalarLiteralParser,
+  GraphQLScalarInputLiteralCoercer,
   GraphQLDefaultValueUsage,
 } from './definition.js';
 

--- a/src/type/scalars.ts
+++ b/src/type/scalars.ts
@@ -68,7 +68,7 @@ export const GraphQLInt = new GraphQLScalarType<number>({
     return inputValue;
   },
 
-  parseConstLiteral(valueNode) {
+  coerceInputLiteral(valueNode) {
     if (valueNode.kind !== Kind.INT) {
       throw new GraphQLError(
         `Int cannot represent non-integer value: ${print(valueNode)}`,
@@ -130,7 +130,7 @@ export const GraphQLFloat = new GraphQLScalarType<number>({
     return inputValue;
   },
 
-  parseConstLiteral(valueNode) {
+  coerceInputLiteral(valueNode) {
     if (valueNode.kind !== Kind.FLOAT && valueNode.kind !== Kind.INT) {
       throw new GraphQLError(
         `Float cannot represent non numeric value: ${print(valueNode)}`,
@@ -180,7 +180,7 @@ export const GraphQLString = new GraphQLScalarType<string>({
     return inputValue;
   },
 
-  parseConstLiteral(valueNode) {
+  coerceInputLiteral(valueNode) {
     if (valueNode.kind !== Kind.STRING) {
       throw new GraphQLError(
         `String cannot represent a non string value: ${print(valueNode)}`,
@@ -224,7 +224,7 @@ export const GraphQLBoolean = new GraphQLScalarType<boolean>({
     return inputValue;
   },
 
-  parseConstLiteral(valueNode) {
+  coerceInputLiteral(valueNode) {
     if (valueNode.kind !== Kind.BOOLEAN) {
       throw new GraphQLError(
         `Boolean cannot represent a non boolean value: ${print(valueNode)}`,
@@ -270,7 +270,7 @@ export const GraphQLID = new GraphQLScalarType<string>({
     throw new GraphQLError(`ID cannot represent value: ${inspect(inputValue)}`);
   },
 
-  parseConstLiteral(valueNode) {
+  coerceInputLiteral(valueNode) {
     if (valueNode.kind !== Kind.STRING && valueNode.kind !== Kind.INT) {
       throw new GraphQLError(
         'ID cannot represent a non-string and non-integer value: ' +

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -669,10 +669,10 @@ describe('coerceInputLiteral', () => {
     test('123.456', GraphQLID, undefined);
   });
 
-  it('convert using parseConstLiteral from a custom scalar type', () => {
+  it('convert using coerceInputLiteral from a custom scalar type', () => {
     const passthroughScalar = new GraphQLScalarType({
       name: 'PassthroughScalar',
-      parseConstLiteral(node) {
+      coerceInputLiteral(node) {
         invariant(node.kind === 'StringValue');
         return node.value;
       },
@@ -683,7 +683,7 @@ describe('coerceInputLiteral', () => {
 
     const printScalar = new GraphQLScalarType({
       name: 'PrintScalar',
-      parseConstLiteral(node) {
+      coerceInputLiteral(node) {
         return `~~~${print(node)}~~~`;
       },
       parseValue: identityFunc,
@@ -700,7 +700,7 @@ describe('coerceInputLiteral', () => {
 
     const throwScalar = new GraphQLScalarType({
       name: 'ThrowScalar',
-      parseConstLiteral() {
+      coerceInputLiteral() {
         throw new Error('Test');
       },
       parseValue: identityFunc,
@@ -710,7 +710,7 @@ describe('coerceInputLiteral', () => {
 
     const returnUndefinedScalar = new GraphQLScalarType({
       name: 'ReturnUndefinedScalar',
-      parseConstLiteral() {
+      coerceInputLiteral() {
         return undefined;
       },
       parseValue: identityFunc,

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -408,8 +408,8 @@ export function coerceInputLiteral(
 
   const leafType = assertLeafType(type);
   try {
-    return leafType.parseConstLiteral
-      ? leafType.parseConstLiteral(
+    return leafType.coerceInputLiteral
+      ? leafType.coerceInputLiteral(
           replaceVariables(valueNode, variableValues, fragmentVariableValues),
           hideSuggestions,
         )

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -155,11 +155,11 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
     return;
   }
 
-  // Scalars and Enums determine if a literal value is valid via parseConstLiteral(),
+  // Scalars and Enums determine if a literal value is valid via coerceInputLiteral(),
   // which may throw or return undefined to indicate an invalid value.
   try {
-    const parseResult = type.parseConstLiteral
-      ? type.parseConstLiteral(replaceVariables(node), context.hideSuggestions)
+    const parseResult = type.coerceInputLiteral
+      ? type.coerceInputLiteral(replaceVariables(node), context.hideSuggestions)
       : type.parseLiteral(node, undefined, context.hideSuggestions);
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);


### PR DESCRIPTION
the new method was introduced in #3812 with upgrade path improved in #4209.

This PR completes polishes this work a bit:

1. The method is renamed to `coerceInputLiteral()` following the naming convention suggested in #2357, with the other methods to be renamed in later PRs.
2. The type of the method `GraphQLScalarInputLiteralCoercer` is exported, which was not done in the initial work. The old `GraphQLScalarLiteralParser` type is deprecated.