### PR TITLE
fix sidebar instability

### DIFF
--- a/website/pages/_meta.ts
+++ b/website/pages/_meta.ts
@@ -21,10 +21,15 @@ const meta = {
   'defer-stream': '',
   '-- 3': {
     type: 'separator',
+    title: 'API',
+  },
+  'api-v16': 'v16',
+  '-- 4': {
+    type: 'separator',
     title: 'FAQ',
   },
   'going-to-production': '',
-  'api-v16': {
+  'api-menu': {
     type: 'menu',
     title: 'API',
     items: {


### PR DESCRIPTION
when navigating to https://www.graphql-js.org/api-v16/graphql/ using the top menu bar, the sidebar content expands with the individual mdx files from the api-v16 folder, as if the api/v16 option had been in the sidebar in the first place.

This PR adds the API/v16 to the sidebar (in addition to the placement within the menu bar) to avoid this instability.

![image](https://github.com/user-attachments/assets/353c1ff2-cf1a-40f0-9e97-2170932cf9eb)
