### PR TITLE
avoid bind in favor of arrow functions

### DIFF
--- a/src/execution/AbortSignalListener.ts
+++ b/src/execution/AbortSignalListener.ts
@@ -70,7 +70,7 @@ export function cancellableIterable<T>(
 ): AsyncIterable<T> {
   const iterator = iterable[Symbol.asyncIterator]();
 
-  const _next = iterator.next.bind(iterator);
+  const _next = () => iterator.next();
 
   if (iterator.return) {
     const _return = iterator.return.bind(iterator);

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -918,12 +918,8 @@ export class GraphQLObjectType<TSource = any, TContext = any>
     this.extensions = toObjMapWithSymbols(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
-    this._fields = (defineFieldMap<TSource, TContext>).bind(
-      undefined,
-      this,
-      config.fields,
-    );
-    this._interfaces = defineInterfaces.bind(undefined, config.interfaces);
+    this._fields = () => defineFieldMap<TSource, TContext>(this, config.fields);
+    this._interfaces = () => defineInterfaces(config.interfaces);
   }
 
   get [Symbol.toStringTag]() {
@@ -1325,12 +1321,8 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
     this.extensions = toObjMapWithSymbols(config.extensions);
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
-    this._fields = (defineFieldMap<TSource, TContext>).bind(
-      undefined,
-      this,
-      config.fields,
-    );
-    this._interfaces = defineInterfaces.bind(undefined, config.interfaces);
+    this._fields = () => defineFieldMap<TSource, TContext>(this, config.fields);
+    this._interfaces = () => defineInterfaces(config.interfaces);
   }
 
   get [Symbol.toStringTag]() {
@@ -1454,7 +1446,7 @@ export class GraphQLUnionType implements GraphQLSchemaElement {
     this.astNode = config.astNode;
     this.extensionASTNodes = config.extensionASTNodes ?? [];
 
-    this._types = defineTypes.bind(undefined, config.types);
+    this._types = () => defineTypes(config.types);
   }
 
   get [Symbol.toStringTag]() {
@@ -1881,7 +1873,7 @@ export class GraphQLInputObjectType implements GraphQLSchemaElement {
     this.extensionASTNodes = config.extensionASTNodes ?? [];
     this.isOneOf = config.isOneOf ?? false;
 
-    this._fields = defineInputFieldMap.bind(undefined, this, config.fields);
+    this._fields = () => defineInputFieldMap(this, config.fields);
   }
 
   get [Symbol.toStringTag]() {


### PR DESCRIPTION
this unfortunately seems in some scenarios to carry a performance cost.

<img width="751" height="141" alt="image" src="https://github.com/user-attachments/assets/73de0dd4-041c-4cd5-a842-a7f4066a6a59" />

https://github.com/graphql/graphql-js/pull/4424#discussion_r2156707413