### PR TITLE
Implement schema coordinate spec as of 2025-06-06

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -703,14 +703,14 @@ describe('Parser', () => {
     it('parses Name . Name', () => {
       const result = parseSchemaCoordinate('MyType.field');
       expectJSON(result).toDeepEqual({
-        kind: Kind.FIELD_COORDINATE,
+        kind: Kind.MEMBER_COORDINATE,
         loc: { start: 0, end: 12 },
         name: {
           kind: Kind.NAME,
           loc: { start: 0, end: 6 },
           value: 'MyType',
         },
-        fieldName: {
+        memberName: {
           kind: Kind.NAME,
           loc: { start: 7, end: 12 },
           value: 'field',
@@ -725,24 +725,6 @@ describe('Parser', () => {
           message: 'Syntax Error: Expected <EOF>, found ".".',
           locations: [{ line: 1, column: 13 }],
         });
-    });
-
-    it('parses Name :: Name', () => {
-      const result = parseSchemaCoordinate('MyEnum::value');
-      expectJSON(result).toDeepEqual({
-        kind: Kind.VALUE_COORDINATE,
-        loc: { start: 0, end: 13 },
-        name: {
-          kind: Kind.NAME,
-          loc: { start: 0, end: 6 },
-          value: 'MyEnum',
-        },
-        valueName: {
-          kind: Kind.NAME,
-          loc: { start: 8, end: 13 },
-          value: 'value',
-        },
-      });
     });
 
     it('parses Name . Name ( Name : )', () => {

--- a/src/language/__tests__/predicates-test.ts
+++ b/src/language/__tests__/predicates-test.ts
@@ -148,9 +148,8 @@ describe('AST node predicates', () => {
       'ArgumentCoordinate',
       'DirectiveArgumentCoordinate',
       'DirectiveCoordinate',
-      'FieldCoordinate',
+      'MemberCoordinate',
       'TypeCoordinate',
-      'ValueCoordinate',
     ]);
   });
 });

--- a/src/language/__tests__/printer-test.ts
+++ b/src/language/__tests__/printer-test.ts
@@ -308,6 +308,9 @@ describe('Printer: Query document', () => {
     expect(print(parseSchemaCoordinate('  Name . field ( arg: )'))).to.equal(
       'Name.field(arg:)',
     );
+    expect(print(parseSchemaCoordinate('  Name :: Name '))).to.equal(
+      'Name::Name',
+    );
     expect(print(parseSchemaCoordinate(' @ name  '))).to.equal('@name');
     expect(print(parseSchemaCoordinate(' @ name (arg:) '))).to.equal(
       '@name(arg:)',

--- a/src/language/__tests__/printer-test.ts
+++ b/src/language/__tests__/printer-test.ts
@@ -308,9 +308,6 @@ describe('Printer: Query document', () => {
     expect(print(parseSchemaCoordinate('  Name . field ( arg: )'))).to.equal(
       'Name.field(arg:)',
     );
-    expect(print(parseSchemaCoordinate('  Name :: Name '))).to.equal(
-      'Name::Name',
-    );
     expect(print(parseSchemaCoordinate(' @ name  '))).to.equal('@name');
     expect(print(parseSchemaCoordinate(' @ name (arg:) '))).to.equal(
       '@name(arg:)',

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -183,9 +183,8 @@ export type ASTNode =
   | EnumTypeExtensionNode
   | InputObjectTypeExtensionNode
   | TypeCoordinateNode
-  | FieldCoordinateNode
+  | MemberCoordinateNode
   | ArgumentCoordinateNode
-  | ValueCoordinateNode
   | DirectiveCoordinateNode
   | DirectiveArgumentCoordinateNode;
 
@@ -296,9 +295,8 @@ export const QueryDocumentKeys: {
 
   // Schema Coordinates
   TypeCoordinate: ['name'],
-  FieldCoordinate: ['name', 'fieldName'],
+  MemberCoordinate: ['name', 'memberName'],
   ArgumentCoordinate: ['name', 'fieldName', 'argumentName'],
-  ValueCoordinate: ['name', 'valueName'],
   DirectiveCoordinate: ['name'],
   DirectiveArgumentCoordinate: ['name', 'argumentName'],
 };
@@ -781,9 +779,8 @@ export interface InputObjectTypeExtensionNode {
 
 export type SchemaCoordinateNode =
   | TypeCoordinateNode
-  | FieldCoordinateNode
+  | MemberCoordinateNode
   | ArgumentCoordinateNode
-  | ValueCoordinateNode
   | DirectiveCoordinateNode
   | DirectiveArgumentCoordinateNode;
 
@@ -793,11 +790,11 @@ export interface TypeCoordinateNode {
   readonly name: NameNode;
 }
 
-export interface FieldCoordinateNode {
-  readonly kind: typeof Kind.FIELD_COORDINATE;
+export interface MemberCoordinateNode {
+  readonly kind: typeof Kind.MEMBER_COORDINATE;
   readonly loc?: Location;
   readonly name: NameNode;
-  readonly fieldName: NameNode;
+  readonly memberName: NameNode;
 }
 
 export interface ArgumentCoordinateNode {
@@ -806,13 +803,6 @@ export interface ArgumentCoordinateNode {
   readonly name: NameNode;
   readonly fieldName: NameNode;
   readonly argumentName: NameNode;
-}
-
-export interface ValueCoordinateNode {
-  readonly kind: typeof Kind.VALUE_COORDINATE;
-  readonly loc?: Location;
-  readonly name: NameNode;
-  readonly valueName: NameNode;
 }
 
 export interface DirectiveCoordinateNode {

--- a/src/language/kinds_.ts
+++ b/src/language/kinds_.ts
@@ -113,14 +113,11 @@ export type INPUT_OBJECT_TYPE_EXTENSION = typeof INPUT_OBJECT_TYPE_EXTENSION;
 export const TYPE_COORDINATE = 'TypeCoordinate';
 export type TYPE_COORDINATE = typeof TYPE_COORDINATE;
 
-export const FIELD_COORDINATE = 'FieldCoordinate';
-export type FIELD_COORDINATE = typeof FIELD_COORDINATE;
+export const MEMBER_COORDINATE = 'MemberCoordinate';
+export type MEMBER_COORDINATE = typeof MEMBER_COORDINATE;
 
 export const ARGUMENT_COORDINATE = 'ArgumentCoordinate';
 export type ARGUMENT_COORDINATE = typeof ARGUMENT_COORDINATE;
-
-export const VALUE_COORDINATE = 'ValueCoordinate';
-export type VALUE_COORDINATE = typeof VALUE_COORDINATE;
 
 export const DIRECTIVE_COORDINATE = 'DirectiveCoordinate';
 export type DIRECTIVE_COORDINATE = typeof DIRECTIVE_COORDINATE;

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -98,7 +98,6 @@ export function isPunctuatorTokenKind(kind: TokenKind): boolean {
     kind === TokenKind.DOT ||
     kind === TokenKind.SPREAD ||
     kind === TokenKind.COLON ||
-    kind === TokenKind.TWO_COLON ||
     kind === TokenKind.EQUALS ||
     kind === TokenKind.AT ||
     kind === TokenKind.BRACKET_L ||
@@ -272,14 +271,6 @@ function readNextToken(lexer: Lexer, start: number): Token {
         return readDot(lexer, position);
       }
       case 0x003a: // :
-        if (body.charCodeAt(position + 1) === 0x003a) {
-          return createToken(
-            lexer,
-            TokenKind.TWO_COLON,
-            position,
-            position + 2,
-          );
-        }
         return createToken(lexer, TokenKind.COLON, position, position + 1);
       case 0x003d: // =
         return createToken(lexer, TokenKind.EQUALS, position, position + 1);

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -23,7 +23,6 @@ import type {
   EnumTypeExtensionNode,
   EnumValueDefinitionNode,
   EnumValueNode,
-  FieldCoordinateNode,
   FieldDefinitionNode,
   FieldNode,
   FloatValueNode,
@@ -39,6 +38,7 @@ import type {
   IntValueNode,
   ListTypeNode,
   ListValueNode,
+  MemberCoordinateNode,
   NamedTypeNode,
   NameNode,
   NonNullTypeNode,
@@ -63,7 +63,6 @@ import type {
   TypeSystemExtensionNode,
   UnionTypeDefinitionNode,
   UnionTypeExtensionNode,
-  ValueCoordinateNode,
   ValueNode,
   VariableDefinitionNode,
   VariableNode,
@@ -1467,7 +1466,6 @@ export class Parser {
    *   - Name
    *   - Name . Name
    *   - Name . Name ( Name : )
-   *   - Name :: Name
    *   - @ Name
    *   - @ Name ( Name : )
    */
@@ -1475,16 +1473,6 @@ export class Parser {
     const start = this._lexer.token;
     const ofDirective = this.expectOptionalToken(TokenKind.AT);
     const name = this.parseName();
-
-    if (!ofDirective && this.expectOptionalToken(TokenKind.TWO_COLON)) {
-      const valueName = this.parseName();
-      return this.node<ValueCoordinateNode>(start, {
-        kind: Kind.VALUE_COORDINATE,
-        name,
-        valueName,
-      });
-    }
-
     let memberName: NameNode | undefined;
     if (!ofDirective && this.expectOptionalToken(TokenKind.DOT)) {
       memberName = this.parseName();
@@ -1520,10 +1508,10 @@ export class Parser {
           argumentName,
         });
       }
-      return this.node<FieldCoordinateNode>(start, {
-        kind: Kind.FIELD_COORDINATE,
+      return this.node<MemberCoordinateNode>(start, {
+        kind: Kind.MEMBER_COORDINATE,
         name,
-        fieldName: memberName,
+        memberName,
       });
     }
 

--- a/src/language/predicates.ts
+++ b/src/language/predicates.ts
@@ -117,9 +117,8 @@ export function isSchemaCoordinateNode(
 ): node is SchemaCoordinateNode {
   return (
     node.kind === Kind.TYPE_COORDINATE ||
-    node.kind === Kind.FIELD_COORDINATE ||
+    node.kind === Kind.MEMBER_COORDINATE ||
     node.kind === Kind.ARGUMENT_COORDINATE ||
-    node.kind === Kind.VALUE_COORDINATE ||
     node.kind === Kind.DIRECTIVE_COORDINATE ||
     node.kind === Kind.DIRECTIVE_ARGUMENT_COORDINATE
   );

--- a/src/language/printer.ts
+++ b/src/language/printer.ts
@@ -325,17 +325,13 @@ const printDocASTReducer: ASTReducer<string> = {
 
   TypeCoordinate: { leave: ({ name }) => name },
 
-  FieldCoordinate: {
-    leave: ({ name, fieldName }) => join([name, wrap('.', fieldName)]),
+  MemberCoordinate: {
+    leave: ({ name, memberName }) => join([name, wrap('.', memberName)]),
   },
 
   ArgumentCoordinate: {
     leave: ({ name, fieldName, argumentName }) =>
       join([name, wrap('.', fieldName), wrap('(', argumentName, ':)')]),
-  },
-
-  ValueCoordinate: {
-    leave: ({ name, valueName }) => join([name, wrap('::', valueName)]),
   },
 
   DirectiveCoordinate: { leave: ({ name }) => join(['@', name]) },

--- a/src/language/tokenKind.ts
+++ b/src/language/tokenKind.ts
@@ -13,7 +13,6 @@ export const TokenKind = {
   DOT: '.' as const,
   SPREAD: '...' as const,
   COLON: ':' as const,
-  TWO_COLON: '::' as const,
   EQUALS: '=' as const,
   AT: '@' as const,
   BRACKET_L: '[' as const,

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -111,6 +111,14 @@ describe('resolveSchemaCoordinate', () => {
     expect(
       resolveSchemaCoordinate(schema, 'SearchFilter::UNKNOWN'),
     ).to.deep.equal(undefined);
+
+    expect(() => resolveSchemaCoordinate(schema, 'Unknown::UNKNOWN')).to.throw(
+      'Expected "Unknown" to be defined as a type in the schema.',
+    );
+
+    expect(() => resolveSchemaCoordinate(schema, 'Business::id')).to.throw(
+      'Expected "Business" to be an Enum type.',
+    );
   });
 
   it('resolves a Field Argument', () => {

--- a/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
+++ b/src/utilities/__tests__/resolveSchemaCoordinate-test.ts
@@ -111,14 +111,6 @@ describe('resolveSchemaCoordinate', () => {
     expect(
       resolveSchemaCoordinate(schema, 'SearchFilter::UNKNOWN'),
     ).to.deep.equal(undefined);
-
-    expect(() => resolveSchemaCoordinate(schema, 'Unknown::UNKNOWN')).to.throw(
-      'Expected "Unknown" to be defined as a type in the schema.',
-    );
-
-    expect(() => resolveSchemaCoordinate(schema, 'Business::id')).to.throw(
-      'Expected "Business" to be an Enum type.',
-    );
   });
 
   it('resolves a Field Argument', () => {


### PR DESCRIPTION
This PR is applied to the `schema-coordinates` branch PR here: https://github.com/graphql/graphql-js/pull/3044

Implements schema coordinate spec changes per the June 5th 2025 WG discussion

https://github.com/graphql/graphql-spec/pull/794

- Add support for meta-fields (e.g. `__typename`)
- Add support for introspection types
- Revert back from FieldCoordinate+ValueCoordinate -> MemberCoordinate

cc @benjie 