### PR TITLE
fix(incremental): failed fragments should never be re-added to the graph 

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -132,14 +132,8 @@ export class IncrementalGraph {
     return { newRootNodes, successfulExecutionGroups };
   }
 
-  removeDeferredFragment(
-    deferredFragmentRecord: DeferredFragmentRecord,
-  ): boolean {
-    if (!this._rootNodes.has(deferredFragmentRecord)) {
-      return false;
-    }
+  removeDeferredFragment(deferredFragmentRecord: DeferredFragmentRecord): void {
     this._rootNodes.delete(deferredFragmentRecord);
-    return true;
   }
 
   removeStream(streamRecord: StreamRecord): void {
@@ -219,7 +213,10 @@ export class IncrementalGraph {
     deferredFragmentRecord: DeferredFragmentRecord,
     initialResultChildren: Set<DeliveryGroup> | undefined,
   ): void {
-    if (this._rootNodes.has(deferredFragmentRecord)) {
+    if (
+      deferredFragmentRecord.failed ||
+      this._rootNodes.has(deferredFragmentRecord)
+    ) {
       return;
     }
     const parent = deferredFragmentRecord.parent;

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -231,13 +231,13 @@ class IncrementalPublisher {
     if (isFailedExecutionGroup(completedExecutionGroup)) {
       for (const deferredFragmentRecord of completedExecutionGroup
         .pendingExecutionGroup.deferredFragmentRecords) {
-        const id = deferredFragmentRecord.id;
-        if (
-          !this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord)
-        ) {
-          // This can occur if multiple deferred grouped field sets error for a fragment.
+        const failed = deferredFragmentRecord.failed;
+        if (failed) {
           continue;
         }
+        deferredFragmentRecord.failed = true;
+        const id = deferredFragmentRecord.id;
+        this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord);
         invariant(id !== undefined);
         context.completed.push({
           id,

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -224,6 +224,7 @@ export class DeferredFragmentRecord {
   pendingExecutionGroups: Set<PendingExecutionGroup>;
   successfulExecutionGroups: Set<SuccessfulExecutionGroup>;
   children: Set<DeliveryGroup>;
+  failed: true | undefined;
 
   constructor(
     path: Path | undefined,


### PR DESCRIPTION
After an execution group "fails," i.e. a null has bubbled up too far, it fails the entire associated deferred fragment. But if the query includes a shared execution group between the failing deferred fragment and a non-failing deferred fragment with some unique subfields, those subfields will still be added to the graph for the failed deferred fragment, which is not present.

This throws an error, because the code assumes that in the situation above, i.e. a shared execution group between two fragments and some unique subfields, both of the deferred fragments must already be in the graph. So a runtime-error is triggered because some of the invariants we rely on when adding deferred fragments are violated.

But even if we didn't have an error, this would be an erroneous situation, as we should never add back a node to the graph that has been failed! The fix should be to retain the failure state on the deferred fragment so as not to attempt to readd the node to the graph.