### PR TITLE
Remove a few deopts already

### DIFF
--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -85,7 +85,7 @@ export class Token {
    * Note: is undefined for punctuation tokens, but typed as string for
    * convenience in the parser.
    */
-  readonly value: string;
+  readonly value: string | undefined;
 
   /**
    * Tokens exist as nodes in a double-linked-list amongst all tokens
@@ -101,15 +101,14 @@ export class Token {
     end: number,
     line: number,
     column: number,
-    value?: string,
+    value: string | undefined,
   ) {
     this.kind = kind;
     this.start = start;
     this.end = end;
     this.line = line;
     this.column = column;
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.value = value!;
+    this.value = value;
     this.prev = null;
     this.next = null;
   }

--- a/src/language/blockString.ts
+++ b/src/language/blockString.ts
@@ -31,12 +31,19 @@ export function dedentBlockStringLines(
     }
   }
 
+  if (lastNonEmptyLine === -1) {
+    return [];
+  }
+
+  firstNonEmptyLine = firstNonEmptyLine ?? 0;
+
+  const removeCommonIndentation = (line: string, i: number) =>
+    i === 0 ? line : commonIndent && line ? line.substring(commonIndent) : line;
   return (
     lines
       // Remove common indentation from all lines but first.
-      .map((line, i) => (i === 0 ? line : line.slice(commonIndent)))
-      // Remove leading and trailing blank lines.
-      .slice(firstNonEmptyLine ?? 0, lastNonEmptyLine + 1)
+      .map(removeCommonIndentation)
+      .slice(firstNonEmptyLine, lastNonEmptyLine + 1)
   );
 }
 

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -269,6 +269,7 @@ export class Parser {
       : this._lexer.token;
 
     if (keywordToken.kind === TokenKind.NAME) {
+      // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
       switch (keywordToken.value) {
         case 'schema':
           return this.parseSchemaDefinition();
@@ -296,6 +297,7 @@ export class Parser {
         );
       }
 
+      // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
       switch (keywordToken.value) {
         case 'query':
         case 'mutation':

--- a/src/utilities/stripIgnoredCharacters.ts
+++ b/src/utilities/stripIgnoredCharacters.ts
@@ -89,7 +89,9 @@ export function stripIgnoredCharacters(source: string | Source): string {
 
     const tokenBody = body.slice(currentToken.start, currentToken.end);
     if (tokenKind === TokenKind.BLOCK_STRING) {
-      strippedBody += printBlockString(currentToken.value, { minimize: true });
+      strippedBody += printBlockString(currentToken.value ?? '', {
+        minimize: true,
+      });
     } else {
       strippedBody += tokenBody;
     }


### PR DESCRIPTION
I've started digging through the codebase on wins with regards to performance, I've seen a lot of them.... However, some of them also come down to our ... weird usage of TypeScript.

Let's take the `Token` as an example, we did a great thing in creating it as a class as it enforced consistent monomorphic backing shapes, however we do a non-null assertion, for the reason that `value` can actually be undefined. When we use `Token` we always assume that `value` is defined which makes all of this deopt as we will call functions with `string | undefined` the whole thing while our code is geared for `string`.

I've attempted to make `value` the correct type which resulted in a lot more issues.

In addition to that we have a lot of call-sites for the `.slice` method, we however do polymorphic access on it as adjacent call-sites will invoke `String.slice` right next to `Array.slice` which makes `.slice` not optimizeable, instead we can resort to converting `String.slice` into `String.substring` to avoid this issue all together.

The last noLocation parse bailout remaining is the `.slice` case of `blockstring.ts`

<img width="608" alt="A tooltip showing us that a slice on a newly created array through .map deopts over polymorphic access" src="https://github.com/user-attachments/assets/28a6325f-35c9-467f-b9f3-3895a4492852" />

The improvements on the parser benchmark are currently minimal, I am trying to discover the deopts and how we can have a way forward.