### PR TITLE
fix(replaceVariables): preserve sources for fragment variable values

### DIFF
--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -938,6 +938,26 @@ describe('Execute: Handles inputs', () => {
         },
       });
     });
+
+    it('allows custom scalars with embedded nested fragment variables', () => {
+      const result = executeQueryWithFragmentArguments(`
+        {
+          ...JSONFragment(input1: "foo")
+        }
+        fragment JSONFragment($input1: String) on TestType {
+          ...JSONNestedFragment(input2: $input1)
+        }
+        fragment JSONNestedFragment($input2: String) on TestType {
+          fieldWithJSONScalarInput(input: { a: $input2, b: ["bar"], c: "baz" })
+        }
+      `);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          fieldWithJSONScalarInput: '{ a: "foo", b: ["bar"], c: "baz" }',
+        },
+      });
+    });
   });
 
   describe('Handles lists and nullability', () => {

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -30,6 +30,8 @@ import {
 import { GraphQLBoolean, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
+import { valueFromASTUntyped } from '../../utilities/valueFromASTUntyped.js';
+
 import { executeSync, experimentalExecuteIncrementally } from '../execute.js';
 import { getVariableValues } from '../values.js';
 
@@ -61,6 +63,16 @@ const TestComplexScalar = new GraphQLScalarType({
   coerceInputLiteral(ast) {
     expect(ast).to.include({ kind: 'StringValue', value: 'ExternalValue' });
     return 'InternalValue';
+  },
+});
+
+const TestJSONScalar = new GraphQLScalarType({
+  name: 'JSONScalar',
+  coerceInputValue(value) {
+    return value;
+  },
+  coerceInputLiteral(value) {
+    return valueFromASTUntyped(value);
   },
 });
 
@@ -151,6 +163,7 @@ const TestType = new GraphQLObjectType({
     fieldWithNestedInputObject: fieldWithInputArg({
       type: TestNestedInputObject,
     }),
+    fieldWithJSONScalarInput: fieldWithInputArg({ type: TestJSONScalar }),
     list: fieldWithInputArg({ type: new GraphQLList(GraphQLString) }),
     nested: {
       type: NestedType,
@@ -855,6 +868,74 @@ describe('Execute: Handles inputs', () => {
             path: ['fieldWithNonNullableStringInput'],
           },
         ],
+      });
+    });
+  });
+
+  // Note: the below is non-specified custom graphql-js behavior.
+  describe('Handles custom scalars with embedded variables', () => {
+    it('allows custom scalars', () => {
+      const result = executeQuery(`
+        {
+          fieldWithJSONScalarInput(input: { a: "foo", b: ["bar"], c: "baz" })
+        }
+      `);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          fieldWithJSONScalarInput: '{ a: "foo", b: ["bar"], c: "baz" }',
+        },
+      });
+    });
+
+    it('allows custom scalars with non-embedded variables', () => {
+      const result = executeQuery(
+        `
+          query ($input: JSONScalar) {
+            fieldWithJSONScalarInput(input: $input)
+          }
+        `,
+        { input: { a: 'foo', b: ['bar'], c: 'baz' } },
+      );
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          fieldWithJSONScalarInput: '{ a: "foo", b: ["bar"], c: "baz" }',
+        },
+      });
+    });
+
+    it('allows custom scalars with embedded operation variables', () => {
+      const result = executeQuery(
+        `
+          query ($input: String) {
+            fieldWithJSONScalarInput(input: { a: $input, b: ["bar"], c: "baz" })
+          }
+        `,
+        { input: 'foo' },
+      );
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          fieldWithJSONScalarInput: '{ a: "foo", b: ["bar"], c: "baz" }',
+        },
+      });
+    });
+
+    it('allows custom scalars with embedded fragment variables', () => {
+      const result = executeQueryWithFragmentArguments(`
+        {
+          ...JSONFragment(input: "foo")
+        }
+        fragment JSONFragment($input: String) on TestType {
+          fieldWithJSONScalarInput(input: { a: $input, b: ["bar"], c: "baz" })
+        }
+      `);
+
+      expectJSON(result).toDeepEqual({
+        data: {
+          fieldWithJSONScalarInput: '{ a: "foo", b: ["bar"], c: "baz" }',
+        },
       });
     });
   });

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -1,5 +1,5 @@
 import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
-import type { ObjMap } from '../jsutils/ObjMap.js';
+import type { ObjMap, ReadOnlyObjMap } from '../jsutils/ObjMap.js';
 
 import type {
   DirectiveNode,
@@ -35,10 +35,20 @@ export interface DeferUsage {
   parentDeferUsage: DeferUsage | undefined;
 }
 
+export interface FragmentVariableValues {
+  readonly sources: ReadOnlyObjMap<FragmentVariableValueSource>;
+  readonly coerced: ReadOnlyObjMap<unknown>;
+}
+
+interface FragmentVariableValueSource {
+  readonly signature: GraphQLVariableSignature;
+  readonly value?: unknown;
+}
+
 export interface FieldDetails {
   node: FieldNode;
   deferUsage?: DeferUsage | undefined;
-  fragmentVariableValues?: VariableValues | undefined;
+  fragmentVariableValues?: FragmentVariableValues | undefined;
 }
 
 export type FieldDetailsList = ReadonlyArray<FieldDetails>;
@@ -168,7 +178,7 @@ function collectFieldsImpl(
   groupedFieldSet: AccumulatorMap<string, FieldDetails>,
   newDeferUsages: Array<DeferUsage>,
   deferUsage?: DeferUsage,
-  fragmentVariableValues?: VariableValues,
+  fragmentVariableValues?: FragmentVariableValues,
 ): void {
   const {
     schema,
@@ -318,7 +328,7 @@ function collectFieldsImpl(
  */
 function getDeferUsage(
   variableValues: VariableValues,
-  fragmentVariableValues: VariableValues | undefined,
+  fragmentVariableValues: FragmentVariableValues | undefined,
   node: FragmentSpreadNode | InlineFragmentNode,
   parentDeferUsage: DeferUsage | undefined,
 ): DeferUsage | undefined {
@@ -351,7 +361,7 @@ function shouldIncludeNode(
   context: CollectFieldsContext,
   node: FragmentSpreadNode | FieldNode | InlineFragmentNode,
   variableValues: VariableValues,
-  fragmentVariableValues: VariableValues | undefined,
+  fragmentVariableValues: FragmentVariableValues | undefined,
 ): boolean {
   const skipDirectiveNode = node.directives?.find(
     (directive) => directive.name.value === GraphQLSkipDirective.name,

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -2,6 +2,7 @@ import { AccumulatorMap } from '../jsutils/AccumulatorMap.js';
 import type { ObjMap, ReadOnlyObjMap } from '../jsutils/ObjMap.js';
 
 import type {
+  ConstValueNode,
   DirectiveNode,
   FieldNode,
   FragmentDefinitionNode,
@@ -42,7 +43,7 @@ export interface FragmentVariableValues {
 
 interface FragmentVariableValueSource {
   readonly signature: GraphQLVariableSignature;
-  readonly value?: unknown;
+  readonly value?: ConstValueNode;
 }
 
 export interface FieldDetails {
@@ -283,7 +284,7 @@ function collectFieldsImpl(
         );
 
         const fragmentVariableSignatures = fragment.variableSignatures;
-        let newFragmentVariableValues: VariableValues | undefined;
+        let newFragmentVariableValues: FragmentVariableValues | undefined;
         if (fragmentVariableSignatures) {
           newFragmentVariableValues = getFragmentVariableValues(
             selection,

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -44,6 +44,7 @@ export interface FragmentVariableValues {
 interface FragmentVariableValueSource {
   readonly signature: GraphQLVariableSignature;
   readonly value?: ConstValueNode;
+  readonly fragmentVariableValues?: FragmentVariableValues;
 }
 
 export interface FieldDetails {

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -26,7 +26,7 @@ import { typeFromAST } from '../utilities/typeFromAST.js';
 import type { GraphQLVariableSignature } from './getVariableSignature.js';
 import type { VariableValues } from './values.js';
 import {
-  experimentalGetArgumentValues,
+  getArgumentValues,
   getDirectiveValues,
   getFragmentVariableValues,
 } from './values.js';
@@ -373,9 +373,9 @@ function shouldIncludeNode(
     return false;
   }
   const skip = skipDirectiveNode
-    ? experimentalGetArgumentValues(
+    ? getArgumentValues(
+        GraphQLSkipDirective,
         skipDirectiveNode,
-        GraphQLSkipDirective.args,
         variableValues,
         fragmentVariableValues,
         context.hideSuggestions,
@@ -393,9 +393,9 @@ function shouldIncludeNode(
     return false;
   }
   const include = includeDirectiveNode
-    ? experimentalGetArgumentValues(
+    ? getArgumentValues(
+        GraphQLIncludeDirective,
         includeDirectiveNode,
-        GraphQLIncludeDirective.args,
         variableValues,
         fragmentVariableValues,
         context.hideSuggestions,

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -85,7 +85,6 @@ import type {
 import { DeferredFragmentRecord } from './types.js';
 import type { VariableValues } from './values.js';
 import {
-  experimentalGetArgumentValues,
   getArgumentValues,
   getDirectiveValues,
   getVariableValues,
@@ -877,9 +876,9 @@ function executeField(
     // Build a JS object of arguments from the field.arguments AST, using the
     // variables scope to fulfill any variable references.
     // TODO: find a way to memoize, in case this field is within a List type.
-    const args = experimentalGetArgumentValues(
+    const args = getArgumentValues(
+      fieldDef,
       fieldDetailsList[0].node,
-      fieldDef.args,
       variableValues,
       fieldDetailsList[0].fragmentVariableValues,
       hideSuggestions,
@@ -2298,6 +2297,7 @@ function executeSubscription(
       fieldDef,
       fieldNodes[0],
       variableValues,
+      fieldDetailsList[0].fragmentVariableValues,
       hideSuggestions,
     );
 

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -32,6 +32,7 @@ import {
   validateInputValue,
 } from '../utilities/validateInputValue.js';
 
+import type { FragmentVariableValues } from './collectFields.js';
 import type { GraphQLVariableSignature } from './getVariableSignature.js';
 import { getVariableSignature } from './getVariableSignature.js';
 
@@ -154,9 +155,9 @@ export function getFragmentVariableValues(
   fragmentSpreadNode: FragmentSpreadNode,
   fragmentSignatures: ReadOnlyObjMap<GraphQLVariableSignature>,
   variableValues: VariableValues,
-  fragmentVariableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<FragmentVariableValues>,
   hideSuggestions?: Maybe<boolean>,
-): VariableValues {
+): FragmentVariableValues {
   const varSignatures: Array<GraphQLVariableSignature> = [];
   const sources = Object.create(null);
   for (const [varName, varSignature] of Object.entries(fragmentSignatures)) {
@@ -207,7 +208,7 @@ export function experimentalGetArgumentValues(
   node: FieldNode | DirectiveNode | FragmentSpreadNode,
   argDefs: ReadonlyArray<GraphQLArgument | GraphQLVariableSignature>,
   variableValues: Maybe<VariableValues>,
-  fragmentVariableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<FragmentVariableValues>,
   hideSuggestions?: Maybe<boolean>,
 ): { [argument: string]: unknown } {
   const coercedValues: { [argument: string]: unknown } = {};
@@ -306,7 +307,7 @@ export function getDirectiveValues(
   directiveDef: GraphQLDirective,
   node: { readonly directives?: ReadonlyArray<DirectiveNode> | undefined },
   variableValues?: Maybe<VariableValues>,
-  fragmentVariableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<FragmentVariableValues>,
   hideSuggestions?: Maybe<boolean>,
 ): undefined | { [argument: string]: unknown } {
   const directiveNode = node.directives?.find(

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -28,7 +28,6 @@ import {
   coerceInputLiteral,
   coerceInputValue,
 } from '../utilities/coerceInputValue.js';
-import { replaceVariables } from '../utilities/replaceVariables.js';
 import {
   validateInputLiteral,
   validateInputValue,
@@ -173,12 +172,9 @@ export function getFragmentVariableValues(
     };
     const arg = args[varName];
     if (arg !== undefined) {
-      const value = arg.value;
-      sources[varName].value = replaceVariables(
-        value,
-        variableValues,
-        fragmentVariableValues,
-      );
+      const source = sources[varName];
+      source.value = arg.value;
+      source.fragmentVariableValues = fragmentVariableValues;
     }
   }
 

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -18,6 +18,7 @@ import {
   isRequiredInputField,
 } from '../type/definition.js';
 
+import type { FragmentVariableValues } from '../execution/collectFields.js';
 import type { VariableValues } from '../execution/values.js';
 
 import { replaceVariables } from './replaceVariables.js';
@@ -130,7 +131,7 @@ export function coerceInputLiteral(
   valueNode: ValueNode,
   type: GraphQLInputType,
   variableValues?: Maybe<VariableValues>,
-  fragmentVariableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<FragmentVariableValues>,
 ): unknown {
   if (valueNode.kind === Kind.VARIABLE) {
     const coercedVariableValue = getCoercedVariableValue(
@@ -283,7 +284,7 @@ export function coerceInputLiteral(
 function getCoercedVariableValue(
   variableNode: VariableNode,
   variableValues: Maybe<VariableValues>,
-  fragmentVariableValues: Maybe<VariableValues>,
+  fragmentVariableValues: Maybe<FragmentVariableValues>,
 ): unknown {
   const varName = variableNode.name.value;
   if (fragmentVariableValues?.sources[varName] !== undefined) {

--- a/src/utilities/replaceVariables.ts
+++ b/src/utilities/replaceVariables.ts
@@ -28,25 +28,36 @@ export function replaceVariables(
   switch (valueNode.kind) {
     case Kind.VARIABLE: {
       const varName = valueNode.name.value;
-      const scopedVariableValues = fragmentVariableValues?.sources[varName]
-        ? fragmentVariableValues
-        : variableValues;
+      const fragmentVariableValueSource =
+        fragmentVariableValues?.sources[varName];
 
-      const scopedVariableSource = scopedVariableValues?.sources[varName];
-      if (scopedVariableSource == null) {
+      if (fragmentVariableValueSource) {
+        const value = fragmentVariableValueSource.value;
+        if (value === undefined) {
+          const defaultValue = fragmentVariableValueSource.signature.default;
+          if (defaultValue !== undefined) {
+            return defaultValue.literal;
+          }
+          return { kind: Kind.NULL };
+        }
+        return value;
+      }
+
+      const variableValueSource = variableValues?.sources[varName];
+      if (variableValueSource == null) {
         return { kind: Kind.NULL };
       }
 
-      if (scopedVariableSource.value === undefined) {
-        const defaultValue = scopedVariableSource.signature.default;
+      if (variableValueSource.value === undefined) {
+        const defaultValue = variableValueSource.signature.default;
         if (defaultValue !== undefined) {
           return defaultValue.literal;
         }
       }
 
       return valueToLiteral(
-        scopedVariableSource.value,
-        scopedVariableSource.signature.type,
+        variableValueSource.value,
+        variableValueSource.signature.type,
       ) as ConstValueNode;
     }
     case Kind.OBJECT: {

--- a/src/utilities/replaceVariables.ts
+++ b/src/utilities/replaceVariables.ts
@@ -40,7 +40,11 @@ export function replaceVariables(
           }
           return { kind: Kind.NULL };
         }
-        return value;
+        return replaceVariables(
+          value,
+          variableValues,
+          fragmentVariableValueSource.fragmentVariableValues,
+        );
       }
 
       const variableValueSource = variableValues?.sources[varName];

--- a/src/utilities/replaceVariables.ts
+++ b/src/utilities/replaceVariables.ts
@@ -7,6 +7,7 @@ import type {
 } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
 
+import type { FragmentVariableValues } from '../execution/collectFields.js';
 import type { VariableValues } from '../execution/values.js';
 
 import { valueToLiteral } from './valueToLiteral.js';
@@ -22,7 +23,7 @@ import { valueToLiteral } from './valueToLiteral.js';
 export function replaceVariables(
   valueNode: ValueNode,
   variableValues?: Maybe<VariableValues>,
-  fragmentVariableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<FragmentVariableValues>,
 ): ConstValueNode {
   switch (valueNode.kind) {
     case Kind.VARIABLE: {

--- a/src/utilities/validateInputValue.ts
+++ b/src/utilities/validateInputValue.ts
@@ -457,7 +457,14 @@ function validateInputLiteralImpl(
     let caughtError;
     try {
       result = type.coerceInputLiteral
-        ? type.coerceInputLiteral(replaceVariables(valueNode), hideSuggestions)
+        ? type.coerceInputLiteral(
+            replaceVariables(
+              valueNode,
+              context.variables,
+              context.fragmentVariableValues,
+            ),
+            hideSuggestions,
+          )
         : type.parseLiteral(valueNode, undefined, hideSuggestions);
     } catch (error) {
       if (error instanceof GraphQLError) {

--- a/src/utilities/validateInputValue.ts
+++ b/src/utilities/validateInputValue.ts
@@ -23,6 +23,7 @@ import {
   isRequiredInputField,
 } from '../type/definition.js';
 
+import type { FragmentVariableValues } from '../execution/collectFields.js';
 import type { VariableValues } from '../execution/values.js';
 
 import { replaceVariables } from './replaceVariables.js';
@@ -231,7 +232,7 @@ export function validateInputLiteral(
   type: GraphQLInputType,
   onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void,
   variables?: Maybe<VariableValues>,
-  fragmentVariableValues?: Maybe<VariableValues>,
+  fragmentVariableValues?: Maybe<FragmentVariableValues>,
   hideSuggestions?: Maybe<boolean>,
 ): void {
   const context: ValidationContext = {
@@ -253,7 +254,7 @@ interface ValidationContext {
   static: boolean;
   onError: (error: GraphQLError, path: ReadonlyArray<string | number>) => void;
   variables?: Maybe<VariableValues>;
-  fragmentVariableValues?: Maybe<VariableValues>;
+  fragmentVariableValues?: Maybe<FragmentVariableValues>;
 }
 
 function validateInputLiteralImpl(


### PR DESCRIPTION
The new flow for coercing input literals -- see https://github.com/graphql/graphql-js/pull/3814 -- introduces a `replaceVariables()` prior to calling `coerceInputLiteral()` such that we go:

from `ValueNode` => `ConstValueNode` => coerced value

The main advantages being that:
(1) we can trivially support embedding variables within complex scalars -- despite this being non-spec defined behavior!
(2) userland implementations of custom scalar `coerceInputLiteral()` methods do not need to worry about handling variables or fragment variables.

Prior to this PR, we did not properly handle this in the case of fragment definition variables/fragment spread arguments. `replaceVariableValues()` assumes that the uncoerced value is preserved as source, but instead of grabbing this value from the argument on the spread, we were incorrectly attempting to retrieve the already stored value from existing variables.

This was not caught because we previously did not have any actual tests for this custom unspecified behavior and were using incorrect types and bespoke builders in our tests for `replaceVariables()`.

This PR:

(a) fixes the bug by storing the argument from the spread
(b) fixes our bespoke builders in `replaceVariables()`
(c) add explicit tests for embedding variables within custom scalars to protect against future changes.

As a post-script, because within `getFragmentVariableValues()` we now end up within a `ValueNode` stored on source, to  coerce this value, we can extract a new helper `coerceArgumentValue()` from `experimentalGetArgumentValues()`, rather than calling it after we are done for all the values, which has some additional overhead.

This has the side benefit of removing the need for a separate `experimentalGetArgumentValues()` function altogether. We initially introduced it to have a more flexible signature for `getArgumentValues()` that encompasses argument for fragment spreads, but now this is taken care of using our more directed helper.