### PR TITLE
further refine incremental result types

### DIFF
--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -36,12 +36,13 @@ export interface FormattedExecutionResult<
 
 export interface ExperimentalIncrementalExecutionResults<
   TInitial = ObjMap<unknown>,
-  TSubsequent = unknown,
+  TData = ObjMap<unknown>,
+  TItems = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   initialResult: InitialIncrementalExecutionResult<TInitial, TExtensions>;
   subsequentResults: AsyncGenerator<
-    SubsequentIncrementalExecutionResult<TSubsequent, TExtensions>,
+    SubsequentIncrementalExecutionResult<TData, TItems, TExtensions>,
     void,
     void
   >;
@@ -68,23 +69,27 @@ export interface FormattedInitialIncrementalExecutionResult<
 }
 
 export interface SubsequentIncrementalExecutionResult<
-  TData = unknown,
+  TData = ObjMap<unknown>,
+  TItems = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  incremental?: ReadonlyArray<IncrementalResult<TData, TItems, TExtensions>>;
   completed?: ReadonlyArray<CompletedResult>;
   hasNext: boolean;
   extensions?: TExtensions;
 }
 
 export interface FormattedSubsequentIncrementalExecutionResult<
-  TData = unknown,
+  TData = ObjMap<unknown>,
+  TItems = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   hasNext: boolean;
   pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
+  incremental?: ReadonlyArray<
+    FormattedIncrementalResult<TData, TItems, TExtensions>
+  >;
   completed?: ReadonlyArray<FormattedCompletedResult>;
   extensions?: TExtensions;
 }
@@ -114,41 +119,46 @@ export interface FormattedIncrementalDeferResult<
   extensions?: TExtensions;
 }
 
-interface StreamItemsRecordResult<TData = ReadonlyArray<unknown>> {
+interface StreamItemsRecordResult<TItems = ReadonlyArray<unknown>> {
   errors?: ReadonlyArray<GraphQLError>;
-  items: TData;
+  items: TItems;
 }
 
 export interface IncrementalStreamResult<
-  TData = ReadonlyArray<unknown>,
+  TItems = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends StreamItemsRecordResult<TData> {
+> extends StreamItemsRecordResult<TItems> {
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
 export interface FormattedIncrementalStreamResult<
-  TData = Array<unknown>,
+  TItems = Array<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  items: TData;
+  items: TItems;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
-export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
+export type IncrementalResult<
+  TData = ObjMap<unknown>,
+  TItems = ReadonlyArray<unknown>,
+  TExtensions = ObjMap<unknown>,
+> =
   | IncrementalDeferResult<TData, TExtensions>
-  | IncrementalStreamResult<TData, TExtensions>;
+  | IncrementalStreamResult<TItems, TExtensions>;
 
 export type FormattedIncrementalResult<
-  TData = unknown,
+  TData = ObjMap<unknown>,
+  TItems = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
 > =
   | FormattedIncrementalDeferResult<TData, TExtensions>
-  | FormattedIncrementalStreamResult<TData, TExtensions>;
+  | FormattedIncrementalStreamResult<TItems, TExtensions>;
 
 export interface PendingResult {
   id: string;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -37,12 +37,12 @@ export interface FormattedExecutionResult<
 export interface ExperimentalIncrementalExecutionResults<
   TInitial = ObjMap<unknown>,
   TData = ObjMap<unknown>,
-  TItems = ReadonlyArray<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   initialResult: InitialIncrementalExecutionResult<TInitial, TExtensions>;
   subsequentResults: AsyncGenerator<
-    SubsequentIncrementalExecutionResult<TData, TItems, TExtensions>,
+    SubsequentIncrementalExecutionResult<TData, TIncrementalItem, TExtensions>,
     void,
     void
   >;
@@ -70,11 +70,13 @@ export interface FormattedInitialIncrementalExecutionResult<
 
 export interface SubsequentIncrementalExecutionResult<
   TData = ObjMap<unknown>,
-  TItems = ReadonlyArray<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<IncrementalResult<TData, TItems, TExtensions>>;
+  incremental?: ReadonlyArray<
+    IncrementalResult<TData, TIncrementalItem, TExtensions>
+  >;
   completed?: ReadonlyArray<CompletedResult>;
   hasNext: boolean;
   extensions?: TExtensions;
@@ -82,13 +84,13 @@ export interface SubsequentIncrementalExecutionResult<
 
 export interface FormattedSubsequentIncrementalExecutionResult<
   TData = ObjMap<unknown>,
-  TItems = ReadonlyArray<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   hasNext: boolean;
   pending?: ReadonlyArray<PendingResult>;
   incremental?: ReadonlyArray<
-    FormattedIncrementalResult<TData, TItems, TExtensions>
+    FormattedIncrementalResult<TData, TIncrementalItem, TExtensions>
   >;
   completed?: ReadonlyArray<FormattedCompletedResult>;
   extensions?: TExtensions;
@@ -119,26 +121,26 @@ export interface FormattedIncrementalDeferResult<
   extensions?: TExtensions;
 }
 
-interface StreamItemsRecordResult<TItems = ReadonlyArray<unknown>> {
+interface StreamItemsRecordResult<TIncrementalItem = unknown> {
   errors?: ReadonlyArray<GraphQLError>;
-  items: TItems;
+  items: ReadonlyArray<TIncrementalItem>;
 }
 
 export interface IncrementalStreamResult<
-  TItems = ReadonlyArray<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
-> extends StreamItemsRecordResult<TItems> {
+> extends StreamItemsRecordResult<TIncrementalItem> {
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
 export interface FormattedIncrementalStreamResult<
-  TItems = Array<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  items: TItems;
+  items: ReadonlyArray<TIncrementalItem>;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
@@ -146,19 +148,19 @@ export interface FormattedIncrementalStreamResult<
 
 export type IncrementalResult<
   TData = ObjMap<unknown>,
-  TItems = ReadonlyArray<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
 > =
   | IncrementalDeferResult<TData, TExtensions>
-  | IncrementalStreamResult<TItems, TExtensions>;
+  | IncrementalStreamResult<TIncrementalItem, TExtensions>;
 
 export type FormattedIncrementalResult<
   TData = ObjMap<unknown>,
-  TItems = ReadonlyArray<unknown>,
+  TIncrementalItem = unknown,
   TExtensions = ObjMap<unknown>,
 > =
   | FormattedIncrementalDeferResult<TData, TExtensions>
-  | FormattedIncrementalStreamResult<TItems, TExtensions>;
+  | FormattedIncrementalStreamResult<TIncrementalItem, TExtensions>;
 
 export interface PendingResult {
   id: string;


### PR DESCRIPTION
continue work with #4313

Fixes the types for Subsequent Execution Results. Currently, the generic argument for subsequent results is passed to deferred and streamed results. By providing two different generic arguments, we can get properly types individual members of the incremental array.
