### PR TITLE
polish: skip recollecting a named fragment's selections even when deferred

### DIFF
--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -222,21 +222,9 @@ function collectFieldsImpl(
       case Kind.FRAGMENT_SPREAD: {
         const fragName = selection.name.value;
 
-        const newDeferUsage = getDeferUsage(
-          variableValues,
-          fragmentVariableValues,
-          selection,
-          deferUsage,
-        );
-
         if (
-          !newDeferUsage &&
-          (visitedFragmentNames.has(fragName) ||
-            !shouldIncludeNode(
-              selection,
-              variableValues,
-              fragmentVariableValues,
-            ))
+          visitedFragmentNames.has(fragName) ||
+          !shouldIncludeNode(selection, variableValues, fragmentVariableValues)
         ) {
           continue;
         }
@@ -248,6 +236,13 @@ function collectFieldsImpl(
         ) {
           continue;
         }
+
+        const newDeferUsage = getDeferUsage(
+          variableValues,
+          fragmentVariableValues,
+          selection,
+          deferUsage,
+        );
 
         const fragmentVariableSignatures = fragment.variableSignatures;
         let newFragmentVariableValues: VariableValues | undefined;


### PR DESCRIPTION
In the "old" duplicating version of incremental delivery, `collectFields()` was responsible for branching, and it therefore allowed processing a deferred named fragment even if that named fragment had already been visited as a regular non-deferred named fragment.

One could have argued against that, as the old version had the concept of inlining, and so we could have just skipped the named fragment and considered it inlined, but chose not to do that.

Now that we have an algorithm without duplication of fields, revisiting a named fragment will have no effect, as within the `buildExecutionPlan()` step, all the duplicated fields will be removed. So we can just remove the exception and go back to the version pre-incremental delivery where we always skip a visited named fragment.

Note that we still only consider a named fragment to have been visited if it was not marked as deferred, because in the case of overlapping deferred and non-deferred spreads of the same named fragment, we need to visit it as the non-deferred spread to actually realize that it is non-deferred.

[As an aside, looks like I made a mistake in https://github.com/graphql/graphql-js/pull/3994 => we would never have wanted to ignore the result of `shouldIncludeNode()` => since we are removing all ignoring of these conditions with respect to defer,  this PR "fixes" that mistake as well.]