### PR TITLE
move errors to GraphQLWrappedError rather than context

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -680,14 +680,10 @@ describe('Execute: Handles basic execution tasks', () => {
 
     const result = execute({ schema, document });
 
+    // a bubbling error is allowed to mask the non-bubbling error
     expectJSON(await result).toDeepEqual({
       data: null,
       errors: [
-        {
-          message: 'Oops',
-          locations: [{ line: 3, column: 9 }],
-          path: ['asyncError'],
-        },
         {
           message:
             'Cannot return null for non-nullable field Query.asyncNonNullError.',

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -255,14 +255,14 @@ describe('Execute: handles non-nullable types', () => {
             locations: [{ line: 4, column: 11 }],
           },
           {
-            message: syncError.message,
-            path: ['syncNest', 'syncNest', 'sync'],
-            locations: [{ line: 6, column: 22 }],
-          },
-          {
             message: promiseError.message,
             path: ['syncNest', 'promise'],
             locations: [{ line: 5, column: 11 }],
+          },
+          {
+            message: syncError.message,
+            path: ['syncNest', 'syncNest', 'sync'],
+            locations: [{ line: 6, column: 22 }],
           },
           {
             message: promiseError.message,
@@ -275,24 +275,24 @@ describe('Execute: handles non-nullable types', () => {
             locations: [{ line: 7, column: 25 }],
           },
           {
-            message: syncError.message,
-            path: ['promiseNest', 'sync'],
-            locations: [{ line: 10, column: 11 }],
-          },
-          {
-            message: syncError.message,
-            path: ['promiseNest', 'syncNest', 'sync'],
-            locations: [{ line: 12, column: 22 }],
-          },
-          {
             message: promiseError.message,
             path: ['syncNest', 'promiseNest', 'promise'],
             locations: [{ line: 7, column: 30 }],
           },
           {
+            message: syncError.message,
+            path: ['promiseNest', 'sync'],
+            locations: [{ line: 10, column: 11 }],
+          },
+          {
             message: promiseError.message,
             path: ['promiseNest', 'promise'],
             locations: [{ line: 11, column: 11 }],
+          },
+          {
+            message: syncError.message,
+            path: ['promiseNest', 'syncNest', 'sync'],
+            locations: [{ line: 12, column: 22 }],
           },
           {
             message: promiseError.message,


### PR DESCRIPTION
- preserves order of errors with respect to operation
- bubbling errors mask the non-bubbling errors such that extra information does not leak