### PR TITLE
fix for mixture of default and custom root type names

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -1033,6 +1033,22 @@ describe('Schema Builder', () => {
     expect(schema.getSubscriptionType()).to.include({ name: 'Subscription' });
   });
 
+  it('Mixture of default and custom root operation types', () => {
+    const schema = buildSchema(`
+      extend schema {
+        query: SomeQuery
+      }
+      type SomeQuery
+      type Query
+      type Mutation
+      type Subscription
+    `);
+
+    expect(schema.getQueryType()).to.include({ name: 'SomeQuery' });
+    expect(schema.getMutationType()).to.include({ name: 'Mutation' });
+    expect(schema.getSubscriptionType()).to.include({ name: 'Subscription' });
+  });
+
   it('can build invalid schema', () => {
     // Invalid schema, because it is missing query root type
     const schema = buildSchema('type Mutation');

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -3,7 +3,6 @@ import type { ParseOptions } from '../language/parser.js';
 import { parse } from '../language/parser.js';
 import type { Source } from '../language/source.js';
 
-import { specifiedDirectives } from '../type/directives.js';
 import type { GraphQLSchemaValidationOptions } from '../type/schema.js';
 import { GraphQLSchema } from '../type/schema.js';
 
@@ -38,49 +37,9 @@ export function buildASTSchema(
     assertValidSDL(documentAST);
   }
 
-  const emptySchemaConfig = {
-    description: undefined,
-    types: [],
-    directives: [],
-    extensions: Object.create(null),
-    extensionASTNodes: [],
-    assumeValid: false,
-  };
-  const config = extendSchemaImpl(emptySchemaConfig, documentAST, options);
+  const config = extendSchemaImpl(documentAST, undefined, options);
 
-  if (config.astNode == null) {
-    for (const type of config.types) {
-      switch (type.name) {
-        // Note: While this could make early assertions to get the correctly
-        // typed values below, that would throw immediately while type system
-        // validation with validateSchema() will produce more actionable results.
-        case 'Query':
-          // @ts-expect-error validated in `validateSchema`
-          config.query = type;
-          break;
-        case 'Mutation':
-          // @ts-expect-error validated in `validateSchema`
-          config.mutation = type;
-          break;
-        case 'Subscription':
-          // @ts-expect-error validated in `validateSchema`
-          config.subscription = type;
-          break;
-      }
-    }
-  }
-
-  const directives = [
-    ...config.directives,
-    // If specified directives were not explicitly declared, add them.
-    ...specifiedDirectives.filter((stdDirective) =>
-      config.directives.every(
-        (directive) => directive.name !== stdDirective.name,
-      ),
-    ),
-  ];
-
-  return new GraphQLSchema({ ...config, directives });
+  return new GraphQLSchema(config);
 }
 
 /**


### PR DESCRIPTION
Is it legal to use “extend schema” if the schema definition is omitted and the default types could have been used?