### PR TITLE
Subscriptions docs suggestions

### DIFF
--- a/website/pages/docs/subscriptions.mdx
+++ b/website/pages/docs/subscriptions.mdx
@@ -86,30 +86,59 @@ GraphQL.js supports subscription execution, but you’re responsible for setting
 - An event-publishing mechanism
 - A transport layer to maintain the connection
 
-The following examples use the [`@graphql-yoga/subscriptions`](https://github.com/graphql-hive/graphql-yoga/tree/main/packages/subscription) package to set up an in-memory event system.
+The following examples use a small in-memory pub/sub helper to set up an event
+system for local development.
 
 ### Install dependencies
 
 Start by installing the necessary packages:
 
 ```bash
-npm install graphql @graphql-yoga/subscriptions
+npm install graphql
 ```
 
-To serve subscriptions over a network, you’ll also need a transport implementation. Two popular options are [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a community-maintained WebSocket library and [`graphql-sse`](https://github.com/enisdenjo/graphql-sse) a community-maintained Server-Sent Events library. This guide focuses on schema-level implementation.
+To serve subscriptions over a network, you’ll also need a transport implementation. Two common options are [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a community-maintained WebSocket library, and [`graphql-sse`](https://github.com/enisdenjo/graphql-sse), a community-maintained Server-Sent Events library. This guide focuses on schema-level implementation.
 
 ### Set up a pub/sub instance
 
-Create a `PubSub` instance to manage your in-memory event system:
+In production, subscriptions are typically backed by a robust pub/sub system
+that can span processes and servers. For this demonstration, you can use an
+in-memory pub/sub system of your choice, or an implementation such as the
+following:
 
-```js
-import { createPubSub } from '@graphql-yoga/subscriptions'
+```ts
+import { EventEmitter, on } from 'node:events';
 
-const pubSub = createPubSub();
+export class InMemoryPubSub<T extends Record<string, unknown>> {
+  private emitter = new EventEmitter();
+
+  publish<K extends keyof T & string>(topic: K, value: T[K]): boolean {
+    return this.emitter.emit(topic, value);
+  }
+
+  async *subscribe<K extends keyof T & string>(
+    topic: K,
+    signal?: AbortSignal,
+  ): AsyncGenerator<T[K], void, unknown> {
+    for await (const [value] of on(this.emitter, topic, { signal })) {
+      yield value as T[K];
+    }
+  }
+}
 ```
 
-This `pubsub` object provides `publish` and `asyncIterator` methods, allowing
-you to broadcast and listen for events.
+Then create a typed pub/sub instance for the subscription events in your schema:
+
+```ts
+type PubSubEvents = {
+  MESSAGE_SENT: { messageSent: string };
+};
+
+const pubsub = new InMemoryPubSub<PubSubEvents>();
+```
+
+This `pubsub` object provides `publish` and `subscribe` methods, allowing you to
+broadcast and listen for events.
 
 ### Define a subscription type
 
@@ -167,8 +196,8 @@ Whenever your server publishes a `MESSAGE_SENT` event, clients subscribed to
 
 ## Planning for production
 
-The in-memory `PubSub` used in this example is suitable for development only.
-It does not support multiple server instances or distributed environments.
+The in-memory pub/sub helper used in this example is suitable for development
+only. It does not support multiple server instances or distributed environments.
 
 For production, consider using a more robust event system such as:
 

--- a/website/pages/docs/subscriptions.mdx
+++ b/website/pages/docs/subscriptions.mdx
@@ -12,8 +12,8 @@ This guide covers how to implement subscriptions in GraphQL.js, when to use them
 
 A subscription is a GraphQL operation that delivers ongoing results to the client when a specific event happens. Unlike queries or mutations, which return a single response, a subscription delivers data over time through a persistent connection.
 
-GraphQL.js implements the subscription execution algorithm, but it's up to you to connect it to your event system and transport layer. Most implementations use WebSockets or SSE for transport, though any full-duplex protocol can work.
-You can find [here](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions#sse-vs-websocket) some valuable information about the differences between WebSockets and SSE.
+GraphQL.js implements the subscription execution algorithm, but it's up to you to connect it to your event system and transport layer. Common transport options include WebSockets and Server-Sent Events (SSE).
+For more context on the advantages of each approach, consider a [general comparison of WebSockets and SSE](https://websocket.org/comparisons/sse/) as well as [GraphQL Yoga's breakdown with respect to GraphQL](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions#sse-vs-websocket).
 
 ## How execution works
 

--- a/website/pages/docs/subscriptions.mdx
+++ b/website/pages/docs/subscriptions.mdx
@@ -12,7 +12,8 @@ This guide covers how to implement subscriptions in GraphQL.js, when to use them
 
 A subscription is a GraphQL operation that delivers ongoing results to the client when a specific event happens. Unlike queries or mutations, which return a single response, a subscription delivers data over time through a persistent connection.
 
-GraphQL.js implements the subscription execution algorithm, but it's up to you to connect it to your event system and transport layer. Most implementations use WebSockets for transport, though any full-duplex protocol can work.
+GraphQL.js implements the subscription execution algorithm, but it's up to you to connect it to your event system and transport layer. Most implementations use WebSockets or SSE for transport, though any full-duplex protocol can work.
+You can find [here](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions#sse-vs-websocket) some valuable information about the differences between WebSockets and SSE.
 
 ## How execution works
 
@@ -85,26 +86,26 @@ GraphQL.js supports subscription execution, but you’re responsible for setting
 - An event-publishing mechanism
 - A transport layer to maintain the connection
 
-The following examples use the [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package to set up an in-memory event system.
+The following examples use the [`@graphql-yoga/subscriptions`](https://github.com/graphql-hive/graphql-yoga/tree/main/packages/subscription) package to set up an in-memory event system.
 
 ### Install dependencies
 
 Start by installing the necessary packages:
 
 ```bash
-npm install graphql graphql-subscriptions
+npm install graphql @graphql-yoga/subscriptions
 ```
 
-To serve subscriptions over a network, you’ll also need a transport implementation. One option is [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a community-maintained WebSocket library. This guide focuses on schema-level implementation.
+To serve subscriptions over a network, you’ll also need a transport implementation. Two popular options are [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a community-maintained WebSocket library and [`graphql-sse`](https://github.com/enisdenjo/graphql-sse) a community-maintained Server-Sent Events library. This guide focuses on schema-level implementation.
 
 ### Set up a pub/sub instance
 
 Create a `PubSub` instance to manage your in-memory event system:
 
 ```js
-import { PubSub } from 'graphql-subscriptions';
+import { createPubSub } from '@graphql-yoga/subscriptions'
 
-const pubsub = new PubSub();
+const pubSub = createPubSub();
 ```
 
 This `pubsub` object provides `publish` and `asyncIterator` methods, allowing
@@ -124,7 +125,7 @@ const SubscriptionType = new GraphQLObjectType({
   fields: {
     messageSent: {
       type: GraphQLString,
-      subscribe: () => pubsub.asyncIterator(['MESSAGE_SENT']),
+      subscribe: () => pubsub.subscribe('MESSAGE_SENT'),
     },
   },
 });

--- a/website/pages/docs/subscriptions.mdx
+++ b/website/pages/docs/subscriptions.mdx
@@ -12,7 +12,8 @@ This guide covers how to implement subscriptions in GraphQL.js, when to use them
 
 A subscription is a GraphQL operation that delivers ongoing results to the client when a specific event happens. Unlike queries or mutations, which return a single response, a subscription delivers data over time through a persistent connection.
 
-GraphQL.js implements the subscription execution algorithm, but it's up to you to connect it to your event system and transport layer. Most implementations use WebSockets for transport, though any full-duplex protocol can work.
+GraphQL.js implements the subscription execution algorithm, but it's up to you to connect it to your event system and transport layer. Most implementations use WebSockets or SSE for transport, though any full-duplex protocol can work.
+You can find [here](https://the-guild.dev/graphql/yoga-server/docs/features/subscriptions#sse-vs-websocket) some valuable information about the differences between WebSockets and SSE.
 
 ## How execution works
 
@@ -58,26 +59,26 @@ GraphQL.js supports subscription execution, but you’re responsible for setting
 - An event-publishing mechanism
 - A transport layer to maintain the connection
 
-The following examples use the [`graphql-subscriptions`](https://github.com/apollographql/graphql-subscriptions) package to set up an in-memory event system.
+The following examples use the [`@graphql-yoga/subscriptions`](https://github.com/graphql-hive/graphql-yoga/tree/main/packages/subscription) package to set up an in-memory event system.
 
 ### Install dependencies
 
 Start by installing the necessary packages:
 
 ```bash
-npm install graphql graphql-subscriptions
+npm install graphql @graphql-yoga/subscriptions
 ```
 
-To serve subscriptions over a network, you’ll also need a transport implementation. One option is [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a community-maintained WebSocket library. This guide focuses on schema-level implementation.
+To serve subscriptions over a network, you’ll also need a transport implementation. Two popular options are [`graphql-ws`](https://github.com/enisdenjo/graphql-ws), a community-maintained WebSocket library and [`graphql-sse`](https://github.com/enisdenjo/graphql-sse) a community-maintained Server-Sent Events library. This guide focuses on schema-level implementation.
 
 ### Set up a pub/sub instance
 
 Create a `PubSub` instance to manage your in-memory event system:
 
 ```js
-import { PubSub } from 'graphql-subscriptions';
+import { createPubSub } from '@graphql-yoga/subscriptions'
 
-const pubsub = new PubSub();
+const pubSub = createPubSub();
 ```
 
 This `pubsub` object provides `publish` and `asyncIterator` methods, allowing
@@ -97,7 +98,7 @@ const SubscriptionType = new GraphQLObjectType({
   fields: {
     messageSent: {
       type: GraphQLString,
-      subscribe: () => pubsub.asyncIterator(['MESSAGE_SENT']),
+      subscribe: () => pubsub.subscribe('MESSAGE_SENT'),
     },
   },
 });


### PR DESCRIPTION
Adding some suggestions to the subscriptions section:

As mentioned in [this comment](https://github.com/graphql/graphql-js/pull/4406#discussion_r2115674774), the `graphql-subscriptions` library is not maintained ([reference](https://github.com/apollographql/graphql-subscriptions/issues/240)) I've made a change to recommend another library for the solution.

In order to move this our of draft, @enisdenjo @ardatan I believe we'll need to publish a README specifically for that library.

I've also changed the comment about WebSockets and SSE, I'm not sure if we want to say that most people use WebSockets?