### PR TITLE
polish: fix lexer state comment

### DIFF
--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -62,7 +62,7 @@ export class Lexer {
 
   /**
    * Looks ahead and returns the next non-ignored token, but does not change
-   * the state of Lexer.
+   * the current Lexer token.
    */
   lookahead(): Token {
     let token = this.token;


### PR DESCRIPTION
we must update the lexer line number and the line start position, because lookahead saves the token within the linked list, and so will never be called again on this token

we do not change the current token, however, until the lexer is advanced

closes #2764