### PR TITLE
Allow for tree-shaking the Kind enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,7 @@ export type {
 } from './type/index.js';
 
 // Parse and operate on GraphQL language source files.
+// eslint-disable-next-line @typescript-eslint/consistent-type-exports
 export {
   Token,
   Source,

--- a/src/language/__tests__/predicates-test.ts
+++ b/src/language/__tests__/predicates-test.ts
@@ -26,54 +26,55 @@ function filterNodes(predicate: (node: ASTNode) => boolean): Array<string> {
 
 describe('AST node predicates', () => {
   it('isDefinitionNode', () => {
-    expect(filterNodes(isDefinitionNode)).to.deep.equal([
-      'OperationDefinition',
-      'FragmentDefinition',
-      'SchemaDefinition',
-      'ScalarTypeDefinition',
-      'ObjectTypeDefinition',
-      'InterfaceTypeDefinition',
-      'UnionTypeDefinition',
-      'EnumTypeDefinition',
-      'InputObjectTypeDefinition',
-      'DirectiveDefinition',
-      'SchemaExtension',
-      'ScalarTypeExtension',
-      'ObjectTypeExtension',
-      'InterfaceTypeExtension',
-      'UnionTypeExtension',
-      'EnumTypeExtension',
-      'InputObjectTypeExtension',
-    ]);
+    expect(filterNodes(isDefinitionNode)).to.deep.equal(
+      [
+        'OperationDefinition',
+        'FragmentDefinition',
+        'SchemaDefinition',
+        'ScalarTypeDefinition',
+        'ObjectTypeDefinition',
+        'InterfaceTypeDefinition',
+        'UnionTypeDefinition',
+        'EnumTypeDefinition',
+        'InputObjectTypeDefinition',
+        'DirectiveDefinition',
+        'SchemaExtension',
+        'ScalarTypeExtension',
+        'ObjectTypeExtension',
+        'InterfaceTypeExtension',
+        'UnionTypeExtension',
+        'EnumTypeExtension',
+        'InputObjectTypeExtension',
+      ].sort(),
+    );
   });
 
   it('isExecutableDefinitionNode', () => {
-    expect(filterNodes(isExecutableDefinitionNode)).to.deep.equal([
-      'OperationDefinition',
-      'FragmentDefinition',
-    ]);
+    expect(filterNodes(isExecutableDefinitionNode)).to.deep.equal(
+      ['OperationDefinition', 'FragmentDefinition'].sort(),
+    );
   });
 
   it('isSelectionNode', () => {
-    expect(filterNodes(isSelectionNode)).to.deep.equal([
-      'Field',
-      'FragmentSpread',
-      'InlineFragment',
-    ]);
+    expect(filterNodes(isSelectionNode)).to.deep.equal(
+      ['Field', 'FragmentSpread', 'InlineFragment'].sort(),
+    );
   });
 
   it('isValueNode', () => {
-    expect(filterNodes(isValueNode)).to.deep.equal([
-      'Variable',
-      'IntValue',
-      'FloatValue',
-      'StringValue',
-      'BooleanValue',
-      'NullValue',
-      'EnumValue',
-      'ListValue',
-      'ObjectValue',
-    ]);
+    expect(filterNodes(isValueNode)).to.deep.equal(
+      [
+        'Variable',
+        'IntValue',
+        'FloatValue',
+        'StringValue',
+        'BooleanValue',
+        'NullValue',
+        'EnumValue',
+        'ListValue',
+        'ObjectValue',
+      ].sort(),
+    );
   });
 
   it('isConstValueNode', () => {
@@ -88,57 +89,63 @@ describe('AST node predicates', () => {
   });
 
   it('isTypeNode', () => {
-    expect(filterNodes(isTypeNode)).to.deep.equal([
-      'NamedType',
-      'ListType',
-      'NonNullType',
-    ]);
+    expect(filterNodes(isTypeNode)).to.deep.equal(
+      ['NamedType', 'ListType', 'NonNullType'].sort(),
+    );
   });
 
   it('isTypeSystemDefinitionNode', () => {
-    expect(filterNodes(isTypeSystemDefinitionNode)).to.deep.equal([
-      'SchemaDefinition',
-      'ScalarTypeDefinition',
-      'ObjectTypeDefinition',
-      'InterfaceTypeDefinition',
-      'UnionTypeDefinition',
-      'EnumTypeDefinition',
-      'InputObjectTypeDefinition',
-      'DirectiveDefinition',
-    ]);
+    expect(filterNodes(isTypeSystemDefinitionNode)).to.deep.equal(
+      [
+        'SchemaDefinition',
+        'ScalarTypeDefinition',
+        'ObjectTypeDefinition',
+        'InterfaceTypeDefinition',
+        'UnionTypeDefinition',
+        'EnumTypeDefinition',
+        'InputObjectTypeDefinition',
+        'DirectiveDefinition',
+      ].sort(),
+    );
   });
 
   it('isTypeDefinitionNode', () => {
-    expect(filterNodes(isTypeDefinitionNode)).to.deep.equal([
-      'ScalarTypeDefinition',
-      'ObjectTypeDefinition',
-      'InterfaceTypeDefinition',
-      'UnionTypeDefinition',
-      'EnumTypeDefinition',
-      'InputObjectTypeDefinition',
-    ]);
+    expect(filterNodes(isTypeDefinitionNode)).to.deep.equal(
+      [
+        'ScalarTypeDefinition',
+        'ObjectTypeDefinition',
+        'InterfaceTypeDefinition',
+        'UnionTypeDefinition',
+        'EnumTypeDefinition',
+        'InputObjectTypeDefinition',
+      ].sort(),
+    );
   });
 
   it('isTypeSystemExtensionNode', () => {
-    expect(filterNodes(isTypeSystemExtensionNode)).to.deep.equal([
-      'SchemaExtension',
-      'ScalarTypeExtension',
-      'ObjectTypeExtension',
-      'InterfaceTypeExtension',
-      'UnionTypeExtension',
-      'EnumTypeExtension',
-      'InputObjectTypeExtension',
-    ]);
+    expect(filterNodes(isTypeSystemExtensionNode)).to.deep.equal(
+      [
+        'SchemaExtension',
+        'ScalarTypeExtension',
+        'ObjectTypeExtension',
+        'InterfaceTypeExtension',
+        'UnionTypeExtension',
+        'EnumTypeExtension',
+        'InputObjectTypeExtension',
+      ].sort(),
+    );
   });
 
   it('isTypeExtensionNode', () => {
-    expect(filterNodes(isTypeExtensionNode)).to.deep.equal([
-      'ScalarTypeExtension',
-      'ObjectTypeExtension',
-      'InterfaceTypeExtension',
-      'UnionTypeExtension',
-      'EnumTypeExtension',
-      'InputObjectTypeExtension',
-    ]);
+    expect(filterNodes(isTypeExtensionNode)).to.deep.equal(
+      [
+        'ScalarTypeExtension',
+        'ObjectTypeExtension',
+        'InterfaceTypeExtension',
+        'UnionTypeExtension',
+        'EnumTypeExtension',
+        'InputObjectTypeExtension',
+      ].sort(),
+    );
   });
 });

--- a/src/language/_kinds.ts
+++ b/src/language/_kinds.ts
@@ -1,0 +1,65 @@
+/** Name */
+export const NAME = 'Name';
+
+/** Document */
+export const DOCUMENT = 'Document';
+export const OPERATION_DEFINITION = 'OperationDefinition';
+export const VARIABLE_DEFINITION = 'VariableDefinition';
+export const SELECTION_SET = 'SelectionSet';
+export const FIELD = 'Field';
+export const ARGUMENT = 'Argument';
+export const FRAGMENT_ARGUMENT = 'FragmentArgument';
+
+/** Fragments */
+export const FRAGMENT_SPREAD = 'FragmentSpread';
+export const INLINE_FRAGMENT = 'InlineFragment';
+export const FRAGMENT_DEFINITION = 'FragmentDefinition';
+
+/** Values */
+export const VARIABLE = 'Variable';
+export const INT = 'IntValue';
+export const FLOAT = 'FloatValue';
+export const STRING = 'StringValue';
+export const BOOLEAN = 'BooleanValue';
+export const NULL = 'NullValue';
+export const ENUM = 'EnumValue';
+export const LIST = 'ListValue';
+export const OBJECT = 'ObjectValue';
+export const OBJECT_FIELD = 'ObjectField';
+
+/** Directives */
+export const DIRECTIVE = 'Directive';
+
+/** Types */
+export const NAMED_TYPE = 'NamedType';
+export const LIST_TYPE = 'ListType';
+export const NON_NULL_TYPE = 'NonNullType';
+
+/** Type System Definitions */
+export const SCHEMA_DEFINITION = 'SchemaDefinition';
+export const OPERATION_TYPE_DEFINITION = 'OperationTypeDefinition';
+
+/** Type Definitions */
+export const SCALAR_TYPE_DEFINITION = 'ScalarTypeDefinition';
+export const OBJECT_TYPE_DEFINITION = 'ObjectTypeDefinition';
+export const FIELD_DEFINITION = 'FieldDefinition';
+export const INPUT_VALUE_DEFINITION = 'InputValueDefinition';
+export const INTERFACE_TYPE_DEFINITION = 'InterfaceTypeDefinition';
+export const UNION_TYPE_DEFINITION = 'UnionTypeDefinition';
+export const ENUM_TYPE_DEFINITION = 'EnumTypeDefinition';
+export const ENUM_VALUE_DEFINITION = 'EnumValueDefinition';
+export const INPUT_OBJECT_TYPE_DEFINITION = 'InputObjectTypeDefinition';
+
+/** Directive Definitions */
+export const DIRECTIVE_DEFINITION = 'DirectiveDefinition';
+
+/** Type System Extensions */
+export const SCHEMA_EXTENSION = 'SchemaExtension';
+
+/** Type Extensions */
+export const SCALAR_TYPE_EXTENSION = 'ScalarTypeExtension';
+export const OBJECT_TYPE_EXTENSION = 'ObjectTypeExtension';
+export const INTERFACE_TYPE_EXTENSION = 'InterfaceTypeExtension';
+export const UNION_TYPE_EXTENSION = 'UnionTypeExtension';
+export const ENUM_TYPE_EXTENSION = 'EnumTypeExtension';
+export const INPUT_OBJECT_TYPE_EXTENSION = 'InputObjectTypeExtension';

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -5,7 +5,7 @@ export type { SourceLocation } from './location.js';
 
 export { printLocation, printSourceLocation } from './printLocation.js';
 
-export { Kind } from './kinds.js';
+export * from './kinds.js';
 
 export { TokenKind } from './tokenKind.js';
 

--- a/src/language/kinds.ts
+++ b/src/language/kinds.ts
@@ -45,7 +45,10 @@ import type {
   VARIABLE_DEFINITION,
 } from './_kinds.js';
 
-export type Kind =
+/**
+ * The set of allowed kind values for AST nodes.
+ */
+export type Kind = 
   | typeof NAME
   | typeof DOCUMENT
   | typeof OPERATION_DEFINITION

--- a/src/language/kinds.ts
+++ b/src/language/kinds.ts
@@ -1,72 +1,97 @@
+import type {
+  ARGUMENT,
+  BOOLEAN,
+  DIRECTIVE,
+  DIRECTIVE_DEFINITION,
+  DOCUMENT,
+  ENUM,
+  ENUM_TYPE_DEFINITION,
+  ENUM_TYPE_EXTENSION,
+  ENUM_VALUE_DEFINITION,
+  FIELD,
+  FIELD_DEFINITION,
+  FLOAT,
+  FRAGMENT_ARGUMENT,
+  FRAGMENT_DEFINITION,
+  FRAGMENT_SPREAD,
+  INLINE_FRAGMENT,
+  INPUT_OBJECT_TYPE_DEFINITION,
+  INPUT_OBJECT_TYPE_EXTENSION,
+  INPUT_VALUE_DEFINITION,
+  INT,
+  INTERFACE_TYPE_DEFINITION,
+  INTERFACE_TYPE_EXTENSION,
+  LIST,
+  LIST_TYPE,
+  NAME,
+  NAMED_TYPE,
+  NON_NULL_TYPE,
+  NULL,
+  OBJECT,
+  OBJECT_FIELD,
+  OBJECT_TYPE_DEFINITION,
+  OBJECT_TYPE_EXTENSION,
+  OPERATION_DEFINITION,
+  OPERATION_TYPE_DEFINITION,
+  SCALAR_TYPE_DEFINITION,
+  SCALAR_TYPE_EXTENSION,
+  SCHEMA_DEFINITION,
+  SCHEMA_EXTENSION,
+  SELECTION_SET,
+  STRING,
+  UNION_TYPE_DEFINITION,
+  UNION_TYPE_EXTENSION,
+  VARIABLE,
+  VARIABLE_DEFINITION,
+} from './_kinds.js';
+
+export type Kind =
+  | typeof NAME
+  | typeof DOCUMENT
+  | typeof OPERATION_DEFINITION
+  | typeof VARIABLE_DEFINITION
+  | typeof SELECTION_SET
+  | typeof FIELD
+  | typeof ARGUMENT
+  | typeof FRAGMENT_ARGUMENT
+  | typeof FRAGMENT_SPREAD
+  | typeof INLINE_FRAGMENT
+  | typeof FRAGMENT_DEFINITION
+  | typeof VARIABLE
+  | typeof INT
+  | typeof FLOAT
+  | typeof STRING
+  | typeof BOOLEAN
+  | typeof NULL
+  | typeof ENUM
+  | typeof LIST
+  | typeof OBJECT
+  | typeof OBJECT_FIELD
+  | typeof DIRECTIVE
+  | typeof NAMED_TYPE
+  | typeof LIST_TYPE
+  | typeof NON_NULL_TYPE
+  | typeof SCHEMA_DEFINITION
+  | typeof OPERATION_TYPE_DEFINITION
+  | typeof SCALAR_TYPE_DEFINITION
+  | typeof OBJECT_TYPE_DEFINITION
+  | typeof FIELD_DEFINITION
+  | typeof INPUT_VALUE_DEFINITION
+  | typeof INTERFACE_TYPE_DEFINITION
+  | typeof UNION_TYPE_DEFINITION
+  | typeof ENUM_TYPE_DEFINITION
+  | typeof ENUM_VALUE_DEFINITION
+  | typeof INPUT_OBJECT_TYPE_DEFINITION
+  | typeof DIRECTIVE_DEFINITION
+  | typeof SCHEMA_EXTENSION
+  | typeof SCALAR_TYPE_EXTENSION
+  | typeof OBJECT_TYPE_EXTENSION
+  | typeof INTERFACE_TYPE_EXTENSION
+  | typeof UNION_TYPE_EXTENSION
+  | typeof ENUM_TYPE_EXTENSION
+  | typeof INPUT_OBJECT_TYPE_EXTENSION;
+
 /**
  * The set of allowed kind values for AST nodes.
  */
-export const Kind = {
-  /** Name */
-  NAME: 'Name' as const,
-
-  /** Document */
-  DOCUMENT: 'Document' as const,
-  OPERATION_DEFINITION: 'OperationDefinition' as const,
-  VARIABLE_DEFINITION: 'VariableDefinition' as const,
-  SELECTION_SET: 'SelectionSet' as const,
-  FIELD: 'Field' as const,
-  ARGUMENT: 'Argument' as const,
-  FRAGMENT_ARGUMENT: 'FragmentArgument' as const,
-
-  /** Fragments */
-  FRAGMENT_SPREAD: 'FragmentSpread' as const,
-  INLINE_FRAGMENT: 'InlineFragment' as const,
-  FRAGMENT_DEFINITION: 'FragmentDefinition' as const,
-
-  /** Values */
-  VARIABLE: 'Variable' as const,
-  INT: 'IntValue' as const,
-  FLOAT: 'FloatValue' as const,
-  STRING: 'StringValue' as const,
-  BOOLEAN: 'BooleanValue' as const,
-  NULL: 'NullValue' as const,
-  ENUM: 'EnumValue' as const,
-  LIST: 'ListValue' as const,
-  OBJECT: 'ObjectValue' as const,
-  OBJECT_FIELD: 'ObjectField' as const,
-
-  /** Directives */
-  DIRECTIVE: 'Directive' as const,
-
-  /** Types */
-  NAMED_TYPE: 'NamedType' as const,
-  LIST_TYPE: 'ListType' as const,
-  NON_NULL_TYPE: 'NonNullType' as const,
-
-  /** Type System Definitions */
-  SCHEMA_DEFINITION: 'SchemaDefinition' as const,
-  OPERATION_TYPE_DEFINITION: 'OperationTypeDefinition' as const,
-
-  /** Type Definitions */
-  SCALAR_TYPE_DEFINITION: 'ScalarTypeDefinition' as const,
-  OBJECT_TYPE_DEFINITION: 'ObjectTypeDefinition' as const,
-  FIELD_DEFINITION: 'FieldDefinition' as const,
-  INPUT_VALUE_DEFINITION: 'InputValueDefinition' as const,
-  INTERFACE_TYPE_DEFINITION: 'InterfaceTypeDefinition' as const,
-  UNION_TYPE_DEFINITION: 'UnionTypeDefinition' as const,
-  ENUM_TYPE_DEFINITION: 'EnumTypeDefinition' as const,
-  ENUM_VALUE_DEFINITION: 'EnumValueDefinition' as const,
-  INPUT_OBJECT_TYPE_DEFINITION: 'InputObjectTypeDefinition' as const,
-
-  /** Directive Definitions */
-  DIRECTIVE_DEFINITION: 'DirectiveDefinition' as const,
-
-  /** Type System Extensions */
-  SCHEMA_EXTENSION: 'SchemaExtension' as const,
-
-  /** Type Extensions */
-  SCALAR_TYPE_EXTENSION: 'ScalarTypeExtension' as const,
-  OBJECT_TYPE_EXTENSION: 'ObjectTypeExtension' as const,
-  INTERFACE_TYPE_EXTENSION: 'InterfaceTypeExtension' as const,
-  UNION_TYPE_EXTENSION: 'UnionTypeExtension' as const,
-  ENUM_TYPE_EXTENSION: 'EnumTypeExtension' as const,
-  INPUT_OBJECT_TYPE_EXTENSION: 'InputObjectTypeExtension' as const,
-};
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export type Kind = (typeof Kind)[keyof typeof Kind];
+export * as Kind from './_kinds.js';


### PR DESCRIPTION
Resolves #4253 

This enables tree-shaking `Kind` - I opted to only do this with Kind as the other enums are either tiny or included by default if you are using `parseSchema`.