### PR TITLE
Improve flow of documentation around GraphiQL

### DIFF
--- a/website/pages/docs/running-an-express-graphql-server.mdx
+++ b/website/pages/docs/running-an-express-graphql-server.mdx
@@ -95,6 +95,8 @@ You can run this GraphQL server with:
 node server.js
 ```
 
+At this point you will have a running GraphQL API; but you can't just visit it in your web browser to use it - you need a GraphQL client to issue GraphQL queries to the API. Let's take a look at how to add the GraphiQL (GraphQL with an `i` in the middle) integrated development environment to your server.
+
 ## Using GraphiQL
 
 [GraphiQL](https://github.com/graphql/graphiql) is GraphQL's IDE; a great way of querying and exploring your GraphQL API.


### PR DESCRIPTION
See graphql/graphql.github.io#1951

For someone following the tutorial they may well get as far as running the server (`node server.js`) and then attempt to visit their new API and get confused because they're met with an error such as `{"errors":[{"message":"Missing query"}]}`.

This PR adds some joining text to make it clear this is the expected outcome, and they must read on to get the GraphiQL IDE set up so that they can write queries.