### PR TITLE
transmit source event stream errors as an error payload

### DIFF
--- a/src/execution/__tests__/cancellation-test.ts
+++ b/src/execution/__tests__/cancellation-test.ts
@@ -2,7 +2,6 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
-import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import { isAsyncIterable } from '../../jsutils/isAsyncIterable.js';
@@ -902,9 +901,15 @@ describe('Execute: Cancellation', () => {
 
     abortController.abort();
 
-    await expectPromise(subscription.next()).toRejectWith(
-      'This operation was aborted',
-    );
+    expectJSON(await subscription.next()).toDeepEqual({
+      value: { errors: [{ message: 'This operation was aborted' }] },
+      done: false,
+    });
+
+    expectJSON(await subscription.next()).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
   });
 
   it('should stop the execution when aborted during subscription returned asynchronously', async () => {
@@ -941,8 +946,14 @@ describe('Execute: Cancellation', () => {
 
     abortController.abort();
 
-    await expectPromise(subscription.next()).toRejectWith(
-      'This operation was aborted',
-    );
+    expectJSON(await subscription.next()).toDeepEqual({
+      value: { errors: [{ message: 'This operation was aborted' }] },
+      done: false,
+    });
+
+    expectJSON(await subscription.next()).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
   });
 });

--- a/src/execution/__tests__/mapAsyncIterable-test.ts
+++ b/src/execution/__tests__/mapAsyncIterable-test.ts
@@ -89,6 +89,26 @@ describe('mapAsyncIterable', () => {
     });
   });
 
+  it('calls onError with iterator errors', async () => {
+    async function* source() {
+      yield 1;
+      throw new Error('Oops');
+    }
+
+    const doubles = mapAsyncIterable(
+      source(),
+      (x) => Promise.resolve(x + x),
+      () => Promise.resolve(0),
+    );
+
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 0, done: false });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+  });
+
   it('calls done when completes', async () => {
     async function* source() {
       yield 1;
@@ -100,6 +120,7 @@ describe('mapAsyncIterable', () => {
     const doubles = mapAsyncIterable(
       source(),
       (x) => Promise.resolve(x + x),
+      undefined,
       () => {
         done = true;
       },
@@ -126,6 +147,7 @@ describe('mapAsyncIterable', () => {
     const doubles = mapAsyncIterable(
       source(),
       (x) => Promise.resolve(x + x),
+      undefined,
       () => {
         done = true;
       },

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -2137,6 +2137,7 @@ function mapSourceToResponse(
       };
       return validatedExecutionArgs.perEventExecutor(perEventExecutionArgs);
     },
+    (error) => ({ errors: [locatedError(error, undefined)] }),
     () => abortSignalListener?.disconnect(),
   );
 }


### PR DESCRIPTION
implements https://github.com/graphql/graphql-spec/pull/1127

1. akin to a request error, without any data field
2. and close the response event stream ensuring no further events are sent