### PR TITLE
Add note about defer/stream being v17

### DIFF
--- a/website/pages/defer-stream.mdx
+++ b/website/pages/defer-stream.mdx
@@ -5,7 +5,7 @@ title: Enabling Defer & Stream
 import { Callout } from 'nextra/components'
  
 <Callout type="info" emoji="ℹ️">
-  These exports are only availble in v17 and beyond.
+  These exports are only available in v17 and beyond.
 </Callout>
 
 The `@defer` and `@stream` directives are not enabled by default.

--- a/website/pages/defer-stream.mdx
+++ b/website/pages/defer-stream.mdx
@@ -2,7 +2,15 @@
 title: Enabling Defer & Stream
 ---
 
-The `@defer` and `@stream` directives are not enabled by default. In order to use these directives, you must add them to your GraphQL Schema and use the `experimentalExecuteIncrementally` function instead of `execute`.
+import { Callout } from 'nextra/components'
+ 
+<Callout type="info" emoji="ℹ️">
+  These exports are only availble in v17 and beyond.
+</Callout>
+
+The `@defer` and `@stream` directives are not enabled by default.
+In order to use these directives, you must add them to your GraphQL Schema and
+use the `experimentalExecuteIncrementally` function instead of `execute`.
 
 ```js
 import {


### PR DESCRIPTION
This is currently not available in the latest release of GraphQL.JS and I wanted to add an explicit call-out for that.