### PR TITLE
Include kind in the types

### DIFF
--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -32,7 +32,7 @@ describe('Introspection', () => {
     expect(result).to.deep.equal({
       data: {
         __schema: {
-          queryType: { name: 'SomeObject' },
+          queryType: { name: 'SomeObject', kind: 'OBJECT' },
           mutationType: null,
           subscriptionType: null,
           types: [

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -716,7 +716,7 @@ describe('Type System: build schema from introspection', () => {
       delete introspection.__schema.queryType.name;
 
       expect(() => buildClientSchema(introspection)).to.throw(
-        'Unknown type reference: {}.',
+        'Unknown type reference: { kind: "OBJECT" }.',
       );
     });
 

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -77,9 +77,9 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     query IntrospectionQuery {
       __schema {
         ${schemaDescription}
-        queryType { name }
-        mutationType { name }
-        subscriptionType { name }
+        queryType { name kind }
+        mutationType { name kind }
+        subscriptionType { name kind }
         types {
           ...FullType
         }


### PR DESCRIPTION
Supersedes https://github.com/graphql/graphql-js/pull/3910
Fixes https://github.com/graphql/graphql-js/issues/3909
Fixes https://github.com/graphql/graphql-js/issues/3409

This puts the Selection-set in line with the expected type