### PR TITLE
Catch unhandled exception in abstract resolution

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -8,7 +8,8 @@
     "src/jsutils/ObjMap.ts",
     "src/jsutils/PromiseOrValue.ts",
     "src/utilities/assertValidName.ts",
-    "src/utilities/typedQueryDocumentNode.ts"
+    "src/utilities/typedQueryDocumentNode.ts",
+    "src/**/__tests__/**/*.ts"
   ],
   "clean": true,
   "temp-directory": "coverage",

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -12,7 +12,7 @@ import {
 import { GraphQLBoolean, GraphQLString } from '../../type/scalars';
 import { GraphQLSchema } from '../../type/schema';
 
-import { executeSync } from '../execute';
+import { execute, executeSync } from '../execute';
 
 class Dog {
   name: string;
@@ -153,6 +153,77 @@ odie.mother.progeny = [odie];
 
 const liz = new Person('Liz');
 const john = new Person('John', [garfield, odie], [liz, odie]);
+
+const SearchableInterface = new GraphQLInterfaceType({
+  name: 'Searchable',
+  fields: {
+    id: { type: GraphQLString },
+  },
+});
+
+const TypeA = new GraphQLObjectType({
+  name: 'TypeA',
+  interfaces: [SearchableInterface],
+  fields: () => ({
+    id: { type: GraphQLString },
+    nameA: { type: GraphQLString },
+  }),
+  isTypeOf: (_value, _context, _info) => {
+    return new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        reject(new Error('TypeA_isTypeOf_rejected'));
+      }, 10);
+    });
+  },
+});
+
+const TypeB = new GraphQLObjectType({
+  name: 'TypeB',
+  interfaces: [SearchableInterface],
+  fields: () => ({
+    id: { type: GraphQLString },
+    nameB: { type: GraphQLString },
+  }),
+  isTypeOf: (value: any, _context, _info) => {
+    return value.id === 'b';
+  },
+});
+
+const queryTypeWithSearchable = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    person: {
+      type: PersonType,
+      resolve: () => john,
+    },
+    search: {
+      type: SearchableInterface,
+      args: { id: { type: GraphQLString } },
+      resolve: (_source, { id }) => {
+        /* c8 ignore start */
+        if (id === 'a') {
+          return { id: 'a', nameA: 'Object A' };
+          /* c8 ignore end */
+        } else if (id === 'b') {
+          return { id: 'b', nameB: 'Object B' };
+        }
+      },
+    },
+  },
+});
+
+const schemaWithSearchable = new GraphQLSchema({
+  query: queryTypeWithSearchable,
+  types: [
+    PetType,
+    TypeA,
+    TypeB,
+    SearchableInterface,
+    PersonType,
+    DogType,
+    CatType,
+  ],
+});
 
 describe('Execute: Union and intersection types', () => {
   it('can introspect on union and intersection types', () => {
@@ -544,5 +615,51 @@ describe('Execute: Union and intersection types', () => {
     expect(encounteredSchema).to.equal(schema2);
     expect(encounteredRootValue).to.equal(rootValue);
     expect(encounteredContext).to.equal(contextValue);
+  });
+
+  it('handles promises from isTypeOf correctly when a later type matches synchronously', async () => {
+    const document = parse(`
+      query TestSearch {
+        search(id: "b") {
+          __typename
+          id
+          ... on TypeA {
+            nameA
+          }
+          ... on TypeB {
+            nameB
+          }
+        }
+      }
+    `);
+
+    let unhandledRejection: any = null;
+    /* c8 ignore start */
+    const unhandledRejectionListener = (reason: any) => {
+      unhandledRejection = reason;
+    };
+    process.on('unhandledRejection', unhandledRejectionListener);
+    /* c8 ignore end */
+
+    const result = await execute({
+      schema: schemaWithSearchable,
+      document,
+    });
+
+    expect(result.errors).to.be.undefined;
+    expect(result.data).to.deep.equal({
+      search: {
+        __typename: 'TypeB',
+        id: 'b',
+        nameB: 'Object B',
+      },
+    });
+
+    // Give the TypeA promise a chance to reject and the listener to fire
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    process.removeListener('unhandledRejection', unhandledRejectionListener);
+
+    expect(unhandledRejection).to.be.null;
   });
 });

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -168,12 +168,14 @@ const TypeA = new GraphQLObjectType({
     id: { type: GraphQLString },
     nameA: { type: GraphQLString },
   }),
-  isTypeOf: (_value, _context, _info) => {
-    return new Promise((_resolve, reject) => {
-      setTimeout(() => {
-        reject(new Error('TypeA_isTypeOf_rejected'));
-      }, 10);
-    });
+  isTypeOf: (_value, _context, _info) =>
+    new Promise(
+      (_resolve, reject) =>
+        void setTimeout(
+          () => void reject(new Error("TypeA_isTypeOf_rejected")),
+          10,
+        ),
+    ),
   },
 });
 

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -118,7 +118,6 @@ const PetType = new GraphQLUnionType({
     if (value instanceof Cat) {
       return CatType.name;
     }
-    /* c8 ignore next 3 */
     // Not reachable, all possible types have been considered.
     expect.fail('Not reachable');
   },
@@ -169,14 +168,10 @@ const TypeA = new GraphQLObjectType({
     nameA: { type: GraphQLString },
   }),
   isTypeOf: (_value, _context, _info) =>
-    new Promise(
-      (_resolve, reject) =>
-        void setTimeout(
-          () => void reject(new Error("TypeA_isTypeOf_rejected")),
-          10,
-        ),
+    new Promise((_resolve, reject) =>
+      // eslint-disable-next-line
+      setTimeout(() => reject(new Error('TypeA_isTypeOf_rejected')), 10),
     ),
-  },
 });
 
 const TypeB = new GraphQLObjectType({
@@ -186,9 +181,7 @@ const TypeB = new GraphQLObjectType({
     id: { type: GraphQLString },
     nameB: { type: GraphQLString },
   }),
-  isTypeOf: (value: any, _context, _info) => {
-    return value.id === 'b';
-  },
+  isTypeOf: (value: any, _context, _info) => value.id === 'b',
 });
 
 const queryTypeWithSearchable = new GraphQLObjectType({
@@ -202,10 +195,8 @@ const queryTypeWithSearchable = new GraphQLObjectType({
       type: SearchableInterface,
       args: { id: { type: GraphQLString } },
       resolve: (_source, { id }) => {
-        /* c8 ignore start */
         if (id === 'a') {
           return { id: 'a', nameA: 'Object A' };
-          /* c8 ignore end */
         } else if (id === 'b') {
           return { id: 'b', nameB: 'Object B' };
         }
@@ -636,19 +627,18 @@ describe('Execute: Union and intersection types', () => {
     `);
 
     let unhandledRejection: any = null;
-    /* c8 ignore start */
     const unhandledRejectionListener = (reason: any) => {
       unhandledRejection = reason;
     };
+    // eslint-disable-next-line
     process.on('unhandledRejection', unhandledRejectionListener);
-    /* c8 ignore end */
 
     const result = await execute({
       schema: schemaWithSearchable,
       document,
     });
 
-    expect(result.errors).to.be.undefined;
+    expect(result.errors).to.equal(undefined);
     expect(result.data).to.deep.equal({
       search: {
         __typename: 'TypeB',
@@ -658,10 +648,12 @@ describe('Execute: Union and intersection types', () => {
     });
 
     // Give the TypeA promise a chance to reject and the listener to fire
+    // eslint-disable-next-line
     await new Promise((resolve) => setTimeout(resolve, 20));
 
+    // eslint-disable-next-line
     process.removeListener('unhandledRejection', unhandledRejectionListener);
 
-    expect(unhandledRejection).to.be.null;
+    expect(unhandledRejection).to.equal(null);
   });
 });

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1003,7 +1003,12 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
           promisedIsTypeOfResults[i] = isTypeOfResult;
         } else if (isTypeOfResult) {
           if (promisedIsTypeOfResults.length) {
-            Promise.allSettled(promisedIsTypeOfResults);
+            // Explicitly ignore any promise rejections
+            Promise.allSettled(promisedIsTypeOfResults)
+              /* c8 ignore next 3 */
+              .catch(() => {
+                // Do nothing
+              });
           }
           return type.name;
         }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1002,6 +1002,9 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
         if (isPromise(isTypeOfResult)) {
           promisedIsTypeOfResults[i] = isTypeOfResult;
         } else if (isTypeOfResult) {
+          if (promisedIsTypeOfResults.length) {
+            Promise.allSettled(promisedIsTypeOfResults);
+          }
           return type.name;
         }
       }


### PR DESCRIPTION
Fixes #4375

The assertion was correct that we have an unhandled Promise rejection going on when we have resolved a type and the rejection comes in at a later time.

We really have to revamp our tooling, the things that the linter is surfacing in tests and especially uncovered branches in tests... it really makes for a bad DX on this repo