### PR TITLE
enable conditional exports

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -66,6 +66,7 @@ words:
 
   # TODO: contribute upstream
   - deno
+  - denoland
   - hashbang
   - Rspack
   - Rollup

--- a/integrationTests/README.md
+++ b/integrationTests/README.md
@@ -14,6 +14,10 @@ Each subdirectory represents a different environment/bundler:
 - `ts` - tests for supported Typescript versions
 - `webpack` - tests for Webpack
 
+### Verifying Conditional Exports
+
+The `conditions` subdirectory contains tests that verify the conditional exports of GraphQL.js. These tests ensure that the correct files are imported based on the environment being used.
+
 ### Verifying Development Mode Tests
 
 Each subdirectory represents a different environment/bundler demonstrating enabling development mode by setting the environment variable `NODE_ENV` to `development`.

--- a/integrationTests/conditions/check.mjs
+++ b/integrationTests/conditions/check.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+
+import { GraphQLObjectType as ESMGraphQLObjectType } from 'graphql';
+
+import { CJSGraphQLObjectType, cjsPath } from './cjs-importer.cjs';
+
+const moduleSync = process.env.MODULE_SYNC === 'true';
+const expectedExtension = moduleSync ? '.mjs' : '.js';
+assert.ok(
+  cjsPath.endsWith(expectedExtension),
+  `require('graphql') should resolve to a file with extension "${expectedExtension}", but got "${cjsPath}".`,
+);
+
+const isSameModule = ESMGraphQLObjectType === CJSGraphQLObjectType;
+assert.strictEqual(
+  isSameModule,
+  true,
+  'ESM and CJS imports should be the same module instances.',
+);
+
+console.log('Module identity and path checks passed.');

--- a/integrationTests/conditions/cjs-importer.cjs
+++ b/integrationTests/conditions/cjs-importer.cjs
@@ -1,0 +1,11 @@
+'use strict';
+
+const { GraphQLObjectType } = require('graphql');
+
+const cjsPath = require.resolve('graphql');
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  CJSGraphQLObjectType: GraphQLObjectType,
+  cjsPath,
+};

--- a/integrationTests/conditions/package.json
+++ b/integrationTests/conditions/package.json
@@ -1,0 +1,10 @@
+{
+  "description": "graphql-js should be loaded correctly on different versions of Node.js, Deno and Bun",
+  "private": true,
+  "scripts": {
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "graphql": "file:../graphql.tgz"
+  }
+}

--- a/integrationTests/conditions/test.js
+++ b/integrationTests/conditions/test.js
@@ -1,0 +1,31 @@
+import childProcess from 'node:child_process';
+
+const nodeTests = [
+  // Old node versions, require => CJS
+  { version: '20.18.0', moduleSync: false },
+  { version: '22.11.0', moduleSync: false },
+  // New node versions, module-sync => ESM
+  { version: '20.19.0', moduleSync: true },
+  { version: '22.12.0', moduleSync: true },
+  { version: '24.0.0', moduleSync: true },
+];
+
+for (const { version, moduleSync } of nodeTests) {
+  console.log(`Testing on node@${version} (moduleSync: ${moduleSync}) ...`);
+  childProcess.execSync(
+    `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=${moduleSync} node:${version}-slim node ./check.mjs`,
+    { stdio: 'inherit' },
+  );
+}
+
+console.log('Testing on bun (moduleSync: true) ...');
+childProcess.execSync(
+  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=true oven/bun:alpine bun ./check.mjs`,
+  { stdio: 'inherit' },
+);
+
+console.log('Testing on deno (moduleSync: false) ...');
+childProcess.execSync(
+  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=false denoland/deno:2.4.0 deno run --allow-read --allow-env ./check.mjs`,
+  { stdio: 'inherit' },
+);

--- a/integrationTests/conditions/test.js
+++ b/integrationTests/conditions/test.js
@@ -26,6 +26,6 @@ childProcess.execSync(
 
 console.log('Testing on deno (moduleSync: false) ...');
 childProcess.execSync(
-  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=false denoland/deno:2.4.0 deno run --allow-read --allow-env ./check.mjs`,
+  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=false denoland/alpine-2.4.1 deno run --allow-read --allow-env ./check.mjs`,
   { stdio: 'inherit' },
 );

--- a/integrationTests/conditions/test.js
+++ b/integrationTests/conditions/test.js
@@ -26,6 +26,6 @@ childProcess.execSync(
 
 console.log('Testing on deno (moduleSync: false) ...');
 childProcess.execSync(
-  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=false denoland/alpine-2.4.1 deno run --allow-read --allow-env ./check.mjs`,
+  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app --env MODULE_SYNC=false denoland/deno:alpine-2.4.1 deno run --allow-read --allow-env ./check.mjs`,
   { stdio: 'inherit' },
 );

--- a/integrationTests/ts/esm.ts
+++ b/integrationTests/ts/esm.ts
@@ -18,7 +18,7 @@ const queryType: GraphQLObjectType = new GraphQLObjectType({
           default: { value: 'World' },
         },
       },
-      resolve(_root, args: { who: string }) {
+      resolve(_root: unknown, args: { who: string }) {
         return 'Hello ' + args.who;
       },
     },

--- a/integrationTests/ts/extensions-test.ts
+++ b/integrationTests/ts/extensions-test.ts
@@ -5,6 +5,8 @@ interface SomeExtension {
   meaningOfLife: 42;
 }
 
+// Import added to support deno, which does not scan node_modules automatically.
+import 'graphql';
 declare module 'graphql' {
   interface GraphQLObjectTypeExtensions<_TSource, _TContext> {
     someObjectExtension?: SomeExtension;
@@ -32,7 +34,8 @@ const queryType: GraphQLObjectType = new GraphQLObjectType({
           },
         },
       },
-      resolve: (_root, args) => 'Hello ' + (args.who || 'World'),
+      resolve: (_root: unknown, args: { who: string }) =>
+        'Hello ' + (args.who || 'World'),
       extensions: {
         someFieldExtension: { meaningOfLife: 42 },
       },

--- a/integrationTests/ts/package.json
+++ b/integrationTests/ts/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "graphql": "file:../graphql.tgz",
     "graphql-esm": "file:../graphql-esm.tgz",
+    "@types/node": "~24.0.10",
     "typescript-4.9": "npm:typescript@4.9.x",
     "typescript-5.0": "npm:typescript@5.0.x",
     "typescript-5.1": "npm:typescript@5.1.x",

--- a/integrationTests/ts/test.js
+++ b/integrationTests/ts/test.js
@@ -15,7 +15,7 @@ for (const version of tsVersions) {
 
 console.log('Testing on deno ...');
 childProcess.execSync(
-  `docker run --rm --volume "${process.cwd()}:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
+  'docker run --rm --volume ".:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check',
   { stdio: 'inherit' },
 );
 

--- a/integrationTests/ts/test.js
+++ b/integrationTests/ts/test.js
@@ -1,7 +1,6 @@
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 const { dependencies } = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
 
@@ -14,11 +13,9 @@ for (const version of tsVersions) {
   childProcess.execSync(tscPath(version), { stdio: 'inherit' });
 }
 
-const dirname = path.dirname(fileURLToPath(import.meta.url));
-
 console.log('Testing on deno ...');
 childProcess.execSync(
-  `docker run --rm --volume "${dirname}:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
+  `docker run --rm --volume "$PWD:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
   { stdio: 'inherit' },
 );
 

--- a/integrationTests/ts/test.js
+++ b/integrationTests/ts/test.js
@@ -15,7 +15,7 @@ for (const version of tsVersions) {
 
 console.log('Testing on deno ...');
 childProcess.execSync(
-  `docker run --rm --volume "$PWD:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
+  `docker run --rm --volume "$PWD":/usr/src/app -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
   { stdio: 'inherit' },
 );
 

--- a/integrationTests/ts/test.js
+++ b/integrationTests/ts/test.js
@@ -1,6 +1,7 @@
 import childProcess from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const { dependencies } = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
 
@@ -13,9 +14,11 @@ for (const version of tsVersions) {
   childProcess.execSync(tscPath(version), { stdio: 'inherit' });
 }
 
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
 console.log('Testing on deno ...');
 childProcess.execSync(
-  'docker run --rm --volume ".:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check',
+  `docker run --rm --volume "${dirname}:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
   { stdio: 'inherit' },
 );
 

--- a/integrationTests/ts/test.js
+++ b/integrationTests/ts/test.js
@@ -9,9 +9,15 @@ const tsVersions = Object.keys(dependencies)
   .sort((a, b) => b.localeCompare(a));
 
 for (const version of tsVersions) {
-  console.log(`Testing on ${version} ...`);
+  console.log(`Testing on node ${version} ...`);
   childProcess.execSync(tscPath(version), { stdio: 'inherit' });
 }
+
+console.log('Testing on deno ...');
+childProcess.execSync(
+  `docker run --rm --volume "${process.cwd()}:/usr/src/app" -w /usr/src/app denoland/deno:alpine-2.4.1 deno check`,
+  { stdio: 'inherit' },
+);
 
 function tscPath(version) {
   return path.join('node_modules', version, 'bin', 'tsc');

--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -6,6 +6,7 @@ import ts from 'typescript';
 
 import { changeExtensionInImportPaths } from './change-extension-in-import-paths.js';
 import { inlineInvariant } from './inline-invariant.js';
+import type { ConditionalExports } from './utils.js';
 import {
   prettify,
   readPackageJSON,
@@ -98,7 +99,6 @@ async function buildPackage(outDir: string, isESMOnly: boolean): Promise<void> {
       }
     }
 
-    // Temporary workaround to allow "internal" imports, no grantees provided
     packageJSON.exports['./*.js'] = './*.js';
     packageJSON.exports['./*'] = './*.js';
 
@@ -106,10 +106,28 @@ async function buildPackage(outDir: string, isESMOnly: boolean): Promise<void> {
     packageJSON.version += '+esm';
   } else {
     delete packageJSON.type;
-    packageJSON.main = 'index';
+    packageJSON.main = 'index.js';
     packageJSON.module = 'index.mjs';
-    emitTSFiles({ outDir, module: 'commonjs', extension: '.js' });
+    packageJSON.types = 'index.d.ts';
+
+    const { emittedTSFiles } = emitTSFiles({
+      outDir,
+      module: 'commonjs',
+      extension: '.js',
+    });
     emitTSFiles({ outDir, module: 'es2020', extension: '.mjs' });
+
+    packageJSON.exports = {};
+    for (const filepath of emittedTSFiles) {
+      if (path.basename(filepath) === 'index.js') {
+        const relativePath = './' + path.relative('./npmDist', filepath);
+        packageJSON.exports[path.dirname(relativePath)] =
+          buildExports(relativePath);
+      }
+    }
+
+    packageJSON.exports['./*.js'] = buildExports('./*.js');
+    packageJSON.exports['./*'] = buildExports('./*.js');
   }
 
   const packageJsonPath = `./${outDir}/package.json`;
@@ -141,21 +159,31 @@ function emitTSFiles(options: {
 
   const tsHost = ts.createCompilerHost(tsOptions);
   tsHost.writeFile = (filepath, body) => {
-    if (filepath.match(/.js$/) && extension === '.mjs') {
-      let bodyToWrite = body;
-      bodyToWrite = bodyToWrite.replace(
-        '//# sourceMappingURL=graphql.js.map',
-        '//# sourceMappingURL=graphql.mjs.map',
-      );
-      writeGeneratedFile(filepath.replace(/.js$/, extension), bodyToWrite);
-    } else if (filepath.match(/.js.map$/) && extension === '.mjs') {
-      writeGeneratedFile(
-        filepath.replace(/.js.map$/, extension + '.map'),
-        body,
-      );
-    } else {
-      writeGeneratedFile(filepath, body);
+    if (extension === '.mjs') {
+      if (filepath.match(/.js$/)) {
+        let bodyToWrite = body;
+        bodyToWrite = bodyToWrite.replace(
+          '//# sourceMappingURL=graphql.js.map',
+          '//# sourceMappingURL=graphql.mjs.map',
+        );
+        writeGeneratedFile(filepath.replace(/.js$/, extension), bodyToWrite);
+        return;
+      }
+
+      if (filepath.match(/.js.map$/)) {
+        writeGeneratedFile(
+          filepath.replace(/.js.map$/, extension + '.map'),
+          body,
+        );
+        return;
+      }
+
+      if (filepath.match(/.d.ts$/)) {
+        writeGeneratedFile(filepath.replace(/.d.ts$/, '.d.mts'), body);
+        return;
+      }
     }
+    writeGeneratedFile(filepath, body);
   };
 
   const tsProgram = ts.createProgram(['src/index.ts'], tsOptions, tsHost);
@@ -170,5 +198,26 @@ function emitTSFiles(options: {
   assert(tsResult.emittedFiles != null);
   return {
     emittedTSFiles: tsResult.emittedFiles.sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+function buildExports(filepath: string): ConditionalExports {
+  const { dir, name } = path.parse(filepath);
+  const base = `./${path.join(dir, name)}`;
+  return {
+    types: {
+      module: `${base}.d.mts`,
+      'module-sync': `${base}.d.mts`,
+      bun: `${base}.d.mts`,
+      node: `${base}.d.ts`,
+      require: `${base}.d.ts`,
+      default: `${base}.d.mts`,
+    },
+    module: `${base}.mjs`,
+    bun: `${base}.mjs`,
+    'module-sync': `${base}.mjs`,
+    node: `${base}.js`,
+    require: `${base}.js`,
+    default: `${base}.mjs`,
   };
 }

--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -205,14 +205,6 @@ function buildExports(filepath: string): ConditionalExports {
   const { dir, name } = path.parse(filepath);
   const base = `./${path.join(dir, name)}`;
   return {
-    types: {
-      module: `${base}.d.mts`,
-      'module-sync': `${base}.d.mts`,
-      bun: `${base}.d.mts`,
-      node: `${base}.d.ts`,
-      require: `${base}.d.ts`,
-      default: `${base}.d.mts`,
-    },
     module: `${base}.mjs`,
     bun: `${base}.mjs`,
     'module-sync': `${base}.mjs`,

--- a/resources/integration-test.ts
+++ b/resources/integration-test.ts
@@ -39,6 +39,9 @@ describe('Integration Tests', () => {
   testOnNodeProject('node');
   testOnNodeProject('webpack');
 
+  // Conditional export tests
+  testOnNodeProject('conditions');
+
   // Development mode tests
   testOnNodeProject('dev-node');
   testOnNodeProject('dev-deno');

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -245,11 +245,7 @@ interface PackageJSON {
   module?: string;
 }
 
-export interface ConditionalExports extends BaseExports {
-  types: BaseExports;
-}
-
-interface BaseExports {
+export interface ConditionalExports {
   module: string;
   bun: string;
   'module-sync': string;

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -234,7 +234,7 @@ interface PackageJSON {
   repository?: { url?: string };
   scripts?: { [name: string]: string };
   type?: string;
-  exports: { [path: string]: string };
+  exports: { [path: string]: string | ConditionalExports };
   types?: string;
   typesVersions: { [ranges: string]: { [path: string]: Array<string> } };
   devDependencies?: { [name: string]: string };
@@ -243,6 +243,19 @@ interface PackageJSON {
   // TODO: remove after we drop CJS support
   main?: string;
   module?: string;
+}
+
+export interface ConditionalExports extends BaseExports {
+  types: BaseExports;
+}
+
+interface BaseExports {
+  module: string;
+  bun: string;
+  'module-sync': string;
+  node: string;
+  require: string;
+  default: string;
 }
 
 export function readPackageJSON(

--- a/website/pages/upgrade-guides/v16-v17.mdx
+++ b/website/pages/upgrade-guides/v16-v17.mdx
@@ -18,9 +18,9 @@ The v17 release drops support for end-of-life versions of Node.JS, retaining sup
 
 ## ESM and conditional exports
 
-Earlier versions of GraphQL.js shipped dual builds for CommonJS and ESM, with ESM "*.mjs" files sitting alongside CommonJS "*.js" files.
+Earlier versions of GraphQL.js shipped dual builds for CommonJS and ESM, with ESM ".mjs" files sitting alongside CommonJS ".js" files.
 The ESM build was accessible via tooling recognizing the `module` field in `package.json`, while the CommonJS build was accessible via
-the "main" field. Unless configured carefully, this could sometimes lead to multiple copies of GraphQL.js being loaded in the same
+the `main` field. Unless configured carefully, this could sometimes lead to multiple copies of GraphQL.js being loaded in the same
 process, i.e. the dual-package hazard.
 
 v17 enables access to the ESM build via the `exports` field in `package.json` in a scheme designed to avoid the dual-package hazard as

--- a/website/pages/upgrade-guides/v16-v17.mdx
+++ b/website/pages/upgrade-guides/v16-v17.mdx
@@ -16,6 +16,25 @@ import { Callout } from 'nextra/components'
 
 The v17 release drops support for end-of-life versions of Node.JS, retaining support for versions 20, 22, and 24 or above.
 
+## ESM and conditional exports
+
+Earlier versions of GraphQL.js shipped dual builds for CommonJS and ESM, with ESM "*.mjs" files sitting alongside CommonJS "*.js" files.
+The ESM build was accessible via tooling recognizing the `module` field in `package.json`, while the CommonJS build was accessible via
+the "main" field. Unless configured carefully, this could sometimes lead to multiple copies of GraphQL.js being loaded in the same
+process, i.e. the dual-package hazard.
+
+v17 enables access to the ESM build via the `exports` field in `package.json` in a scheme designed to avoid the dual-package hazard as
+best as possible, relying on the ability of bun and newer versions of Node.js to consistently load ESM modules via `require` by
+indicating support for specific conditions. __ESM will now be served by default__, unless the requesting environment tooling __both__
+(A) supports the `node` or `require` conditions __and__ (B) does NOT support `bun`, `module`, `module-sync`. In that scenario, the
+CommonJS build will be served instead.
+
+Note: ESM is not served to deno even though it supports require(esm) because deno not yet support the `module-sync` condition, nor
+does it seem to provide the `deno` condition when calling `require`, see https://github.com/denoland/deno/issues/29970.
+
+Deno users can access a Typescript build for deno via git://github.com/graphql/graphql-js.git#deno as well as by specifically loading
+the index.mjs file, i.e. `import { graphql } from 'graphql/index.mjs'`, although this does not protect against the dual-package hazard.
+
 ## Default values
 
 GraphQL schemas allow default values for input fields and arguments. Historically, GraphQL.js did not rigorously validate or coerce these


### PR DESCRIPTION
depends on #4446

before:

![image](https://github.com/user-attachments/assets/e3e4d695-d596-444a-a932-0a50221652a9)

i.e. importing from esm gives you cjs

after:

![image](https://github.com/user-attachments/assets/0c7216aa-c66e-4be5-a85e-bf504b275ef3)

we have conditional exports, and it looks like nothing has changed.....

BUT:

Any version of Node honoring the module-sync condition i.e. where require(esm) is enabled will load ESM both when imported and required, i.e. `^20.19.0 || ^22.12.0 || >=23.0.0`, i.e. latest versions of all current Node.JS releases.

We have been delaying this for some time secondary to dual-package-hazard concerns, but this looks like we can release ESM to the broader community via package exports while retaining whatever legacy CJS build we might need for those environments that need it => looking at you Jest.

We can look into whether we want to drop cjs support entirely as a follow-on PR => see https://github.com/graphql/graphql-js/pull/4437