### PR TITLE
Fix int/float coercion according to the execution algo

### DIFF
--- a/src/type/__tests__/scalars-test.ts
+++ b/src/type/__tests__/scalars-test.ts
@@ -161,17 +161,14 @@ describe('Type System: Specified scalar types', () => {
       expect(() => serialize(-1e100)).to.throw(
         'Int cannot represent non 32-bit signed integer value: -1e+100',
       );
-      expect(() => serialize('one')).to.throw(
-        'Int cannot represent non-integer value: "one"',
-      );
 
       // Doesn't represent number
       expect(() => serialize('')).to.throw(
         'Int cannot represent non-integer value: ""',
       );
-      expect(() => serialize(NaN)).to.throw(
-        'Int cannot represent non-integer value: NaN',
-      );
+
+      expect(serialize(NaN)).to.equal(null);
+
       expect(() => serialize(Infinity)).to.throw(
         'Int cannot represent non-integer value: Infinity',
       );
@@ -293,17 +290,10 @@ describe('Type System: Specified scalar types', () => {
       };
       expect(serialize(customValueOfObj)).to.equal(5.5);
 
-      expect(() => serialize(NaN)).to.throw(
-        'Float cannot represent non numeric value: NaN',
-      );
+      expect(serialize(NaN)).to.equal(null);
+
       expect(() => serialize(Infinity)).to.throw(
         'Float cannot represent non numeric value: Infinity',
-      );
-      expect(() => serialize('one')).to.throw(
-        'Float cannot represent non numeric value: "one"',
-      );
-      expect(() => serialize('')).to.throw(
-        'Float cannot represent non numeric value: ""',
       );
       expect(() => serialize([5])).to.throw(
         'Float cannot represent non numeric value: [5]',

--- a/src/type/scalars.ts
+++ b/src/type/scalars.ts
@@ -21,7 +21,7 @@ export const GRAPHQL_MAX_INT = 2147483647;
  * */
 export const GRAPHQL_MIN_INT = -2147483648;
 
-export const GraphQLInt = new GraphQLScalarType<number>({
+export const GraphQLInt = new GraphQLScalarType<number | null>({
   name: 'Int',
   description:
     'The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.',
@@ -36,6 +36,10 @@ export const GraphQLInt = new GraphQLScalarType<number>({
     let num = coercedValue;
     if (typeof coercedValue === 'string' && coercedValue !== '') {
       num = Number(coercedValue);
+    }
+
+    if (typeof num === 'number' && Number.isNaN(num)) {
+      return null;
     }
 
     if (typeof num !== 'number' || !Number.isInteger(num)) {
@@ -84,7 +88,7 @@ export const GraphQLInt = new GraphQLScalarType<number>({
   },
 });
 
-export const GraphQLFloat = new GraphQLScalarType<number>({
+export const GraphQLFloat = new GraphQLScalarType<number | null>({
   name: 'Float',
   description:
     'The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).',
@@ -99,6 +103,10 @@ export const GraphQLFloat = new GraphQLScalarType<number>({
     let num = coercedValue;
     if (typeof coercedValue === 'string' && coercedValue !== '') {
       num = Number(coercedValue);
+    }
+
+    if (typeof num === 'number' && Number.isNaN(num)) {
+      return null;
     }
 
     if (typeof num !== 'number' || !Number.isFinite(num)) {

--- a/src/utilities/__tests__/astFromValue-test.ts
+++ b/src/utilities/__tests__/astFromValue-test.ts
@@ -79,10 +79,6 @@ describe('astFromValue', () => {
     expect(() => astFromValue(1e40, GraphQLInt)).to.throw(
       'Int cannot represent non 32-bit signed integer value: 1e+40',
     );
-
-    expect(() => astFromValue(NaN, GraphQLInt)).to.throw(
-      'Int cannot represent non-integer value: NaN',
-    );
   });
 
   it('converts Float values to Int/Float ASTs', () => {


### PR DESCRIPTION
Resolves #4488 

This is kind of ... hard to assess where to best put this. I've put it in the scalar serialize as it felt the most appropriate, we could also put it in `completeValue` and return `null` regardless of whether this is an int/float scalar. We should however not throw errors so instead we'd return NaN from the scalars then instead of null and catch that in `completeValue`.

I found it a bit awkward to disregard the value completely for other types so I opted to put it in the scalars for that reason, i.e. there could be legitimate use cases for test-results or others where N/A is different from null.

We are sacrificing some form of accuracy here as a non-nullable field will return "cannot return null for x" when NaN is supplied while we do become more accurate by returning null for a nullable field rather than an error.