### PR TITLE
adjust prefix for toError

### DIFF
--- a/src/error/__tests__/locatedError-test.ts
+++ b/src/error/__tests__/locatedError-test.ts
@@ -17,8 +17,8 @@ describe('locatedError', () => {
 
     expect(error).to.be.instanceOf(GraphQLError);
     expect(error.originalError).to.include({
-      name: 'NonErrorThrown',
-      thrownValue: testObject,
+      name: 'WrappedNonErrorValueError',
+      rawError: testObject,
     });
   });
 

--- a/src/execution/__tests__/abort-signal-test.ts
+++ b/src/execution/__tests__/abort-signal-test.ts
@@ -196,7 +196,7 @@ describe('Execute: Cancellation', () => {
       },
       errors: [
         {
-          message: 'Unexpected error value: "Custom abort error message"',
+          message: 'Encountered error: "Custom abort error message"',
           path: ['todo'],
           locations: [{ line: 3, column: 9 }],
         },

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -494,7 +494,7 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['syncError'],
         },
         {
-          message: 'Unexpected error value: "Error getting syncRawError"',
+          message: 'Encountered error: "Error getting syncRawError"',
           locations: [{ line: 5, column: 9 }],
           path: ['syncRawError'],
         },
@@ -519,12 +519,12 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['asyncReject'],
         },
         {
-          message: 'Unexpected error value: "Error getting asyncRawReject"',
+          message: 'Encountered error: "Error getting asyncRawReject"',
           locations: [{ line: 10, column: 9 }],
           path: ['asyncRawReject'],
         },
         {
-          message: 'Unexpected error value: undefined',
+          message: 'Encountered error: undefined',
           locations: [{ line: 11, column: 9 }],
           path: ['asyncEmptyReject'],
         },
@@ -534,7 +534,7 @@ describe('Execute: Handles basic execution tasks', () => {
           path: ['asyncError'],
         },
         {
-          message: 'Unexpected error value: "Error getting asyncRawError"',
+          message: 'Encountered error: "Error getting asyncRawError"',
           locations: [{ line: 13, column: 9 }],
           path: ['asyncRawError'],
         },

--- a/src/jsutils/toError.ts
+++ b/src/jsutils/toError.ts
@@ -1,20 +1,21 @@
 import { inspect } from './inspect.js';
 
 /**
- * Sometimes a non-error is thrown, wrap it as an Error instance to ensure a consistent Error interface.
+ * Sometimes a non-error is provided, either thrown within a resolver or as an rejection/abort reason,
+ * wrap it as an Error instance to ensure a consistent Error interface.
  */
-export function toError(thrownValue: unknown): Error {
-  return thrownValue instanceof Error
-    ? thrownValue
-    : new NonErrorThrown(thrownValue);
+export function toError(rawError: unknown): Error {
+  return rawError instanceof Error
+    ? rawError
+    : new WrappedNonErrorValueError(rawError);
 }
 
-class NonErrorThrown extends Error {
-  thrownValue: unknown;
+class WrappedNonErrorValueError extends Error {
+  rawError: unknown;
 
-  constructor(thrownValue: unknown) {
-    super('Unexpected error value: ' + inspect(thrownValue));
-    this.name = 'NonErrorThrown';
-    this.thrownValue = thrownValue;
+  constructor(rawError: unknown) {
+    super('Encountered error: ' + inspect(rawError));
+    this.name = 'WrappedNonErrorValueError';
+    this.rawError = rawError;
   }
 }


### PR DESCRIPTION
should encompass thrown errors and encountered abort errors