### PR TITLE
add cancellation support to async iterable iteration

### DIFF
--- a/src/execution/PromiseCanceller.ts
+++ b/src/execution/PromiseCanceller.ts
@@ -35,9 +35,7 @@ export class PromiseCanceller {
     }
 
     const { promise, resolve, reject } = promiseWithResolvers<T>();
-    const abort = () => {
-      reject(this.abortSignal.reason);
-    };
+    const abort = () => reject(this.abortSignal.reason);
     this._aborts.add(abort);
     originalPromise.then(
       (resolved) => {

--- a/src/execution/PromiseCanceller.ts
+++ b/src/execution/PromiseCanceller.ts
@@ -28,14 +28,19 @@ export class PromiseCanceller {
     this.abortSignal.removeEventListener('abort', this.abort);
   }
 
-  cancellablePromise<T>(originalPromise: Promise<T>): Promise<T> {
+  cancellablePromise<T>(
+    originalPromise: Promise<T>,
+    onCancel?: (() => unknown) | undefined,
+  ): Promise<T> {
     if (this.abortSignal.aborted) {
+      onCancel?.();
       // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
       return Promise.reject(this.abortSignal.reason);
     }
 
     const { promise, resolve, reject } = promiseWithResolvers<T>();
     const abort = () => {
+      onCancel?.();
       reject(this.abortSignal.reason);
     };
     this._aborts.add(abort);
@@ -57,45 +62,20 @@ export class PromiseCanceller {
     const iterator = iterable[Symbol.asyncIterator]();
 
     if (iterator.return) {
-      const _next = iterator.next.bind(iterator);
       const _return = iterator.return.bind(iterator);
-
-      const abort = () => {
+      const _returnIgnoringErrors = async (): Promise<IteratorResult<T>> => {
         _return().catch(() => {
           /* c8 ignore next */
           // ignore
         });
+        return Promise.resolve({ value: undefined, done: true });
       };
 
-      if (this.abortSignal.aborted) {
-        abort();
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        const onMethod = () => Promise.reject(this.abortSignal.reason);
-        return {
-          [Symbol.asyncIterator]: () => ({
-            next: onMethod,
-            return: onMethod,
-          }),
-        };
-      }
-
-      this._aborts.add(abort);
-      const on = (method: () => Promise<IteratorResult<T>>) => async () => {
-        try {
-          const iteration = await this.cancellablePromise(method());
-          if (iteration.done) {
-            this._aborts.delete(abort);
-          }
-          return iteration;
-        } catch (error) {
-          this._aborts.delete(abort);
-          throw error;
-        }
-      };
       return {
         [Symbol.asyncIterator]: () => ({
-          next: on(_next),
-          return: on(_return),
+          next: () =>
+            this.cancellablePromise(iterator.next(), _returnIgnoringErrors),
+          return: () => this.cancellablePromise(_return()),
         }),
       };
     }

--- a/src/execution/__tests__/PromiseCanceller-test.ts
+++ b/src/execution/__tests__/PromiseCanceller-test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectPromise } from '../../__testUtils__/expectPromise.js';
@@ -70,62 +69,6 @@ describe('PromiseCanceller', () => {
 
       await expectPromise(withCancellation).toRejectWith('Cancelled!');
     });
-
-    it('works to trigger onCancel when cancelling a hanging promise', async () => {
-      const abortController = new AbortController();
-      const abortSignal = abortController.signal;
-
-      const promiseCanceller = new PromiseCanceller(abortSignal);
-
-      const promise = new Promise(() => {
-        /* never resolves */
-      });
-
-      let onCancelCalled = false;
-      const onCancel = () => {
-        onCancelCalled = true;
-      };
-
-      const withCancellation = promiseCanceller.cancellablePromise(
-        promise,
-        onCancel,
-      );
-
-      expect(onCancelCalled).to.equal(false);
-
-      abortController.abort(new Error('Cancelled!'));
-
-      expect(onCancelCalled).to.equal(true);
-
-      await expectPromise(withCancellation).toRejectWith('Cancelled!');
-    });
-
-    it('works to trigger onCancel when cancelling a hanging promise created after abort signal triggered', async () => {
-      const abortController = new AbortController();
-      const abortSignal = abortController.signal;
-
-      abortController.abort(new Error('Cancelled!'));
-
-      const promiseCanceller = new PromiseCanceller(abortSignal);
-
-      const promise = new Promise(() => {
-        /* never resolves */
-      });
-
-      let onCancelCalled = false;
-      const onCancel = () => {
-        onCancelCalled = true;
-      };
-
-      const withCancellation = promiseCanceller.cancellablePromise(
-        promise,
-        onCancel,
-      );
-
-      expect(onCancelCalled).to.equal(true);
-
-      await expectPromise(withCancellation).toRejectWith('Cancelled!');
-    });
   });
 
   describe('cancellableAsyncIterable', () => {
@@ -171,70 +114,6 @@ describe('PromiseCanceller', () => {
 
       const nextPromise =
         cancellableAsyncIterable[Symbol.asyncIterator]().next();
-
-      await expectPromise(nextPromise).toRejectWith('Cancelled!');
-    });
-
-    it('works to call return', async () => {
-      const abortController = new AbortController();
-      const abortSignal = abortController.signal;
-
-      const promiseCanceller = new PromiseCanceller(abortSignal);
-
-      let returned = false;
-      const asyncIterable = {
-        [Symbol.asyncIterator]: () => ({
-          next: () => Promise.resolve({ value: 1, done: false }),
-          return: () => {
-            returned = true;
-            return Promise.resolve({ value: undefined, done: true });
-          },
-        }),
-      };
-
-      const cancellableAsyncIterable =
-        promiseCanceller.cancellableIterable(asyncIterable);
-
-      abortController.abort(new Error('Cancelled!'));
-
-      expect(returned).to.equal(false);
-
-      const nextPromise =
-        cancellableAsyncIterable[Symbol.asyncIterator]().next();
-
-      expect(returned).to.equal(true);
-
-      await expectPromise(nextPromise).toRejectWith('Cancelled!');
-    });
-
-    it('works to call return when already aborted', async () => {
-      const abortController = new AbortController();
-      const abortSignal = abortController.signal;
-
-      abortController.abort(new Error('Cancelled!'));
-
-      const promiseCanceller = new PromiseCanceller(abortSignal);
-
-      let returned = false;
-      const asyncIterable = {
-        [Symbol.asyncIterator]: () => ({
-          next: () => Promise.resolve({ value: 1, done: false }),
-          return: () => {
-            returned = true;
-            return Promise.resolve({ value: undefined, done: true });
-          },
-        }),
-      };
-
-      const cancellableAsyncIterable =
-        promiseCanceller.cancellableIterable(asyncIterable);
-
-      expect(returned).to.equal(false);
-
-      const nextPromise =
-        cancellableAsyncIterable[Symbol.asyncIterator]().next();
-
-      expect(returned).to.equal(true);
 
       await expectPromise(nextPromise).toRejectWith('Cancelled!');
     });

--- a/src/execution/__tests__/PromiseCanceller-test.ts
+++ b/src/execution/__tests__/PromiseCanceller-test.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectPromise } from '../../__testUtils__/expectPromise.js';
@@ -5,52 +6,237 @@ import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { PromiseCanceller } from '../PromiseCanceller.js';
 
 describe('PromiseCanceller', () => {
-  it('works to cancel an already resolved promise', async () => {
-    const abortController = new AbortController();
-    const abortSignal = abortController.signal;
+  describe('cancellablePromise', () => {
+    it('works to cancel an already resolved promise', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
 
-    const promiseCanceller = new PromiseCanceller(abortSignal);
+      const promiseCanceller = new PromiseCanceller(abortSignal);
 
-    const promise = Promise.resolve(1);
+      const promise = Promise.resolve(1);
 
-    const withCancellation = promiseCanceller.withCancellation(promise);
+      const withCancellation = promiseCanceller.cancellablePromise(promise);
 
-    abortController.abort(new Error('Cancelled!'));
+      abortController.abort(new Error('Cancelled!'));
 
-    await expectPromise(withCancellation).toRejectWith('Cancelled!');
-  });
-
-  it('works to cancel a hanging promise', async () => {
-    const abortController = new AbortController();
-    const abortSignal = abortController.signal;
-
-    const promiseCanceller = new PromiseCanceller(abortSignal);
-
-    const promise = new Promise(() => {
-      /* never resolves */
+      await expectPromise(withCancellation).toRejectWith('Cancelled!');
     });
 
-    const withCancellation = promiseCanceller.withCancellation(promise);
+    it('works to cancel an already resolved promise after abort signal triggered', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
 
-    abortController.abort(new Error('Cancelled!'));
+      abortController.abort(new Error('Cancelled!'));
 
-    await expectPromise(withCancellation).toRejectWith('Cancelled!');
-  });
+      const promiseCanceller = new PromiseCanceller(abortSignal);
 
-  it('works to cancel a hanging promise created after abort signal triggered', async () => {
-    const abortController = new AbortController();
-    const abortSignal = abortController.signal;
+      const promise = Promise.resolve(1);
 
-    abortController.abort(new Error('Cancelled!'));
+      const withCancellation = promiseCanceller.cancellablePromise(promise);
 
-    const promiseCanceller = new PromiseCanceller(abortSignal);
-
-    const promise = new Promise(() => {
-      /* never resolves */
+      await expectPromise(withCancellation).toRejectWith('Cancelled!');
     });
 
-    const withCancellation = promiseCanceller.withCancellation(promise);
+    it('works to cancel a hanging promise', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
 
-    await expectPromise(withCancellation).toRejectWith('Cancelled!');
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      const promise = new Promise(() => {
+        /* never resolves */
+      });
+
+      const withCancellation = promiseCanceller.cancellablePromise(promise);
+
+      abortController.abort(new Error('Cancelled!'));
+
+      await expectPromise(withCancellation).toRejectWith('Cancelled!');
+    });
+
+    it('works to cancel a hanging promise created after abort signal triggered', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      abortController.abort(new Error('Cancelled!'));
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      const promise = new Promise(() => {
+        /* never resolves */
+      });
+
+      const withCancellation = promiseCanceller.cancellablePromise(promise);
+
+      await expectPromise(withCancellation).toRejectWith('Cancelled!');
+    });
+
+    it('works to trigger onCancel when cancelling a hanging promise', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      const promise = new Promise(() => {
+        /* never resolves */
+      });
+
+      let onCancelCalled = false;
+      const onCancel = () => {
+        onCancelCalled = true;
+      };
+
+      const withCancellation = promiseCanceller.cancellablePromise(
+        promise,
+        onCancel,
+      );
+
+      expect(onCancelCalled).to.equal(false);
+
+      abortController.abort(new Error('Cancelled!'));
+
+      expect(onCancelCalled).to.equal(true);
+
+      await expectPromise(withCancellation).toRejectWith('Cancelled!');
+    });
+
+    it('works to trigger onCancel when cancelling a hanging promise created after abort signal triggered', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      abortController.abort(new Error('Cancelled!'));
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      const promise = new Promise(() => {
+        /* never resolves */
+      });
+
+      let onCancelCalled = false;
+      const onCancel = () => {
+        onCancelCalled = true;
+      };
+
+      const withCancellation = promiseCanceller.cancellablePromise(
+        promise,
+        onCancel,
+      );
+
+      expect(onCancelCalled).to.equal(true);
+
+      await expectPromise(withCancellation).toRejectWith('Cancelled!');
+    });
+  });
+
+  describe('cancellableAsyncIterable', () => {
+    it('works to abort a next call', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      const asyncIterable = {
+        [Symbol.asyncIterator]: () => ({
+          next: () => Promise.resolve({ value: 1, done: false }),
+        }),
+      };
+
+      const cancellableAsyncIterable =
+        promiseCanceller.cancellableIterable(asyncIterable);
+
+      const nextPromise =
+        cancellableAsyncIterable[Symbol.asyncIterator]().next();
+
+      abortController.abort(new Error('Cancelled!'));
+
+      await expectPromise(nextPromise).toRejectWith('Cancelled!');
+    });
+
+    it('works to abort a next call when already aborted', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      abortController.abort(new Error('Cancelled!'));
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      const asyncIterable = {
+        [Symbol.asyncIterator]: () => ({
+          next: () => Promise.resolve({ value: 1, done: false }),
+        }),
+      };
+
+      const cancellableAsyncIterable =
+        promiseCanceller.cancellableIterable(asyncIterable);
+
+      const nextPromise =
+        cancellableAsyncIterable[Symbol.asyncIterator]().next();
+
+      await expectPromise(nextPromise).toRejectWith('Cancelled!');
+    });
+
+    it('works to call return', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      let returned = false;
+      const asyncIterable = {
+        [Symbol.asyncIterator]: () => ({
+          next: () => Promise.resolve({ value: 1, done: false }),
+          return: () => {
+            returned = true;
+            return Promise.resolve({ value: undefined, done: true });
+          },
+        }),
+      };
+
+      const cancellableAsyncIterable =
+        promiseCanceller.cancellableIterable(asyncIterable);
+
+      abortController.abort(new Error('Cancelled!'));
+
+      expect(returned).to.equal(false);
+
+      const nextPromise =
+        cancellableAsyncIterable[Symbol.asyncIterator]().next();
+
+      expect(returned).to.equal(true);
+
+      await expectPromise(nextPromise).toRejectWith('Cancelled!');
+    });
+
+    it('works to call return when already aborted', async () => {
+      const abortController = new AbortController();
+      const abortSignal = abortController.signal;
+
+      abortController.abort(new Error('Cancelled!'));
+
+      const promiseCanceller = new PromiseCanceller(abortSignal);
+
+      let returned = false;
+      const asyncIterable = {
+        [Symbol.asyncIterator]: () => ({
+          next: () => Promise.resolve({ value: 1, done: false }),
+          return: () => {
+            returned = true;
+            return Promise.resolve({ value: undefined, done: true });
+          },
+        }),
+      };
+
+      const cancellableAsyncIterable =
+        promiseCanceller.cancellableIterable(asyncIterable);
+
+      expect(returned).to.equal(false);
+
+      const nextPromise =
+        cancellableAsyncIterable[Symbol.asyncIterator]().next();
+
+      expect(returned).to.equal(true);
+
+      await expectPromise(nextPromise).toRejectWith('Cancelled!');
+    });
   });
 });

--- a/src/execution/__tests__/abort-signal-test.ts
+++ b/src/execution/__tests__/abort-signal-test.ts
@@ -795,7 +795,7 @@ describe('Execute: Cancellation', () => {
     });
   });
 
-  it('should stop the execution when aborted prior to return of the subscription resolver', async () => {
+  it('should stop the execution when aborted during subscription', async () => {
     const abortController = new AbortController();
     const document = parse(`
       subscription {
@@ -830,42 +830,6 @@ describe('Execute: Cancellation', () => {
     });
   });
 
-  it('should successfully wrap the subscription', async () => {
-    const abortController = new AbortController();
-    const document = parse(`
-      subscription {
-        foo
-      }
-    `);
-
-    const subscription = subscribe({
-      document,
-      schema,
-      abortSignal: abortController.signal,
-      rootValue: {
-        async *foo() {
-          yield await Promise.resolve({ foo: 'foo' });
-        },
-      },
-    });
-
-    assert(isAsyncIterable(subscription));
-
-    expectJSON(await subscription.next()).toDeepEqual({
-      value: {
-        data: {
-          foo: 'foo',
-        },
-      },
-      done: false,
-    });
-
-    expectJSON(await subscription.next()).toDeepEqual({
-      value: undefined,
-      done: true,
-    });
-  });
-
   it('should stop the execution when aborted during subscription', async () => {
     const abortController = new AbortController();
     const document = parse(`
@@ -880,6 +844,7 @@ describe('Execute: Cancellation', () => {
       abortSignal: abortController.signal,
       rootValue: {
         async *foo() {
+          yield await Promise.resolve({ foo: 'foo' });
           yield await Promise.resolve({ foo: 'foo' }); /* c8 ignore start */
         } /* c8 ignore stop */,
       },

--- a/src/execution/__tests__/abort-signal-test.ts
+++ b/src/execution/__tests__/abort-signal-test.ts
@@ -1,8 +1,11 @@
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { isAsyncIterable } from '../../jsutils/isAsyncIterable.js';
 
 import type { DocumentNode } from '../../language/ast.js';
 import { parse } from '../../language/parser.js';
@@ -400,6 +403,56 @@ describe('Execute: Cancellation', () => {
     });
   });
 
+  it('should stop the execution when aborted despite a hanging async item', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          items
+        }
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        todo: () => ({
+          id: '1',
+          async *items() {
+            yield await new Promise(() => {
+              /* will never resolve */
+            }); /* c8 ignore start */
+          } /* c8 ignore stop */,
+        }),
+      },
+    });
+
+    abortController.abort();
+
+    const result = await resultPromise;
+
+    expect(result.errors?.[0].originalError?.name).to.equal('AbortError');
+
+    expectJSON(result).toDeepEqual({
+      data: {
+        todo: {
+          id: '1',
+          items: null,
+        },
+      },
+      errors: [
+        {
+          message: 'This operation was aborted',
+          path: ['todo', 'items'],
+          locations: [{ line: 5, column: 11 }],
+        },
+      ],
+    });
+  });
+
   it('should stop the execution when aborted with proper null bubbling', async () => {
     const abortController = new AbortController();
     const document = parse(`
@@ -610,6 +663,63 @@ describe('Execute: Cancellation', () => {
     ]);
   });
 
+  it('should stop streamed execution when aborted', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          items @stream
+        }
+      }
+    `);
+
+    const resultPromise = complete(
+      document,
+      {
+        todo: {
+          id: '1',
+          items: [Promise.resolve('item')],
+        },
+      },
+      abortController.signal,
+    );
+
+    abortController.abort();
+
+    const result = await resultPromise;
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          todo: {
+            id: '1',
+            items: [],
+          },
+        },
+        pending: [{ id: '0', path: ['todo', 'items'] }],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message: 'This operation was aborted',
+                path: ['todo', 'items', 0],
+                locations: [{ line: 5, column: 11 }],
+              },
+            ],
+            id: '0',
+          },
+        ],
+        completed: [{ id: '0' }],
+        hasNext: false,
+      },
+    ]);
+  });
+
   it('should stop the execution when aborted mid-mutation', async () => {
     const abortController = new AbortController();
     const document = parse(`
@@ -693,7 +803,7 @@ describe('Execute: Cancellation', () => {
       }
     `);
 
-    const resultPromise = subscribe({
+    const subscriptionPromise = subscribe({
       document,
       schema,
       abortSignal: abortController.signal,
@@ -707,7 +817,7 @@ describe('Execute: Cancellation', () => {
 
     abortController.abort();
 
-    const result = await resultPromise;
+    const result = await subscriptionPromise;
 
     expectJSON(result).toDeepEqual({
       errors: [
@@ -718,5 +828,82 @@ describe('Execute: Cancellation', () => {
         },
       ],
     });
+  });
+
+  it('should stop the execution when aborted during subscription', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      subscription {
+        foo
+      }
+    `);
+
+    const subscription = subscribe({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        async *foo() {
+          yield await Promise.resolve({ foo: 'foo' });
+          yield await Promise.resolve({ foo: 'foo' }); /* c8 ignore start */
+        } /* c8 ignore stop */,
+      },
+    });
+
+    assert(isAsyncIterable(subscription));
+
+    expectJSON(await subscription.next()).toDeepEqual({
+      value: {
+        data: {
+          foo: 'foo',
+        },
+      },
+      done: false,
+    });
+
+    abortController.abort();
+
+    await expectPromise(subscription.next()).toRejectWith(
+      'This operation was aborted',
+    );
+  });
+
+  it('should stop the execution when aborted during subscription returned asynchronously', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      subscription {
+        foo
+      }
+    `);
+
+    async function* foo() {
+      yield await Promise.resolve({ foo: 'foo' });
+    }
+
+    const subscription = await subscribe({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        foo: Promise.resolve(foo()),
+      },
+    });
+
+    assert(isAsyncIterable(subscription));
+
+    expectJSON(await subscription.next()).toDeepEqual({
+      value: {
+        data: {
+          foo: 'foo',
+        },
+      },
+      done: false,
+    });
+
+    abortController.abort();
+
+    await expectPromise(subscription.next()).toRejectWith(
+      'This operation was aborted',
+    );
   });
 });

--- a/src/execution/__tests__/mapAsyncIterable-test.ts
+++ b/src/execution/__tests__/mapAsyncIterable-test.ts
@@ -89,6 +89,54 @@ describe('mapAsyncIterable', () => {
     });
   });
 
+  it('calls done when completes', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    let done = false;
+    const doubles = mapAsyncIterable(
+      source(),
+      (x) => Promise.resolve(x + x),
+      () => {
+        done = true;
+      },
+    );
+
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 6, done: false });
+    expect(done).to.equal(false);
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(done).to.equal(true);
+  });
+
+  it('calls done when completes with error', async () => {
+    async function* source() {
+      yield 1;
+      throw new Error('Oops');
+    }
+
+    let done = false;
+    const doubles = mapAsyncIterable(
+      source(),
+      (x) => Promise.resolve(x + x),
+      () => {
+        done = true;
+      },
+    );
+
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(done).to.equal(false);
+    await expectPromise(doubles.next()).toRejectWith('Oops');
+    expect(done).to.equal(true);
+  });
+
   it('allows returning early from mapped async generator', async () => {
     async function* source() {
       try {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -2108,10 +2108,10 @@ function mapSourceToResponse(
   }
 
   const abortSignal = validatedExecutionArgs.abortSignal;
-
   const promiseCanceller = abortSignal
     ? new PromiseCanceller(abortSignal)
     : undefined;
+
   // For each payload yielded from a subscription, map it over the normal
   // GraphQL `execute` function, with `payload` as the rootValue.
   // This implements the "MapSourceToResponseEvent" algorithm described in

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -2292,8 +2292,7 @@ function executeSubscription(
       );
     }
 
-    const eventStream = assertEventStream(result);
-    return eventStream;
+    return assertEventStream(result);
   } catch (error) {
     throw locatedError(error, fieldNodes, pathToArray(path));
   }

--- a/src/execution/mapAsyncIterable.ts
+++ b/src/execution/mapAsyncIterable.ts
@@ -7,18 +7,28 @@ import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
 export function mapAsyncIterable<T, U, R = undefined>(
   iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
   callback: (value: T) => PromiseOrValue<U>,
+  onDone?: (() => void) | undefined,
 ): AsyncGenerator<U, R, void> {
   const iterator = iterable[Symbol.asyncIterator]();
 
   async function mapResult(
-    result: IteratorResult<T, R>,
+    promise: Promise<IteratorResult<T, R>>,
   ): Promise<IteratorResult<U, R>> {
-    if (result.done) {
-      return result;
+    let value: T;
+    try {
+      const result = await promise;
+      if (result.done) {
+        onDone?.();
+        return result;
+      }
+      value = result.value;
+    } catch (error) {
+      onDone?.();
+      throw error;
     }
 
     try {
-      return { value: await callback(result.value), done: false };
+      return { value: await callback(value), done: false };
     } catch (error) {
       /* c8 ignore start */
       // FIXME: add test case
@@ -36,17 +46,17 @@ export function mapAsyncIterable<T, U, R = undefined>(
 
   return {
     async next() {
-      return mapResult(await iterator.next());
+      return mapResult(iterator.next());
     },
     async return(): Promise<IteratorResult<U, R>> {
       // If iterator.return() does not exist, then type R must be undefined.
       return typeof iterator.return === 'function'
-        ? mapResult(await iterator.return())
+        ? mapResult(iterator.return())
         : { value: undefined as any, done: true };
     },
     async throw(error?: unknown) {
       if (typeof iterator.throw === 'function') {
-        return mapResult(await iterator.throw(error));
+        return mapResult(iterator.throw(error));
       }
       throw error;
     },


### PR DESCRIPTION
When the abort signal is triggered, any pending `.next()` calls should return immediately, ~~and the underlying async iterables `.return()` method should be called~~