### PR TITLE
updated location of ModelSim gitignore file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Check if commit contains files that should be ignored
         run: |
-          git clone --depth 1 https://github.com/github/gitignore.git
+          git clone --depth 1 https://github.com/github/gitignore.git --revision b19bb58983cdae1e3a3fd6eafba0b9f2ec3c53ca
 
           rm gitignore/ModelSim.gitignore
           rm gitignore/Global/Images.gitignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/github/gitignore.git
 
-          rm gitignore/Global/ModelSim.gitignore
+          rm gitignore/ModelSim.gitignore
           rm gitignore/Global/Images.gitignore
           cat gitignore/Node.gitignore gitignore/Global/*.gitignore > all.gitignore
 


### PR DESCRIPTION
per https://github.com/github/gitignore/commit/ca05a4dafd96ec7fe03b0aa5d284a4bebf0f59e9 this file has been moved

this is causing this error: https://github.com/graphql/graphql-js/actions/runs/17255990646/job/48967789469?pr=4478:

```
Run git clone --depth 1 https://github.com/github/gitignore.git
  git clone --depth 1 https://github.com/github/gitignore.git
  
  rm gitignore/Global/ModelSim.gitignore
  rm gitignore/Global/Images.gitignore
  cat gitignore/Node.gitignore gitignore/Global/*.gitignore > all.gitignore
  
  IGNORED_FILES=$(git ls-files --cached --ignored --exclude-from=all.gitignore)
  if  [[ "$IGNORED_FILES" != "" ]]; then
    echo -e "::error::Please remove these files:\n$IGNORED_FILES" | sed -z 's/\n/%0A/g'
    exit 1
  fi
  shell: /usr/bin/bash -e {0}
Cloning into 'gitignore'...
rm: cannot remove 'gitignore/Global/ModelSim.gitignore': No such file or directory
Error: Process completed with exit code 1.
```