### PR TITLE
Prevents injecting Node.js globals like process, which can break browser features when loading graphql from ESM-based CDN like esm.sh

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,5 +77,8 @@
   },
   "publishConfig": {
     "tag": "latest"
-  }
+  },
+  "browser": {
+		"process": false
+	}
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,6 @@
     "tag": "latest"
   },
   "browser": {
-		"process": false
-	}
+    "process": false
+  }
 }


### PR DESCRIPTION
see https://esm.sh/graphql

```
/* esm.sh - graphql@16.11.0 */
import "/node/process.mjs";
export * from "/graphql@16.11.0/es2022/graphql.mjs";
```

where process is polyfilled

ref https://github.com/esm-dev/esm.sh/issues/1134#issuecomment-2870426164