### PR TITLE
Remove the normalized config export

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1187,7 +1187,7 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
   extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 }
 
-export interface GraphQLInterfaceTypeNormalizedConfig<TSource, TContext>
+interface GraphQLInterfaceTypeNormalizedConfig<TSource, TContext>
   extends GraphQLInterfaceTypeConfig<any, any> {
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
   fields: GraphQLFieldConfigMap<TSource, TContext>;


### PR DESCRIPTION
Closes https://github.com/graphql/graphql-js/issues/3853

There's only one normalizedConfig we export and these are just the type config with a few extras. I would rather than exporting all of them just stop exporting them for the time being as we don't accept them as inputs and it can still be derived by doing `ReturnType<GraphQLInterfaceType['toConfig']>` if it's really needed