### PR TITLE
Increase print/visit performance

### DIFF
--- a/benchmark/fixtures.js
+++ b/benchmark/fixtures.js
@@ -8,6 +8,11 @@ exports.bigSchemaSDL = fs.readFileSync(
   'utf8',
 );
 
+exports.bigDocumentSDL = fs.readFileSync(
+  path.join(__dirname, 'kitchen-sink.graphql'),
+  'utf8',
+);
+
 exports.bigSchemaIntrospectionResult = JSON.parse(
   fs.readFileSync(path.join(__dirname, 'github-schema.json'), 'utf8'),
 );

--- a/benchmark/kitchen-sink.graphql
+++ b/benchmark/kitchen-sink.graphql
@@ -1,0 +1,65 @@
+query queryName($foo: ComplexType, $site: Site = MOBILE) @onQuery {
+  whoever123is: node(id: [123, 456]) {
+    id
+    ... on User @onInlineFragment {
+      field2 {
+        id
+        alias: field1(first: 10, after: $foo) @include(if: $foo) {
+          id
+          ...frag @onFragmentSpread
+        }
+      }
+    }
+    ... @skip(unless: $foo) {
+      id
+    }
+    ... {
+      id
+    }
+  }
+}
+
+mutation likeStory @onMutation {
+  like(story: 123) @onField {
+    story {
+      id @onField
+    }
+  }
+}
+
+subscription StoryLikeSubscription(
+  $input: StoryLikeSubscribeInput @onVariableDefinition
+) @onSubscription {
+  storyLikeSubscribe(input: $input) {
+    story {
+      likers {
+        count
+      }
+      likeSentence {
+        text
+      }
+    }
+  }
+}
+
+fragment frag on Friend @onFragmentDefinition {
+  foo(
+    size: $size
+    bar: $b
+    obj: {
+      key: "value"
+      block: """
+      block string uses \"""
+      """
+    }
+  )
+}
+
+{
+  unnamed(truthy: true, falsy: false, nullish: null)
+  query
+}
+
+query {
+  __typename
+}

--- a/benchmark/printer-benchmark.js
+++ b/benchmark/printer-benchmark.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const { parse } = require('graphql/language/parser.js');
+const { print } = require('graphql/language/printer.js');
+
+const { bigDocumentSDL } = require('./fixtures.js');
+
+const document = parse(bigDocumentSDL);
+
+module.exports = {
+  name: 'Print kitchen sink document',
+  count: 1000,
+  measure() {
+    print(document);
+  },
+};

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -222,23 +222,9 @@ export function visit(
             }
           }
         } else {
-          const descriptors = Object.getOwnPropertyDescriptors(node);
           node = { ...node };
-          for (const nodeKey of Object.keys(descriptors)) {
-            if (!(nodeKey in node)) {
-              const descriptor = descriptors[nodeKey];
-              if (
-                descriptor.enumerable &&
-                descriptor.configurable &&
-                descriptor.writable &&
-                !descriptor.get &&
-                !descriptor.set
-              ) {
-                // We already own this by means of the spread
-              } else {
-                Object.defineProperty(node, nodeKey, descriptor);
-              }
-            }
+          for (const [editKey, editValue] of edits) {
+            node[editKey] = editValue;
           }
         }
       }

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -222,12 +222,23 @@ export function visit(
             }
           }
         } else {
-          node = Object.defineProperties(
-            {},
-            Object.getOwnPropertyDescriptors(node),
-          );
-          for (const [editKey, editValue] of edits) {
-            node[editKey] = editValue;
+          const descriptors = Object.getOwnPropertyDescriptors(node);
+          node = { ...node };
+          for (const nodeKey of Object.keys(descriptors)) {
+            if (!(nodeKey in node)) {
+              const descriptor = descriptors[nodeKey];
+              if (
+                descriptor.enumerable &&
+                descriptor.configurable &&
+                descriptor.writable &&
+                !descriptor.get &&
+                !descriptor.set
+              ) {
+                // We already own this by means of the spread
+              } else {
+                Object.defineProperty(node, nodeKey, descriptor);
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This replaces our expensive method that changes the underlying V8 shape multiple times with a loop that preserves the identity as much as possible.

```
⏱   Print kitchen sink document
  1 tests completed.
  2 tests completed.

  HEAD x 9,290 ops/sec ±0.21% x 1.51 KB/op (24 runs sampled)
  BASE x 2,645 ops/sec ±0.18% x 2.18 KB/op (11 runs sampled)
```