### PR TITLE
Allow for serializing int as BigInt

### DIFF
--- a/src/type/__tests__/scalars-test.ts
+++ b/src/type/__tests__/scalars-test.ts
@@ -534,6 +534,8 @@ describe('Type System: Specified scalar types', () => {
       expect(parseValue(1)).to.equal('1');
       expect(parseValue(0)).to.equal('0');
       expect(parseValue(-1)).to.equal('-1');
+      expect(parseValue(BigInt(123))).to.equal('123');
+      expect(parseValue(1n)).to.equal('1');
 
       // Maximum and minimum safe numbers in JS
       expect(parseValue(9007199254740991)).to.equal('9007199254740991');
@@ -614,6 +616,8 @@ describe('Type System: Specified scalar types', () => {
       expect(serialize(123)).to.equal('123');
       expect(serialize(0)).to.equal('0');
       expect(serialize(-1)).to.equal('-1');
+      expect(serialize(BigInt(123))).to.equal('123');
+      expect(serialize(1n)).to.equal('1');
 
       const valueOf = () => 'valueOf ID';
       const toJSON = () => 'toJSON ID';

--- a/src/type/scalars.ts
+++ b/src/type/scalars.ts
@@ -252,7 +252,7 @@ export const GraphQLID = new GraphQLScalarType<string>({
     if (typeof coercedValue === 'string') {
       return coercedValue;
     }
-    if (Number.isInteger(coercedValue)) {
+    if (Number.isInteger(coercedValue) || typeof coercedValue === 'bigint') {
       return String(coercedValue);
     }
     throw new GraphQLError(
@@ -265,6 +265,9 @@ export const GraphQLID = new GraphQLScalarType<string>({
       return inputValue;
     }
     if (typeof inputValue === 'number' && Number.isInteger(inputValue)) {
+      return inputValue.toString();
+    }
+    if (typeof inputValue === 'bigint') {
       return inputValue.toString();
     }
     throw new GraphQLError(`ID cannot represent value: ${inspect(inputValue)}`);


### PR DESCRIPTION
Fixes https://github.com/graphql/graphql-js/issues/3913

In the spec we say that we allow for `BigInt` as an `ID` value in [here](https://spec.graphql.org/draft/#sel-GAHXZFDCAACCBshF). However in JS we don't support serializing a response value from `BigInt` to `String`.

