### PR TITLE
use `operation.selectionSet` as argument to `collectFields()` instead of `operation`

### DIFF
--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -6,7 +6,6 @@ import type {
   FragmentDefinitionNode,
   FragmentSpreadNode,
   InlineFragmentNode,
-  OperationDefinitionNode,
   SelectionSetNode,
 } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
@@ -70,7 +69,7 @@ export function collectFields(
   fragments: ObjMap<FragmentDetails>,
   variableValues: VariableValues,
   runtimeType: GraphQLObjectType,
-  operation: OperationDefinitionNode,
+  selectionSet: SelectionSetNode,
   hideSuggestions: boolean,
 ): {
   groupedFieldSet: GroupedFieldSet;
@@ -87,12 +86,7 @@ export function collectFields(
     hideSuggestions,
   };
 
-  collectFieldsImpl(
-    context,
-    operation.selectionSet,
-    groupedFieldSet,
-    newDeferUsages,
-  );
+  collectFieldsImpl(context, selectionSet, groupedFieldSet, newDeferUsages);
   return { groupedFieldSet, newDeferUsages };
 }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -337,10 +337,12 @@ export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
       hideSuggestions,
     } = validatedExecutionArgs;
 
-    const rootType = schema.getRootType(operation.operation);
+    const { operation: operationType, selectionSet } = operation;
+
+    const rootType = schema.getRootType(operationType);
     if (rootType == null) {
       throw new GraphQLError(
-        `Schema is not configured to execute ${operation.operation} operation.`,
+        `Schema is not configured to execute ${operationType} operation.`,
         { nodes: operation },
       );
     }
@@ -350,7 +352,7 @@ export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
       fragments,
       variableValues,
       rootType,
-      operation,
+      selectionSet,
       hideSuggestions,
     );
 
@@ -2244,7 +2246,7 @@ function executeSubscription(
     fragments,
     variableValues,
     rootType,
-    operation,
+    operation.selectionSet,
     hideSuggestions,
   );
 

--- a/src/validation/rules/SingleFieldSubscriptionsRule.ts
+++ b/src/validation/rules/SingleFieldSubscriptionsRule.ts
@@ -50,7 +50,7 @@ export function SingleFieldSubscriptionsRule(
             fragments,
             variableValues,
             subscriptionType,
-            node,
+            node.selectionSet,
             context.hideSuggestions,
           );
           if (groupedFieldSet.size > 1) {


### PR DESCRIPTION
this is the 16.x.x behavior, unlocked by #4308, further reducing the set of breaking changes to this utility