### PR TITLE
fix(docs/mutations-and-input-types.mdx): root being inside of SDL

### DIFF
--- a/website/pages/docs/mutations-and-input-types.mdx
+++ b/website/pages/docs/mutations-and-input-types.mdx
@@ -230,26 +230,6 @@ type Query {
 	getMessages: [Message]
 }
 
-const root = {
-	getMessage: ({ id }) => {
-		return fakeDatabase[id]
-	},
-	getMessages: () => {
-		return Object.values(fakeDatabase)
-	},
-	createMessage: ({ input }) => {
-		const id = String(Object.keys(fakeDatabase).length + 1)
-		const message = new Message(id, input)
-		fakeDatabase[id] = message
-		return message
-	},
-	updateMessage: ({ id, input }) => {
-		const message = fakeDatabase[id]
-		Object.assign(message, input)
-		return message
-	}
-}
-
 type Mutation {
   createMessage(input: MessageInput): Message
   updateMessage(id: ID!, input: MessageInput): Message
@@ -262,6 +242,26 @@ class Message {
     this.id = id;
     this.content = content;
     this.author = author;
+  }
+}
+
+const root = {
+  getMessage: ({ id }) => {
+    return fakeDatabase[id]
+  },
+  getMessages: () => {
+    return Object.values(fakeDatabase)
+  },
+  createMessage: ({ input }) => {
+    const id = String(Object.keys(fakeDatabase).length + 1)
+    const message = new Message(id, input)
+    fakeDatabase[id] = message
+    return message
+  },
+  updateMessage: ({ id, input }) => {
+    const message = fakeDatabase[id]
+    Object.assign(message, input)
+    return message
   }
 }
 


### PR DESCRIPTION
The example shows graphql implementation, where the "root" is by mistake put as string as part of the schema definition instead being a native js const

BEFORE (root is undefined and wongly put into the schema itself):

![image](https://github.com/user-attachments/assets/3908e84e-1c3e-43b5-8633-163ea66fdfa0)


AFTER (root correctly defined outside of the schema):

![image](https://github.com/user-attachments/assets/e14d51cc-2f36-450d-aea8-384d6c6a0703)
