### PR TITLE
introduces mapSchemaConfig utility function

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -738,7 +738,7 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   extensionASTNodes?: Maybe<ReadonlyArray<ScalarTypeExtensionNode>>;
 }
 
-interface GraphQLScalarTypeNormalizedConfig<TInternal, TExternal>
+export interface GraphQLScalarTypeNormalizedConfig<TInternal, TExternal>
   extends GraphQLScalarTypeConfig<TInternal, TExternal> {
   serialize: GraphQLScalarSerializer<TExternal>;
   parseValue: GraphQLScalarValueParser<TInternal>;
@@ -914,7 +914,7 @@ export function defineArguments(
 
 function fieldsToFieldsConfig<TSource, TContext>(
   fields: GraphQLFieldMap<TSource, TContext>,
-): GraphQLFieldConfigMap<TSource, TContext> {
+): GraphQLFieldNormalizedConfigMap<TSource, TContext> {
   return mapValue(fields, (field) => ({
     description: field.description,
     type: field.type,
@@ -932,7 +932,7 @@ function fieldsToFieldsConfig<TSource, TContext>(
  */
 export function argsToArgsConfig(
   args: ReadonlyArray<GraphQLArgument>,
-): GraphQLFieldConfigArgumentMap {
+): GraphQLFieldNormalizedConfigArgumentMap {
   return keyValMap(
     args,
     (arg) => arg.name,
@@ -959,10 +959,10 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
   extensionASTNodes?: Maybe<ReadonlyArray<ObjectTypeExtensionNode>>;
 }
 
-interface GraphQLObjectTypeNormalizedConfig<TSource, TContext>
+export interface GraphQLObjectTypeNormalizedConfig<TSource, TContext>
   extends GraphQLObjectTypeConfig<any, any> {
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
-  fields: GraphQLFieldConfigMap<any, any>;
+  fields: GraphQLFieldNormalizedConfigMap<any, any>;
   extensions: Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>;
   extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>;
 }
@@ -1035,7 +1035,16 @@ export interface GraphQLFieldConfig<TSource, TContext, TArgs = any> {
   astNode?: Maybe<FieldDefinitionNode>;
 }
 
+export interface GraphQLFieldNormalizedConfig<TSource, TContext, TArgs = any>
+  extends GraphQLFieldConfig<TSource, TContext, TArgs> {
+  args: GraphQLFieldNormalizedConfigArgumentMap;
+  extensions: Readonly<GraphQLFieldExtensions<TSource, TContext, TArgs>>;
+}
+
 export type GraphQLFieldConfigArgumentMap = ObjMap<GraphQLArgumentConfig>;
+
+export type GraphQLFieldNormalizedConfigArgumentMap =
+  ObjMap<GraphQLArgumentNormalizedConfig>;
 
 /**
  * Custom extensions
@@ -1060,8 +1069,16 @@ export interface GraphQLArgumentConfig {
   astNode?: Maybe<InputValueDefinitionNode>;
 }
 
+export interface GraphQLArgumentNormalizedConfig extends GraphQLArgumentConfig {
+  extensions: Readonly<GraphQLArgumentExtensions>;
+}
+
 export type GraphQLFieldConfigMap<TSource, TContext> = ObjMap<
   GraphQLFieldConfig<TSource, TContext>
+>;
+
+export type GraphQLFieldNormalizedConfigMap<TSource, TContext> = ObjMap<
+  GraphQLFieldNormalizedConfig<TSource, TContext>
 >;
 
 export interface GraphQLField<TSource, TContext, TArgs = any> {
@@ -1229,10 +1246,10 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
   extensionASTNodes?: Maybe<ReadonlyArray<InterfaceTypeExtensionNode>>;
 }
 
-interface GraphQLInterfaceTypeNormalizedConfig<TSource, TContext>
+export interface GraphQLInterfaceTypeNormalizedConfig<TSource, TContext>
   extends GraphQLInterfaceTypeConfig<any, any> {
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
-  fields: GraphQLFieldConfigMap<TSource, TContext>;
+  fields: GraphQLFieldNormalizedConfigMap<TSource, TContext>;
   extensions: Readonly<GraphQLInterfaceTypeExtensions>;
   extensionASTNodes: ReadonlyArray<InterfaceTypeExtensionNode>;
 }
@@ -1348,7 +1365,7 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
   extensionASTNodes?: Maybe<ReadonlyArray<UnionTypeExtensionNode>>;
 }
 
-interface GraphQLUnionTypeNormalizedConfig
+export interface GraphQLUnionTypeNormalizedConfig
   extends GraphQLUnionTypeConfig<any, any> {
   types: ReadonlyArray<GraphQLObjectType>;
   extensions: Readonly<GraphQLUnionTypeExtensions>;
@@ -1594,14 +1611,17 @@ export interface GraphQLEnumTypeConfig {
   extensionASTNodes?: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 }
 
-interface GraphQLEnumTypeNormalizedConfig extends GraphQLEnumTypeConfig {
-  values: ObjMap<GraphQLEnumValueConfig /* <T> */>;
+export interface GraphQLEnumTypeNormalizedConfig extends GraphQLEnumTypeConfig {
+  values: GraphQLEnumValueNormalizedConfigMap;
   extensions: Readonly<GraphQLEnumTypeExtensions>;
   extensionASTNodes: ReadonlyArray<EnumTypeExtensionNode>;
 }
 
 export type GraphQLEnumValueConfigMap /* <T> */ =
   ObjMap<GraphQLEnumValueConfig /* <T> */>;
+
+export type GraphQLEnumValueNormalizedConfigMap /* <T> */ =
+  ObjMap<GraphQLEnumValueNormalizedConfig /* <T> */>;
 
 /**
  * Custom extensions
@@ -1622,6 +1642,11 @@ export interface GraphQLEnumValueConfig {
   deprecationReason?: Maybe<string>;
   extensions?: Maybe<Readonly<GraphQLEnumValueExtensions>>;
   astNode?: Maybe<EnumValueDefinitionNode>;
+}
+
+export interface GraphQLEnumValueNormalizedConfig
+  extends GraphQLEnumValueConfig {
+  extensions: Readonly<GraphQLEnumValueExtensions>;
 }
 
 export interface GraphQLEnumValue {
@@ -1755,9 +1780,9 @@ export interface GraphQLInputObjectTypeConfig {
   isOneOf?: boolean;
 }
 
-interface GraphQLInputObjectTypeNormalizedConfig
+export interface GraphQLInputObjectTypeNormalizedConfig
   extends GraphQLInputObjectTypeConfig {
-  fields: GraphQLInputFieldConfigMap;
+  fields: GraphQLInputFieldNormalizedConfigMap;
   extensions: Readonly<GraphQLInputObjectTypeExtensions>;
   extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
 }
@@ -1786,6 +1811,14 @@ export interface GraphQLInputFieldConfig {
 }
 
 export type GraphQLInputFieldConfigMap = ObjMap<GraphQLInputFieldConfig>;
+
+export interface GraphQLInputFieldNormalizedConfig
+  extends GraphQLInputFieldConfig {
+  extensions: Readonly<GraphQLInputFieldExtensions>;
+}
+
+export type GraphQLInputFieldNormalizedConfigMap =
+  ObjMap<GraphQLInputFieldNormalizedConfig>;
 
 export interface GraphQLInputField {
   name: string;

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -10,6 +10,7 @@ import { assertName } from './assertName.js';
 import type {
   GraphQLArgument,
   GraphQLFieldConfigArgumentMap,
+  GraphQLFieldNormalizedConfigArgumentMap,
 } from './definition.js';
 import {
   argsToArgsConfig,
@@ -107,8 +108,9 @@ export interface GraphQLDirectiveConfig {
   astNode?: Maybe<DirectiveDefinitionNode>;
 }
 
-interface GraphQLDirectiveNormalizedConfig extends GraphQLDirectiveConfig {
-  args: GraphQLFieldConfigArgumentMap;
+export interface GraphQLDirectiveNormalizedConfig
+  extends GraphQLDirectiveConfig {
+  args: GraphQLFieldNormalizedConfigArgumentMap;
   isRepeatable: boolean;
   extensions: Readonly<GraphQLDirectiveExtensions>;
 }

--- a/src/utilities/__tests__/mapSchemaConfig-test.ts
+++ b/src/utilities/__tests__/mapSchemaConfig-test.ts
@@ -1,0 +1,919 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { dedentString } from '../../__testUtils__/dedent.js';
+
+import { GraphQLObjectType } from '../../type/definition.js';
+import type { GraphQLSchemaNormalizedConfig } from '../../type/schema.js';
+import { GraphQLSchema } from '../../type/schema.js';
+
+import { buildSchema } from '../buildASTSchema.js';
+import type {
+  ConfigMapperMap,
+  MappedSchemaContext,
+} from '../mapSchemaConfig.js';
+import { mapSchemaConfig, SchemaElementKind } from '../mapSchemaConfig.js';
+import { printSchema } from '../printSchema.js';
+
+function expectSchemaMapping(
+  schemaConfig: GraphQLSchemaNormalizedConfig,
+  configMapperMapFn: (context: MappedSchemaContext) => ConfigMapperMap,
+  expected: string,
+) {
+  const newSchemaConfig = mapSchemaConfig(schemaConfig, configMapperMapFn);
+  expect(printSchema(new GraphQLSchema(newSchemaConfig))).to.equal(
+    dedentString(expected),
+  );
+}
+
+describe('mapSchemaConfig', () => {
+  it('returns the original config when no mappers are included', () => {
+    const sdl = 'type Query';
+    const schemaConfig = buildSchema(sdl).toConfig();
+    expectSchemaMapping(schemaConfig, () => ({}), sdl);
+  });
+
+  describe('scalar mapping', () => {
+    it('can map scalar types', () => {
+      const sdl = 'scalar SomeScalar';
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.SCALAR]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          scalar SomeScalar
+        `,
+      );
+    });
+  });
+
+  describe('argument mapping', () => {
+    it('can map arguments', () => {
+      const sdl = `
+        type SomeType {
+          field(arg: String): String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.ARGUMENT]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          type SomeType {
+            field(
+              """Some description"""
+              arg: String
+            ): String
+          }
+        `,
+      );
+    });
+  });
+
+  describe('field mapping', () => {
+    it('can map fields', () => {
+      const sdl = `
+      type SomeType {
+        field: String
+      }
+    `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.FIELD]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          type SomeType {
+            """Some description"""
+            field: String
+          }
+        `,
+      );
+    });
+
+    it('maps fields after mapping arguments', () => {
+      const sdl = `
+        type SomeType {
+          field(arg: String): String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.ARGUMENT]: (config) => ({
+            ...config,
+            description: 'Some argument description',
+          }),
+          [SchemaElementKind.FIELD]: (config) => {
+            expect(config.args.arg.description).to.equal(
+              'Some argument description',
+            );
+            return {
+              ...config,
+              description: 'Some field description',
+            };
+          },
+        }),
+        `
+          type SomeType {
+            """Some field description"""
+            field(
+              """Some argument description"""
+              arg: String
+            ): String
+          }
+        `,
+      );
+    });
+  });
+
+  describe('object type mapping', () => {
+    it('can map object types', () => {
+      const sdl = 'type SomeType';
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.OBJECT]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          type SomeType
+        `,
+      );
+    });
+
+    it('maps object types after mapping fields', () => {
+      const sdl = `
+        type SomeType {
+          field: String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.FIELD]: (config) => ({
+            ...config,
+            description: 'Some field description',
+          }),
+          [SchemaElementKind.OBJECT]: (config) => {
+            expect(config.fields().field.description).to.equal(
+              'Some field description',
+            );
+            return {
+              ...config,
+              description: 'Some object description',
+            };
+          },
+        }),
+        `
+          """Some object description"""
+          type SomeType {
+            """Some field description"""
+            field: String
+          }
+        `,
+      );
+    });
+
+    it('maps object types after mapping interfaces', () => {
+      const sdl = `
+        interface SomeInterface
+        type SomeType implements SomeInterface
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.INTERFACE]: (config) => ({
+            ...config,
+            description: 'Some interface description',
+          }),
+          [SchemaElementKind.OBJECT]: (config) => {
+            expect(config.interfaces()[0].description).to.equal(
+              'Some interface description',
+            );
+            return {
+              ...config,
+              description: 'Some object description',
+            };
+          },
+        }),
+        `
+          """Some interface description"""
+          interface SomeInterface
+
+          """Some object description"""
+          type SomeType implements SomeInterface
+        `,
+      );
+    });
+  });
+
+  describe('interface type mapping', () => {
+    it('can map interface types', () => {
+      const sdl = 'interface SomeInterface';
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.INTERFACE]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          interface SomeInterface
+        `,
+      );
+    });
+
+    it('maps interface types after mapping fields', () => {
+      const sdl = `
+        interface SomeInterface {
+          field: String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.FIELD]: (config) => ({
+            ...config,
+            description: 'Some field description',
+          }),
+          [SchemaElementKind.INTERFACE]: (config) => {
+            expect(config.fields().field.description).to.equal(
+              'Some field description',
+            );
+            return {
+              ...config,
+              description: 'Some interface description',
+            };
+          },
+        }),
+        `
+          """Some interface description"""
+          interface SomeInterface {
+            """Some field description"""
+            field: String
+          }
+        `,
+      );
+    });
+
+    it('maps interface types after mapping parent interfaces', () => {
+      const sdl = `
+        interface SomeParentInterface
+        interface SomeInterface implements SomeParentInterface
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.INTERFACE]: (config) => {
+            if (config.name === 'SomeInterface') {
+              expect(config.interfaces()[0].description).to.equal(
+                'Some interface description',
+              );
+            }
+            return {
+              ...config,
+              description: 'Some interface description',
+            };
+          },
+        }),
+        `
+          """Some interface description"""
+          interface SomeParentInterface
+
+          """Some interface description"""
+          interface SomeInterface implements SomeParentInterface
+        `,
+      );
+    });
+  });
+
+  describe('union type mapping', () => {
+    it('can map union types', () => {
+      const sdl = 'union SomeUnion';
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.UNION]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          union SomeUnion
+        `,
+      );
+    });
+
+    it('maps union types after mapping types', () => {
+      const sdl = `
+        type SomeType
+        union SomeUnion = SomeType
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.OBJECT]: (config) => ({
+            ...config,
+            description: 'Some type description',
+          }),
+          [SchemaElementKind.UNION]: (config) => {
+            expect(config.types()[0].description).to.equal(
+              'Some type description',
+            );
+            return {
+              ...config,
+              description: 'Some union description',
+            };
+          },
+        }),
+        `
+          """Some type description"""
+          type SomeType
+
+          """Some union description"""
+          union SomeUnion = SomeType
+        `,
+      );
+    });
+  });
+
+  describe('enum value mapping', () => {
+    it('can map enum values', () => {
+      const sdl = `
+        enum SomeEnum {
+          SOME_VALUE
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.ENUM_VALUE]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          enum SomeEnum {
+            """Some description"""
+            SOME_VALUE
+          }
+        `,
+      );
+    });
+  });
+
+  describe('enum type mapping', () => {
+    it('can map enum types', () => {
+      const sdl = 'enum SomeEnum';
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.ENUM]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          enum SomeEnum
+        `,
+      );
+    });
+
+    it('maps enum types after mapping values', () => {
+      const sdl = `
+        enum SomeEnum {
+          SOME_VALUE
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.ENUM_VALUE]: (config) => ({
+            ...config,
+            description: 'Some value description',
+          }),
+          [SchemaElementKind.ENUM]: (config) => {
+            expect(config.values().SOME_VALUE.description).to.equal(
+              'Some value description',
+            );
+            return {
+              ...config,
+              description: 'Some enum description',
+            };
+          },
+        }),
+        `
+          """Some enum description"""
+          enum SomeEnum {
+            """Some value description"""
+            SOME_VALUE
+          }
+        `,
+      );
+    });
+  });
+
+  describe('input field mapping', () => {
+    it('can map input fields', () => {
+      const sdl = `
+        input SomeInput {
+          field: String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.INPUT_FIELD]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          input SomeInput {
+            """Some description"""
+            field: String
+          }
+        `,
+      );
+    });
+  });
+
+  describe('input object type mapping', () => {
+    it('can map input object types', () => {
+      const sdl = 'input SomeInput';
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.INPUT_OBJECT]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          input SomeInput
+        `,
+      );
+    });
+
+    it('maps input object types after mapping input fields', () => {
+      const sdl = `
+        input SomeInput {
+          field: String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.INPUT_FIELD]: (config) => ({
+            ...config,
+            description: 'Some input field description',
+          }),
+          [SchemaElementKind.INPUT_OBJECT]: (config) => {
+            expect(config.fields().field.description).to.equal(
+              'Some input field description',
+            );
+            return {
+              ...config,
+              description: 'Some input object description',
+            };
+          },
+        }),
+        `
+          """Some input object description"""
+          input SomeInput {
+            """Some input field description"""
+            field: String
+          }
+        `,
+      );
+    });
+  });
+
+  describe('directive mapping', () => {
+    it('can map directives', () => {
+      const sdl = `
+        directive @SomeDirective on FIELD
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.DIRECTIVE]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          directive @SomeDirective on FIELD
+        `,
+      );
+    });
+
+    it('maps directives after mapping arguments', () => {
+      const sdl = `
+        directive @SomeDirective(arg: String) on FIELD
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.ARGUMENT]: (config) => ({
+            ...config,
+            description: 'Some argument description',
+          }),
+          [SchemaElementKind.DIRECTIVE]: (config) => {
+            expect(config.args.arg.description).to.equal(
+              'Some argument description',
+            );
+            return {
+              ...config,
+              description: 'Some directive description',
+            };
+          },
+        }),
+        `
+          """Some directive description"""
+          directive @SomeDirective(
+            """Some argument description"""
+            arg: String
+          ) on FIELD
+        `,
+      );
+    });
+  });
+
+  describe('schema mapping', () => {
+    it('can map the schema', () => {
+      const sdl = `
+        type Query
+
+        type Mutation
+
+        type Subscription
+
+        directive @SomeDirective on FIELD
+
+        scalar SomeScalar
+
+        type SomeType {
+          field: String
+        }
+
+        interface SomeInterface
+
+        union SomeUnion
+
+        enum SomeEnum {
+          SOME_VALUE
+        }
+
+        input SomeInput {
+          field: String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.SCHEMA]: (config) => ({
+            ...config,
+            description: 'Some description',
+          }),
+        }),
+        `
+          """Some description"""
+          schema {
+            query: Query
+            mutation: Mutation
+            subscription: Subscription
+          }
+
+          directive @SomeDirective on FIELD
+
+          type Query
+
+          type Mutation
+
+          type Subscription
+
+          scalar SomeScalar
+
+          type SomeType {
+            field: String
+          }
+
+          interface SomeInterface
+
+          union SomeUnion
+
+          enum SomeEnum {
+            SOME_VALUE
+          }
+
+          input SomeInput {
+            field: String
+          }
+        `,
+      );
+    });
+
+    it('maps the schema after mapping types and directives', () => {
+      const sdl = `
+        type Query
+
+        type Mutation
+
+        type Subscription
+
+        directive @SomeDirective on FIELD
+
+        scalar SomeScalar
+
+        type SomeType {
+          field: String
+        }
+
+        interface SomeInterface
+
+        union SomeUnion
+
+        enum SomeEnum {
+          SOME_VALUE
+        }
+
+        input SomeInput {
+          field: String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        () => ({
+          [SchemaElementKind.DIRECTIVE]: (config) => ({
+            ...config,
+            description: 'Some directive description',
+          }),
+          [SchemaElementKind.SCALAR]: (config) => ({
+            ...config,
+            description: 'Some scalar description',
+          }),
+          [SchemaElementKind.OBJECT]: (config) => ({
+            ...config,
+            description: 'Some object description',
+          }),
+          [SchemaElementKind.INTERFACE]: (config) => ({
+            ...config,
+            description: 'Some interface description',
+          }),
+          [SchemaElementKind.UNION]: (config) => ({
+            ...config,
+            description: 'Some union description',
+          }),
+          [SchemaElementKind.ENUM]: (config) => ({
+            ...config,
+            description: 'Some enum description',
+          }),
+          [SchemaElementKind.INPUT_OBJECT]: (config) => ({
+            ...config,
+            description: 'Some input object description',
+          }),
+          [SchemaElementKind.SCHEMA]: (config) => {
+            for (const directive of config.directives) {
+              if (directive.name === 'SomeDirective') {
+                expect(directive.description).to.equal(
+                  'Some directive description',
+                );
+              }
+            }
+
+            for (const type of config.types) {
+              switch (type.name) {
+                case 'SomeScalar':
+                  expect(type.description).to.equal('Some scalar description');
+                  break;
+                case 'SomeType':
+                  expect(type.description).to.equal('Some object description');
+                  break;
+                case 'SomeInterface':
+                  expect(type.description).to.equal(
+                    'Some interface description',
+                  );
+                  break;
+                case 'SomeUnion':
+                  expect(type.description).to.equal('Some union description');
+                  break;
+                case 'SomeEnum':
+                  expect(type.description).to.equal('Some enum description');
+                  break;
+                case 'SomeInput':
+                  expect(type.description).to.equal(
+                    'Some input object description',
+                  );
+                  break;
+              }
+            }
+
+            return {
+              ...config,
+              description: 'Some schema description',
+            };
+          },
+        }),
+        `
+          """Some schema description"""
+          schema {
+            query: Query
+            mutation: Mutation
+            subscription: Subscription
+          }
+
+          """Some directive description"""
+          directive @SomeDirective on FIELD
+
+          """Some object description"""
+          type Query
+
+          """Some object description"""
+          type Mutation
+
+          """Some object description"""
+          type Subscription
+
+          """Some scalar description"""
+          scalar SomeScalar
+
+          """Some object description"""
+          type SomeType {
+            field: String
+          }
+
+          """Some interface description"""
+          interface SomeInterface
+
+          """Some union description"""
+          union SomeUnion
+
+          """Some enum description"""
+          enum SomeEnum {
+            SOME_VALUE
+          }
+
+          """Some input object description"""
+          input SomeInput {
+            field: String
+          }
+        `,
+      );
+    });
+  });
+
+  describe('schema context', () => {
+    it('allows access to the final mapped named type via getNamedType()', () => {
+      const sdl = `
+        """Some description"""
+        type SomeType
+      `;
+
+      const schema = buildSchema(sdl);
+      const schemaConfig = schema.toConfig();
+      const someType = schema.getType('SomeType') as GraphQLObjectType;
+
+      expectSchemaMapping(
+        schemaConfig,
+        ({ getNamedType }) => {
+          return {
+            [SchemaElementKind.OBJECT]: (config) => ({
+              ...config,
+              fields: () => {
+                expectMappedSomeType();
+                return config.fields();
+              },
+            }),
+            [SchemaElementKind.SCHEMA]: (config) => {
+              expectMappedSomeType();
+              return config;
+            },
+          };
+
+          function expectMappedSomeType() {
+            const mappedType = getNamedType(someType.name);
+            expect(mappedType).not.to.equal(someType);
+            expect(mappedType.description).to.equal(someType.description);
+          }
+        },
+        sdl,
+      );
+    });
+
+    it('allows adding a named type via setNamedType() and retrieving the new list via getNamedTypes', () => {
+      const sdl = 'type SomeType';
+
+      const schema = buildSchema(sdl);
+      const schemaConfig = schema.toConfig();
+
+      expectSchemaMapping(
+        schemaConfig,
+        ({ setNamedType, getNamedTypes }) => ({
+          [SchemaElementKind.SCHEMA]: (config) => {
+            setNamedType(
+              new GraphQLObjectType({ name: 'AnotherType', fields: {} }),
+            );
+            return {
+              ...config,
+              types: getNamedTypes(),
+            };
+          },
+        }),
+        `
+          type SomeType
+
+          type AnotherType
+        `,
+      );
+    });
+  });
+});

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -1,7 +1,5 @@
 import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
-import { inspect } from '../jsutils/inspect.js';
 import { invariant } from '../jsutils/invariant.js';
-import { mapValue } from '../jsutils/mapValue.js';
 import type { Maybe } from '../jsutils/Maybe.js';
 
 import type {
@@ -31,12 +29,10 @@ import type {
 import { Kind } from '../language/kinds.js';
 
 import type {
-  GraphQLArgumentConfig,
-  GraphQLEnumValueConfigMap,
-  GraphQLFieldConfig,
+  GraphQLEnumValueNormalizedConfigMap,
   GraphQLFieldConfigArgumentMap,
-  GraphQLFieldConfigMap,
-  GraphQLInputFieldConfigMap,
+  GraphQLFieldNormalizedConfigMap,
+  GraphQLInputFieldNormalizedConfigMap,
   GraphQLNamedType,
   GraphQLType,
 } from '../type/definition.js';
@@ -49,30 +45,15 @@ import {
   GraphQLObjectType,
   GraphQLScalarType,
   GraphQLUnionType,
-  isEnumType,
-  isInputObjectType,
-  isInterfaceType,
-  isListType,
-  isNonNullType,
-  isObjectType,
-  isScalarType,
-  isUnionType,
 } from '../type/definition.js';
 import {
   GraphQLDeprecatedDirective,
   GraphQLDirective,
   GraphQLOneOfDirective,
   GraphQLSpecifiedByDirective,
-  isSpecifiedDirective,
 } from '../type/directives.js';
-import {
-  introspectionTypes,
-  isIntrospectionType,
-} from '../type/introspection.js';
-import {
-  isSpecifiedScalarType,
-  specifiedScalarTypes,
-} from '../type/scalars.js';
+import { introspectionTypes } from '../type/introspection.js';
+import { specifiedScalarTypes } from '../type/scalars.js';
 import type {
   GraphQLSchemaNormalizedConfig,
   GraphQLSchemaValidationOptions,
@@ -82,6 +63,8 @@ import { assertSchema, GraphQLSchema } from '../type/schema.js';
 import { assertValidSDLExtension } from '../validation/validate.js';
 
 import { getDirectiveValues } from '../execution/values.js';
+
+import { mapSchemaConfig, SchemaElementKind } from './mapSchemaConfig.js';
 
 interface Options extends GraphQLSchemaValidationOptions {
   /**
@@ -214,478 +197,378 @@ export function extendSchemaImpl(
     return schemaConfig;
   }
 
-  const typeMap = new Map<string, GraphQLNamedType>(
-    schemaConfig.types.map((type) => [type.name, extendNamedType(type)]),
-  );
+  return mapSchemaConfig(schemaConfig, (context) => {
+    const { getNamedType, setNamedType, getNamedTypes } = context;
+    return {
+      [SchemaElementKind.SCHEMA]: (config) => {
+        for (const typeNode of typeDefs) {
+          const type =
+            stdTypeMap.get(typeNode.name.value) ?? buildNamedType(typeNode);
+          setNamedType(type);
+        }
 
-  for (const typeNode of typeDefs) {
-    const name = typeNode.name.value;
-    typeMap.set(name, stdTypeMap.get(name) ?? buildType(typeNode));
-  }
+        const operationTypes = {
+          // Get the extended root operation types.
+          query:
+            config.query &&
+            (getNamedType(config.query.name) as GraphQLObjectType),
+          mutation:
+            config.mutation &&
+            (getNamedType(config.mutation.name) as GraphQLObjectType),
+          subscription:
+            config.subscription &&
+            (getNamedType(config.subscription.name) as GraphQLObjectType),
+          // Then, incorporate schema definition and all schema extensions.
+          ...(schemaDef && getOperationTypes([schemaDef])),
+          ...getOperationTypes(schemaExtensions),
+        };
 
-  const operationTypes = {
-    // Get the extended root operation types.
-    query: schemaConfig.query && replaceNamedType(schemaConfig.query),
-    mutation: schemaConfig.mutation && replaceNamedType(schemaConfig.mutation),
-    subscription:
-      schemaConfig.subscription && replaceNamedType(schemaConfig.subscription),
-    // Then, incorporate schema definition and all schema extensions.
-    ...(schemaDef && getOperationTypes([schemaDef])),
-    ...getOperationTypes(schemaExtensions),
-  };
+        // Then produce and return a Schema config with these types.
+        return {
+          description: schemaDef?.description?.value ?? config.description,
+          ...operationTypes,
+          types: getNamedTypes(),
+          directives: [
+            ...config.directives,
+            ...directiveDefs.map(buildDirective),
+          ],
+          extensions: config.extensions,
+          astNode: schemaDef ?? config.astNode,
+          extensionASTNodes: config.extensionASTNodes.concat(schemaExtensions),
+          assumeValid: options?.assumeValid ?? false,
+        };
+      },
+      [SchemaElementKind.INPUT_OBJECT]: (config) => {
+        const extensions = inputObjectExtensions.get(config.name) ?? [];
+        return {
+          ...config,
+          fields: () => ({
+            ...config.fields(),
+            ...buildInputFieldMap(extensions),
+          }),
+          extensionASTNodes: config.extensionASTNodes.concat(extensions),
+        };
+      },
+      [SchemaElementKind.ENUM]: (config) => {
+        const extensions = enumExtensions.get(config.name) ?? [];
+        return {
+          ...config,
+          values: () => ({
+            ...config.values(),
+            ...buildEnumValueMap(extensions),
+          }),
+          extensionASTNodes: config.extensionASTNodes.concat(extensions),
+        };
+      },
+      [SchemaElementKind.SCALAR]: (config) => {
+        const extensions = scalarExtensions.get(config.name) ?? [];
+        let specifiedByURL = config.specifiedByURL;
+        for (const extensionNode of extensions) {
+          specifiedByURL = getSpecifiedByURL(extensionNode) ?? specifiedByURL;
+        }
+        return {
+          ...config,
+          specifiedByURL,
+          extensionASTNodes: config.extensionASTNodes.concat(extensions),
+        };
+      },
+      [SchemaElementKind.OBJECT]: (config) => {
+        const extensions = objectExtensions.get(config.name) ?? [];
+        return {
+          ...config,
+          interfaces: () => [
+            ...config.interfaces(),
+            ...buildInterfaces(extensions),
+          ],
+          fields: () => ({
+            ...config.fields(),
+            ...buildFieldMap(extensions),
+          }),
+          extensionASTNodes: config.extensionASTNodes.concat(extensions),
+        };
+      },
+      [SchemaElementKind.INTERFACE]: (config) => {
+        const extensions = interfaceExtensions.get(config.name) ?? [];
+        return {
+          ...config,
+          interfaces: () => [
+            ...config.interfaces(),
+            ...buildInterfaces(extensions),
+          ],
+          fields: () => ({
+            ...config.fields(),
+            ...buildFieldMap(extensions),
+          }),
+          extensionASTNodes: config.extensionASTNodes.concat(extensions),
+        };
+      },
+      [SchemaElementKind.UNION]: (config) => {
+        const extensions = unionExtensions.get(config.name) ?? [];
+        return {
+          ...config,
+          types: () => [...config.types(), ...buildUnionTypes(extensions)],
+          extensionASTNodes: config.extensionASTNodes.concat(extensions),
+        };
+      },
+    };
 
-  // Then produce and return a Schema config with these types.
-  return {
-    description: schemaDef?.description?.value ?? schemaConfig.description,
-    ...operationTypes,
-    types: Array.from(typeMap.values()),
-    directives: [
-      ...schemaConfig.directives.map(replaceDirective),
-      ...directiveDefs.map(buildDirective),
-    ],
-    extensions: schemaConfig.extensions,
-    astNode: schemaDef ?? schemaConfig.astNode,
-    extensionASTNodes: schemaConfig.extensionASTNodes.concat(schemaExtensions),
-    assumeValid: options?.assumeValid ?? false,
-  };
+    function getOperationTypes(
+      nodes: ReadonlyArray<SchemaDefinitionNode | SchemaExtensionNode>,
+    ): {
+      query?: Maybe<GraphQLObjectType>;
+      mutation?: Maybe<GraphQLObjectType>;
+      subscription?: Maybe<GraphQLObjectType>;
+    } {
+      const opTypes = {};
+      for (const node of nodes) {
+        const operationTypesNodes = node.operationTypes ?? [];
 
-  // Below are functions used for producing this schema that have closed over
-  // this scope and have access to the schema, cache, and newly defined types.
+        for (const operationType of operationTypesNodes) {
+          // Note: While this could make early assertions to get the correctly
+          // typed values below, that would throw immediately while type system
+          // validation with validateSchema() will produce more actionable results.
+          // @ts-expect-error
+          opTypes[operationType.operation] = namedTypeFromAST(
+            operationType.type,
+          );
+        }
+      }
 
-  function replaceType<T extends GraphQLType>(type: T): T {
-    if (isListType(type)) {
-      // @ts-expect-error
-      return new GraphQLList(replaceType(type.ofType));
+      return opTypes;
     }
-    if (isNonNullType(type)) {
-      // @ts-expect-error
-      return new GraphQLNonNull(replaceType(type.ofType));
-    }
-    // @ts-expect-error FIXME
-    return replaceNamedType(type);
-  }
 
-  function replaceNamedType<T extends GraphQLNamedType>(type: T): T {
-    // Note: While this could make early assertions to get the correctly
-    // typed values, that would throw immediately while type system
-    // validation with validateSchema() will produce more actionable results.
-    return typeMap.get(type.name) as T;
-  }
-
-  function replaceDirective(directive: GraphQLDirective): GraphQLDirective {
-    if (isSpecifiedDirective(directive)) {
-      // Builtin directives are not extended.
-      return directive;
-    }
-
-    const config = directive.toConfig();
-    return new GraphQLDirective({
-      ...config,
-      args: mapValue(config.args, extendArg),
-    });
-  }
-
-  function extendNamedType(type: GraphQLNamedType): GraphQLNamedType {
-    if (isIntrospectionType(type) || isSpecifiedScalarType(type)) {
-      // Builtin types are not extended.
+    function namedTypeFromAST(node: NamedTypeNode): GraphQLNamedType {
+      const name = node.name.value;
+      const type = getNamedType(name);
+      invariant(type !== undefined, `Unknown type: "${name}".`);
       return type;
     }
-    if (isScalarType(type)) {
-      return extendScalarType(type);
-    }
-    if (isObjectType(type)) {
-      return extendObjectType(type);
-    }
-    if (isInterfaceType(type)) {
-      return extendInterfaceType(type);
-    }
-    if (isUnionType(type)) {
-      return extendUnionType(type);
-    }
-    if (isEnumType(type)) {
-      return extendEnumType(type);
-    }
-    if (isInputObjectType(type)) {
-      return extendInputObjectType(type);
-    }
-    /* c8 ignore next 3 */
-    // Not reachable, all possible type definition nodes have been considered.
-    invariant(false, 'Unexpected type: ' + inspect(type));
-  }
 
-  function extendInputObjectType(
-    type: GraphQLInputObjectType,
-  ): GraphQLInputObjectType {
-    const config = type.toConfig();
-    const extensions = inputObjectExtensions.get(config.name) ?? [];
-
-    return new GraphQLInputObjectType({
-      ...config,
-      fields: () => ({
-        ...mapValue(config.fields, (field) => ({
-          ...field,
-          type: replaceType(field.type),
-        })),
-        ...buildInputFieldMap(extensions),
-      }),
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
-    });
-  }
-
-  function extendEnumType(type: GraphQLEnumType): GraphQLEnumType {
-    const config = type.toConfig();
-    const extensions = enumExtensions.get(type.name) ?? [];
-
-    return new GraphQLEnumType({
-      ...config,
-      values: {
-        ...config.values,
-        ...buildEnumValueMap(extensions),
-      },
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
-    });
-  }
-
-  function extendScalarType(type: GraphQLScalarType): GraphQLScalarType {
-    const config = type.toConfig();
-    const extensions = scalarExtensions.get(config.name) ?? [];
-
-    let specifiedByURL = config.specifiedByURL;
-    for (const extensionNode of extensions) {
-      specifiedByURL = getSpecifiedByURL(extensionNode) ?? specifiedByURL;
+    function typeFromAST(node: TypeNode): GraphQLType {
+      if (node.kind === Kind.LIST_TYPE) {
+        return new GraphQLList(typeFromAST(node.type));
+      }
+      if (node.kind === Kind.NON_NULL_TYPE) {
+        return new GraphQLNonNull(typeFromAST(node.type));
+      }
+      return namedTypeFromAST(node);
     }
 
-    return new GraphQLScalarType({
-      ...config,
-      specifiedByURL,
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
-    });
-  }
-
-  function extendObjectType(type: GraphQLObjectType): GraphQLObjectType {
-    const config = type.toConfig();
-    const extensions = objectExtensions.get(config.name) ?? [];
-
-    return new GraphQLObjectType({
-      ...config,
-      interfaces: () => [
-        ...type.getInterfaces().map(replaceNamedType),
-        ...buildInterfaces(extensions),
-      ],
-      fields: () => ({
-        ...mapValue(config.fields, extendField),
-        ...buildFieldMap(extensions),
-      }),
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
-    });
-  }
-
-  function extendInterfaceType(
-    type: GraphQLInterfaceType,
-  ): GraphQLInterfaceType {
-    const config = type.toConfig();
-    const extensions = interfaceExtensions.get(config.name) ?? [];
-
-    return new GraphQLInterfaceType({
-      ...config,
-      interfaces: () => [
-        ...type.getInterfaces().map(replaceNamedType),
-        ...buildInterfaces(extensions),
-      ],
-      fields: () => ({
-        ...mapValue(config.fields, extendField),
-        ...buildFieldMap(extensions),
-      }),
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
-    });
-  }
-
-  function extendUnionType(type: GraphQLUnionType): GraphQLUnionType {
-    const config = type.toConfig();
-    const extensions = unionExtensions.get(config.name) ?? [];
-
-    return new GraphQLUnionType({
-      ...config,
-      types: () => [
-        ...type.getTypes().map(replaceNamedType),
-        ...buildUnionTypes(extensions),
-      ],
-      extensionASTNodes: config.extensionASTNodes.concat(extensions),
-    });
-  }
-
-  function extendField(
-    field: GraphQLFieldConfig<unknown, unknown>,
-  ): GraphQLFieldConfig<unknown, unknown> {
-    return {
-      ...field,
-      type: replaceType(field.type),
-      args: field.args && mapValue(field.args, extendArg),
-    };
-  }
-
-  function extendArg(arg: GraphQLArgumentConfig) {
-    return {
-      ...arg,
-      type: replaceType(arg.type),
-    };
-  }
-
-  function getOperationTypes(
-    nodes: ReadonlyArray<SchemaDefinitionNode | SchemaExtensionNode>,
-  ): {
-    query?: Maybe<GraphQLObjectType>;
-    mutation?: Maybe<GraphQLObjectType>;
-    subscription?: Maybe<GraphQLObjectType>;
-  } {
-    const opTypes = {};
-    for (const node of nodes) {
-      const operationTypesNodes = node.operationTypes ?? [];
-
-      for (const operationType of operationTypesNodes) {
-        // Note: While this could make early assertions to get the correctly
-        // typed values below, that would throw immediately while type system
-        // validation with validateSchema() will produce more actionable results.
+    function buildDirective(node: DirectiveDefinitionNode): GraphQLDirective {
+      return new GraphQLDirective({
+        name: node.name.value,
+        description: node.description?.value,
         // @ts-expect-error
-        opTypes[operationType.operation] = getNamedType(operationType.type);
+        locations: node.locations.map(({ value }) => value),
+        isRepeatable: node.repeatable,
+        args: buildArgumentMap(node.arguments),
+        astNode: node,
+      });
+    }
+
+    function buildFieldMap(
+      nodes: ReadonlyArray<
+        | InterfaceTypeDefinitionNode
+        | InterfaceTypeExtensionNode
+        | ObjectTypeDefinitionNode
+        | ObjectTypeExtensionNode
+      >,
+    ): GraphQLFieldNormalizedConfigMap<unknown, unknown> {
+      const fieldConfigMap = Object.create(null);
+      for (const node of nodes) {
+        const nodeFields = node.fields ?? [];
+
+        for (const field of nodeFields) {
+          fieldConfigMap[field.name.value] = {
+            // Note: While this could make assertions to get the correctly typed
+            // value, that would throw immediately while type system validation
+            // with validateSchema() will produce more actionable results.
+            type: typeFromAST(field.type),
+            description: field.description?.value,
+            args: buildArgumentMap(field.arguments),
+            deprecationReason: getDeprecationReason(field),
+            astNode: field,
+          };
+        }
       }
+      return fieldConfigMap;
     }
 
-    return opTypes;
-  }
+    function buildArgumentMap(
+      args: Maybe<ReadonlyArray<InputValueDefinitionNode>>,
+    ): GraphQLFieldConfigArgumentMap {
+      const argsNodes = args ?? [];
 
-  function getNamedType(node: NamedTypeNode): GraphQLNamedType {
-    const name = node.name.value;
-    const type = stdTypeMap.get(name) ?? typeMap.get(name);
-
-    if (type === undefined) {
-      throw new Error(`Unknown type: "${name}".`);
-    }
-    return type;
-  }
-
-  function getWrappedType(node: TypeNode): GraphQLType {
-    if (node.kind === Kind.LIST_TYPE) {
-      return new GraphQLList(getWrappedType(node.type));
-    }
-    if (node.kind === Kind.NON_NULL_TYPE) {
-      return new GraphQLNonNull(getWrappedType(node.type));
-    }
-    return getNamedType(node);
-  }
-
-  function buildDirective(node: DirectiveDefinitionNode): GraphQLDirective {
-    return new GraphQLDirective({
-      name: node.name.value,
-      description: node.description?.value,
-      // @ts-expect-error
-      locations: node.locations.map(({ value }) => value),
-      isRepeatable: node.repeatable,
-      args: buildArgumentMap(node.arguments),
-      astNode: node,
-    });
-  }
-
-  function buildFieldMap(
-    nodes: ReadonlyArray<
-      | InterfaceTypeDefinitionNode
-      | InterfaceTypeExtensionNode
-      | ObjectTypeDefinitionNode
-      | ObjectTypeExtensionNode
-    >,
-  ): GraphQLFieldConfigMap<unknown, unknown> {
-    const fieldConfigMap = Object.create(null);
-    for (const node of nodes) {
-      const nodeFields = node.fields ?? [];
-
-      for (const field of nodeFields) {
-        fieldConfigMap[field.name.value] = {
-          // Note: While this could make assertions to get the correctly typed
-          // value, that would throw immediately while type system validation
-          // with validateSchema() will produce more actionable results.
-          type: getWrappedType(field.type),
-          description: field.description?.value,
-          args: buildArgumentMap(field.arguments),
-          deprecationReason: getDeprecationReason(field),
-          astNode: field,
-        };
-      }
-    }
-    return fieldConfigMap;
-  }
-
-  function buildArgumentMap(
-    args: Maybe<ReadonlyArray<InputValueDefinitionNode>>,
-  ): GraphQLFieldConfigArgumentMap {
-    const argsNodes = args ?? [];
-
-    const argConfigMap = Object.create(null);
-    for (const arg of argsNodes) {
-      // Note: While this could make assertions to get the correctly typed
-      // value, that would throw immediately while type system validation
-      // with validateSchema() will produce more actionable results.
-      const type: any = getWrappedType(arg.type);
-
-      argConfigMap[arg.name.value] = {
-        type,
-        description: arg.description?.value,
-        defaultValueLiteral: arg.defaultValue,
-        deprecationReason: getDeprecationReason(arg),
-        astNode: arg,
-      };
-    }
-    return argConfigMap;
-  }
-
-  function buildInputFieldMap(
-    nodes: ReadonlyArray<
-      InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode
-    >,
-  ): GraphQLInputFieldConfigMap {
-    const inputFieldMap = Object.create(null);
-    for (const node of nodes) {
-      const fieldsNodes = node.fields ?? [];
-
-      for (const field of fieldsNodes) {
+      const argConfigMap = Object.create(null);
+      for (const arg of argsNodes) {
         // Note: While this could make assertions to get the correctly typed
         // value, that would throw immediately while type system validation
         // with validateSchema() will produce more actionable results.
-        const type: any = getWrappedType(field.type);
+        const type: any = typeFromAST(arg.type);
 
-        inputFieldMap[field.name.value] = {
+        argConfigMap[arg.name.value] = {
           type,
-          description: field.description?.value,
-          defaultValueLiteral: field.defaultValue,
-          deprecationReason: getDeprecationReason(field),
-          astNode: field,
+          description: arg.description?.value,
+          defaultValueLiteral: arg.defaultValue,
+          deprecationReason: getDeprecationReason(arg),
+          astNode: arg,
         };
       }
+      return argConfigMap;
     }
-    return inputFieldMap;
-  }
 
-  function buildEnumValueMap(
-    nodes: ReadonlyArray<EnumTypeDefinitionNode | EnumTypeExtensionNode>,
-  ): GraphQLEnumValueConfigMap {
-    const enumValueMap = Object.create(null);
-    for (const node of nodes) {
-      const valuesNodes = node.values ?? [];
+    function buildInputFieldMap(
+      nodes: ReadonlyArray<
+        InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode
+      >,
+    ): GraphQLInputFieldNormalizedConfigMap {
+      const inputFieldMap = Object.create(null);
+      for (const node of nodes) {
+        const fieldsNodes = node.fields ?? [];
 
-      for (const value of valuesNodes) {
-        enumValueMap[value.name.value] = {
-          description: value.description?.value,
-          deprecationReason: getDeprecationReason(value),
-          astNode: value,
-        };
+        for (const field of fieldsNodes) {
+          // Note: While this could make assertions to get the correctly typed
+          // value, that would throw immediately while type system validation
+          // with validateSchema() will produce more actionable results.
+          const type: any = typeFromAST(field.type);
+
+          inputFieldMap[field.name.value] = {
+            type,
+            description: field.description?.value,
+            defaultValueLiteral: field.defaultValue,
+            deprecationReason: getDeprecationReason(field),
+            astNode: field,
+          };
+        }
+      }
+      return inputFieldMap;
+    }
+
+    function buildEnumValueMap(
+      nodes: ReadonlyArray<EnumTypeDefinitionNode | EnumTypeExtensionNode>,
+    ): GraphQLEnumValueNormalizedConfigMap {
+      const enumValueMap = Object.create(null);
+      for (const node of nodes) {
+        const valuesNodes = node.values ?? [];
+
+        for (const value of valuesNodes) {
+          enumValueMap[value.name.value] = {
+            description: value.description?.value,
+            deprecationReason: getDeprecationReason(value),
+            astNode: value,
+          };
+        }
+      }
+      return enumValueMap;
+    }
+
+    function buildInterfaces(
+      nodes: ReadonlyArray<
+        | InterfaceTypeDefinitionNode
+        | InterfaceTypeExtensionNode
+        | ObjectTypeDefinitionNode
+        | ObjectTypeExtensionNode
+      >,
+    ): Array<GraphQLInterfaceType> {
+      // Note: While this could make assertions to get the correctly typed
+      // values below, that would throw immediately while type system
+      // validation with validateSchema() will produce more actionable results.
+      // @ts-expect-error
+      return nodes.flatMap(
+        (node) => node.interfaces?.map(namedTypeFromAST) ?? [],
+      );
+    }
+
+    function buildUnionTypes(
+      nodes: ReadonlyArray<UnionTypeDefinitionNode | UnionTypeExtensionNode>,
+    ): Array<GraphQLObjectType> {
+      // Note: While this could make assertions to get the correctly typed
+      // values below, that would throw immediately while type system
+      // validation with validateSchema() will produce more actionable results.
+      // @ts-expect-error
+      return nodes.flatMap((node) => node.types?.map(namedTypeFromAST) ?? []);
+    }
+
+    function buildNamedType(astNode: TypeDefinitionNode): GraphQLNamedType {
+      const name = astNode.name.value;
+
+      switch (astNode.kind) {
+        case Kind.OBJECT_TYPE_DEFINITION: {
+          const extensionASTNodes = objectExtensions.get(name) ?? [];
+          const allNodes = [astNode, ...extensionASTNodes];
+
+          return new GraphQLObjectType({
+            name,
+            description: astNode.description?.value,
+            interfaces: () => buildInterfaces(allNodes),
+            fields: () => buildFieldMap(allNodes),
+            astNode,
+            extensionASTNodes,
+          });
+        }
+        case Kind.INTERFACE_TYPE_DEFINITION: {
+          const extensionASTNodes = interfaceExtensions.get(name) ?? [];
+          const allNodes = [astNode, ...extensionASTNodes];
+
+          return new GraphQLInterfaceType({
+            name,
+            description: astNode.description?.value,
+            interfaces: () => buildInterfaces(allNodes),
+            fields: () => buildFieldMap(allNodes),
+            astNode,
+            extensionASTNodes,
+          });
+        }
+        case Kind.ENUM_TYPE_DEFINITION: {
+          const extensionASTNodes = enumExtensions.get(name) ?? [];
+          const allNodes = [astNode, ...extensionASTNodes];
+
+          return new GraphQLEnumType({
+            name,
+            description: astNode.description?.value,
+            values: () => buildEnumValueMap(allNodes),
+            astNode,
+            extensionASTNodes,
+          });
+        }
+        case Kind.UNION_TYPE_DEFINITION: {
+          const extensionASTNodes = unionExtensions.get(name) ?? [];
+          const allNodes = [astNode, ...extensionASTNodes];
+
+          return new GraphQLUnionType({
+            name,
+            description: astNode.description?.value,
+            types: () => buildUnionTypes(allNodes),
+            astNode,
+            extensionASTNodes,
+          });
+        }
+        case Kind.SCALAR_TYPE_DEFINITION: {
+          const extensionASTNodes = scalarExtensions.get(name) ?? [];
+          return new GraphQLScalarType({
+            name,
+            description: astNode.description?.value,
+            specifiedByURL: getSpecifiedByURL(astNode),
+            astNode,
+            extensionASTNodes,
+          });
+        }
+        case Kind.INPUT_OBJECT_TYPE_DEFINITION: {
+          const extensionASTNodes = inputObjectExtensions.get(name) ?? [];
+          const allNodes = [astNode, ...extensionASTNodes];
+
+          return new GraphQLInputObjectType({
+            name,
+            description: astNode.description?.value,
+            fields: () => buildInputFieldMap(allNodes),
+            astNode,
+            extensionASTNodes,
+            isOneOf: isOneOf(astNode),
+          });
+        }
       }
     }
-    return enumValueMap;
-  }
-
-  function buildInterfaces(
-    nodes: ReadonlyArray<
-      | InterfaceTypeDefinitionNode
-      | InterfaceTypeExtensionNode
-      | ObjectTypeDefinitionNode
-      | ObjectTypeExtensionNode
-    >,
-  ): Array<GraphQLInterfaceType> {
-    // Note: While this could make assertions to get the correctly typed
-    // values below, that would throw immediately while type system
-    // validation with validateSchema() will produce more actionable results.
-    // @ts-expect-error
-    return nodes.flatMap((node) => node.interfaces?.map(getNamedType) ?? []);
-  }
-
-  function buildUnionTypes(
-    nodes: ReadonlyArray<UnionTypeDefinitionNode | UnionTypeExtensionNode>,
-  ): Array<GraphQLObjectType> {
-    // Note: While this could make assertions to get the correctly typed
-    // values below, that would throw immediately while type system
-    // validation with validateSchema() will produce more actionable results.
-    // @ts-expect-error
-    return nodes.flatMap((node) => node.types?.map(getNamedType) ?? []);
-  }
-
-  function buildType(astNode: TypeDefinitionNode): GraphQLNamedType {
-    const name = astNode.name.value;
-
-    switch (astNode.kind) {
-      case Kind.OBJECT_TYPE_DEFINITION: {
-        const extensionASTNodes = objectExtensions.get(name) ?? [];
-        const allNodes = [astNode, ...extensionASTNodes];
-
-        return new GraphQLObjectType({
-          name,
-          description: astNode.description?.value,
-          interfaces: () => buildInterfaces(allNodes),
-          fields: () => buildFieldMap(allNodes),
-          astNode,
-          extensionASTNodes,
-        });
-      }
-      case Kind.INTERFACE_TYPE_DEFINITION: {
-        const extensionASTNodes = interfaceExtensions.get(name) ?? [];
-        const allNodes = [astNode, ...extensionASTNodes];
-
-        return new GraphQLInterfaceType({
-          name,
-          description: astNode.description?.value,
-          interfaces: () => buildInterfaces(allNodes),
-          fields: () => buildFieldMap(allNodes),
-          astNode,
-          extensionASTNodes,
-        });
-      }
-      case Kind.ENUM_TYPE_DEFINITION: {
-        const extensionASTNodes = enumExtensions.get(name) ?? [];
-        const allNodes = [astNode, ...extensionASTNodes];
-
-        return new GraphQLEnumType({
-          name,
-          description: astNode.description?.value,
-          values: buildEnumValueMap(allNodes),
-          astNode,
-          extensionASTNodes,
-        });
-      }
-      case Kind.UNION_TYPE_DEFINITION: {
-        const extensionASTNodes = unionExtensions.get(name) ?? [];
-        const allNodes = [astNode, ...extensionASTNodes];
-
-        return new GraphQLUnionType({
-          name,
-          description: astNode.description?.value,
-          types: () => buildUnionTypes(allNodes),
-          astNode,
-          extensionASTNodes,
-        });
-      }
-      case Kind.SCALAR_TYPE_DEFINITION: {
-        const extensionASTNodes = scalarExtensions.get(name) ?? [];
-        return new GraphQLScalarType({
-          name,
-          description: astNode.description?.value,
-          specifiedByURL: getSpecifiedByURL(astNode),
-          astNode,
-          extensionASTNodes,
-        });
-      }
-      case Kind.INPUT_OBJECT_TYPE_DEFINITION: {
-        const extensionASTNodes = inputObjectExtensions.get(name) ?? [];
-        const allNodes = [astNode, ...extensionASTNodes];
-
-        return new GraphQLInputObjectType({
-          name,
-          description: astNode.description?.value,
-          fields: () => buildInputFieldMap(allNodes),
-          astNode,
-          extensionASTNodes,
-          isOneOf: isOneOf(astNode),
-        });
-      }
-    }
-  }
+  });
 }
 
 const stdTypeMap = new Map(

--- a/src/utilities/lexicographicSortSchema.ts
+++ b/src/utilities/lexicographicSortSchema.ts
@@ -1,36 +1,9 @@
-import { inspect } from '../jsutils/inspect.js';
-import { invariant } from '../jsutils/invariant.js';
-import type { Maybe } from '../jsutils/Maybe.js';
 import { naturalCompare } from '../jsutils/naturalCompare.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
 
-import type {
-  GraphQLFieldConfigArgumentMap,
-  GraphQLFieldConfigMap,
-  GraphQLInputFieldConfigMap,
-  GraphQLNamedType,
-  GraphQLType,
-} from '../type/definition.js';
-import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
-  GraphQLList,
-  GraphQLNonNull,
-  GraphQLObjectType,
-  GraphQLUnionType,
-  isEnumType,
-  isInputObjectType,
-  isInterfaceType,
-  isListType,
-  isNonNullType,
-  isObjectType,
-  isScalarType,
-  isUnionType,
-} from '../type/definition.js';
-import { GraphQLDirective } from '../type/directives.js';
-import { isIntrospectionType } from '../type/introspection.js';
 import { GraphQLSchema } from '../type/schema.js';
+
+import { mapSchemaConfig, SchemaElementKind } from './mapSchemaConfig.js';
 
 /**
  * Sort GraphQLSchema.
@@ -38,136 +11,52 @@ import { GraphQLSchema } from '../type/schema.js';
  * This function returns a sorted copy of the given GraphQLSchema.
  */
 export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
-  const schemaConfig = schema.toConfig();
-  const typeMap = new Map<string, GraphQLNamedType>(
-    sortByName(schemaConfig.types).map((type) => [
-      type.name,
-      sortNamedType(type),
-    ]),
+  return new GraphQLSchema(
+    mapSchemaConfig(schema.toConfig(), () => ({
+      [SchemaElementKind.OBJECT]: (config) => ({
+        ...config,
+        interfaces: () => sortByName(config.interfaces()),
+        fields: () => sortObjMap(config.fields()),
+      }),
+      [SchemaElementKind.FIELD]: (config) => ({
+        ...config,
+        args: sortObjMap(config.args),
+      }),
+      [SchemaElementKind.INTERFACE]: (config) => ({
+        ...config,
+        interfaces: () => sortByName(config.interfaces()),
+        fields: () => sortObjMap(config.fields()),
+      }),
+      [SchemaElementKind.UNION]: (config) => ({
+        ...config,
+        types: () => sortByName(config.types()),
+      }),
+      [SchemaElementKind.ENUM]: (config) => ({
+        ...config,
+        values: () => sortObjMap(config.values()),
+      }),
+      [SchemaElementKind.INPUT_OBJECT]: (config) => ({
+        ...config,
+        fields: () => sortObjMap(config.fields()),
+      }),
+      [SchemaElementKind.DIRECTIVE]: (config) => ({
+        ...config,
+        locations: sortBy(config.locations, (x) => x),
+        args: sortObjMap(config.args),
+      }),
+      [SchemaElementKind.SCHEMA]: (config) => ({
+        ...config,
+        types: sortByName(config.types),
+        directives: sortByName(config.directives),
+      }),
+    })),
   );
-
-  return new GraphQLSchema({
-    ...schemaConfig,
-    types: Array.from(typeMap.values()),
-    directives: sortByName(schemaConfig.directives).map(sortDirective),
-    query: replaceMaybeType(schemaConfig.query),
-    mutation: replaceMaybeType(schemaConfig.mutation),
-    subscription: replaceMaybeType(schemaConfig.subscription),
-  });
-
-  function replaceType<T extends GraphQLType>(type: T): T {
-    if (isListType(type)) {
-      // @ts-expect-error
-      return new GraphQLList(replaceType(type.ofType));
-    } else if (isNonNullType(type)) {
-      // @ts-expect-error
-      return new GraphQLNonNull(replaceType(type.ofType));
-    }
-    // @ts-expect-error FIXME: TS Conversion
-    return replaceNamedType<GraphQLNamedType>(type);
-  }
-
-  function replaceNamedType<T extends GraphQLNamedType>(type: T): T {
-    return typeMap.get(type.name) as T;
-  }
-
-  function replaceMaybeType<T extends GraphQLNamedType>(
-    maybeType: Maybe<T>,
-  ): Maybe<T> {
-    return maybeType && replaceNamedType(maybeType);
-  }
-
-  function sortDirective(directive: GraphQLDirective) {
-    const config = directive.toConfig();
-    return new GraphQLDirective({
-      ...config,
-      locations: sortBy(config.locations, (x) => x),
-      args: sortArgs(config.args),
-    });
-  }
-
-  function sortArgs(args: GraphQLFieldConfigArgumentMap) {
-    return sortObjMap(args, (arg) => ({
-      ...arg,
-      type: replaceType(arg.type),
-    }));
-  }
-
-  function sortFields(fieldsMap: GraphQLFieldConfigMap<unknown, unknown>) {
-    return sortObjMap(fieldsMap, (field) => ({
-      ...field,
-      type: replaceType(field.type),
-      args: field.args && sortArgs(field.args),
-    }));
-  }
-
-  function sortInputFields(fieldsMap: GraphQLInputFieldConfigMap) {
-    return sortObjMap(fieldsMap, (field) => ({
-      ...field,
-      type: replaceType(field.type),
-    }));
-  }
-
-  function sortTypes<T extends GraphQLNamedType>(
-    array: ReadonlyArray<T>,
-  ): Array<T> {
-    return sortByName(array).map(replaceNamedType);
-  }
-
-  function sortNamedType(type: GraphQLNamedType): GraphQLNamedType {
-    if (isScalarType(type) || isIntrospectionType(type)) {
-      return type;
-    }
-    if (isObjectType(type)) {
-      const config = type.toConfig();
-      return new GraphQLObjectType({
-        ...config,
-        interfaces: () => sortTypes(config.interfaces),
-        fields: () => sortFields(config.fields),
-      });
-    }
-    if (isInterfaceType(type)) {
-      const config = type.toConfig();
-      return new GraphQLInterfaceType({
-        ...config,
-        interfaces: () => sortTypes(config.interfaces),
-        fields: () => sortFields(config.fields),
-      });
-    }
-    if (isUnionType(type)) {
-      const config = type.toConfig();
-      return new GraphQLUnionType({
-        ...config,
-        types: () => sortTypes(config.types),
-      });
-    }
-    if (isEnumType(type)) {
-      const config = type.toConfig();
-      return new GraphQLEnumType({
-        ...config,
-        values: sortObjMap(config.values, (value) => value),
-      });
-    }
-    if (isInputObjectType(type)) {
-      const config = type.toConfig();
-      return new GraphQLInputObjectType({
-        ...config,
-        fields: () => sortInputFields(config.fields),
-      });
-    }
-    /* c8 ignore next 3 */
-    // Not reachable, all possible types have been considered.
-    invariant(false, 'Unexpected type: ' + inspect(type));
-  }
 }
 
-function sortObjMap<T, R>(
-  map: ObjMap<T>,
-  sortValueFn: (value: T) => R,
-): ObjMap<R> {
+function sortObjMap<T, R>(map: ObjMap<T>): ObjMap<R> {
   const sortedMap = Object.create(null);
   for (const key of Object.keys(map).sort(naturalCompare)) {
-    sortedMap[key] = sortValueFn(map[key]);
+    sortedMap[key] = map[key];
   }
   return sortedMap;
 }

--- a/src/utilities/mapSchemaConfig.ts
+++ b/src/utilities/mapSchemaConfig.ts
@@ -1,0 +1,464 @@
+import { inspect } from '../jsutils/inspect.js';
+import { invariant } from '../jsutils/invariant.js';
+import type { Maybe } from '../jsutils/Maybe.js';
+
+import type {
+  GraphQLArgumentNormalizedConfig,
+  GraphQLEnumTypeNormalizedConfig,
+  GraphQLEnumValueConfig,
+  GraphQLFieldNormalizedConfig,
+  GraphQLFieldNormalizedConfigArgumentMap,
+  GraphQLFieldNormalizedConfigMap,
+  GraphQLInputFieldConfig,
+  GraphQLInputObjectTypeNormalizedConfig,
+  GraphQLInterfaceTypeNormalizedConfig,
+  GraphQLNamedType,
+  GraphQLObjectTypeNormalizedConfig,
+  GraphQLScalarTypeNormalizedConfig,
+  GraphQLType,
+  GraphQLUnionTypeNormalizedConfig,
+} from '../type/definition.js';
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLScalarType,
+  GraphQLUnionType,
+  isEnumType,
+  isInputObjectType,
+  isInterfaceType,
+  isListType,
+  isNonNullType,
+  isObjectType,
+  isScalarType,
+  isUnionType,
+} from '../type/definition.js';
+import type { GraphQLDirectiveNormalizedConfig } from '../type/directives.js';
+import { GraphQLDirective, isSpecifiedDirective } from '../type/directives.js';
+import {
+  introspectionTypes,
+  isIntrospectionType,
+} from '../type/introspection.js';
+import {
+  isSpecifiedScalarType,
+  specifiedScalarTypes,
+} from '../type/scalars.js';
+import type { GraphQLSchemaNormalizedConfig } from '../type/schema.js';
+
+/**
+ * The set of GraphQL Schema Elements.
+ */
+export const SchemaElementKind = {
+  SCHEMA: 'SCHEMA' as const,
+  SCALAR: 'SCALAR' as const,
+  OBJECT: 'OBJECT' as const,
+  FIELD: 'FIELD' as const,
+  ARGUMENT: 'ARGUMENT' as const,
+  INTERFACE: 'INTERFACE' as const,
+  UNION: 'UNION' as const,
+  ENUM: 'ENUM' as const,
+  ENUM_VALUE: 'ENUM_VALUE' as const,
+  INPUT_OBJECT: 'INPUT_OBJECT' as const,
+  INPUT_FIELD: 'INPUT_FIELD' as const,
+  DIRECTIVE: 'DIRECTIVE' as const,
+} as const;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+type SchemaElementKind =
+  (typeof SchemaElementKind)[keyof typeof SchemaElementKind];
+
+export interface MappedSchemaContext {
+  getNamedType: (typeName: string) => GraphQLNamedType;
+  setNamedType: (type: GraphQLNamedType) => void;
+  getNamedTypes: () => ReadonlyArray<GraphQLNamedType>;
+}
+
+type GraphQLScalarTypeMappedConfig = GraphQLScalarTypeNormalizedConfig<
+  any,
+  any
+>;
+
+type EnsureThunks<T, ThunkFields extends keyof T> = {
+  [K in keyof T]: K extends ThunkFields ? () => T[K] : T[K];
+};
+
+type GraphQLObjectTypeMappedConfig = EnsureThunks<
+  GraphQLObjectTypeNormalizedConfig<any, any>,
+  'interfaces' | 'fields'
+>;
+type GraphQLInterfaceTypeMappedConfig = EnsureThunks<
+  GraphQLInterfaceTypeNormalizedConfig<any, any>,
+  'interfaces' | 'fields'
+>;
+type GraphQLUnionTypeMappedConfig = EnsureThunks<
+  GraphQLUnionTypeNormalizedConfig,
+  'types'
+>;
+type GraphQLEnumTypeMappedConfig = EnsureThunks<
+  GraphQLEnumTypeNormalizedConfig,
+  'values'
+>;
+type GraphQLInputObjectTypeMappedConfig = EnsureThunks<
+  GraphQLInputObjectTypeNormalizedConfig,
+  'fields'
+>;
+
+type ScalarTypeConfigMapper = (
+  scalarConfig: GraphQLScalarTypeMappedConfig,
+) => GraphQLScalarTypeMappedConfig;
+
+type ObjectTypeConfigMapper = (
+  objectConfig: GraphQLObjectTypeMappedConfig,
+) => GraphQLObjectTypeMappedConfig;
+
+type FieldConfigMapper = (
+  fieldConfig: GraphQLFieldNormalizedConfig<any, any>,
+  parentTypeName: string,
+) => GraphQLFieldNormalizedConfig<any, any>;
+
+type ArgumentConfigMapper = (
+  argConfig: GraphQLArgumentNormalizedConfig,
+  fieldOrDirectiveName: string,
+  parentTypeName?: string | undefined,
+) => GraphQLArgumentNormalizedConfig;
+
+type InterfaceTypeConfigMapper = (
+  interfaceConfig: GraphQLInterfaceTypeMappedConfig,
+) => GraphQLInterfaceTypeMappedConfig;
+
+type UnionTypeConfigMapper = (
+  unionConfig: GraphQLUnionTypeMappedConfig,
+) => GraphQLUnionTypeMappedConfig;
+
+type EnumTypeConfigMapper = (
+  enumConfig: GraphQLEnumTypeMappedConfig,
+) => GraphQLEnumTypeMappedConfig;
+
+type EnumValueConfigMapper = (
+  enumValueConfig: GraphQLEnumValueConfig,
+  valueName: string,
+  enumName: string,
+) => GraphQLEnumValueConfig;
+
+type InputObjectTypeConfigMapper = (
+  inputObjectConfig: GraphQLInputObjectTypeMappedConfig,
+) => GraphQLInputObjectTypeMappedConfig;
+
+type InputFieldConfigMapper = (
+  inputFieldConfig: GraphQLInputFieldConfig,
+  inputFieldName: string,
+  inputObjectTypeName: string,
+) => GraphQLInputFieldConfig;
+
+type DirectiveConfigMapper = (
+  directiveConfig: GraphQLDirectiveNormalizedConfig,
+) => GraphQLDirectiveNormalizedConfig;
+
+type SchemaConfigMapper = (
+  originalSchemaConfig: GraphQLSchemaNormalizedConfig,
+) => GraphQLSchemaNormalizedConfig;
+
+export interface ConfigMapperMap {
+  [SchemaElementKind.SCALAR]?: ScalarTypeConfigMapper;
+  [SchemaElementKind.OBJECT]?: ObjectTypeConfigMapper;
+  [SchemaElementKind.FIELD]?: FieldConfigMapper;
+  [SchemaElementKind.ARGUMENT]?: ArgumentConfigMapper;
+  [SchemaElementKind.INTERFACE]?: InterfaceTypeConfigMapper;
+  [SchemaElementKind.UNION]?: UnionTypeConfigMapper;
+  [SchemaElementKind.ENUM]?: EnumTypeConfigMapper;
+  [SchemaElementKind.ENUM_VALUE]?: EnumValueConfigMapper;
+  [SchemaElementKind.INPUT_OBJECT]?: InputObjectTypeConfigMapper;
+  [SchemaElementKind.INPUT_FIELD]?: InputFieldConfigMapper;
+  [SchemaElementKind.DIRECTIVE]?: DirectiveConfigMapper;
+  [SchemaElementKind.SCHEMA]?: SchemaConfigMapper;
+}
+
+/**
+ * @internal
+ */
+export function mapSchemaConfig(
+  schemaConfig: GraphQLSchemaNormalizedConfig,
+  configMapperMapFn: (context: MappedSchemaContext) => ConfigMapperMap,
+): GraphQLSchemaNormalizedConfig {
+  const configMapperMap = configMapperMapFn({
+    getNamedType,
+    setNamedType,
+    getNamedTypes,
+  });
+
+  const mappedTypeMap = new Map<string, GraphQLNamedType>();
+  for (const type of schemaConfig.types) {
+    const typeName = type.name;
+    const mappedNamedType = mapNamedType(type);
+    if (mappedNamedType) {
+      mappedTypeMap.set(typeName, mappedNamedType);
+    }
+  }
+
+  const mappedDirectives: Array<GraphQLDirective> = [];
+  for (const directive of schemaConfig.directives) {
+    if (isSpecifiedDirective(directive)) {
+      // Builtin directives cannot be mapped.
+      mappedDirectives.push(directive);
+      continue;
+    }
+
+    const mappedDirectiveConfig = mapDirective(directive.toConfig());
+    if (mappedDirectiveConfig) {
+      mappedDirectives.push(new GraphQLDirective(mappedDirectiveConfig));
+    }
+  }
+
+  const mappedSchemaConfig = {
+    ...schemaConfig,
+    query:
+      schemaConfig.query &&
+      (getNamedType(schemaConfig.query.name) as GraphQLObjectType),
+    mutation:
+      schemaConfig.mutation &&
+      (getNamedType(schemaConfig.mutation.name) as GraphQLObjectType),
+    subscription:
+      schemaConfig.subscription &&
+      (getNamedType(schemaConfig.subscription.name) as GraphQLObjectType),
+    types: Array.from(mappedTypeMap.values()),
+    directives: mappedDirectives,
+  };
+
+  const schemaMapper = configMapperMap[SchemaElementKind.SCHEMA];
+
+  return schemaMapper == null
+    ? mappedSchemaConfig
+    : schemaMapper(mappedSchemaConfig);
+
+  function getType<T extends GraphQLType>(type: T): T {
+    if (isListType(type)) {
+      return new GraphQLList(getType(type.ofType)) as T;
+    }
+    if (isNonNullType(type)) {
+      return new GraphQLNonNull(getType(type.ofType)) as T;
+    }
+
+    return getNamedType(type.name) as T;
+  }
+
+  function getNamedType(typeName: string): GraphQLNamedType {
+    const type = stdTypeMap.get(typeName) ?? mappedTypeMap.get(typeName);
+    invariant(type !== undefined, `Unknown type: "${typeName}".`);
+    return type;
+  }
+
+  function setNamedType(type: GraphQLNamedType): void {
+    mappedTypeMap.set(type.name, type);
+  }
+
+  function getNamedTypes(): ReadonlyArray<GraphQLNamedType> {
+    return Array.from(mappedTypeMap.values());
+  }
+
+  function mapNamedType(type: GraphQLNamedType): Maybe<GraphQLNamedType> {
+    if (isIntrospectionType(type) || isSpecifiedScalarType(type)) {
+      // Builtin types cannot be mapped.
+      return type;
+    }
+
+    if (isScalarType(type)) {
+      return mapScalarType(type);
+    }
+    if (isObjectType(type)) {
+      return mapObjectType(type);
+    }
+    if (isInterfaceType(type)) {
+      return mapInterfaceType(type);
+    }
+    if (isUnionType(type)) {
+      return mapUnionType(type);
+    }
+    if (isEnumType(type)) {
+      return mapEnumType(type);
+    }
+    if (isInputObjectType(type)) {
+      return mapInputObjectType(type);
+    }
+    /* c8 ignore next 3 */
+    // Not reachable, all possible type definition nodes have been considered.
+    invariant(false, 'Unexpected type: ' + inspect(type));
+  }
+
+  function mapScalarType(type: GraphQLScalarType): GraphQLScalarType {
+    let mappedConfig: Maybe<GraphQLScalarTypeMappedConfig> = type.toConfig();
+    const mapper = configMapperMap[SchemaElementKind.SCALAR];
+    mappedConfig = mapper == null ? mappedConfig : mapper(mappedConfig);
+    return new GraphQLScalarType(mappedConfig);
+  }
+
+  function mapObjectType(type: GraphQLObjectType): GraphQLObjectType {
+    const config = type.toConfig();
+    let mappedConfig: Maybe<GraphQLObjectTypeMappedConfig> = {
+      ...config,
+      interfaces: () =>
+        config.interfaces.map(
+          (iface) => getNamedType(iface.name) as GraphQLInterfaceType,
+        ),
+      fields: () => mapFields(config.fields, type.name),
+    };
+    const mapper = configMapperMap[SchemaElementKind.OBJECT];
+    mappedConfig = mapper == null ? mappedConfig : mapper(mappedConfig);
+    return new GraphQLObjectType(mappedConfig);
+  }
+
+  function mapFields(
+    fieldMap: GraphQLFieldNormalizedConfigMap<any, any>,
+    parentTypeName: string,
+  ): GraphQLFieldNormalizedConfigMap<any, any> {
+    const newFieldMap = Object.create(null);
+    for (const [fieldName, field] of Object.entries(fieldMap)) {
+      let mappedField = {
+        ...field,
+        type: getType(field.type),
+        args: mapArgs(field.args, parentTypeName, fieldName),
+      };
+      const mapper = configMapperMap[SchemaElementKind.FIELD];
+      if (mapper) {
+        mappedField = mapper(mappedField, parentTypeName);
+      }
+      newFieldMap[fieldName] = mappedField;
+    }
+    return newFieldMap;
+  }
+
+  function mapArgs(
+    argumentMap: GraphQLFieldNormalizedConfigArgumentMap,
+    fieldOrDirectiveName: string,
+    parentTypeName?: string | undefined,
+  ): GraphQLFieldNormalizedConfigArgumentMap {
+    const newArgumentMap = Object.create(null);
+
+    for (const [argName, arg] of Object.entries(argumentMap)) {
+      let mappedArg = {
+        ...arg,
+        type: getType(arg.type),
+      };
+      const mapper = configMapperMap[SchemaElementKind.ARGUMENT];
+      if (mapper) {
+        mappedArg = mapper(mappedArg, fieldOrDirectiveName, parentTypeName);
+      }
+      newArgumentMap[argName] = mappedArg;
+    }
+
+    return newArgumentMap;
+  }
+
+  function mapInterfaceType(type: GraphQLInterfaceType): GraphQLInterfaceType {
+    const config = type.toConfig();
+    let mappedConfig: Maybe<GraphQLInterfaceTypeMappedConfig> = {
+      ...config,
+      interfaces: () =>
+        config.interfaces.map(
+          (iface) => getNamedType(iface.name) as GraphQLInterfaceType,
+        ),
+      fields: () => mapFields(config.fields, type.name),
+    };
+    const mapper = configMapperMap[SchemaElementKind.INTERFACE];
+    mappedConfig = mapper == null ? mappedConfig : mapper(mappedConfig);
+    return new GraphQLInterfaceType(mappedConfig);
+  }
+
+  function mapUnionType(type: GraphQLUnionType): GraphQLUnionType {
+    const config = type.toConfig();
+    let mappedConfig: Maybe<GraphQLUnionTypeMappedConfig> = {
+      ...config,
+      types: () =>
+        config.types.map(
+          (memberType) => getNamedType(memberType.name) as GraphQLObjectType,
+        ),
+    };
+    const mapper = configMapperMap[SchemaElementKind.UNION];
+    mappedConfig = mapper == null ? mappedConfig : mapper(mappedConfig);
+    return new GraphQLUnionType(mappedConfig);
+  }
+
+  function mapEnumType(type: GraphQLEnumType): GraphQLEnumType {
+    const config = type.toConfig();
+    let mappedConfig: Maybe<GraphQLEnumTypeMappedConfig> = {
+      ...config,
+      values: () => {
+        const newEnumValues = Object.create(null);
+        for (const [valueName, value] of Object.entries(config.values)) {
+          const mappedValue = mapEnumValue(value, valueName, type.name);
+          newEnumValues[valueName] = mappedValue;
+        }
+        return newEnumValues;
+      },
+    };
+    const mapper = configMapperMap[SchemaElementKind.ENUM];
+    mappedConfig = mapper == null ? mappedConfig : mapper(mappedConfig);
+    return new GraphQLEnumType(mappedConfig);
+  }
+
+  function mapEnumValue(
+    valueConfig: GraphQLEnumValueConfig,
+    valueName: string,
+    enumName: string,
+  ): GraphQLEnumValueConfig {
+    const mappedConfig = { ...valueConfig };
+    const mapper = configMapperMap[SchemaElementKind.ENUM_VALUE];
+    return mapper == null
+      ? mappedConfig
+      : mapper(mappedConfig, valueName, enumName);
+  }
+
+  function mapInputObjectType(
+    type: GraphQLInputObjectType,
+  ): GraphQLInputObjectType {
+    const config = type.toConfig();
+    let mappedConfig: Maybe<GraphQLInputObjectTypeMappedConfig> = {
+      ...config,
+      fields: () => {
+        const newInputFieldMap = Object.create(null);
+        for (const [fieldName, field] of Object.entries(config.fields)) {
+          const mappedField = mapInputField(field, fieldName, type.name);
+          newInputFieldMap[fieldName] = mappedField;
+        }
+        return newInputFieldMap;
+      },
+    };
+    const mapper = configMapperMap[SchemaElementKind.INPUT_OBJECT];
+    mappedConfig = mapper == null ? mappedConfig : mapper(mappedConfig);
+    return new GraphQLInputObjectType(mappedConfig);
+  }
+
+  function mapInputField(
+    inputFieldConfig: GraphQLInputFieldConfig,
+    inputFieldName: string,
+    inputObjectTypeName: string,
+  ): GraphQLInputFieldConfig {
+    const mappedConfig = {
+      ...inputFieldConfig,
+      type: getType(inputFieldConfig.type),
+    };
+    const mapper = configMapperMap[SchemaElementKind.INPUT_FIELD];
+    return mapper == null
+      ? mappedConfig
+      : mapper(mappedConfig, inputFieldName, inputObjectTypeName);
+  }
+
+  function mapDirective(
+    config: GraphQLDirectiveNormalizedConfig,
+  ): Maybe<GraphQLDirectiveNormalizedConfig> {
+    const mappedConfig = {
+      ...config,
+      args: mapArgs(config.args, config.name, undefined),
+    };
+    const mapper = configMapperMap[SchemaElementKind.DIRECTIVE];
+    return mapper == null ? mappedConfig : mapper(mappedConfig);
+  }
+}
+
+const stdTypeMap = new Map(
+  [...specifiedScalarTypes, ...introspectionTypes].map((type) => [
+    type.name,
+    type,
+  ]),
+);


### PR DESCRIPTION
motivation:

1. rebuilds `lexicographicSortSchema()` on this generic utility, better demonstrating only the sorting
2. rebuilds `extendSchemaImpl()` on this utility
3. can be used as base to more easily enhance `extendSchema()`/`buildASTSchema()`/`buildSchema()` to take resolvers, etc
4. can be used to expose a generic safe `mapSchemaConfig()` utility
5. improved performance -- not the initial motivation, but turns out these changes bring an 80% speed improvement to `buildSchema()`.