### PR TITLE
Schema coordinates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -230,7 +230,6 @@ export {
   printSourceLocation,
   // Lex
   Lexer,
-  SchemaCoordinateLexer,
   TokenKind,
   // Parse
   parse,
@@ -262,7 +261,6 @@ export {
 
 export type {
   ParseOptions,
-  ParseSchemaCoordinateOptions,
   SourceLocation,
   // Visitor utilities
   ASTVisitor,

--- a/src/language/__tests__/lexer-test.ts
+++ b/src/language/__tests__/lexer-test.ts
@@ -166,8 +166,8 @@ describe('Lexer', () => {
   });
 
   it('reports unexpected characters', () => {
-    expectSyntaxError('^').to.deep.equal({
-      message: 'Syntax Error: Unexpected character: "^".',
+    expectSyntaxError('.').to.deep.equal({
+      message: 'Syntax Error: Unexpected character: ".".',
       locations: [{ line: 1, column: 1 }],
     });
   });
@@ -960,13 +960,6 @@ describe('Lexer', () => {
 
     expect(lexOne(')')).to.contain({
       kind: TokenKind.PAREN_R,
-      start: 0,
-      end: 1,
-      value: undefined,
-    });
-
-    expect(lexOne('.')).to.contain({
-      kind: TokenKind.DOT,
       start: 0,
       end: 1,
       value: undefined,

--- a/src/language/__tests__/lexer-test.ts
+++ b/src/language/__tests__/lexer-test.ts
@@ -9,11 +9,7 @@ import { inspect } from '../../jsutils/inspect.js';
 import { GraphQLError } from '../../error/GraphQLError.js';
 
 import type { Token } from '../ast.js';
-import {
-  isPunctuatorTokenKind,
-  Lexer,
-  SchemaCoordinateLexer,
-} from '../lexer.js';
+import { isPunctuatorTokenKind, Lexer } from '../lexer.js';
 import { Source } from '../source.js';
 import { TokenKind } from '../tokenKind.js';
 
@@ -1189,33 +1185,6 @@ describe('Lexer', () => {
     expectSyntaxError('# Invalid surrogate \uDEAD').to.deep.equal({
       message: 'Syntax Error: Invalid character: U+DEAD.',
       locations: [{ line: 1, column: 21 }],
-    });
-  });
-});
-
-describe('SchemaCoordinateLexer', () => {
-  it('can be stringified', () => {
-    const lexer = new SchemaCoordinateLexer(new Source('Name.field'));
-    expect(Object.prototype.toString.call(lexer)).to.equal(
-      '[object SchemaCoordinateLexer]',
-    );
-  });
-
-  it('tracks a schema coordinate', () => {
-    const lexer = new SchemaCoordinateLexer(new Source('Name.field'));
-    expect(lexer.advance()).to.contain({
-      kind: TokenKind.NAME,
-      start: 0,
-      end: 4,
-      value: 'Name',
-    });
-  });
-
-  it('forbids ignored tokens', () => {
-    const lexer = new SchemaCoordinateLexer(new Source('\nName.field'));
-    expectToThrowJSON(() => lexer.advance()).to.deep.equal({
-      message: 'Syntax Error: Invalid character: U+000A.',
-      locations: [{ line: 1, column: 1 }],
     });
   });
 });

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -722,7 +722,7 @@ describe('Parser', () => {
       expect(() => parseSchemaCoordinate('MyType.field.deep'))
         .to.throw()
         .to.deep.include({
-          message: 'Syntax Error: Expected <EOF>, found ".".',
+          message: 'Syntax Error: Expected <EOF>, found ..',
           locations: [{ line: 1, column: 13 }],
         });
     });
@@ -754,8 +754,8 @@ describe('Parser', () => {
       expect(() => parseSchemaCoordinate('MyType.field(arg: value)'))
         .to.throw()
         .to.deep.include({
-          message: 'Syntax Error: Expected ")", found Name "value".',
-          locations: [{ line: 1, column: 19 }],
+          message: 'Syntax Error: Invalid character: " ".',
+          locations: [{ line: 1, column: 18 }],
         });
     });
 
@@ -794,9 +794,15 @@ describe('Parser', () => {
       expect(() => parseSchemaCoordinate('@myDirective.field'))
         .to.throw()
         .to.deep.include({
-          message: 'Syntax Error: Expected <EOF>, found ".".',
+          message: 'Syntax Error: Expected <EOF>, found ..',
           locations: [{ line: 1, column: 13 }],
         });
+    });
+
+    it('accepts a Source object', () => {
+      expect(parseSchemaCoordinate('MyType')).to.deep.equal(
+        parseSchemaCoordinate(new Source('MyType')),
+      );
     });
   });
 });

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -751,11 +751,11 @@ describe('Parser', () => {
     });
 
     it('rejects Name . Name ( Name : Name )', () => {
-      expect(() => parseSchemaCoordinate('MyType.field(arg:value)'))
+      expect(() => parseSchemaCoordinate('MyType.field(arg: value)'))
         .to.throw()
         .to.deep.include({
           message: 'Syntax Error: Expected ")", found Name "value".',
-          locations: [{ line: 1, column: 18 }],
+          locations: [{ line: 1, column: 19 }],
         });
     });
 

--- a/src/language/__tests__/printer-test.ts
+++ b/src/language/__tests__/printer-test.ts
@@ -301,16 +301,24 @@ describe('Printer: Query document', () => {
   });
 
   it('prints schema coordinates', () => {
-    expect(print(parseSchemaCoordinate('  Name  '))).to.equal('Name');
-    expect(print(parseSchemaCoordinate('  Name . field '))).to.equal(
-      'Name.field',
-    );
-    expect(print(parseSchemaCoordinate('  Name . field ( arg: )'))).to.equal(
+    expect(print(parseSchemaCoordinate('Name'))).to.equal('Name');
+    expect(print(parseSchemaCoordinate('Name.field'))).to.equal('Name.field');
+    expect(print(parseSchemaCoordinate('Name.field(arg:)'))).to.equal(
       'Name.field(arg:)',
     );
-    expect(print(parseSchemaCoordinate(' @ name  '))).to.equal('@name');
-    expect(print(parseSchemaCoordinate(' @ name (arg:) '))).to.equal(
-      '@name(arg:)',
+    expect(print(parseSchemaCoordinate('@name'))).to.equal('@name');
+    expect(print(parseSchemaCoordinate('@name(arg:)'))).to.equal('@name(arg:)');
+  });
+
+  it('throws syntax error for ignored tokens in schema coordinates', () => {
+    expect(() => print(parseSchemaCoordinate('# foo\nName'))).to.throw(
+      'Syntax Error: Invalid character: "#"',
+    );
+    expect(() => print(parseSchemaCoordinate('\nName'))).to.throw(
+      'Syntax Error: Invalid character: U+000A.',
+    );
+    expect(() => print(parseSchemaCoordinate('Name .field'))).to.throw(
+      'Syntax Error: Invalid character: " "',
     );
   });
 });

--- a/src/language/__tests__/printer-test.ts
+++ b/src/language/__tests__/printer-test.ts
@@ -301,24 +301,16 @@ describe('Printer: Query document', () => {
   });
 
   it('prints schema coordinates', () => {
-    expect(print(parseSchemaCoordinate('Name'))).to.equal('Name');
-    expect(print(parseSchemaCoordinate('Name.field'))).to.equal('Name.field');
-    expect(print(parseSchemaCoordinate('Name.field(arg:)'))).to.equal(
+    expect(print(parseSchemaCoordinate('  Name  '))).to.equal('Name');
+    expect(print(parseSchemaCoordinate('  Name . field '))).to.equal(
+      'Name.field',
+    );
+    expect(print(parseSchemaCoordinate('  Name . field ( arg: )'))).to.equal(
       'Name.field(arg:)',
     );
-    expect(print(parseSchemaCoordinate('@name'))).to.equal('@name');
-    expect(print(parseSchemaCoordinate('@name(arg:)'))).to.equal('@name(arg:)');
-  });
-
-  it('throws syntax error for ignored tokens in schema coordinates', () => {
-    expect(() => print(parseSchemaCoordinate('# foo\nName'))).to.throw(
-      'Syntax Error: Invalid character: "#"',
-    );
-    expect(() => print(parseSchemaCoordinate('\nName'))).to.throw(
-      'Syntax Error: Invalid character: U+000A.',
-    );
-    expect(() => print(parseSchemaCoordinate('Name .field'))).to.throw(
-      'Syntax Error: Invalid character: " "',
+    expect(print(parseSchemaCoordinate(' @ name  '))).to.equal('@name');
+    expect(print(parseSchemaCoordinate(' @ name (arg:) '))).to.equal(
+      '@name(arg:)',
     );
   });
 });

--- a/src/language/__tests__/schemaCoordinateLexer-test.ts
+++ b/src/language/__tests__/schemaCoordinateLexer-test.ts
@@ -7,11 +7,6 @@ import { SchemaCoordinateLexer } from '../schemaCoordinateLexer.js';
 import { Source } from '../source.js';
 import { TokenKind } from '../tokenKind.js';
 
-function lexOne(str: string) {
-  const lexer = new SchemaCoordinateLexer(new Source(str));
-  return lexer.advance();
-}
-
 function lexSecond(str: string) {
   const lexer = new SchemaCoordinateLexer(new Source(str));
   lexer.advance();
@@ -45,15 +40,6 @@ describe('SchemaCoordinateLexer', () => {
     expectToThrowJSON(() => lexer.advance()).to.deep.equal({
       message: 'Syntax Error: Invalid character: U+000A.',
       locations: [{ line: 1, column: 1 }],
-    });
-  });
-
-  it('ignores BOM header', () => {
-    expect(lexOne('\uFEFFfoo')).to.contain({
-      kind: TokenKind.NAME,
-      start: 1,
-      end: 4,
-      value: 'foo',
     });
   });
 

--- a/src/language/__tests__/schemaCoordinateLexer-test.ts
+++ b/src/language/__tests__/schemaCoordinateLexer-test.ts
@@ -30,6 +30,24 @@ describe('SchemaCoordinateLexer', () => {
     );
   });
 
+  it('tracks a schema coordinate', () => {
+    const lexer = new SchemaCoordinateLexer(new Source('Name.field'));
+    expect(lexer.advance()).to.contain({
+      kind: TokenKind.NAME,
+      start: 0,
+      end: 4,
+      value: 'Name',
+    });
+  });
+
+  it('forbids ignored tokens', () => {
+    const lexer = new SchemaCoordinateLexer(new Source('\nName.field'));
+    expectToThrowJSON(() => lexer.advance()).to.deep.equal({
+      message: 'Syntax Error: Invalid character: U+000A.',
+      locations: [{ line: 1, column: 1 }],
+    });
+  });
+
   it('ignores BOM header', () => {
     expect(lexOne('\uFEFFfoo')).to.contain({
       kind: TokenKind.NAME,

--- a/src/language/__tests__/schemaCoordinateLexer-test.ts
+++ b/src/language/__tests__/schemaCoordinateLexer-test.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectToThrowJSON } from '../../__testUtils__/expectJSON.js';
+
+import { SchemaCoordinateLexer } from '../schemaCoordinateLexer.js';
+import { Source } from '../source.js';
+import { TokenKind } from '../tokenKind.js';
+
+function lexOne(str: string) {
+  const lexer = new SchemaCoordinateLexer(new Source(str));
+  return lexer.advance();
+}
+
+function lexSecond(str: string) {
+  const lexer = new SchemaCoordinateLexer(new Source(str));
+  lexer.advance();
+  return lexer.advance();
+}
+
+function expectSyntaxError(text: string) {
+  return expectToThrowJSON(() => lexSecond(text));
+}
+
+describe('SchemaCoordinateLexer', () => {
+  it('can be stringified', () => {
+    const lexer = new SchemaCoordinateLexer(new Source('Name.field'));
+    expect(Object.prototype.toString.call(lexer)).to.equal(
+      '[object SchemaCoordinateLexer]',
+    );
+  });
+
+  it('ignores BOM header', () => {
+    expect(lexOne('\uFEFFfoo')).to.contain({
+      kind: TokenKind.NAME,
+      start: 1,
+      end: 4,
+      value: 'foo',
+    });
+  });
+
+  it('lex reports a useful syntax errors', () => {
+    expectSyntaxError('Foo .bar').to.deep.equal({
+      message: 'Syntax Error: Invalid character: " ".',
+      locations: [{ line: 1, column: 4 }],
+    });
+  });
+});

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -11,7 +11,7 @@ export { Kind } from './kinds.js';
 
 export { TokenKind } from './tokenKind.js';
 
-export { Lexer, SchemaCoordinateLexer } from './lexer.js';
+export { Lexer } from './lexer.js';
 
 export {
   parse,
@@ -20,7 +20,7 @@ export {
   parseType,
   parseSchemaCoordinate,
 } from './parser.js';
-export type { ParseOptions, ParseSchemaCoordinateOptions } from './parser.js';
+export type { ParseOptions } from './parser.js';
 
 export { print } from './printer.js';
 

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -83,27 +83,6 @@ export class Lexer {
     }
     return token;
   }
-
-  validateIgnoredToken(_position: number): void {
-    /* noop - ignored tokens are ignored */
-  }
-}
-
-/**
- * As `Lexer`, but forbids ignored tokens as required of schema coordinates.
- */
-export class SchemaCoordinateLexer extends Lexer {
-  override get [Symbol.toStringTag]() {
-    return 'SchemaCoordinateLexer';
-  }
-
-  override validateIgnoredToken(position: number): void {
-    throw syntaxError(
-      this.source,
-      position,
-      `Invalid character: ${printCodePointAt(this, position)}.`,
-    );
-  }
 }
 
 /**
@@ -238,7 +217,6 @@ function readNextToken(lexer: Lexer, start: number): Token {
       case 0x0009: // \t
       case 0x0020: // <space>
       case 0x002c: // ,
-        lexer.validateIgnoredToken(position);
         ++position;
         continue;
       // LineTerminator ::
@@ -246,13 +224,11 @@ function readNextToken(lexer: Lexer, start: number): Token {
       //   - "Carriage Return (U+000D)" [lookahead != "New Line (U+000A)"]
       //   - "Carriage Return (U+000D)" "New Line (U+000A)"
       case 0x000a: // \n
-        lexer.validateIgnoredToken(position);
         ++position;
         ++lexer.line;
         lexer.lineStart = position;
         continue;
       case 0x000d: // \r
-        lexer.validateIgnoredToken(position);
         if (body.charCodeAt(position + 1) === 0x000a) {
           position += 2;
         } else {
@@ -263,7 +239,6 @@ function readNextToken(lexer: Lexer, start: number): Token {
         continue;
       // Comment
       case 0x0023: // #
-        lexer.validateIgnoredToken(position);
         return readComment(lexer, position);
       // Token ::
       //   - Punctuator

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -119,7 +119,7 @@ export interface ParseOptions {
 
   /**
    * You may override the Lexer class used to lex the source; this is used by
-   * schema coordinates to introduce a lexer with a resticted syntax.
+   * schema coordinates to introduce a lexer with a restricted syntax.
    */
   lexer?: LexerInterface | undefined;
 }

--- a/src/language/schemaCoordinateLexer.ts
+++ b/src/language/schemaCoordinateLexer.ts
@@ -90,16 +90,12 @@ export class SchemaCoordinateLexer implements LexerInterface {
 function readNextToken(lexer: SchemaCoordinateLexer, start: number): Token {
   const body = lexer.source.body;
   const bodyLength = body.length;
-  let position = start;
+  const position = start;
 
-  while (position < bodyLength) {
+  if (position < bodyLength) {
     const code = body.charCodeAt(position);
 
-    // SourceCharacter
     switch (code) {
-      case 0xfeff: // <BOM>
-        ++position;
-        continue;
       case 0x002e: // .
         return createToken(lexer, TokenKind.DOT, position, position + 1);
       case 0x0028: // (

--- a/src/language/schemaCoordinateLexer.ts
+++ b/src/language/schemaCoordinateLexer.ts
@@ -1,0 +1,128 @@
+import { syntaxError } from '../error/syntaxError.js';
+
+import { Token } from './ast.js';
+import { isNameStart } from './characterClasses.js';
+import type { LexerInterface } from './lexer.js';
+import { createToken, printCodePointAt, readName } from './lexer.js';
+import type { Source } from './source.js';
+import { TokenKind } from './tokenKind.js';
+
+/**
+ * Given a Source schema coordinate, creates a Lexer for that source.
+ * A SchemaCoordinateLexer is a stateful stream generator in that every time
+ * it is advanced, it returns the next token in the Source. Assuming the
+ * source lexes, the final Token emitted by the lexer will be of kind
+ * EOF, after which the lexer will repeatedly return the same EOF token
+ * whenever called.
+ */
+export class SchemaCoordinateLexer implements LexerInterface {
+  source: Source;
+
+  /**
+   * The previously focused non-ignored token.
+   */
+  lastToken: Token;
+
+  /**
+   * The currently focused non-ignored token.
+   */
+  token: Token;
+
+  /**
+   * The (1-indexed) line containing the current token.
+   * Since a schema coordinate may not contain newline, this value is always 1.
+   */
+  line: 1 = 1 as const;
+
+  /**
+   * The character offset at which the current line begins.
+   * Since a schema coordinate may not contain newline, this value is always 0.
+   */
+  lineStart: 0 = 0 as const;
+
+  constructor(source: Source) {
+    const startOfFileToken = new Token(TokenKind.SOF, 0, 0, 0, 0);
+
+    this.source = source;
+    this.lastToken = startOfFileToken;
+    this.token = startOfFileToken;
+  }
+
+  get [Symbol.toStringTag]() {
+    return 'SchemaCoordinateLexer';
+  }
+
+  /**
+   * Advances the token stream to the next non-ignored token.
+   */
+  advance(): Token {
+    this.lastToken = this.token;
+    const token = (this.token = this.lookahead());
+    return token;
+  }
+
+  /**
+   * Looks ahead and returns the next non-ignored token, but does not change
+   * the current Lexer token.
+   */
+  lookahead(): Token {
+    let token = this.token;
+    if (token.kind !== TokenKind.EOF) {
+      // Read the next token and form a link in the token linked-list.
+      const nextToken = readNextToken(this, token.end);
+      // @ts-expect-error next is only mutable during parsing.
+      token.next = nextToken;
+      // @ts-expect-error prev is only mutable during parsing.
+      nextToken.prev = token;
+      token = nextToken;
+    }
+    return token;
+  }
+}
+
+/**
+ * Gets the next token from the source starting at the given position.
+ *
+ * This skips over whitespace until it finds the next lexable token, then lexes
+ * punctuators immediately or calls the appropriate helper function for more
+ * complicated tokens.
+ */
+function readNextToken(lexer: SchemaCoordinateLexer, start: number): Token {
+  const body = lexer.source.body;
+  const bodyLength = body.length;
+  let position = start;
+
+  while (position < bodyLength) {
+    const code = body.charCodeAt(position);
+
+    // SourceCharacter
+    switch (code) {
+      case 0xfeff: // <BOM>
+        ++position;
+        continue;
+      case 0x002e: // .
+        return createToken(lexer, TokenKind.DOT, position, position + 1);
+      case 0x0028: // (
+        return createToken(lexer, TokenKind.PAREN_L, position, position + 1);
+      case 0x0029: // )
+        return createToken(lexer, TokenKind.PAREN_R, position, position + 1);
+      case 0x003a: // :
+        return createToken(lexer, TokenKind.COLON, position, position + 1);
+      case 0x0040: // @
+        return createToken(lexer, TokenKind.AT, position, position + 1);
+    }
+
+    // Name
+    if (isNameStart(code)) {
+      return readName(lexer, position);
+    }
+
+    throw syntaxError(
+      lexer.source,
+      position,
+      `Invalid character: ${printCodePointAt(lexer, position)}.`,
+    );
+  }
+
+  return createToken(lexer, TokenKind.EOF, bodyLength, bodyLength);
+}

--- a/src/language/schemaCoordinateLexer.ts
+++ b/src/language/schemaCoordinateLexer.ts
@@ -82,10 +82,6 @@ export class SchemaCoordinateLexer implements LexerInterface {
 
 /**
  * Gets the next token from the source starting at the given position.
- *
- * This skips over whitespace until it finds the next lexable token, then lexes
- * punctuators immediately or calls the appropriate helper function for more
- * complicated tokens.
  */
 function readNextToken(lexer: SchemaCoordinateLexer, start: number): Token {
   const body = lexer.source.body;


### PR DESCRIPTION
@benjie @leebyron This PR implements the changes on top of the existing `schema-coordinates` branch as discussed in July's WG meeting:

https://github.com/graphql/graphql-wg/blob/main/notes/2025/2025-07.md#schema-coordinates

Specifically:
- introduces a new `SchemaCoordinateLexer` class inside `src/language/schemaCoordinateLexer`
- imports and reuses the existing `{createToken, printCodePointAt, readName}` helpers
- creates a new `LexerInterface` interface to allow the helpers to accept either instance of a Lexer without copy/pasting.


What I dislike about this PR:
- continues to "infect" the rest of parser.ts with the knowledge/existence of schema coordinates (`LexerInterface`)
- does not meet the "this is it's own thing and tree-shakable" dream as discussed in the meeting

What I like about this PR:
- seems like the minimal diff required to do this "properly" (including locations, useful error messages)

tl;dr if we tried to completely devolve `Parser` of responsibility of schema coordinates, and started on a minimal implementation of `parseSchemaCoordinate()` that advances a lexer instance token by token, we'd end up at something very similar to Parser.... I did try a few versions of this and copy and pasting things but this ended up being neater overall.

FWIW I did start to a attempt a minimal `parseSchemaCoordinate()` function here: https://github.com/magicmark/graphql-js/blob/586b7174dc730fef47368ce4fbc385fb1f733360/src/language/schemaCoordinate.ts#L44

but it turns out that doing it imperatively and correctly without a nice lexer/parser is kinda hard! the more logic I add to this, the closer I get to essentially recreating a lexer/parser... which we already have :)

wdyt? should we keep trying for more of a middle ground here?