### PR TITLE
Add safe schema change for descriptions changing

### DIFF
--- a/src/utilities/__tests__/findSchemaChanges-test.ts
+++ b/src/utilities/__tests__/findSchemaChanges-test.ts
@@ -22,6 +22,23 @@ describe('findSchemaChanges', () => {
     ]);
   });
 
+  it('should detect a type changing description', () => {
+    const newSchema = buildSchema(`
+      "New Description"
+      type Type1
+    `);
+
+    const oldSchema = buildSchema(`
+      type Type1
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: 'Description of Type1 has changed to "New Description".',
+      },
+    ]);
+  });
+
   it('should detect if a field was added', () => {
     const oldSchema = buildSchema(`
       type Query {
@@ -39,6 +56,30 @@ describe('findSchemaChanges', () => {
       {
         type: SafeChangeType.FIELD_ADDED,
         description: 'Field Query.bar was added.',
+      },
+    ]);
+  });
+
+  it('should detect a field changing description', () => {
+    const oldSchema = buildSchema(`
+      type Query {
+        foo: String
+        bar: String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      type Query {
+        foo: String
+        "New Description"
+        bar: String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description:
+          'Description of field Query.bar has changed to "New Description".',
       },
     ]);
   });
@@ -84,6 +125,30 @@ describe('findSchemaChanges', () => {
     ]);
   });
 
+  it('should detect if an arg value changes description', () => {
+    const oldSchema = buildSchema(`
+      type Query {
+        foo(x: String!): String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      type Query {
+        foo(
+          "New Description"
+          x: String!
+        ): String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description:
+          'Description of argument Query.foo(x) has changed to "New Description".',
+      },
+    ]);
+  });
+
   it('should detect if a directive was added', () => {
     const oldSchema = buildSchema(`
       type Query {
@@ -102,6 +167,31 @@ describe('findSchemaChanges', () => {
       {
         description: 'Directive @Foo was added.',
         type: SafeChangeType.DIRECTIVE_ADDED,
+      },
+    ]);
+  });
+
+  it('should detect if a directive changes description', () => {
+    const oldSchema = buildSchema(`
+      directive @Foo on FIELD_DEFINITION
+
+      type Query {
+        foo: String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      "New Description"
+      directive @Foo on FIELD_DEFINITION
+
+      type Query {
+        foo: String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description: 'Description of @Foo has changed to "New Description".',
+        type: SafeChangeType.DESCRIPTION_CHANGED,
       },
     ]);
   });
@@ -174,6 +264,96 @@ describe('findSchemaChanges', () => {
       {
         description: 'An optional argument @Foo(arg1:) was added.',
         type: SafeChangeType.OPTIONAL_DIRECTIVE_ARG_ADDED,
+      },
+    ]);
+  });
+
+  it('should detect if a directive arg changes description', () => {
+    const oldSchema = buildSchema(`
+      directive @Foo(
+        arg1: String
+      ) on FIELD_DEFINITION
+
+      type Query {
+        foo: String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      directive @Foo(
+        "New Description"
+        arg1: String
+      ) on FIELD_DEFINITION
+
+      type Query {
+        foo: String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description:
+          'Description of @Foo(Foo) has changed to "New Description".',
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+      },
+    ]);
+  });
+
+  it('should detect if an enum member changes description', () => {
+    const oldSchema = buildSchema(`
+      enum Foo {
+        TEST
+      }
+
+      type Query {
+        foo: String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      enum Foo {
+        "New Description"
+        TEST
+      }
+
+      type Query {
+        foo: String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description:
+          'Description of enum value Foo.TEST has changed to "New Description".',
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+      },
+    ]);
+  });
+
+  it('should detect if an input field changes description', () => {
+    const oldSchema = buildSchema(`
+      input Foo {
+        x: String
+      }
+
+      type Query {
+        foo: String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      input Foo {
+        "New Description"
+        x: String
+      }
+
+      type Query {
+        foo: String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description:
+          'Description of input-field Foo.x has changed to "New Description".',
+        type: SafeChangeType.DESCRIPTION_CHANGED,
       },
     ]);
   });

--- a/src/utilities/findSchemaChanges.ts
+++ b/src/utilities/findSchemaChanges.ts
@@ -70,6 +70,7 @@ export type DangerousChangeType =
   (typeof DangerousChangeType)[keyof typeof DangerousChangeType];
 
 export const SafeChangeType = {
+  DESCRIPTION_CHANGED: 'DESCRIPTION_CHANGED' as const,
   TYPE_ADDED: 'TYPE_ADDED' as const,
   OPTIONAL_INPUT_FIELD_ADDED: 'OPTIONAL_INPUT_FIELD_ADDED' as const,
   OPTIONAL_ARG_ADDED: 'OPTIONAL_ARG_ADDED' as const,
@@ -194,6 +195,15 @@ function findDirectiveChanges(
       });
     }
 
+    for (const [oldArg, newArg] of argsDiff.persisted) {
+      if (oldArg.description !== newArg.description) {
+        schemaChanges.push({
+          type: SafeChangeType.DESCRIPTION_CHANGED,
+          description: `Description of @${oldDirective.name}(${oldDirective.name}) has changed to "${newArg.description}".`,
+        });
+      }
+    }
+
     if (oldDirective.isRepeatable && !newDirective.isRepeatable) {
       schemaChanges.push({
         type: BreakingChangeType.DIRECTIVE_REPEATABLE_REMOVED,
@@ -203,6 +213,13 @@ function findDirectiveChanges(
       schemaChanges.push({
         type: SafeChangeType.DIRECTIVE_REPEATABLE_ADDED,
         description: `Repeatable flag was added to @${oldDirective.name}.`,
+      });
+    }
+
+    if (oldDirective.description !== newDirective.description) {
+      schemaChanges.push({
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: `Description of @${oldDirective.name} has changed to "${newDirective.description}".`,
       });
     }
 
@@ -256,6 +273,13 @@ function findTypeChanges(
   }
 
   for (const [oldType, newType] of typesDiff.persisted) {
+    if (oldType.description !== newType.description) {
+      schemaChanges.push({
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: `Description of ${oldType.name} has changed to "${newType.description}".`,
+      });
+    }
+
     if (isEnumType(oldType) && isEnumType(newType)) {
       schemaChanges.push(...findEnumTypeChanges(oldType, newType));
     } else if (isUnionType(oldType) && isUnionType(newType)) {
@@ -328,12 +352,19 @@ function findInputObjectTypeChanges(
           `Field ${oldType}.${oldField.name} changed type from ` +
           `${String(oldField.type)} to ${String(newField.type)}.`,
       });
-    } else {
+    } else if (oldField.type.toString() !== newField.type.toString()) {
       schemaChanges.push({
         type: SafeChangeType.FIELD_CHANGED_KIND_SAFE,
         description:
           `Field ${oldType}.${oldField.name} changed type from ` +
           `${String(oldField.type)} to ${String(newField.type)}.`,
+      });
+    }
+
+    if (oldField.description !== newField.description) {
+      schemaChanges.push({
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: `Description of input-field ${newType}.${newField.name} has changed to "${newField.description}".`,
       });
     }
   }
@@ -368,7 +399,7 @@ function findUnionTypeChanges(
 function findEnumTypeChanges(
   oldType: GraphQLEnumType,
   newType: GraphQLEnumType,
-): Array<BreakingChange | DangerousChange> {
+): Array<SchemaChange> {
   const schemaChanges = [];
   const valuesDiff = diff(oldType.getValues(), newType.getValues());
 
@@ -384,6 +415,15 @@ function findEnumTypeChanges(
       type: BreakingChangeType.VALUE_REMOVED_FROM_ENUM,
       description: `Enum value ${oldType}.${oldValue.name} was removed.`,
     });
+  }
+
+  for (const [oldValue, newValue] of valuesDiff.persisted) {
+    if (oldValue.description !== newValue.description) {
+      schemaChanges.push({
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: `Description of enum value ${oldType}.${oldValue.name} has changed to "${newValue.description}".`,
+      });
+    }
   }
 
   return schemaChanges;
@@ -459,6 +499,13 @@ function findFieldChanges(
           `${String(oldField.type)} to ${String(newField.type)}.`,
       });
     }
+
+    if (oldField.description !== newField.description) {
+      schemaChanges.push({
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: `Description of field ${oldType}.${oldField.name} has changed to "${newField.description}".`,
+      });
+    }
   }
 
   return schemaChanges;
@@ -484,6 +531,7 @@ function findArgChanges(
       oldArg.type,
       newArg.type,
     );
+
     if (!isSafe) {
       schemaChanges.push({
         type: BreakingChangeType.ARG_CHANGED_KIND,
@@ -520,12 +568,19 @@ function findArgChanges(
         type: SafeChangeType.ARG_DEFAULT_VALUE_ADDED,
         description: `${oldType}.${oldField.name}(${oldArg.name}:) added a defaultValue ${newValueStr}.`,
       });
-    } else {
+    } else if (oldArg.type.toString() !== newArg.type.toString()) {
       schemaChanges.push({
         type: SafeChangeType.ARG_CHANGED_KIND_SAFE,
         description:
           `Argument ${oldType}.${oldField.name}(${oldArg.name}:) has changed type from ` +
           `${String(oldArg.type)} to ${String(newArg.type)}.`,
+      });
+    }
+
+    if (oldArg.description !== newArg.description) {
+      schemaChanges.push({
+        type: SafeChangeType.DESCRIPTION_CHANGED,
+        description: `Description of argument ${oldType}.${oldField.name}(${oldArg.name}) has changed to "${newArg.description}".`,
       });
     }
   }


### PR DESCRIPTION
This adds a new safe schema-change when a description changes of any schema-member. Do note that there are some drive-by fixes in here as I noticed a bug in safe-argument changes where we'd just always report the changes rather than actually see whether something changed 😅 

Resolves https://github.com/graphql/graphql-js/issues/4245