### PR TITLE
AbortController support

### DIFF
--- a/integrationTests/ts/tsconfig.json
+++ b/integrationTests/ts/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string"],
+    "lib": [
+      "es2019",
+      "es2020.promise",
+      "es2020.bigint",
+      "es2020.string",
+      "DOM"
+    ],
     "noEmit": true,
     "types": [],
     "strict": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@svgr/webpack": "8.1.0",
         "@types/chai": "4.3.19",
         "@types/mocha": "10.0.7",
-        "@types/node": "22.5.4",
+        "@types/node": "22.7.7",
         "@typescript-eslint/eslint-plugin": "8.4.0",
         "@typescript-eslint/parser": "8.4.0",
         "c8": "10.1.2",
@@ -4946,11 +4946,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
-      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "version": "22.7.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
+      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@svgr/webpack": "8.1.0",
     "@types/chai": "4.3.19",
     "@types/mocha": "10.0.7",
-    "@types/node": "22.5.4",
+    "@types/node": "22.7.7",
     "@typescript-eslint/eslint-plugin": "8.4.0",
     "@typescript-eslint/parser": "8.4.0",
     "c8": "10.1.2",

--- a/src/execution/__tests__/abort-signal-test.ts
+++ b/src/execution/__tests__/abort-signal-test.ts
@@ -1,0 +1,352 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import type { DocumentNode } from '../../language/ast.js';
+import { parse } from '../../language/parser.js';
+
+import { buildSchema } from '../../utilities/buildASTSchema.js';
+
+import { execute, experimentalExecuteIncrementally } from '../execute.js';
+import type {
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
+} from '../types.js';
+
+async function complete(
+  document: DocumentNode,
+  rootValue: unknown,
+  abortSignal: AbortSignal,
+) {
+  const result = await experimentalExecuteIncrementally({
+    schema,
+    document,
+    rootValue,
+    abortSignal,
+  });
+
+  if ('initialResult' in result) {
+    const results: Array<
+      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+    > = [result.initialResult];
+    for await (const patch of result.subsequentResults) {
+      results.push(patch);
+    }
+    return results;
+  }
+}
+
+const schema = buildSchema(`
+  type Todo {
+    id: ID
+    text: String
+    author: User
+  }
+
+  type User {
+    id: ID
+    name: String
+  }
+
+  type Query {
+    todo: Todo
+  }
+
+  type Mutation {
+    foo: String
+    bar: String
+  }
+`);
+
+describe('Execute: Cancellation', () => {
+  it('should stop the execution when aborted during object field completion', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          author {
+            id
+          }
+        }
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        todo: async () =>
+          Promise.resolve({
+            id: '1',
+            text: 'Hello, World!',
+            /* c8 ignore next */
+            author: () => expect.fail('Should not be called'),
+          }),
+      },
+    });
+
+    abortController.abort('Aborted');
+
+    const result = await resultPromise;
+
+    expectJSON(result).toDeepEqual({
+      data: {
+        todo: null,
+      },
+      errors: [
+        {
+          message: 'Aborted',
+          path: ['todo', 'id'],
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
+    });
+  });
+
+  it('should stop the execution when aborted during nested object field completion', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          author {
+            id
+          }
+        }
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        todo: {
+          id: '1',
+          text: 'Hello, World!',
+          /* c8 ignore next 3 */
+          author: async () =>
+            Promise.resolve(() => expect.fail('Should not be called')),
+        },
+      },
+    });
+
+    abortController.abort('Aborted');
+
+    const result = await resultPromise;
+
+    expectJSON(result).toDeepEqual({
+      data: {
+        todo: {
+          id: '1',
+          author: null,
+        },
+      },
+      errors: [
+        {
+          message: 'Aborted',
+          path: ['todo', 'author', 'id'],
+          locations: [{ line: 6, column: 13 }],
+        },
+      ],
+    });
+  });
+
+  it('should stop deferred execution when aborted', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          ... on Todo @defer {
+            text
+            author {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema,
+      rootValue: {
+        todo: async () =>
+          Promise.resolve({
+            id: '1',
+            text: 'hello world',
+            /* c8 ignore next */
+            author: () => expect.fail('Should not be called'),
+          }),
+      },
+      abortSignal: abortController.signal,
+    });
+
+    abortController.abort('Aborted');
+
+    const result = await resultPromise;
+
+    expectJSON(result).toDeepEqual({
+      data: {
+        todo: null,
+      },
+      errors: [
+        {
+          message: 'Aborted',
+          path: ['todo', 'id'],
+          locations: [{ line: 4, column: 11 }],
+        },
+      ],
+    });
+  });
+
+  it('should stop deferred execution when aborted mid-execution', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          ... on Todo @defer {
+            text
+            author {
+              ... on Author @defer {
+                id
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const resultPromise = complete(
+      document,
+      {
+        todo: async () =>
+          Promise.resolve({
+            id: '1',
+            text: 'hello world',
+            /* c8 ignore next 2 */
+            author: async () =>
+              Promise.resolve(() => expect.fail('Should not be called')),
+          }),
+      },
+      abortController.signal,
+    );
+
+    await resolveOnNextTick();
+    await resolveOnNextTick();
+    await resolveOnNextTick();
+
+    abortController.abort('Aborted');
+
+    const result = await resultPromise;
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          todo: {
+            id: '1',
+          },
+        },
+        pending: [{ id: '0', path: ['todo'] }],
+        hasNext: true,
+      },
+      {
+        completed: [
+          {
+            errors: [
+              {
+                locations: [
+                  {
+                    column: 13,
+                    line: 6,
+                  },
+                ],
+                message: 'Aborted',
+                path: ['todo', 'text'],
+              },
+            ],
+            id: '0',
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+
+  it('should stop the execution when aborted mid-mutation', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      mutation {
+        foo
+        bar
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        foo: async () => Promise.resolve('baz'),
+        /* c8 ignore next */
+        bar: () => expect.fail('Should not be called'),
+      },
+    });
+
+    abortController.abort('Aborted');
+
+    const result = await resultPromise;
+
+    expectJSON(result).toDeepEqual({
+      data: {
+        foo: 'baz',
+        bar: null,
+      },
+      errors: [
+        {
+          message: 'Aborted',
+          path: ['bar'],
+          locations: [{ line: 4, column: 9 }],
+        },
+      ],
+    });
+  });
+
+  it('should stop the execution when aborted pre-execute', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          author {
+            id
+          }
+        }
+      }
+    `);
+    abortController.abort('Aborted');
+    const result = await execute({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        /* c8 ignore next */
+        todo: () => expect.fail('Should not be called'),
+      },
+    });
+
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'Aborted',
+        },
+      ],
+    });
+  });
+});

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -68,6 +68,7 @@ export interface GraphQLArgs {
   operationName?: Maybe<string>;
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  abortSignal?: Maybe<AbortSignal>;
 }
 
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {


### PR DESCRIPTION
This adds support for aborting execution from the outside or resolvers, this adds a few tests and tries to make the support as easy as possible.

Do we want to support having abort support on subscriptions, I guess it makes sense for server-sent events.

I've chosen 2 places to place these interrupts

- `executeFieldsSerially` - every time we start a new mutation we check whether the runtime has interrupted
- `executeFields` - every time we start executing a new field we check whether the runtime has interrupted
  - inside of the catch block as well so we return a singular error, all though this doesn't really matter as the consumer would not receive anything 
  - this here should also take care of deferred fields

When comparing this to `graphql-tools/execute` I am not sure whether we want to match this behavior, this throws a DomException which would be a whole new exception that gets thrown while normally during execution we wrap everything with GraphQLErrors.

Supersedes https://github.com/graphql/graphql-js/pull/3791
Resolves https://github.com/graphql/graphql-js/issues/3764