### PR TITLE
Cover empty field-selections

### DIFF
--- a/src/validation/rules/ScalarLeafsRule.ts
+++ b/src/validation/rules/ScalarLeafsRule.ts
@@ -41,6 +41,15 @@ export function ScalarLeafsRule(context: ValidationContext): ASTVisitor {
               { nodes: node },
             ),
           );
+        } else if (selectionSet.selections.length === 0) {
+          const fieldName = node.name.value;
+          const typeStr = inspect(type);
+          context.reportError(
+            new GraphQLError(
+              `Field "${fieldName}" of type "${typeStr}" must have at least one field selected.`,
+              { nodes: node },
+            ),
+          );
         }
       }
     },


### PR DESCRIPTION
Closes https://github.com/graphql/graphql-js/issues/3790

This follows the spec closer to the letter as we consider empty selection-sets invalid as well. This however does not cover empty operation-definitions, which should also be considered invalid.

The parser itself considers empty-selections invalid as it requires you to specify a name before a closing curly, hence why testing happens a bit more manual here. Despite our parser not considering this valid, I think this is good to validate when folks use a separate parser or construct documents manually as this is valid in our type-system.