### PR TITLE
Add star syntax proposal

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -658,38 +658,12 @@ describe('Parser', () => {
     });
   });
 
-  describe('parseDocumentDirective', () => {
-    it("doesn't throw on document-level directive", () => {
-      parse(dedent`
-        @SemanticNullability
-        type Query {
-          hello: String
-          world: String?
-          foo: String!
-        }
-      `);
-    });
-
-    it('parses semantic-non-null types', () => {
-      const result = parseType('MyType', { allowSemanticNullability: true });
-      expectJSON(result).toDeepEqual({
-        kind: Kind.SEMANTIC_NON_NULL_TYPE,
-        loc: { start: 0, end: 6 },
-        type: {
-          kind: Kind.NAMED_TYPE,
-          loc: { start: 0, end: 6 },
-          name: {
-            kind: Kind.NAME,
-            loc: { start: 0, end: 6 },
-            value: 'MyType',
-          },
-        },
-      });
-    });
-
-    it('parses nullable types', () => {
-      const result = parseType('MyType?', { allowSemanticNullability: true });
-      expectJSON(result).toDeepEqual({
+  it('parses semantic-non-null types', () => {
+    const result = parseType('MyType*');
+    expectJSON(result).toDeepEqual({
+      kind: Kind.SEMANTIC_NON_NULL_TYPE,
+      loc: { start: 0, end: 7 },
+      type: {
         kind: Kind.NAMED_TYPE,
         loc: { start: 0, end: 6 },
         name: {
@@ -697,24 +671,7 @@ describe('Parser', () => {
           loc: { start: 0, end: 6 },
           value: 'MyType',
         },
-      });
-    });
-
-    it('parses non-nullable types', () => {
-      const result = parseType('MyType!', { allowSemanticNullability: true });
-      expectJSON(result).toDeepEqual({
-        kind: Kind.NON_NULL_TYPE,
-        loc: { start: 0, end: 7 },
-        type: {
-          kind: Kind.NAMED_TYPE,
-          loc: { start: 0, end: 6 },
-          name: {
-            kind: Kind.NAME,
-            loc: { start: 0, end: 6 },
-            value: 'MyType',
-          },
-        },
-      });
+      },
     });
   });
 });

--- a/src/language/__tests__/schema-printer-test.ts
+++ b/src/language/__tests__/schema-printer-test.ts
@@ -182,39 +182,18 @@ describe('Printer: SDL document', () => {
   });
 
   it('prints NamedType', () => {
-    expect(
-      print(parseType('MyType', { allowSemanticNullability: false }), {
-        useSemanticNullability: false,
-      }),
-    ).to.equal(dedent`MyType`);
+    expect(print(parseType('MyType'))).to.equal(dedent`MyType`);
   });
 
-  it('prints SemanticNullableType', () => {
-    expect(
-      print(parseType('MyType?', { allowSemanticNullability: true }), {
-        useSemanticNullability: true,
-      }),
-    ).to.equal(dedent`MyType?`);
+  it('prints nullable types', () => {
+    expect(print(parseType('MyType'))).to.equal(dedent`MyType`);
   });
 
   it('prints SemanticNonNullType', () => {
-    expect(
-      print(parseType('MyType', { allowSemanticNullability: true }), {
-        useSemanticNullability: true,
-      }),
-    ).to.equal(dedent`MyType`);
+    expect(print(parseType('MyType*'))).to.equal(dedent`MyType*`);
   });
 
   it('prints NonNullType', () => {
-    expect(
-      print(parseType('MyType!', { allowSemanticNullability: true }), {
-        useSemanticNullability: true,
-      }),
-    ).to.equal(dedent`MyType!`);
-    expect(
-      print(parseType('MyType!', { allowSemanticNullability: false }), {
-        useSemanticNullability: true,
-      }),
-    ).to.equal(dedent`MyType!`);
+    expect(print(parseType('MyType!'))).to.equal(dedent`MyType!`);
   });
 });

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -91,7 +91,7 @@ export class Lexer {
 export function isPunctuatorTokenKind(kind: TokenKind): boolean {
   return (
     kind === TokenKind.BANG ||
-    kind === TokenKind.QUESTION_MARK ||
+    kind === TokenKind.STAR ||
     kind === TokenKind.DOLLAR ||
     kind === TokenKind.AMP ||
     kind === TokenKind.PAREN_L ||
@@ -247,16 +247,11 @@ function readNextToken(lexer: Lexer, start: number): Token {
       //   - FloatValue
       //   - StringValue
       //
-      // Punctuator :: one of ! ? $ & ( ) ... : = @ [ ] { | }
+      // Punctuator :: one of ! * $ & ( ) ... : = @ [ ] { | }
       case 0x0021: // !
         return createToken(lexer, TokenKind.BANG, position, position + 1);
-      case 0x003f: // ?
-        return createToken(
-          lexer,
-          TokenKind.QUESTION_MARK,
-          position,
-          position + 1,
-        );
+      case 0x002a: // *
+        return createToken(lexer, TokenKind.STAR, position, position + 1);
       case 0x0024: // $
         return createToken(lexer, TokenKind.DOLLAR, position, position + 1);
       case 0x0026: // &

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -2,22 +2,14 @@ import type { Maybe } from '../jsutils/Maybe';
 
 import type { ASTNode } from './ast';
 import { printBlockString } from './blockString';
-import { Kind } from './kinds';
 import { printString } from './printString';
 import { visit } from './visitor';
-
-/**
- * Configuration options to control parser behavior
- */
-export interface PrintOptions {
-  useSemanticNullability?: boolean;
-}
 
 /**
  * Converts an AST into a string, using one set of reasonable
  * formatting rules.
  */
-export function print(ast: ASTNode, options: PrintOptions = {}): string {
+export function print(ast: ASTNode): string {
   return visit<string>(ast, {
     Name: { leave: (node) => node.value },
     Variable: { leave: (node) => '$' + node.name },
@@ -131,19 +123,11 @@ export function print(ast: ASTNode, options: PrintOptions = {}): string {
     // Type
 
     NamedType: {
-      leave: ({ name }, _, parent) =>
-        parent &&
-        !Array.isArray(parent) &&
-        ((parent as ASTNode).kind === Kind.SEMANTIC_NON_NULL_TYPE ||
-          (parent as ASTNode).kind === Kind.NON_NULL_TYPE)
-          ? name
-          : options?.useSemanticNullability
-          ? `${name}?`
-          : name,
+      leave: ({ name }) => name,
     },
     ListType: { leave: ({ type }) => '[' + type + ']' },
     NonNullType: { leave: ({ type }) => type + '!' },
-    SemanticNonNullType: { leave: ({ type }) => type },
+    SemanticNonNullType: { leave: ({ type }) => type + '*' },
 
     // Type System Definitions
 

--- a/src/language/tokenKind.ts
+++ b/src/language/tokenKind.ts
@@ -6,7 +6,7 @@ enum TokenKind {
   SOF = '<SOF>',
   EOF = '<EOF>',
   BANG = '!',
-  QUESTION_MARK = '?',
+  STAR = '*',
   DOLLAR = '$',
   AMP = '&',
   PAREN_L = '(',

--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -1798,11 +1798,10 @@ describe('Introspection', () => {
   describe('semantic nullability', () => {
     it('casts semantic-non-null types to nullable types in traditional mode', () => {
       const schema = buildSchema(`
-        @SemanticNullability
         type Query {
           someField: String!
-          someField2: String
-          someField3: String?
+          someField2: String*
+          someField3: String
         }
       `);
 
@@ -1847,11 +1846,10 @@ describe('Introspection', () => {
 
     it('returns semantic-non-null types in full mode', () => {
       const schema = buildSchema(`
-        @SemanticNullability
         type Query {
           someField: String!
-          someField2: String
-          someField3: String?
+          someField2: String*
+          someField3: String
         }
       `);
 

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -502,7 +502,7 @@ export class GraphQLSemanticNonNull<T extends GraphQLNullableType> {
   }
 
   toString(): string {
-    return String(this.ofType);
+    return String(this.ofType) + '*';
   }
 
   toJSON(): string {

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -460,11 +460,10 @@ describe('visitWithTypeInfo', () => {
 
   it('supports traversals of semantic non-null types', () => {
     const schema = buildSchema(`
-      @SemanticNullability
       type Query {
         id: String!
-        name: String
-        something: String?
+        name: String*
+        something: String
       }
     `);
 
@@ -506,10 +505,10 @@ describe('visitWithTypeInfo', () => {
       ['enter', 'Name', 'id', 'String!'],
       ['leave', 'Name', 'id', 'String!'],
       ['leave', 'Field', null, 'String!'],
-      ['enter', 'Field', null, 'String'],
-      ['enter', 'Name', 'name', 'String'],
-      ['leave', 'Name', 'name', 'String'],
-      ['leave', 'Field', null, 'String'],
+      ['enter', 'Field', null, 'String*'],
+      ['enter', 'Name', 'name', 'String*'],
+      ['leave', 'Name', 'name', 'String*'],
+      ['leave', 'Field', null, 'String*'],
       ['enter', 'Field', null, 'String'],
       ['enter', 'Name', 'something', 'String'],
       ['leave', 'Name', 'something', 'String'],

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -988,11 +988,9 @@ describe('Type System: build schema from introspection', () => {
   describe('SemanticNullability', () => {
     it('should build a client schema with semantic-non-null types', () => {
       const sdl = dedent`
-        @SemanticNullability
-
         type Query {
-          foo: String
-          bar: String?
+          foo: String*
+          bar: String
         }
       `;
       const schema = buildSchema(sdl, { assumeValid: true });
@@ -1027,10 +1025,8 @@ describe('Type System: build schema from introspection', () => {
 
     it('should throw when semantic-non-null types are too deep', () => {
       const sdl = dedent`
-        @SemanticNullability
-
         type Query {
-          bar: [[[[[[String?]]]]]]?
+          bar: [[[[[[String]*]*]*]*]*]
         }
       `;
       const schema = buildSchema(sdl, { assumeValid: true });

--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -579,22 +579,20 @@ describe('findBreakingChanges', () => {
 
   it('should consider semantic non-null output types that change type as breaking', () => {
     const oldSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: String
+        field1: String*
       }
     `);
 
     const newSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: Int
+        field1: Int*
       }
     `);
 
     expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([
       {
-        description: 'Type1.field1 changed type from String to Int.',
+        description: 'Type1.field1 changed type from String* to Int*.',
         type: BreakingChangeType.FIELD_CHANGED_KIND,
       },
     ]);
@@ -602,14 +600,12 @@ describe('findBreakingChanges', () => {
 
   it('should consider output types that move away from SemanticNonNull to non-null as non-breaking', () => {
     const oldSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: String
+        field1: String*
       }
     `);
 
     const newSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
         field1: String!
       }
@@ -620,16 +616,14 @@ describe('findBreakingChanges', () => {
 
   it('should consider output types that move away from nullable to semantic non-null as non-breaking', () => {
     const oldSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: String?
+        field1: String
       }
     `);
 
     const newSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: String
+        field1: String*
       }
     `);
 
@@ -638,16 +632,14 @@ describe('findBreakingChanges', () => {
 
   it('should consider list output types that move away from nullable to semantic non-null as non-breaking', () => {
     const oldSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: [String?]?
+        field1: [String]
       }
     `);
 
     const newSchema = buildSchema(`
-      @SemanticNullability
       type Type1 {
-        field1: [String]
+        field1: [String*]*
       }
     `);
 
@@ -656,22 +648,20 @@ describe('findBreakingChanges', () => {
 
   it('should consider output types that move away from SemanticNonNull to null as breaking', () => {
     const oldSchema = buildSchema(`
-      @SemanticNullability
+      type Type1 {
+        field1: String*
+      }
+    `);
+
+    const newSchema = buildSchema(`
       type Type1 {
         field1: String
       }
     `);
 
-    const newSchema = buildSchema(`
-      @SemanticNullability
-      type Type1 {
-        field1: String?
-      }
-    `);
-
     expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([
       {
-        description: 'Type1.field1 changed type from String to String.',
+        description: 'Type1.field1 changed type from String* to String.',
         type: BreakingChangeType.FIELD_CHANGED_KIND,
       },
     ]);

--- a/src/utilities/__tests__/lexicographicSortSchema-test.ts
+++ b/src/utilities/__tests__/lexicographicSortSchema-test.ts
@@ -65,54 +65,50 @@ describe('lexicographicSortSchema', () => {
 
   it('sort fields w/ semanticNonNull', () => {
     const sorted = sortSDL(`
-      @SemanticNullability
-
       input Bar {
         barB: String!
-        barA: String
-        barC: [String]
+        barA: String*
+        barC: [String*]*
       }
 
       interface FooInterface {
         fooB: String!
-        fooA: String
-        fooC: [String]
+        fooA: String*
+        fooC: [String*]*
       }
 
       type FooType implements FooInterface {
-        fooC: [String]
-        fooA: String
+        fooC: [String*]*
+        fooA: String*
         fooB: String!
       }
 
       type Query {
-        dummy(arg: Bar): FooType?
+        dummy(arg: Bar): FooType
       }
     `);
 
     expect(sorted).to.equal(dedent`
-      @SemanticNullability
-
       input Bar {
-        barA: String
+        barA: String*
         barB: String!
-        barC: [String]
+        barC: [String*]*
       }
 
       interface FooInterface {
-        fooA: String
+        fooA: String*
         fooB: String!
-        fooC: [String]
+        fooC: [String*]*
       }
 
       type FooType implements FooInterface {
-        fooA: String
+        fooA: String*
         fooB: String!
-        fooC: [String]
+        fooC: [String*]*
       }
 
       type Query {
-        dummy(arg: Bar): FooType?
+        dummy(arg: Bar): FooType
       }
     `);
   });

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1195,27 +1195,26 @@ describe('Validate: Overlapping fields can be merged', () => {
 
   describe('semantic non-null', () => {
     const schema = buildSchema(`
-      @SemanticNullability
       type Query {
-        box: Box
+        box: Box*
       }
 
       interface Box {
-        id: String
+        id: String*
       }
 
       type IntBox implements Box {
-        id: String
-        field: Int
-        field2: Int?
-        field3: Int
+        id: String*
+        field: Int*
+        field2: Int
+        field3: Int*
       }
 
       type StringBox implements Box {
-        id: String
-        field: String
-        field2: Int
-        field3: Int
+        id: String*
+        field: String*
+        field2: Int*
+        field3: Int*
       }
     `);
 
@@ -1273,7 +1272,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       ).toDeepEqual([
         {
           message:
-            'Fields "field" conflict because they return conflicting types "Int" and "String". Use different aliases on the fields to fetch both if this was intentional.',
+            'Fields "field" conflict because they return conflicting types "Int*" and "String*". Use different aliases on the fields to fetch both if this was intentional.',
           locations: [
             { line: 5, column: 17 },
             { line: 8, column: 17 },
@@ -1300,7 +1299,7 @@ describe('Validate: Overlapping fields can be merged', () => {
       ).toDeepEqual([
         {
           message:
-            'Fields "field2" conflict because they return conflicting types "Int" and "Int". Use different aliases on the fields to fetch both if this was intentional.',
+            'Fields "field2" conflict because they return conflicting types "Int*" and "Int". Use different aliases on the fields to fetch both if this was intentional.',
           locations: [
             { line: 5, column: 17 },
             { line: 8, column: 17 },
@@ -1326,9 +1325,8 @@ describe('Validate: Overlapping fields can be merged', () => {
         `,
       ).toDeepEqual([
         {
-          // TODO: inspect currently returns "Int" for both types
           message:
-            'Fields "field2" conflict because they return conflicting types "Int" and "Int". Use different aliases on the fields to fetch both if this was intentional.',
+            'Fields "field2" conflict because they return conflicting types "Int" and "Int*". Use different aliases on the fields to fetch both if this was intentional.',
           locations: [
             { line: 5, column: 17 },
             { line: 8, column: 17 },


### PR DESCRIPTION
This is mainly an alternative syntax proposal that removes the need for `@SemanticNullability` and the `parse/print` flags. The reduction in code needed is a pretty good indicator for me personally.

This proposal lets our schema be backwards compatible as well which is quite neat! We could guard this functionality in the parser with something like `allowNullability`