### PR TITLE
fix(benchmark): fix benchmark shell command built from environment values

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -29,8 +29,8 @@ function localDir(...paths) {
   return path.join(__dirname, '..', ...paths);
 }
 
-function exec(command, options = {}) {
-  const result = cp.execSync(command, {
+function exec(command, args = [], options = {}) {
+  const result = cp.execFileSync(command, args, {
     encoding: 'utf-8',
     stdio: ['inherit', 'pipe', 'inherit'],
     ...options,
@@ -62,7 +62,7 @@ function prepareBenchmarkProjects(revisionList) {
       'npm --quiet install --ignore-scripts ' + prepareNPMPackage(revision),
       { cwd: projectPath },
     );
-    exec(`cp -R ${localDir('benchmark')} ${projectPath}`);
+    exec('cp', ['-R', localDir('benchmark'), projectPath]);
 
     return { revision, projectPath };
   });
@@ -76,7 +76,7 @@ function prepareBenchmarkProjects(revisionList) {
     }
 
     // Returns the complete git hash for a given git revision reference.
-    const hash = exec(`git rev-parse "${revision}"`);
+    const hash = exec('git', ['rev-parse', revision]);
 
     const archivePath = path.join(tmpDir, `graphql-${hash}.tgz`);
     if (fs.existsSync(archivePath)) {
@@ -86,8 +86,8 @@ function prepareBenchmarkProjects(revisionList) {
     const repoDir = path.join(tmpDir, hash);
     fs.rmSync(repoDir, { recursive: true, force: true });
     fs.mkdirSync(repoDir);
-    exec(`git archive "${hash}" | tar -xC "${repoDir}"`);
-    exec('npm --quiet ci --ignore-scripts', { cwd: repoDir });
+    exec('sh', ['-c', `git archive "${hash}" | tar -xC "${repoDir}"`]);
+    exec('npm', ['--quiet', 'ci', '--ignore-scripts'], { cwd: repoDir });
     fs.renameSync(buildNPMArchive(repoDir), archivePath);
     fs.rmSync(repoDir, { recursive: true });
     return archivePath;


### PR DESCRIPTION
https://github.com/graphql/graphql-js/blob/ba4b411385507929b6c4c7905eb04b3e6bd1e93c/benchmark/benchmark.js#L32-L33
https://github.com/graphql/graphql-js/blob/ba4b411385507929b6c4c7905eb04b3e6bd1e93c/benchmark/benchmark.js#L65-L79
https://github.com/graphql/graphql-js/blob/ba4b411385507929b6c4c7905eb04b3e6bd1e93c/benchmark/benchmark.js#L89-L90


Fix the issue should avoid passing dynamically constructed shell commands to `cp.execSync`. Instead, we can use `cp.execFileSync`, which allows us to pass the command and its arguments as separate parameters. This approach ensures that the shell does not interpret special characters in the arguments, mitigating the risk of command injection or misinterpretation.
1. Replace the `exec` function to use `cp.execFileSync` instead of `cp.execSync`.
2. Update all calls to `exec` to pass the command and arguments as separate parameters.


## Recommendation
If possible, use hard-coded string literals to specify the shell command to run, and provide the dynamic arguments to the shell command separately to avoid interpretation by the shell. Alternatively, if the shell command must be constructed dynamically, then add code to ensure that special characters in environment values do not alter the shell command unexpectedly.

