### PR TITLE
integrationTests: pin bun/deno versions

### DIFF
--- a/integrationTests/dev-bun/package.json
+++ b/integrationTests/dev-bun/package.json
@@ -2,7 +2,7 @@
   "description": "graphql-js development mode should work with Bun",
   "private": true,
   "scripts": {
-    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app oven/bun:latest bun test.js"
+    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app oven/bun:1.2.18-slim bun test.js"
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz"

--- a/integrationTests/dev-deno/package.json
+++ b/integrationTests/dev-deno/package.json
@@ -2,7 +2,7 @@
   "description": "graphql-js development mode should work with Deno",
   "private": true,
   "scripts": {
-    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app denoland/deno:latest deno run --allow-env=NODE_ENV test.js"
+    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app denoland/deno:alpine-2.4.1 deno run --allow-env=NODE_ENV test.js"
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz"

--- a/integrationTests/prod-bun/package.json
+++ b/integrationTests/prod-bun/package.json
@@ -2,7 +2,7 @@
   "description": "graphql-js production mode should work with Bun",
   "private": true,
   "scripts": {
-    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app oven/bun:latest bun --define process.env.NODE_ENV='\"production\"' test.js"
+    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app oven/bun:1.2.18-slim bun --define process.env.NODE_ENV='\"production\"' test.js"
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz"

--- a/integrationTests/prod-deno/package.json
+++ b/integrationTests/prod-deno/package.json
@@ -2,7 +2,7 @@
   "description": "graphql-js production mode should work with Deno",
   "private": true,
   "scripts": {
-    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app denoland/deno:latest deno run --allow-env --preload env-shim.js test.js"
+    "test": "docker run --rm --volume \"$PWD:/usr/src/app\" -w /usr/src/app denoland/deno:alpine-2.4.1 deno run --allow-env --preload env-shim.js test.js"
   },
   "dependencies": {
     "graphql": "file:../graphql.tgz"


### PR DESCRIPTION
Motivation: this protects against any confusion/caching/"does not work on my machine" issues.