### PR TITLE
adjust GraphQLResolveInfo to remove breaking change from v16

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -222,6 +222,7 @@ describe('Execute: Handles basic execution tasks', () => {
       'rootValue',
       'operation',
       'variableValues',
+      'variableValuesWithSources',
     );
 
     const operation = document.definitions[0];
@@ -240,7 +241,8 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(resolvedInfo).to.deep.include({
       fieldNodes: [field],
       path: { prev: undefined, key: 'result', typename: 'Test' },
-      variableValues: {
+      variableValues: { var: 'abc' },
+      variableValuesWithSources: {
         sources: {
           var: {
             signature: {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -955,7 +955,8 @@ export function buildResolveInfo(
     fragments: fragmentDefinitions,
     rootValue,
     operation,
-    variableValues,
+    variableValues: variableValues.coerced,
+    variableValuesWithSources: variableValues,
   };
 }
 

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1003,7 +1003,8 @@ export interface GraphQLResolveInfo {
   readonly fragments: ObjMap<FragmentDefinitionNode>;
   readonly rootValue: unknown;
   readonly operation: OperationDefinitionNode;
-  readonly variableValues: VariableValues;
+  readonly variableValues: { [variable: string]: unknown };
+  readonly variableValuesWithSources: VariableValues;
 }
 
 /**


### PR DESCRIPTION
#3811 internally preserved the sources of variable values so that we could properly replace variables within complex scalars, but it also exposed this within the GraphQLResolveInfo interface available to resolvers in a breaking manner, by changing the type of the `variableValues` property.

This PR reverts the change to the `variableValues` property, but exposed the extended variable information under a new `variableValuesWithSources` property.