### PR TITLE
introduce simple user provided caches for parse/validate

### DIFF
--- a/src/__tests__/starWarsValidation-test.ts
+++ b/src/__tests__/starWarsValidation-test.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../language/parser.js';
+import { parseSync as parse } from '../language/parser.js';
 import { Source } from '../language/source.js';
 
-import { validate } from '../validation/validate.js';
+import { validateSync as validate } from '../validation/validate.js';
 
 import { StarWarsSchema } from './starWarsSchema.js';
 

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import { dedent } from '../../__testUtils__/dedent.js';
 
 import { Kind } from '../../language/kinds.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 import { Source } from '../../language/source.js';
 
 import { GraphQLError } from '../GraphQLError.js';

--- a/src/execution/__tests__/abort-signal-test.ts
+++ b/src/execution/__tests__/abort-signal-test.ts
@@ -5,7 +5,7 @@ import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import type { DocumentNode } from '../../language/ast.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import {
   assertInterfaceType,

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -8,7 +8,7 @@ import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
 
 import type { DocumentNode } from '../../language/ast.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import {
   GraphQLList,

--- a/src/execution/__tests__/directives-test.ts
+++ b/src/execution/__tests__/directives-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLString } from '../../type/scalars.js';

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -7,7 +7,7 @@ import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 import { inspect } from '../../jsutils/inspect.js';
 
 import { Kind } from '../../language/kinds.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import {
   GraphQLInterfaceType,

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -5,7 +5,7 @@ import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
 import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import type { GraphQLFieldResolver } from '../../type/definition.js';
 import {

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -4,7 +4,7 @@ import { describe, it } from 'mocha';
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLInt } from '../../type/scalars.js';

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -6,7 +6,7 @@ import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLNonNull, GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLString } from '../../type/scalars.js';

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 

--- a/src/execution/__tests__/resolve-test.ts
+++ b/src/execution/__tests__/resolve-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import type { GraphQLFieldConfig } from '../../type/definition.js';
 import { GraphQLObjectType } from '../../type/definition.js';

--- a/src/execution/__tests__/schema-test.ts
+++ b/src/execution/__tests__/schema-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import {
   GraphQLList,

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -9,7 +9,7 @@ import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
 
 import type { DocumentNode } from '../../language/ast.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import {
   GraphQLList,

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -10,7 +10,7 @@ import { isAsyncIterable } from '../../jsutils/isAsyncIterable.js';
 import { isPromise } from '../../jsutils/isPromise.js';
 import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLList, GraphQLObjectType } from '../../type/definition.js';
 import {

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -3,13 +3,13 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { validate } from '../../validation/validate.js';
+import { validateSync as validate } from '../../validation/validate.js';
 
 import { graphqlSync } from '../../graphql.js';
 

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import {
   GraphQLInterfaceType,

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -9,7 +9,7 @@ import { GraphQLError } from '../../error/GraphQLError.js';
 
 import { DirectiveLocation } from '../../language/directiveLocation.js';
 import { Kind } from '../../language/kinds.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import type {
   GraphQLArgumentConfig,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -2,7 +2,7 @@ import { isPromise } from './jsutils/isPromise.js';
 import type { Maybe } from './jsutils/Maybe.js';
 import type { PromiseOrValue } from './jsutils/PromiseOrValue.js';
 
-import { parse } from './language/parser.js';
+import { parseSync as parse } from './language/parser.js';
 import type { Source } from './language/source.js';
 
 import type {
@@ -12,7 +12,7 @@ import type {
 import type { GraphQLSchema } from './type/schema.js';
 import { validateSchema } from './type/validate.js';
 
-import { validate } from './validation/validate.js';
+import { validateSync as validate } from './validation/validate.js';
 
 import { execute } from './execution/execute.js';
 import type { ExecutionResult } from './execution/types.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,7 @@ export {
   TokenKind,
   // Parse
   parse,
+  parseSync,
   parseValue,
   parseConstValue,
   parseType,
@@ -247,6 +248,7 @@ export {
 
 export type {
   ParseOptions,
+  ParseCache,
   SourceLocation,
   // Visitor utilities
   ASTVisitor,
@@ -356,6 +358,7 @@ export type {
 // Validate GraphQL documents.
 export {
   validate,
+  validateSync,
   ValidationContext,
   // All validation rules in the GraphQL Specification.
   specifiedRules,
@@ -402,7 +405,11 @@ export {
   NoSchemaIntrospectionCustomRule,
 } from './validation/index.js';
 
-export type { ValidationRule } from './validation/index.js';
+export type {
+  ValidationRule,
+  ValidateOptions,
+  ValidateCache,
+} from './validation/index.js';
 
 // Create, format, and print GraphQL errors.
 export { GraphQLError, syntaxError, locatedError } from './error/index.js';

--- a/src/jsutils/__tests__/withCache-test.ts
+++ b/src/jsutils/__tests__/withCache-test.ts
@@ -1,0 +1,154 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { isPromise } from '../isPromise.js';
+import { withCache } from '../withCache.js';
+
+describe('withCache', () => {
+  it('returns asynchronously using asynchronous cache', async () => {
+    let cached: string | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache = {
+      set: async (result: string) => {
+        await resolveOnNextTick();
+        cached = result;
+      },
+      get: () => {
+        getAttempts++;
+        if (cached !== undefined) {
+          cacheHits++;
+        }
+        return Promise.resolve(cached);
+      },
+    };
+
+    const fnWithCache = withCache((arg: string) => arg, customCache);
+
+    const firstResultPromise = fnWithCache('arg');
+    expect(isPromise(firstResultPromise)).to.equal(true);
+    const firstResult = await firstResultPromise;
+
+    expect(firstResult).to.equal('arg');
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondResultPromise = fnWithCache('arg');
+
+    expect(isPromise(secondResultPromise)).to.equal(true);
+
+    const secondResult = await secondResultPromise;
+    expect(secondResult).to.equal('arg');
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('returns synchronously using cache with sync getter and async setter', async () => {
+    let cached: string | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache = {
+      set: async (result: string) => {
+        await resolveOnNextTick();
+        cached = result;
+      },
+      get: () => {
+        getAttempts++;
+        if (cached !== undefined) {
+          cacheHits++;
+        }
+        return cached;
+      },
+    };
+
+    const fnWithCache = withCache((arg: string) => arg, customCache);
+
+    const firstResult = fnWithCache('arg');
+    expect(firstResult).to.equal('arg');
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    await resolveOnNextTick();
+
+    const secondResult = fnWithCache('arg');
+
+    expect(secondResult).to.equal('arg');
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('returns asynchronously using cache with async getter and sync setter', async () => {
+    let cached: string | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache = {
+      set: (result: string) => {
+        cached = result;
+      },
+      get: () => {
+        getAttempts++;
+        if (cached !== undefined) {
+          cacheHits++;
+        }
+        return Promise.resolve(cached);
+      },
+    };
+
+    const fnWithCache = withCache((arg: string) => arg, customCache);
+
+    const firstResultPromise = fnWithCache('arg');
+    expect(isPromise(firstResultPromise)).to.equal(true);
+    const firstResult = await firstResultPromise;
+
+    expect(firstResult).to.equal('arg');
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondResultPromise = fnWithCache('arg');
+
+    expect(isPromise(secondResultPromise)).to.equal(true);
+
+    const secondResult = await secondResultPromise;
+    expect(secondResult).to.equal('arg');
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('ignores async setter errors', async () => {
+    let cached: string | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache = {
+      set: () => Promise.reject(new Error('Oops')),
+      get: () => {
+        getAttempts++;
+        /* c8 ignore next 3 */
+        if (cached !== undefined) {
+          cacheHits++;
+        }
+        return Promise.resolve(cached);
+      },
+    };
+
+    const fnWithCache = withCache((arg: string) => arg, customCache);
+
+    const firstResultPromise = fnWithCache('arg');
+    expect(isPromise(firstResultPromise)).to.equal(true);
+    const firstResult = await firstResultPromise;
+
+    expect(firstResult).to.equal('arg');
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondResultPromise = fnWithCache('arg');
+
+    expect(isPromise(secondResultPromise)).to.equal(true);
+
+    const secondResult = await secondResultPromise;
+    expect(secondResult).to.equal('arg');
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(0);
+  });
+});

--- a/src/jsutils/withCache.ts
+++ b/src/jsutils/withCache.ts
@@ -1,0 +1,49 @@
+import { isPromise } from './isPromise.js';
+import type { PromiseOrValue } from './PromiseOrValue.js';
+
+export interface FnCache<
+  T extends (...args: Array<any>) => Exclude<any, undefined>,
+> {
+  set: (result: ReturnType<T>, ...args: Parameters<T>) => PromiseOrValue<void>;
+  get: (...args: Parameters<T>) => PromiseOrValue<ReturnType<T> | undefined>;
+}
+
+export function withCache<
+  T extends (...args: Array<any>) => Exclude<any, undefined>,
+>(
+  fn: T,
+  cache: FnCache<T>,
+): (...args: Parameters<T>) => ReturnType<T> | Promise<Awaited<ReturnType<T>>> {
+  return (...args: Parameters<T>) => {
+    const maybeResult = cache.get(...args);
+    if (isPromise(maybeResult)) {
+      return maybeResult.then((resolved) =>
+        handleCacheResult(resolved, fn, cache, args),
+      );
+    }
+
+    return handleCacheResult(maybeResult, fn, cache, args);
+  };
+}
+
+function handleCacheResult<
+  T extends (...args: Array<any>) => Exclude<any, undefined>,
+>(
+  cachedResult: Awaited<ReturnType<T>> | undefined,
+  fn: T,
+  cache: FnCache<T>,
+  args: Parameters<T>,
+): Awaited<ReturnType<T>> {
+  if (cachedResult !== undefined) {
+    return cachedResult;
+  }
+
+  const result = fn(...args);
+  const setResult = cache.set(result, ...args);
+  if (isPromise(setResult)) {
+    setResult.catch(() => {
+      /* c8 ignore next */
+    });
+  }
+  return result;
+}

--- a/src/language/__tests__/parser-cache-test.ts
+++ b/src/language/__tests__/parser-cache-test.ts
@@ -1,0 +1,267 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { isPromise } from '../../jsutils/isPromise.js';
+
+import type { DocumentNode } from '../ast.js';
+import type { ParseCache } from '../parser.js';
+import { parse, parseSync } from '../parser.js';
+
+describe('Parser Cache', () => {
+  const fooDocument = {
+    kind: 'Document',
+    definitions: [
+      {
+        kind: 'OperationDefinition',
+        name: undefined,
+        operation: 'query',
+        selectionSet: {
+          kind: 'SelectionSet',
+          selections: [
+            {
+              alias: undefined,
+              arguments: undefined,
+              directives: undefined,
+              kind: 'Field',
+              loc: { start: 2, end: 5 },
+              name: {
+                kind: 'Name',
+                value: 'foo',
+                loc: { start: 2, end: 5 },
+              },
+              selectionSet: undefined,
+            },
+          ],
+          loc: { start: 0, end: 7 },
+        },
+        variableDefinitions: undefined,
+        directives: undefined,
+        loc: { start: 0, end: 7 },
+      },
+    ],
+    loc: { start: 0, end: 7 },
+  };
+
+  it('parses asynchronously using asynchronous cache', async () => {
+    let cachedDocument: DocumentNode | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache: ParseCache = {
+      set: async (resultedDocument) => {
+        await resolveOnNextTick();
+        cachedDocument = resultedDocument;
+      },
+      get: () => {
+        getAttempts++;
+        if (cachedDocument) {
+          cacheHits++;
+        }
+        return Promise.resolve(cachedDocument);
+      },
+    };
+
+    const firstDocumentPromise = parse('{ foo }', {
+      cache: customCache,
+    });
+    expect(isPromise(firstDocumentPromise)).to.equal(true);
+    const firstDocument = await firstDocumentPromise;
+
+    expectJSON(firstDocument).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondDocumentPromise = parse('{ foo }', {
+      cache: customCache,
+    });
+
+    expect(isPromise(secondDocumentPromise)).to.equal(true);
+
+    const secondErrors = await secondDocumentPromise;
+    expectJSON(secondErrors).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('parses synchronously using cache with sync getter and async setter', async () => {
+    let cachedDocument: DocumentNode | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache: ParseCache = {
+      set: async (resultedDocument) => {
+        await resolveOnNextTick();
+        cachedDocument = resultedDocument;
+      },
+      get: () => {
+        getAttempts++;
+        if (cachedDocument) {
+          cacheHits++;
+        }
+        return cachedDocument;
+      },
+    };
+
+    const firstDocument = parse('{ foo }', {
+      cache: customCache,
+    });
+
+    expectJSON(firstDocument).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    await resolveOnNextTick();
+
+    const secondErrors = parse('{ foo }', {
+      cache: customCache,
+    });
+
+    expectJSON(secondErrors).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('parses asynchronously using cache with async getter and sync setter', async () => {
+    let cachedDocument: DocumentNode | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache: ParseCache = {
+      set: (resultedDocument) => {
+        cachedDocument = resultedDocument;
+      },
+      get: () => {
+        getAttempts++;
+        if (cachedDocument) {
+          cacheHits++;
+        }
+        return Promise.resolve(cachedDocument);
+      },
+    };
+
+    const firstDocumentPromise = parse('{ foo }', {
+      cache: customCache,
+    });
+    const firstDocument = await firstDocumentPromise;
+
+    expectJSON(firstDocument).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondDocumentPromise = parse('{ foo }', {
+      cache: customCache,
+    });
+
+    expect(isPromise(secondDocumentPromise)).to.equal(true);
+
+    const secondErrors = await secondDocumentPromise;
+    expectJSON(secondErrors).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('parseSync parses synchronously using synchronous cache', () => {
+    let cachedDocument: DocumentNode | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache: ParseCache = {
+      set: (resultedDocument) => {
+        cachedDocument = resultedDocument;
+      },
+      get: () => {
+        getAttempts++;
+        if (cachedDocument) {
+          cacheHits++;
+        }
+        return cachedDocument;
+      },
+    };
+
+    const firstDocument = parseSync('{ foo }', {
+      cache: customCache,
+    });
+
+    expectJSON(firstDocument).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondErrors = parseSync('{ foo }', {
+      cache: customCache,
+    });
+
+    expectJSON(secondErrors).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('parseSync throws using asynchronous cache', () => {
+    let cachedDocument: DocumentNode | undefined;
+    const customCache: ParseCache = {
+      set: async (resultedDocument) => {
+        await resolveOnNextTick();
+        cachedDocument = resultedDocument;
+      },
+      get: () => Promise.resolve(cachedDocument),
+    };
+
+    expect(() =>
+      parseSync('{ foo }', {
+        cache: customCache,
+      }),
+    ).to.throw('GraphQL parsing failed to complete synchronously.');
+  });
+
+  it('parseSync parses synchronously using sync getter and async setter', async () => {
+    let cachedDocument: DocumentNode | undefined;
+    let getAttempts = 0;
+    let cacheHits = 0;
+    const customCache: ParseCache = {
+      set: async (resultedDocument) => {
+        await resolveOnNextTick();
+        cachedDocument = resultedDocument;
+      },
+      get: () => {
+        getAttempts++;
+        if (cachedDocument) {
+          cacheHits++;
+        }
+        return cachedDocument;
+      },
+    };
+
+    const firstDocument = parseSync('{ foo }', {
+      cache: customCache,
+    });
+
+    await resolveOnNextTick();
+
+    expectJSON(firstDocument).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(1);
+    expect(cacheHits).to.equal(0);
+
+    const secondErrors = parseSync('{ foo }', {
+      cache: customCache,
+    });
+
+    expectJSON(secondErrors).toDeepEqual(fooDocument);
+    expect(getAttempts).to.equal(2);
+    expect(cacheHits).to.equal(1);
+  });
+
+  it('parseSync throws using asynchronous cache', () => {
+    let cachedDocument: DocumentNode | undefined;
+    const customCache: ParseCache = {
+      set: async (resultedDocument) => {
+        await resolveOnNextTick();
+        cachedDocument = resultedDocument;
+      },
+      get: () => Promise.resolve(cachedDocument),
+    };
+
+    expect(() =>
+      parseSync('{ foo }', {
+        cache: customCache,
+      }),
+    ).to.throw('GraphQL parsing failed to complete synchronously.');
+  });
+});

--- a/src/language/__tests__/parser-cache-test.ts
+++ b/src/language/__tests__/parser-cache-test.ts
@@ -46,7 +46,7 @@ describe('Parser Cache', () => {
   };
 
   it('parses asynchronously using asynchronous cache', async () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ParseCache = {
@@ -86,7 +86,7 @@ describe('Parser Cache', () => {
   });
 
   it('parses synchronously using cache with sync getter and async setter', async () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ParseCache = {
@@ -123,7 +123,7 @@ describe('Parser Cache', () => {
   });
 
   it('parses asynchronously using cache with async getter and sync setter', async () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ParseCache = {
@@ -161,7 +161,7 @@ describe('Parser Cache', () => {
   });
 
   it('parseSync parses synchronously using synchronous cache', () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ParseCache = {
@@ -195,7 +195,7 @@ describe('Parser Cache', () => {
   });
 
   it('parseSync throws using asynchronous cache', () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     const customCache: ParseCache = {
       set: async (resultedDocument) => {
         await resolveOnNextTick();
@@ -212,7 +212,7 @@ describe('Parser Cache', () => {
   });
 
   it('parseSync parses synchronously using sync getter and async setter', async () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ParseCache = {
@@ -249,7 +249,7 @@ describe('Parser Cache', () => {
   });
 
   it('parseSync throws using asynchronous cache', () => {
-    let cachedDocument: DocumentNode | undefined;
+    let cachedDocument: DocumentNode | Error | undefined;
     const customCache: ParseCache = {
       set: async (resultedDocument) => {
         await resolveOnNextTick();

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -11,7 +11,12 @@ import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery.js';
 import { inspect } from '../../jsutils/inspect.js';
 
 import { Kind } from '../kinds.js';
-import { parse, parseConstValue, parseType, parseValue } from '../parser.js';
+import {
+  parseConstValue,
+  parseSync as parse,
+  parseType,
+  parseValue,
+} from '../parser.js';
 import { Source } from '../source.js';
 import { TokenKind } from '../tokenKind.js';
 

--- a/src/language/__tests__/printer-test.ts
+++ b/src/language/__tests__/printer-test.ts
@@ -5,7 +5,7 @@ import { dedent, dedentString } from '../../__testUtils__/dedent.js';
 import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery.js';
 
 import { Kind } from '../kinds.js';
-import { parse } from '../parser.js';
+import { parseSync as parse } from '../parser.js';
 import { print } from '../printer.js';
 
 describe('Printer: Query document', () => {

--- a/src/language/__tests__/schema-parser-test.ts
+++ b/src/language/__tests__/schema-parser-test.ts
@@ -8,7 +8,7 @@ import {
 } from '../../__testUtils__/expectJSON.js';
 import { kitchenSinkSDL } from '../../__testUtils__/kitchenSinkSDL.js';
 
-import { parse } from '../parser.js';
+import { parseSync as parse } from '../parser.js';
 
 function expectSyntaxError(text: string) {
   return expectToThrowJSON(() => parse(text));

--- a/src/language/__tests__/schema-printer-test.ts
+++ b/src/language/__tests__/schema-printer-test.ts
@@ -5,7 +5,7 @@ import { dedent } from '../../__testUtils__/dedent.js';
 import { kitchenSinkSDL } from '../../__testUtils__/kitchenSinkSDL.js';
 
 import { Kind } from '../kinds.js';
-import { parse } from '../parser.js';
+import { parseSync as parse } from '../parser.js';
 import { print } from '../printer.js';
 
 describe('Printer: SDL document', () => {

--- a/src/language/__tests__/visitor-test.ts
+++ b/src/language/__tests__/visitor-test.ts
@@ -6,7 +6,7 @@ import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery.js';
 import type { ASTNode, SelectionSetNode } from '../ast.js';
 import { isNode } from '../ast.js';
 import { Kind } from '../kinds.js';
-import { parse } from '../parser.js';
+import { parseSync as parse } from '../parser.js';
 import type { ASTVisitor, ASTVisitorKeyMap } from '../visitor.js';
 import { BREAK, visit, visitInParallel } from '../visitor.js';
 

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -11,8 +11,14 @@ export { TokenKind } from './tokenKind.js';
 
 export { Lexer } from './lexer.js';
 
-export { parse, parseValue, parseConstValue, parseType } from './parser.js';
-export type { ParseOptions } from './parser.js';
+export {
+  parse,
+  parseSync,
+  parseValue,
+  parseConstValue,
+  parseType,
+} from './parser.js';
+export type { ParseOptions, ParseCache } from './parser.js';
 
 export { print } from './printer.js';
 

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -120,14 +120,14 @@ export interface ParseOptions {
 
 export interface ParseCache {
   set: (
-    document: DocumentNode,
+    document: DocumentNode | Error,
     source: string | Source,
     options?: ParseOptions | undefined,
   ) => PromiseOrValue<void> | void;
   get: (
     source: string | Source,
     options?: ParseOptions | undefined,
-  ) => PromiseOrValue<DocumentNode | undefined>;
+  ) => PromiseOrValue<DocumentNode | Error | undefined>;
 }
 
 /**

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -7,7 +7,7 @@ import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { inspect } from '../../jsutils/inspect.js';
 
 import { DirectiveLocation } from '../../language/directiveLocation.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 import { extendSchema } from '../../utilities/extendSchema.js';

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse, parseValue } from '../../language/parser.js';
+import { parseSync as parse, parseValue } from '../../language/parser.js';
 import { print } from '../../language/printer.js';
 import { visit } from '../../language/visitor.js';
 

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -8,7 +8,7 @@ import type { Maybe } from '../../jsutils/Maybe.js';
 
 import type { ASTNode } from '../../language/ast.js';
 import { Kind } from '../../language/kinds.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 import { print } from '../../language/printer.js';
 
 import {

--- a/src/utilities/__tests__/concatAST-test.ts
+++ b/src/utilities/__tests__/concatAST-test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 import { print } from '../../language/printer.js';
 import { Source } from '../../language/source.js';
 

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -6,7 +6,7 @@ import { dedent } from '../../__testUtils__/dedent.js';
 import type { Maybe } from '../../jsutils/Maybe.js';
 
 import type { ASTNode } from '../../language/ast.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 import { print } from '../../language/printer.js';
 
 import {

--- a/src/utilities/__tests__/getIntrospectionQuery-test.ts
+++ b/src/utilities/__tests__/getIntrospectionQuery-test.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
-import { validate } from '../../validation/validate.js';
+import { validateSync as validate } from '../../validation/validate.js';
 
 import { buildSchema } from '../buildASTSchema.js';
 import type { IntrospectionOptions } from '../getIntrospectionQuery.js';

--- a/src/utilities/__tests__/getOperationAST-test.ts
+++ b/src/utilities/__tests__/getOperationAST-test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { getOperationAST } from '../getOperationAST.js';
 

--- a/src/utilities/__tests__/separateOperations-test.ts
+++ b/src/utilities/__tests__/separateOperations-test.ts
@@ -5,7 +5,7 @@ import { dedent } from '../../__testUtils__/dedent.js';
 
 import { mapValue } from '../../jsutils/mapValue.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 import { print } from '../../language/printer.js';
 
 import { separateOperations } from '../separateOperations.js';

--- a/src/utilities/__tests__/stripIgnoredCharacters-test.ts
+++ b/src/utilities/__tests__/stripIgnoredCharacters-test.ts
@@ -8,7 +8,7 @@ import { kitchenSinkSDL } from '../../__testUtils__/kitchenSinkSDL.js';
 import type { Maybe } from '../../jsutils/Maybe.js';
 
 import { Lexer } from '../../language/lexer.js';
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 import { Source } from '../../language/source.js';
 
 import { stripIgnoredCharacters } from '../stripIgnoredCharacters.js';

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -1,6 +1,6 @@
 import type { DocumentNode } from '../language/ast.js';
 import type { ParseOptions } from '../language/parser.js';
-import { parse } from '../language/parser.js';
+import { parseSync as parse } from '../language/parser.js';
 import type { Source } from '../language/source.js';
 
 import { specifiedDirectives } from '../type/directives.js';

--- a/src/utilities/introspectionFromSchema.ts
+++ b/src/utilities/introspectionFromSchema.ts
@@ -1,6 +1,6 @@
 import { invariant } from '../jsutils/invariant.js';
 
-import { parse } from '../language/parser.js';
+import { parseSync as parse } from '../language/parser.js';
 
 import type { GraphQLSchema } from '../type/schema.js';
 

--- a/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import type { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
 import { FieldsOnCorrectTypeRule } from '../rules/FieldsOnCorrectTypeRule.js';
-import { validate } from '../validate.js';
+import { validateSync as validate } from '../validate.js';
 
 import { expectValidationErrorsWithSchema } from './harness.js';
 

--- a/src/validation/__tests__/ScalarLeafsRule-test.ts
+++ b/src/validation/__tests__/ScalarLeafsRule-test.ts
@@ -7,7 +7,7 @@ import { OperationTypeNode } from '../../language/ast.js';
 import { Kind } from '../../language/kinds.js';
 
 import { ScalarLeafsRule } from '../rules/ScalarLeafsRule.js';
-import { validate } from '../validate.js';
+import { validateSync as validate } from '../validate.js';
 
 import { expectValidationErrors, testSchema } from './harness.js';
 

--- a/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.ts
+++ b/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import type { GraphQLSchema } from '../../type/schema.js';
 

--- a/src/validation/__tests__/ValidationContext-test.ts
+++ b/src/validation/__tests__/ValidationContext-test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha';
 
 import { identityFunc } from '../../jsutils/identityFunc.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLSchema } from '../../type/schema.js';
 

--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -3,14 +3,14 @@ import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import { GraphQLObjectType, GraphQLScalarType } from '../../type/definition.js';
 import { GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
 import { ValuesOfCorrectTypeRule } from '../rules/ValuesOfCorrectTypeRule.js';
-import { validate } from '../validate.js';
+import { validateSync as validate } from '../validate.js';
 
 import {
   expectValidationErrors,

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -2,13 +2,13 @@ import { expectJSON } from '../../__testUtils__/expectJSON.js';
 
 import type { Maybe } from '../../jsutils/Maybe.js';
 
-import { parse } from '../../language/parser.js';
+import { parseSync as parse } from '../../language/parser.js';
 
 import type { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { validate, validateSDL } from '../validate.js';
+import { validateSDL, validateSync as validate } from '../validate.js';
 import type {
   SDLValidationRule,
   ValidationRule,

--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -63,7 +63,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    let cachedErrors: ReadonlyArray<GraphQLError> | undefined;
+    let cachedErrors: ReadonlyArray<GraphQLError> | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ValidateCache = {
@@ -119,7 +119,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    let cachedErrors: ReadonlyArray<GraphQLError> | undefined;
+    let cachedErrors: ReadonlyArray<GraphQLError> | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ValidateCache = {
@@ -172,7 +172,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    let cachedErrors: ReadonlyArray<GraphQLError> | undefined;
+    let cachedErrors: ReadonlyArray<GraphQLError> | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ValidateCache = {
@@ -226,7 +226,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    let cachedErrors: ReadonlyArray<GraphQLError> | undefined;
+    let cachedErrors: ReadonlyArray<GraphQLError> | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ValidateCache = {
@@ -276,7 +276,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    let cachedErrors: ReadonlyArray<GraphQLError> | undefined;
+    let cachedErrors: ReadonlyArray<GraphQLError> | Error | undefined;
     let getAttempts = 0;
     let cacheHits = 0;
     const customCache: ValidateCache = {
@@ -329,7 +329,7 @@ describe('Validate: Supports full validation', () => {
       }
     `);
 
-    let cachedErrors: ReadonlyArray<GraphQLError> | undefined;
+    let cachedErrors: ReadonlyArray<GraphQLError> | Error | undefined;
     const customCache: ValidateCache = {
       set: async (resultedErrors) => {
         await resolveOnNextTick();

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,4 +1,5 @@
-export { validate } from './validate.js';
+export { validate, validateSync } from './validate.js';
+export type { ValidateOptions, ValidateCache } from './validate.js';
 
 export { ValidationContext } from './ValidationContext.js';
 export type { ValidationRule } from './ValidationContext.js';

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -28,7 +28,7 @@ export interface ValidateOptions {
 
 export interface ValidateCache {
   set: (
-    errors: ReadonlyArray<GraphQLError>,
+    errors: ReadonlyArray<GraphQLError> | Error,
     schema: GraphQLSchema,
     documentAST: DocumentNode,
     rules?: ReadonlyArray<ValidationRule> | undefined,
@@ -39,7 +39,7 @@ export interface ValidateCache {
     documentAST: DocumentNode,
     rules?: ReadonlyArray<ValidationRule> | undefined,
     options?: ValidateOptions | undefined,
-  ) => PromiseOrValue<ReadonlyArray<GraphQLError> | undefined>;
+  ) => PromiseOrValue<ReadonlyArray<GraphQLError> | Error | undefined>;
 }
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: parse/validate become potentially async when provided with a cache with an async getter,

Introduces parseSync/validateSync to throw when an async value is returned.

Updates all non-cache tests to use parseSync/validateSync.