### PR TITLE
feat(execution): add max coercion errors option to execution context

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -24,7 +24,7 @@ import { GraphQLSchema } from '../../type/schema';
 
 import { execute, executeSync } from '../execute';
 
-describe.only('Execute: Handles basic execution tasks', () => {
+describe('Execute: Handles basic execution tasks', () => {
   it('throws if no document is provided', () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -24,7 +24,7 @@ import { GraphQLSchema } from '../../type/schema';
 
 import { execute, executeSync } from '../execute';
 
-describe('Execute: Handles basic execution tasks', () => {
+describe.only('Execute: Handles basic execution tasks', () => {
   it('throws if no document is provided', () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({
@@ -1376,12 +1376,19 @@ describe('Execute: Handles basic execution tasks', () => {
 
     // Returns at least 2 errors, one for the first 'wrongArg', and one for coercion limit
     expect(result.errors).to.have.lengthOf(options.maxCoercionErrors + 1);
-    expect(
-      result.errors && result.errors.length > 0
-        ? result.errors[result.errors.length - 1].message
-        : undefined,
-    ).to.equal(
-      'Too many errors processing variables, error limit reached. Execution aborted.',
-    );
+
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Variable "$data" got invalid value { email: "", wrongArg: "wrong", wrongArg2: "wrong", wrongArg3: "wrong" }; Field "wrongArg" is not defined by type "User".',
+          locations: [{ line: 2, column: 17 }],
+        },
+        {
+          message:
+            'Too many errors processing variables, error limit reached. Execution aborted.',
+        },
+      ],
+    });
   });
 });

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -1356,7 +1356,7 @@ describe('Execute: Handles basic execution tasks', () => {
       }
     `);
 
-    const executionOptions = {
+    const options = {
       maxCoercionErrors: 1,
     };
 
@@ -1371,13 +1371,11 @@ describe('Execute: Handles basic execution tasks', () => {
           wrongArg3: 'wrong',
         },
       },
-      executionOptions,
+      options,
     });
 
     // Returns at least 2 errors, one for the first 'wrongArg', and one for coercion limit
-    expect(result.errors).to.have.lengthOf(
-      executionOptions.maxCoercionErrors + 1,
-    );
+    expect(result.errors).to.have.lengthOf(options.maxCoercionErrors + 1);
     expect(
       result.errors && result.errors.length > 0
         ? result.errors[result.errors.length - 1].message

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -152,7 +152,9 @@ export interface ExecutionArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  executionOptions?: {
+  /** Additional execution options. */
+  options?: {
+    /** Set the maximum number of errors allowed for coercing (defaults to 50). */
     maxCoercionErrors?: number;
   };
 }
@@ -289,7 +291,7 @@ export function buildExecutionContext(
     fieldResolver,
     typeResolver,
     subscribeFieldResolver,
-    executionOptions,
+    options,
   } = args;
 
   let operation: OperationDefinitionNode | undefined;
@@ -333,7 +335,7 @@ export function buildExecutionContext(
     schema,
     variableDefinitions,
     rawVariableValues ?? {},
-    { maxErrors: executionOptions?.maxCoercionErrors ?? 50 },
+    { maxErrors: options?.maxCoercionErrors ?? 50 },
   );
 
   if (coercedVariableValues.errors) {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -152,6 +152,9 @@ export interface ExecutionArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  executionOptions?: {
+    maxCoercionErrors?: number;
+  };
 }
 
 /**
@@ -286,6 +289,7 @@ export function buildExecutionContext(
     fieldResolver,
     typeResolver,
     subscribeFieldResolver,
+    executionOptions,
   } = args;
 
   let operation: OperationDefinitionNode | undefined;
@@ -329,7 +333,7 @@ export function buildExecutionContext(
     schema,
     variableDefinitions,
     rawVariableValues ?? {},
-    { maxErrors: 50 },
+    { maxErrors: executionOptions?.maxCoercionErrors ?? 50 },
   );
 
   if (coercedVariableValues.errors) {

--- a/website/pages/api-v16/execution.mdx
+++ b/website/pages/api-v16/execution.mdx
@@ -29,20 +29,16 @@ const { execute } = require('graphql'); // CommonJS
 ### execute
 
 ```ts
-export function execute({
+export function execute(
   schema: GraphQLSchema,
-  document: DocumentNode,
-  rootValue?: unknown,
-  contextValue?: unknown,
+  documentAST: Document,
+  rootValue?: mixed,
+  contextValue?: mixed,
   variableValues?: { [key: string]: mixed },
   operationName?: string,
-  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
-  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  options?: { maxCoercionErrors?: number };
-}): PromiseOrValue<ExecutionResult>;
+): MaybePromise<ExecutionResult>;
 
-type PromiseOrValue<T> = Promise<T> | T;
+type MaybePromise<T> = Promise<T> | T;
 
 interface ExecutionResult<
   TData = ObjMap<unknown>,
@@ -65,32 +61,21 @@ a GraphQLError will be thrown immediately explaining the invalid input.
 executing the query, `errors` is null if no errors occurred, and is a
 non-empty array if an error occurred.
 
-#### options
-
-##### maxCoercionErrors
-
-Set the maximum number of errors allowed for coercing (defaults to 50).
-
 ### executeSync
 
 ```ts
-export function executeSync({
+export function executeSync(
   schema: GraphQLSchema,
-  document: DocumentNode,
-  rootValue?: unknown,
-  contextValue?: unknown,
+  documentAST: Document,
+  rootValue?: mixed,
+  contextValue?: mixed,
   variableValues?: { [key: string]: mixed },
   operationName?: string,
-  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
-  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  options?: { maxCoercionErrors?: number };
-}): ExecutionResult;
+): ExecutionResult;
 
 type ExecutionResult = {
-  errors?: ReadonlyArray<GraphQLError>;
-  data?: TData | null;
-  extensions?: TExtensions;
+  data: Object;
+  errors?: GraphQLError[];
 };
 ```
 

--- a/website/pages/api-v16/execution.mdx
+++ b/website/pages/api-v16/execution.mdx
@@ -29,16 +29,20 @@ const { execute } = require('graphql'); // CommonJS
 ### execute
 
 ```ts
-export function execute(
+export function execute({
   schema: GraphQLSchema,
-  documentAST: Document,
-  rootValue?: mixed,
-  contextValue?: mixed,
+  document: DocumentNode,
+  rootValue?: unknown,
+  contextValue?: unknown,
   variableValues?: { [key: string]: mixed },
   operationName?: string,
-): MaybePromise<ExecutionResult>;
+  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  options?: { maxCoercionErrors?: number };
+}): PromiseOrValue<ExecutionResult>;
 
-type MaybePromise<T> = Promise<T> | T;
+type PromiseOrValue<T> = Promise<T> | T;
 
 interface ExecutionResult<
   TData = ObjMap<unknown>,
@@ -61,21 +65,32 @@ a GraphQLError will be thrown immediately explaining the invalid input.
 executing the query, `errors` is null if no errors occurred, and is a
 non-empty array if an error occurred.
 
+#### options
+
+##### maxCoercionErrors
+
+Set the maximum number of errors allowed for coercing (defaults to 50).
+
 ### executeSync
 
 ```ts
-export function executeSync(
+export function executeSync({
   schema: GraphQLSchema,
-  documentAST: Document,
-  rootValue?: mixed,
-  contextValue?: mixed,
+  document: DocumentNode,
+  rootValue?: unknown,
+  contextValue?: unknown,
   variableValues?: { [key: string]: mixed },
   operationName?: string,
-): ExecutionResult;
+  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  options?: { maxCoercionErrors?: number };
+}): ExecutionResult;
 
 type ExecutionResult = {
-  data: Object;
-  errors?: GraphQLError[];
+  errors?: ReadonlyArray<GraphQLError>;
+  data?: TData | null;
+  extensions?: TExtensions;
 };
 ```
 


### PR DESCRIPTION
This PR add `executionOptions` property to the `ExecutionArgs`. Currently only one option can be configured, as is the one I need, but I have built an object so it can easily be extended in the future.

The property allows the configuration of the maximum number of errors (`maxErrors`) for coercion. This allows the current hardcoded limit (`50`) to be reduced to a small number to avoid possible DoS attacks.

> Also, it updates the execution docs to reflect this new change. I think the documentation was outdated since functions were using positional arguments and now they only accept an object.

No longer updates the docs. 