### PR TITLE
fix(coerce-input-value): input object coercion rejects arrays

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -11,7 +11,6 @@ import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
 
 import {
-  GraphQLInputObjectType,
   GraphQLInterfaceType,
   GraphQLList,
   GraphQLNonNull,
@@ -1320,120 +1319,5 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expect(result).to.deep.equal({ data: { foo: { bar: 'bar' } } });
     expect(possibleTypes).to.deep.equal([fooObject]);
-  });
-});
-
-describe('Execute: Input coercion', () => {
-  it('should reject an array directly when input is an object', () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
-        name: 'Query',
-        fields: {
-          dummy: { type: GraphQLString },
-        },
-      }),
-      mutation: new GraphQLObjectType({
-        name: 'Mutation',
-        fields: {
-          updateUser: {
-            type: GraphQLString,
-            args: {
-              data: {
-                type: new GraphQLInputObjectType({
-                  name: 'User',
-                  fields: {
-                    email: { type: new GraphQLNonNull(GraphQLString) },
-                  },
-                }),
-              },
-            },
-          },
-        },
-      }),
-    });
-
-    const document = parse(`
-      mutation ($data: User) {
-        updateUser(data: $data)
-      }
-    `);
-
-    const result = executeSync({
-      schema,
-      document,
-      variableValues: {
-        data: [
-          { email: 'test@email.com' },
-          { email: 'test1@email.com' },
-          { email: 'test2@email.com' },
-        ],
-      },
-    });
-
-    expect(result.errors).to.have.lengthOf(1);
-    expect(
-      result.errors && result.errors.length > 0
-        ? result.errors[result.errors.length - 1].message
-        : undefined,
-    ).to.contain('Expected type "User" to be an object.');
-  });
-
-  it('should not process an array when variable is an object', () => {
-    const schema = new GraphQLSchema({
-      query: new GraphQLObjectType({
-        name: 'Query',
-        fields: {
-          dummy: { type: GraphQLString },
-        },
-      }),
-      mutation: new GraphQLObjectType({
-        name: 'Mutation',
-        fields: {
-          updateUser: {
-            type: GraphQLString,
-            args: {
-              data: {
-                type: new GraphQLInputObjectType({
-                  name: 'User',
-                  fields: {
-                    metadata: {
-                      type: new GraphQLInputObjectType({
-                        name: 'Metadata',
-                        fields: {
-                          location: { type: GraphQLString },
-                        },
-                      }),
-                    },
-                  },
-                }),
-              },
-            },
-          },
-        },
-      }),
-    });
-
-    const document = parse(`
-      mutation ($data: User) {
-        updateUser(data: $data)
-      }
-    `);
-
-    const result = executeSync({
-      schema,
-      document,
-      variableValues: {
-        data: {
-          metadata: [{ location: 'USA' }, { location: 'USA' }],
-        },
-      },
-    });
-
-    expect(result.errors).to.have.lengthOf(1);
-    expect(
-      result.errors && result.errors.length > 0
-        ? result.errors[result.errors.length - 1].message
-        : undefined,
-    ).to.contain('Expected type "Metadata" to be an object.');
   });
 });

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -11,6 +11,7 @@ import { Kind } from '../../language/kinds';
 import { parse } from '../../language/parser';
 
 import {
+  GraphQLInputObjectType,
   GraphQLInterfaceType,
   GraphQLList,
   GraphQLNonNull,
@@ -1319,5 +1320,120 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expect(result).to.deep.equal({ data: { foo: { bar: 'bar' } } });
     expect(possibleTypes).to.deep.equal([fooObject]);
+  });
+});
+
+describe('Execute: Input coercion', () => {
+  it('should reject an array directly when input is an object', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          dummy: { type: GraphQLString },
+        },
+      }),
+      mutation: new GraphQLObjectType({
+        name: 'Mutation',
+        fields: {
+          updateUser: {
+            type: GraphQLString,
+            args: {
+              data: {
+                type: new GraphQLInputObjectType({
+                  name: 'User',
+                  fields: {
+                    email: { type: new GraphQLNonNull(GraphQLString) },
+                  },
+                }),
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    const document = parse(`
+      mutation ($data: User) {
+        updateUser(data: $data)
+      }
+    `);
+
+    const result = executeSync({
+      schema,
+      document,
+      variableValues: {
+        data: [
+          { email: 'test@email.com' },
+          { email: 'test1@email.com' },
+          { email: 'test2@email.com' },
+        ],
+      },
+    });
+
+    expect(result.errors).to.have.lengthOf(1);
+    expect(
+      result.errors && result.errors.length > 0
+        ? result.errors[result.errors.length - 1].message
+        : undefined,
+    ).to.contain('Expected type "User" to be an object.');
+  });
+
+  it('should not process an array when variable is an object', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          dummy: { type: GraphQLString },
+        },
+      }),
+      mutation: new GraphQLObjectType({
+        name: 'Mutation',
+        fields: {
+          updateUser: {
+            type: GraphQLString,
+            args: {
+              data: {
+                type: new GraphQLInputObjectType({
+                  name: 'User',
+                  fields: {
+                    metadata: {
+                      type: new GraphQLInputObjectType({
+                        name: 'Metadata',
+                        fields: {
+                          location: { type: GraphQLString },
+                        },
+                      }),
+                    },
+                  },
+                }),
+              },
+            },
+          },
+        },
+      }),
+    });
+
+    const document = parse(`
+      mutation ($data: User) {
+        updateUser(data: $data)
+      }
+    `);
+
+    const result = executeSync({
+      schema,
+      document,
+      variableValues: {
+        data: {
+          metadata: [{ location: 'USA' }, { location: 'USA' }],
+        },
+      },
+    });
+
+    expect(result.errors).to.have.lengthOf(1);
+    expect(
+      result.errors && result.errors.length > 0
+        ? result.errors[result.errors.length - 1].message
+        : undefined,
+    ).to.contain('Expected type "Metadata" to be an object.');
   });
 });

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -182,12 +182,20 @@ describe('coerceInputValue', () => {
     });
   });
 
-  describe('for GraphQLInputObject', () => {
+  describe.only('for GraphQLInputObject', () => {
+    const DeepObject = new GraphQLInputObjectType({
+      name: 'DeepObject',
+      fields: {
+        foo: { type: new GraphQLNonNull(GraphQLInt) },
+        bar: { type: GraphQLInt },
+      },
+    });
     const TestInputObject = new GraphQLInputObjectType({
       name: 'TestInputObject',
       fields: {
         foo: { type: new GraphQLNonNull(GraphQLInt) },
         bar: { type: GraphQLInt },
+        deepObject: { type: DeepObject },
       },
     });
 
@@ -268,6 +276,31 @@ describe('coerceInputValue', () => {
             'Field "bart" is not defined by type "TestInputObject". Did you mean "bar"?',
           path: [],
           value: { foo: 123, bart: 123 },
+        },
+      ]);
+    });
+
+    it('returns an error for an array type', () => {
+      const result = coerceValue([{ foo: 1 }, { bar: 1 }], TestInputObject);
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Expected type "TestInputObject" to be an object.',
+          path: [],
+          value: [{ foo: 1 }, { bar: 1 }],
+        },
+      ]);
+    });
+
+    it('returns an error for an array type on a nested field', () => {
+      const result = coerceValue(
+        { foo: 1, deepObject: [1, 2, 3] },
+        TestInputObject,
+      );
+      expectErrors(result).to.deep.equal([
+        {
+          error: 'Expected type "DeepObject" to be an object.',
+          path: ['deepObject'],
+          value: [1, 2, 3],
         },
       ]);
     });

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -182,7 +182,7 @@ describe('coerceInputValue', () => {
     });
   });
 
-  describe.only('for GraphQLInputObject', () => {
+  describe('for GraphQLInputObject', () => {
     const DeepObject = new GraphQLInputObjectType({
       name: 'DeepObject',
       fields: {

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -86,7 +86,7 @@ function coerceInputValueImpl(
   }
 
   if (isInputObjectType(type)) {
-    if (!isObjectLike(inputValue)) {
+    if (!isObjectLike(inputValue) || Array.isArray(inputValue)) {
       onError(
         pathToArray(path),
         inputValue,


### PR DESCRIPTION
This PR closes #4365 

Rejects arrays when input type is an object. Works for top level arrays and deep ones. 