### PR TITLE
suggestions

### DIFF
--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -55,7 +55,7 @@ interface CollectFieldsContext {
   operation: OperationDefinitionNode;
   runtimeType: GraphQLObjectType;
   visitedFragmentNames: Set<string>;
-  shouldProvideSuggestions: boolean;
+  maskSuggestions: boolean;
 }
 
 /**
@@ -74,7 +74,7 @@ export function collectFields(
   variableValues: VariableValues,
   runtimeType: GraphQLObjectType,
   operation: OperationDefinitionNode,
-  shouldProvideSuggestions: boolean,
+  maskSuggestions: boolean,
 ): {
   groupedFieldSet: GroupedFieldSet;
   newDeferUsages: ReadonlyArray<DeferUsage>;
@@ -88,7 +88,7 @@ export function collectFields(
     runtimeType,
     operation,
     visitedFragmentNames: new Set(),
-    shouldProvideSuggestions,
+    maskSuggestions,
   };
 
   collectFieldsImpl(
@@ -118,7 +118,7 @@ export function collectSubfields(
   operation: OperationDefinitionNode,
   returnType: GraphQLObjectType,
   fieldDetailsList: FieldDetailsList,
-  shouldProvideSuggestions: boolean,
+  maskSuggestions: boolean,
 ): {
   groupedFieldSet: GroupedFieldSet;
   newDeferUsages: ReadonlyArray<DeferUsage>;
@@ -130,7 +130,7 @@ export function collectSubfields(
     runtimeType: returnType,
     operation,
     visitedFragmentNames: new Set(),
-    shouldProvideSuggestions,
+    maskSuggestions,
   };
   const subGroupedFieldSet = new AccumulatorMap<string, FieldDetails>();
   const newDeferUsages: Array<DeferUsage> = [];
@@ -178,12 +178,7 @@ function collectFieldsImpl(
     switch (selection.kind) {
       case Kind.FIELD: {
         if (
-          !shouldIncludeNode(
-            selection,
-            variableValues,
-            fragmentVariableValues,
-            context.shouldProvideSuggestions,
-          )
+          !shouldIncludeNode(selection, variableValues, fragmentVariableValues)
         ) {
           continue;
         }
@@ -200,7 +195,6 @@ function collectFieldsImpl(
             selection,
             variableValues,
             fragmentVariableValues,
-            context.shouldProvideSuggestions,
           ) ||
           !doesFragmentConditionMatch(schema, selection, runtimeType)
         ) {
@@ -213,7 +207,6 @@ function collectFieldsImpl(
           fragmentVariableValues,
           selection,
           deferUsage,
-          context.shouldProvideSuggestions,
         );
 
         if (!newDeferUsage) {
@@ -248,7 +241,6 @@ function collectFieldsImpl(
           fragmentVariableValues,
           selection,
           deferUsage,
-          context.shouldProvideSuggestions,
         );
 
         if (
@@ -258,7 +250,6 @@ function collectFieldsImpl(
               selection,
               variableValues,
               fragmentVariableValues,
-              context.shouldProvideSuggestions,
             ))
         ) {
           continue;
@@ -279,8 +270,8 @@ function collectFieldsImpl(
             selection,
             fragmentVariableSignatures,
             variableValues,
-            context.shouldProvideSuggestions,
             fragmentVariableValues,
+            false,
           );
         }
 
@@ -316,19 +307,16 @@ function collectFieldsImpl(
  * deferred based on the experimental flag, defer directive present and
  * not disabled by the "if" argument.
  */
-// eslint-disable-next-line @typescript-eslint/max-params
 function getDeferUsage(
   operation: OperationDefinitionNode,
   variableValues: VariableValues,
   fragmentVariableValues: VariableValues | undefined,
   node: FragmentSpreadNode | InlineFragmentNode,
   parentDeferUsage: DeferUsage | undefined,
-  shouldProvideSuggestions: boolean,
 ): DeferUsage | undefined {
   const defer = getDirectiveValues(
     GraphQLDeferDirective,
     node,
-    shouldProvideSuggestions,
     variableValues,
     fragmentVariableValues,
   );
@@ -360,12 +348,10 @@ function shouldIncludeNode(
   node: FragmentSpreadNode | FieldNode | InlineFragmentNode,
   variableValues: VariableValues,
   fragmentVariableValues: VariableValues | undefined,
-  shouldProvideSuggestions: boolean,
 ): boolean {
   const skip = getDirectiveValues(
     GraphQLSkipDirective,
     node,
-    shouldProvideSuggestions,
     variableValues,
     fragmentVariableValues,
   );
@@ -376,7 +362,6 @@ function shouldIncludeNode(
   const include = getDirectiveValues(
     GraphQLIncludeDirective,
     node,
-    shouldProvideSuggestions,
     variableValues,
     fragmentVariableValues,
   );

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -179,12 +179,7 @@ function collectFieldsImpl(
     switch (selection.kind) {
       case Kind.FIELD: {
         if (
-          !shouldIncludeNode(
-            selection,
-            variableValues,
-            fragmentVariableValues,
-            maskSuggestions,
-          )
+          !shouldIncludeNode(selection, variableValues, fragmentVariableValues)
         ) {
           continue;
         }
@@ -201,7 +196,6 @@ function collectFieldsImpl(
             selection,
             variableValues,
             fragmentVariableValues,
-            maskSuggestions,
           ) ||
           !doesFragmentConditionMatch(schema, selection, runtimeType)
         ) {
@@ -214,7 +208,6 @@ function collectFieldsImpl(
           fragmentVariableValues,
           selection,
           deferUsage,
-          maskSuggestions,
         );
 
         if (!newDeferUsage) {
@@ -249,7 +242,6 @@ function collectFieldsImpl(
           fragmentVariableValues,
           selection,
           deferUsage,
-          maskSuggestions,
         );
 
         if (
@@ -259,7 +251,6 @@ function collectFieldsImpl(
               selection,
               variableValues,
               fragmentVariableValues,
-              maskSuggestions,
             ))
         ) {
           continue;
@@ -279,9 +270,9 @@ function collectFieldsImpl(
           newFragmentVariableValues = getFragmentVariableValues(
             selection,
             fragmentVariableSignatures,
+            maskSuggestions,
             variableValues,
             fragmentVariableValues,
-            maskSuggestions,
           );
         }
 
@@ -317,21 +308,19 @@ function collectFieldsImpl(
  * deferred based on the experimental flag, defer directive present and
  * not disabled by the "if" argument.
  */
-// eslint-disable-next-line @typescript-eslint/max-params
 function getDeferUsage(
   operation: OperationDefinitionNode,
   variableValues: VariableValues,
   fragmentVariableValues: VariableValues | undefined,
   node: FragmentSpreadNode | InlineFragmentNode,
   parentDeferUsage: DeferUsage | undefined,
-  maskSuggestions: boolean,
 ): DeferUsage | undefined {
   const defer = getDirectiveValues(
     GraphQLDeferDirective,
     node,
+    false,
     variableValues,
     fragmentVariableValues,
-    maskSuggestions,
   );
 
   if (!defer) {
@@ -361,14 +350,13 @@ function shouldIncludeNode(
   node: FragmentSpreadNode | FieldNode | InlineFragmentNode,
   variableValues: VariableValues,
   fragmentVariableValues: VariableValues | undefined,
-  maskSuggestions: boolean,
 ): boolean {
   const skip = getDirectiveValues(
     GraphQLSkipDirective,
     node,
+    false,
     variableValues,
     fragmentVariableValues,
-    maskSuggestions,
   );
   if (skip?.if === true) {
     return false;
@@ -377,9 +365,9 @@ function shouldIncludeNode(
   const include = getDirectiveValues(
     GraphQLIncludeDirective,
     node,
+    false,
     variableValues,
     fragmentVariableValues,
-    maskSuggestions,
   );
   if (include?.if === false) {
     return false;

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -804,9 +804,9 @@ function executeField(
     const args = experimentalGetArgumentValues(
       fieldDetailsList[0].node,
       fieldDef.args,
+      maskSuggestions,
       variableValues,
       fieldDetailsList[0].fragmentVariableValues,
-      maskSuggestions,
     );
 
     // The resolve function's optional third argument is a context value that
@@ -1110,15 +1110,15 @@ function getStreamUsage(
       ._streamUsage;
   }
 
-  const { operation, variableValues, maskSuggestions } = validatedExecutionArgs;
+  const { operation, variableValues } = validatedExecutionArgs;
   // validation only allows equivalent streams on multiple fields, so it is
   // safe to only check the first fieldNode for the stream directive
   const stream = getDirectiveValues(
     GraphQLStreamDirective,
     fieldDetailsList[0].node,
+    false,
     variableValues,
     fieldDetailsList[0].fragmentVariableValues,
-    maskSuggestions,
   );
 
   if (!stream) {
@@ -2137,8 +2137,8 @@ function executeSubscription(
     const args = getArgumentValues(
       fieldDef,
       fieldNodes[0],
-      variableValues,
       maskSuggestions,
+      variableValues,
     );
 
     // Call the `subscribe()` resolver or the default resolver to produce an

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -59,6 +59,7 @@ export function getVariableValues(
 ): VariableValuesOrErrors {
   const errors: Array<GraphQLError> = [];
   const maxErrors = options?.maxErrors;
+  const maskSuggestions = options?.maskSuggestions;
   try {
     const variableValues = coerceVariableValues(
       schema,
@@ -72,7 +73,7 @@ export function getVariableValues(
         }
         errors.push(error);
       },
-      options?.maskSuggestions,
+      maskSuggestions,
     );
 
     if (errors.length === 0) {
@@ -90,7 +91,7 @@ function coerceVariableValues(
   varDefNodes: ReadonlyArray<VariableDefinitionNode>,
   inputs: { readonly [variable: string]: unknown },
   onError: (error: GraphQLError) => void,
-  maskSuggestions?: Maybe<boolean>,
+  maskSuggestions: boolean | undefined,
 ): VariableValues {
   const sources: ObjMap<VariableValueSource> = Object.create(null);
   const coerced: ObjMap<unknown> = Object.create(null);
@@ -142,6 +143,7 @@ function coerceVariableValues(
     coerced[varName] = coerceInputValue(
       value,
       varType,
+      maskSuggestions,
       (path, invalidValue, error) => {
         let prefix =
           `Variable "$${varName}" got invalid value ` + inspect(invalidValue);
@@ -155,7 +157,6 @@ function coerceVariableValues(
           }),
         );
       },
-      maskSuggestions,
     );
   }
 
@@ -165,9 +166,9 @@ function coerceVariableValues(
 export function getFragmentVariableValues(
   fragmentSpreadNode: FragmentSpreadNode,
   fragmentSignatures: ReadOnlyObjMap<GraphQLVariableSignature>,
+  maskSuggestions: boolean,
   variableValues: VariableValues,
   fragmentVariableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
 ): VariableValues {
   const varSignatures: Array<GraphQLVariableSignature> = [];
   const sources = Object.create(null);
@@ -184,9 +185,9 @@ export function getFragmentVariableValues(
   const coerced = experimentalGetArgumentValues(
     fragmentSpreadNode,
     varSignatures,
+    maskSuggestions,
     variableValues,
     fragmentVariableValues,
-    maskSuggestions,
   );
 
   return { sources, coerced };
@@ -203,24 +204,23 @@ export function getFragmentVariableValues(
 export function getArgumentValues(
   def: GraphQLField<unknown, unknown> | GraphQLDirective,
   node: FieldNode | DirectiveNode,
+  maskSuggestions?: boolean | undefined,
   variableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
 ): { [argument: string]: unknown } {
   return experimentalGetArgumentValues(
     node,
     def.args,
-    variableValues,
-    undefined,
     maskSuggestions,
+    variableValues,
   );
 }
 
 export function experimentalGetArgumentValues(
   node: FieldNode | DirectiveNode | FragmentSpreadNode,
   argDefs: ReadonlyArray<GraphQLArgument | GraphQLVariableSignature>,
-  variableValues: Maybe<VariableValues>,
+  maskSuggestions?: boolean | undefined,
+  variableValues?: Maybe<VariableValues>,
   fragmentVariablesValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
 ): { [argument: string]: unknown } {
   const coercedValues: { [argument: string]: unknown } = {};
 
@@ -294,9 +294,9 @@ export function experimentalGetArgumentValues(
     const coercedValue = coerceInputLiteral(
       valueNode,
       argType,
+      maskSuggestions,
       variableValues,
       fragmentVariablesValues,
-      maskSuggestions,
     );
     if (coercedValue === undefined) {
       // Note: ValuesOfCorrectTypeRule validation should catch this before
@@ -328,9 +328,9 @@ export function experimentalGetArgumentValues(
 export function getDirectiveValues(
   directiveDef: GraphQLDirective,
   node: { readonly directives?: ReadonlyArray<DirectiveNode> | undefined },
+  maskSuggestions?: boolean | undefined,
   variableValues?: Maybe<VariableValues>,
   fragmentVariableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
 ): undefined | { [argument: string]: unknown } {
   const directiveNode = node.directives?.find(
     (directive) => directive.name.value === directiveDef.name,
@@ -340,9 +340,9 @@ export function getDirectiveValues(
     return experimentalGetArgumentValues(
       directiveNode,
       directiveDef.args,
+      maskSuggestions,
       variableValues,
       fragmentVariableValues,
-      maskSuggestions,
     );
   }
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -67,7 +67,7 @@ export interface GraphQLArgs {
   operationName?: Maybe<string>;
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
-  maskSuggestions?: Maybe<boolean>;
+  maskSuggestions?: boolean;
 }
 
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {
@@ -121,7 +121,7 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
 
   // Validate
   const validationErrors = validate(schema, document, undefined, {
-    maskSuggestions,
+    maskSuggestions: maskSuggestions ?? false,
   });
   if (validationErrors.length > 0) {
     return { errors: validationErrors };

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -61,6 +61,7 @@ import type { ExecutionResult } from './execution/types.js';
 export interface GraphQLArgs {
   schema: GraphQLSchema;
   source: string | Source;
+  maskSuggestions?: boolean;
   rootValue?: unknown;
   contextValue?: unknown;
   variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
@@ -101,6 +102,7 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
+    maskSuggestions,
   } = args;
 
   // Validate Schema
@@ -118,7 +120,9 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
   }
 
   // Validate
-  const validationErrors = validate(schema, document);
+  const validationErrors = validate(schema, document, undefined, {
+    maskSuggestions,
+  });
   if (validationErrors.length > 0) {
     return { errors: validationErrors };
   }
@@ -133,5 +137,6 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
+    maskSuggestions,
   });
 }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -61,13 +61,13 @@ import type { ExecutionResult } from './execution/types.js';
 export interface GraphQLArgs {
   schema: GraphQLSchema;
   source: string | Source;
-  maskSuggestions?: boolean;
   rootValue?: unknown;
   contextValue?: unknown;
   variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
   operationName?: Maybe<string>;
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  maskSuggestions?: Maybe<boolean>;
 }
 
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -135,7 +135,7 @@ const schema = new GraphQLSchema({
 function executeQuery(
   source: string,
   variableValues?: { readonly [variable: string]: unknown },
-  maskSuggestions = false,
+  maskSuggestions: boolean = false,
 ) {
   return graphqlSync({
     schema,

--- a/src/type/__tests__/enumType-test.ts
+++ b/src/type/__tests__/enumType-test.ts
@@ -135,8 +135,14 @@ const schema = new GraphQLSchema({
 function executeQuery(
   source: string,
   variableValues?: { readonly [variable: string]: unknown },
+  maskSuggestions = false,
 ) {
-  return graphqlSync({ schema, source, variableValues });
+  return graphqlSync({
+    schema,
+    source,
+    variableValues,
+    maskSuggestions,
+  });
 }
 
 describe('Type System: Enum Values', () => {
@@ -186,6 +192,23 @@ describe('Type System: Enum Values', () => {
         {
           message:
             'Value "GREENISH" does not exist in "Color" enum. Did you mean the enum value "GREEN"?',
+          locations: [{ line: 1, column: 23 }],
+        },
+      ],
+    });
+  });
+
+  it('does not accept values not in the enum (no suggestions)', () => {
+    const result = executeQuery(
+      '{ colorEnum(fromEnum: GREENISH) }',
+      undefined,
+      true,
+    );
+
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'Value "GREENISH" does not exist in "Color" enum.',
           locations: [{ line: 1, column: 23 }],
         },
       ],

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1424,7 +1424,7 @@ export class GraphQLEnumType /* <T> */ {
 
   parseValue(
     inputValue: unknown,
-    maskSuggestions?: Maybe<boolean>,
+    maskSuggestions?: boolean | undefined,
   ): Maybe<any> /* T */ {
     if (typeof inputValue !== 'string') {
       const valueStr = inspect(inputValue);
@@ -1448,7 +1448,7 @@ export class GraphQLEnumType /* <T> */ {
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
-    maskSuggestions?: Maybe<boolean>,
+    maskSuggestions?: boolean | undefined,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
     return this.parseConstLiteral(valueNode as ConstValueNode, maskSuggestions);

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1422,12 +1422,15 @@ export class GraphQLEnumType /* <T> */ {
     return enumValue.name;
   }
 
-  parseValue(inputValue: unknown): Maybe<any> /* T */ {
+  parseValue(
+    inputValue: unknown,
+    shouldProvideSuggestions: boolean,
+  ): Maybe<any> /* T */ {
     if (typeof inputValue !== 'string') {
       const valueStr = inspect(inputValue);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-string value: ${valueStr}.` +
-          didYouMeanEnumValue(this, valueStr),
+          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
       );
     }
 
@@ -1435,7 +1438,9 @@ export class GraphQLEnumType /* <T> */ {
     if (enumValue == null) {
       throw new GraphQLError(
         `Value "${inputValue}" does not exist in "${this.name}" enum.` +
-          didYouMeanEnumValue(this, inputValue),
+          (shouldProvideSuggestions
+            ? didYouMeanEnumValue(this, inputValue)
+            : ''),
       );
     }
     return enumValue.value;
@@ -1445,17 +1450,24 @@ export class GraphQLEnumType /* <T> */ {
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
+    shouldProvideSuggestions: boolean,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
-    return this.parseConstLiteral(valueNode as ConstValueNode);
+    return this.parseConstLiteral(
+      valueNode as ConstValueNode,
+      shouldProvideSuggestions,
+    );
   }
 
-  parseConstLiteral(valueNode: ConstValueNode): Maybe<any> /* T */ {
+  parseConstLiteral(
+    valueNode: ConstValueNode,
+    shouldProvideSuggestions: boolean,
+  ): Maybe<any> /* T */ {
     if (valueNode.kind !== Kind.ENUM) {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-enum value: ${valueStr}.` +
-          didYouMeanEnumValue(this, valueStr),
+          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
         { nodes: valueNode },
       );
     }
@@ -1465,7 +1477,7 @@ export class GraphQLEnumType /* <T> */ {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Value "${valueStr}" does not exist in "${this.name}" enum.` +
-          didYouMeanEnumValue(this, valueStr),
+          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
         { nodes: valueNode },
       );
     }

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1424,13 +1424,13 @@ export class GraphQLEnumType /* <T> */ {
 
   parseValue(
     inputValue: unknown,
-    shouldProvideSuggestions: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     if (typeof inputValue !== 'string') {
       const valueStr = inspect(inputValue);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-string value: ${valueStr}.` +
-          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
       );
     }
 
@@ -1438,9 +1438,7 @@ export class GraphQLEnumType /* <T> */ {
     if (enumValue == null) {
       throw new GraphQLError(
         `Value "${inputValue}" does not exist in "${this.name}" enum.` +
-          (shouldProvideSuggestions
-            ? didYouMeanEnumValue(this, inputValue)
-            : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, inputValue)),
       );
     }
     return enumValue.value;
@@ -1450,24 +1448,21 @@ export class GraphQLEnumType /* <T> */ {
   parseLiteral(
     valueNode: ValueNode,
     _variables: Maybe<ObjMap<unknown>>,
-    shouldProvideSuggestions: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     // Note: variables will be resolved to a value before calling this function.
-    return this.parseConstLiteral(
-      valueNode as ConstValueNode,
-      shouldProvideSuggestions,
-    );
+    return this.parseConstLiteral(valueNode as ConstValueNode, maskSuggestions);
   }
 
   parseConstLiteral(
     valueNode: ConstValueNode,
-    shouldProvideSuggestions: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ): Maybe<any> /* T */ {
     if (valueNode.kind !== Kind.ENUM) {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Enum "${this.name}" cannot represent non-enum value: ${valueStr}.` +
-          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
         { nodes: valueNode },
       );
     }
@@ -1477,7 +1472,7 @@ export class GraphQLEnumType /* <T> */ {
       const valueStr = print(valueNode);
       throw new GraphQLError(
         `Value "${valueStr}" does not exist in "${this.name}" enum.` +
-          (shouldProvideSuggestions ? didYouMeanEnumValue(this, valueStr) : ''),
+          (maskSuggestions ? '' : didYouMeanEnumValue(this, valueStr)),
         { nodes: valueNode },
       );
     }

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -55,6 +55,7 @@ function coerceValue(
   const value = coerceInputValue(
     inputValue,
     type,
+    true,
     (path, invalidValue, error) => {
       errors.push({ path, value: invalidValue, error: error.message });
     },
@@ -538,7 +539,7 @@ describe('coerceInputValue', () => {
   describe('with default onError', () => {
     it('throw error without path', () => {
       expect(() =>
-        coerceInputValue(null, new GraphQLNonNull(GraphQLInt)),
+        coerceInputValue(null, new GraphQLNonNull(GraphQLInt), true),
       ).to.throw(
         'Invalid value null: Expected non-nullable type "Int!" not to be null.',
       );
@@ -549,6 +550,7 @@ describe('coerceInputValue', () => {
         coerceInputValue(
           [null],
           new GraphQLList(new GraphQLNonNull(GraphQLInt)),
+          true,
         ),
       ).to.throw(
         'Invalid value null at "value[0]": Expected non-nullable type "Int!" not to be null.',
@@ -565,7 +567,7 @@ describe('coerceInputLiteral', () => {
     variableValues?: VariableValues,
   ) {
     const ast = parseValue(valueText);
-    const value = coerceInputLiteral(ast, type, variableValues);
+    const value = coerceInputLiteral(ast, type, true, variableValues);
     expect(value).to.deep.equal(expected);
   }
 
@@ -892,10 +894,14 @@ describe('coerceDefaultValue', () => {
     const defaultValueUsage = {
       literal: { kind: Kind.STRING, value: 'hello' },
     } as const;
-    expect(coerceDefaultValue(defaultValueUsage, spyScalar)).to.equal('hello');
+    expect(coerceDefaultValue(defaultValueUsage, spyScalar, true)).to.equal(
+      'hello',
+    );
 
     // Call a second time
-    expect(coerceDefaultValue(defaultValueUsage, spyScalar)).to.equal('hello');
+    expect(coerceDefaultValue(defaultValueUsage, spyScalar, true)).to.equal(
+      'hello',
+    );
     expect(parseValueCalls).to.deep.equal(['hello']);
   });
 });

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -50,16 +50,16 @@ interface CoerceError {
 function coerceValue(
   inputValue: unknown,
   type: GraphQLInputType,
-  maskSuggestions = false,
+  maskSuggestions: boolean = false,
 ): CoerceResult {
   const errors: Array<CoerceError> = [];
   const value = coerceInputValue(
     inputValue,
     type,
+    maskSuggestions,
     (path, invalidValue, error) => {
       errors.push({ path, value: invalidValue, error: error.message });
     },
-    maskSuggestions,
   );
 
   return { errors, value };
@@ -589,7 +589,7 @@ describe('coerceInputValue', () => {
   describe('with default onError', () => {
     it('throw error without path', () => {
       expect(() =>
-        coerceInputValue(null, new GraphQLNonNull(GraphQLInt), undefined, true),
+        coerceInputValue(null, new GraphQLNonNull(GraphQLInt), true),
       ).to.throw(
         'Invalid value null: Expected non-nullable type "Int!" not to be null.',
       );
@@ -600,7 +600,6 @@ describe('coerceInputValue', () => {
         coerceInputValue(
           [null],
           new GraphQLList(new GraphQLNonNull(GraphQLInt)),
-          undefined,
           true,
         ),
       ).to.throw(
@@ -618,13 +617,7 @@ describe('coerceInputLiteral', () => {
     variableValues?: VariableValues,
   ) {
     const ast = parseValue(valueText);
-    const value = coerceInputLiteral(
-      ast,
-      type,
-      variableValues,
-      undefined,
-      true,
-    );
+    const value = coerceInputLiteral(ast, type, true, variableValues);
     expect(value).to.deep.equal(expected);
   }
 

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -50,7 +50,7 @@ interface CoerceError {
 function coerceValue(
   inputValue: unknown,
   type: GraphQLInputType,
-  maskSuggestions: boolean = false,
+  maskSuggestions = false,
 ): CoerceResult {
   const errors: Array<CoerceError> = [];
   const value = coerceInputValue(

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -43,15 +43,15 @@ type OnErrorCB = (
 export function coerceInputValue(
   inputValue: unknown,
   type: GraphQLInputType,
+  maskSuggestions?: boolean,
   onError: OnErrorCB = defaultOnError,
-  maskSuggestions?: Maybe<boolean>,
 ): unknown {
   return coerceInputValueImpl(
     inputValue,
     type,
     onError,
     undefined,
-    maskSuggestions,
+    maskSuggestions ?? false,
   );
 }
 
@@ -73,7 +73,7 @@ function coerceInputValueImpl(
   type: GraphQLInputType,
   onError: OnErrorCB,
   path: Path | undefined,
-  maskSuggestions?: Maybe<boolean>,
+  maskSuggestions: boolean,
 ): unknown {
   if (isNonNullType(type)) {
     if (inputValue != null) {
@@ -260,9 +260,9 @@ function coerceInputValueImpl(
 export function coerceInputLiteral(
   valueNode: ValueNode,
   type: GraphQLInputType,
+  maskSuggestions?: boolean,
   variableValues?: Maybe<VariableValues>,
   fragmentVariableValues?: Maybe<VariableValues>,
-  maskSuggestions?: Maybe<boolean>,
 ): unknown {
   if (valueNode.kind === Kind.VARIABLE) {
     const coercedVariableValue = getCoercedVariableValue(
@@ -285,9 +285,9 @@ export function coerceInputLiteral(
     return coerceInputLiteral(
       valueNode,
       type.ofType,
+      maskSuggestions,
       variableValues,
       fragmentVariableValues,
-      maskSuggestions,
     );
   }
 
@@ -301,9 +301,9 @@ export function coerceInputLiteral(
       const itemValue = coerceInputLiteral(
         valueNode,
         type.ofType,
+        maskSuggestions,
         variableValues,
         fragmentVariableValues,
-        maskSuggestions,
       );
       if (itemValue === undefined) {
         return; // Invalid: intentionally return no value.
@@ -315,9 +315,9 @@ export function coerceInputLiteral(
       let itemValue = coerceInputLiteral(
         itemNode,
         type.ofType,
+        maskSuggestions,
         variableValues,
         fragmentVariableValues,
-        maskSuggestions,
       );
       if (itemValue === undefined) {
         if (
@@ -381,9 +381,9 @@ export function coerceInputLiteral(
         const fieldValue = coerceInputLiteral(
           fieldNode.value,
           field.type,
+          maskSuggestions,
           variableValues,
           fragmentVariableValues,
-          maskSuggestions,
         );
         if (fieldValue === undefined) {
           return; // Invalid: intentionally return no value.
@@ -443,19 +443,13 @@ function getCoercedVariableValue(
 export function coerceDefaultValue(
   defaultValue: GraphQLDefaultValueUsage,
   type: GraphQLInputType,
-  maskSuggestions?: Maybe<boolean>,
+  maskSuggestions?: boolean,
 ): unknown {
   // Memoize the result of coercing the default value in a hidden field.
   let coercedValue = (defaultValue as any)._memoizedCoercedValue;
   if (coercedValue === undefined) {
     coercedValue = defaultValue.literal
-      ? coerceInputLiteral(
-          defaultValue.literal,
-          type,
-          undefined,
-          undefined,
-          maskSuggestions,
-        )
+      ? coerceInputLiteral(defaultValue.literal, type, maskSuggestions)
       : defaultValue.value;
     (defaultValue as any)._memoizedCoercedValue = coercedValue;
   }

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -148,7 +148,7 @@ export function valueFromAST(
     // no value is returned.
     let result;
     try {
-      result = type.parseLiteral(valueNode, variables);
+      result = type.parseLiteral(valueNode, variables, true);
     } catch (_error) {
       return; // Invalid: intentionally return no value.
     }

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -188,7 +188,7 @@ export class ValidationContext extends ASTValidationContext {
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
-    maskSuggestions?: Maybe<boolean>,
+    maskSuggestions?: boolean,
   ) {
     super(ast, onError);
     this._schema = schema;

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -154,8 +154,8 @@ export class SDLValidationContext extends ASTValidationContext {
     this._schema = schema;
   }
 
-  get shouldProvideSuggestions() {
-    return true;
+  get maskSuggestions() {
+    return false;
   }
 
   get [Symbol.toStringTag]() {
@@ -181,29 +181,29 @@ export class ValidationContext extends ASTValidationContext {
     OperationDefinitionNode,
     ReadonlyArray<VariableUsage>
   >;
-  private _shouldProvideSuggestions: boolean;
+  private _maskSuggestions: boolean;
 
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
-    shouldProvideSuggestions?: boolean,
+    maskSuggestions?: Maybe<boolean>,
   ) {
     super(ast, onError);
     this._schema = schema;
     this._typeInfo = typeInfo;
     this._variableUsages = new Map();
     this._recursiveVariableUsages = new Map();
-    this._shouldProvideSuggestions = shouldProvideSuggestions ?? true;
+    this._maskSuggestions = maskSuggestions ?? false;
   }
 
   get [Symbol.toStringTag]() {
     return 'ValidationContext';
   }
 
-  get shouldProvideSuggestions() {
-    return this._shouldProvideSuggestions;
+  get maskSuggestions() {
+    return this._maskSuggestions;
   }
 
   getSchema(): GraphQLSchema {

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -154,6 +154,10 @@ export class SDLValidationContext extends ASTValidationContext {
     this._schema = schema;
   }
 
+  get shouldProvideSuggestions() {
+    return true;
+  }
+
   get [Symbol.toStringTag]() {
     return 'SDLValidationContext';
   }
@@ -177,22 +181,29 @@ export class ValidationContext extends ASTValidationContext {
     OperationDefinitionNode,
     ReadonlyArray<VariableUsage>
   >;
+  private _shouldProvideSuggestions: boolean;
 
   constructor(
     schema: GraphQLSchema,
     ast: DocumentNode,
     typeInfo: TypeInfo,
     onError: (error: GraphQLError) => void,
+    shouldProvideSuggestions?: boolean,
   ) {
     super(ast, onError);
     this._schema = schema;
     this._typeInfo = typeInfo;
     this._variableUsages = new Map();
     this._recursiveVariableUsages = new Map();
+    this._shouldProvideSuggestions = shouldProvideSuggestions ?? true;
   }
 
   get [Symbol.toStringTag]() {
     return 'ValidationContext';
+  }
+
+  get shouldProvideSuggestions() {
+    return this._shouldProvideSuggestions;
   }
 
   getSchema(): GraphQLSchema {

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
@@ -12,11 +12,12 @@ import { validate } from '../validate.js';
 
 import { expectValidationErrorsWithSchema } from './harness.js';
 
-function expectErrors(queryStr: string) {
+function expectErrors(queryStr: string, maskSuggestions = false) {
   return expectValidationErrorsWithSchema(
     testSchema,
     FieldsOnCorrectTypeRule,
     queryStr,
+    maskSuggestions,
   );
 }
 
@@ -135,6 +136,22 @@ describe('Validate: Fields on correct type', () => {
       {
         message:
           'Cannot query field "meowVolume" on type "Dog". Did you mean "barkVolume"?',
+        locations: [{ line: 3, column: 9 }],
+      },
+    ]);
+  });
+
+  it('Field not defined on fragment (no suggestions)', () => {
+    expectErrors(
+      `
+      fragment fieldNotDefined on Dog {
+        meowVolume
+      }
+    `,
+      true,
+    ).toDeepEqual([
+      {
+        message: 'Cannot query field "meowVolume" on type "Dog".',
         locations: [{ line: 3, column: 9 }],
       },
     ]);

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
@@ -12,7 +12,7 @@ import { validate } from '../validate.js';
 
 import { expectValidationErrorsWithSchema } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, maskSuggestions: boolean = false) {
   return expectValidationErrorsWithSchema(
     testSchema,
     FieldsOnCorrectTypeRule,

--- a/src/validation/__tests__/KnownArgumentNamesRule-test.ts
+++ b/src/validation/__tests__/KnownArgumentNamesRule-test.ts
@@ -14,7 +14,7 @@ import {
   expectValidationErrors,
 } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, maskSuggestions: boolean = false) {
   return expectValidationErrors(
     KnownArgumentNamesRule,
     queryStr,

--- a/src/validation/__tests__/KnownTypeNamesRule-test.ts
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.ts
@@ -12,8 +12,8 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string) {
-  return expectValidationErrors(KnownTypeNamesRule, queryStr);
+function expectErrors(queryStr: string, maskSuggestions = false) {
+  return expectValidationErrors(KnownTypeNamesRule, queryStr, maskSuggestions);
 }
 
 function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
@@ -73,6 +73,36 @@ describe('Validate: Known type names', () => {
       },
       {
         message: 'Unknown type "Peat". Did you mean "Pet" or "Cat"?',
+        locations: [{ line: 8, column: 29 }],
+      },
+    ]);
+  });
+
+  it('unknown type names are invalid (no suggestions)', () => {
+    expectErrors(
+      `
+      query Foo($var: [JumbledUpLetters!]!) {
+        user(id: 4) {
+          name
+          pets { ... on Badger { name }, ...PetFields }
+        }
+      }
+      fragment PetFields on Peat {
+        name
+      }
+    `,
+      true,
+    ).toDeepEqual([
+      {
+        message: 'Unknown type "JumbledUpLetters".',
+        locations: [{ line: 2, column: 24 }],
+      },
+      {
+        message: 'Unknown type "Badger".',
+        locations: [{ line: 5, column: 25 }],
+      },
+      {
+        message: 'Unknown type "Peat".',
         locations: [{ line: 8, column: 29 }],
       },
     ]);

--- a/src/validation/__tests__/KnownTypeNamesRule-test.ts
+++ b/src/validation/__tests__/KnownTypeNamesRule-test.ts
@@ -12,7 +12,7 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, maskSuggestions: boolean = false) {
   return expectValidationErrors(KnownTypeNamesRule, queryStr, maskSuggestions);
 }
 

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -19,8 +19,12 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string) {
-  return expectValidationErrors(ValuesOfCorrectTypeRule, queryStr);
+function expectErrors(queryStr: string, maskSuggestions = false) {
+  return expectValidationErrors(
+    ValuesOfCorrectTypeRule,
+    queryStr,
+    maskSuggestions,
+  );
 }
 
 function expectErrorsWithSchema(schema: GraphQLSchema, queryStr: string) {
@@ -526,6 +530,24 @@ describe('Validate: Values of correct type', () => {
       ]);
     });
 
+    it('String into Enum (no suggestion)', () => {
+      expectErrors(
+        `
+        {
+          dog {
+            doesKnowCommand(dogCommand: "SIT")
+          }
+        }
+      `,
+        true,
+      ).toDeepEqual([
+        {
+          message: 'Enum "DogCommand" cannot represent non-enum value: "SIT".',
+          locations: [{ line: 4, column: 41 }],
+        },
+      ]);
+    });
+
     it('Boolean into Enum', () => {
       expectErrors(`
         {
@@ -567,6 +589,24 @@ describe('Validate: Values of correct type', () => {
         {
           message:
             'Value "sit" does not exist in "DogCommand" enum. Did you mean the enum value "SIT"?',
+          locations: [{ line: 4, column: 41 }],
+        },
+      ]);
+    });
+
+    it('Different case Enum Value into Enum (no suggestion)', () => {
+      expectErrors(
+        `
+        {
+          dog {
+            doesKnowCommand(dogCommand: sit)
+          }
+        }
+      `,
+        true,
+      ).toDeepEqual([
+        {
+          message: 'Value "sit" does not exist in "DogCommand" enum.',
           locations: [{ line: 4, column: 41 }],
         },
       ]);
@@ -963,6 +1003,28 @@ describe('Validate: Values of correct type', () => {
         {
           message:
             'Field "invalidField" is not defined by type "ComplexInput". Did you mean "intField"?',
+          locations: [{ line: 6, column: 15 }],
+        },
+      ]);
+    });
+
+    it('Partial object, unknown field arg (no suggestions)', () => {
+      expectErrors(
+        `
+        {
+          complicatedArgs {
+            complexArgField(complexArg: {
+              requiredField: true,
+              invalidField: "value"
+            })
+          }
+        }
+      `,
+        true,
+      ).toDeepEqual([
+        {
+          message:
+            'Field "invalidField" is not defined by type "ComplexInput".',
           locations: [{ line: 6, column: 15 }],
         },
       ]);

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -19,7 +19,7 @@ import {
   expectValidationErrorsWithSchema,
 } from './harness.js';
 
-function expectErrors(queryStr: string, maskSuggestions = false) {
+function expectErrors(queryStr: string, maskSuggestions: boolean = false) {
   return expectValidationErrors(
     ValuesOfCorrectTypeRule,
     queryStr,

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -128,17 +128,24 @@ export function expectValidationErrorsWithSchema(
   schema: GraphQLSchema,
   rule: ValidationRule,
   queryStr: string,
+  maskSuggestions = false,
 ): any {
   const doc = parse(queryStr, { experimentalFragmentArguments: true });
-  const errors = validate(schema, doc, [rule]);
+  const errors = validate(schema, doc, [rule], { maskSuggestions });
   return expectJSON(errors);
 }
 
 export function expectValidationErrors(
   rule: ValidationRule,
   queryStr: string,
+  maskSuggestions = false,
 ): any {
-  return expectValidationErrorsWithSchema(testSchema, rule, queryStr);
+  return expectValidationErrorsWithSchema(
+    testSchema,
+    rule,
+    queryStr,
+    maskSuggestions,
+  );
 }
 
 export function expectSDLValidationErrors(

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -128,7 +128,7 @@ export function expectValidationErrorsWithSchema(
   schema: GraphQLSchema,
   rule: ValidationRule,
   queryStr: string,
-  maskSuggestions = false,
+  maskSuggestions: boolean = false,
 ): any {
   const doc = parse(queryStr, { experimentalFragmentArguments: true });
   const errors = validate(schema, doc, [rule], { maskSuggestions });

--- a/src/validation/rules/FieldsOnCorrectTypeRule.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.ts
@@ -45,17 +45,17 @@ export function FieldsOnCorrectTypeRule(
           // First determine if there are any suggested types to condition on.
           let suggestion = didYouMean(
             'to use an inline fragment on',
-            context.shouldProvideSuggestions
-              ? getSuggestedTypeNames(schema, type, fieldName)
-              : [],
+            context.maskSuggestions
+              ? []
+              : getSuggestedTypeNames(schema, type, fieldName),
           );
 
           // If there are no suggested types, then perhaps this was a typo?
           if (suggestion === '') {
             suggestion = didYouMean(
-              context.shouldProvideSuggestions
-                ? getSuggestedFieldNames(type, fieldName)
-                : [],
+              context.maskSuggestions
+                ? []
+                : getSuggestedFieldNames(type, fieldName),
             );
           }
 

--- a/src/validation/rules/FieldsOnCorrectTypeRule.ts
+++ b/src/validation/rules/FieldsOnCorrectTypeRule.ts
@@ -45,12 +45,18 @@ export function FieldsOnCorrectTypeRule(
           // First determine if there are any suggested types to condition on.
           let suggestion = didYouMean(
             'to use an inline fragment on',
-            getSuggestedTypeNames(schema, type, fieldName),
+            context.shouldProvideSuggestions
+              ? getSuggestedTypeNames(schema, type, fieldName)
+              : [],
           );
 
           // If there are no suggested types, then perhaps this was a typo?
           if (suggestion === '') {
-            suggestion = didYouMean(getSuggestedFieldNames(type, fieldName));
+            suggestion = didYouMean(
+              context.shouldProvideSuggestions
+                ? getSuggestedFieldNames(type, fieldName)
+                : [],
+            );
           }
 
           // Report an error, including helpful suggestions.

--- a/src/validation/rules/KnownArgumentNamesRule.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.ts
@@ -34,12 +34,14 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
         );
         if (!varDef) {
           const argName = argNode.name.value;
-          const suggestions = suggestionList(
-            argName,
-            Array.from(fragmentSignature.variableDefinitions.values()).map(
-              (varSignature) => varSignature.variable.name.value,
-            ),
-          );
+          const suggestions = context.shouldProvideSuggestions
+            ? suggestionList(
+                argName,
+                Array.from(fragmentSignature.variableDefinitions.values()).map(
+                  (varSignature) => varSignature.variable.name.value,
+                ),
+              )
+            : [];
           context.reportError(
             new GraphQLError(
               `Unknown argument "${argName}" on fragment "${fragmentSignature.definition.name.value}".` +
@@ -57,10 +59,12 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
 
       if (!argDef && fieldDef && parentType) {
         const argName = argNode.name.value;
-        const suggestions = suggestionList(
-          argName,
-          fieldDef.args.map((arg) => arg.name),
-        );
+        const suggestions = context.shouldProvideSuggestions
+          ? suggestionList(
+              argName,
+              fieldDef.args.map((arg) => arg.name),
+            )
+          : [];
         context.reportError(
           new GraphQLError(
             `Unknown argument "${argName}" on field "${parentType}.${fieldDef.name}".` +

--- a/src/validation/rules/KnownArgumentNamesRule.ts
+++ b/src/validation/rules/KnownArgumentNamesRule.ts
@@ -34,14 +34,14 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
         );
         if (!varDef) {
           const argName = argNode.name.value;
-          const suggestions = context.shouldProvideSuggestions
-            ? suggestionList(
+          const suggestions = context.maskSuggestions
+            ? []
+            : suggestionList(
                 argName,
                 Array.from(fragmentSignature.variableDefinitions.values()).map(
                   (varSignature) => varSignature.variable.name.value,
                 ),
-              )
-            : [];
+              );
           context.reportError(
             new GraphQLError(
               `Unknown argument "${argName}" on fragment "${fragmentSignature.definition.name.value}".` +
@@ -59,12 +59,12 @@ export function KnownArgumentNamesRule(context: ValidationContext): ASTVisitor {
 
       if (!argDef && fieldDef && parentType) {
         const argName = argNode.name.value;
-        const suggestions = context.shouldProvideSuggestions
-          ? suggestionList(
+        const suggestions = context.maskSuggestions
+          ? []
+          : suggestionList(
               argName,
               fieldDef.args.map((arg) => arg.name),
-            )
-          : [];
+            );
         context.reportError(
           new GraphQLError(
             `Unknown argument "${argName}" on field "${parentType}.${fieldDef.name}".` +
@@ -123,7 +123,7 @@ export function KnownArgumentNamesOnDirectivesRule(
             context.reportError(
               new GraphQLError(
                 `Unknown argument "${argName}" on directive "@${directiveName}".` +
-                  didYouMean(suggestions),
+                  (context.maskSuggestions ? '' : didYouMean(suggestions)),
                 { nodes: argNode },
               ),
             );

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -48,10 +48,12 @@ export function KnownTypeNamesRule(
           return;
         }
 
-        const suggestedTypes = suggestionList(
-          typeName,
-          isSDL ? [...standardTypeNames, ...typeNames] : [...typeNames],
-        );
+        const suggestedTypes = context.shouldProvideSuggestions
+          ? suggestionList(
+              typeName,
+              isSDL ? [...standardTypeNames, ...typeNames] : [...typeNames],
+            )
+          : [];
         context.reportError(
           new GraphQLError(
             `Unknown type "${typeName}".` + didYouMean(suggestedTypes),

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -48,12 +48,12 @@ export function KnownTypeNamesRule(
           return;
         }
 
-        const suggestedTypes = context.shouldProvideSuggestions
-          ? suggestionList(
+        const suggestedTypes = context.maskSuggestions
+          ? []
+          : suggestionList(
               typeName,
               isSDL ? [...standardTypeNames, ...typeNames] : [...typeNames],
-            )
-          : [];
+            );
         context.reportError(
           new GraphQLError(
             `Unknown type "${typeName}".` + didYouMean(suggestedTypes),

--- a/src/validation/rules/PossibleTypeExtensionsRule.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.ts
@@ -78,13 +78,10 @@ export function PossibleTypeExtensionsRule(
         ...Object.keys(schema?.getTypeMap() ?? {}),
       ];
 
-      const suggestedTypes = context.shouldProvideSuggestions
-        ? suggestionList(typeName, allTypeNames)
-        : [];
       context.reportError(
         new GraphQLError(
           `Cannot extend type "${typeName}" because it is not defined.` +
-            didYouMean(suggestedTypes),
+            didYouMean(suggestionList(typeName, allTypeNames)),
           { nodes: node.name },
         ),
       );

--- a/src/validation/rules/PossibleTypeExtensionsRule.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.ts
@@ -78,10 +78,11 @@ export function PossibleTypeExtensionsRule(
         ...Object.keys(schema?.getTypeMap() ?? {}),
       ];
 
+      const suggestedTypes = suggestionList(typeName, allTypeNames);
       context.reportError(
         new GraphQLError(
           `Cannot extend type "${typeName}" because it is not defined.` +
-            didYouMean(suggestionList(typeName, allTypeNames)),
+            didYouMean(suggestedTypes),
           { nodes: node.name },
         ),
       );

--- a/src/validation/rules/PossibleTypeExtensionsRule.ts
+++ b/src/validation/rules/PossibleTypeExtensionsRule.ts
@@ -78,7 +78,9 @@ export function PossibleTypeExtensionsRule(
         ...Object.keys(schema?.getTypeMap() ?? {}),
       ];
 
-      const suggestedTypes = suggestionList(typeName, allTypeNames);
+      const suggestedTypes = context.shouldProvideSuggestions
+        ? suggestionList(typeName, allTypeNames)
+        : [];
       context.reportError(
         new GraphQLError(
           `Cannot extend type "${typeName}" because it is not defined.` +

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -51,6 +51,7 @@ export function SingleFieldSubscriptionsRule(
             variableValues,
             subscriptionType,
             node,
+            context.maskSuggestions,
           );
           if (groupedFieldSet.size > 1) {
             const fieldDetailsLists = [...groupedFieldSet.values()];

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -97,10 +97,9 @@ export function ValuesOfCorrectTypeRule(
       const parentType = getNamedType(context.getParentInputType());
       const fieldType = context.getInputType();
       if (!fieldType && isInputObjectType(parentType)) {
-        const suggestions = suggestionList(
-          node.name.value,
-          Object.keys(parentType.getFields()),
-        );
+        const suggestions = context.shouldProvideSuggestions
+          ? suggestionList(node.name.value, Object.keys(parentType.getFields()))
+          : [];
         context.reportError(
           new GraphQLError(
             `Field "${node.name.value}" is not defined by type "${parentType}".` +
@@ -157,8 +156,11 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // which may throw or return undefined to indicate an invalid value.
   try {
     const parseResult = type.parseConstLiteral
-      ? type.parseConstLiteral(replaceVariables(node))
-      : type.parseLiteral(node, undefined);
+      ? type.parseConstLiteral(
+          replaceVariables(node),
+          context.shouldProvideSuggestions,
+        )
+      : type.parseLiteral(node, undefined, context.shouldProvideSuggestions);
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -97,9 +97,12 @@ export function ValuesOfCorrectTypeRule(
       const parentType = getNamedType(context.getParentInputType());
       const fieldType = context.getInputType();
       if (!fieldType && isInputObjectType(parentType)) {
-        const suggestions = context.shouldProvideSuggestions
-          ? suggestionList(node.name.value, Object.keys(parentType.getFields()))
-          : [];
+        const suggestions = context.maskSuggestions
+          ? []
+          : suggestionList(
+              node.name.value,
+              Object.keys(parentType.getFields()),
+            );
         context.reportError(
           new GraphQLError(
             `Field "${node.name.value}" is not defined by type "${parentType}".` +
@@ -156,11 +159,8 @@ function isValidValueNode(context: ValidationContext, node: ValueNode): void {
   // which may throw or return undefined to indicate an invalid value.
   try {
     const parseResult = type.parseConstLiteral
-      ? type.parseConstLiteral(
-          replaceVariables(node),
-          context.shouldProvideSuggestions,
-        )
-      : type.parseLiteral(node, undefined, context.shouldProvideSuggestions);
+      ? type.parseConstLiteral(replaceVariables(node), context.maskSuggestions)
+      : type.parseLiteral(node, undefined, context.maskSuggestions);
     if (parseResult === undefined) {
       const typeStr = inspect(locationType);
       context.reportError(

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -41,7 +41,7 @@ export function validate(
   schema: GraphQLSchema,
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
-  options?: { maxErrors?: number; maskSuggestions?: Maybe<boolean> },
+  options?: { maxErrors?: number; maskSuggestions?: boolean },
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
   const maskSuggestions = options?.maskSuggestions ?? false;

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -41,10 +41,10 @@ export function validate(
   schema: GraphQLSchema,
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
-  options?: { maxErrors?: number; shouldProvideSuggestions?: boolean },
+  options?: { maxErrors?: number; maskSuggestions?: Maybe<boolean> },
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
-  const shouldProvideSuggestions = options?.shouldProvideSuggestions ?? true;
+  const maskSuggestions = options?.maskSuggestions ?? false;
 
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
@@ -64,7 +64,7 @@ export function validate(
       }
       errors.push(error);
     },
-    shouldProvideSuggestions,
+    maskSuggestions,
   );
 
   // This uses a specialized visitor which runs multiple visitors in parallel,

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -41,9 +41,10 @@ export function validate(
   schema: GraphQLSchema,
   documentAST: DocumentNode,
   rules: ReadonlyArray<ValidationRule> = specifiedRules,
-  options?: { maxErrors?: number },
+  options?: { maxErrors?: number; shouldProvideSuggestions?: boolean },
 ): ReadonlyArray<GraphQLError> {
   const maxErrors = options?.maxErrors ?? 100;
+  const shouldProvideSuggestions = options?.shouldProvideSuggestions ?? true;
 
   // If the schema used for validation is invalid, throw an error.
   assertValidSchema(schema);
@@ -63,6 +64,7 @@ export function validate(
       }
       errors.push(error);
     },
+    shouldProvideSuggestions,
   );
 
   // This uses a specialized visitor which runs multiple visitors in parallel,


### PR DESCRIPTION
includes:

1. changes just to reduce the diff
2. use of Maybe<boolean> for some of our exported helper functions to match rest of our API
3. reverts some of my previous suggestions revolving around collectFields() => i was under the mistaken assumption that we never needed to pass maskSuggestions to collectFields, but because of fragment arguments, we might have complex inputs and we might need to mask suggestions
4. errata