### PR TITLE
reintroduce incremental delivery support for subscriptions

### DIFF
--- a/src/execution/__tests__/flattenAsyncIterable-test.ts
+++ b/src/execution/__tests__/flattenAsyncIterable-test.ts
@@ -1,0 +1,219 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectPromise } from '../../__testUtils__/expectPromise.js';
+
+import { flattenAsyncIterable } from '../flattenAsyncIterable.js';
+
+describe('flattenAsyncIterable', () => {
+  it('flatten nested async generators', async () => {
+    async function* source() {
+      yield await Promise.resolve({
+        value: 1,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(1.1);
+          yield await Promise.resolve(1.2);
+        })(),
+      });
+      yield await Promise.resolve({
+        value: 2,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(2.1);
+          yield await Promise.resolve(2.2);
+        })(),
+      });
+    }
+
+    const doubles = flattenAsyncIterable(source(), (item) => item);
+
+    const result = [];
+    for await (const x of doubles) {
+      result.push(x);
+    }
+    expect(result).to.deep.equal([1, 1.1, 1.2, 2, 2.1, 2.2]);
+  });
+
+  it('passes through errors from a nested async generator', async () => {
+    async function* source() {
+      yield await Promise.resolve({
+        value: 1,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(1.1);
+          yield await Promise.resolve(1.2);
+        })(),
+      });
+      throw new Error('ouch');
+    }
+    /* c8 ignore stop */
+
+    const doubles = flattenAsyncIterable(source(), (item) => item);
+
+    expect(await doubles.next()).to.deep.equal({ value: 1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 1.1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 1.2, done: false });
+
+    await expectPromise(doubles.next()).toRejectWith('ouch');
+  });
+
+  it('allows returning early from a nested async generator', async () => {
+    async function* source() {
+      yield await Promise.resolve({
+        value: 1,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(1.1);
+          yield await Promise.resolve(1.2);
+        })(),
+      });
+      yield await Promise.resolve({
+        value: 2,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(2.1); /* c8 ignore start */
+          // Not reachable, early return
+          yield await Promise.resolve(2.2);
+        })(),
+      });
+      // Not reachable, early return
+      yield await Promise.resolve({
+        value: 3,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(3.1);
+          yield await Promise.resolve(3.2);
+        })(),
+      });
+    }
+    /* c8 ignore stop */
+
+    const doubles = flattenAsyncIterable(source(), (item) => item);
+
+    expect(await doubles.next()).to.deep.equal({ value: 1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 1.1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 1.2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2.1, done: false });
+
+    // Early return
+    expect(await doubles.return()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+
+    // Subsequent next calls
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(await doubles.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+  });
+
+  it('allows throwing errors into a nested async generator', async () => {
+    async function* source() {
+      yield await Promise.resolve({
+        value: 1,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(1.1);
+          yield await Promise.resolve(1.2);
+        })(),
+      });
+      yield await Promise.resolve({
+        value: 2,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(2.1); /* c8 ignore start */
+          // Not reachable, early return
+          yield await Promise.resolve(2.2);
+        })(),
+      });
+      // Not reachable, early return
+      yield await Promise.resolve({ value: 3 });
+    }
+    /* c8 ignore stop */
+
+    const doubles = flattenAsyncIterable(source(), (item) => item);
+
+    expect(await doubles.next()).to.deep.equal({ value: 1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 1.1, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 1.2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
+    expect(await doubles.next()).to.deep.equal({ value: 2.1, done: false });
+
+    // Throw error
+    await expectPromise(doubles.throw(new Error('ouch'))).toRejectWith('ouch');
+  });
+
+  it('completely yields sub-iterables even when next() called in parallel', async () => {
+    async function* source() {
+      yield await Promise.resolve({
+        value: 1,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(1.1);
+          yield await Promise.resolve(1.2);
+        })(),
+      });
+      yield await Promise.resolve({
+        value: 2,
+        nestedIterable: (async function* nested(): AsyncGenerator<
+          number,
+          void,
+          void
+        > {
+          yield await Promise.resolve(2.1);
+          yield await Promise.resolve(2.2);
+        })(),
+      });
+    }
+
+    const result = flattenAsyncIterable(source(), (item) => item);
+
+    const promise1 = result.next();
+    const promise2 = result.next();
+    const promise3 = result.next();
+    expect(await promise1).to.deep.equal({ value: 1, done: false });
+    expect(await promise2).to.deep.equal({ value: 1.1, done: false });
+    expect(await promise3).to.deep.equal({ value: 1.2, done: false });
+    expect(await result.next()).to.deep.equal({ value: 2, done: false });
+    expect(await result.next()).to.deep.equal({ value: 2.1, done: false });
+    expect(await result.next()).to.deep.equal({ value: 2.2, done: false });
+    expect(await result.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+  });
+});

--- a/src/execution/flattenAsyncIterable.ts
+++ b/src/execution/flattenAsyncIterable.ts
@@ -1,0 +1,114 @@
+import { promiseWithResolvers } from '../jsutils/promiseWithResolvers.js';
+
+/**
+ * Given an AsyncIterable possibly containing additional AsyncIterables,
+ * flatten all items into a single AsyncIterable.
+ */
+export function flattenAsyncIterable<TItem, TSingle, TInitial, TSubsequent>(
+  iterable: AsyncIterable<TItem>,
+  onValue: (maybeValueWithIterable: TItem) => {
+    value: TSingle | TInitial;
+    nestedIterable?: AsyncIterable<TSubsequent> | undefined;
+  },
+): AsyncGenerator<TSingle | TInitial | TSubsequent, void, void> {
+  // You might think this whole function could be replaced with
+  //
+  //    async function* flattenAsyncIterable(iterable) {
+  //      for await (const item of iterable) {
+  //        yield item.value;
+  //        yield* item.iterable;
+  //      }
+  //    }
+  //
+  // but calling `.return()` on the iterable it returns won't interrupt the `for await`.
+
+  const topIterator = iterable[Symbol.asyncIterator]();
+  let currentNestedIterator: AsyncIterator<TSubsequent> | undefined;
+  let waitForCurrentNestedIterator: Promise<void> | undefined;
+  let done = false;
+
+  async function next(): Promise<
+    IteratorResult<TSingle | TInitial | TSubsequent, void>
+  > {
+    if (done) {
+      return { value: undefined, done: true };
+    }
+
+    try {
+      if (!currentNestedIterator) {
+        // Somebody else is getting it already.
+        if (waitForCurrentNestedIterator) {
+          await waitForCurrentNestedIterator;
+          return await next();
+        }
+        // Nobody else is getting it. We should!
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        const { resolve, promise } = promiseWithResolvers<void>();
+        waitForCurrentNestedIterator = promise;
+        const topIteratorResult = await topIterator.next();
+        if (topIteratorResult.done) {
+          // Given that done only ever transitions from false to true,
+          // require-atomic-updates is being unnecessarily cautious.
+          // eslint-disable-next-line require-atomic-updates
+          done = true;
+          return await next();
+        }
+        const { value, nestedIterable } = onValue(topIteratorResult.value);
+        if (nestedIterable) {
+          // eslint is making a reasonable point here, but we've explicitly protected
+          // ourself from the race condition by ensuring that only the single call
+          // that assigns to waitForCurrentNestedIterator is allowed to assign to
+          // currentNestedIterator or waitForCurrentNestedIterator.
+          // eslint-disable-next-line require-atomic-updates
+          currentNestedIterator = nestedIterable[Symbol.asyncIterator]();
+        }
+        // eslint-disable-next-line require-atomic-updates
+        waitForCurrentNestedIterator = undefined;
+        resolve();
+        return { value, done: false };
+      }
+
+      const rememberCurrentNestedIterator = currentNestedIterator;
+      const nestedIteratorResult = await currentNestedIterator.next();
+      if (!nestedIteratorResult.done) {
+        return nestedIteratorResult;
+      }
+
+      // The nested iterator is done. If it's still the current one, make it not
+      // current. (If it's not the current one, somebody else has made us move on.)
+      if (currentNestedIterator === rememberCurrentNestedIterator) {
+        currentNestedIterator = undefined;
+      }
+      return await next();
+    } catch (err) {
+      done = true;
+      throw err;
+    }
+  }
+  return {
+    next,
+    async return(): Promise<IteratorResult<TSingle | TInitial | TSubsequent>> {
+      done = true;
+      await Promise.all([
+        currentNestedIterator?.return?.(),
+        topIterator.return?.(),
+      ]);
+      return { value: undefined, done: true };
+    },
+    async throw(
+      error?: unknown,
+    ): Promise<IteratorResult<TSingle | TInitial | TSubsequent>> {
+      done = true;
+      await Promise.all([
+        currentNestedIterator?.throw?.(error),
+        topIterator.throw?.(error),
+      ]);
+      /* c8 ignore next */
+      throw error;
+    },
+    [Symbol.asyncIterator]() {
+      /* c8 ignore next */
+      return this;
+    },
+  };
+}

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -11,6 +11,7 @@ export {
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,
+  legacyExperimentalSubscribeIncrementally,
 } from './execute.js';
 
 export type { ExecutionArgs, ValidatedExecutionArgs } from './execute.js';

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -35,12 +35,13 @@ export interface FormattedExecutionResult<
 }
 
 export interface ExperimentalIncrementalExecutionResults<
-  TData = unknown,
+  TInitial = ObjMap<unknown>,
+  TSubsequent = unknown,
   TExtensions = ObjMap<unknown>,
 > {
-  initialResult: InitialIncrementalExecutionResult<TData, TExtensions>;
+  initialResult: InitialIncrementalExecutionResult<TInitial, TExtensions>;
   subsequentResults: AsyncGenerator<
-    SubsequentIncrementalExecutionResult<TData, TExtensions>,
+    SubsequentIncrementalExecutionResult<TSubsequent, TExtensions>,
     void,
     void
   >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,6 +344,7 @@ export {
   getVariableValues,
   getDirectiveValues,
   subscribe,
+  legacyExperimentalSubscribeIncrementally,
   createSourceEventStream,
 } from './execution/index.js';
 


### PR DESCRIPTION
depends on #4313

Motivation: based on discussion at most recent WG, a concern for v17 migration is that there are breaking changes to incremental delivery support from prior alphas/experimental branches.

This PR reduces one of those changes, i.e. restores an entry point for allowing incremental delivery support with subscriptions.