### PR TITLE
fix(benchmark): fix my incorrect merge of original commit from v16

### DIFF
--- a/benchmark/fixtures.js
+++ b/benchmark/fixtures.js
@@ -5,8 +5,9 @@ export const bigSchemaSDL = fs.readFileSync(
   'utf8',
 );
 
-export const bigDocumentSDL = JSON.parse(
-  fs.readFileSync(new URL('kitchen-sink.graphql', import.meta.url), 'utf8'),
+export const bigDocumentSDL = fs.readFileSync(
+  new URL('kitchen-sink.graphql', import.meta.url),
+  'utf8',
 );
 
 export const bigSchemaIntrospectionResult = JSON.parse(


### PR DESCRIPTION
this broke benchmarking, not tests

another reason to think about integrating benchmarking back into tests