### PR TITLE
docs(getting-started): promises current links

### DIFF
--- a/website/pages/docs/getting-started.mdx
+++ b/website/pages/docs/getting-started.mdx
@@ -13,7 +13,7 @@ import { Tabs } from 'nextra/components';
 
 Before getting started, you should have Node v6 installed, although the examples should mostly work in previous versions of Node as well.
 For this guide, we won't use any language features that require transpilation, but we will use some ES6 features like
-[Promises](http://www.html5rocks.com/en/tutorials/es6/promises/), classes,
+[Promises](http://web.dev/articles/promises/), classes,
 and arrow functions, so if you aren't familiar with them you might want to read up on them first.
 
 > Alternatively you can start from [this StackBlitz](https://stackblitz.com/edit/stackblitz-starters-znvgwr) - if you choose


### PR DESCRIPTION
See: [Archived repo](https://github.com/html5rocks/www.html5rocks.com/blob/master/content/tutorials/es6/promises/en/index.html#L6) redirected the links.