### PR TITLE
Updates to schema coordinates (#3044)

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -737,7 +737,7 @@ describe('Parser', () => {
           loc: { start: 0, end: 6 },
           value: 'MyType',
         },
-        memberName: {
+        fieldName: {
           kind: Kind.NAME,
           loc: { start: 7, end: 12 },
           value: 'field',

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -690,25 +690,21 @@ describe('Parser', () => {
     it('parses Name', () => {
       const result = parseSchemaCoordinate('MyType');
       expectJSON(result).toDeepEqual({
-        kind: Kind.SCHEMA_COORDINATE,
+        kind: Kind.TYPE_COORDINATE,
         loc: { start: 0, end: 6 },
-        ofDirective: false,
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
           value: 'MyType',
         },
-        memberName: undefined,
-        argumentName: undefined,
       });
     });
 
     it('parses Name . Name', () => {
       const result = parseSchemaCoordinate('MyType.field');
       expectJSON(result).toDeepEqual({
-        kind: Kind.SCHEMA_COORDINATE,
+        kind: Kind.MEMBER_COORDINATE,
         loc: { start: 0, end: 12 },
-        ofDirective: false,
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
@@ -719,7 +715,6 @@ describe('Parser', () => {
           loc: { start: 7, end: 12 },
           value: 'field',
         },
-        argumentName: undefined,
       });
     });
 
@@ -735,9 +730,8 @@ describe('Parser', () => {
     it('parses Name . Name ( Name : )', () => {
       const result = parseSchemaCoordinate('MyType.field(arg:)');
       expectJSON(result).toDeepEqual({
-        kind: Kind.SCHEMA_COORDINATE,
+        kind: Kind.ARGUMENT_COORDINATE,
         loc: { start: 0, end: 18 },
-        ofDirective: false,
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
@@ -768,31 +762,26 @@ describe('Parser', () => {
     it('parses @ Name', () => {
       const result = parseSchemaCoordinate('@myDirective');
       expectJSON(result).toDeepEqual({
-        kind: Kind.SCHEMA_COORDINATE,
+        kind: Kind.DIRECTIVE_COORDINATE,
         loc: { start: 0, end: 12 },
-        ofDirective: true,
         name: {
           kind: Kind.NAME,
           loc: { start: 1, end: 12 },
           value: 'myDirective',
         },
-        memberName: undefined,
-        argumentName: undefined,
       });
     });
 
     it('parses @ Name ( Name : )', () => {
       const result = parseSchemaCoordinate('@myDirective(arg:)');
       expectJSON(result).toDeepEqual({
-        kind: Kind.SCHEMA_COORDINATE,
+        kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE,
         loc: { start: 0, end: 18 },
-        ofDirective: true,
         name: {
           kind: Kind.NAME,
           loc: { start: 1, end: 12 },
           value: 'myDirective',
         },
-        memberName: undefined,
         argumentName: {
           kind: Kind.NAME,
           loc: { start: 13, end: 16 },

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -703,14 +703,14 @@ describe('Parser', () => {
     it('parses Name . Name', () => {
       const result = parseSchemaCoordinate('MyType.field');
       expectJSON(result).toDeepEqual({
-        kind: Kind.MEMBER_COORDINATE,
+        kind: Kind.FIELD_COORDINATE,
         loc: { start: 0, end: 12 },
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
           value: 'MyType',
         },
-        memberName: {
+        fieldName: {
           kind: Kind.NAME,
           loc: { start: 7, end: 12 },
           value: 'field',
@@ -725,6 +725,24 @@ describe('Parser', () => {
           message: 'Syntax Error: Expected <EOF>, found ".".',
           locations: [{ line: 1, column: 13 }],
         });
+    });
+
+    it('parses Name :: Name', () => {
+      const result = parseSchemaCoordinate('MyEnum::value');
+      expectJSON(result).toDeepEqual({
+        kind: Kind.VALUE_COORDINATE,
+        loc: { start: 0, end: 13 },
+        name: {
+          kind: Kind.NAME,
+          loc: { start: 0, end: 6 },
+          value: 'MyEnum',
+        },
+        valueName: {
+          kind: Kind.NAME,
+          loc: { start: 8, end: 13 },
+          value: 'value',
+        },
+      });
     });
 
     it('parses Name . Name ( Name : )', () => {

--- a/src/language/__tests__/predicates-test.ts
+++ b/src/language/__tests__/predicates-test.ts
@@ -145,7 +145,11 @@ describe('AST node predicates', () => {
 
   it('isSchemaCoordinateNode', () => {
     expect(filterNodes(isSchemaCoordinateNode)).to.deep.equal([
-      'SchemaCoordinate',
+      'ArgumentCoordinate',
+      'DirectiveArgumentCoordinate',
+      'DirectiveCoordinate',
+      'MemberCoordinate',
+      'TypeCoordinate',
     ]);
   });
 });

--- a/src/language/__tests__/predicates-test.ts
+++ b/src/language/__tests__/predicates-test.ts
@@ -148,8 +148,9 @@ describe('AST node predicates', () => {
       'ArgumentCoordinate',
       'DirectiveArgumentCoordinate',
       'DirectiveCoordinate',
-      'MemberCoordinate',
+      'FieldCoordinate',
       'TypeCoordinate',
+      'ValueCoordinate',
     ]);
   });
 });

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -182,7 +182,11 @@ export type ASTNode =
   | UnionTypeExtensionNode
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
-  | SchemaCoordinateNode;
+  | TypeCoordinateNode
+  | MemberCoordinateNode
+  | ArgumentCoordinateNode
+  | DirectiveCoordinateNode
+  | DirectiveArgumentCoordinateNode;
 
 /**
  * Utility type listing all nodes indexed by their kind.
@@ -288,7 +292,13 @@ export const QueryDocumentKeys: {
   UnionTypeExtension: ['name', 'directives', 'types'],
   EnumTypeExtension: ['name', 'directives', 'values'],
   InputObjectTypeExtension: ['name', 'directives', 'fields'],
-  SchemaCoordinate: ['name', 'memberName', 'argumentName'],
+
+  // Schema Coordinates
+  TypeCoordinate: ['name'],
+  MemberCoordinate: ['name', 'memberName'],
+  ArgumentCoordinate: ['name', 'memberName', 'argumentName'],
+  DirectiveCoordinate: ['name'],
+  DirectiveArgumentCoordinate: ['name', 'argumentName'],
 };
 
 const kindValues = new Set<string>(Object.keys(QueryDocumentKeys));
@@ -765,13 +775,45 @@ export interface InputObjectTypeExtensionNode {
   readonly fields?: ReadonlyArray<InputValueDefinitionNode> | undefined;
 }
 
-// Schema Coordinates
+/** Schema Coordinates */
 
-export interface SchemaCoordinateNode {
-  readonly kind: 'SchemaCoordinate';
+export type SchemaCoordinateNode =
+  | TypeCoordinateNode
+  | MemberCoordinateNode
+  | ArgumentCoordinateNode
+  | DirectiveCoordinateNode
+  | DirectiveArgumentCoordinateNode;
+
+export interface TypeCoordinateNode {
+  readonly kind: typeof Kind.TYPE_COORDINATE;
   readonly loc?: Location;
-  readonly ofDirective: boolean;
   readonly name: NameNode;
-  readonly memberName?: NameNode | undefined;
-  readonly argumentName?: NameNode | undefined;
+}
+
+export interface MemberCoordinateNode {
+  readonly kind: typeof Kind.MEMBER_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly memberName: NameNode;
+}
+
+export interface ArgumentCoordinateNode {
+  readonly kind: typeof Kind.ARGUMENT_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly memberName: NameNode;
+  readonly argumentName: NameNode;
+}
+
+export interface DirectiveCoordinateNode {
+  readonly kind: typeof Kind.DIRECTIVE_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+}
+
+export interface DirectiveArgumentCoordinateNode {
+  readonly kind: typeof Kind.DIRECTIVE_ARGUMENT_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly argumentName: NameNode;
 }

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -296,7 +296,7 @@ export const QueryDocumentKeys: {
   // Schema Coordinates
   TypeCoordinate: ['name'],
   MemberCoordinate: ['name', 'memberName'],
-  ArgumentCoordinate: ['name', 'memberName', 'argumentName'],
+  ArgumentCoordinate: ['name', 'fieldName', 'argumentName'],
   DirectiveCoordinate: ['name'],
   DirectiveArgumentCoordinate: ['name', 'argumentName'],
 };
@@ -801,7 +801,7 @@ export interface ArgumentCoordinateNode {
   readonly kind: typeof Kind.ARGUMENT_COORDINATE;
   readonly loc?: Location;
   readonly name: NameNode;
-  readonly memberName: NameNode;
+  readonly fieldName: NameNode;
   readonly argumentName: NameNode;
 }
 

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -183,8 +183,9 @@ export type ASTNode =
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
   | TypeCoordinateNode
-  | MemberCoordinateNode
+  | FieldCoordinateNode
   | ArgumentCoordinateNode
+  | ValueCoordinateNode
   | DirectiveCoordinateNode
   | DirectiveArgumentCoordinateNode;
 
@@ -295,8 +296,9 @@ export const QueryDocumentKeys: {
 
   // Schema Coordinates
   TypeCoordinate: ['name'],
-  MemberCoordinate: ['name', 'memberName'],
+  FieldCoordinate: ['name', 'fieldName'],
   ArgumentCoordinate: ['name', 'fieldName', 'argumentName'],
+  ValueCoordinate: ['name', 'valueName'],
   DirectiveCoordinate: ['name'],
   DirectiveArgumentCoordinate: ['name', 'argumentName'],
 };
@@ -779,8 +781,9 @@ export interface InputObjectTypeExtensionNode {
 
 export type SchemaCoordinateNode =
   | TypeCoordinateNode
-  | MemberCoordinateNode
+  | FieldCoordinateNode
   | ArgumentCoordinateNode
+  | ValueCoordinateNode
   | DirectiveCoordinateNode
   | DirectiveArgumentCoordinateNode;
 
@@ -790,11 +793,11 @@ export interface TypeCoordinateNode {
   readonly name: NameNode;
 }
 
-export interface MemberCoordinateNode {
-  readonly kind: typeof Kind.MEMBER_COORDINATE;
+export interface FieldCoordinateNode {
+  readonly kind: typeof Kind.FIELD_COORDINATE;
   readonly loc?: Location;
   readonly name: NameNode;
-  readonly memberName: NameNode;
+  readonly fieldName: NameNode;
 }
 
 export interface ArgumentCoordinateNode {
@@ -803,6 +806,13 @@ export interface ArgumentCoordinateNode {
   readonly name: NameNode;
   readonly fieldName: NameNode;
   readonly argumentName: NameNode;
+}
+
+export interface ValueCoordinateNode {
+  readonly kind: typeof Kind.VALUE_COORDINATE;
+  readonly loc?: Location;
+  readonly name: NameNode;
+  readonly valueName: NameNode;
 }
 
 export interface DirectiveCoordinateNode {

--- a/src/language/kinds_.ts
+++ b/src/language/kinds_.ts
@@ -110,5 +110,18 @@ export const INPUT_OBJECT_TYPE_EXTENSION = 'InputObjectTypeExtension';
 export type INPUT_OBJECT_TYPE_EXTENSION = typeof INPUT_OBJECT_TYPE_EXTENSION;
 
 /** Schema Coordinates */
-export const SCHEMA_COORDINATE = 'SchemaCoordinate';
-export type SCHEMA_COORDINATE = typeof SCHEMA_COORDINATE;
+export const TYPE_COORDINATE = 'TypeCoordinate';
+export type TYPE_COORDINATE = typeof TYPE_COORDINATE;
+
+export const MEMBER_COORDINATE = 'MemberCoordinate';
+export type MEMBER_COORDINATE = typeof MEMBER_COORDINATE;
+
+export const ARGUMENT_COORDINATE = 'ArgumentCoordinate';
+export type ARGUMENT_COORDINATE = typeof ARGUMENT_COORDINATE;
+
+export const DIRECTIVE_COORDINATE = 'DirectiveCoordinate';
+export type DIRECTIVE_COORDINATE = typeof DIRECTIVE_COORDINATE;
+
+export const DIRECTIVE_ARGUMENT_COORDINATE = 'DirectiveArgumentCoordinate';
+export type DIRECTIVE_ARGUMENT_COORDINATE =
+  typeof DIRECTIVE_ARGUMENT_COORDINATE;

--- a/src/language/kinds_.ts
+++ b/src/language/kinds_.ts
@@ -113,11 +113,14 @@ export type INPUT_OBJECT_TYPE_EXTENSION = typeof INPUT_OBJECT_TYPE_EXTENSION;
 export const TYPE_COORDINATE = 'TypeCoordinate';
 export type TYPE_COORDINATE = typeof TYPE_COORDINATE;
 
-export const MEMBER_COORDINATE = 'MemberCoordinate';
-export type MEMBER_COORDINATE = typeof MEMBER_COORDINATE;
+export const FIELD_COORDINATE = 'FieldCoordinate';
+export type FIELD_COORDINATE = typeof FIELD_COORDINATE;
 
 export const ARGUMENT_COORDINATE = 'ArgumentCoordinate';
 export type ARGUMENT_COORDINATE = typeof ARGUMENT_COORDINATE;
+
+export const VALUE_COORDINATE = 'ValueCoordinate';
+export type VALUE_COORDINATE = typeof VALUE_COORDINATE;
 
 export const DIRECTIVE_COORDINATE = 'DirectiveCoordinate';
 export type DIRECTIVE_COORDINATE = typeof DIRECTIVE_COORDINATE;

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -98,6 +98,7 @@ export function isPunctuatorTokenKind(kind: TokenKind): boolean {
     kind === TokenKind.DOT ||
     kind === TokenKind.SPREAD ||
     kind === TokenKind.COLON ||
+    kind === TokenKind.TWO_COLON ||
     kind === TokenKind.EQUALS ||
     kind === TokenKind.AT ||
     kind === TokenKind.BRACKET_L ||
@@ -271,6 +272,14 @@ function readNextToken(lexer: Lexer, start: number): Token {
         return readDot(lexer, position);
       }
       case 0x003a: // :
+        if (body.charCodeAt(position + 1) === 0x003a) {
+          return createToken(
+            lexer,
+            TokenKind.TWO_COLON,
+            position,
+            position + 2,
+          );
+        }
         return createToken(lexer, TokenKind.COLON, position, position + 1);
       case 0x003d: // =
         return createToken(lexer, TokenKind.EQUALS, position, position + 1);

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -4,6 +4,7 @@ import type { GraphQLError } from '../error/GraphQLError.js';
 import { syntaxError } from '../error/syntaxError.js';
 
 import type {
+  ArgumentCoordinateNode,
   ArgumentNode,
   BooleanValueNode,
   ConstArgumentNode,
@@ -13,6 +14,8 @@ import type {
   ConstObjectValueNode,
   ConstValueNode,
   DefinitionNode,
+  DirectiveArgumentCoordinateNode,
+  DirectiveCoordinateNode,
   DirectiveDefinitionNode,
   DirectiveNode,
   DocumentNode,
@@ -35,6 +38,7 @@ import type {
   IntValueNode,
   ListTypeNode,
   ListValueNode,
+  MemberCoordinateNode,
   NamedTypeNode,
   NameNode,
   NonNullTypeNode,
@@ -54,6 +58,7 @@ import type {
   SelectionSetNode,
   StringValueNode,
   Token,
+  TypeCoordinateNode,
   TypeNode,
   TypeSystemExtensionNode,
   UnionTypeDefinitionNode,
@@ -1481,12 +1486,42 @@ export class Parser {
       this.expectToken(TokenKind.COLON);
       this.expectToken(TokenKind.PAREN_R);
     }
-    return this.node<SchemaCoordinateNode>(start, {
-      kind: Kind.SCHEMA_COORDINATE,
-      ofDirective,
+
+    if (ofDirective && !argumentName) {
+      return this.node<DirectiveCoordinateNode>(start, {
+        kind: Kind.DIRECTIVE_COORDINATE,
+        name,
+      });
+    }
+
+    if (ofDirective && argumentName) {
+      return this.node<DirectiveArgumentCoordinateNode>(start, {
+        kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE,
+        name,
+        argumentName,
+      });
+    }
+
+    if (!ofDirective && memberName && argumentName) {
+      return this.node<ArgumentCoordinateNode>(start, {
+        kind: Kind.ARGUMENT_COORDINATE,
+        name,
+        memberName,
+        argumentName,
+      });
+    }
+
+    if (!ofDirective && memberName && !argumentName) {
+      return this.node<MemberCoordinateNode>(start, {
+        kind: Kind.MEMBER_COORDINATE,
+        name,
+        memberName,
+      });
+    }
+
+    return this.node<TypeCoordinateNode>(start, {
+      kind: Kind.TYPE_COORDINATE,
       name,
-      memberName,
-      argumentName,
     });
   }
 

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -1487,31 +1487,27 @@ export class Parser {
       this.expectToken(TokenKind.PAREN_R);
     }
 
-    if (ofDirective && !argumentName) {
+    if (ofDirective) {
+      if (argumentName) {
+        return this.node<DirectiveArgumentCoordinateNode>(start, {
+          kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE,
+          name,
+          argumentName,
+        });
+      }
       return this.node<DirectiveCoordinateNode>(start, {
         kind: Kind.DIRECTIVE_COORDINATE,
         name,
       });
-    }
-
-    if (ofDirective && argumentName) {
-      return this.node<DirectiveArgumentCoordinateNode>(start, {
-        kind: Kind.DIRECTIVE_ARGUMENT_COORDINATE,
-        name,
-        argumentName,
-      });
-    }
-
-    if (!ofDirective && memberName && argumentName) {
-      return this.node<ArgumentCoordinateNode>(start, {
-        kind: Kind.ARGUMENT_COORDINATE,
-        name,
-        memberName,
-        argumentName,
-      });
-    }
-
-    if (!ofDirective && memberName && !argumentName) {
+    } else if (memberName) {
+      if (argumentName) {
+        return this.node<ArgumentCoordinateNode>(start, {
+          kind: Kind.ARGUMENT_COORDINATE,
+          name,
+          memberName,
+          argumentName,
+        });
+      }
       return this.node<MemberCoordinateNode>(start, {
         kind: Kind.MEMBER_COORDINATE,
         name,

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -1504,7 +1504,7 @@ export class Parser {
         return this.node<ArgumentCoordinateNode>(start, {
           kind: Kind.ARGUMENT_COORDINATE,
           name,
-          memberName,
+          fieldName: memberName,
           argumentName,
         });
       }

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -23,6 +23,7 @@ import type {
   EnumTypeExtensionNode,
   EnumValueDefinitionNode,
   EnumValueNode,
+  FieldCoordinateNode,
   FieldDefinitionNode,
   FieldNode,
   FloatValueNode,
@@ -38,7 +39,6 @@ import type {
   IntValueNode,
   ListTypeNode,
   ListValueNode,
-  MemberCoordinateNode,
   NamedTypeNode,
   NameNode,
   NonNullTypeNode,
@@ -63,6 +63,7 @@ import type {
   TypeSystemExtensionNode,
   UnionTypeDefinitionNode,
   UnionTypeExtensionNode,
+  ValueCoordinateNode,
   ValueNode,
   VariableDefinitionNode,
   VariableNode,
@@ -1466,6 +1467,7 @@ export class Parser {
    *   - Name
    *   - Name . Name
    *   - Name . Name ( Name : )
+   *   - Name :: Name
    *   - @ Name
    *   - @ Name ( Name : )
    */
@@ -1473,6 +1475,16 @@ export class Parser {
     const start = this._lexer.token;
     const ofDirective = this.expectOptionalToken(TokenKind.AT);
     const name = this.parseName();
+
+    if (!ofDirective && this.expectOptionalToken(TokenKind.TWO_COLON)) {
+      const valueName = this.parseName();
+      return this.node<ValueCoordinateNode>(start, {
+        kind: Kind.VALUE_COORDINATE,
+        name,
+        valueName,
+      });
+    }
+
     let memberName: NameNode | undefined;
     if (!ofDirective && this.expectOptionalToken(TokenKind.DOT)) {
       memberName = this.parseName();
@@ -1508,10 +1520,10 @@ export class Parser {
           argumentName,
         });
       }
-      return this.node<MemberCoordinateNode>(start, {
-        kind: Kind.MEMBER_COORDINATE,
+      return this.node<FieldCoordinateNode>(start, {
+        kind: Kind.FIELD_COORDINATE,
         name,
-        memberName,
+        fieldName: memberName,
       });
     }
 

--- a/src/language/predicates.ts
+++ b/src/language/predicates.ts
@@ -115,5 +115,11 @@ export function isTypeExtensionNode(node: ASTNode): node is TypeExtensionNode {
 export function isSchemaCoordinateNode(
   node: ASTNode,
 ): node is SchemaCoordinateNode {
-  return node.kind === Kind.SCHEMA_COORDINATE;
+  return (
+    node.kind === Kind.TYPE_COORDINATE ||
+    node.kind === Kind.MEMBER_COORDINATE ||
+    node.kind === Kind.ARGUMENT_COORDINATE ||
+    node.kind === Kind.DIRECTIVE_COORDINATE ||
+    node.kind === Kind.DIRECTIVE_ARGUMENT_COORDINATE
+  );
 }

--- a/src/language/predicates.ts
+++ b/src/language/predicates.ts
@@ -117,8 +117,9 @@ export function isSchemaCoordinateNode(
 ): node is SchemaCoordinateNode {
   return (
     node.kind === Kind.TYPE_COORDINATE ||
-    node.kind === Kind.MEMBER_COORDINATE ||
+    node.kind === Kind.FIELD_COORDINATE ||
     node.kind === Kind.ARGUMENT_COORDINATE ||
+    node.kind === Kind.VALUE_COORDINATE ||
     node.kind === Kind.DIRECTIVE_COORDINATE ||
     node.kind === Kind.DIRECTIVE_ARGUMENT_COORDINATE
   );

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -321,16 +321,24 @@ const printDocASTReducer: ASTReducer<string> = {
       join(['extend input', name, join(directives, ' '), block(fields)], ' '),
   },
 
-  // Schema Coordinate
+  // Schema Coordinates
 
-  SchemaCoordinate: {
-    leave: ({ ofDirective, name, memberName, argumentName }) =>
-      join([
-        ofDirective ? '@' : '',
-        name,
-        wrap('.', memberName),
-        wrap('(', argumentName, ':)'),
-      ]),
+  TypeCoordinate: { leave: ({ name }) => name },
+
+  MemberCoordinate: {
+    leave: ({ name, memberName }) => join([name, wrap('.', memberName)]),
+  },
+
+  ArgumentCoordinate: {
+    leave: ({ name, memberName, argumentName }) =>
+      join([name, wrap('.', memberName), wrap('(', argumentName, ':)')]),
+  },
+
+  DirectiveCoordinate: { leave: ({ name }) => join(['@', name]) },
+
+  DirectiveArgumentCoordinate: {
+    leave: ({ name, argumentName }) =>
+      join(['@', name, wrap('(', argumentName, ':)')]),
   },
 };
 

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -330,8 +330,8 @@ const printDocASTReducer: ASTReducer<string> = {
   },
 
   ArgumentCoordinate: {
-    leave: ({ name, memberName, argumentName }) =>
-      join([name, wrap('.', memberName), wrap('(', argumentName, ':)')]),
+    leave: ({ name, fieldName, argumentName }) =>
+      join([name, wrap('.', fieldName), wrap('(', argumentName, ':)')]),
   },
 
   DirectiveCoordinate: { leave: ({ name }) => join(['@', name]) },

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -325,13 +325,17 @@ const printDocASTReducer: ASTReducer<string> = {
 
   TypeCoordinate: { leave: ({ name }) => name },
 
-  MemberCoordinate: {
-    leave: ({ name, memberName }) => join([name, wrap('.', memberName)]),
+  FieldCoordinate: {
+    leave: ({ name, fieldName }) => join([name, wrap('.', fieldName)]),
   },
 
   ArgumentCoordinate: {
     leave: ({ name, fieldName, argumentName }) =>
       join([name, wrap('.', fieldName), wrap('(', argumentName, ':)')]),
+  },
+
+  ValueCoordinate: {
+    leave: ({ name, valueName }) => join([name, wrap('::', valueName)]),
   },
 
   DirectiveCoordinate: { leave: ({ name }) => join(['@', name]) },

--- a/src/language/tokenKind.ts
+++ b/src/language/tokenKind.ts
@@ -13,6 +13,7 @@ export const TokenKind = {
   DOT: '.',
   SPREAD: '...' as const,
   COLON: ':' as const,
+  TWO_COLON: '::' as const,
   EQUALS: '=' as const,
   AT: '@' as const,
   BRACKET_L: '[' as const,

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -143,7 +143,7 @@ describe('resolveSchemaCoordinate', () => {
     expect(() =>
       resolveSchemaCoordinate(schema, 'SearchCriteria.name(arg:)'),
     ).to.throw(
-      'Expected "SearchCriteria" to be defined as a type in the schema.',
+      'Expected "SearchCriteria" to be an object type or interface type.',
     );
   });
 

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -71,7 +71,7 @@ describe('resolveSchemaCoordinate', () => {
     );
 
     expect(() => resolveSchemaCoordinate(schema, 'String.field')).to.throw(
-      'Expected "String" to be defined as a type in the schema.',
+      'Expected "String" to be an object type, interface type, input object type, or enum type.',
     );
   });
 

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -66,12 +66,12 @@ describe('resolveSchemaCoordinate', () => {
       undefined,
     );
 
-    expect(resolveSchemaCoordinate(schema, 'Unknown.field')).to.deep.equal(
-      undefined,
+    expect(() => resolveSchemaCoordinate(schema, 'Unknown.field')).to.throw(
+      'Expected "Unknown" to be defined as a type in the schema.',
     );
 
-    expect(resolveSchemaCoordinate(schema, 'String.field')).to.deep.equal(
-      undefined,
+    expect(() => resolveSchemaCoordinate(schema, 'String.field')).to.throw(
+      'Expected "String" to be defined as a type in the schema.',
     );
   });
 
@@ -130,17 +130,21 @@ describe('resolveSchemaCoordinate', () => {
       resolveSchemaCoordinate(schema, 'Business.name(unknown:)'),
     ).to.deep.equal(undefined);
 
-    expect(
+    expect(() =>
       resolveSchemaCoordinate(schema, 'Unknown.field(arg:)'),
-    ).to.deep.equal(undefined);
+    ).to.throw('Expected "Unknown" to be defined as a type in the schema.');
 
-    expect(
+    expect(() =>
       resolveSchemaCoordinate(schema, 'Business.unknown(arg:)'),
-    ).to.deep.equal(undefined);
+    ).to.throw(
+      'Expected "unknown" to exist as an argument of type "Business" in the schema.',
+    );
 
-    expect(
+    expect(() =>
       resolveSchemaCoordinate(schema, 'SearchCriteria.name(arg:)'),
-    ).to.deep.equal(undefined);
+    ).to.throw(
+      'Expected "SearchCriteria" to be defined as a type in the schema.',
+    );
   });
 
   it('resolves a Directive', () => {
@@ -178,8 +182,8 @@ describe('resolveSchemaCoordinate', () => {
       undefined,
     );
 
-    expect(resolveSchemaCoordinate(schema, '@unknown(arg:)')).to.deep.equal(
-      undefined,
+    expect(() => resolveSchemaCoordinate(schema, '@unknown(arg:)')).to.throw(
+      'Expected "unknown" to be defined as a directive in the schema.',
     );
   });
 });

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -137,7 +137,7 @@ describe('resolveSchemaCoordinate', () => {
     expect(() =>
       resolveSchemaCoordinate(schema, 'Business.unknown(arg:)'),
     ).to.throw(
-      'Expected "unknown" to exist as an argument of type "Business" in the schema.',
+      'Expected "unknown" to exist as a field of type "Business" in the schema.',
     );
 
     expect(() =>

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -71,7 +71,7 @@ describe('resolveSchemaCoordinate', () => {
     );
 
     expect(() => resolveSchemaCoordinate(schema, 'String.field')).to.throw(
-      'Expected "String" to be an object type, interface type, input object type, or enum type.',
+      'Expected "String" to be an Input Object, Object or Interface type.',
     );
   });
 
@@ -101,7 +101,7 @@ describe('resolveSchemaCoordinate', () => {
     const type = schema.getType('SearchFilter') as GraphQLEnumType;
     const enumValue = type.getValue('OPEN_NOW');
     expect(
-      resolveSchemaCoordinate(schema, 'SearchFilter.OPEN_NOW'),
+      resolveSchemaCoordinate(schema, 'SearchFilter::OPEN_NOW'),
     ).to.deep.equal({
       kind: 'EnumValue',
       type,
@@ -109,7 +109,7 @@ describe('resolveSchemaCoordinate', () => {
     });
 
     expect(
-      resolveSchemaCoordinate(schema, 'SearchFilter.UNKNOWN'),
+      resolveSchemaCoordinate(schema, 'SearchFilter::UNKNOWN'),
     ).to.deep.equal(undefined);
   });
 

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -274,7 +274,7 @@ function resolveArgumentCoordinate(
   // Assert {type} must be an Object or Interface type.
   if (!isObjectType(type) && !isInterfaceType(type)) {
     throw new Error(
-      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+      `Expected ${inspect(typeName)} to be an object type or interface type.`,
     );
   }
 

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -99,83 +99,23 @@ export function resolveSchemaCoordinate(
 }
 
 /**
- * SchemaCoordinate : @ Name
- */
-function resolveDirectiveCoordinate(
-  schema: GraphQLSchema,
-  schemaCoordinate: DirectiveCoordinateNode,
-): ResolvedDirective | undefined {
-  // Let {directiveName} be the value of the first {Name}.
-  const directiveName = schemaCoordinate.name.value;
-
-  // Let {directive} be the directive in the {schema} named {directiveName}.
-  const directive = schema.getDirective(directiveName);
-
-  // If {directive} does not exist, return undefined.
-  if (!directive) {
-    return;
-  }
-
-  // Otherwise return the directive in the {schema} named {directiveName}.
-  return { kind: 'Directive', directive };
-}
-
-/**
- * SchemaCoordinate : @ Name ( Name : )
- */
-function resolveDirectiveArgumentCoordinate(
-  schema: GraphQLSchema,
-  schemaCoordinate: DirectiveArgumentCoordinateNode,
-): ResolvedDirectiveArgument | undefined {
-  // Let {directiveName} be the value of the first {Name}.
-  const directiveName = schemaCoordinate.name.value;
-
-  // Let {directive} be the directive in the {schema} named {directiveName}.
-  const directive = schema.getDirective(directiveName);
-
-  // Assert that {directive} exists.
-  if (!directive) {
-    throw new Error(
-      `Expected ${inspect(directiveName)} to be defined as a directive in the schema.`,
-    );
-  }
-
-  // Let {directiveArgumentName} be the value of the second {Name}.
-  const {
-    argumentName: { value: directiveArgumentName },
-  } = schemaCoordinate;
-  const directiveArgument = directive.args.find(
-    (arg) => arg.name === directiveArgumentName,
-  );
-
-  // If {directiveArgumentName} does not exist, return undefined.
-  if (!directiveArgument) {
-    return;
-  }
-
-  // Return the argument of {directive} named {directiveArgumentName}.
-  return { kind: 'DirectiveArgument', directive, directiveArgument };
-}
-
-/**
  * SchemaCoordinate : Name
  */
 function resolveTypeCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: TypeCoordinateNode,
 ): ResolvedNamedType | undefined {
-  // Let {typeName} be the value of the first {Name}.
+  // 1. Let {typeName} be the value of the first {Name}.
+  // 2. Let {type} be the type in the {schema} named {typeName}.
   const typeName = schemaCoordinate.name.value;
-
-  // Let {type} be the type in the {schema} named {typeName}.
   const type = schema.getType(typeName);
 
-  // If {type} does not exist, return undefined.
+  // 3. If {type} does not exist, return {void}.
   if (!type) {
     return;
   }
 
-  // Return the type in the {schema} named {typeName}.
+  // 4. {type}
   return { kind: 'NamedType', type };
 }
 
@@ -186,66 +126,69 @@ function resolveMemberCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: MemberCoordinateNode,
 ): ResolvedField | ResolvedInputField | ResolvedEnumValue | undefined {
-  // Let {typeName} be the value of the first {Name}.
+  // 1. Let {typeName} be the value of the first {Name}.
+  // 2. Let {type} be the type in the {schema} named {typeName}.
   const typeName = schemaCoordinate.name.value;
-
-  // Let {type} be the type in the {schema} named {typeName}.
   const type = schema.getType(typeName);
 
-  // Assert that {type} exists.
+  // 3. Assert that {type} exists.
   if (!type) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
     );
   }
 
-  const memberName = schemaCoordinate.memberName.value;
-
-  // If {type} is an Enum type:
+  // 4. If {type} is an Enum type:
   if (isEnumType(type)) {
-    // Let {enumValueName} be the value of the second {Name}.
-    const enumValue = type.getValue(memberName);
+    // 5. Let {enumValueName} be the value of the second {Name}.
+    // 6. Let {enumValue} be the enum value of {type} named {enumValueName}.
+    const enumValueName = schemaCoordinate.memberName.value;
+    const enumValue = type.getValue(enumValueName);
 
-    // TODO: Add a spec line about returning undefined if the member name does not exist.
+    // 7. If {enumValue} does not exist, return {void}.
     if (enumValue == null) {
       return;
     }
 
-    // Return the enum value of {type} named {enumValueName}.
+    // 8. Return {enumValue}
     return { kind: 'EnumValue', type, enumValue };
   }
 
-  // Otherwise if {type} is an Input Object type:
+  // 9. Otherwise if {type} is an Input Object type:
   if (isInputObjectType(type)) {
-    // Let {inputFieldName} be the value of the second {Name}.
-    const inputField = type.getFields()[memberName];
+    // 10. Let {inputFieldName} be the value of the second {Name}.
+    // 11. Let {inputField} be the input field of {type} named {inputFieldName}.
+    const inputFieldName = schemaCoordinate.memberName.value;
+    const inputField = type.getFields()[inputFieldName];
 
-    // TODO: Add a spec line about returning undefined if the member name does not exist.
+    // 12. If {inputField} does not exist, return {void}.
     if (inputField == null) {
       return;
     }
 
-    // Return the input field of {type} named {inputFieldName}.
+    // 13. Return {inputField}
     return { kind: 'InputField', type, inputField };
   }
 
-  // Otherwise:
-  // Assert {type} must be an Object or Interface type.
+  // 14. Otherwise:
+  // 15. Assert {type} must be an Object or Interface type.
   if (!isObjectType(type) && !isInterfaceType(type)) {
     throw new Error(
       `Expected ${inspect(typeName)} to be an object type, interface type, input object type, or enum type.`,
     );
   }
 
-  // Let {fieldName} be the value of the second {Name}.
-  const field = type.getFields()[memberName];
+  // 16. Let {fieldName} be the value of the second {Name}.
+  // 17. Let {field} be the field of {type} named {fieldName}.
+  const fieldName = schemaCoordinate.memberName.value;
+  const field = type.getFields()[fieldName];
 
-  // TODO: Add a spec line about returning undefined if the member name does not exist.
+  // 18. If {field} does not exist, return {void}.
   if (field == null) {
     return;
   }
 
-  // Return the field of {type} named {fieldName}.
+  // 19. Return {field}
   return { kind: 'Field', type, field };
 }
 
@@ -256,52 +199,109 @@ function resolveArgumentCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: ArgumentCoordinateNode,
 ): ResolvedFieldArgument | undefined {
-  // Let {typeName} be the value of the first {Name}.
+  // 1. Let {typeName} be the value of the first {Name}.
+  // 2. Let {type} be the type in the {schema} named {typeName}.
   const typeName = schemaCoordinate.name.value;
-
-  // Let {type} be the type in the {schema} named {typeName}.
   const type = schema.getType(typeName);
 
-  // Assert that {type} exists.
-  if (!type) {
+  // 3. Assert that {type} exists.
+  if (type == null) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
     );
   }
 
-  const fieldName = schemaCoordinate.fieldName.value;
-
-  // Assert {type} must be an Object or Interface type.
+  // 4. Assert {type} must be an Object or Interface type.
   if (!isObjectType(type) && !isInterfaceType(type)) {
     throw new Error(
       `Expected ${inspect(typeName)} to be an object type or interface type.`,
     );
   }
 
-  // Let {fieldName} be the value of the second {Name}.
-  // Let {field} be the field of {type} named {fieldName}.
+  // 5. Let {fieldName} be the value of the second {Name}.
+  // 6. Let {field} be the field of {type} named {fieldName}.
+  const fieldName = schemaCoordinate.fieldName.value;
   const field = type.getFields()[fieldName];
 
-  // Assert {field} must exist.
+  // 7. Assert {field} must exist.
   if (field == null) {
     throw new Error(
       `Expected ${inspect(fieldName)} to exist as a field of type ${inspect(typeName)} in the schema.`,
     );
   }
 
-  // Let {fieldArgumentName} be the value of the third {Name}.
+  // 8. Let {fieldArgumentName} be the value of the third {Name}.
+  // 9. Let {fieldArgument} be the argument of {field} named {fieldArgumentName}.
   const fieldArgumentName = schemaCoordinate.argumentName.value;
   const fieldArgument = field.args.find(
     (arg) => arg.name === fieldArgumentName,
   );
 
-  // TODO: Add a spec line about returning undefined if the argument does not exist.
+  // 10. If {fieldArgument} does not exist, return {void}.
   if (fieldArgument == null) {
     return;
   }
 
-  // Return the argument of {field} named {fieldArgumentName}.
+  // 11. Return {fieldArgument}.
   return { kind: 'FieldArgument', type, field, fieldArgument };
+}
+
+/**
+ * SchemaCoordinate : @ Name
+ */
+function resolveDirectiveCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: DirectiveCoordinateNode,
+): ResolvedDirective | undefined {
+  // 1. Let {directiveName} be the value of the first {Name}.
+  // 2. Let {directive} be the directive in the {schema} named {directiveName}.
+  const directiveName = schemaCoordinate.name.value;
+  const directive = schema.getDirective(directiveName);
+
+  // 3. If {directive} does not exist, return {void}.
+  if (!directive) {
+    return;
+  }
+
+  // 4. Otherwise return {directive}.
+  return { kind: 'Directive', directive };
+}
+
+/**
+ * SchemaCoordinate : @ Name ( Name : )
+ */
+function resolveDirectiveArgumentCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: DirectiveArgumentCoordinateNode,
+): ResolvedDirectiveArgument | undefined {
+  // 1. Let {directiveName} be the value of the first {Name}.
+  // 2. Let {directive} be the directive in the {schema} named {directiveName}.
+  const directiveName = schemaCoordinate.name.value;
+  const directive = schema.getDirective(directiveName);
+
+  // 3. Assert {directive} must exist.
+  if (!directive) {
+    throw new Error(
+      `Expected ${inspect(directiveName)} to be defined as a directive in the schema.`,
+    );
+  }
+
+  // 4. Let {directiveArgumentName} be the value of the second {Name}.
+  // 5. Let {directiveArgument} be the argument of {directive} named {directiveArgumentName}.
+  const {
+    argumentName: { value: directiveArgumentName },
+  } = schemaCoordinate;
+  const directiveArgument = directive.args.find(
+    (arg) => arg.name === directiveArgumentName,
+  );
+
+  // 6. If {directiveArgument} does not exist, return {void}.
+  if (!directiveArgument) {
+    return;
+  }
+
+  // 7. Return {directiveArgument}.
+  return { kind: 'DirectiveArgument', directive, directiveArgument };
 }
 
 /**

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -81,8 +81,6 @@ export function resolveASTSchemaCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: SchemaCoordinateNode,
 ): ResolvedSchemaElement | undefined {
-  // const { ofDirective, name, memberName, argumentName } = schemaCoordinate;
-
   if (
     schemaCoordinate.kind === 'DirectiveCoordinate' ||
     schemaCoordinate.kind === 'DirectiveArgumentCoordinate'

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -131,7 +131,7 @@ function resolveMemberCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert that {type} exists.
+  // 3. Assert {type} exists.
   if (!type) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
@@ -204,7 +204,7 @@ function resolveArgumentCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert that {type} exists.
+  // 3. Assert {type} exists.
   if (type == null) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -110,7 +110,7 @@ function resolveTypeCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. If {type} does not exist, return {void}.
+  // 3. If {type} does not exist, return {null}.
   if (!type) {
     return;
   }
@@ -145,7 +145,7 @@ function resolveMemberCoordinate(
     const enumValueName = schemaCoordinate.memberName.value;
     const enumValue = type.getValue(enumValueName);
 
-    // 7. If {enumValue} does not exist, return {void}.
+    // 7. If {enumValue} does not exist, return {null}.
     if (enumValue == null) {
       return;
     }
@@ -161,7 +161,7 @@ function resolveMemberCoordinate(
     const inputFieldName = schemaCoordinate.memberName.value;
     const inputField = type.getFields()[inputFieldName];
 
-    // 12. If {inputField} does not exist, return {void}.
+    // 12. If {inputField} does not exist, return {null}.
     if (inputField == null) {
       return;
     }
@@ -183,7 +183,7 @@ function resolveMemberCoordinate(
   const fieldName = schemaCoordinate.memberName.value;
   const field = type.getFields()[fieldName];
 
-  // 18. If {field} does not exist, return {void}.
+  // 18. If {field} does not exist, return {null}.
   if (field == null) {
     return;
   }
@@ -237,7 +237,7 @@ function resolveArgumentCoordinate(
     (arg) => arg.name === fieldArgumentName,
   );
 
-  // 10. If {fieldArgument} does not exist, return {void}.
+  // 10. If {fieldArgument} does not exist, return {null}.
   if (fieldArgument == null) {
     return;
   }
@@ -258,7 +258,7 @@ function resolveDirectiveCoordinate(
   const directiveName = schemaCoordinate.name.value;
   const directive = schema.getDirective(directiveName);
 
-  // 3. If {directive} does not exist, return {void}.
+  // 3. If {directive} does not exist, return {null}.
   if (!directive) {
     return;
   }
@@ -295,7 +295,7 @@ function resolveDirectiveArgumentCoordinate(
     (arg) => arg.name === directiveArgumentName,
   );
 
-  // 6. If {directiveArgument} does not exist, return {void}.
+  // 6. If {directiveArgument} does not exist, return {null}.
   if (!directiveArgument) {
     return;
   }

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -1,4 +1,14 @@
-import type { SchemaCoordinateNode } from '../language/ast.js';
+import { inspect } from '../jsutils/inspect.js';
+
+import type {
+  ArgumentCoordinateNode,
+  DirectiveArgumentCoordinateNode,
+  DirectiveCoordinateNode,
+  MemberCoordinateNode,
+  SchemaCoordinateNode,
+  TypeCoordinateNode,
+} from '../language/ast.js';
+import { Kind } from '../language/kinds.js';
 import { parseSchemaCoordinate } from '../language/parser.js';
 import type { Source } from '../language/source.js';
 
@@ -21,41 +31,55 @@ import type { GraphQLSchema } from '../type/schema.js';
 /**
  * A resolved schema element may be one of the following kinds:
  */
+export interface ResolvedNamedType {
+  readonly kind: 'NamedType';
+  readonly type: GraphQLNamedType;
+}
+
+export interface ResolvedField {
+  readonly kind: 'Field';
+  readonly type: GraphQLNamedType;
+  readonly field: GraphQLField<unknown, unknown>;
+}
+
+export interface ResolvedInputField {
+  readonly kind: 'InputField';
+  readonly type: GraphQLNamedType;
+  readonly inputField: GraphQLInputField;
+}
+
+export interface ResolvedEnumValue {
+  readonly kind: 'EnumValue';
+  readonly type: GraphQLNamedType;
+  readonly enumValue: GraphQLEnumValue;
+}
+
+export interface ResolvedFieldArgument {
+  readonly kind: 'FieldArgument';
+  readonly type: GraphQLNamedType;
+  readonly field: GraphQLField<unknown, unknown>;
+  readonly fieldArgument: GraphQLArgument;
+}
+
+export interface ResolvedDirective {
+  readonly kind: 'Directive';
+  readonly directive: GraphQLDirective;
+}
+
+export interface ResolvedDirectiveArgument {
+  readonly kind: 'DirectiveArgument';
+  readonly directive: GraphQLDirective;
+  readonly directiveArgument: GraphQLArgument;
+}
+
 export type ResolvedSchemaElement =
-  | {
-      readonly kind: 'NamedType';
-      readonly type: GraphQLNamedType;
-    }
-  | {
-      readonly kind: 'Field';
-      readonly type: GraphQLNamedType;
-      readonly field: GraphQLField<unknown, unknown>;
-    }
-  | {
-      readonly kind: 'InputField';
-      readonly type: GraphQLNamedType;
-      readonly inputField: GraphQLInputField;
-    }
-  | {
-      readonly kind: 'EnumValue';
-      readonly type: GraphQLNamedType;
-      readonly enumValue: GraphQLEnumValue;
-    }
-  | {
-      readonly kind: 'FieldArgument';
-      readonly type: GraphQLNamedType;
-      readonly field: GraphQLField<unknown, unknown>;
-      readonly fieldArgument: GraphQLArgument;
-    }
-  | {
-      readonly kind: 'Directive';
-      readonly directive: GraphQLDirective;
-    }
-  | {
-      readonly kind: 'DirectiveArgument';
-      readonly directive: GraphQLDirective;
-      readonly directiveArgument: GraphQLArgument;
-    };
+  | ResolvedNamedType
+  | ResolvedField
+  | ResolvedInputField
+  | ResolvedEnumValue
+  | ResolvedFieldArgument
+  | ResolvedDirective
+  | ResolvedDirectiveArgument;
 
 /**
  * A schema coordinate is resolved in the context of a GraphQL schema to
@@ -75,139 +99,228 @@ export function resolveSchemaCoordinate(
 }
 
 /**
+ * SchemaCoordinate : @ Name
+ */
+function resolveDirectiveCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: DirectiveCoordinateNode,
+): ResolvedDirective | undefined {
+  // Let {directiveName} be the value of the first {Name}.
+  const directiveName = schemaCoordinate.name.value;
+
+  // Let {directive} be the directive in the {schema} named {directiveName}.
+  const directive = schema.getDirective(directiveName);
+
+  // If {directive} does not exist, return undefined.
+  if (!directive) {
+    return;
+  }
+
+  // Otherwise return the directive in the {schema} named {directiveName}.
+  return { kind: 'Directive', directive };
+}
+
+/**
+ * SchemaCoordinate : @ Name ( Name : )
+ */
+function resolveDirectiveArgumentCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: DirectiveArgumentCoordinateNode,
+): ResolvedDirectiveArgument | undefined {
+  // Let {directiveName} be the value of the first {Name}.
+  const directiveName = schemaCoordinate.name.value;
+
+  // Let {directive} be the directive in the {schema} named {directiveName}.
+  const directive = schema.getDirective(directiveName);
+
+  // Assert that {directive} exists.
+  if (!directive) {
+    throw new Error(
+      `Expected ${inspect(directiveName)} to be defined as a directive in the schema.`,
+    );
+  }
+
+  // Let {directiveArgumentName} be the value of the second {Name}.
+  const {
+    argumentName: { value: directiveArgumentName },
+  } = schemaCoordinate;
+  const directiveArgument = directive.args.find(
+    (arg) => arg.name === directiveArgumentName,
+  );
+
+  // If {directiveArgumentName} does not exist, return undefined.
+  if (!directiveArgument) {
+    return;
+  }
+
+  // Return the argument of {directive} named {directiveArgumentName}.
+  return { kind: 'DirectiveArgument', directive, directiveArgument };
+}
+
+/**
+ * SchemaCoordinate : Name
+ */
+function resolveTypeCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: TypeCoordinateNode,
+): ResolvedNamedType | undefined {
+  // Let {typeName} be the value of the first {Name}.
+  const typeName = schemaCoordinate.name.value;
+
+  // Let {type} be the type in the {schema} named {typeName}.
+  const type = schema.getType(typeName);
+
+  // If {type} does not exist, return undefined.
+  if (!type) {
+    return;
+  }
+
+  // Return the type in the {schema} named {typeName}.
+  return { kind: 'NamedType', type };
+}
+
+/**
+ * SchemaCoordinate : Name . Name
+ */
+function resolveMemberCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: MemberCoordinateNode,
+): ResolvedField | ResolvedInputField | ResolvedEnumValue | undefined {
+  // Let {typeName} be the value of the first {Name}.
+  const typeName = schemaCoordinate.name.value;
+
+  // Let {type} be the type in the {schema} named {typeName}.
+  const type = schema.getType(typeName);
+
+  // Assert that {type} exists.
+  if (!type) {
+    throw new Error(
+      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+    );
+  }
+
+  const memberName = schemaCoordinate.memberName.value;
+
+  // If {type} is an Enum type:
+  if (isEnumType(type)) {
+    // Let {enumValueName} be the value of the second {Name}.
+    const enumValue = type.getValue(memberName);
+
+    // TODO: Add a spec line about returning undefined if the member name does not exist.
+    if (enumValue == null) {
+      return;
+    }
+
+    // Return the enum value of {type} named {enumValueName}.
+    return { kind: 'EnumValue', type, enumValue };
+  }
+
+  // Otherwise if {type} is an Input Object type:
+  if (isInputObjectType(type)) {
+    // Let {inputFieldName} be the value of the second {Name}.
+    const inputField = type.getFields()[memberName];
+
+    // TODO: Add a spec line about returning undefined if the member name does not exist.
+    if (inputField == null) {
+      return;
+    }
+
+    // Return the input field of {type} named {inputFieldName}.
+    return { kind: 'InputField', type, inputField };
+  }
+
+  // Otherwise:
+  // Assert {type} must be an Object or Interface type.
+  if (!isObjectType(type) && !isInterfaceType(type)) {
+    throw new Error(
+      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+    );
+  }
+
+  // Let {fieldName} be the value of the second {Name}.
+  const field = type.getFields()[memberName];
+
+  // TODO: Add a spec line about returning undefined if the member name does not exist.
+  if (field == null) {
+    return;
+  }
+
+  // Return the field of {type} named {fieldName}.
+  return { kind: 'Field', type, field };
+}
+
+/**
+ * SchemaCoordinate : Name . Name ( Name : )
+ */
+function resolveArgumentCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: ArgumentCoordinateNode,
+): ResolvedFieldArgument | undefined {
+  // Let {typeName} be the value of the first {Name}.
+  const typeName = schemaCoordinate.name.value;
+
+  // Let {type} be the type in the {schema} named {typeName}.
+  const type = schema.getType(typeName);
+
+  // Assert that {type} exists.
+  if (!type) {
+    throw new Error(
+      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+    );
+  }
+
+  const fieldName = schemaCoordinate.fieldName.value;
+
+  // Assert {type} must be an Object or Interface type.
+  if (!isObjectType(type) && !isInterfaceType(type)) {
+    throw new Error(
+      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+    );
+  }
+
+  // Let {fieldName} be the value of the second {Name}.
+  // Let {field} be the field of {type} named {fieldName}.
+  const field = type.getFields()[fieldName];
+
+  // Assert {field} must exist.
+  if (field == null) {
+    throw new Error(
+      `Expected ${inspect(fieldName)} to exist as an argument of type ${inspect(typeName)} in the schema.`,
+    );
+  }
+
+  // Let {fieldArgumentName} be the value of the third {Name}.
+  const fieldArgumentName = schemaCoordinate.argumentName.value;
+  const fieldArgument = field.args.find(
+    (arg) => arg.name === fieldArgumentName,
+  );
+
+  // TODO: Add a spec line about returning undefined if the argument does not exist.
+  if (fieldArgument == null) {
+    return;
+  }
+
+  // Return the argument of {field} named {fieldArgumentName}.
+  return { kind: 'FieldArgument', type, field, fieldArgument };
+}
+
+/**
  * Resolves schema coordinate from a parsed SchemaCoordinate node.
  */
 export function resolveASTSchemaCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: SchemaCoordinateNode,
 ): ResolvedSchemaElement | undefined {
-  if (
-    schemaCoordinate.kind === 'DirectiveCoordinate' ||
-    schemaCoordinate.kind === 'DirectiveArgumentCoordinate'
-  ) {
-    // SchemaCoordinate :
-    //   - @ Name
-    //   - @ Name ( Name : )
-    // Let {directiveName} be the value of the first {Name}.
-    // Let {directive} be the directive in the {schema} named {directiveName}.
-    const {
-      name: { value: directiveName },
-    } = schemaCoordinate;
-    const directive = schema.getDirective(directiveName);
-
-    if (schemaCoordinate.kind === 'DirectiveCoordinate') {
-      // SchemaCoordinate : @ Name
-      // Return the directive in the {schema} named {directiveName}.
-      if (!directive) {
-        return;
-      }
-      return { kind: 'Directive', directive };
-    }
-
-    // SchemaCoordinate : @ Name ( Name : )
-    // TODO: Assert {directive} must exist.
-    if (!directive) {
-      return;
-    }
-    // Let {directiveArgumentName} be the value of the second {Name}.
-    // Return the argument of {directive} named {directiveArgumentName}.
-    const {
-      argumentName: { value: directiveArgumentName },
-    } = schemaCoordinate;
-    const directiveArgument = directive.args.find(
-      (arg) => arg.name === directiveArgumentName,
-    );
-    if (!directiveArgument) {
-      return;
-    }
-    return { kind: 'DirectiveArgument', directive, directiveArgument };
+  switch (schemaCoordinate.kind) {
+    case Kind.DIRECTIVE_COORDINATE:
+      return resolveDirectiveCoordinate(schema, schemaCoordinate);
+    case Kind.DIRECTIVE_ARGUMENT_COORDINATE:
+      return resolveDirectiveArgumentCoordinate(schema, schemaCoordinate);
+    case Kind.TYPE_COORDINATE:
+      return resolveTypeCoordinate(schema, schemaCoordinate);
+    case Kind.MEMBER_COORDINATE:
+      return resolveMemberCoordinate(schema, schemaCoordinate);
+    case Kind.ARGUMENT_COORDINATE:
+      return resolveArgumentCoordinate(schema, schemaCoordinate);
   }
-
-  // SchemaCoordinate :
-  //   - Name
-  //   - Name . Name
-  //   - Name . Name ( Name : )
-  // Let {typeName} be the value of the first {Name}.
-  // Let {type} be the type in the {schema} named {typeName}.
-  const {
-    name: { value: typeName },
-  } = schemaCoordinate;
-  const type = schema.getType(typeName);
-  if (schemaCoordinate.kind === 'TypeCoordinate') {
-    // SchemaCoordinate : Name
-    // Return the type in the {schema} named {typeName}.
-    if (!type) {
-      return;
-    }
-    return { kind: 'NamedType', type };
-  }
-
-  if (schemaCoordinate.kind === 'MemberCoordinate') {
-    const {
-      memberName: { value: memberName },
-    } = schemaCoordinate;
-
-    // SchemaCoordinate : Name . Name
-    // If {type} is an Enum type:
-    if (isEnumType(type)) {
-      // Let {enumValueName} be the value of the second {Name}.
-      // Return the enum value of {type} named {enumValueName}.
-      const enumValue = type.getValue(memberName);
-      if (enumValue == null) {
-        return;
-      }
-      return { kind: 'EnumValue', type, enumValue };
-    }
-    // Otherwise if {type} is an Input Object type:
-    if (isInputObjectType(type)) {
-      // Let {inputFieldName} be the value of the second {Name}.
-      // Return the input field of {type} named {inputFieldName}.
-      const inputField = type.getFields()[memberName];
-      if (inputField == null) {
-        return;
-      }
-      return { kind: 'InputField', type, inputField };
-    }
-    // Otherwise:
-    // Assert {type} must be an Object or Interface type.
-    if (!isObjectType(type) && !isInterfaceType(type)) {
-      return;
-    }
-    // Let {fieldName} be the value of the second {Name}.
-    // Return the field of {type} named {fieldName}.
-    const field = type.getFields()[memberName];
-    if (field == null) {
-      return;
-    }
-    return { kind: 'Field', type, field };
-  }
-
-  const {
-    fieldName: { value: fieldName },
-  } = schemaCoordinate;
-
-  // SchemaCoordinate : Name . Name ( Name : )
-  // Assert {type} must be an Object or Interface type.
-  if (!isObjectType(type) && !isInterfaceType(type)) {
-    return;
-  }
-  // Let {fieldName} be the value of the second {Name}.
-  // Let {field} be the field of {type} named {fieldName}.
-  const field = type.getFields()[fieldName];
-  // Assert {field} must exist.
-  if (field == null) {
-    return;
-  }
-  // Let {fieldArgumentName} be the value of the third {Name}.
-  // Return the argument of {field} named {fieldArgumentName}.
-  const {
-    argumentName: { value: fieldArgumentName },
-  } = schemaCoordinate;
-  const fieldArgument = field.args.find(
-    (arg) => arg.name === fieldArgumentName,
-  );
-  if (fieldArgument == null) {
-    return;
-  }
-  return { kind: 'FieldArgument', type, field, fieldArgument };
 }

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -285,7 +285,7 @@ function resolveArgumentCoordinate(
   // Assert {field} must exist.
   if (field == null) {
     throw new Error(
-      `Expected ${inspect(fieldName)} to exist as an argument of type ${inspect(typeName)} in the schema.`,
+      `Expected ${inspect(fieldName)} to exist as a field of type ${inspect(typeName)} in the schema.`,
     );
   }
 

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -99,28 +99,26 @@ export function resolveSchemaCoordinate(
 }
 
 /**
- * SchemaCoordinate : Name
+ * TypeCoordinate : Name
  */
 function resolveTypeCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: TypeCoordinateNode,
 ): ResolvedNamedType | undefined {
-  // 1. Let {typeName} be the value of the first {Name}.
-  // 2. Let {type} be the type in the {schema} named {typeName}.
+  // 1. Let {typeName} be the value of {Name}.
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. If {type} does not exist, return {null}.
-  if (!type) {
+  // 2. Return the type in the {schema} named {typeName}, or {null} if no such type exists.
+  if (type == null) {
     return;
   }
 
-  // 4. {type}
   return { kind: 'NamedType', type };
 }
 
 /**
- * SchemaCoordinate : Name . Name
+ * MemberCoordinate : Name . Name
  */
 function resolveMemberCoordinate(
   schema: GraphQLSchema,
@@ -131,69 +129,66 @@ function resolveMemberCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert {type} must exist.
+  // 3. Assert: {type} must exist, and must be an Enum, Input Object, Object or Interface type.
   if (!type) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
     );
   }
-
-  // 4. If {type} is an Enum type:
-  if (isEnumType(type)) {
-    // 5. Let {enumValueName} be the value of the second {Name}.
-    // 6. Let {enumValue} be the enum value of {type} named {enumValueName}.
-    const enumValueName = schemaCoordinate.memberName.value;
-    const enumValue = type.getValue(enumValueName);
-
-    // 7. If {enumValue} does not exist, return {null}.
-    if (enumValue == null) {
-      return;
-    }
-
-    // 8. Return {enumValue}
-    return { kind: 'EnumValue', type, enumValue };
-  }
-
-  // 9. Otherwise if {type} is an Input Object type:
-  if (isInputObjectType(type)) {
-    // 10. Let {inputFieldName} be the value of the second {Name}.
-    // 11. Let {inputField} be the input field of {type} named {inputFieldName}.
-    const inputFieldName = schemaCoordinate.memberName.value;
-    const inputField = type.getFields()[inputFieldName];
-
-    // 12. If {inputField} does not exist, return {null}.
-    if (inputField == null) {
-      return;
-    }
-
-    // 13. Return {inputField}
-    return { kind: 'InputField', type, inputField };
-  }
-
-  // 14. Otherwise:
-  // 15. Assert {type} must be an Object or Interface type.
-  if (!isObjectType(type) && !isInterfaceType(type)) {
+  if (
+    !isEnumType(type) &&
+    !isInputObjectType(type) &&
+    !isObjectType(type) &&
+    !isInterfaceType(type)
+  ) {
     throw new Error(
       `Expected ${inspect(typeName)} to be an object type, interface type, input object type, or enum type.`,
     );
   }
 
-  // 16. Let {fieldName} be the value of the second {Name}.
-  // 17. Let {field} be the field of {type} named {fieldName}.
+  // 4. If {type} is an Enum type:
+  if (isEnumType(type)) {
+    // 1. Let {enumValueName} be the value of the second {Name}.
+    const enumValueName = schemaCoordinate.memberName.value;
+    const enumValue = type.getValue(enumValueName);
+
+    // 2. Return the enum value of {type} named {enumValueName}, or {null} if no such value exists.
+    if (enumValue == null) {
+      return;
+    }
+
+    return { kind: 'EnumValue', type, enumValue };
+  }
+
+  // 5. Otherwise, if {type} is an Input Object type:
+  if (isInputObjectType(type)) {
+    // 1. Let {inputFieldName} be the value of the second {Name}.
+    const inputFieldName = schemaCoordinate.memberName.value;
+    const inputField = type.getFields()[inputFieldName];
+
+    // 2. Return the input field of {type} named {inputFieldName}, or {null} if no such input field exists.
+    if (inputField == null) {
+      return;
+    }
+
+    return { kind: 'InputField', type, inputField };
+  }
+
+  // 6. Otherwise:
+  // 1. Let {fieldName} be the value of the second {Name}.
   const fieldName = schemaCoordinate.memberName.value;
   const field = type.getFields()[fieldName];
 
-  // 18. If {field} does not exist, return {null}.
+  // 2. Return the field of {type} named {fieldName}, or {null} if no such field exists.
   if (field == null) {
     return;
   }
 
-  // 19. Return {field}
   return { kind: 'Field', type, field };
 }
 
 /**
- * SchemaCoordinate : Name . Name ( Name : )
+ * ArgumentCoordinate : Name . Name ( Name : )
  */
 function resolveArgumentCoordinate(
   schema: GraphQLSchema,
@@ -204,71 +199,65 @@ function resolveArgumentCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert {type} must exist.
+  // 3. Assert: {type} must exist, and be an Object or Interface type.
   if (type == null) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
     );
   }
-
-  // 4. Assert {type} must be an Object or Interface type.
   if (!isObjectType(type) && !isInterfaceType(type)) {
     throw new Error(
       `Expected ${inspect(typeName)} to be an object type or interface type.`,
     );
   }
 
-  // 5. Let {fieldName} be the value of the second {Name}.
-  // 6. Let {field} be the field of {type} named {fieldName}.
+  // 4. Let {fieldName} be the value of the second {Name}.
+  // 5. Let {field} be the field of {type} named {fieldName}.
   const fieldName = schemaCoordinate.fieldName.value;
   const field = type.getFields()[fieldName];
 
-  // 7. Assert {field} must exist.
+  // 7. Assert: {field} must exist.
   if (field == null) {
     throw new Error(
       `Expected ${inspect(fieldName)} to exist as a field of type ${inspect(typeName)} in the schema.`,
     );
   }
 
-  // 8. Let {fieldArgumentName} be the value of the third {Name}.
-  // 9. Let {fieldArgument} be the argument of {field} named {fieldArgumentName}.
+  // 7. Let {fieldArgumentName} be the value of the third {Name}.
   const fieldArgumentName = schemaCoordinate.argumentName.value;
   const fieldArgument = field.args.find(
     (arg) => arg.name === fieldArgumentName,
   );
 
-  // 10. If {fieldArgument} does not exist, return {null}.
+  // 8. Return the argument of {field} named {fieldArgumentName}, or {null} if no such argument exists.
   if (fieldArgument == null) {
     return;
   }
 
-  // 11. Return {fieldArgument}.
   return { kind: 'FieldArgument', type, field, fieldArgument };
 }
 
 /**
- * SchemaCoordinate : @ Name
+ * DirectiveCoordinate : @ Name
  */
 function resolveDirectiveCoordinate(
   schema: GraphQLSchema,
   schemaCoordinate: DirectiveCoordinateNode,
 ): ResolvedDirective | undefined {
-  // 1. Let {directiveName} be the value of the first {Name}.
-  // 2. Let {directive} be the directive in the {schema} named {directiveName}.
+  // 1. Let {directiveName} be the value of {Name}.
   const directiveName = schemaCoordinate.name.value;
   const directive = schema.getDirective(directiveName);
 
-  // 3. If {directive} does not exist, return {null}.
+  // 2. Return the directive in the {schema} named {directiveName}, or {null} if no such directive exists.
   if (!directive) {
     return;
   }
 
-  // 4. Otherwise return {directive}.
   return { kind: 'Directive', directive };
 }
 
 /**
- * SchemaCoordinate : @ Name ( Name : )
+ * DirectiveArgumentCoordinate : @ Name ( Name : )
  */
 function resolveDirectiveArgumentCoordinate(
   schema: GraphQLSchema,
@@ -287,7 +276,6 @@ function resolveDirectiveArgumentCoordinate(
   }
 
   // 4. Let {directiveArgumentName} be the value of the second {Name}.
-  // 5. Let {directiveArgument} be the argument of {directive} named {directiveArgumentName}.
   const {
     argumentName: { value: directiveArgumentName },
   } = schemaCoordinate;
@@ -295,12 +283,11 @@ function resolveDirectiveArgumentCoordinate(
     (arg) => arg.name === directiveArgumentName,
   );
 
-  // 6. If {directiveArgument} does not exist, return {null}.
+  // 5. Return the argument of {directive} named {directiveArgumentName}, or {null} if no such argument exists.
   if (!directiveArgument) {
     return;
   }
 
-  // 7. Return {directiveArgument}.
   return { kind: 'DirectiveArgument', directive, directiveArgument };
 }
 

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -233,7 +233,7 @@ function resolveMemberCoordinate(
   // Assert {type} must be an Object or Interface type.
   if (!isObjectType(type) && !isInterfaceType(type)) {
     throw new Error(
-      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+      `Expected ${inspect(typeName)} to be an object type, interface type, input object type, or enum type.`,
     );
   }
 

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -131,7 +131,7 @@ function resolveMemberCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert {type} exists.
+  // 3. Assert {type} must exist.
   if (!type) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
@@ -204,7 +204,7 @@ function resolveArgumentCoordinate(
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert {type} exists.
+  // 3. Assert {type} must exist.
   if (type == null) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -144,11 +144,11 @@ export function resolveASTSchemaCoordinate(
     return { kind: 'NamedType', type };
   }
 
-  const {
-    memberName: { value: memberName },
-  } = schemaCoordinate;
-
   if (schemaCoordinate.kind === 'MemberCoordinate') {
+    const {
+      memberName: { value: memberName },
+    } = schemaCoordinate;
+
     // SchemaCoordinate : Name . Name
     // If {type} is an Enum type:
     if (isEnumType(type)) {
@@ -184,6 +184,10 @@ export function resolveASTSchemaCoordinate(
     return { kind: 'Field', type, field };
   }
 
+  const {
+    fieldName: { value: fieldName },
+  } = schemaCoordinate;
+
   // SchemaCoordinate : Name . Name ( Name : )
   // Assert {type} must be an Object or Interface type.
   if (!isObjectType(type) && !isInterfaceType(type)) {
@@ -191,7 +195,7 @@ export function resolveASTSchemaCoordinate(
   }
   // Let {fieldName} be the value of the second {Name}.
   // Let {field} be the field of {type} named {fieldName}.
-  const field = type.getFields()[memberName];
+  const field = type.getFields()[fieldName];
   // Assert {field} must exist.
   if (field == null) {
     return;

--- a/src/utilities/resolveSchemaCoordinate.ts
+++ b/src/utilities/resolveSchemaCoordinate.ts
@@ -4,9 +4,10 @@ import type {
   ArgumentCoordinateNode,
   DirectiveArgumentCoordinateNode,
   DirectiveCoordinateNode,
-  MemberCoordinateNode,
+  FieldCoordinateNode,
   SchemaCoordinateNode,
   TypeCoordinateNode,
+  ValueCoordinateNode,
 } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
 import { parseSchemaCoordinate } from '../language/parser.js';
@@ -118,52 +119,37 @@ function resolveTypeCoordinate(
 }
 
 /**
- * MemberCoordinate : Name . Name
+ * FieldCoordinate : Name . Name
  */
-function resolveMemberCoordinate(
+function resolveFieldCoordinate(
   schema: GraphQLSchema,
-  schemaCoordinate: MemberCoordinateNode,
-): ResolvedField | ResolvedInputField | ResolvedEnumValue | undefined {
+  schemaCoordinate: FieldCoordinateNode,
+): ResolvedField | ResolvedInputField | undefined {
   // 1. Let {typeName} be the value of the first {Name}.
   // 2. Let {type} be the type in the {schema} named {typeName}.
   const typeName = schemaCoordinate.name.value;
   const type = schema.getType(typeName);
 
-  // 3. Assert: {type} must exist, and must be an Enum, Input Object, Object or Interface type.
+  // 3. Assert: {type} must exist, and must be an Input Object, Object or Interface type.
   if (!type) {
     throw new Error(
       `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
     );
   }
   if (
-    !isEnumType(type) &&
     !isInputObjectType(type) &&
     !isObjectType(type) &&
     !isInterfaceType(type)
   ) {
     throw new Error(
-      `Expected ${inspect(typeName)} to be an object type, interface type, input object type, or enum type.`,
+      `Expected ${inspect(typeName)} to be an Input Object, Object or Interface type.`,
     );
   }
 
-  // 4. If {type} is an Enum type:
-  if (isEnumType(type)) {
-    // 1. Let {enumValueName} be the value of the second {Name}.
-    const enumValueName = schemaCoordinate.memberName.value;
-    const enumValue = type.getValue(enumValueName);
-
-    // 2. Return the enum value of {type} named {enumValueName}, or {null} if no such value exists.
-    if (enumValue == null) {
-      return;
-    }
-
-    return { kind: 'EnumValue', type, enumValue };
-  }
-
-  // 5. Otherwise, if {type} is an Input Object type:
+  // 4. If {type} is an Input Object type:
   if (isInputObjectType(type)) {
     // 1. Let {inputFieldName} be the value of the second {Name}.
-    const inputFieldName = schemaCoordinate.memberName.value;
+    const inputFieldName = schemaCoordinate.fieldName.value;
     const inputField = type.getFields()[inputFieldName];
 
     // 2. Return the input field of {type} named {inputFieldName}, or {null} if no such input field exists.
@@ -174,9 +160,9 @@ function resolveMemberCoordinate(
     return { kind: 'InputField', type, inputField };
   }
 
-  // 6. Otherwise:
+  // 5. Otherwise:
   // 1. Let {fieldName} be the value of the second {Name}.
-  const fieldName = schemaCoordinate.memberName.value;
+  const fieldName = schemaCoordinate.fieldName.value;
   const field = type.getFields()[fieldName];
 
   // 2. Return the field of {type} named {fieldName}, or {null} if no such field exists.
@@ -235,6 +221,40 @@ function resolveArgumentCoordinate(
   }
 
   return { kind: 'FieldArgument', type, field, fieldArgument };
+}
+
+/**
+ * ValueCoordinate : Name :: Name
+ */
+function resolveValueCoordinate(
+  schema: GraphQLSchema,
+  schemaCoordinate: ValueCoordinateNode,
+): ResolvedEnumValue | undefined {
+  // 1. Let {typeName} be the value of the first {Name}.
+  // 2. Let {type} be the type in the {schema} named {typeName}.
+  const typeName = schemaCoordinate.name.value;
+  const type = schema.getType(typeName);
+
+  // 3. Assert: {type} must exist, and must be an Enum type.
+  if (!type) {
+    throw new Error(
+      `Expected ${inspect(typeName)} to be defined as a type in the schema.`,
+    );
+  }
+  if (!isEnumType(type)) {
+    throw new Error(`Expected ${inspect(typeName)} to be an Enum type.`);
+  }
+
+  // 4. Let {enumValueName} be the value of the second {Name}.
+  const enumValueName = schemaCoordinate.valueName.value;
+  const enumValue = type.getValue(enumValueName);
+
+  // 5. Return the enum value of {type} named {enumValueName}, or {null} if no such value exists.
+  if (enumValue == null) {
+    return;
+  }
+
+  return { kind: 'EnumValue', type, enumValue };
 }
 
 /**
@@ -299,15 +319,17 @@ export function resolveASTSchemaCoordinate(
   schemaCoordinate: SchemaCoordinateNode,
 ): ResolvedSchemaElement | undefined {
   switch (schemaCoordinate.kind) {
+    case Kind.TYPE_COORDINATE:
+      return resolveTypeCoordinate(schema, schemaCoordinate);
+    case Kind.FIELD_COORDINATE:
+      return resolveFieldCoordinate(schema, schemaCoordinate);
+    case Kind.ARGUMENT_COORDINATE:
+      return resolveArgumentCoordinate(schema, schemaCoordinate);
+    case Kind.VALUE_COORDINATE:
+      return resolveValueCoordinate(schema, schemaCoordinate);
     case Kind.DIRECTIVE_COORDINATE:
       return resolveDirectiveCoordinate(schema, schemaCoordinate);
     case Kind.DIRECTIVE_ARGUMENT_COORDINATE:
       return resolveDirectiveArgumentCoordinate(schema, schemaCoordinate);
-    case Kind.TYPE_COORDINATE:
-      return resolveTypeCoordinate(schema, schemaCoordinate);
-    case Kind.MEMBER_COORDINATE:
-      return resolveMemberCoordinate(schema, schemaCoordinate);
-    case Kind.ARGUMENT_COORDINATE:
-      return resolveArgumentCoordinate(schema, schemaCoordinate);
   }
 }


### PR DESCRIPTION
Updates to https://github.com/graphql/graphql-js/pull/3044

Implements the new spec changes:

- Split apart the AST nodes and parsing for the new coordinate types (`FieldCoordinate`, `ArgumentCoordinate` etc)
- Added `MyEnum::value` separator syntax
- Explicit error handling for "containing elements"
- [ ] (todo?) throw on returning meta-fields