### PR TITLE
Adopt Error.cause in favor of originalError

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -46,8 +46,13 @@ export interface GraphQLErrorOptions {
   positions?: Maybe<ReadonlyArray<number>>;
   /** Response path where this error occurred during execution. */
   path?: Maybe<ReadonlyArray<string | number>>;
-  /** Original error that caused this GraphQLError, if one exists. */
+  /**
+   * Original error that caused this GraphQLError, if one exists.
+   * @deprecated Prefer `cause` instead.
+   */
   originalError?: Maybe<Error & { readonly extensions?: unknown }>;
+  /** Cause of this GraphQLError, if one exists. */
+  cause?: unknown;
   /** Extension fields to include in the formatted result. */
   extensions?: Maybe<GraphQLErrorExtensions>;
 }
@@ -96,7 +101,10 @@ export class GraphQLError extends Error {
    */
   readonly positions: ReadonlyArray<number> | undefined;
 
-  /** Original error that caused this GraphQLError, if one exists. */
+  /**
+   * The original error thrown from a field resolver during execution.
+   * @deprecated Prefer using {@link Error.cause} instead
+   */
   readonly originalError: Error | undefined;
 
   /** Extension fields to add to the formatted error. */
@@ -105,7 +113,7 @@ export class GraphQLError extends Error {
   /**
    * Creates a GraphQLError instance.
    * @param message - Human-readable error message.
-   * @param options - Error metadata such as source locations, response path, original error, and extensions.
+   * @param options - Error metadata such as source locations, response path, cause, original error, and extensions.
    * @example
    * ```ts
    * // Create an error from AST nodes and response metadata.
@@ -127,33 +135,34 @@ export class GraphQLError extends Error {
    * ```
    * @example
    * ```ts
-   * // This variant derives locations from source positions and preserves the original error.
+   * // This variant derives locations from source positions and preserves the cause.
    * import { Source } from 'graphql/language';
    * import { GraphQLError } from 'graphql/error';
    *
    * const source = new Source('{ greeting }');
-   * const originalError = new Error('Database unavailable.');
+   * const cause = new Error('Database unavailable.');
    * const error = new GraphQLError('Resolver failed.', {
    *   source,
    *   positions: [2],
    *   path: ['greeting'],
-   *   originalError,
+   *   cause,
    * });
    *
    * error.locations; // => [{ line: 1, column: 3 }]
    * error.path; // => ['greeting']
-   * error.originalError; // => originalError
+   * error.cause; // => cause
    * ```
    */
   constructor(message: string, options: GraphQLErrorOptions = {}) {
-    const { nodes, source, positions, path, originalError, extensions } =
+    const { nodes, source, positions, path, originalError, cause, extensions } =
       options;
 
-    super(message);
+    super(message, { cause: cause ?? originalError });
 
     this.name = 'GraphQLError';
     this.path = path ?? undefined;
-    this.originalError = originalError ?? undefined;
+    this.originalError =
+      originalError ?? (cause instanceof Error ? cause : undefined);
 
     // Compute list of blame nodes.
     this.nodes = undefinedIfEmpty(

--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -103,7 +103,7 @@ export class GraphQLError extends Error {
 
   /**
    * The original error thrown from a field resolver during execution.
-   * @deprecated Prefer using {@link Error.cause} instead
+   * @deprecated Use `cause` instead.
    */
   readonly originalError: Error | undefined;
 
@@ -157,12 +157,19 @@ export class GraphQLError extends Error {
     const { nodes, source, positions, path, originalError, cause, extensions } =
       options;
 
-    super(message, { cause: cause ?? originalError });
+    const hasCause = 'cause' in options;
+    const errorCause = hasCause ? cause : originalError;
+    const errorOptions =
+      hasCause || originalError != null ? { cause: errorCause } : undefined;
+    super(message, errorOptions);
 
     this.name = 'GraphQLError';
     this.path = path ?? undefined;
-    this.originalError =
-      originalError ?? (cause instanceof Error ? cause : undefined);
+    const underlyingError:
+      | (Error & { readonly extensions?: unknown })
+      | undefined =
+      originalError ?? (errorCause instanceof Error ? errorCause : undefined);
+    this.originalError = underlyingError;
 
     // Compute list of blame nodes.
     this.nodes = undefinedIfEmpty(
@@ -185,8 +192,8 @@ export class GraphQLError extends Error {
         ? positions.map((pos) => getLocation(source, pos))
         : nodeLocations?.map((loc) => getLocation(loc.source, loc.start));
 
-    const originalExtensions = isObjectLike(originalError?.extensions)
-      ? originalError?.extensions
+    const originalExtensions = isObjectLike(underlyingError?.extensions)
+      ? underlyingError.extensions
       : undefined;
     this.extensions = extensions ?? originalExtensions ?? Object.create(null);
 
@@ -205,9 +212,9 @@ export class GraphQLError extends Error {
     });
 
     // Include (non-enumerable) stack trace.
-    if (originalError?.stack != null) {
+    if (underlyingError?.stack != null) {
       Object.defineProperty(this, 'stack', {
-        value: originalError.stack,
+        value: underlyingError.stack,
         writable: true,
         configurable: true,
       });

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -38,12 +38,19 @@ describe('GraphQLError', () => {
     expect(e.stack).to.be.a('string');
   });
 
+  it('does not add a cause property without a cause', () => {
+    const e = new GraphQLError('msg');
+
+    expect(Object.hasOwn(e, 'cause')).to.equal(false);
+  });
+
   it('enumerate only properties prescribed by the spec', () => {
     const e = new GraphQLError('msg' /* message */, {
       nodes: [fieldNode],
       source,
       positions: [1, 2, 3],
       path: ['a', 'b', 'c'],
+      cause: new Error('test'),
       originalError: new Error('test'),
       extensions: { foo: 'bar' },
     });
@@ -56,7 +63,21 @@ describe('GraphQLError', () => {
     ]);
   });
 
-  it('uses the stack of an original error', () => {
+  it('uses the stack of cause when possible', () => {
+    const original = new Error('original');
+    const e = new GraphQLError('msg', {
+      cause: original,
+    });
+
+    expect(e).to.include({
+      name: 'GraphQLError',
+      message: 'msg',
+      stack: original.stack,
+      cause: original,
+    });
+  });
+
+  it('uses the stack of an original error via originalError', () => {
     const original = new Error('original');
     const e = new GraphQLError('msg', {
       originalError: original,
@@ -68,6 +89,66 @@ describe('GraphQLError', () => {
       stack: original.stack,
       originalError: original,
     });
+  });
+
+  it('uses an Error cause as the original error for compatibility', () => {
+    class ErrorWithExtensions extends Error {
+      extensions: unknown;
+
+      constructor(message: string) {
+        super(message);
+        this.extensions = { original: 'extensions' };
+      }
+    }
+
+    const cause = new ErrorWithExtensions('cause');
+    const e = new GraphQLError('msg', { cause });
+
+    expect(e).to.deep.include({
+      name: 'GraphQLError',
+      message: 'msg',
+      stack: cause.stack,
+      cause,
+      originalError: cause,
+      extensions: { original: 'extensions' },
+    });
+    expect(Object.keys(e)).to.not.include.members(['cause', 'originalError']);
+  });
+
+  it('preserves a non-Error cause without setting originalError', () => {
+    const cause = 'cause';
+    const e = new GraphQLError('msg', { cause });
+
+    expect(e).to.include({
+      cause,
+      originalError: undefined,
+    });
+    expect(e.stack).to.be.a('string');
+  });
+
+  it('prefers cause for Error.cause and originalError for originalError', () => {
+    const originalError = new Error('original');
+    const cause = new Error('cause');
+    const e = new GraphQLError('msg', { originalError, cause });
+
+    expect(e).to.include({
+      cause,
+      originalError,
+      stack: originalError.stack,
+    });
+  });
+
+  it('creates new stack if cause has no stack', () => {
+    const original = new Error('original');
+    delete original.stack;
+    const e = new GraphQLError('msg', { originalError: original });
+
+    expect(e).to.include({
+      name: 'GraphQLError',
+      message: 'msg',
+      cause: original,
+    });
+    expect(e.stack).to.be.a('string');
   });
 
   it('creates new stack if original error has no stack', () => {
@@ -135,6 +216,50 @@ describe('GraphQLError', () => {
       nodes: undefined,
       positions: [6],
       locations: [{ line: 2, column: 5 }],
+    });
+  });
+
+  it('defaults to original cause extension only if extensions argument is not passed', () => {
+    class ErrorWithExtensions extends Error {
+      extensions: unknown;
+
+      constructor(message: string) {
+        super(message);
+        this.extensions = { original: 'extensions' };
+      }
+    }
+
+    const original = new ErrorWithExtensions('original');
+    const inheritedExtensions = new GraphQLError('InheritedExtensions', {
+      cause: original,
+    });
+
+    expect(inheritedExtensions).to.deep.include({
+      message: 'InheritedExtensions',
+      cause: original,
+      extensions: { original: 'extensions' },
+    });
+
+    const ownExtensions = new GraphQLError('OwnExtensions', {
+      cause: original,
+      extensions: { own: 'extensions' },
+    });
+
+    expect(ownExtensions).to.deep.include({
+      message: 'OwnExtensions',
+      cause: original,
+      extensions: { own: 'extensions' },
+    });
+
+    const ownEmptyExtensions = new GraphQLError('OwnEmptyExtensions', {
+      cause: original,
+      extensions: {},
+    });
+
+    expect(ownEmptyExtensions).to.deep.include({
+      message: 'OwnEmptyExtensions',
+      cause: original,
+      extensions: {},
     });
   });
 


### PR DESCRIPTION
The `@depreacted` marks might be heavy-handed. I am completely fine with reversing those.

For environments that don't have `Error.cause` (ES2021) `@deprecated` might be annoying to deal with, since they don't have the alternative.

Closes #4484