### PR TITLE
Fix incorrect `FormattedCompletedResult` fields and add a `FormattedPendingResult`

### DIFF
--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -62,7 +62,7 @@ export interface FormattedInitialIncrementalExecutionResult<
   TExtensions = ObjMap<unknown>,
 > extends FormattedExecutionResult<TData, TExtensions> {
   data: TData;
-  pending: ReadonlyArray<PendingResult>;
+  pending: ReadonlyArray<FormattedPendingResult>;
   hasNext: boolean;
   extensions?: TExtensions;
 }
@@ -83,7 +83,7 @@ export interface FormattedSubsequentIncrementalExecutionResult<
   TExtensions = ObjMap<unknown>,
 > {
   hasNext: boolean;
-  pending?: ReadonlyArray<PendingResult>;
+  pending?: ReadonlyArray<FormattedPendingResult>;
   incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
   completed?: ReadonlyArray<FormattedCompletedResult>;
   extensions?: TExtensions;
@@ -156,15 +156,20 @@ export interface PendingResult {
   label?: string;
 }
 
+export interface FormattedPendingResult {
+  id: string;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+}
+
 export interface CompletedResult {
   id: string;
   errors?: ReadonlyArray<GraphQLError>;
 }
 
 export interface FormattedCompletedResult {
-  path: ReadonlyArray<string | number>;
-  label?: string;
-  errors?: ReadonlyArray<GraphQLError>;
+  id: string;
+  errors?: ReadonlyArray<GraphQLFormattedError>;
 }
 
 export function isPendingExecutionGroup(

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -62,7 +62,7 @@ export interface FormattedInitialIncrementalExecutionResult<
   TExtensions = ObjMap<unknown>,
 > extends FormattedExecutionResult<TData, TExtensions> {
   data: TData;
-  pending: ReadonlyArray<FormattedPendingResult>;
+  pending: ReadonlyArray<PendingResult>;
   hasNext: boolean;
   extensions?: TExtensions;
 }
@@ -83,7 +83,7 @@ export interface FormattedSubsequentIncrementalExecutionResult<
   TExtensions = ObjMap<unknown>,
 > {
   hasNext: boolean;
-  pending?: ReadonlyArray<FormattedPendingResult>;
+  pending?: ReadonlyArray<PendingResult>;
   incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
   completed?: ReadonlyArray<FormattedCompletedResult>;
   extensions?: TExtensions;
@@ -151,12 +151,6 @@ export type FormattedIncrementalResult<
   | FormattedIncrementalStreamResult<TData, TExtensions>;
 
 export interface PendingResult {
-  id: string;
-  path: ReadonlyArray<string | number>;
-  label?: string;
-}
-
-export interface FormattedPendingResult {
   id: string;
   path: ReadonlyArray<string | number>;
   label?: string;


### PR DESCRIPTION
Fixes #4333 

This change fixes the fields in `FormattedCompletedResult` to match `CompletedResult` (i.e. `id` and `errors`) using the `Formatted*` type variants. This change also adds a `FormattedPendingResult` as an counterpart to `PendingResult` to match the type patterns already established with other `Formatted*` types. 

I ran into this issue when working on adding support for the new incremental format in Apollo Client (https://github.com/apollographql/apollo-client/pull/12906).