### PR TITLE
docs: add page on authorization strategies

### DIFF
--- a/website/pages/docs/_meta.ts
+++ b/website/pages/docs/_meta.ts
@@ -12,6 +12,7 @@ const meta = {
   'object-types': '',
   'mutations-and-input-types': '',
   'authentication-and-express-middleware': '',
+  'authorization-strategies': '',
   '-- 2': {
     type: 'separator',
     title: 'Advanced Guides',

--- a/website/pages/docs/authentication-and-express-middleware.mdx
+++ b/website/pages/docs/authentication-and-express-middleware.mdx
@@ -1,6 +1,6 @@
 ---
-title: Authentication and Express Middleware
-sidebarTitle: Authentication & Middleware
+title: Using Express Middleware with GraphQL.js
+sidebarTitle: Using Express Middleware
 ---
 
 import { Tabs } from 'nextra/components';
@@ -100,3 +100,5 @@ In a REST API, authentication is often handled with a header, that contains an a
 If you aren't familiar with any of these authentication mechanisms, we recommend using `express-jwt` because it's simple without sacrificing any future flexibility.
 
 If you've read through the docs linearly to get to this point, congratulations! You now know everything you need to build a practical GraphQL API server.
+
+Want to control access to specific operations or fields? See [Authorization Strategies](\pages\docs\authorization-strategies.mdx).

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -18,7 +18,9 @@ To run them in Node.js, make sure to:
 - Add `"type": "module"` to your `package.json`, or
 - Use the `.mjs` file extension for your files
 
-These features are supported in Node 12+ and fully stable in Node 16 and later.
+As of Node.js 22, [module syntax detection](https://nodejs.org/docs/latest-v22.x/api/esm.html#automatic-detection-of-modules) 
+is enabled by default. This means Node.js will attempt to run `.js` files 
+using ES module syntax if it can't parse them as CommonJS.
 
 ## What is authorization?
 

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -10,6 +10,16 @@ This guide covers common strategies for implementing authorization in GraphQL
 servers using GraphQL.js. It assumes you're authenticating requests and passing a user or 
 session object into the `context`.
 
+## Before you start
+
+All code examples in this guide use modern JavaScript with [ES module (ESM) syntax](https://nodejs.org/api/esm.html).  
+To run them in Node.js, make sure to:
+
+- Add `"type": "module"` to your `package.json`, or
+- Use the `.mjs` file extension for your files
+
+These features are supported in Node 12+ and fully stable in Node 16 and later.
+
 ## What is authorization?
 
 Authorization determines what a user is allowed to do. It's different from 
@@ -27,7 +37,6 @@ The simplest approach is to enforce access rules directly inside resolvers
 using the `context.user` value:
 
 ```js
-// ES module syntax: Add "type": "module" to your package.json to use import/export
 export const resolvers = {
   Query: {
     secretData: (parent, args, context) => {

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -24,7 +24,7 @@ In GraphQL, authorization typically involves restricting:
 ## Resolver-based authorization
 
 > **Note:**  
-> All examples assume you're using Node.js 22.7 or later with [ES module (ESM) support](https://nodejs.org/api/esm.html) enabled.
+> All examples assume you're using Node.js 20 or later with [ES module (ESM) support](https://nodejs.org/api/esm.html) enabled.
 
 The simplest approach is to enforce access rules directly inside resolvers 
 using the `context.user` value:

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -1,0 +1,152 @@
+---
+title: Authorization Strategies
+---
+
+GraphQL gives you complete control over how to define and enforce access control. 
+That flexibility means it's up to you to decide where authorization rules live and 
+how they're enforced.
+
+This guide covers common strategies for implementing authorization in GraphQL 
+servers using GraphQL.js. It assumes you're authenticating requests and passing a user or 
+session object into the `context`.
+
+## What is authorization?
+
+Authorization determines what a user is allowed to do. It's different from 
+authentication, which verifies who a user is.
+
+In GraphQL, authorization typically involves restricting:
+
+- Access to certain queries or mutations
+- Visibility of specific fields
+- Ability to perform mutations based on roles or ownership
+
+## Resolver-based authorization
+
+The simplest approach is to enforce access rules directly inside resolvers 
+using the `context.user` value:
+
+```js
+// ES module syntax: Add "type": "module" to your package.json to use import/export
+export const resolvers = {
+  Query: {
+    secretData: (parent, args, context) => {
+      if (!context.user || context.user.role !== 'admin') {
+        throw new Error('Not authorized');
+      }
+      return getSecretData();
+    },
+  },
+};
+```
+
+This works well for smaller schemas or one-off checks.
+
+## Centralizing access control logic
+
+As your schema grows, repeating logic like `context.user.role !=='admin'`
+becomes error-prone. Instead, extract shared logic into utility functions:
+
+```js
+export function requireUser(user) {
+  if (!user) {
+    throw new Error('Not authenticated');
+  }
+}
+
+export function requireRole(user, role) {
+  requireUser(user);
+  if (user.role !== role) {
+    throw new Error(`Must be a ${role}`);
+  }
+}
+```
+
+You can use these helpers in resolvers:
+
+```js
+import { requireRole } from './auth.js';
+
+export const resolvers = {
+  Mutation: {
+    deleteUser: (parent, args, context) => {
+      requireRole(context.user, 'admin');
+      return deleteUser(args.id);
+    },
+  },
+};
+```
+
+This pattern makes your access rules easier to read, test, and update.
+
+## Field-level access control
+
+You can also conditionally return or hide data at the field level. This 
+is useful when, for example, users should only see their own private data:
+
+```js
+export const resolvers = {
+  User: {
+    email: (parent, args, context) => {
+      if (context.user.id !== parent.id && context.user.role !== 'admin') {
+        return null;
+      }
+      return parent.email;
+    },
+  },
+};
+```
+
+Returning `null` is a common pattern when fields should be hidden from
+unauthorized users without triggering an error.
+
+## Declaractive authorization with directives
+
+If you prefer a schema-first or declarative style, you can define custom
+schema directives like `@auth(role: "admin")`:
+
+```graphql
+type Query {
+  users: [User] @auth(role: "admin")
+}
+```
+
+GraphQL.js doesn't interpret directives by default, they're just annotations.
+You must implement their behavior manually, usually by:
+
+- Wrapping resolvers in custom logic
+- Using a schema transformation library to inject authorization checks
+
+Directive-based authorization can add complexity, so many teams start with
+resolver-based checks and adopt directives later if needed.
+
+## Best practices
+
+- Keep authorization logic close to business logic. Resolvers are often the
+right place to keep authorization logic.
+- Use shared helper functions to reduce duplication and improve clarity.
+- Avoid tightly coupling authorization logic to your schema. Make it
+reusable where possible.
+- Consider using `null` to hide fields from unauthorized users, rather than
+throwing errors.
+- Be mindful of tools like introspection or GraphQL Playground that can
+expose your schema. Use case when deploying introspection in production
+environments.
+
+## Additional resources
+
+- [Anatomy of a Resolver](./resolver-anatomy): Shows how resolvers work and how the `context` 
+object is passed in. Helpful if you're new to writing custom resolvers or 
+want to understand where authorization logic fits.
+- [GraphQL Specification, Execution section](https://spec.graphql.org/October2021/#sec-Execution): Defines how fields are 
+resolved, including field-level error propagation and execution order. Useful 
+background when building advanced authorization patterns that rely on the 
+structure of GraphQL execution.
+- [`graphql-shield`](https://github.com/dimatill/graphql-shield): A community library for adding rule-based 
+authorization as middleware to resolvers.
+- [`graphql-auth-directives`](https://github.com/the-guild-org/graphql-auth-directives): Adds support for custom directives like 
+`@auth(role: "admin")`, letting you declare access control rules in SDL. 
+Helpful if you're building a schema-first API and prefer declarative access 
+control.
+
+

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -109,7 +109,7 @@ export const resolvers = {
 Returning `null` is a common pattern when fields should be hidden from
 unauthorized users without triggering an error.
 
-## Declaractive authorization with directives
+## Declarative authorization with directives
 
 If you prefer a schema-first or declarative style, you can define custom
 schema directives like `@auth(role: "admin")`:

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -105,13 +105,37 @@ unauthorized users without triggering an error.
 ## Declarative authorization with directives
 
 If you prefer a schema-first or declarative style, you can define custom
-schema directives like `@auth(role: "admin")`:
+schema directives like `@auth(role: "admin")` directly in your SDL:
 
 ```graphql
 type Query {
   users: [User] @auth(role: "admin")
 }
 ```
+
+To enforce this directive during execution, you need to inspect it in your resolvers
+using `getDirectiveValues`:
+
+```js
+import { getDirectiveValues } from 'graphql';
+
+function withAuthCheck(resolverFn, schema, fieldNode, variableValues, context) {
+  const directive = getDirectiveValues(
+    schema.getDirective('auth'),
+    fieldNode,
+    variableValues
+  );
+
+  if (directive?.role && context.user?.role !== directive.role) {
+    throw new Error('Unauthorized');
+  }
+
+  return resolverFn();
+}
+```
+
+You can wrap individual resolvers with this logic, or apply it more broadly using a
+schema visitor or transformation.
 
 GraphQL.js doesn't interpret directives by default, they're just annotations.
 You must implement their behavior manually, usually by:
@@ -132,7 +156,7 @@ reusable where possible.
 - Consider using `null` to hide fields from unauthorized users, rather than
 throwing errors.
 - Be mindful of tools like introspection or GraphQL Playground that can
-expose your schema. Use case when deploying introspection in production
+expose your schema. Use caution when deploying introspection in production
 environments.
 
 ## Additional resources

--- a/website/pages/docs/authorization-strategies.mdx
+++ b/website/pages/docs/authorization-strategies.mdx
@@ -10,18 +10,6 @@ This guide covers common strategies for implementing authorization in GraphQL
 servers using GraphQL.js. It assumes you're authenticating requests and passing a user or 
 session object into the `context`.
 
-## Before you start
-
-All code examples in this guide use modern JavaScript with [ES module (ESM) syntax](https://nodejs.org/api/esm.html).  
-To run them in Node.js, make sure to:
-
-- Add `"type": "module"` to your `package.json`, or
-- Use the `.mjs` file extension for your files
-
-As of Node.js 22, [module syntax detection](https://nodejs.org/docs/latest-v22.x/api/esm.html#automatic-detection-of-modules) 
-is enabled by default. This means Node.js will attempt to run `.js` files 
-using ES module syntax if it can't parse them as CommonJS.
-
 ## What is authorization?
 
 Authorization determines what a user is allowed to do. It's different from 
@@ -34,6 +22,9 @@ In GraphQL, authorization typically involves restricting:
 - Ability to perform mutations based on roles or ownership
 
 ## Resolver-based authorization
+
+> **Note:**  
+> All examples assume you're using Node.js 22.7 or later with [ES module (ESM) support](https://nodejs.org/api/esm.html) enabled.
 
 The simplest approach is to enforce access rules directly inside resolvers 
 using the `context.user` value:

--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -3,16 +3,46 @@ title: Overview
 sidebarTitle: Overview
 ---
 
-GraphQL.JS is the reference implementation to the [GraphQL Specification](https://spec.graphql.org/draft/), it's designed to be simple to use and easy to understand
-while closely following the Specification.
+GraphQL.js is the official JavaScript implementation of the 
+[GraphQL Specification](https://spec.graphql.org/draft/). It provides the core building blocks 
+for constructing GraphQL servers, clients, tools, and utilities in JavaScript and TypeScript.
 
-You can build GraphQL servers, clients, and tools with this library, it's designed so you can choose which parts you use, for example, you can build your own parser
-and use the execution/validation from the library. There also a lot of useful utilities for schema-diffing, working with arguments and many more.
+This documentation site is for developers who want to:
 
-In the following chapters you'll find out more about the three critical pieces of this library
+- Understand how GraphQL works
+- Build a GraphQL API using GraphQL.js
+- Extend, customize, or introspect GraphQL systems
+- Learn best practices for using GraphQL.js in production
 
-- The GraphQL language
-- Document validation
-- GraphQL Execution
+Whether you're writing your own server, building a GraphQL clients, or creating tools
+that work with GraphQL, this site guides you through core concepts, APIs, and
+advanced use cases of GraphQL.js.
 
-You can also code along on [a tutorial](/docs/getting-started).
+## How to use this documentation
+
+To follow along with the code examples in this documentation, make sure your environment
+meets the following requirements.
+
+### Environment
+
+Most code examples use modern JavaScript with [ES module (ESM) syntax](https://nodejs.org/api/esm.html). We recommend:
+
+- Node.js 22.7 or later, which supports automatic module type detection
+    - [Download Node.js 22.7+](https://nodejs.org/en/download/current/)
+- Enable ESM by either:
+    - Adding `"type": "module"` to your `package.json`, or
+    - Using the `.mjs` file extension
+
+If you're using an older version of Node.js or prefer CommonJS, you may need to
+adjust the code examples accordingly.
+
+### Installation
+
+Before running any code examples, install the GraphQL.js package:
+
+```bash
+npm install graphql
+```
+
+You'll see reminders about environment setup throughout the documentation, but this setup
+is assumed by default.

--- a/website/pages/docs/index.mdx
+++ b/website/pages/docs/index.mdx
@@ -17,32 +17,3 @@ This documentation site is for developers who want to:
 Whether you're writing your own server, building a GraphQL clients, or creating tools
 that work with GraphQL, this site guides you through core concepts, APIs, and
 advanced use cases of GraphQL.js.
-
-## How to use this documentation
-
-To follow along with the code examples in this documentation, make sure your environment
-meets the following requirements.
-
-### Environment
-
-Most code examples use modern JavaScript with [ES module (ESM) syntax](https://nodejs.org/api/esm.html). We recommend:
-
-- Node.js 22.7 or later, which supports automatic module type detection
-    - [Download Node.js 22.7+](https://nodejs.org/en/download/current/)
-- Enable ESM by either:
-    - Adding `"type": "module"` to your `package.json`, or
-    - Using the `.mjs` file extension
-
-If you're using an older version of Node.js or prefer CommonJS, you may need to
-adjust the code examples accordingly.
-
-### Installation
-
-Before running any code examples, install the GraphQL.js package:
-
-```bash
-npm install graphql
-```
-
-You'll see reminders about environment setup throughout the documentation, but this setup
-is assumed by default.


### PR DESCRIPTION
Adds page on authorization strategies, right after authentication/middleware page

Also adds a "Before you start" section about using ESM syntax JS code snippets