### PR TITLE
polish: fix switched comments in GraphQLScalarTypeConfig

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -785,9 +785,9 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   /** Parses an externally provided literal value to use as an input. */
   /** @deprecated use `replaceVariables()` and `coerceInputLiteral()` instead, `parseLiteral()` will be removed in v18 */
   parseLiteral?: GraphQLScalarLiteralParser<TInternal> | undefined;
-  /** Coerces an externally provided value to use as an input. */
-  coerceOutputValue?: GraphQLScalarOutputValueCoercer<TExternal> | undefined;
   /** Coerces an internal value to include in a response. */
+  coerceOutputValue?: GraphQLScalarOutputValueCoercer<TExternal> | undefined;
+  /** Coerces an externally provided value to use as an input. */
   coerceInputValue?: GraphQLScalarInputValueCoercer<TInternal> | undefined;
   /** Coerces an externally provided const literal value to use as an input. */
   coerceInputLiteral?: GraphQLScalarInputLiteralCoercer<TInternal> | undefined;


### PR DESCRIPTION
I was just trying to understand the new flows for how scalar values are represented/parsed/serialized, and noticed that the comments for a couple of these methods looked backwards.

Really hoping I am not just confused about the terminology, and that these aren't actually correct 😅 