### PR TITLE
Adjust `items` type for `IncrementalStreamResult` and `FormattedIncrementalStreamResult`

### DIFF
--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -114,13 +114,13 @@ export interface FormattedIncrementalDeferResult<
   extensions?: TExtensions;
 }
 
-interface StreamItemsRecordResult<TData = ReadonlyArray<unknown>> {
+interface StreamItemsRecordResult<TData = unknown> {
   errors?: ReadonlyArray<GraphQLError>;
-  items: TData;
+  items: ReadonlyArray<TData>;
 }
 
 export interface IncrementalStreamResult<
-  TData = ReadonlyArray<unknown>,
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
 > extends StreamItemsRecordResult<TData> {
   id: string;
@@ -129,11 +129,11 @@ export interface IncrementalStreamResult<
 }
 
 export interface FormattedIncrementalStreamResult<
-  TData = Array<unknown>,
+  TData = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  items: TData;
+  items: Array<TData>;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -133,7 +133,7 @@ export interface FormattedIncrementalStreamResult<
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  items: Array<TData>;
+  items: ReadonlyArray<TData>;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;


### PR DESCRIPTION
Take the following:

```ts
declare const chunk: FormattedIncrementalResult<Record<string, unknown>>;

if ("items" in chunk) {
  const { items } = chunk;

  // TypeScript error
  items.slice(0);
}
```

When providing a generic to `*IncrementalResult`, the `items` property on `*IncrementalStreamResult` is typed incorrect due to the `Array<*>` being part of the default type instead of the `items` property. This means calling array methods on `items` results in a TypeScript error since TypeScript doesn't know its an array. This is incorrect since `items` can only be an array type and nothing else. Here is the reproduction in [TS Playground](https://www.typescriptlang.org/play/?ssl=10&ssc=1&pln=11&pc=1#code/JYWwDg9gTgLgBAbzgMWiAhjGBTAJgSQDsBjKbEbQmdAGwCVsBnAVxvgF84AzKCEOAEQBzKOjAALAI40BAbjgB6BXBgBPMEwBccAIwB2AHQAGYwFpaE9AYCcAWABQD3NmI10ZOMQiFG8YuOZCAGttVCgMLDwiUnJKanomVhgAHgYvKFxk3yhgQiEAGjhAoMIIAHdCAD5K2QcHYC44AAoBYBwQRgE4XM8A4IBKRAc4T29fRG72xjhOAF5e4tr7EaURtbgAPQB+B05sGkZsIeXRn3gkXEx0Gbh5-0XhxWV1zZ37diA).

This PR fixes this issue by moving the `Array<*>` wrapper to the `items` type so that this works as expected.
