### PR TITLE
Expose tokenCount on the DocumentNode

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -84,6 +84,11 @@ describe('Parser', () => {
     `);
   });
 
+  it('exposes the tokenCount', () => {
+    expect(parse('{ foo }').tokenCount).to.equal(3);
+    expect(parse('{ foo(bar: "baz") }').tokenCount).to.equal(8);
+  });
+
   it('limit maximum number of tokens', () => {
     expect(() => parse('{ foo }', { maxTokens: 3 })).to.not.throw();
     expect(() => parse('{ foo }', { maxTokens: 2 })).to.throw(

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -302,6 +302,7 @@ export interface DocumentNode {
   readonly kind: Kind.DOCUMENT;
   readonly loc?: Location;
   readonly definitions: ReadonlyArray<DefinitionNode>;
+  readonly tokenCount?: number | undefined;
 }
 
 export type DefinitionNode =

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -114,7 +114,12 @@ export function parse(
   options?: ParseOptions | undefined,
 ): DocumentNode {
   const parser = new Parser(source, options);
-  return parser.parseDocument();
+  const document = parser.parseDocument();
+  Object.defineProperty(document, 'tokenCount', {
+    enumerable: false,
+    value: parser.tokenCount,
+  });
+  return document;
 }
 
 /**
@@ -196,6 +201,10 @@ export class Parser {
     this._lexer = new Lexer(sourceObj);
     this._options = options;
     this._tokenCounter = 0;
+  }
+
+  get tokenCount(): number {
+    return this._tokenCounter;
   }
 
   /**
@@ -1564,9 +1573,9 @@ export class Parser {
     const { maxTokens } = this._options;
     const token = this._lexer.advance();
 
-    if (maxTokens !== undefined && token.kind !== TokenKind.EOF) {
+    if (token.kind !== TokenKind.EOF) {
       ++this._tokenCounter;
-      if (this._tokenCounter > maxTokens) {
+      if (maxTokens !== undefined && this._tokenCounter > maxTokens) {
         throw syntaxError(
           this._lexer.source,
           token.start,


### PR DESCRIPTION
Backports https://github.com/graphql/graphql-js/pull/4251 from v17

Backporting this so we can document the `maxTokens` for production use cases. The performance of this change looks to be neutral