### PR TITLE
Make gql js faster

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -243,7 +243,7 @@ function maxBy(array, fn) {
 
 // Prepare all revisions and run benchmarks matching a pattern against them.
 async function runBenchmarks(benchmarks, benchmarkProjects) {
-  for (const benchmark of benchmarks.filter(x => x.includes('visit-') || x.includes('printer-'))) {
+  for (const benchmark of benchmarks) {
     const results = [];
     for (let i = 0; i < benchmarkProjects.length; ++i) {
       const { revision, projectPath } = benchmarkProjects[i];

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -243,7 +243,7 @@ function maxBy(array, fn) {
 
 // Prepare all revisions and run benchmarks matching a pattern against them.
 async function runBenchmarks(benchmarks, benchmarkProjects) {
-  for (const benchmark of benchmarks) {
+  for (const benchmark of benchmarks.filter(x => x.includes('visit-') || x.includes('printer-'))) {
     const results = [];
     for (let i = 0; i < benchmarkProjects.length; ++i) {
       const { revision, projectPath } = benchmarkProjects[i];

--- a/benchmark/fixtures.js
+++ b/benchmark/fixtures.js
@@ -8,6 +8,11 @@ exports.bigSchemaSDL = fs.readFileSync(
   'utf8',
 );
 
+exports.bigDocument = fs.readFileSync(
+  path.join(__dirname, 'kitchen-sink.graphql'),
+  'utf8',
+);
+
 exports.bigSchemaIntrospectionResult = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'github-schema.json'), 'utf8'),
 );

--- a/benchmark/kitchen-sink.graphql
+++ b/benchmark/kitchen-sink.graphql
@@ -1,0 +1,69 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
+  whoever123is: node(id: [123, 456]) {
+    id
+    ... on User @onInlineFragment {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ...frag @onFragmentSpread
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
+    story {
+      id @onField
+    }
+  }
+}
+
+subscription StoryLikeSubscription($input: StoryLikeSubscribeInput)
+@onSubscription {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend @onFragmentDefinition {
+  foo(
+    size: $site
+    bar: 12
+    obj: {
+      key: "value"
+      block: """
+      block string uses \"""
+      """
+    }
+  )
+}
+
+query teeny {
+  unnamed(truthy: true, falsey: false, nullish: null)
+  query
+}
+
+query tiny {
+  __typename
+}

--- a/benchmark/printer-benchmark.js
+++ b/benchmark/printer-benchmark.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { print } = require('graphql/language/printer.js');
+const { bigDocument } = require('./fixtures')
+
+const document = parse(bigDocument)
+
+module.exports = {
+  name: 'Print ktichen-sink query',
+  count: 1000,
+  measure() {
+    print(document);
+  },
+};

--- a/benchmark/printer-benchmark.js
+++ b/benchmark/printer-benchmark.js
@@ -8,7 +8,7 @@ const { bigDocument } = require('./fixtures.js');
 const document = parse(bigDocument);
 
 module.exports = {
-  name: 'Print ktichen-sink query',
+  name: 'Print kitchen-sink query',
   count: 1000,
   measure() {
     print(document);

--- a/benchmark/printer-benchmark.js
+++ b/benchmark/printer-benchmark.js
@@ -2,9 +2,10 @@
 
 const { parse } = require('graphql/language/parser.js');
 const { print } = require('graphql/language/printer.js');
-const { bigDocument } = require('./fixtures')
 
-const document = parse(bigDocument)
+const { bigDocument } = require('./fixtures.js');
+
+const document = parse(bigDocument);
 
 module.exports = {
   name: 'Print ktichen-sink query',

--- a/cspell.yml
+++ b/cspell.yml
@@ -51,6 +51,7 @@ words:
   # TODO: contribute upstream
   - deno
   - codecov
+  - falsey
 
   # Website tech
   - Nextra

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -23,17 +23,18 @@ const printDocASTReducer: ASTReducer<string> = {
   // Document
 
   Document: {
-    leave: (node) => join(node.definitions, '\n\n'),
+    leave: (node) => truthyJoin(node.definitions, '\n\n'),
   },
 
   OperationDefinition: {
     leave(node) {
-      const varDefs = wrap('(', join(node.variableDefinitions, ', '), ')');
+      const varDefs = wrap('(', truthyJoin(node.variableDefinitions, ', '), ')');
       const prefix = join(
         [
           node.operation,
+          // TODO: optimize
           join([node.name, varDefs]),
-          join(node.directives, ' '),
+          truthyJoin(node.directives, ' '),
         ],
         ' ',
       );
@@ -50,20 +51,20 @@ const printDocASTReducer: ASTReducer<string> = {
       ': ' +
       type +
       wrap(' = ', defaultValue) +
-      wrap(' ', join(directives, ' ')),
+      wrap(' ', truthyJoin(directives, ' ')),
   },
   SelectionSet: { leave: ({ selections }) => block(selections) },
 
   Field: {
     leave({ alias, name, arguments: args, directives, selectionSet }) {
       const prefix = wrap('', alias, ': ') + name;
-      let argsLine = prefix + wrap('(', join(args, ', '), ')');
+      let argsLine = prefix + wrap('(', truthyJoin(args, ', '), ')');
 
       if (argsLine.length > MAX_LINE_LENGTH) {
-        argsLine = prefix + wrap('(\n', indent(join(args, '\n')), '\n)');
+        argsLine = prefix + wrap('(\n', indent(truthyJoin(args, '\n')), '\n)');
       }
 
-      return join([argsLine, join(directives, ' '), selectionSet], ' ');
+      return join([argsLine, truthyJoin(directives, ' '), selectionSet], ' ');
     },
   },
 
@@ -73,7 +74,7 @@ const printDocASTReducer: ASTReducer<string> = {
 
   FragmentSpread: {
     leave: ({ name, directives }) =>
-      '...' + name + wrap(' ', join(directives, ' ')),
+      '...' + name + wrap(' ', truthyJoin(directives, ' ')),
   },
 
   InlineFragment: {
@@ -82,7 +83,7 @@ const printDocASTReducer: ASTReducer<string> = {
         [
           '...',
           wrap('on ', typeCondition),
-          join(directives, ' '),
+          truthyJoin(directives, ' '),
           selectionSet,
         ],
         ' ',
@@ -99,8 +100,8 @@ const printDocASTReducer: ASTReducer<string> = {
     }) =>
       // Note: fragment variable definitions are experimental and may be changed
       // or removed in the future.
-      `fragment ${name}${wrap('(', join(variableDefinitions, ', '), ')')} ` +
-      `on ${typeCondition} ${wrap('', join(directives, ' '), ' ')}` +
+      `fragment ${name}${wrap('(', truthyJoin(variableDefinitions, ', '), ')')} ` +
+      `on ${typeCondition} ${wrap('', truthyJoin(directives, ' '), ' ')}` +
       selectionSet,
   },
 
@@ -115,15 +116,15 @@ const printDocASTReducer: ASTReducer<string> = {
   BooleanValue: { leave: ({ value }) => (value ? 'true' : 'false') },
   NullValue: { leave: () => 'null' },
   EnumValue: { leave: ({ value }) => value },
-  ListValue: { leave: ({ values }) => '[' + join(values, ', ') + ']' },
-  ObjectValue: { leave: ({ fields }) => '{' + join(fields, ', ') + '}' },
+  ListValue: { leave: ({ values }) => '[' + truthyJoin(values, ', ') + ']' },
+  ObjectValue: { leave: ({ fields }) => '{' + truthyJoin(fields, ', ') + '}' },
   ObjectField: { leave: ({ name, value }) => name + ': ' + value },
 
   // Directive
 
   Directive: {
     leave: ({ name, arguments: args }) =>
-      '@' + name + wrap('(', join(args, ', '), ')'),
+      '@' + name + wrap('(', truthyJoin(args, ', '), ')'),
   },
 
   // Type
@@ -147,7 +148,7 @@ const printDocASTReducer: ASTReducer<string> = {
   ScalarTypeDefinition: {
     leave: ({ description, name, directives }) =>
       wrap('', description, '\n') +
-      join(['scalar', name, join(directives, ' ')], ' '),
+      join(['scalar', name, truthyJoin(directives, ' ')], ' '),
   },
 
   ObjectTypeDefinition: {
@@ -157,8 +158,8 @@ const printDocASTReducer: ASTReducer<string> = {
         [
           'type',
           name,
-          wrap('implements ', join(interfaces, ' & ')),
-          join(directives, ' '),
+          wrap('implements ', truthyJoin(interfaces, ' & ')),
+          truthyJoin(directives, ' '),
           block(fields),
         ],
         ' ',
@@ -170,18 +171,18 @@ const printDocASTReducer: ASTReducer<string> = {
       wrap('', description, '\n') +
       name +
       (hasMultilineItems(args)
-        ? wrap('(\n', indent(join(args, '\n')), '\n)')
-        : wrap('(', join(args, ', '), ')')) +
+        ? wrap('(\n', indent(truthyJoin(args, '\n')), '\n)')
+        : wrap('(', truthyJoin(args, ', '), ')')) +
       ': ' +
       type +
-      wrap(' ', join(directives, ' ')),
+      wrap(' ', truthyJoin(directives, ' ')),
   },
 
   InputValueDefinition: {
     leave: ({ description, name, type, defaultValue, directives }) =>
       wrap('', description, '\n') +
       join(
-        [name + ': ' + type, wrap('= ', defaultValue), join(directives, ' ')],
+        [name + ': ' + type, wrap('= ', defaultValue), truthyJoin(directives, ' ')],
         ' ',
       ),
   },
@@ -193,8 +194,8 @@ const printDocASTReducer: ASTReducer<string> = {
         [
           'interface',
           name,
-          wrap('implements ', join(interfaces, ' & ')),
-          join(directives, ' '),
+          wrap('implements ', truthyJoin(interfaces, ' & ')),
+          truthyJoin(directives, ' '),
           block(fields),
         ],
         ' ',
@@ -205,7 +206,7 @@ const printDocASTReducer: ASTReducer<string> = {
     leave: ({ description, name, directives, types }) =>
       wrap('', description, '\n') +
       join(
-        ['union', name, join(directives, ' '), wrap('= ', join(types, ' | '))],
+        ['union', name, truthyJoin(directives, ' '), wrap('= ', truthyJoin(types, ' | '))],
         ' ',
       ),
   },
@@ -213,18 +214,18 @@ const printDocASTReducer: ASTReducer<string> = {
   EnumTypeDefinition: {
     leave: ({ description, name, directives, values }) =>
       wrap('', description, '\n') +
-      join(['enum', name, join(directives, ' '), block(values)], ' '),
+      join(['enum', name, truthyJoin(directives, ' '), block(values)], ' '),
   },
 
   EnumValueDefinition: {
     leave: ({ description, name, directives }) =>
-      wrap('', description, '\n') + join([name, join(directives, ' ')], ' '),
+      wrap('', description, '\n') + join([name, truthyJoin(directives, ' ')], ' '),
   },
 
   InputObjectTypeDefinition: {
     leave: ({ description, name, directives, fields }) =>
       wrap('', description, '\n') +
-      join(['input', name, join(directives, ' '), block(fields)], ' '),
+      join(['input', name, truthyJoin(directives, ' '), block(fields)], ' '),
   },
 
   DirectiveDefinition: {
@@ -233,24 +234,24 @@ const printDocASTReducer: ASTReducer<string> = {
       'directive @' +
       name +
       (hasMultilineItems(args)
-        ? wrap('(\n', indent(join(args, '\n')), '\n)')
-        : wrap('(', join(args, ', '), ')')) +
+        ? wrap('(\n', indent(truthyJoin(args, '\n')), '\n)')
+        : wrap('(', truthyJoin(args, ', '), ')')) +
       (repeatable ? ' repeatable' : '') +
       ' on ' +
-      join(locations, ' | '),
+      truthyJoin(locations, ' | '),
   },
 
   SchemaExtension: {
     leave: ({ directives, operationTypes }) =>
       join(
-        ['extend schema', join(directives, ' '), block(operationTypes)],
+        ['extend schema', truthyJoin(directives, ' '), block(operationTypes)],
         ' ',
       ),
   },
 
   ScalarTypeExtension: {
     leave: ({ name, directives }) =>
-      join(['extend scalar', name, join(directives, ' ')], ' '),
+      join(['extend scalar', name, truthyJoin(directives, ' ')], ' '),
   },
 
   ObjectTypeExtension: {
@@ -259,8 +260,8 @@ const printDocASTReducer: ASTReducer<string> = {
         [
           'extend type',
           name,
-          wrap('implements ', join(interfaces, ' & ')),
-          join(directives, ' '),
+          wrap('implements ', truthyJoin(interfaces, ' & ')),
+          truthyJoin(directives, ' '),
           block(fields),
         ],
         ' ',
@@ -273,8 +274,8 @@ const printDocASTReducer: ASTReducer<string> = {
         [
           'extend interface',
           name,
-          wrap('implements ', join(interfaces, ' & ')),
-          join(directives, ' '),
+          wrap('implements ', truthyJoin(interfaces, ' & ')),
+          truthyJoin(directives, ' '),
           block(fields),
         ],
         ' ',
@@ -287,8 +288,8 @@ const printDocASTReducer: ASTReducer<string> = {
         [
           'extend union',
           name,
-          join(directives, ' '),
-          wrap('= ', join(types, ' | ')),
+          truthyJoin(directives, ' '),
+          wrap('= ', truthyJoin(types, ' | ')),
         ],
         ' ',
       ),
@@ -296,12 +297,12 @@ const printDocASTReducer: ASTReducer<string> = {
 
   EnumTypeExtension: {
     leave: ({ name, directives, values }) =>
-      join(['extend enum', name, join(directives, ' '), block(values)], ' '),
+      join(['extend enum', name, truthyJoin(directives, ' '), block(values)], ' '),
   },
 
   InputObjectTypeExtension: {
     leave: ({ name, directives, fields }) =>
-      join(['extend input', name, join(directives, ' '), block(fields)], ' '),
+      join(['extend input', name, truthyJoin(directives, ' '), block(fields)], ' '),
   },
 };
 
@@ -313,7 +314,30 @@ function join(
   maybeArray: Maybe<ReadonlyArray<string | undefined>>,
   separator = '',
 ): string {
-  return maybeArray?.filter((x) => x).join(separator) ?? '';
+  if (!maybeArray) return ''
+
+  const list = maybeArray.filter((x) => x);
+  const listLength = list.length;
+  let result = '';
+  for (let i = 0; i < listLength; i++) {
+    if (i === listLength - 1) return result + list[i];
+    else result += list[i] + separator;
+  }
+  return result
+}
+
+function truthyJoin(
+  list: ReadonlyArray<string> | undefined,
+  separator: string,
+): string {
+  if (!list) return ''
+  const listLength = list.length;
+  let result = '';
+  for (let i = 0; i < listLength; i++) {
+    if (i === listLength - 1) return result + list[i];
+    else result += list[i] + separator;
+  }
+  return result
 }
 
 /**

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -137,10 +137,7 @@ const printDocASTReducer: ASTReducer<string> = {
   SchemaDefinition: {
     leave: ({ description, directives, operationTypes }) =>
       wrap('', description, '\n') +
-      maybeJoin(
-        ['schema', maybeJoin(directives, ' '), block(operationTypes)],
-        ' ',
-      ),
+      maybeJoin(['schema', join(directives, ' '), block(operationTypes)], ' '),
   },
 
   OperationTypeDefinition: {
@@ -320,13 +317,9 @@ const printDocASTReducer: ASTReducer<string> = {
  * print all items together separated by separator if provided
  */
 function maybeJoin(
-  maybeArray: Maybe<ReadonlyArray<string | undefined>>,
+  maybeArray: ReadonlyArray<string | undefined>,
   separator = '',
 ): string {
-  if (!maybeArray) {
-    return '';
-  }
-
   const list = maybeArray.filter((x) => x);
   const listLength = list.length;
   let result = '';

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -214,8 +214,7 @@ export function visit(
           node = node.slice();
 
           let editOffset = 0;
-          for (let i = 0; i < edits.length; i++) {
-            const { 0: editKey, 1: editValue } = edits[i];
+          for (const [editKey, editValue] of edits) {
             const arrayKey = editKey - editOffset;
             if (editValue === null) {
               node.splice(arrayKey, 1);
@@ -225,9 +224,12 @@ export function visit(
             }
           }
         } else {
-          node = { ...node }
-          for (let i = 0; i < edits.length; i++) {
-            node[edits[i][0]] = edits[i][1];
+          node = Object.defineProperties(
+            {},
+            Object.getOwnPropertyDescriptors(node),
+          );
+          for (const [editKey, editValue] of edits) {
+            node[editKey] = editValue;
           }
         }
       }

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -224,10 +224,7 @@ export function visit(
             }
           }
         } else {
-          node = Object.defineProperties(
-            {},
-            Object.getOwnPropertyDescriptors(node),
-          );
+          node = { ...node };
           for (const [editKey, editValue] of edits) {
             node[editKey] = editValue;
           }


### PR DESCRIPTION
While researching the numbers on v15 vs v16 I realised that our printer became _much_ slower, the reason for this is two-fold.

- We started leveraging a really expensive `join` function that `filters` even when it's not needed
- During `visit` we always recreate the _full_ tree

Now that second point we should discuss, as changing this might be considered a breaking change.

The way `visit` currently behaves is that it is a reducer, whether or not the user returns a value it will always _fully_ recreate the AST without any attempt at reusing parts of it, or as is the issue with our printer, it will recreate the full AST even if we aren't even remotely returning anything AST-like, we are returning strings 😅 

This PR can serve as an exploration of how we can improve things in v17 - I've seen issues flying around about refactoring the visitor, which this seems like a good trigger judging from how the performance is.