### PR TITLE
avoid spawn with shell: true and arguments

### DIFF
--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -33,41 +33,35 @@ interface NPMOptions extends SpawnOptions {
 }
 
 export function npm(options?: NPMOptions) {
-  const globalOptions = options?.quiet === true ? ['--quiet'] : [];
-
-  // `npm` points to an executable shell script; so it doesn't require a shell per se.
-  // On Windows `shell: true` is required or `npm` will be picked rather than `npm.cmd`.
-  // This could alternatively be handled by manually selecting `npm.cmd` on Windows.
+  let npmCmd;
+  let globalOptions = options?.quiet === true ? ['--quiet'] : [];
   // See: https://github.com/nodejs/node/issues/3675 and in particular
   // https://github.com/nodejs/node/issues/3675#issuecomment-308963807.
-  const npmOptions = { shell: true, ...options };
+  if (process.platform === 'win32') {
+    npmCmd = 'cmd';
+    globalOptions = ['/c', 'npm.cmd', ...globalOptions];
+  } else {
+    npmCmd = 'npm';
+  }
 
   return {
     run(...args: ReadonlyArray<string>): void {
-      spawn('npm', [...globalOptions, 'run', ...args], npmOptions);
+      spawn(npmCmd, [...globalOptions, 'run', ...args], options);
     },
     install(...args: ReadonlyArray<string>): void {
-      spawn('npm', [...globalOptions, 'install', ...args], npmOptions);
+      spawn(npmCmd, [...globalOptions, 'install', ...args], options);
     },
     ci(...args: ReadonlyArray<string>): void {
-      spawn('npm', [...globalOptions, 'ci', ...args], npmOptions);
+      spawn(npmCmd, [...globalOptions, 'ci', ...args], options);
     },
     exec(...args: ReadonlyArray<string>): void {
-      spawn('npm', [...globalOptions, 'exec', ...args], npmOptions);
+      spawn(npmCmd, [...globalOptions, 'exec', ...args], options);
     },
     pack(...args: ReadonlyArray<string>): string {
-      return spawnOutput(
-        'npm',
-        [...globalOptions, 'pack', ...args],
-        npmOptions,
-      );
+      return spawnOutput(npmCmd, [...globalOptions, 'pack', ...args], options);
     },
     diff(...args: ReadonlyArray<string>): string {
-      return spawnOutput(
-        'npm',
-        [...globalOptions, 'diff', ...args],
-        npmOptions,
-      );
+      return spawnOutput(npmCmd, [...globalOptions, 'diff', ...args], options);
     },
   };
 }

--- a/resources/utils.ts
+++ b/resources/utils.ts
@@ -35,8 +35,8 @@ interface NPMOptions extends SpawnOptions {
 export function npm(options?: NPMOptions) {
   let npmCmd;
   let globalOptions = options?.quiet === true ? ['--quiet'] : [];
-  // See: https://github.com/nodejs/node/issues/3675 and in particular
-  // https://github.com/nodejs/node/issues/3675#issuecomment-308963807.
+
+  // See: https://github.com/nodejs/node/issues/3675.
   if (process.platform === 'win32') {
     npmCmd = 'cmd';
     globalOptions = ['/c', 'npm.cmd', ...globalOptions];


### PR DESCRIPTION
spawn with shell: true and arguments leads to the below deprecation warning

[DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.

This does not appear to presently cause us any security concerns as this is used only with safe input from our own integration scripts, but we can avoid the use of the shell entirely and protect from removal of this functionality in a later version, while still preserving win32 compatibility.