### PR TITLE
Be selective about instanceof

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@
 
 // The GraphQL.js version info.
 export { version, versionInfo } from './version.js';
+export { setEnv } from './utilities/env.js';
+export type { Env } from './utilities/env.js';
 
 // The primary entry point into fulfilling a GraphQL request.
 export type { GraphQLArgs } from './graphql.js';

--- a/src/jsutils/__tests__/instanceOf-test.ts
+++ b/src/jsutils/__tests__/instanceOf-test.ts
@@ -1,9 +1,15 @@
 import { expect } from 'chai';
-import { describe, it } from 'mocha';
+import { beforeEach, describe, it } from 'mocha';
+
+import { setEnv } from '../../utilities/env.js';
 
 import { instanceOf } from '../instanceOf.js';
 
 describe('instanceOf', () => {
+  beforeEach(() => {
+    setEnv('development');
+  });
+
   it('do not throw on values without prototype', () => {
     class Foo {
       get [Symbol.toStringTag]() {

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,40 +1,28 @@
+import { isProduction } from '../utilities/env.js';
+
 import { inspect } from './inspect.js';
 
-/* c8 ignore next 3 */
-const isProduction =
-  globalThis.process != null &&
-  // eslint-disable-next-line no-undef
-  process.env.NODE_ENV === 'production';
+export function instanceOf(value: unknown, constructor: Constructor): boolean {
+  if (isProduction()) {
+    return value instanceof constructor;
+  }
 
-/**
- * A replacement for instanceof which includes an error warning when multi-realm
- * constructors are detected.
- * See: https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production
- * See: https://webpack.js.org/guides/production/
- */
-export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
-  /* c8 ignore next 6 */
-  // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  isProduction
-    ? function instanceOf(value: unknown, constructor: Constructor): boolean {
-        return value instanceof constructor;
-      }
-    : function instanceOf(value: unknown, constructor: Constructor): boolean {
-        if (value instanceof constructor) {
-          return true;
-        }
-        if (typeof value === 'object' && value !== null) {
-          // Prefer Symbol.toStringTag since it is immune to minification.
-          const className = constructor.prototype[Symbol.toStringTag];
-          const valueClassName =
-            // We still need to support constructor's name to detect conflicts with older versions of this library.
-            Symbol.toStringTag in value
-              ? value[Symbol.toStringTag]
-              : value.constructor?.name;
-          if (className === valueClassName) {
-            const stringifiedValue = inspect(value);
-            throw new Error(
-              `Cannot use ${className} "${stringifiedValue}" from another module or realm.
+  if (value instanceof constructor) {
+    return true;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    // Prefer Symbol.toStringTag since it is immune to minification.
+    const className = constructor.prototype[Symbol.toStringTag];
+    const valueClassName =
+      // We still need to support constructor's name to detect conflicts with older versions of this library.
+      Symbol.toStringTag in value
+        ? value[Symbol.toStringTag]
+        : value.constructor?.name;
+    if (className === valueClassName) {
+      const stringifiedValue = inspect(value);
+      throw new Error(
+        `Cannot use ${className} "${stringifiedValue}" from another module or realm.
 
 Ensure that there is only one instance of "graphql" in the node_modules
 directory. If different versions of "graphql" are the dependencies of other
@@ -46,11 +34,11 @@ Duplicate "graphql" modules cannot be used at the same time since different
 versions may have different capabilities and behavior. The data from one
 version used in the function from another could produce confusing and
 spurious results.`,
-            );
-          }
-        }
-        return false;
-      };
+      );
+    }
+  }
+  return false;
+}
 
 interface Constructor {
   prototype: {

--- a/src/utilities/env.ts
+++ b/src/utilities/env.ts
@@ -1,0 +1,9 @@
+export type Env = 'production' | 'development';
+
+let env: Env = 'production';
+
+export const setEnv = (newEnv: Env): void => {
+  env = newEnv;
+};
+
+export const isProduction = (): boolean => env === 'production';


### PR DESCRIPTION
This creates a new env export that allows the user to selectively opt-in or opt-out of `instanceof` checks and any future debug hints we might introduce