### PR TITLE
fix: properly type `extensions` in GraphQLFormattedError

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -20,6 +20,19 @@ export interface GraphQLErrorExtensions {
   [attributeName: string]: unknown;
 }
 
+/**
+ * Custom formatted extensions
+ *
+ * @remarks
+ * Use a unique identifier name for your extension, for example the name of
+ * your library or project. Do not use a shortened identifier as this increases
+ * the risk of conflicts. We recommend you add at most one extension field,
+ * an object which can contain all the values you need.
+ */
+export interface GraphQLFormattedErrorExtensions {
+  [attributeName: string]: unknown;
+}
+
 export interface GraphQLErrorOptions {
   nodes?: ReadonlyArray<ASTNode> | ASTNode | null;
   source?: Maybe<Source>;
@@ -275,7 +288,7 @@ export interface GraphQLFormattedError {
    * Reserved for implementors to extend the protocol however they see fit,
    * and hence there are no additional restrictions on its contents.
    */
-  readonly extensions?: GraphQLErrorExtensions;
+  readonly extensions?: GraphQLFormattedErrorExtensions;
 }
 
 /**

--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -275,7 +275,7 @@ export interface GraphQLFormattedError {
    * Reserved for implementors to extend the protocol however they see fit,
    * and hence there are no additional restrictions on its contents.
    */
-  readonly extensions?: { [key: string]: unknown };
+  readonly extensions?: GraphQLErrorExtensions;
 }
 
 /**

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -3,6 +3,7 @@ export type {
   GraphQLErrorOptions,
   GraphQLFormattedError,
   GraphQLErrorExtensions,
+  GraphQLFormattedErrorExtensions,
 } from './GraphQLError';
 
 export { syntaxError } from './syntaxError';

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,6 +398,7 @@ export type {
   GraphQLErrorOptions,
   GraphQLFormattedError,
   GraphQLErrorExtensions,
+  GraphQLFormattedErrorExtensions,
 } from './error/index';
 
 // Utilities for operating on GraphQL type schema and parsed sources.


### PR DESCRIPTION
Following typescript documentation, it's not possible override interface property, we can only add new props.

Since it's declared as unknown dict, even if we merge `GraphQLErrorExtensions`, we can't access to our extensions without workaround and verbose typescript in source-code.

It's annoying since apollo expose `GraphQLFormattedError` instead `GraphQLError`

Refs: https://www.typescriptlang.org/docs/handbook/declaration-merging.html
Refs: https://github.com/apollographql/apollo-client/pull/11789