### PR TITLE
incremental: add new deferred fragments to the wrapped graphql result

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -132,14 +132,8 @@ export class IncrementalGraph {
     return { newRootNodes, successfulExecutionGroups };
   }
 
-  removeDeferredFragment(
-    deferredFragmentRecord: DeferredFragmentRecord,
-  ): boolean {
-    if (!this._rootNodes.has(deferredFragmentRecord)) {
-      return false;
-    }
+  removeDeferredFragment(deferredFragmentRecord: DeferredFragmentRecord): void {
     this._rootNodes.delete(deferredFragmentRecord);
-    return true;
   }
 
   removeStream(streamRecord: StreamRecord): void {
@@ -219,7 +213,10 @@ export class IncrementalGraph {
     deferredFragmentRecord: DeferredFragmentRecord,
     initialResultChildren: Set<DeliveryGroup> | undefined,
   ): void {
-    if (this._rootNodes.has(deferredFragmentRecord)) {
+    if (
+      deferredFragmentRecord.failed ||
+      this._rootNodes.has(deferredFragmentRecord)
+    ) {
       return;
     }
     const parent = deferredFragmentRecord.parent;

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -231,13 +231,13 @@ class IncrementalPublisher {
     if (isFailedExecutionGroup(completedExecutionGroup)) {
       for (const deferredFragmentRecord of completedExecutionGroup
         .pendingExecutionGroup.deferredFragmentRecords) {
-        const id = deferredFragmentRecord.id;
-        if (
-          !this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord)
-        ) {
-          // This can occur if multiple deferred grouped field sets error for a fragment.
+        const failed = deferredFragmentRecord.failed;
+        if (failed) {
           continue;
         }
+        deferredFragmentRecord.failed = true;
+        const id = deferredFragmentRecord.id;
+        this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord);
         invariant(id !== undefined);
         context.completed.push({
           id,

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -33,12 +33,14 @@ export function buildIncrementalResponse(
   context: IncrementalPublisherContext,
   result: ObjMap<unknown>,
   errors: ReadonlyArray<GraphQLError> | undefined,
+  newDeferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord> | undefined,
   incrementalDataRecords: ReadonlyArray<IncrementalDataRecord>,
 ): ExperimentalIncrementalExecutionResults {
   const incrementalPublisher = new IncrementalPublisher(context);
   return incrementalPublisher.buildResponse(
     result,
     errors,
+    newDeferredFragmentRecords,
     incrementalDataRecords,
   );
 }
@@ -74,9 +76,13 @@ class IncrementalPublisher {
   buildResponse(
     data: ObjMap<unknown>,
     errors: ReadonlyArray<GraphQLError> | undefined,
+    newDeferredFragmentRecords:
+      | ReadonlyArray<DeferredFragmentRecord>
+      | undefined,
     incrementalDataRecords: ReadonlyArray<IncrementalDataRecord>,
   ): ExperimentalIncrementalExecutionResults {
     const newRootNodes = this._incrementalGraph.getNewRootNodes(
+      newDeferredFragmentRecords,
       incrementalDataRecords,
     );
 
@@ -231,18 +237,16 @@ class IncrementalPublisher {
     if (isFailedExecutionGroup(completedExecutionGroup)) {
       for (const deferredFragmentRecord of completedExecutionGroup
         .pendingExecutionGroup.deferredFragmentRecords) {
-        const failed = deferredFragmentRecord.failed;
-        if (failed) {
-          continue;
+        if (
+          this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord)
+        ) {
+          const id = deferredFragmentRecord.id;
+          invariant(id !== undefined);
+          context.completed.push({
+            id,
+            errors: completedExecutionGroup.errors,
+          });
         }
-        deferredFragmentRecord.failed = true;
-        const id = deferredFragmentRecord.id;
-        this._incrementalGraph.removeDeferredFragment(deferredFragmentRecord);
-        invariant(id !== undefined);
-        context.completed.push({
-          id,
-          errors: completedExecutionGroup.errors,
-        });
       }
       return;
     }
@@ -319,9 +323,11 @@ class IncrementalPublisher {
 
       context.incremental.push(incrementalEntry);
 
-      const incrementalDataRecords = streamItemsResult.incrementalDataRecords;
+      const { newDeferredFragmentRecords, incrementalDataRecords } =
+        streamItemsResult;
       if (incrementalDataRecords !== undefined) {
         const newRootNodes = this._incrementalGraph.getNewRootNodes(
+          newDeferredFragmentRecords,
           incrementalDataRecords,
         );
         context.pending.push(...this._toPendingResults(newRootNodes));

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -1581,8 +1581,8 @@ describe('Execute: defer directive', () => {
           a: {},
         },
         pending: [
-          { id: '0', path: [] },
-          { id: '1', path: ['a'] },
+          { id: '0', path: ['a'] },
+          { id: '1', path: [] },
         ],
         hasNext: true,
       },
@@ -1590,17 +1590,17 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: {} } },
-            id: '1',
+            id: '0',
           },
           {
             data: { d: 'd' },
-            id: '1',
+            id: '0',
             subPath: ['b', 'c'],
           },
         ],
         completed: [
           {
-            id: '0',
+            id: '1',
             errors: [
               {
                 message:
@@ -1610,7 +1610,7 @@ describe('Execute: defer directive', () => {
               },
             ],
           },
-          { id: '1' },
+          { id: '0' },
         ],
         hasNext: false,
       },
@@ -1653,8 +1653,8 @@ describe('Execute: defer directive', () => {
           a: {},
         },
         pending: [
-          { id: '0', path: [] },
-          { id: '1', path: ['a'] },
+          { id: '0', path: ['a'] },
+          { id: '1', path: [] },
         ],
         hasNext: true,
       },
@@ -1662,18 +1662,18 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: {} } },
-            id: '1',
+            id: '0',
           },
           {
             data: { d: 'd' },
-            id: '0',
+            id: '1',
             subPath: ['a', 'b', 'c'],
           },
         ],
         completed: [
-          { id: '0' },
+          { id: '1' },
           {
-            id: '1',
+            id: '0',
             errors: [
               {
                 message:
@@ -1727,15 +1727,15 @@ describe('Execute: defer directive', () => {
           a: {},
         },
         pending: [
-          { id: '0', path: [] },
-          { id: '1', path: ['a'] },
+          { id: '0', path: ['a'] },
+          { id: '1', path: [] },
         ],
         hasNext: true,
       },
       {
         completed: [
           {
-            id: '0',
+            id: '1',
             errors: [
               {
                 message:
@@ -1752,15 +1752,15 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: {}, someField: 'someField' },
-            id: '1',
+            id: '0',
           },
           {
             data: { e: { f: 'f' } },
-            id: '1',
+            id: '0',
             subPath: ['b'],
           },
         ],
-        completed: [{ id: '1' }],
+        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1960,8 +1960,8 @@ describe('Execute: defer directive', () => {
           a: {},
         },
         pending: [
-          { id: '0', path: [] },
-          { id: '1', path: ['a'] },
+          { id: '0', path: ['a'] },
+          { id: '1', path: [] },
         ],
         hasNext: true,
       },
@@ -1969,21 +1969,21 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: {} } },
-            id: '1',
+            id: '0',
           },
           {
             data: { d: 'd' },
-            id: '1',
+            id: '0',
             subPath: ['b', 'c'],
           },
         ],
-        completed: [{ id: '1' }],
+        completed: [{ id: '0' }],
         hasNext: true,
       },
       {
         completed: [
           {
-            id: '0',
+            id: '1',
             errors: [
               {
                 message:

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -214,6 +214,7 @@ export interface StreamUsage {
 
 interface GraphQLWrappedResult<T> {
   rawResult: T;
+  newDeferredFragmentRecords: Array<DeferredFragmentRecord> | undefined;
   incrementalDataRecords: Array<IncrementalDataRecord> | undefined;
 }
 
@@ -421,7 +422,11 @@ function buildDataResponse(
   exeContext: ExecutionContext,
   graphqlWrappedResult: GraphQLWrappedResult<ObjMap<unknown>>,
 ): ExecutionResult | ExperimentalIncrementalExecutionResults {
-  const { rawResult: data, incrementalDataRecords } = graphqlWrappedResult;
+  const {
+    rawResult: data,
+    newDeferredFragmentRecords,
+    incrementalDataRecords,
+  } = graphqlWrappedResult;
   const errors = exeContext.errors;
   if (incrementalDataRecords === undefined) {
     exeContext.abortSignalListener?.disconnect();
@@ -432,6 +437,7 @@ function buildDataResponse(
     exeContext,
     data,
     errors,
+    newDeferredFragmentRecords,
     incrementalDataRecords,
   );
 }
@@ -585,19 +591,29 @@ function executeRootExecutionPlan(
       undefined,
     );
   }
-  const newDeferMap = getNewDeferMap(newDeferUsages, undefined, undefined);
+
+  const { newDeferredFragmentRecords, newDeferMap } = getNewDeferMap(
+    newDeferUsages,
+    undefined,
+    undefined,
+  );
 
   const { groupedFieldSet, newGroupedFieldSets } = buildExecutionPlan(
     originalGroupedFieldSet,
   );
 
-  const graphqlWrappedResult = executeRootGroupedFieldSet(
+  let graphqlWrappedResult = executeRootGroupedFieldSet(
     exeContext,
     operation,
     rootType,
     rootValue,
     groupedFieldSet,
     newDeferMap,
+  );
+
+  graphqlWrappedResult = withNewDeferredFragmentRecords(
+    graphqlWrappedResult,
+    newDeferredFragmentRecords,
   );
 
   if (newGroupedFieldSets.size > 0) {
@@ -617,6 +633,34 @@ function executeRootExecutionPlan(
     );
   }
   return graphqlWrappedResult;
+}
+
+function withNewDeferredFragmentRecords(
+  result: PromiseOrValue<GraphQLWrappedResult<ObjMap<unknown>>>,
+  newDeferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord>,
+): PromiseOrValue<GraphQLWrappedResult<ObjMap<unknown>>> {
+  if (isPromise(result)) {
+    return result.then((resolved) => {
+      addNewDeferredFragmentRecords(resolved, newDeferredFragmentRecords);
+      return resolved;
+    });
+  }
+  addNewDeferredFragmentRecords(result, newDeferredFragmentRecords);
+  return result;
+}
+
+function addNewDeferredFragmentRecords(
+  result: GraphQLWrappedResult<unknown>,
+  newDeferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord> | undefined,
+): void {
+  if (newDeferredFragmentRecords === undefined) {
+    return;
+  }
+  if (result.newDeferredFragmentRecords === undefined) {
+    result.newDeferredFragmentRecords = [...newDeferredFragmentRecords];
+  } else {
+    result.newDeferredFragmentRecords.push(...newDeferredFragmentRecords);
+  }
 }
 
 function withNewExecutionGroups(
@@ -725,6 +769,10 @@ function executeFieldsSerially(
       if (isPromise(result)) {
         return result.then((resolved) => {
           graphqlWrappedResult.rawResult[responseName] = resolved.rawResult;
+          addNewDeferredFragmentRecords(
+            graphqlWrappedResult,
+            resolved.newDeferredFragmentRecords,
+          );
           addIncrementalDataRecords(
             graphqlWrappedResult,
             resolved.incrementalDataRecords,
@@ -733,6 +781,10 @@ function executeFieldsSerially(
         });
       }
       graphqlWrappedResult.rawResult[responseName] = result.rawResult;
+      addNewDeferredFragmentRecords(
+        graphqlWrappedResult,
+        result.newDeferredFragmentRecords,
+      );
       addIncrementalDataRecords(
         graphqlWrappedResult,
         result.incrementalDataRecords,
@@ -741,6 +793,7 @@ function executeFieldsSerially(
     },
     {
       rawResult: Object.create(null),
+      newDeferredFragmentRecords: undefined,
       incrementalDataRecords: undefined,
     },
   );
@@ -776,6 +829,7 @@ function executeFields(
   const results = Object.create(null);
   const graphqlWrappedResult: GraphQLWrappedResult<ObjMap<unknown>> = {
     rawResult: results,
+    newDeferredFragmentRecords: undefined,
     incrementalDataRecords: undefined,
   };
   let containsPromise = false;
@@ -796,6 +850,10 @@ function executeFields(
       if (result !== undefined) {
         if (isPromise(result)) {
           results[responseName] = result.then((resolved) => {
+            addNewDeferredFragmentRecords(
+              graphqlWrappedResult,
+              resolved.newDeferredFragmentRecords,
+            );
             addIncrementalDataRecords(
               graphqlWrappedResult,
               resolved.incrementalDataRecords,
@@ -805,6 +863,10 @@ function executeFields(
           containsPromise = true;
         } else {
           results[responseName] = result.rawResult;
+          addNewDeferredFragmentRecords(
+            graphqlWrappedResult,
+            result.newDeferredFragmentRecords,
+          );
           addIncrementalDataRecords(
             graphqlWrappedResult,
             result.incrementalDataRecords,
@@ -834,6 +896,7 @@ function executeFields(
   // same map, but with any promises replaced with the values they resolved to.
   return promiseForObject(results, (resolved) => ({
     rawResult: resolved,
+    newDeferredFragmentRecords: graphqlWrappedResult.newDeferredFragmentRecords,
     incrementalDataRecords: graphqlWrappedResult.incrementalDataRecords,
   }));
 }
@@ -934,7 +997,11 @@ function executeField(
           path,
           incrementalContext,
         );
-        return { rawResult: null, incrementalDataRecords: undefined };
+        return {
+          rawResult: null,
+          newDeferredFragmentRecords: undefined,
+          incrementalDataRecords: undefined,
+        };
       });
     }
     return completed;
@@ -947,7 +1014,11 @@ function executeField(
       path,
       incrementalContext,
     );
-    return { rawResult: null, incrementalDataRecords: undefined };
+    return {
+      rawResult: null,
+      newDeferredFragmentRecords: undefined,
+      incrementalDataRecords: undefined,
+    };
   }
 }
 
@@ -1072,7 +1143,11 @@ function completeValue(
 
   // If result value is null or undefined then return null.
   if (result == null) {
-    return { rawResult: null, incrementalDataRecords: undefined };
+    return {
+      rawResult: null,
+      newDeferredFragmentRecords: undefined,
+      incrementalDataRecords: undefined,
+    };
   }
 
   // If field type is List, complete each item in the list with the inner type
@@ -1094,6 +1169,7 @@ function completeValue(
   if (isLeafType(returnType)) {
     return {
       rawResult: completeLeafValue(returnType, result),
+      newDeferredFragmentRecords: undefined,
       incrementalDataRecords: undefined,
     };
   }
@@ -1173,7 +1249,11 @@ async function completePromisedValue(
       path,
       incrementalContext,
     );
-    return { rawResult: null, incrementalDataRecords: undefined };
+    return {
+      rawResult: null,
+      newDeferredFragmentRecords: undefined,
+      incrementalDataRecords: undefined,
+    };
   }
 }
 
@@ -1273,6 +1353,7 @@ async function completeAsyncIteratorValue(
   const completedResults: Array<unknown> = [];
   const graphqlWrappedResult: GraphQLWrappedResult<Array<unknown>> = {
     rawResult: completedResults,
+    newDeferredFragmentRecords: undefined,
     incrementalDataRecords: undefined,
   };
   let index = 0;
@@ -1392,6 +1473,8 @@ async function completeAsyncIteratorValue(
   return containsPromise
     ? /* c8 ignore start */ Promise.all(completedResults).then((resolved) => ({
         rawResult: resolved,
+        newDeferredFragmentRecords:
+          graphqlWrappedResult.newDeferredFragmentRecords,
         incrementalDataRecords: graphqlWrappedResult.incrementalDataRecords,
       }))
     : /* c8 ignore stop */ graphqlWrappedResult;
@@ -1466,6 +1549,7 @@ function completeIterableValue(
   const completedResults: Array<unknown> = [];
   const graphqlWrappedResult: GraphQLWrappedResult<Array<unknown>> = {
     rawResult: completedResults,
+    newDeferredFragmentRecords: undefined,
     incrementalDataRecords: undefined,
   };
   let index = 0;
@@ -1542,6 +1626,8 @@ function completeIterableValue(
   return containsPromise
     ? Promise.all(completedResults).then((resolved) => ({
         rawResult: resolved,
+        newDeferredFragmentRecords:
+          graphqlWrappedResult.newDeferredFragmentRecords,
         incrementalDataRecords: graphqlWrappedResult.incrementalDataRecords,
       }))
     : graphqlWrappedResult;
@@ -1582,6 +1668,10 @@ function completeListItemValue(
       completedResults.push(
         completedItem.then(
           (resolved) => {
+            addNewDeferredFragmentRecords(
+              parent,
+              resolved.newDeferredFragmentRecords,
+            );
             addIncrementalDataRecords(parent, resolved.incrementalDataRecords);
             return resolved.rawResult;
           },
@@ -1602,6 +1692,10 @@ function completeListItemValue(
     }
 
     completedResults.push(completedItem.rawResult);
+    addNewDeferredFragmentRecords(
+      parent,
+      completedItem.newDeferredFragmentRecords,
+    );
     addIncrementalDataRecords(parent, completedItem.incrementalDataRecords);
   } catch (rawError) {
     handleFieldError(
@@ -1647,6 +1741,7 @@ async function completePromisedListItemValue(
     if (isPromise(completed)) {
       completed = await completed;
     }
+    addNewDeferredFragmentRecords(parent, completed.newDeferredFragmentRecords);
     addIncrementalDataRecords(parent, completed.incrementalDataRecords);
     return completed.rawResult;
   } catch (rawError) {
@@ -1873,7 +1968,11 @@ function getNewDeferMap(
   newDeferUsages: ReadonlyArray<DeferUsage>,
   deferMap?: ReadonlyMap<DeferUsage, DeferredFragmentRecord>,
   path?: Path,
-): ReadonlyMap<DeferUsage, DeferredFragmentRecord> {
+): {
+  newDeferredFragmentRecords: Array<DeferredFragmentRecord>;
+  newDeferMap: ReadonlyMap<DeferUsage, DeferredFragmentRecord>;
+} {
+  const newDeferredFragmentRecords: Array<DeferredFragmentRecord> = [];
   const newDeferMap = new Map(deferMap);
 
   // For each new deferUsage object:
@@ -1892,11 +1991,17 @@ function getNewDeferMap(
       parent,
     );
 
+    // Add the new record to the list of new records.
+    newDeferredFragmentRecords.push(deferredFragmentRecord);
+
     // Update the map.
     newDeferMap.set(newDeferUsage, deferredFragmentRecord);
   }
 
-  return newDeferMap;
+  return {
+    newDeferredFragmentRecords,
+    newDeferMap,
+  };
 }
 
 function deferredFragmentRecordFromDeferUsage(
@@ -1968,14 +2073,18 @@ function executeSubExecutionPlan(
     );
   }
 
-  const newDeferMap = getNewDeferMap(newDeferUsages, deferMap, path);
+  const { newDeferredFragmentRecords, newDeferMap } = getNewDeferMap(
+    newDeferUsages,
+    deferMap,
+    path,
+  );
 
   const { groupedFieldSet, newGroupedFieldSets } = buildSubExecutionPlan(
     originalGroupedFieldSet,
     incrementalContext?.deferUsageSet,
   );
 
-  const graphqlWrappedResult = executeFields(
+  let graphqlWrappedResult = executeFields(
     exeContext,
     returnType,
     sourceValue,
@@ -1984,6 +2093,13 @@ function executeSubExecutionPlan(
     incrementalContext,
     newDeferMap,
   );
+
+  if (newDeferredFragmentRecords.length > 0) {
+    graphqlWrappedResult = withNewDeferredFragmentRecords(
+      graphqlWrappedResult,
+      newDeferredFragmentRecords,
+    );
+  }
 
   if (newGroupedFieldSets.size > 0) {
     const newPendingExecutionGroups = collectExecutionGroups(
@@ -2503,11 +2619,16 @@ function buildCompletedExecutionGroup(
   path: Path | undefined,
   result: GraphQLWrappedResult<ObjMap<unknown>>,
 ): CompletedExecutionGroup {
-  const { rawResult: data, incrementalDataRecords } = result;
+  const {
+    rawResult: data,
+    newDeferredFragmentRecords,
+    incrementalDataRecords,
+  } = result;
   return {
     pendingExecutionGroup,
     path: pathToArray(path),
     result: errors === undefined ? { data } : { data, errors },
+    newDeferredFragmentRecords,
     incrementalDataRecords,
   };
 }
@@ -2752,7 +2873,11 @@ function completeStreamItem(
         itemPath,
         incrementalContext,
       );
-      result = { rawResult: null, incrementalDataRecords: undefined };
+      result = {
+        rawResult: null,
+        newDeferredFragmentRecords: undefined,
+        incrementalDataRecords: undefined,
+      };
     }
   } catch (error) {
     incrementalContext.completed = true;
@@ -2772,7 +2897,11 @@ function completeStreamItem(
           itemPath,
           incrementalContext,
         );
-        return { rawResult: null, incrementalDataRecords: undefined };
+        return {
+          rawResult: null,
+          newDeferredFragmentRecords: undefined,
+          incrementalDataRecords: undefined,
+        };
       })
       .then(
         (resolvedItem) => {
@@ -2796,10 +2925,15 @@ function buildStreamItemResult(
   errors: ReadonlyArray<GraphQLError> | undefined,
   result: GraphQLWrappedResult<unknown>,
 ): StreamItemResult {
-  const { rawResult: item, incrementalDataRecords } = result;
+  const {
+    rawResult: item,
+    newDeferredFragmentRecords,
+    incrementalDataRecords,
+  } = result;
   return {
     item,
     errors,
+    newDeferredFragmentRecords,
     incrementalDataRecords,
   };
 }

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -224,6 +224,7 @@ export class DeferredFragmentRecord {
   pendingExecutionGroups: Set<PendingExecutionGroup>;
   successfulExecutionGroups: Set<SuccessfulExecutionGroup>;
   children: Set<DeliveryGroup>;
+  failed: true | undefined;
 
   constructor(
     path: Path | undefined,

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -187,6 +187,7 @@ export interface SuccessfulExecutionGroup {
   pendingExecutionGroup: PendingExecutionGroup;
   path: Array<string | number>;
   result: ExecutionGroupResult;
+  newDeferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord> | undefined;
   incrementalDataRecords: ReadonlyArray<IncrementalDataRecord> | undefined;
   errors?: never;
 }
@@ -224,7 +225,6 @@ export class DeferredFragmentRecord {
   pendingExecutionGroups: Set<PendingExecutionGroup>;
   successfulExecutionGroups: Set<SuccessfulExecutionGroup>;
   children: Set<DeliveryGroup>;
-  failed: true | undefined;
 
   constructor(
     path: Path | undefined,
@@ -248,6 +248,9 @@ export function isDeferredFragmentRecord(
 
 export interface StreamItemResult {
   item?: unknown;
+  newDeferredFragmentRecords?:
+    | ReadonlyArray<DeferredFragmentRecord>
+    | undefined;
   incrementalDataRecords?: ReadonlyArray<IncrementalDataRecord> | undefined;
   errors?: ReadonlyArray<GraphQLError> | undefined;
 }
@@ -265,6 +268,9 @@ export interface StreamItemsResult {
   streamRecord: StreamRecord;
   errors?: ReadonlyArray<GraphQLError>;
   result?: StreamItemsRecordResult;
+  newDeferredFragmentRecords?:
+    | ReadonlyArray<DeferredFragmentRecord>
+    | undefined;
   incrementalDataRecords?: ReadonlyArray<IncrementalDataRecord> | undefined;
 }
 


### PR DESCRIPTION
alternative solution to #4357 in which we add the new deferred fragments to the wrapped graphql result

After an execution group "fails," i.e. a null has bubbled up too far, it fails the entire associated deferred fragment. But if the query includes a shared execution group between the failing deferred fragment and a non-failing deferred fragment with some unique subfields, those subfields will still be added to the graph for the failed deferred fragment, which is not present.

This throws an error, because the code assumes that in the situation above, i.e. a shared execution group between two fragments and some unique subfields, both of the deferred fragments must already be in the graph. So a runtime-error is triggered because some of the invariants we rely on when adding deferred fragments are violated.

But even if we didn't have an error, this would be an erroneous situation, as we should never add back a node to the graph that has been failed!

After this change, new deferred fragments are explicitly returned as part of the GraphQLWrappedResult and are only added at a single point when building the graph such that this error can be avoided entirely.