### PR TITLE
Implement schema coordinate spec changes as of 2025-06-06

### DIFF
--- a/src/language/__tests__/printer-test.ts
+++ b/src/language/__tests__/printer-test.ts
@@ -308,6 +308,9 @@ describe('Printer: Query document', () => {
     expect(print(parseSchemaCoordinate('  Name . field ( arg: )'))).to.equal(
       'Name.field(arg:)',
     );
+    expect(print(parseSchemaCoordinate('  Name :: Name '))).to.equal(
+      'Name::Name',
+    );
     expect(print(parseSchemaCoordinate(' @ name  '))).to.equal('@name');
     expect(print(parseSchemaCoordinate(' @ name (arg:) '))).to.equal(
       '@name(arg:)',

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -111,6 +111,14 @@ describe('resolveSchemaCoordinate', () => {
     expect(
       resolveSchemaCoordinate(schema, 'SearchFilter::UNKNOWN'),
     ).to.deep.equal(undefined);
+
+    expect(() => resolveSchemaCoordinate(schema, 'Unknown::UNKNOWN')).to.throw(
+      'Expected "Unknown" to be defined as a type in the schema.',
+    );
+
+    expect(() => resolveSchemaCoordinate(schema, 'Business::id')).to.throw(
+      'Expected "Business" to be an Enum type.',
+    );
   });
 
   it('resolves a Field Argument', () => {


### PR DESCRIPTION
Implements schema coordinate spec changes as of 2025-06-06 (https://github.com/graphql/graphql-spec/pull/794)

- Add support for meta-fields (e.g. `__typename`)
- Add support for introspection types
- Revert back from FieldCoordinate+ValueCoordinate -> MemberCoordinate