### PR TITLE
Expose `tokenCount` on the `DocumentNode`

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -100,6 +100,11 @@ describe('Parser', () => {
     );
   });
 
+  it('exposes the tokenCount', () => {
+    expect(parse('{ foo }').tokenCount).to.equal(3);
+    expect(parse('{ foo(bar: "baz") }').tokenCount).to.equal(8);
+  });
+
   it('parses variable inline values', () => {
     expect(() =>
       parse('{ field(complex: { a: { b: [ $var ] } }) }'),

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -312,6 +312,7 @@ export interface DocumentNode {
   readonly kind: Kind.DOCUMENT;
   readonly loc?: Location | undefined;
   readonly definitions: ReadonlyArray<DefinitionNode>;
+  readonly tokenCount?: number | undefined;
 }
 
 export type DefinitionNode =

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -119,7 +119,12 @@ export function parse(
   options?: ParseOptions | undefined,
 ): DocumentNode {
   const parser = new Parser(source, options);
-  return parser.parseDocument();
+  const document = parser.parseDocument();
+  Object.defineProperty(document, 'tokenCount', {
+    enumerable: false,
+    value: parser.tokenCount,
+  });
+  return document;
 }
 
 /**
@@ -199,6 +204,10 @@ export class Parser {
     this._lexer = new Lexer(sourceObj);
     this._options = options;
     this._tokenCounter = 0;
+  }
+
+  get tokenCount(): number {
+    return this._tokenCounter;
   }
 
   /**
@@ -1601,9 +1610,9 @@ export class Parser {
     const { maxTokens } = this._options;
     const token = this._lexer.advance();
 
-    if (maxTokens !== undefined && token.kind !== TokenKind.EOF) {
+    if (token.kind !== TokenKind.EOF) {
       ++this._tokenCounter;
-      if (this._tokenCounter > maxTokens) {
+      if (maxTokens !== undefined && this._tokenCounter > maxTokens) {
         throw syntaxError(
           this._lexer.source,
           token.start,


### PR DESCRIPTION
This way people can add this to metrics and inform themselves about sane values to use with the `maxTokens` option on `parse`. This was added as a non-enumerable property to increase backwards compatability.

Currently there is now way to know the tokens and by extension set sane defaults.