### PR TITLE
Avoid crash when oneOf input variable is not defined

### DIFF
--- a/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
+++ b/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts
@@ -1125,6 +1125,19 @@ describe('Validate: Values of correct type', () => {
         },
       ]);
     });
+
+    it('Undefined variable in oneOf input object', () => {
+      // This test verifies that undefined variables in OneOf input objects
+      // don't cause a TypeError in ValuesOfCorrectTypeRule.
+      // The undefined variable should be caught by NoUndefinedVariablesRule instead.
+      expectErrors(`
+        {
+          complicatedArgs {
+            oneOfArgField(oneOfArg: { stringField: $undefinedVariable })
+          }
+        }
+      `).toDeepEqual([]);
+    });
   });
 
   describe('Directive arguments', () => {

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -216,6 +216,13 @@ function validateOneOfInputObject(
   if (isVariable) {
     const variableName = value.name.value;
     const definition = variableDefinitions[variableName];
+
+    // If the variable definition is missing, skip validation here.
+    // This should be caught by other validation rules.
+    if (!definition) {
+      return;
+    }
+
     const isNullableVariable = definition.type.kind !== Kind.NON_NULL_TYPE;
 
     if (isNullableVariable) {


### PR DESCRIPTION
CC @benjie should this be added to the spec?

Fixes https://github.com/graphql/graphql-js/issues/4443