### PR TITLE
internal: update CONTRIBUTING guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,9 +77,12 @@ ensure your pull request matches the style guides, run `npm run prettier`.
 
 - Pull requests are required to pass all tests and checks before they can be merged.
 - Ideally, pull requests should be reviewed by _at least two_ members of the [`@graphql/graphql-js-reviewers`](https://github.com/orgs/graphql/teams/graphql-js-reviewers) team before they are merged, preferably from separate organizations. For more complex pull requests, a larger cohort of reviewers is suggested.
-- If a reviewer hasn't responded in 48 hours, feel free to ping them `@graphql/graphql-js-reviewers`.
 - Any reviewer may request that the topic be brought for more in depth discussion at a [GraphQL JS Working Group meeting](https://github.com/graphql/graphql-js-wg/), where decisions will be made by consensus.
 - A PR that has been merged without discussion at a GraphQL JS Working Group meeting may be reverted if a more in depth discussion is later requested.
+
+## Discussion
+
+Feel free to reach out via the [graphql-js channel](https://discord.com/channels/625400653321076807/862957336082645006) on the [official Discord server](https://discord.graphql.org/) to discuss issues, pull requests, or anything graphql-js related.
 
 ## Release on NPM
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 We want to make contributing to this project as easy and transparent as
 possible. Hopefully this document makes the process for contributing clear and
-answers any questions you may have. If not, feel free to open an
-[Issue](https://github.com/graphql/graphql-spec/issues/).
+answers any questions you may have.
 
 ## Issues
 
@@ -21,8 +20,8 @@ your [pull requests](https://help.github.com/articles/creating-a-pull-request).
 Since graphql-js is a reference implementation of the
 [GraphQL spec](https://graphql.github.io/graphql-spec/), only changes which comply
 with this spec will be considered. If you have a change in mind which requires a
-change to the spec, please first open an
-[issue](https://github.com/graphql/graphql-spec/issues/) against the spec.
+change to the spec, please consider opening instead an
+[issue](https://github.com/graphql/graphql-spec/issues/) against the spec and/or attending a [GraphQL Working Group meeting](https://github.com/graphql/graphql-wg) to discuss your proposal. See the [contribution guide for the specification](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md) for further information. Stage 1 and 2 proposals may be implemented within graphql-js behind a feature flag.
 
 ### GraphQL Specification Membership Agreement
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,15 +73,13 @@ ensure your pull request matches the style guides, run `npm run prettier`.
 - Trailing commas,
 - Avd abbr wrds.
 
-## Review Process
+## Review and Merge Process
 
 - Pull requests are required to pass all tests and checks before they can be merged.
-- Pull requests should be reviewed by _at least two_ members of the [`@graphql/graphql-js-reviewers`](https://github.com/orgs/graphql/teams/graphql-js-reviewers) team before they can be merged; ideally reviewers affiliated with different organizations
+- Ideally, pull requests should be reviewed by _at least two_ members of the [`@graphql/graphql-js-reviewers`](https://github.com/orgs/graphql/teams/graphql-js-reviewers) team before they are merged, preferably from separate organizations. For more complex pull requests, a larger cohort of reviewers is suggested.
 - If a reviewer hasn't responded in 48 hours, feel free to ping them `@graphql/graphql-js-reviewers`.
-
-## Merge Process
-
-Once a pull request has been approved by 2 reviewers from [`@graphql/graphql-js-reviewers`](https://github.com/orgs/graphql/teams/graphql-js-reviewers) team, it may be merged by any member of the [`@graphql/graphql-js-reviewers`](https://github.com/orgs/graphql/teams/graphql-js-reviewers-write) team. For more complex pull requests, a larger cohort of reviewers is suggested. Any reviewer may request that the topic be brought for more in depth discussion at GraphQL JS Working Group meeting, where decisions will be made by consensus. A PR that has been merged without discussion at a GraphQL JS Working Group meeting may be reverted if a more in depth discussion is later requested.
+- Any reviewer may request that the topic be brought for more in depth discussion at a [GraphQL JS Working Group meeting](https://github.com/graphql/graphql-js-wg/), where decisions will be made by consensus.
+- A PR that has been merged without discussion at a GraphQL JS Working Group meeting may be reverted if a more in depth discussion is later requested.
 
 ## Release on NPM
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ answers any questions you may have.
 
 We use GitHub issues to track public bugs and requests. Please ensure your bug
 description is clear and has sufficient instructions to be able to reproduce the
-issue. The best way is to add a failing test to our test suite via a pull request.
+issue. The absolute best way to do that is to add a failing test to our test suite via a pull request, but a reduced test case on a site like [StackBlitz](https://stackblitz.com/) or [CodeSandbox](https://codesandbox.io/) is also very helpful.
 
 ## Pull Requests
 
@@ -20,8 +20,8 @@ your [pull requests](https://help.github.com/articles/creating-a-pull-request).
 Since graphql-js is a reference implementation of the
 [GraphQL spec](https://graphql.github.io/graphql-spec/), only changes which comply
 with this spec will be considered. If you have a change in mind which requires a
-change to the spec, please consider opening instead an
-[issue](https://github.com/graphql/graphql-spec/issues/) against the spec and/or attending a [GraphQL Working Group meeting](https://github.com/graphql/graphql-wg) to discuss your proposal. See the [contribution guide for the specification](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md) for further information. Stage 1 and 2 proposals may be implemented within graphql-js behind a feature flag.
+change to the spec, please consider opening an
+[issue](https://github.com/graphql/graphql-spec/issues/) against the spec and/or attending a [GraphQL Working Group meeting](https://github.com/graphql/graphql-wg) to discuss your proposed change. See the [contribution guide of the specification](https://github.com/graphql/graphql-spec/blob/main/CONTRIBUTING.md) for further information. Stage 1 and 2 proposals may be implemented within graphql-js behind a feature flag.
 
 ### GraphQL Specification Membership Agreement
 
@@ -78,7 +78,7 @@ ensure your pull request matches the style guides, run `npm run prettier`.
 - Pull requests are required to pass all tests and checks before they can be merged.
 - Ideally, pull requests should be reviewed by _at least two_ members of the [`@graphql/graphql-js-reviewers`](https://github.com/orgs/graphql/teams/graphql-js-reviewers) team before they are merged, preferably from separate organizations. For more complex pull requests, a larger cohort of reviewers is suggested.
 - Any reviewer may request that the topic be brought for more in depth discussion at a [GraphQL JS Working Group meeting](https://github.com/graphql/graphql-js-wg/), where decisions will be made by consensus.
-- A PR that has been merged without discussion at a GraphQL JS Working Group meeting may be reverted if a more in depth discussion is later requested.
+- A PR that has been merged without discussion at a GraphQL JS Working Group meeting can be revisited in any subsequent meeting; the PR may be reverted as a result of that discussion.
 
 ## Discussion
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ answers any questions you may have.
 
 We use GitHub issues to track public bugs and requests. Please ensure your bug
 description is clear and has sufficient instructions to be able to reproduce the
-issue. The best way is to provide a reduced test case on jsFiddle or jsBin.
+issue. The best way is to add a failing test to our test suite via a pull request.
 
 ## Pull Requests
 


### PR DESCRIPTION
- to separate between this repo and the spec
- suggest adding PRs with failing tests when reporting bugs
- add more flexibility to review/merge process
- suggest using discord to communicate