### PR TITLE
Ensure we validate for using nullable variables in oneOf input fields

### DIFF
--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -33,6 +33,7 @@ interface VariableUsage {
   readonly node: VariableNode;
   readonly type: Maybe<GraphQLInputType>;
   readonly defaultValue: Maybe<unknown>;
+  readonly parentType: Maybe<GraphQLInputType>;
 }
 
 /**
@@ -209,6 +210,7 @@ export class ValidationContext extends ASTValidationContext {
               node: variable,
               type: typeInfo.getInputType(),
               defaultValue: typeInfo.getDefaultValue(),
+              parentType: typeInfo.getParentInputType(),
             });
           },
         }),

--- a/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
+++ b/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
@@ -358,3 +358,34 @@ describe('Validate: Variables are in allowed positions', () => {
     });
   });
 });
+
+describe('Validates OneOf Input Objects', () => {
+  it('Allows exactly one non-nullable variable', () => {
+    expectValid(`
+      query ($string: String!) {
+        complicatedArgs {
+          oneOfArgField(oneOfArg: { stringField: $string })
+        }
+      }
+    `);
+  });
+
+  it('Forbids one nullable variable', () => {
+    expectErrors(`
+      query ($string: String) {
+        complicatedArgs {
+          oneOfArgField(oneOfArg: { stringField: $string })
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Variable "$string" is of type "String" but must be non-nullable to be used for OneOf Input Object "OneOfInput".',
+        locations: [
+          { line: 2, column: 14 },
+          { line: 4, column: 50 },
+        ],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
In the spec we explicitly disallow `nullable` variables to be passed to the fields of a oneOf input object. This is present in v17 but seems missing from v16.