### PR TITLE
fixed wrong variable name

### DIFF
--- a/website/pages/docs/running-an-express-graphql-server.mdx
+++ b/website/pages/docs/running-an-express-graphql-server.mdx
@@ -23,8 +23,8 @@ const express = require('express');
 // Construct a schema, using GraphQL schema language
 const schema = buildSchema(`type Query { hello: String } `);
 
-// The rootValue provides a resolver function for each API endpoint
-const rootValue = {
+// The root provides a resolver function for each API endpoint
+const root = {
   hello() {
     return 'Hello world!';
   },
@@ -63,8 +63,8 @@ const schema = new GraphQLSchema({
   }),
 });
 
-// The rootValue provides a resolver function for each API endpoint
-const rootValue = {
+// The root provides a resolver function for each API endpoint
+const root = {
   hello() {
     return 'Hello world!';
   },


### PR DESCRIPTION
Issue
The server throws an error because the root variable is not defined. The correct variable name should be rootValue, which was previously declared in the code.

Fix
Updated rootValue in the createHandler function to use the correct variable name.

Changes
Replaced root with rootValue in the GraphQL handler configuration.