### PR TITLE
move name validation in production to separate validation step

### DIFF
--- a/src/__tests__/env-test.ts
+++ b/src/__tests__/env-test.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { getEnv, setEnv } from '../setEnv.js';
+
+describe('Env', () => {
+  it('should return undefined if environment is not set', () => {
+    expect(getEnv()).to.equal(undefined);
+  });
+
+  it('should set the environment to development', () => {
+    setEnv('development');
+    expect(getEnv()).to.equal('development');
+  });
+
+  it('should set the environment to production', () => {
+    setEnv('production');
+    expect(getEnv()).to.equal('production');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,7 @@ export {
   validateSchema,
   assertValidSchema,
   // Upholds the spec rules about naming.
+  assertHasValidName,
   assertName,
   assertEnumValueName,
 } from './type/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@
 
 // The GraphQL.js version info.
 export { version, versionInfo } from './version.js';
-export { setEnv } from './setEnv.js';
+export { setEnv, getEnv } from './setEnv.js';
 export type { Env } from './setEnv.js';
 
 // The primary entry point into fulfilling a GraphQL request.

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,8 @@
 
 // The GraphQL.js version info.
 export { version, versionInfo } from './version.js';
+export { setEnv } from './setEnv.js';
+export type { Env } from './setEnv.js';
 
 // The primary entry point into fulfilling a GraphQL request.
 export type { GraphQLArgs } from './graphql.js';

--- a/src/jsutils/__tests__/instanceOf-test.ts
+++ b/src/jsutils/__tests__/instanceOf-test.ts
@@ -1,9 +1,25 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { setEnv } from '../../setEnv.js';
+
 import { instanceOf } from '../instanceOf.js';
 
 describe('instanceOf', () => {
+  function oldVersion() {
+    class Foo {}
+    return Foo;
+  }
+
+  function newVersion() {
+    class Foo {
+      get [Symbol.toStringTag]() {
+        return 'Foo';
+      }
+    }
+    return Foo;
+  }
+
   it('do not throw on values without prototype', () => {
     class Foo {
       get [Symbol.toStringTag]() {
@@ -16,20 +32,15 @@ describe('instanceOf', () => {
     expect(instanceOf(Object.create(null), Foo)).to.equal(false);
   });
 
-  it('detect name clashes with older versions of this lib', () => {
-    function oldVersion() {
-      class Foo {}
-      return Foo;
-    }
+  it('ignore name clashes with older versions of this lib by default', () => {
+    const NewClass = newVersion();
+    const OldClass = oldVersion();
+    expect(instanceOf(new NewClass(), NewClass)).to.equal(true);
+    expect(instanceOf(new OldClass(), NewClass)).to.equal(false);
+  });
 
-    function newVersion() {
-      class Foo {
-        get [Symbol.toStringTag]() {
-          return 'Foo';
-        }
-      }
-      return Foo;
-    }
+  it('detect name clashes with older versions of this lib when set', () => {
+    setEnv('development');
 
     const NewClass = newVersion();
     const OldClass = oldVersion();
@@ -37,7 +48,23 @@ describe('instanceOf', () => {
     expect(() => instanceOf(new OldClass(), NewClass)).to.throw();
   });
 
+  it('ignore name clashes with older versions of this lib when reset', () => {
+    setEnv('development');
+
+    const NewClass = newVersion();
+    const OldClass = oldVersion();
+    expect(instanceOf(new NewClass(), NewClass)).to.equal(true);
+    expect(() => instanceOf(new OldClass(), NewClass)).to.throw();
+
+    setEnv('production');
+
+    expect(instanceOf(new NewClass(), NewClass)).to.equal(true);
+    expect(instanceOf(new OldClass(), NewClass)).to.equal(false);
+  });
+
   it('allows instances to have share the same constructor name', () => {
+    setEnv('development');
+
     function getMinifiedClass(tag: string) {
       class SomeNameAfterMinification {
         get [Symbol.toStringTag]() {
@@ -58,6 +85,8 @@ describe('instanceOf', () => {
   });
 
   it('fails with descriptive error message', () => {
+    setEnv('development');
+
     function getFoo() {
       class Foo {
         get [Symbol.toStringTag]() {

--- a/src/jsutils/instanceOf.ts
+++ b/src/jsutils/instanceOf.ts
@@ -1,10 +1,12 @@
+import type { Env } from '../setEnv.js';
+
 import { inspect } from './inspect.js';
 
-/* c8 ignore next 3 */
-const isProduction =
-  globalThis.process != null &&
-  // eslint-disable-next-line no-undef
-  process.env.NODE_ENV === 'production';
+const noOp = (_value: unknown, _constructor: Constructor): void => {
+  /* no-op */
+};
+
+let check = noOp;
 
 /**
  * A replacement for instanceof which includes an error warning when multi-realm
@@ -12,29 +14,30 @@ const isProduction =
  * See: https://expressjs.com/en/advanced/best-practice-performance.html#set-node_env-to-production
  * See: https://webpack.js.org/guides/production/
  */
-export const instanceOf: (value: unknown, constructor: Constructor) => boolean =
-  /* c8 ignore next 6 */
-  // FIXME: https://github.com/graphql/graphql-js/issues/2317
-  isProduction
-    ? function instanceOf(value: unknown, constructor: Constructor): boolean {
-        return value instanceof constructor;
-      }
-    : function instanceOf(value: unknown, constructor: Constructor): boolean {
-        if (value instanceof constructor) {
-          return true;
-        }
-        if (typeof value === 'object' && value !== null) {
-          // Prefer Symbol.toStringTag since it is immune to minification.
-          const className = constructor.prototype[Symbol.toStringTag];
-          const valueClassName =
-            // We still need to support constructor's name to detect conflicts with older versions of this library.
-            Symbol.toStringTag in value
-              ? value[Symbol.toStringTag]
-              : value.constructor?.name;
-          if (className === valueClassName) {
-            const stringifiedValue = inspect(value);
-            throw new Error(
-              `Cannot use ${className} "${stringifiedValue}" from another module or realm.
+export function instanceOf(value: unknown, constructor: Constructor): boolean {
+  if (value instanceof constructor) {
+    return true;
+  }
+  check(value, constructor);
+  return false;
+}
+
+function developmentInstanceOfCheck(
+  value: unknown,
+  constructor: Constructor,
+): void {
+  if (typeof value === 'object' && value !== null) {
+    // Prefer Symbol.toStringTag since it is immune to minification.
+    const className = constructor.prototype[Symbol.toStringTag];
+    const valueClassName =
+      // We still need to support constructor's name to detect conflicts with older versions of this library.
+      Symbol.toStringTag in value
+        ? value[Symbol.toStringTag]
+        : value.constructor?.name;
+    if (className === valueClassName) {
+      const stringifiedValue = inspect(value);
+      throw new Error(
+        `Cannot use ${className} "${stringifiedValue}" from another module or realm.
 
 Ensure that there is only one instance of "graphql" in the node_modules
 directory. If different versions of "graphql" are the dependencies of other
@@ -46,11 +49,14 @@ Duplicate "graphql" modules cannot be used at the same time since different
 versions may have different capabilities and behavior. The data from one
 version used in the function from another could produce confusing and
 spurious results.`,
-            );
-          }
-        }
-        return false;
-      };
+      );
+    }
+  }
+}
+
+export function setInstanceOfCheckForEnv(newEnv: Env): void {
+  check = newEnv === 'development' ? developmentInstanceOfCheck : noOp;
+}
 
 interface Constructor {
   prototype: {

--- a/src/language/__tests__/schema-parser-test.ts
+++ b/src/language/__tests__/schema-parser-test.ts
@@ -109,6 +109,28 @@ describe('Schema Parser', () => {
     });
   });
 
+  it('parses type with reserved name', () => {
+    const doc = parse(dedent`
+      type __Reserved
+    `);
+
+    expectJSON(doc).toDeepEqual({
+      kind: 'Document',
+      definitions: [
+        {
+          kind: 'ObjectTypeDefinition',
+          name: nameNode('__Reserved', { start: 5, end: 15 }),
+          description: undefined,
+          interfaces: undefined,
+          directives: undefined,
+          fields: undefined,
+          loc: { start: 0, end: 15 },
+        },
+      ],
+      loc: { start: 0, end: 15 },
+    });
+  });
+
   it('parses type with description string', () => {
     const doc = parse(dedent`
       "Description"

--- a/src/setEnv.ts
+++ b/src/setEnv.ts
@@ -1,0 +1,7 @@
+import { setInstanceOfCheckForEnv } from './jsutils/instanceOf.js';
+
+export type Env = 'production' | 'development';
+
+export function setEnv(newEnv: Env): void {
+  setInstanceOfCheckForEnv(newEnv);
+}

--- a/src/setEnv.ts
+++ b/src/setEnv.ts
@@ -2,6 +2,13 @@ import { setInstanceOfCheckForEnv } from './jsutils/instanceOf.js';
 
 export type Env = 'production' | 'development';
 
+let env: Env | undefined;
+
 export function setEnv(newEnv: Env): void {
+  env = newEnv;
   setInstanceOfCheckForEnv(newEnv);
+}
+
+export function getEnv(): Env | undefined {
+  return env;
 }

--- a/src/setEnv.ts
+++ b/src/setEnv.ts
@@ -1,5 +1,8 @@
 import { setInstanceOfCheckForEnv } from './jsutils/instanceOf.js';
 
+import { setDefinitionNameCheckForEnv } from './type/definition.js';
+import { setDirectiveNameCheckForEnv } from './type/directives.js';
+
 export type Env = 'production' | 'development';
 
 let env: Env | undefined;
@@ -7,6 +10,8 @@ let env: Env | undefined;
 export function setEnv(newEnv: Env): void {
   env = newEnv;
   setInstanceOfCheckForEnv(newEnv);
+  setDefinitionNameCheckForEnv(newEnv);
+  setDirectiveNameCheckForEnv(newEnv);
 }
 
 export function getEnv(): Env | undefined {

--- a/src/type/__tests__/assertHasValidName-test.ts
+++ b/src/type/__tests__/assertHasValidName-test.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { beforeEach, describe, it } from 'mocha';
+
+import { setEnv } from '../../setEnv.js';
+
+import { assertHasValidName } from '../assertHasValidName.js';
+import type { GraphQLEnumValue } from '../index.js';
+import { __Type, GraphQLEnumType, GraphQLObjectType } from '../index.js';
+
+describe(assertHasValidName.name, () => {
+  beforeEach(() => {
+    // In 'development', schema element construction will throw on an invalid name.
+    setEnv('production');
+  });
+  it('passthrough valid name', () => {
+    expect(
+      assertHasValidName(
+        new GraphQLObjectType({
+          name: '_ValidName123',
+          fields: {},
+        }),
+      ),
+    ).to.equal('_ValidName123');
+  });
+
+  it('throws on empty strings', () => {
+    expect(() =>
+      assertHasValidName(
+        new GraphQLObjectType({
+          name: '',
+          fields: {},
+        }),
+      ),
+    ).to.throw('Expected name of type "" to be a non-empty string.');
+  });
+
+  it('throws for names with invalid characters', () => {
+    expect(() =>
+      assertHasValidName(
+        new GraphQLObjectType({
+          name: 'Some-Object',
+          fields: {},
+        }),
+      ),
+    ).to.throw('Name of type "Some-Object" must only contain [_a-zA-Z0-9].');
+  });
+
+  it('throws for names starting with invalid characters', () => {
+    expect(() =>
+      assertHasValidName(
+        new GraphQLObjectType({
+          name: '1_ObjectType',
+          fields: {},
+        }),
+      ),
+    ).to.throw('Name of type "1_ObjectType" must start with [_a-zA-Z].');
+  });
+
+  it('throws for reserved names', () => {
+    expect(() =>
+      assertHasValidName(
+        new GraphQLObjectType({
+          name: '__SomeObject',
+          fields: {},
+        }),
+      ),
+    ).to.throw(
+      'Name of type "__SomeObject" must not begin with "__", which is reserved by GraphQL introspection.',
+    );
+  });
+
+  it('allows reserved names when specified', () => {
+    expect(assertHasValidName(__Type, true)).to.equal('__Type');
+  });
+
+  it('throws for reserved names in enum values', () => {
+    const someEnum = new GraphQLEnumType({
+      name: 'SomeEnum',
+      values: {
+        true: {},
+      },
+    });
+    const value = someEnum.getValue('true') as GraphQLEnumValue;
+    expect(() => assertHasValidName(value)).to.throw(
+      'Name "true" of enum value "SomeEnum.true" cannot be: true.',
+    );
+  });
+});

--- a/src/type/__tests__/definition-test.ts
+++ b/src/type/__tests__/definition-test.ts
@@ -7,6 +7,8 @@ import { inspect } from '../../jsutils/inspect.js';
 import { Kind } from '../../language/kinds.js';
 import { parseConstValue } from '../../language/parser.js';
 
+import { setEnv } from '../../setEnv.js';
+
 import type {
   GraphQLEnumTypeConfig,
   GraphQLInputObjectTypeConfig,
@@ -415,13 +417,22 @@ describe('Type System: Objects', () => {
     expect(() => objType.getFields()).to.not.throw();
   });
 
-  it('rejects an Object type with invalid name', () => {
+  it('rejects an Object type with invalid name in development', () => {
+    setEnv('development');
     expect(
       () => new GraphQLObjectType({ name: 'bad-name', fields: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
-  it('rejects an Object type with incorrectly named fields', () => {
+  it('accepts an Object type with invalid name in production', () => {
+    setEnv('production');
+    expect(
+      () => new GraphQLObjectType({ name: 'bad-name', fields: {} }),
+    ).not.to.throw();
+  });
+
+  it('rejects an Object type with incorrectly named fields in development', () => {
+    setEnv('development');
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
       fields: {
@@ -433,18 +444,19 @@ describe('Type System: Objects', () => {
     );
   });
 
-  it('rejects an Object type with a field function that returns incorrect type', () => {
+  it('accepts an Object type with incorrectly named fields in production', () => {
+    setEnv('production');
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
-      // @ts-expect-error (Wrong type of return)
-      fields() {
-        return [{ field: ScalarType }];
+      fields: {
+        'bad-name': { type: ScalarType },
       },
     });
-    expect(() => objType.getFields()).to.throw();
+    expect(() => objType.getFields()).not.to.throw();
   });
 
-  it('rejects an Object type with incorrectly named field args', () => {
+  it('rejects an Object type with incorrectly named field args in development', () => {
+    setEnv('development');
     const objType = new GraphQLObjectType({
       name: 'SomeObject',
       fields: {
@@ -459,6 +471,22 @@ describe('Type System: Objects', () => {
     expect(() => objType.getFields()).to.throw(
       'Names must only contain [_a-zA-Z0-9] but "bad-name" does not.',
     );
+  });
+
+  it('accepts an Object type with incorrectly named field args in production', () => {
+    setEnv('production');
+    const objType = new GraphQLObjectType({
+      name: 'SomeObject',
+      fields: {
+        badField: {
+          type: ScalarType,
+          args: {
+            'bad-name': { type: ScalarType },
+          },
+        },
+      },
+    });
+    expect(() => objType.getFields()).not.to.throw();
   });
 });
 
@@ -564,10 +592,18 @@ describe('Type System: Interfaces', () => {
     expect(implementing.getInterfaces()).to.deep.equal([InterfaceType]);
   });
 
-  it('rejects an Interface type with invalid name', () => {
+  it('rejects an Interface type with invalid name in development', () => {
+    setEnv('development');
     expect(
       () => new GraphQLInterfaceType({ name: 'bad-name', fields: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
+  });
+
+  it('accepts an Interface type with invalid name in production', () => {
+    setEnv('production');
+    expect(
+      () => new GraphQLInterfaceType({ name: 'bad-name', fields: {} }),
+    ).not.to.throw();
   });
 });
 
@@ -636,10 +672,18 @@ describe('Type System: Unions', () => {
     expect(unionType.getTypes()).to.deep.equal([]);
   });
 
-  it('rejects an Union type with invalid name', () => {
+  it('rejects an Union type with invalid name in development', () => {
+    setEnv('development');
     expect(
       () => new GraphQLUnionType({ name: 'bad-name', types: [] }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
+  });
+
+  it('accepts an Union type with invalid name in production', () => {
+    setEnv('production');
+    expect(
+      () => new GraphQLUnionType({ name: 'bad-name', types: [] }),
+    ).not.to.throw();
   });
 });
 
@@ -787,13 +831,22 @@ describe('Type System: Enums', () => {
     expect(enumType.getValue('BAR')).has.property('value', 20);
   });
 
-  it('rejects an Enum type with invalid name', () => {
+  it('rejects an Enum type with invalid name in development', () => {
+    setEnv('development');
     expect(
       () => new GraphQLEnumType({ name: 'bad-name', values: {} }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
-  it('rejects an Enum type with incorrectly named values', () => {
+  it('rejects an Enum type with invalid name in production', () => {
+    setEnv('production');
+    expect(
+      () => new GraphQLEnumType({ name: 'bad-name', values: {} }),
+    ).not.to.throw();
+  });
+
+  it('rejects an Enum type with incorrectly named values in development', () => {
+    setEnv('development');
     expect(
       () =>
         new GraphQLEnumType({
@@ -803,6 +856,19 @@ describe('Type System: Enums', () => {
           },
         }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
+  });
+
+  it('accepts an Enum type with incorrectly named values in production', () => {
+    setEnv('production');
+    expect(
+      () =>
+        new GraphQLEnumType({
+          name: 'SomeEnum',
+          values: {
+            'bad-name': {},
+          },
+        }),
+    ).not.to.throw();
   });
 });
 
@@ -888,7 +954,8 @@ describe('Type System: Input Objects', () => {
       });
     });
 
-    it('rejects an Input Object type with invalid name', () => {
+    it('rejects an Input Object type with invalid name in development', () => {
+      setEnv('development');
       expect(
         () => new GraphQLInputObjectType({ name: 'bad-name', fields: {} }),
       ).to.throw(
@@ -896,7 +963,15 @@ describe('Type System: Input Objects', () => {
       );
     });
 
-    it('rejects an Input Object type with incorrectly named fields', () => {
+    it('accepts an Input Object type with invalid name in production', () => {
+      setEnv('production');
+      expect(
+        () => new GraphQLInputObjectType({ name: 'bad-name', fields: {} }),
+      ).not.to.throw();
+    });
+
+    it('rejects an Input Object type with incorrectly named fields in development', () => {
+      setEnv('development');
       const inputObjType = new GraphQLInputObjectType({
         name: 'SomeInputObject',
         fields: {
@@ -906,6 +981,17 @@ describe('Type System: Input Objects', () => {
       expect(() => inputObjType.getFields()).to.throw(
         'Names must only contain [_a-zA-Z0-9] but "bad-name" does not.',
       );
+    });
+
+    it('accepts an Input Object type with incorrectly named fields in production', () => {
+      setEnv('production');
+      const inputObjType = new GraphQLInputObjectType({
+        name: 'SomeInputObject',
+        fields: {
+          'bad-name': { type: ScalarType },
+        },
+      });
+      expect(() => inputObjType.getFields()).not.to.throw();
     });
   });
 

--- a/src/type/__tests__/directive-test.ts
+++ b/src/type/__tests__/directive-test.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 
 import { DirectiveLocation } from '../../language/directiveLocation.js';
 
+import { setEnv } from '../../setEnv.js';
+
 import { GraphQLDirective } from '../directives.js';
 import { GraphQLInt, GraphQLString } from '../scalars.js';
 
@@ -92,7 +94,8 @@ describe('Type System: Directive', () => {
     );
   });
 
-  it('rejects a directive with invalid name', () => {
+  it('rejects a directive with invalid name in development', () => {
+    setEnv('development');
     expect(
       () =>
         new GraphQLDirective({
@@ -102,7 +105,19 @@ describe('Type System: Directive', () => {
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
   });
 
-  it('rejects a directive with incorrectly named arg', () => {
+  it('accepts a directive with invalid name in production', () => {
+    setEnv('production');
+    expect(
+      () =>
+        new GraphQLDirective({
+          name: 'bad-name',
+          locations: [DirectiveLocation.QUERY],
+        }),
+    ).not.to.throw();
+  });
+
+  it('rejects a directive with incorrectly named arg in development', () => {
+    setEnv('development');
     expect(
       () =>
         new GraphQLDirective({
@@ -113,5 +128,19 @@ describe('Type System: Directive', () => {
           },
         }),
     ).to.throw('Names must only contain [_a-zA-Z0-9] but "bad-name" does not.');
+  });
+
+  it('accepts a directive with incorrectly named arg in production', () => {
+    setEnv('production');
+    expect(
+      () =>
+        new GraphQLDirective({
+          name: 'Foo',
+          locations: [DirectiveLocation.QUERY],
+          args: {
+            'bad-name': { type: GraphQLString },
+          },
+        }),
+    ).not.to.throw();
   });
 });

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -531,6 +531,284 @@ describe('Type System: Root types must all be different if provided', () => {
   });
 });
 
+describe('Type System: Schema elements must be properly named', () => {
+  it('accepts types with valid names', () => {
+    const schema = buildSchema(`
+      directive @SomeDirective(someArg: String) on QUERY
+
+      type Query {
+        f1: SomeObject
+        f2: SomeInterface
+        f3: SomeUnion
+        f4: SomeEnum
+        f5: SomeScalar
+      }
+
+      input SomeInputObject {
+        someField: String
+      }
+
+      type SomeObject {
+        someField(someArg: SomeInputObject): String
+      }
+
+      interface SomeInterface {
+        someField: String
+      }
+
+      type SomeUnionMember {
+        field: String
+      }
+
+      union SomeUnion = SomeUnionMember
+
+      enum SomeEnum {
+        SOME_ENUM_VALUE
+      }
+
+      scalar SomeScalar
+    `);
+
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
+  });
+
+  it('rejects types with invalid names', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          f1: {
+            type: new GraphQLObjectType({
+              name: 'Some-Object',
+              fields: {
+                'some-Field': {
+                  type: GraphQLString,
+                  args: {
+                    'some-Arg': {
+                      type: new GraphQLInputObjectType({
+                        name: 'Some-Input-Object',
+                        fields: {
+                          'some-Field': { type: GraphQLString },
+                        },
+                      }),
+                    },
+                  },
+                },
+              },
+            }),
+          },
+          f2: {
+            type: new GraphQLInterfaceType({
+              name: 'Some-Interface',
+              fields: { 'some-Field': { type: GraphQLString } },
+            }),
+          },
+          f3: {
+            type: new GraphQLUnionType({
+              name: 'Some-Union',
+              types: [
+                new GraphQLObjectType({
+                  name: 'SomeUnionMember',
+                  fields: { field: { type: GraphQLString } },
+                }),
+              ],
+            }),
+          },
+          f4: {
+            type: new GraphQLEnumType({
+              name: 'Some-Enum',
+              values: { 'SOME-ENUM-VALUE': {}, true: {}, false: {}, null: {} },
+            }),
+          },
+          f5: {
+            type: new GraphQLScalarType({
+              name: 'Some-Scalar',
+            }),
+          },
+        },
+      }),
+      directives: [
+        new GraphQLDirective({
+          name: 'Some-Directive',
+          args: {
+            'some-Arg': {
+              type: GraphQLString,
+            },
+          },
+          locations: [DirectiveLocation.QUERY],
+        }),
+      ],
+    });
+
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name of directive "@Some-Directive" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name "some-Arg" of argument "@Some-Directive(some-Arg:)" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message: 'Name of type "Some-Object" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name "some-Field" of field "Some-Object.some-Field" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name "some-Arg" of argument "Some-Object.some-Field(some-Arg:)" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name of type "Some-Input-Object" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name "some-Field" of input field "Some-Input-Object.some-Field" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name of type "Some-Interface" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name "some-Field" of field "Some-Interface.some-Field" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message: 'Name of type "Some-Union" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message: 'Name of type "Some-Enum" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message:
+          'Name "SOME-ENUM-VALUE" of enum value "Some-Enum.SOME-ENUM-VALUE" must only contain [_a-zA-Z0-9].',
+      },
+      {
+        message: 'Name "true" of enum value "Some-Enum.true" cannot be: true.',
+      },
+      {
+        message:
+          'Name "false" of enum value "Some-Enum.false" cannot be: false.',
+      },
+      {
+        message: 'Name "null" of enum value "Some-Enum.null" cannot be: null.',
+      },
+      {
+        message: 'Name of type "Some-Scalar" must only contain [_a-zA-Z0-9].',
+      },
+    ]);
+  });
+
+  it('rejects types with reserved names', () => {
+    const schema = buildSchema(`
+      directive @__SomeDirective(__someArg: String) on QUERY
+
+      type Query {
+        f1: __SomeObject
+        f2: __SomeInterface
+        f3: __SomeUnion
+        f4: __SomeEnum
+        f5: __SomeScalar
+      }
+
+      input __SomeInputObject {
+        __someField: String
+      }
+
+      type __SomeObject {
+        __someField(__someArg: __SomeInputObject): String
+      }
+
+      interface __SomeInterface {
+        __someField: String
+      }
+
+      type SomeUnionMember {
+        field: String
+      }
+
+      union __SomeUnion = SomeUnionMember
+
+      enum __SomeEnum {
+        __SOME_ENUM_VALUE
+      }
+
+      scalar __SomeScalar
+    `);
+
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name of directive "@__SomeDirective" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 2, column: 7 }],
+      },
+      {
+        message:
+          'Name "__someArg" of argument "@__SomeDirective(__someArg:)" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 2, column: 34 }],
+      },
+      {
+        message:
+          'Name of type "__SomeInputObject" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 12, column: 7 }],
+      },
+      {
+        message:
+          'Name "__someField" of input field "__SomeInputObject.__someField" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 13, column: 9 }],
+      },
+      {
+        message:
+          'Name of type "__SomeObject" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 16, column: 7 }],
+      },
+      {
+        message:
+          'Name "__someField" of field "__SomeObject.__someField" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 17, column: 9 }],
+      },
+      {
+        message:
+          'Name "__someArg" of argument "__SomeObject.__someField(__someArg:)" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 17, column: 21 }],
+      },
+      {
+        message:
+          'Name of type "__SomeInterface" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 20, column: 7 }],
+      },
+      {
+        message:
+          'Name "__someField" of field "__SomeInterface.__someField" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 21, column: 9 }],
+      },
+      {
+        message:
+          'Name of type "__SomeUnion" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 28, column: 7 }],
+      },
+      {
+        message:
+          'Name of type "__SomeEnum" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 30, column: 7 }],
+      },
+      {
+        message:
+          'Name "__SOME_ENUM_VALUE" of enum value "__SomeEnum.__SOME_ENUM_VALUE" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 31, column: 9 }],
+      },
+      {
+        message:
+          'Name of type "__SomeScalar" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 34, column: 7 }],
+      },
+    ]);
+  });
+});
+
 describe('Type System: Objects must have fields', () => {
   it('accepts an Object type with fields object', () => {
     const schema = buildSchema(`
@@ -583,65 +861,6 @@ describe('Type System: Objects must have fields', () => {
     expectJSON(validateSchema(manualSchema2)).toDeepEqual([
       {
         message: 'Type IncompleteObject must define one or more fields.',
-      },
-    ]);
-  });
-
-  it('rejects an Object type with incorrectly named fields', () => {
-    const schema = schemaWithFieldType(
-      new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          __badName: { type: GraphQLString },
-        },
-      }),
-    );
-    expectJSON(validateSchema(schema)).toDeepEqual([
-      {
-        message:
-          'Name "__badName" must not begin with "__", which is reserved by GraphQL introspection.',
-      },
-    ]);
-  });
-});
-
-describe('Type System: Fields args must be properly named', () => {
-  it('accepts field args with valid names', () => {
-    const schema = schemaWithFieldType(
-      new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          goodField: {
-            type: GraphQLString,
-            args: {
-              goodArg: { type: GraphQLString },
-            },
-          },
-        },
-      }),
-    );
-    expectJSON(validateSchema(schema)).toDeepEqual([]);
-  });
-
-  it('rejects field arg with invalid names', () => {
-    const schema = schemaWithFieldType(
-      new GraphQLObjectType({
-        name: 'SomeObject',
-        fields: {
-          badField: {
-            type: GraphQLString,
-            args: {
-              __badName: { type: GraphQLString },
-            },
-          },
-        },
-      }),
-    );
-
-    expectJSON(validateSchema(schema)).toDeepEqual([
-      {
-        message:
-          'Name "__badName" must not begin with "__", which is reserved by GraphQL introspection.',
       },
     ]);
   });
@@ -1373,24 +1592,6 @@ describe('Type System: Enum types must be well defined', () => {
           { line: 6, column: 7 },
           { line: 4, column: 9 },
         ],
-      },
-    ]);
-  });
-
-  it('rejects an Enum type with incorrectly named values', () => {
-    const schema = schemaWithFieldType(
-      new GraphQLEnumType({
-        name: 'SomeEnum',
-        values: {
-          __badName: {},
-        },
-      }),
-    );
-
-    expectJSON(validateSchema(schema)).toDeepEqual([
-      {
-        message:
-          'Name "__badName" must not begin with "__", which is reserved by GraphQL introspection.',
       },
     ]);
   });

--- a/src/type/assertHasValidName.ts
+++ b/src/type/assertHasValidName.ts
@@ -1,0 +1,86 @@
+import { inspect } from '../jsutils/inspect.js';
+import { invariant } from '../jsutils/invariant.js';
+
+import { isNameContinue, isNameStart } from '../language/characterClasses.js';
+
+import type { GraphQLSchemaElement } from './definition.js';
+import {
+  isArgument,
+  isEnumValue,
+  isField,
+  isInputField,
+  isNamedType,
+} from './definition.js';
+import { isDirective } from './directives.js';
+
+function getDescriptor(
+  schemaElement: GraphQLSchemaElement & {
+    readonly name: string;
+  },
+): string {
+  if (isNamedType(schemaElement)) {
+    return `of type "${schemaElement.name}"`;
+  }
+  if (isField(schemaElement)) {
+    return `"${schemaElement.name}" of field "${schemaElement}"`;
+  }
+  if (isArgument(schemaElement)) {
+    return `"${schemaElement.name}" of argument "${schemaElement}"`;
+  }
+  if (isInputField(schemaElement)) {
+    return `"${schemaElement.name}" of input field "${schemaElement}"`;
+  }
+  if (isEnumValue(schemaElement)) {
+    return `"${schemaElement.name}" of enum value "${schemaElement}"`;
+  }
+  if (isDirective(schemaElement)) {
+    return `of directive "${schemaElement}"`;
+  }
+  /* c8 ignore next 3 */
+  // Not reachable, all possible inputs have been considered)
+  invariant(false, `Unexpected schema element: "${inspect(schemaElement)}".`);
+}
+
+export function assertHasValidName(
+  schemaElement: GraphQLSchemaElement & {
+    readonly name: string;
+  },
+  allowReservedNames = false,
+): string {
+  const name = schemaElement.name;
+  if (name.length === 0) {
+    throw new Error(
+      `Expected name ${getDescriptor(schemaElement)} to be a non-empty string.`,
+    );
+  }
+
+  for (let i = 1; i < name.length; ++i) {
+    if (!isNameContinue(name.charCodeAt(i))) {
+      throw new Error(
+        `Name ${getDescriptor(schemaElement)} must only contain [_a-zA-Z0-9].`,
+      );
+    }
+  }
+
+  if (!isNameStart(name.charCodeAt(0))) {
+    throw new Error(
+      `Name ${getDescriptor(schemaElement)} must start with [_a-zA-Z].`,
+    );
+  }
+
+  if (!allowReservedNames && name.startsWith('__')) {
+    throw new Error(
+      `Name ${getDescriptor(schemaElement)} must not begin with "__", which is reserved by GraphQL introspection.`,
+    );
+  }
+
+  if (isEnumValue(schemaElement)) {
+    if (name === 'true' || name === 'false' || name === 'null') {
+      throw new Error(
+        `Name ${getDescriptor(schemaElement)} cannot be: ${name}.`,
+      );
+    }
+  }
+
+  return name;
+}

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -45,9 +45,27 @@ import type { VariableValues } from '../execution/values.js';
 
 import { valueFromASTUntyped } from '../utilities/valueFromASTUntyped.js';
 
+import type { Env } from '../setEnv.js';
+
 import { assertEnumValueName, assertName } from './assertName.js';
 import type { GraphQLDirective } from './directives.js';
 import type { GraphQLSchema } from './schema.js';
+
+const noOp = (_name: string): void => {
+  /* no-op */
+};
+
+let nameCheck = noOp;
+let enumValueNameCheck = noOp;
+
+export function setDefinitionNameCheckForEnv(newEnv: Env): void {
+  if (newEnv === 'development') {
+    nameCheck = assertName;
+    enumValueNameCheck = assertEnumValueName;
+    return;
+  }
+  nameCheck = enumValueNameCheck = noOp;
+}
 
 // Predicates & Assertions
 
@@ -669,7 +687,8 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
   extensionASTNodes: ReadonlyArray<ScalarTypeExtensionNode>;
 
   constructor(config: Readonly<GraphQLScalarTypeConfig<TInternal, TExternal>>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.specifiedByURL = config.specifiedByURL;
     this.serialize =
@@ -880,7 +899,8 @@ export class GraphQLObjectType<TSource = any, TContext = any>
   private _interfaces: ThunkReadonlyArray<GraphQLInterfaceType>;
 
   constructor(config: Readonly<GraphQLObjectTypeConfig<TSource, TContext>>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.isTypeOf = config.isTypeOf;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1116,7 +1136,8 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
     config: GraphQLFieldConfig<TSource, TContext, TArgs>,
   ) {
     this.parentType = parentType;
-    this.name = assertName(name);
+    this.name = name;
+    nameCheck(this.name);
     this.description = config.description;
     this.type = config.type;
 
@@ -1182,7 +1203,8 @@ export class GraphQLArgument implements GraphQLSchemaElement {
     config: GraphQLArgumentConfig,
   ) {
     this.parent = parent;
-    this.name = assertName(name);
+    this.name = name;
+    nameCheck(this.name);
     this.description = config.description;
     this.type = config.type;
     this.defaultValue = config.defaultValue;
@@ -1281,7 +1303,8 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
   private _interfaces: ThunkReadonlyArray<GraphQLInterfaceType>;
 
   constructor(config: Readonly<GraphQLInterfaceTypeConfig<TSource, TContext>>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.resolveType = config.resolveType;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1407,7 +1430,8 @@ export class GraphQLUnionType implements GraphQLSchemaElement {
   private _types: ThunkReadonlyArray<GraphQLObjectType>;
 
   constructor(config: Readonly<GraphQLUnionTypeConfig<any, any>>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.resolveType = config.resolveType;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1528,7 +1552,8 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
   private _nameLookup: ObjMap<GraphQLEnumValue> | null;
 
   constructor(config: Readonly<GraphQLEnumTypeConfig /* <T> */>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);
     this.astNode = config.astNode;
@@ -1756,7 +1781,8 @@ export class GraphQLEnumValue implements GraphQLSchemaElement {
     config: GraphQLEnumValueConfig,
   ) {
     this.parentEnum = parentEnum;
-    this.name = assertEnumValueName(name);
+    this.name = name;
+    enumValueNameCheck(this.name);
     this.description = config.description;
     this.value = config.value !== undefined ? config.value : name;
     this.deprecationReason = config.deprecationReason;
@@ -1832,7 +1858,8 @@ export class GraphQLInputObjectType implements GraphQLSchemaElement {
   private _fields: ThunkObjMap<GraphQLInputField>;
 
   constructor(config: Readonly<GraphQLInputObjectTypeConfig>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);
     this.astNode = config.astNode;
@@ -1960,7 +1987,8 @@ export class GraphQLInputField implements GraphQLSchemaElement {
     );
 
     this.parentType = parentType;
-    this.name = assertName(name);
+    this.name = name;
+    nameCheck(this.name);
     this.description = config.description;
     this.type = config.type;
     this.defaultValue = config.defaultValue;

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -10,6 +10,8 @@ import { toObjMapWithSymbols } from '../jsutils/toObjMap.js';
 import type { DirectiveDefinitionNode } from '../language/ast.js';
 import { DirectiveLocation } from '../language/directiveLocation.js';
 
+import type { Env } from '../setEnv.js';
+
 import { assertName } from './assertName.js';
 import type {
   GraphQLArgumentConfig,
@@ -18,6 +20,16 @@ import type {
 } from './definition.js';
 import { GraphQLArgument, GraphQLNonNull } from './definition.js';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from './scalars.js';
+
+const noOp = (_name: string): void => {
+  /* no-op */
+};
+
+let nameCheck = noOp;
+
+export function setDirectiveNameCheckForEnv(newEnv: Env): void {
+  nameCheck = newEnv === 'development' ? assertName : noOp;
+}
 
 /**
  * Test if the given value is a GraphQL directive.
@@ -62,7 +74,8 @@ export class GraphQLDirective implements GraphQLSchemaElement {
   astNode: Maybe<DirectiveDefinitionNode>;
 
   constructor(config: Readonly<GraphQLDirectiveConfig>) {
-    this.name = assertName(config.name);
+    this.name = config.name;
+    nameCheck(this.name);
     this.description = config.description;
     this.locations = config.locations;
     this.isRepeatable = config.isRepeatable ?? false;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -202,4 +202,5 @@ export {
 export { validateSchema, assertValidSchema } from './validate.js';
 
 // Upholds the spec rules about naming.
+export { assertHasValidName } from './assertHasValidName.js';
 export { assertName, assertEnumValueName } from './assertName.js';

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -34,6 +34,7 @@ import {
   validateInputValue,
 } from '../utilities/validateInputValue.js';
 
+import { assertHasValidName } from './assertHasValidName.js';
 import type {
   GraphQLArgument,
   GraphQLEnumType,
@@ -42,6 +43,7 @@ import type {
   GraphQLInputType,
   GraphQLInterfaceType,
   GraphQLObjectType,
+  GraphQLSchemaElement,
   GraphQLUnionType,
 } from './definition.js';
 import {
@@ -196,7 +198,7 @@ function validateDirectives(context: SchemaValidationContext): void {
     }
 
     // Ensure they are named correctly.
-    validateName(context, directive);
+    validateName(context, directive, false);
 
     if (directive.locations.length === 0) {
       context.reportError(
@@ -208,7 +210,7 @@ function validateDirectives(context: SchemaValidationContext): void {
     // Ensure the arguments are valid.
     for (const arg of directive.args) {
       // Ensure they are named correctly.
-      validateName(context, arg);
+      validateName(context, arg, false);
 
       // Ensure the type is an input type.
       if (!isInputType(arg.type)) {
@@ -348,14 +350,16 @@ function uncoerceDefaultValue(value: unknown, type: GraphQLInputType): unknown {
 
 function validateName(
   context: SchemaValidationContext,
-  node: { readonly name: string; readonly astNode: Maybe<ASTNode> },
+  schemaElement: GraphQLSchemaElement & {
+    readonly name: string;
+    readonly astNode: Maybe<ASTNode>;
+  },
+  allowReservedNames: boolean,
 ): void {
-  // Ensure names are valid, however introspection types opt out.
-  if (node.name.startsWith('__')) {
-    context.reportError(
-      `Name "${node.name}" must not begin with "__", which is reserved by GraphQL introspection.`,
-      node.astNode,
-    );
+  try {
+    assertHasValidName(schemaElement, allowReservedNames);
+  } catch (error: unknown) {
+    context.reportError((error as Error).message, schemaElement.astNode);
   }
 }
 
@@ -376,20 +380,18 @@ function validateTypes(context: SchemaValidationContext): void {
       continue;
     }
 
-    // Ensure it is named correctly (excluding introspection types).
-    if (!isIntrospectionType(type)) {
-      validateName(context, type);
-    }
+    const allowReservedNames = isIntrospectionType(type);
+    validateName(context, type, allowReservedNames);
 
     if (isObjectType(type)) {
       // Ensure fields are valid
-      validateFields(context, type);
+      validateFields(context, type, allowReservedNames);
 
       // Ensure objects implement the interfaces they claim to.
       validateInterfaces(context, type);
     } else if (isInterfaceType(type)) {
       // Ensure fields are valid.
-      validateFields(context, type);
+      validateFields(context, type, allowReservedNames);
 
       // Ensure interfaces implement the interfaces they claim to.
       validateInterfaces(context, type);
@@ -398,10 +400,10 @@ function validateTypes(context: SchemaValidationContext): void {
       validateUnionMembers(context, type);
     } else if (isEnumType(type)) {
       // Ensure Enums have valid values.
-      validateEnumValues(context, type);
+      validateEnumValues(context, type, allowReservedNames);
     } else if (isInputObjectType(type)) {
       // Ensure Input Object fields are valid.
-      validateInputFields(context, type);
+      validateInputFields(context, type, allowReservedNames);
 
       // Ensure Input Objects do not contain invalid field circular references.
       // Ensure Input Objects do not contain non-nullable circular references.
@@ -416,6 +418,7 @@ function validateTypes(context: SchemaValidationContext): void {
 function validateFields(
   context: SchemaValidationContext,
   type: GraphQLObjectType | GraphQLInterfaceType,
+  allowReservedNames: boolean,
 ): void {
   const fields = Object.values(type.getFields());
 
@@ -429,7 +432,7 @@ function validateFields(
 
   for (const field of fields) {
     // Ensure they are named correctly.
-    validateName(context, field);
+    validateName(context, field, allowReservedNames);
 
     // Ensure the type is an output type
     if (!isOutputType(field.type)) {
@@ -443,7 +446,7 @@ function validateFields(
     // Ensure the arguments are valid
     for (const arg of field.args) {
       // Ensure they are named correctly.
-      validateName(context, arg);
+      validateName(context, arg, allowReservedNames);
 
       // Ensure the type is an input type
       if (!isInputType(arg.type)) {
@@ -648,6 +651,7 @@ function validateUnionMembers(
 function validateEnumValues(
   context: SchemaValidationContext,
   enumType: GraphQLEnumType,
+  allowReservedNames: boolean,
 ): void {
   const enumValues = enumType.getValues();
 
@@ -660,13 +664,14 @@ function validateEnumValues(
 
   for (const enumValue of enumValues) {
     // Ensure valid name.
-    validateName(context, enumValue);
+    validateName(context, enumValue, allowReservedNames);
   }
 }
 
 function validateInputFields(
   context: SchemaValidationContext,
   inputObj: GraphQLInputObjectType,
+  allowReservedNames: boolean,
 ): void {
   const fields = Object.values(inputObj.getFields());
 
@@ -680,7 +685,7 @@ function validateInputFields(
   // Ensure the input fields are valid
   for (const field of fields) {
     // Ensure they are named correctly.
-    validateName(context, field);
+    validateName(context, field, allowReservedNames);
 
     // Ensure the type is an input type
     if (!isInputType(field.type)) {

--- a/website/pages/upgrade-guides/v16-v17.mdx
+++ b/website/pages/upgrade-guides/v16-v17.mdx
@@ -145,7 +145,7 @@ Use the `validateInputValue` helper to retrieve the actual errors.
 - Removed deprecated `getOperationType` function, use `getRootType` on the `GraphQLSchema` instance instead
 - Removed deprecated `getVisitFn` function, use `getEnterLeaveForKind` instead
 - Removed deprecated `printError` and `formatError` utilities, you can use `toString` or `toJSON` on the error as a replacement
-- Removed deprecated `assertValidName` and `isValidNameError` utilities, use `assertName` instead
+- Removed deprecated `assertValidName` and `isValidNameError` utilities, use `assertHasValidName` instead
 - Removed deprecated `assertValidExecutionArguments` function, use `assertValidSchema` instead
 - Removed deprecated `getFieldDefFn` from `TypeInfo`
 - Removed deprecated `TypeInfo` from `validate` https://github.com/graphql/graphql-js/pull/4187


### PR DESCRIPTION
Motivation:

- Improve known-valid schema construction time as much as possible.

Background:
- All schema validation except name validation is currently performed separately in the `validateSchema(...)`, which optimizes schema construction for known-valid schemas.
- Name validation is an exception, which provides useful localized dev feedback if a naming mistake has been made, see #4362 and especially [this comment](https://github.com/graphql/graphql-js/issues/4362#issuecomment-2910123920) which details some history of the code changes.
- This PR adds name validation to the `validateSchema(...)` step and makes it so that in a production environment only, name validation is skipped during schema construction.

Depends on:

- #4426

Prior proposals:
- #4423
- #4427