### PR TITLE
Implement onError proposal (but with `ErrorBehavior` rather than `__ErrorBehavior`)

### DIFF
--- a/src/__tests__/starWarsIntrospection-test.ts
+++ b/src/__tests__/starWarsIntrospection-test.ts
@@ -37,7 +37,7 @@ describe('Star Wars Introspection Tests', () => {
             { name: 'Droid' },
             { name: 'Query' },
             { name: 'Boolean' },
-            { name: '__ErrorBehavior' },
+            { name: 'ErrorBehavior' },
             { name: '__Schema' },
             { name: '__Type' },
             { name: '__TypeKind' },

--- a/src/__tests__/starWarsIntrospection-test.ts
+++ b/src/__tests__/starWarsIntrospection-test.ts
@@ -37,6 +37,7 @@ describe('Star Wars Introspection Tests', () => {
             { name: 'Droid' },
             { name: 'Query' },
             { name: 'Boolean' },
+            { name: '__ErrorBehavior' },
             { name: '__Schema' },
             { name: '__Type' },
             { name: '__TypeKind' },

--- a/src/error/ErrorBehavior.ts
+++ b/src/error/ErrorBehavior.ts
@@ -1,9 +1,9 @@
-export type GraphQLErrorBehavior = 'PROPAGATE' | 'NO_PROPAGATE' | 'ABORT';
+export type GraphQLErrorBehavior = 'NO_PROPAGATE' | 'PROPAGATE' | 'ABORT';
 
 export function isErrorBehavior(
   onError: unknown,
 ): onError is GraphQLErrorBehavior {
   return (
-    onError === 'PROPAGATE' || onError === 'NO_PROPAGATE' || onError === 'ABORT'
+    onError === 'NO_PROPAGATE' || onError === 'PROPAGATE' || onError === 'ABORT'
   );
 }

--- a/src/error/ErrorBehavior.ts
+++ b/src/error/ErrorBehavior.ts
@@ -1,8 +1,6 @@
-export type GraphQLErrorBehavior = 'NO_PROPAGATE' | 'PROPAGATE' | 'ABORT';
+export type ErrorBehavior = 'NO_PROPAGATE' | 'PROPAGATE' | 'ABORT';
 
-export function isErrorBehavior(
-  onError: unknown,
-): onError is GraphQLErrorBehavior {
+export function isErrorBehavior(onError: unknown): onError is ErrorBehavior {
   return (
     onError === 'NO_PROPAGATE' || onError === 'PROPAGATE' || onError === 'ABORT'
   );

--- a/src/error/ErrorBehavior.ts
+++ b/src/error/ErrorBehavior.ts
@@ -1,0 +1,9 @@
+export type GraphQLErrorBehavior = 'PROPAGATE' | 'NO_PROPAGATE' | 'ABORT';
+
+export function isErrorBehavior(
+  onError: unknown,
+): onError is GraphQLErrorBehavior {
+  return (
+    onError === 'PROPAGATE' || onError === 'NO_PROPAGATE' || onError === 'ABORT'
+  );
+}

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -9,3 +9,4 @@ export type {
 export { syntaxError } from './syntaxError';
 
 export { locatedError } from './locatedError';
+export type { GraphQLErrorBehavior } from './ErrorBehavior';

--- a/src/error/index.ts
+++ b/src/error/index.ts
@@ -9,4 +9,4 @@ export type {
 export { syntaxError } from './syntaxError';
 
 export { locatedError } from './locatedError';
-export type { GraphQLErrorBehavior } from './ErrorBehavior';
+export type { ErrorBehavior } from './ErrorBehavior';

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -941,7 +941,6 @@ describe('Execute: Handles basic execution tasks', () => {
         fields: () => ({
           a: {
             type: GraphQLInt,
-            resolve: () => ({}),
           },
         }),
       }),

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -934,6 +934,36 @@ describe('Execute: Handles basic execution tasks', () => {
     });
   });
 
+  it('raises request error with invalid onError', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'query',
+        fields: () => ({
+          a: {
+            type: GraphQLInt,
+            resolve: () => ({}),
+          },
+        }),
+      }),
+    });
+
+    const document = parse('{ a }');
+    const result = executeSync({
+      schema,
+      document,
+      // @ts-expect-error
+      onError: 'DANCE',
+    });
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Unsupported `onError` value; supported values are `PROPAGATE`, `NO_PROPAGATE` and `ABORT`.',
+        },
+      ],
+    });
+  });
+
   it('uses the inline operation if no operation name is provided', () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -957,7 +957,7 @@ describe('Execute: Handles basic execution tasks', () => {
       errors: [
         {
           message:
-            'Unsupported `onError` value; supported values are `PROPAGATE`, `NO_PROPAGATE` and `ABORT`.',
+            'Unsupported `onError` value; supported values are `NO_PROPAGATE`, `PROPAGATE` and `ABORT`.',
         },
       ],
     });

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -288,6 +288,70 @@ describe('Execute: Handles basic execution tasks', () => {
     });
   });
 
+  it('reflects onError:NO_PROPAGATE via errorBehavior', () => {
+    let resolvedInfo;
+    const testType = new GraphQLObjectType({
+      name: 'Test',
+      fields: {
+        test: {
+          type: GraphQLString,
+          resolve(_val, _args, _ctx, info) {
+            resolvedInfo = info;
+          },
+        },
+      },
+    });
+    const schema = new GraphQLSchema({ query: testType });
+
+    const document = parse('query ($var: String) { result: test }');
+    const rootValue = { root: 'val' };
+    const variableValues = { var: 'abc' };
+
+    executeSync({
+      schema,
+      document,
+      rootValue,
+      variableValues,
+      onError: 'NO_PROPAGATE',
+    });
+
+    expect(resolvedInfo).to.include({
+      errorBehavior: 'NO_PROPAGATE',
+    });
+  });
+
+  it('reflects onError:ABORT via errorBehavior', () => {
+    let resolvedInfo;
+    const testType = new GraphQLObjectType({
+      name: 'Test',
+      fields: {
+        test: {
+          type: GraphQLString,
+          resolve(_val, _args, _ctx, info) {
+            resolvedInfo = info;
+          },
+        },
+      },
+    });
+    const schema = new GraphQLSchema({ query: testType });
+
+    const document = parse('query ($var: String) { result: test }');
+    const rootValue = { root: 'val' };
+    const variableValues = { var: 'abc' };
+
+    executeSync({
+      schema,
+      document,
+      rootValue,
+      variableValues,
+      onError: 'ABORT',
+    });
+
+    expect(resolvedInfo).to.include({
+      errorBehavior: 'ABORT',
+    });
+  });
+
   it('populates path correctly with complex types', () => {
     let path;
     const someObject = new GraphQLObjectType({
@@ -732,6 +796,134 @@ describe('Execute: Handles basic execution tasks', () => {
           aliasedA: null,
         },
       },
+      errors: [
+        {
+          message: 'Catch me if you can',
+          locations: [{ line: 7, column: 17 }],
+          path: ['nullableA', 'aliasedA', 'nonNullA', 'anotherA', 'throws'],
+        },
+      ],
+    });
+  });
+
+  it('Full response path is included for non-nullable fields with onError:NO_PROPAGATE', () => {
+    const A: GraphQLObjectType = new GraphQLObjectType({
+      name: 'A',
+      fields: () => ({
+        nullableA: {
+          type: A,
+          resolve: () => ({}),
+        },
+        nonNullA: {
+          type: new GraphQLNonNull(A),
+          resolve: () => ({}),
+        },
+        throws: {
+          type: new GraphQLNonNull(GraphQLString),
+          resolve: () => {
+            throw new Error('Catch me if you can');
+          },
+        },
+      }),
+    });
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'query',
+        fields: () => ({
+          nullableA: {
+            type: A,
+            resolve: () => ({}),
+          },
+        }),
+      }),
+    });
+
+    const document = parse(`
+      query {
+        nullableA {
+          aliasedA: nullableA {
+            nonNullA {
+              anotherA: nonNullA {
+                throws
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const result = executeSync({ schema, document, onError: 'NO_PROPAGATE' });
+    expectJSON(result).toDeepEqual({
+      data: {
+        nullableA: {
+          aliasedA: {
+            nonNullA: {
+              anotherA: {
+                throws: null,
+              },
+            },
+          },
+        },
+      },
+      errors: [
+        {
+          message: 'Catch me if you can',
+          locations: [{ line: 7, column: 17 }],
+          path: ['nullableA', 'aliasedA', 'nonNullA', 'anotherA', 'throws'],
+        },
+      ],
+    });
+  });
+
+  it('Full response path is included for non-nullable fields with onError:ABORT', () => {
+    const A: GraphQLObjectType = new GraphQLObjectType({
+      name: 'A',
+      fields: () => ({
+        nullableA: {
+          type: A,
+          resolve: () => ({}),
+        },
+        nonNullA: {
+          type: new GraphQLNonNull(A),
+          resolve: () => ({}),
+        },
+        throws: {
+          type: new GraphQLNonNull(GraphQLString),
+          resolve: () => {
+            throw new Error('Catch me if you can');
+          },
+        },
+      }),
+    });
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'query',
+        fields: () => ({
+          nullableA: {
+            type: A,
+            resolve: () => ({}),
+          },
+        }),
+      }),
+    });
+
+    const document = parse(`
+      query {
+        nullableA {
+          aliasedA: nullableA {
+            nonNullA {
+              anotherA: nonNullA {
+                throws
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const result = executeSync({ schema, document, onError: 'ABORT' });
+    expectJSON(result).toDeepEqual({
+      data: null,
       errors: [
         {
           message: 'Catch me if you can',

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -264,6 +264,7 @@ describe('Execute: Handles basic execution tasks', () => {
       'rootValue',
       'operation',
       'variableValues',
+      'errorBehavior',
     );
 
     const operation = document.definitions[0];
@@ -276,6 +277,7 @@ describe('Execute: Handles basic execution tasks', () => {
       schema,
       rootValue,
       operation,
+      errorBehavior: 'PROPAGATE',
     });
 
     const field = operation.selectionSet.selections[0];

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -13,6 +13,8 @@ import { promiseForObject } from '../jsutils/promiseForObject';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import { promiseReduce } from '../jsutils/promiseReduce';
 
+import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+import { isErrorBehavior } from '../error/ErrorBehavior';
 import type { GraphQLFormattedError } from '../error/GraphQLError';
 import { GraphQLError } from '../error/GraphQLError';
 import { locatedError } from '../error/locatedError';
@@ -115,6 +117,7 @@ export interface ExecutionContext {
   typeResolver: GraphQLTypeResolver<any, any>;
   subscribeFieldResolver: GraphQLFieldResolver<any, any>;
   errors: Array<GraphQLError>;
+  errorBehavior: GraphQLErrorBehavior;
 }
 
 /**
@@ -130,6 +133,7 @@ export interface ExecutionResult<
 > {
   errors?: ReadonlyArray<GraphQLError>;
   data?: TData | null;
+  onError?: GraphQLErrorBehavior;
   extensions?: TExtensions;
 }
 
@@ -152,6 +156,15 @@ export interface ExecutionArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  /**
+   * Experimental. Set to NO_PROPAGATE to prevent error propagation. Set to ABORT to
+   * abort a request when any error occurs.
+   *
+   * Default: PROPAGATE
+   *
+   * @experimental
+   */
+  onError?: GraphQLErrorBehavior;
   /** Additional execution options. */
   options?: {
     /** Set the maximum number of errors allowed for coercing (defaults to 50). */
@@ -291,8 +304,17 @@ export function buildExecutionContext(
     fieldResolver,
     typeResolver,
     subscribeFieldResolver,
+    onError,
     options,
   } = args;
+
+  if (onError != null && !isErrorBehavior(onError)) {
+    return [
+      new GraphQLError(
+        'Unsupported `onError` value; supported values are `PROPAGATE`, `NO_PROPAGATE` and `ABORT`.',
+      ),
+    ];
+  }
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);
@@ -353,6 +375,7 @@ export function buildExecutionContext(
     typeResolver: typeResolver ?? defaultTypeResolver,
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
     errors: [],
+    errorBehavior: onError ?? 'PROPAGATE',
   };
 }
 
@@ -591,6 +614,7 @@ export function buildResolveInfo(
     rootValue: exeContext.rootValue,
     operation: exeContext.operation,
     variableValues: exeContext.variableValues,
+    errorBehavior: exeContext.errorBehavior,
   };
 }
 
@@ -599,10 +623,25 @@ function handleFieldError(
   returnType: GraphQLOutputType,
   exeContext: ExecutionContext,
 ): null {
-  // If the field type is non-nullable, then it is resolved without any
-  // protection from errors, however it still properly locates the error.
-  if (isNonNullType(returnType)) {
+  if (exeContext.errorBehavior === 'PROPAGATE') {
+    // If the field type is non-nullable, then it is resolved without any
+    // protection from errors, however it still properly locates the error.
+    // Note: semantic non-null types are treated as nullable for the purposes
+    // of error handling.
+    if (isNonNullType(returnType)) {
+      throw error;
+    }
+  } else if (exeContext.errorBehavior === 'ABORT') {
+    // In this mode, any error aborts the request
     throw error;
+  } else if (exeContext.errorBehavior === 'NO_PROPAGATE') {
+    // In this mode, the client takes responsibility for error handling, so we
+    // treat the field as if it were nullable.
+  } else {
+    invariant(
+      false,
+      'Unexpected errorBehavior setting: ' + inspect(exeContext.errorBehavior),
+    );
   }
 
   // Otherwise, error protection is applied, logging the error and resolving

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -375,7 +375,7 @@ export function buildExecutionContext(
     typeResolver: typeResolver ?? defaultTypeResolver,
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
     errors: [],
-    errorBehavior: onError ?? 'PROPAGATE',
+    errorBehavior: onError ?? schema.defaultErrorBehavior,
   };
 }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -13,7 +13,7 @@ import { promiseForObject } from '../jsutils/promiseForObject';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import { promiseReduce } from '../jsutils/promiseReduce';
 
-import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+import type { ErrorBehavior } from '../error/ErrorBehavior';
 import { isErrorBehavior } from '../error/ErrorBehavior';
 import type { GraphQLFormattedError } from '../error/GraphQLError';
 import { GraphQLError } from '../error/GraphQLError';
@@ -117,7 +117,7 @@ export interface ExecutionContext {
   typeResolver: GraphQLTypeResolver<any, any>;
   subscribeFieldResolver: GraphQLFieldResolver<any, any>;
   errors: Array<GraphQLError>;
-  errorBehavior: GraphQLErrorBehavior;
+  errorBehavior: ErrorBehavior;
 }
 
 /**
@@ -133,7 +133,6 @@ export interface ExecutionResult<
 > {
   errors?: ReadonlyArray<GraphQLError>;
   data?: TData | null;
-  onError?: GraphQLErrorBehavior;
   extensions?: TExtensions;
 }
 
@@ -164,7 +163,7 @@ export interface ExecutionArgs {
    *
    * @experimental
    */
-  onError?: GraphQLErrorBehavior;
+  onError?: ErrorBehavior;
   /** Additional execution options. */
   options?: {
     /** Set the maximum number of errors allowed for coercing (defaults to 50). */

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -637,8 +637,8 @@ function handleFieldError(
   } else if (exeContext.errorBehavior === 'NO_PROPAGATE') {
     // In this mode, the client takes responsibility for error handling, so we
     // treat the field as if it were nullable.
+    /* c8 ignore next 6 */
   } else {
-    /* c8 ignore next 5 */
     invariant(
       false,
       'Unexpected errorBehavior setting: ' + inspect(exeContext.errorBehavior),

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -638,6 +638,7 @@ function handleFieldError(
     // In this mode, the client takes responsibility for error handling, so we
     // treat the field as if it were nullable.
   } else {
+    /* c8 ignore next 4 */
     invariant(
       false,
       'Unexpected errorBehavior setting: ' + inspect(exeContext.errorBehavior),

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -638,7 +638,7 @@ function handleFieldError(
     // In this mode, the client takes responsibility for error handling, so we
     // treat the field as if it were nullable.
   } else {
-    /* c8 ignore next 4 */
+    /* c8 ignore next 5 */
     invariant(
       false,
       'Unexpected errorBehavior setting: ' + inspect(exeContext.errorBehavior),

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -311,7 +311,7 @@ export function buildExecutionContext(
   if (onError != null && !isErrorBehavior(onError)) {
     return [
       new GraphQLError(
-        'Unsupported `onError` value; supported values are `PROPAGATE`, `NO_PROPAGATE` and `ABORT`.',
+        'Unsupported `onError` value; supported values are `NO_PROPAGATE`, `PROPAGATE` and `ABORT`.',
       ),
     ];
   }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3,7 +3,7 @@ import { isPromise } from './jsutils/isPromise';
 import type { Maybe } from './jsutils/Maybe';
 import type { PromiseOrValue } from './jsutils/PromiseOrValue';
 
-import type { GraphQLErrorBehavior } from './error/ErrorBehavior';
+import type { ErrorBehavior } from './error/ErrorBehavior';
 
 import { parse } from './language/parser';
 import type { Source } from './language/source';
@@ -76,7 +76,7 @@ export interface GraphQLArgs {
    *
    * @experimental
    */
-  onError?: GraphQLErrorBehavior;
+  onError?: ErrorBehavior;
 }
 
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -3,6 +3,8 @@ import { isPromise } from './jsutils/isPromise';
 import type { Maybe } from './jsutils/Maybe';
 import type { PromiseOrValue } from './jsutils/PromiseOrValue';
 
+import type { GraphQLErrorBehavior } from './error/ErrorBehavior';
+
 import { parse } from './language/parser';
 import type { Source } from './language/source';
 
@@ -66,6 +68,15 @@ export interface GraphQLArgs {
   operationName?: Maybe<string>;
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  /**
+   * Experimental. Set to NO_PROPAGATE to prevent error propagation. Set to ABORT to
+   * abort a request when any error occurs.
+   *
+   * Default: PROPAGATE
+   *
+   * @experimental
+   */
+  onError?: GraphQLErrorBehavior;
 }
 
 export function graphql(args: GraphQLArgs): Promise<ExecutionResult> {
@@ -106,6 +117,7 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
+    onError,
   } = args;
 
   // Validate Schema
@@ -138,5 +150,6 @@ function graphqlImpl(args: GraphQLArgs): PromiseOrValue<ExecutionResult> {
     operationName,
     fieldResolver,
     typeResolver,
+    onError,
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
+  __ErrorBehavior,
   // Meta-field definitions.
   SchemaMetaFieldDef,
   TypeMetaFieldDef,

--- a/src/index.ts
+++ b/src/index.ts
@@ -395,6 +395,7 @@ export {
 } from './error/index';
 
 export type {
+  GraphQLErrorBehavior,
   GraphQLErrorOptions,
   GraphQLFormattedError,
   GraphQLErrorExtensions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,9 @@ export {
   GraphQLString,
   GraphQLBoolean,
   GraphQLID,
+  // Standard GraphQL Enums
+  specifiedEnumTypes,
+  GraphQLErrorBehavior,
   // Int boundaries constants
   GRAPHQL_MAX_INT,
   GRAPHQL_MIN_INT,
@@ -79,7 +82,6 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-  __ErrorBehavior,
   // Meta-field definitions.
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
@@ -107,6 +109,7 @@ export {
   isRequiredArgument,
   isRequiredInputField,
   isSpecifiedScalarType,
+  isSpecifiedEnumType,
   isIntrospectionType,
   isSpecifiedDirective,
   // Assertions
@@ -396,7 +399,7 @@ export {
 } from './error/index';
 
 export type {
-  GraphQLErrorBehavior,
+  ErrorBehavior,
   GraphQLErrorOptions,
   GraphQLFormattedError,
   GraphQLErrorExtensions,

--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -102,7 +102,7 @@ describe('Introspection', () => {
               inputFields: null,
               interfaces: null,
               kind: 'ENUM',
-              name: '__ErrorBehavior',
+              name: 'ErrorBehavior',
               possibleTypes: null,
               specifiedByURL: null,
             },
@@ -213,7 +213,7 @@ describe('Introspection', () => {
                     name: null,
                     ofType: {
                       kind: 'ENUM',
-                      name: '__ErrorBehavior',
+                      name: 'ErrorBehavior',
                       ofType: null,
                     },
                   },
@@ -1059,7 +1059,7 @@ describe('Introspection', () => {
                     name: null,
                     ofType: {
                       kind: 'ENUM',
-                      name: '__ErrorBehavior',
+                      name: 'ErrorBehavior',
                       ofType: null,
                     },
                   },

--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -81,6 +81,32 @@ describe('Introspection', () => {
               possibleTypes: null,
             },
             {
+              enumValues: [
+                {
+                  deprecationReason: null,
+                  isDeprecated: false,
+                  name: 'NO_PROPAGATE',
+                },
+                {
+                  deprecationReason: null,
+                  isDeprecated: false,
+                  name: 'PROPAGATE',
+                },
+                {
+                  deprecationReason: null,
+                  isDeprecated: false,
+                  name: 'ABORT',
+                },
+              ],
+              fields: null,
+              inputFields: null,
+              interfaces: null,
+              kind: 'ENUM',
+              name: '__ErrorBehavior',
+              possibleTypes: null,
+              specifiedByURL: null,
+            },
+            {
               kind: 'OBJECT',
               name: '__Schema',
               specifiedByURL: null,
@@ -174,6 +200,21 @@ describe('Introspection', () => {
                           ofType: null,
                         },
                       },
+                    },
+                  },
+                  isDeprecated: false,
+                  deprecationReason: null,
+                },
+                {
+                  name: 'defaultErrorBehavior',
+                  args: [],
+                  type: {
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'ENUM',
+                      name: '__ErrorBehavior',
+                      ofType: null,
                     },
                   },
                   isDeprecated: false,
@@ -1008,6 +1049,26 @@ describe('Introspection', () => {
               locations: ['INPUT_OBJECT'],
               args: [],
             },
+            {
+              args: [
+                {
+                  defaultValue: 'PROPAGATE',
+                  name: 'onError',
+                  type: {
+                    kind: 'NON_NULL',
+                    name: null,
+                    ofType: {
+                      kind: 'ENUM',
+                      name: '__ErrorBehavior',
+                      ofType: null,
+                    },
+                  },
+                },
+              ],
+              isRepeatable: false,
+              locations: ['SCHEMA'],
+              name: 'behavior',
+            },
           ],
         },
       },
@@ -1768,11 +1829,13 @@ describe('Introspection', () => {
       }
     `);
 
-    const source = getIntrospectionQuery({
-      descriptions: false,
-      specifiedByUrl: true,
-      directiveIsRepeatable: true,
-    });
+    const source = /* GraphQL */ `
+      {
+        __schema {
+          defaultErrorBehavior
+        }
+      }
+    `;
 
     const result = graphqlSync({ schema, source });
     expect(result).to.deep.equal({

--- a/src/type/__tests__/predicate-test.ts
+++ b/src/type/__tests__/predicate-test.ts
@@ -65,6 +65,7 @@ import {
   isDirective,
   isSpecifiedDirective,
 } from '../directives';
+import { GraphQLErrorBehavior, isSpecifiedEnumType } from '../enums';
 import {
   GraphQLBoolean,
   GraphQLFloat,
@@ -163,6 +164,16 @@ describe('Type predicates', () => {
 
     it('returns false for custom scalar', () => {
       expect(isSpecifiedScalarType(ScalarType)).to.equal(false);
+    });
+  });
+
+  describe('isSpecifiedEnumType', () => {
+    it('returns true for specified enums', () => {
+      expect(isSpecifiedEnumType(GraphQLErrorBehavior)).to.equal(true);
+    });
+
+    it('returns false for custom scalar', () => {
+      expect(isSpecifiedEnumType(EnumType)).to.equal(false);
     });
   });
 

--- a/src/type/__tests__/schema-test.ts
+++ b/src/type/__tests__/schema-test.ts
@@ -296,7 +296,7 @@ describe('Type System: Schema', () => {
       'ASub',
       'Boolean',
       'String',
-      '__ErrorBehavior',
+      'ErrorBehavior',
       '__Schema',
       '__Type',
       '__TypeKind',

--- a/src/type/__tests__/schema-test.ts
+++ b/src/type/__tests__/schema-test.ts
@@ -296,6 +296,7 @@ describe('Type System: Schema', () => {
       'ASub',
       'Boolean',
       'String',
+      '__ErrorBehavior',
       '__Schema',
       '__Type',
       '__TypeKind',

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -14,6 +14,7 @@ import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import { suggestionList } from '../jsutils/suggestionList';
 import { toObjMap } from '../jsutils/toObjMap';
 
+import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
 import { GraphQLError } from '../error/GraphQLError';
 
 import type {
@@ -988,6 +989,8 @@ export interface GraphQLResolveInfo {
   readonly rootValue: unknown;
   readonly operation: OperationDefinitionNode;
   readonly variableValues: { [variable: string]: unknown };
+  /** @experimental */
+  readonly errorBehavior: GraphQLErrorBehavior;
 }
 
 /**

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -14,7 +14,7 @@ import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import { suggestionList } from '../jsutils/suggestionList';
 import { toObjMap } from '../jsutils/toObjMap';
 
-import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+import type { ErrorBehavior } from '../error/ErrorBehavior';
 import { GraphQLError } from '../error/GraphQLError';
 
 import type {
@@ -990,7 +990,7 @@ export interface GraphQLResolveInfo {
   readonly operation: OperationDefinitionNode;
   readonly variableValues: { [variable: string]: unknown };
   /** @experimental */
-  readonly errorBehavior: GraphQLErrorBehavior;
+  readonly errorBehavior: ErrorBehavior;
 }
 
 /**

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -18,7 +18,7 @@ import {
   defineArguments,
   GraphQLNonNull,
 } from './definition';
-import { __ErrorBehavior } from './introspection';
+import { GraphQLErrorBehavior } from './enums';
 import { GraphQLBoolean, GraphQLString } from './scalars';
 
 /**
@@ -230,7 +230,7 @@ export const GraphQLBehaviorDirective: GraphQLDirective = new GraphQLDirective({
   locations: [DirectiveLocation.SCHEMA],
   args: {
     onError: {
-      type: new GraphQLNonNull(__ErrorBehavior),
+      type: new GraphQLNonNull(GraphQLErrorBehavior),
       defaultValue: 'PROPAGATE',
     },
   },

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -18,6 +18,7 @@ import {
   defineArguments,
   GraphQLNonNull,
 } from './definition';
+import { __ErrorBehavior } from './introspection';
 import { GraphQLBoolean, GraphQLString } from './scalars';
 
 /**
@@ -221,6 +222,21 @@ export const GraphQLOneOfDirective: GraphQLDirective = new GraphQLDirective({
 });
 
 /**
+ * Used to indicate the default error behavior.
+ */
+export const GraphQLBehaviorDirective: GraphQLDirective = new GraphQLDirective({
+  name: 'behavior',
+  description: 'Indicates the default error behavior of the schema.',
+  locations: [DirectiveLocation.SCHEMA],
+  args: {
+    onError: {
+      type: new GraphQLNonNull(__ErrorBehavior),
+      defaultValue: 'PROPAGATE',
+    },
+  },
+});
+
+/**
  * The full list of specified directives.
  */
 export const specifiedDirectives: ReadonlyArray<GraphQLDirective> =
@@ -230,6 +246,7 @@ export const specifiedDirectives: ReadonlyArray<GraphQLDirective> =
     GraphQLDeprecatedDirective,
     GraphQLSpecifiedByDirective,
     GraphQLOneOfDirective,
+    GraphQLBehaviorDirective,
   ]);
 
 export function isSpecifiedDirective(directive: GraphQLDirective): boolean {

--- a/src/type/enums.ts
+++ b/src/type/enums.ts
@@ -1,0 +1,33 @@
+import type { GraphQLNamedType } from './definition';
+import { GraphQLEnumType } from './definition';
+
+export const GraphQLErrorBehavior: GraphQLEnumType = new GraphQLEnumType({
+  name: 'ErrorBehavior',
+  description:
+    'An enum detailing the error behavior a GraphQL request should use.',
+  values: {
+    NO_PROPAGATE: {
+      value: 'NO_PROPAGATE',
+      description:
+        'Indicates that an error should result in the response position becoming null, even if it is marked as non-null.',
+    },
+    PROPAGATE: {
+      value: 'PROPAGATE',
+      description:
+        'Indicates that an error that occurs in a non-null position should propagate to the nearest nullable response position.',
+    },
+    ABORT: {
+      value: 'ABORT',
+      description:
+        'Indicates execution should cease when the first error occurs, and that the response data should be null.',
+    },
+  },
+});
+
+export const specifiedEnumTypes: ReadonlyArray<GraphQLEnumType> = Object.freeze(
+  [GraphQLErrorBehavior],
+);
+
+export function isSpecifiedEnumType(type: GraphQLNamedType): boolean {
+  return specifiedEnumTypes.some(({ name }) => type.name === name);
+}

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -158,6 +158,13 @@ export {
   GRAPHQL_MAX_INT,
   GRAPHQL_MIN_INT,
 } from './scalars';
+export {
+  // Predicate
+  isSpecifiedEnumType,
+  // Standard GraphQL Enums
+  specifiedEnumTypes,
+  GraphQLErrorBehavior,
+} from './enums';
 
 export {
   // Predicate
@@ -172,7 +179,6 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
-  __ErrorBehavior,
   // "Enum" of Type Kinds
   TypeKind,
   // Meta-field definitions.

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -172,6 +172,7 @@ export {
   __InputValue,
   __EnumValue,
   __TypeKind,
+  __ErrorBehavior,
   // "Enum" of Type Kinds
   TypeKind,
   // Meta-field definitions.

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -74,6 +74,12 @@ export const __Schema: GraphQLObjectType = new GraphQLObjectType({
         ),
         resolve: (schema) => schema.getDirectives(),
       },
+      defaultErrorBehavior: {
+        description:
+          'The default error behavior that will be used for requests which do not specify `onError`.',
+        type: new GraphQLNonNull(__ErrorBehavior),
+        resolve: (schema) => schema.defaultErrorBehavior,
+      },
     } as GraphQLFieldConfigMap<GraphQLSchema, unknown>),
 });
 
@@ -500,6 +506,29 @@ export const __TypeKind: GraphQLEnumType = new GraphQLEnumType({
   },
 });
 
+export const __ErrorBehavior: GraphQLEnumType = new GraphQLEnumType({
+  name: '__ErrorBehavior',
+  description:
+    'An enum detailing the error behavior a GraphQL request should use.',
+  values: {
+    NO_PROPAGATE: {
+      value: 'NO_PROPAGATE',
+      description:
+        'Indicates that an error should result in the response position becoming null, even if it is marked as non-null.',
+    },
+    PROPAGATE: {
+      value: 'PROPAGATE',
+      description:
+        'Indicates that an error that occurs in a non-null position should propagate to the nearest nullable response position.',
+    },
+    ABORT: {
+      value: 'ABORT',
+      description:
+        'Indicates execution should cease when the first error occurs, and that the response data should be null.',
+    },
+  },
+});
+
 /**
  * Note that these are GraphQLField and not GraphQLFieldConfig,
  * so the format for args is different.
@@ -558,6 +587,7 @@ export const introspectionTypes: ReadonlyArray<GraphQLNamedType> =
     __InputValue,
     __EnumValue,
     __TypeKind,
+    __ErrorBehavior,
   ]);
 
 export function isIntrospectionType(type: GraphQLNamedType): boolean {

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -30,6 +30,7 @@ import {
   isUnionType,
 } from './definition';
 import type { GraphQLDirective } from './directives';
+import { GraphQLErrorBehavior } from './enums';
 import { GraphQLBoolean, GraphQLString } from './scalars';
 import type { GraphQLSchema } from './schema';
 
@@ -77,7 +78,7 @@ export const __Schema: GraphQLObjectType = new GraphQLObjectType({
       defaultErrorBehavior: {
         description:
           'The default error behavior that will be used for requests which do not specify `onError`.',
-        type: new GraphQLNonNull(__ErrorBehavior),
+        type: new GraphQLNonNull(GraphQLErrorBehavior),
         resolve: (schema) => schema.defaultErrorBehavior,
       },
     } as GraphQLFieldConfigMap<GraphQLSchema, unknown>),
@@ -506,29 +507,6 @@ export const __TypeKind: GraphQLEnumType = new GraphQLEnumType({
   },
 });
 
-export const __ErrorBehavior: GraphQLEnumType = new GraphQLEnumType({
-  name: '__ErrorBehavior',
-  description:
-    'An enum detailing the error behavior a GraphQL request should use.',
-  values: {
-    NO_PROPAGATE: {
-      value: 'NO_PROPAGATE',
-      description:
-        'Indicates that an error should result in the response position becoming null, even if it is marked as non-null.',
-    },
-    PROPAGATE: {
-      value: 'PROPAGATE',
-      description:
-        'Indicates that an error that occurs in a non-null position should propagate to the nearest nullable response position.',
-    },
-    ABORT: {
-      value: 'ABORT',
-      description:
-        'Indicates execution should cease when the first error occurs, and that the response data should be null.',
-    },
-  },
-});
-
 /**
  * Note that these are GraphQLField and not GraphQLFieldConfig,
  * so the format for args is different.
@@ -587,7 +565,7 @@ export const introspectionTypes: ReadonlyArray<GraphQLNamedType> =
     __InputValue,
     __EnumValue,
     __TypeKind,
-    __ErrorBehavior,
+    // ErrorBehavior,
   ]);
 
 export function isIntrospectionType(type: GraphQLNamedType): boolean {

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -6,7 +6,7 @@ import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
 import { toObjMap } from '../jsutils/toObjMap';
 
-import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+import type { ErrorBehavior } from '../error/ErrorBehavior';
 import { isErrorBehavior } from '../error/ErrorBehavior';
 import type { GraphQLError } from '../error/GraphQLError';
 
@@ -132,7 +132,7 @@ export interface GraphQLSchemaExtensions {
 export class GraphQLSchema {
   description: Maybe<string>;
   /** @experimental */
-  readonly defaultErrorBehavior: GraphQLErrorBehavior;
+  readonly defaultErrorBehavior: ErrorBehavior;
   extensions: Readonly<GraphQLSchemaExtensions>;
   astNode: Maybe<SchemaDefinitionNode>;
   extensionASTNodes: ReadonlyArray<SchemaExtensionNode>;
@@ -410,7 +410,7 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
    *
    * @experimental
    */
-  defaultErrorBehavior?: Maybe<GraphQLErrorBehavior>;
+  defaultErrorBehavior?: Maybe<ErrorBehavior>;
   extensions?: Maybe<Readonly<GraphQLSchemaExtensions>>;
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -31,6 +31,8 @@ import {
 import type { GraphQLDirective } from './directives';
 import { isDirective, specifiedDirectives } from './directives';
 import { __Schema } from './introspection';
+import type { GraphQLErrorBehavior } from '../error';
+import { isErrorBehavior } from '../error/ErrorBehavior';
 
 /**
  * Test if the given value is a GraphQL schema.
@@ -129,6 +131,8 @@ export interface GraphQLSchemaExtensions {
  */
 export class GraphQLSchema {
   description: Maybe<string>;
+  /** @experimental */
+  readonly defaultErrorBehavior: GraphQLErrorBehavior;
   extensions: Readonly<GraphQLSchemaExtensions>;
   astNode: Maybe<SchemaDefinitionNode>;
   extensionASTNodes: ReadonlyArray<SchemaExtensionNode>;
@@ -163,8 +167,15 @@ export class GraphQLSchema {
       '"directives" must be Array if provided but got: ' +
         `${inspect(config.directives)}.`,
     );
+    devAssert(
+      !config.defaultErrorBehavior ||
+        isErrorBehavior(config.defaultErrorBehavior),
+      '"defaultErrorBehavior" must be one of "NO_PROPAGATE", "PROPAGATE" or "ABORT", but got: ' +
+        `${inspect(config.defaultErrorBehavior)}.`,
+    );
 
     this.description = config.description;
+    this.defaultErrorBehavior = config.defaultErrorBehavior ?? 'PROPAGATE';
     this.extensions = toObjMap(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
@@ -386,6 +397,20 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
   subscription?: Maybe<GraphQLObjectType>;
   types?: Maybe<ReadonlyArray<GraphQLNamedType>>;
   directives?: Maybe<ReadonlyArray<GraphQLDirective>>;
+  /**
+   * Experimental. Defines the default GraphQL error behavior when the
+   * GraphQLArgs does not include an `onError` property.
+   *
+   * Set to NO_PROPAGATE if your schema only needs to support modern
+   * "error-handling" clients.
+   *
+   * It is not recommended to set this to ABORT.
+   *
+   * Default: PROPAGATE
+   *
+   * @experimental
+   */
+  defaultErrorBehavior?: GraphQLErrorBehavior;
   extensions?: Maybe<Readonly<GraphQLSchemaExtensions>>;
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -6,6 +6,8 @@ import type { Maybe } from '../jsutils/Maybe';
 import type { ObjMap } from '../jsutils/ObjMap';
 import { toObjMap } from '../jsutils/toObjMap';
 
+import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+import { isErrorBehavior } from '../error/ErrorBehavior';
 import type { GraphQLError } from '../error/GraphQLError';
 
 import type {
@@ -31,8 +33,6 @@ import {
 import type { GraphQLDirective } from './directives';
 import { isDirective, specifiedDirectives } from './directives';
 import { __Schema } from './introspection';
-import type { GraphQLErrorBehavior } from '../error';
-import { isErrorBehavior } from '../error/ErrorBehavior';
 
 /**
  * Test if the given value is a GraphQL schema.

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -410,7 +410,7 @@ export interface GraphQLSchemaConfig extends GraphQLSchemaValidationOptions {
    *
    * @experimental
    */
-  defaultErrorBehavior?: GraphQLErrorBehavior;
+  defaultErrorBehavior?: Maybe<GraphQLErrorBehavior>;
   extensions?: Maybe<Readonly<GraphQLSchemaExtensions>>;
   astNode?: Maybe<SchemaDefinitionNode>;
   extensionASTNodes?: Maybe<ReadonlyArray<SchemaExtensionNode>>;

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -21,6 +21,7 @@ import {
 } from '../../type/definition';
 import {
   assertDirective,
+  GraphQLBehaviorDirective,
   GraphQLDeprecatedDirective,
   GraphQLIncludeDirective,
   GraphQLOneOfDirective,
@@ -223,7 +224,7 @@ describe('Schema Builder', () => {
   it('Maintains @include, @skip & @specifiedBy', () => {
     const schema = buildSchema('type Query');
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.equal(GraphQLIncludeDirective);
     expect(schema.getDirective('deprecated')).to.equal(
@@ -232,6 +233,7 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('behavior')).to.equal(GraphQLBehaviorDirective);
     expect(schema.getDirective('oneOf')).to.equal(GraphQLOneOfDirective);
   });
 
@@ -241,10 +243,11 @@ describe('Schema Builder', () => {
       directive @include on FIELD
       directive @deprecated on FIELD_DEFINITION
       directive @specifiedBy on FIELD_DEFINITION
+      directive @behavior on SCHEMA
       directive @oneOf on OBJECT
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(5);
+    expect(schema.getDirectives()).to.have.lengthOf(6);
     expect(schema.getDirective('skip')).to.not.equal(GraphQLSkipDirective);
     expect(schema.getDirective('include')).to.not.equal(
       GraphQLIncludeDirective,
@@ -255,19 +258,23 @@ describe('Schema Builder', () => {
     expect(schema.getDirective('specifiedBy')).to.not.equal(
       GraphQLSpecifiedByDirective,
     );
+    expect(schema.getDirective('behavior')).to.not.equal(
+      GraphQLBehaviorDirective,
+    );
     expect(schema.getDirective('oneOf')).to.not.equal(GraphQLOneOfDirective);
   });
 
-  it('Adding directives maintains @include, @skip, @deprecated, @specifiedBy, and @oneOf', () => {
+  it('Adding directives maintains @include, @skip, @deprecated, @specifiedBy, @behavior and @oneOf', () => {
     const schema = buildSchema(`
       directive @foo(arg: Int) on FIELD
     `);
 
-    expect(schema.getDirectives()).to.have.lengthOf(6);
+    expect(schema.getDirectives()).to.have.lengthOf(7);
     expect(schema.getDirective('skip')).to.not.equal(undefined);
     expect(schema.getDirective('include')).to.not.equal(undefined);
     expect(schema.getDirective('deprecated')).to.not.equal(undefined);
     expect(schema.getDirective('specifiedBy')).to.not.equal(undefined);
+    expect(schema.getDirective('behavior')).to.not.equal(undefined);
     expect(schema.getDirective('oneOf')).to.not.equal(undefined);
   });
 

--- a/src/utilities/__tests__/buildClientSchema-test.ts
+++ b/src/utilities/__tests__/buildClientSchema-test.ts
@@ -18,6 +18,7 @@ import {
   GraphQLString,
 } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
+import { validateSchema } from '../../type/validate';
 
 import { graphqlSync } from '../../graphql';
 
@@ -156,6 +157,26 @@ describe('Type System: build schema from introspection', () => {
     expect(clientSchema.getType('Int')).to.equal(undefined);
     expect(clientSchema.getType('Float')).to.equal(undefined);
     expect(clientSchema.getType('ID')).to.equal(undefined);
+  });
+
+  it('reflects defaultErrorBehavior', () => {
+    const schema = buildSchema(`
+      schema @behavior(onError: NO_PROPAGATE) {
+        query: Query
+      }
+      type Query {
+        foo: String
+      }
+    `);
+    const introspection = introspectionFromSchema(schema, {
+      errorBehavior: true,
+    });
+    const clientSchema = buildClientSchema(introspection);
+
+    expect(clientSchema.defaultErrorBehavior).to.equal('NO_PROPAGATE');
+
+    const errors = validateSchema(clientSchema);
+    expect(errors).to.have.length(0);
   });
 
   it('builds a schema with a recursive type reference', () => {

--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import {
+  GraphQLBehaviorDirective,
   GraphQLDeprecatedDirective,
   GraphQLIncludeDirective,
   GraphQLOneOfDirective,
@@ -803,6 +804,7 @@ describe('findBreakingChanges', () => {
         GraphQLSkipDirective,
         GraphQLIncludeDirective,
         GraphQLSpecifiedByDirective,
+        GraphQLBehaviorDirective,
         GraphQLOneOfDirective,
       ],
     });

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -710,10 +710,10 @@ describe('Type System Printer', () => {
       directive @oneOf on INPUT_OBJECT
 
       """Indicates the default error behavior of the schema."""
-      directive @behavior(onError: __ErrorBehavior! = PROPAGATE) on SCHEMA
+      directive @behavior(onError: ErrorBehavior! = PROPAGATE) on SCHEMA
       
       """An enum detailing the error behavior a GraphQL request should use."""
-      enum __ErrorBehavior {
+      enum ErrorBehavior {
         """
         Indicates that an error should result in the response position becoming null, even if it is marked as non-null.
         """
@@ -758,7 +758,7 @@ describe('Type System Printer', () => {
         """
         The default error behavior that will be used for requests which do not specify \`onError\`.
         """
-        defaultErrorBehavior: __ErrorBehavior!
+        defaultErrorBehavior: ErrorBehavior!
       }
 
       """

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -694,6 +694,27 @@ describe('Type System Printer', () => {
       """
       directive @oneOf on INPUT_OBJECT
 
+      """Indicates the default error behavior of the schema."""
+      directive @behavior(onError: __ErrorBehavior! = PROPAGATE) on SCHEMA
+      
+      """An enum detailing the error behavior a GraphQL request should use."""
+      enum __ErrorBehavior {
+        """
+        Indicates that an error should result in the response position becoming null, even if it is marked as non-null.
+        """
+        NO_PROPAGATE
+      
+        """
+        Indicates that an error that occurs in a non-null position should propagate to the nearest nullable response position.
+        """
+        PROPAGATE
+      
+        """
+        Indicates execution should cease when the first error occurs, and that the response data should be null.
+        """
+        ABORT
+      }
+
       """
       A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.
       """
@@ -718,6 +739,11 @@ describe('Type System Printer', () => {
 
         """A list of all directives supported by this server."""
         directives: [__Directive!]!
+
+        """
+        The default error behavior that will be used for requests which do not specify \`onError\`.
+        """
+        defaultErrorBehavior: __ErrorBehavior!
       }
 
       """

--- a/src/utilities/__tests__/printSchema-test.ts
+++ b/src/utilities/__tests__/printSchema-test.ts
@@ -276,6 +276,21 @@ describe('Type System Printer', () => {
     `);
   });
 
+  it('Prints schema with NO_PROPAGATE error behavior', () => {
+    const schema = new GraphQLSchema({
+      defaultErrorBehavior: 'NO_PROPAGATE',
+      query: new GraphQLObjectType({ name: 'Query', fields: {} }),
+    });
+
+    expectPrintedSchema(schema).to.equal(dedent`
+      schema @behavior(onError: NO_PROPAGATE) {
+        query: Query
+      }
+
+      type Query
+    `);
+  });
+
   it('Omits schema of common names', () => {
     const schema = new GraphQLSchema({
       query: new GraphQLObjectType({ name: 'Query', fields: {} }),

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -27,6 +27,7 @@ import {
   isOutputType,
 } from '../type/definition';
 import { GraphQLDirective } from '../type/directives';
+import { specifiedEnumTypes } from '../type/enums';
 import { introspectionTypes, TypeKind } from '../type/introspection';
 import { specifiedScalarTypes } from '../type/scalars';
 import type { GraphQLSchemaValidationOptions } from '../type/schema';
@@ -83,7 +84,11 @@ export function buildClientSchema(
   );
 
   // Include standard types only if they are used.
-  for (const stdType of [...specifiedScalarTypes, ...introspectionTypes]) {
+  for (const stdType of [
+    ...specifiedScalarTypes,
+    ...specifiedEnumTypes,
+    ...introspectionTypes,
+  ]) {
     if (typeMap[stdType.name]) {
       typeMap[stdType.name] = stdType;
     }

--- a/src/utilities/buildClientSchema.ts
+++ b/src/utilities/buildClientSchema.ts
@@ -108,6 +108,8 @@ export function buildClientSchema(
     ? schemaIntrospection.directives.map(buildDirective)
     : [];
 
+  const defaultErrorBehavior = schemaIntrospection.defaultErrorBehavior;
+
   // Then produce and return a Schema with these types.
   return new GraphQLSchema({
     description: schemaIntrospection.description,
@@ -116,6 +118,7 @@ export function buildClientSchema(
     subscription: subscriptionType,
     types: Object.values(typeMap),
     directives,
+    defaultErrorBehavior,
     assumeValid: options?.assumeValid,
   });
 

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -5,6 +5,8 @@ import { keyMap } from '../jsutils/keyMap';
 import { mapValue } from '../jsutils/mapValue';
 import type { Maybe } from '../jsutils/Maybe';
 
+import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+
 import type {
   DirectiveDefinitionNode,
   DocumentNode,
@@ -83,7 +85,6 @@ import { assertValidSDLExtension } from '../validation/validate';
 import { getDirectiveValues } from '../execution/values';
 
 import { valueFromAST } from './valueFromAST';
-import type { GraphQLErrorBehavior } from '../error';
 
 interface Options extends GraphQLSchemaValidationOptions {
   /**

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -184,10 +184,10 @@ function findTypeChanges(
   for (const oldType of typesDiff.removed) {
     schemaChanges.push({
       type: BreakingChangeType.TYPE_REMOVED,
+      /* c8 ignore next 5 */
       description: isSpecifiedScalarType(oldType)
         ? `Standard scalar ${oldType.name} was removed because it is not referenced anymore.`
-        : /* c8 ignore next 2 */
-        isSpecifiedEnumType(oldType)
+        : isSpecifiedEnumType(oldType)
         ? `Standard enum ${oldType.name} was removed because it is not referenced anymore.`
         : `${oldType.name} was removed.`,
     });

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -186,7 +186,8 @@ function findTypeChanges(
       type: BreakingChangeType.TYPE_REMOVED,
       description: isSpecifiedScalarType(oldType)
         ? `Standard scalar ${oldType.name} was removed because it is not referenced anymore.`
-        : isSpecifiedEnumType(oldType)
+        : /* c8 ignore next 2 */
+        isSpecifiedEnumType(oldType)
         ? `Standard enum ${oldType.name} was removed because it is not referenced anymore.`
         : `${oldType.name} was removed.`,
     });

--- a/src/utilities/findBreakingChanges.ts
+++ b/src/utilities/findBreakingChanges.ts
@@ -28,6 +28,7 @@ import {
   isScalarType,
   isUnionType,
 } from '../type/definition';
+import { isSpecifiedEnumType } from '../type/enums';
 import { isSpecifiedScalarType } from '../type/scalars';
 import type { GraphQLSchema } from '../type/schema';
 
@@ -185,6 +186,8 @@ function findTypeChanges(
       type: BreakingChangeType.TYPE_REMOVED,
       description: isSpecifiedScalarType(oldType)
         ? `Standard scalar ${oldType.name} was removed because it is not referenced anymore.`
+        : isSpecifiedEnumType(oldType)
+        ? `Standard enum ${oldType.name} was removed because it is not referenced anymore.`
         : `${oldType.name} was removed.`,
     });
   }

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -1,5 +1,7 @@
 import type { Maybe } from '../jsutils/Maybe';
 
+import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+
 import type { DirectiveLocation } from '../language/directiveLocation';
 
 export interface IntrospectionOptions {
@@ -206,6 +208,7 @@ export interface IntrospectionSchema {
   >;
   readonly types: ReadonlyArray<IntrospectionType>;
   readonly directives: ReadonlyArray<IntrospectionDirective>;
+  readonly defaultErrorBehavior?: Maybe<GraphQLErrorBehavior>;
 }
 
 export type IntrospectionType =

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -38,6 +38,12 @@ export interface IntrospectionOptions {
    * Default: false
    */
   oneOf?: boolean;
+
+  /**
+   * Whether target GraphQL server supports changing error behaviors.
+   * Default: false
+   */
+  errorBehavior?: boolean;
 }
 
 /**
@@ -52,6 +58,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     schemaDescription: false,
     inputValueDeprecation: false,
     oneOf: false,
+    errorBehavior: false,
     ...options,
   };
 
@@ -64,6 +71,9 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
     : '';
   const schemaDescription = optionsWithDefault.schemaDescription
     ? descriptions
+    : '';
+  const defaultErrorBehavior = optionsWithDefault.errorBehavior
+    ? 'defaultErrorBehavior'
     : '';
 
   function inputDeprecation(str: string) {
@@ -78,6 +88,7 @@ export function getIntrospectionQuery(options?: IntrospectionOptions): string {
         queryType { name kind }
         mutationType { name kind }
         subscriptionType { name kind }
+        ${defaultErrorBehavior}
         types {
           ...FullType
         }

--- a/src/utilities/getIntrospectionQuery.ts
+++ b/src/utilities/getIntrospectionQuery.ts
@@ -1,6 +1,6 @@
 import type { Maybe } from '../jsutils/Maybe';
 
-import type { GraphQLErrorBehavior } from '../error/ErrorBehavior';
+import type { ErrorBehavior } from '../error/ErrorBehavior';
 
 import type { DirectiveLocation } from '../language/directiveLocation';
 
@@ -208,7 +208,7 @@ export interface IntrospectionSchema {
   >;
   readonly types: ReadonlyArray<IntrospectionType>;
   readonly directives: ReadonlyArray<IntrospectionDirective>;
-  readonly defaultErrorBehavior?: Maybe<GraphQLErrorBehavior>;
+  readonly defaultErrorBehavior?: Maybe<ErrorBehavior>;
 }
 
 export type IntrospectionType =

--- a/src/utilities/lexicographicSortSchema.ts
+++ b/src/utilities/lexicographicSortSchema.ts
@@ -30,6 +30,7 @@ import {
   isUnionType,
 } from '../type/definition';
 import { GraphQLDirective } from '../type/directives';
+import { isSpecifiedEnumType } from '../type/enums';
 import { isIntrospectionType } from '../type/introspection';
 import { GraphQLSchema } from '../type/schema';
 
@@ -115,7 +116,12 @@ export function lexicographicSortSchema(schema: GraphQLSchema): GraphQLSchema {
   }
 
   function sortNamedType(type: GraphQLNamedType): GraphQLNamedType {
-    if (isScalarType(type) || isIntrospectionType(type)) {
+    if (
+      isScalarType(type) ||
+      isIntrospectionType(type) ||
+      isIntrospectionType(type) ||
+      isSpecifiedEnumType(type)
+    ) {
       return type;
     }
     if (isObjectType(type)) {

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -70,7 +70,11 @@ function printFilteredSchema(
 }
 
 function printSchemaDefinition(schema: GraphQLSchema): Maybe<string> {
-  if (schema.description == null && isSchemaOfCommonNames(schema)) {
+  if (
+    schema.description == null &&
+    schema.defaultErrorBehavior === 'PROPAGATE' &&
+    isSchemaOfCommonNames(schema)
+  ) {
     return;
   }
 
@@ -90,8 +94,15 @@ function printSchemaDefinition(schema: GraphQLSchema): Maybe<string> {
   if (subscriptionType) {
     operationTypes.push(`  subscription: ${subscriptionType.name}`);
   }
+  const directives =
+    schema.defaultErrorBehavior !== 'PROPAGATE'
+      ? `@behavior(onError: ${schema.defaultErrorBehavior}) `
+      : ``;
 
-  return printDescription(schema) + `schema {\n${operationTypes.join('\n')}\n}`;
+  return (
+    printDescription(schema) +
+    `schema ${directives}{\n${operationTypes.join('\n')}\n}`
+  );
 }
 
 /**

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -97,7 +97,7 @@ function printSchemaDefinition(schema: GraphQLSchema): Maybe<string> {
   const directives =
     schema.defaultErrorBehavior !== 'PROPAGATE'
       ? `@behavior(onError: ${schema.defaultErrorBehavior}) `
-      : ``;
+      : '';
 
   return (
     printDescription(schema) +

--- a/src/utilities/printSchema.ts
+++ b/src/utilities/printSchema.ts
@@ -30,6 +30,7 @@ import {
   DEFAULT_DEPRECATION_REASON,
   isSpecifiedDirective,
 } from '../type/directives';
+import { isSpecifiedEnumType } from '../type/enums';
 import { isIntrospectionType } from '../type/introspection';
 import { isSpecifiedScalarType } from '../type/scalars';
 import type { GraphQLSchema } from '../type/schema';
@@ -45,11 +46,23 @@ export function printSchema(schema: GraphQLSchema): string {
 }
 
 export function printIntrospectionSchema(schema: GraphQLSchema): string {
-  return printFilteredSchema(schema, isSpecifiedDirective, isIntrospectionType);
+  return printFilteredSchema(
+    schema,
+    isSpecifiedDirective,
+    isIntrospectionSchemaType,
+  );
 }
 
 function isDefinedType(type: GraphQLNamedType): boolean {
-  return !isSpecifiedScalarType(type) && !isIntrospectionType(type);
+  return (
+    !isSpecifiedScalarType(type) &&
+    !isSpecifiedEnumType(type) &&
+    !isIntrospectionType(type)
+  );
+}
+
+function isIntrospectionSchemaType(type: GraphQLNamedType): boolean {
+  return isIntrospectionType(type) || isSpecifiedEnumType(type);
 }
 
 function printFilteredSchema(

--- a/src/validation/rules/KnownTypeNamesRule.ts
+++ b/src/validation/rules/KnownTypeNamesRule.ts
@@ -11,6 +11,7 @@ import {
 } from '../../language/predicates';
 import type { ASTVisitor } from '../../language/visitor';
 
+import { specifiedEnumTypes } from '../../type/enums';
 import { introspectionTypes } from '../../type/introspection';
 import { specifiedScalarTypes } from '../../type/scalars';
 
@@ -70,9 +71,11 @@ export function KnownTypeNamesRule(
   };
 }
 
-const standardTypeNames = [...specifiedScalarTypes, ...introspectionTypes].map(
-  (type) => type.name,
-);
+const standardTypeNames = [
+  ...specifiedScalarTypes,
+  ...specifiedEnumTypes,
+  ...introspectionTypes,
+].map((type) => type.name);
 
 function isSDLNode(value: ASTNode | ReadonlyArray<ASTNode>): boolean {
   return (


### PR DESCRIPTION
Alternative to:
- #4364 

Using `__ErrorBehavior` causes older GraphiQL to baulk. I'm hoping that this approach will not.
