### PR TITLE
increase memory allowance for benchmarks

### DIFF
--- a/resources/benchmark.ts
+++ b/resources/benchmark.ts
@@ -132,11 +132,11 @@ function collectSamples(modulePath: string) {
 // See http://www.itl.nist.gov/div898/handbook/eda/section3/eda3672.htm.
 // prettier-ignore
 const tTable: { [v: number]: number } = {
-  1:  12.706, 2:  4.303, 3:  3.182, 4:  2.776, 5:  2.571, 6:  2.447,
-  7:  2.365,  8:  2.306, 9:  2.262, 10: 2.228, 11: 2.201, 12: 2.179,
-  13: 2.16,   14: 2.145, 15: 2.131, 16: 2.12,  17: 2.11,  18: 2.101,
-  19: 2.093,  20: 2.086, 21: 2.08,  22: 2.074, 23: 2.069, 24: 2.064,
-  25: 2.06,   26: 2.056, 27: 2.052, 28: 2.048, 29: 2.045, 30: 2.042,
+  1: 12.706, 2: 4.303, 3: 3.182, 4: 2.776, 5: 2.571, 6: 2.447,
+  7: 2.365, 8: 2.306, 9: 2.262, 10: 2.228, 11: 2.201, 12: 2.179,
+  13: 2.16, 14: 2.145, 15: 2.131, 16: 2.12, 17: 2.11, 18: 2.101,
+  19: 2.093, 20: 2.086, 21: 2.08, 22: 2.074, 23: 2.069, 24: 2.064,
+  25: 2.06, 26: 2.056, 27: 2.052, 28: 2.048, 29: 2.045, 30: 2.042,
 };
 const tTableInfinity = 1.96;
 
@@ -405,8 +405,8 @@ function sampleModule(modulePath: string): BenchmarkSample {
       '--predictable',
       '--no-concurrent-sweeping',
       '--no-minor-gc-task',
-      '--min-semi-space-size=1024', // 1GB
-      '--max-semi-space-size=1024', // 1GB
+      '--min-semi-space-size=1280', // 1.25GB
+      '--max-semi-space-size=1280', // 1.25GB
       '--trace-gc', // no gc calls should happen during benchmark, so trace them
 
       // Node.js flags


### PR DESCRIPTION
esm appears to require slightly more memory than common-js