### PR TITLE
refactor(execution): extract withCleanup from mapAsyncIterable

### DIFF
--- a/src/execution/IncrementalGraph.ts
+++ b/src/execution/IncrementalGraph.ts
@@ -97,11 +97,6 @@ export class IncrementalGraph {
     while ((completed = this._completedQueue.shift()) !== undefined) {
       yield completed;
     }
-    if (this._rootNodes.size === 0) {
-      for (const resolve of this._nextQueue) {
-        resolve(undefined);
-      }
-    }
   }
 
   nextCompletedBatch(): Promise<

--- a/src/execution/IncrementalPublisher.ts
+++ b/src/execution/IncrementalPublisher.ts
@@ -28,6 +28,7 @@ import {
   isCompletedExecutionGroup,
   isFailedExecutionGroup,
 } from './types.js';
+import { withCleanup } from './withCleanup.js';
 
 export function buildIncrementalResponse(
   context: IncrementalPublisherContext,
@@ -63,11 +64,13 @@ interface SubsequentIncrementalExecutionResultContext {
  * @internal
  */
 class IncrementalPublisher {
+  private _isDone: boolean;
   private _context: IncrementalPublisherContext;
   private _nextId: number;
   private _incrementalGraph: IncrementalGraph;
 
   constructor(context: IncrementalPublisherContext) {
+    this._isDone = false;
     this._context = context;
     this._nextId = 0;
     this._incrementalGraph = new IncrementalGraph();
@@ -92,10 +95,14 @@ class IncrementalPublisher {
       ? { errors, data, pending, hasNext: true }
       : { data, pending, hasNext: true };
 
-    return {
-      initialResult,
-      subsequentResults: this._subscribe(),
-    };
+    const subsequentResults = withCleanup(this._subscribe(), async () => {
+      this._isDone = true;
+      this._context.abortSignalListener?.disconnect();
+      this._incrementalGraph.abort();
+      await this._returnAsyncIteratorsIgnoringErrors();
+    });
+
+    return { initialResult, subsequentResults };
   }
 
   private _toPendingResults(
@@ -121,22 +128,12 @@ class IncrementalPublisher {
     return String(this._nextId++);
   }
 
-  private _subscribe(): AsyncGenerator<
+  private async *_subscribe(): AsyncGenerator<
     SubsequentIncrementalExecutionResult,
     void,
     void
   > {
-    let isDone = false;
-
-    const _next = async (): Promise<
-      IteratorResult<SubsequentIncrementalExecutionResult, void>
-    > => {
-      if (isDone) {
-        this._context.abortSignalListener?.disconnect();
-        await this._returnAsyncIteratorsIgnoringErrors();
-        return { value: undefined, done: true };
-      }
-
+    while (!this._isDone) {
       const context: SubsequentIncrementalExecutionResultContext = {
         pending: [],
         incremental: [],
@@ -155,7 +152,7 @@ class IncrementalPublisher {
           const hasNext = this._incrementalGraph.hasNext();
 
           if (!hasNext) {
-            isDone = true;
+            this._isDone = true;
           }
 
           const subsequentIncrementalExecutionResult: SubsequentIncrementalExecutionResult =
@@ -172,50 +169,14 @@ class IncrementalPublisher {
             subsequentIncrementalExecutionResult.completed = completed;
           }
 
-          return { value: subsequentIncrementalExecutionResult, done: false };
+          yield subsequentIncrementalExecutionResult;
+          break;
         }
 
         // eslint-disable-next-line no-await-in-loop
         batch = await this._incrementalGraph.nextCompletedBatch();
       } while (batch !== undefined);
-
-      // TODO: add test for this case
-      /* c8 ignore next */
-      this._context.abortSignalListener?.disconnect();
-      await this._returnAsyncIteratorsIgnoringErrors();
-      return { value: undefined, done: true };
-    };
-
-    const _return = async (): Promise<
-      IteratorResult<SubsequentIncrementalExecutionResult, void>
-    > => {
-      isDone = true;
-      this._incrementalGraph.abort();
-      await this._returnAsyncIterators();
-      return { value: undefined, done: true };
-    };
-
-    const _throw = async (
-      error?: unknown,
-    ): Promise<IteratorResult<SubsequentIncrementalExecutionResult, void>> => {
-      isDone = true;
-      this._incrementalGraph.abort();
-      await this._returnAsyncIterators();
-      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-      return Promise.reject(error);
-    };
-
-    return {
-      [Symbol.asyncIterator]() {
-        return this;
-      },
-      next: _next,
-      return: _return,
-      throw: _throw,
-      async [Symbol.asyncDispose]() {
-        await _return();
-      },
-    };
+    }
   }
 
   private _handleCompletedIncrementalData(

--- a/src/execution/__tests__/mapAsyncIterable-test.ts
+++ b/src/execution/__tests__/mapAsyncIterable-test.ts
@@ -89,54 +89,6 @@ describe('mapAsyncIterable', () => {
     });
   });
 
-  it('calls done when completes', async () => {
-    async function* source() {
-      yield 1;
-      yield 2;
-      yield 3;
-    }
-
-    let done = false;
-    const doubles = mapAsyncIterable(
-      source(),
-      (x) => Promise.resolve(x + x),
-      () => {
-        done = true;
-      },
-    );
-
-    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
-    expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
-    expect(await doubles.next()).to.deep.equal({ value: 6, done: false });
-    expect(done).to.equal(false);
-    expect(await doubles.next()).to.deep.equal({
-      value: undefined,
-      done: true,
-    });
-    expect(done).to.equal(true);
-  });
-
-  it('calls done when completes with error', async () => {
-    async function* source() {
-      yield 1;
-      throw new Error('Oops');
-    }
-
-    let done = false;
-    const doubles = mapAsyncIterable(
-      source(),
-      (x) => Promise.resolve(x + x),
-      () => {
-        done = true;
-      },
-    );
-
-    expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
-    expect(done).to.equal(false);
-    await expectPromise(doubles.next()).toRejectWith('Oops');
-    expect(done).to.equal(true);
-  });
-
   it('allows returning early from mapped async generator', async () => {
     async function* source() {
       try {

--- a/src/execution/__tests__/simplePubSub.ts
+++ b/src/execution/__tests__/simplePubSub.ts
@@ -1,4 +1,6 @@
-import { assert } from 'chai';
+import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
+
+import { withCleanup } from '../withCleanup.js';
 
 /**
  * Create an AsyncIterator from an EventEmitter. Useful for mocking a
@@ -21,7 +23,7 @@ export class SimplePubSub<T> {
   }
 
   getSubscriber<R>(transform: (value: T) => R): AsyncGenerator<R, void, void> {
-    const pullQueue: Array<(result: IteratorResult<R, void>) => void> = [];
+    let pendingNext: ((result: R) => void) | undefined;
     const pushQueue: Array<R> = [];
     let listening = true;
     this._subscribers.add(pushValue);
@@ -29,49 +31,41 @@ export class SimplePubSub<T> {
     const emptyQueue = () => {
       listening = false;
       this._subscribers.delete(pushValue);
-      for (const resolve of pullQueue) {
-        resolve({ value: undefined, done: true });
+      if (pendingNext) {
+        pendingNext(undefined as R);
       }
-      pullQueue.length = 0;
+      pendingNext = undefined;
       pushQueue.length = 0;
     };
 
-    return {
-      next(): Promise<IteratorResult<R, void>> {
-        if (!listening) {
-          return Promise.resolve({ value: undefined, done: true });
-        }
-
+    async function* getSubscriberImpl(): AsyncGenerator<R, void, void> {
+      // eslint-disable-next-line no-unmodified-loop-condition
+      while (listening) {
         if (pushQueue.length > 0) {
           const value = pushQueue[0];
           pushQueue.shift();
-          return Promise.resolve({ value, done: false });
+          yield value;
+          continue;
         }
-        return new Promise((resolve) => pullQueue.push(resolve));
-      },
-      return(): Promise<IteratorResult<R, void>> {
-        emptyQueue();
-        return Promise.resolve({ value: undefined, done: true });
-      },
-      throw(error: unknown) {
-        emptyQueue();
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        return Promise.reject(error);
-      },
-      [Symbol.asyncIterator]() {
-        return this;
-      },
-      async [Symbol.asyncDispose]() {
-        await this.return();
-      },
-    };
+
+        const { promise, resolve } = promiseWithResolvers<R>();
+        pendingNext = resolve;
+        // eslint-disable-next-line no-await-in-loop
+        const value = await promise;
+        if (!listening) {
+          return;
+        }
+        yield value;
+      }
+    }
+
+    return withCleanup(getSubscriberImpl(), emptyQueue);
 
     function pushValue(event: T): void {
       const value: R = transform(event);
-      if (pullQueue.length > 0) {
-        const receiver = pullQueue.shift();
-        assert(receiver != null);
-        receiver({ value, done: false });
+      if (pendingNext) {
+        pendingNext(value);
+        pendingNext = undefined;
       } else {
         pushQueue.push(value);
       }

--- a/src/execution/__tests__/withCleanup-test.ts
+++ b/src/execution/__tests__/withCleanup-test.ts
@@ -1,0 +1,137 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectPromise } from '../../__testUtils__/expectPromise.js';
+
+import { withCleanup } from '../withCleanup.js';
+
+/* eslint-disable @typescript-eslint/require-await */
+describe('withCleanup', () => {
+  it('calls cleanup function when completes', async () => {
+    async function* source() {
+      yield 1;
+    }
+
+    let done = false;
+    const generator = withCleanup(source(), () => {
+      done = true;
+    });
+
+    expect(await generator.next()).to.deep.equal({ value: 1, done: false });
+    expect(done).to.equal(false);
+    expect(await generator.next()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(done).to.equal(true);
+  });
+
+  it('calls cleanup function when completes with error', async () => {
+    async function* source() {
+      yield 1;
+      throw new Error('Oops');
+    }
+
+    let done = false;
+    const generator = withCleanup(source(), () => {
+      done = true;
+    });
+
+    expect(await generator.next()).to.deep.equal({ value: 1, done: false });
+    expect(done).to.equal(false);
+    await expectPromise(generator.next()).toRejectWith('Oops');
+    expect(done).to.equal(true);
+  });
+
+  it('calls cleanup function when returned', async () => {
+    async function* source() {
+      yield 1;
+    }
+
+    let done = false;
+    const generator = withCleanup(source(), () => {
+      done = true;
+    });
+
+    expect(await generator.next()).to.deep.equal({ value: 1, done: false });
+    expect(done).to.equal(false);
+    expect(await generator.return()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+    expect(done).to.equal(true);
+  });
+
+  it('calls cleanup function when thrown', async () => {
+    async function* source() {
+      yield 1;
+    }
+
+    let done = false;
+    const generator = withCleanup(source(), () => {
+      done = true;
+    });
+
+    expect(await generator.next()).to.deep.equal({ value: 1, done: false });
+    expect(done).to.equal(false);
+    await expectPromise(generator.throw(new Error('Oops'))).toRejectWith(
+      'Oops',
+    );
+    expect(done).to.equal(true);
+  });
+
+  it('calls cleanup function when disposed', async () => {
+    let returned = false;
+
+    const items = [1, 2, 3];
+    const source: AsyncGenerator<number, void, void> = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next(): Promise<IteratorResult<number, void>> {
+        const value = items.shift();
+        if (value !== undefined) {
+          return Promise.resolve({ done: false, value });
+        }
+
+        return Promise.resolve({ done: true, value: undefined });
+      },
+      return(): Promise<IteratorResult<number, void>> {
+        returned = true;
+        return Promise.resolve({ done: true, value: undefined });
+      },
+      throw(): Promise<IteratorResult<number, void>> {
+        returned = true;
+        return Promise.reject(new Error());
+      },
+      async [Symbol.asyncDispose]() {
+        await this.return();
+      },
+    };
+
+    let cleanedUp = false;
+    {
+      await using generator = withCleanup(source, () => {
+        cleanedUp = true;
+      });
+
+      expect(await generator.next()).to.deep.equal({ value: 1, done: false });
+      expect(await generator.next()).to.deep.equal({ value: 2, done: false });
+    }
+
+    expect(cleanedUp).to.equal(true);
+    expect(returned).to.equal(true);
+  });
+
+  it('returns the generator itself when the `Symbol.asyncIterator` method is called', async () => {
+    async function* source() {
+      yield 1;
+    }
+
+    const generator = withCleanup(source(), () => {
+      /* noop */
+    });
+
+    expect(generator[Symbol.asyncIterator]()).to.equal(generator);
+  });
+});

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -89,6 +89,7 @@ import {
   getDirectiveValues,
   getVariableValues,
 } from './values.js';
+import { withCleanup } from './withCleanup.js';
 
 /* eslint-disable max-params */
 // This file contains a lot of such errors but we plan to refactor it anyway
@@ -2265,19 +2266,23 @@ function mapSourceToResponse(
   // GraphQL `execute` function, with `payload` as the rootValue.
   // This implements the "MapSourceToResponseEvent" algorithm described in
   // the GraphQL specification..
-  return mapAsyncIterable(
-    abortSignalListener
-      ? cancellableIterable(resultOrStream, abortSignalListener)
-      : resultOrStream,
-    (payload: unknown) => {
-      const perEventExecutionArgs: ValidatedExecutionArgs = {
-        ...validatedExecutionArgs,
-        rootValue: payload,
-      };
-      return validatedExecutionArgs.perEventExecutor(perEventExecutionArgs);
-    },
-    () => abortSignalListener?.disconnect(),
-  );
+  function mapFn(payload: unknown): PromiseOrValue<ExecutionResult> {
+    const perEventExecutionArgs: ValidatedExecutionArgs = {
+      ...validatedExecutionArgs,
+      rootValue: payload,
+    };
+    return validatedExecutionArgs.perEventExecutor(perEventExecutionArgs);
+  }
+
+  return abortSignalListener
+    ? withCleanup(
+        mapAsyncIterable(
+          cancellableIterable(resultOrStream, abortSignalListener),
+          mapFn,
+        ),
+        () => abortSignalListener.disconnect(),
+      )
+    : mapAsyncIterable(resultOrStream, mapFn);
 }
 
 export function executeSubscriptionEvent(

--- a/src/execution/mapAsyncIterable.ts
+++ b/src/execution/mapAsyncIterable.ts
@@ -7,26 +7,18 @@ import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
 export function mapAsyncIterable<T, U, R = undefined>(
   iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
   callback: (value: T) => PromiseOrValue<U>,
-  onDone?: () => void,
 ): AsyncGenerator<U, R, void> {
   const iterator = iterable[Symbol.asyncIterator]();
 
   async function mapResult(
     promise: Promise<IteratorResult<T, R>>,
   ): Promise<IteratorResult<U, R>> {
-    let value: T;
-    try {
-      const result = await promise;
-      if (result.done) {
-        onDone?.();
-        return result;
-      }
-      value = result.value;
-    } catch (error) {
-      onDone?.();
-      throw error;
+    const result = await promise;
+    if (result.done) {
+      return result;
     }
 
+    const value = result.value;
     try {
       return { value: await callback(value), done: false };
     } catch (error) {
@@ -45,6 +37,10 @@ export function mapAsyncIterable<T, U, R = undefined>(
       } /* c8 ignore stop */
     }
   }
+
+  const asyncDispose: typeof Symbol.asyncDispose =
+    Symbol.asyncDispose /* c8 ignore start */ ??
+    Symbol.for('Symbol.asyncDispose'); /* c8 ignore stop */
 
   return {
     async next() {
@@ -70,13 +66,13 @@ export function mapAsyncIterable<T, U, R = undefined>(
     [Symbol.asyncIterator]() {
       return this;
     },
-    async [Symbol.asyncDispose]() {
+    async [asyncDispose]() {
       await this.return(undefined as R);
       if (
-        typeof (iterable as AsyncGenerator<T, R, void>)[Symbol.asyncDispose] ===
+        typeof (iterable as AsyncGenerator<T, R, void>)[asyncDispose] ===
         'function'
       ) {
-        await (iterable as AsyncGenerator<T, R, void>)[Symbol.asyncDispose]();
+        await (iterable as AsyncGenerator<T, R, void>)[asyncDispose]();
       }
     },
   };

--- a/src/execution/withCleanup.ts
+++ b/src/execution/withCleanup.ts
@@ -1,0 +1,59 @@
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
+
+/**
+ * Given an AsyncGenerator and a cleanup function, return an AsyncGenerator
+ * which calls the given function when the generator closes.
+ *
+ * This is useful for ensuring cleanup logic is called immediately when the
+ * generator's `return()` method is called, even if the generator is currently
+ * paused, e.g. if a `await` is pending within the generator's `next()` method.
+ */
+export function withCleanup<T>(
+  generator: AsyncGenerator<T, void, void>,
+  onDone: () => PromiseOrValue<void>,
+): AsyncGenerator<T, void, void> {
+  let finished = false;
+  const finish = async () => {
+    if (!finished) {
+      finished = true;
+      await onDone();
+    }
+  };
+
+  const asyncDispose: typeof Symbol.asyncDispose =
+    Symbol.asyncDispose /* c8 ignore start */ ??
+    Symbol.for('Symbol.asyncDispose'); /* c8 ignore stop */
+
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next() {
+      try {
+        const result = await generator.next();
+        if (result.done) {
+          await finish();
+          return result;
+        }
+        return { value: await result.value, done: false };
+      } catch (error) {
+        await finish();
+        throw error;
+      }
+    },
+    async return(): Promise<IteratorResult<T>> {
+      await finish();
+      return generator.return();
+    },
+    async throw(error?: unknown) {
+      await finish();
+      return generator.throw(error);
+    },
+    async [asyncDispose]() {
+      await finish();
+      if (typeof generator[asyncDispose] === 'function') {
+        await generator[asyncDispose]();
+      }
+    },
+  };
+}


### PR DESCRIPTION
motivations:

1. separation of concerns (`mapAsyncIterable` should have single function)
2. `withCleanUp` is useful independently, i.e. it removes the need to "hand-roll" AsyncGenerators across the codebase

Some background for Point 2:

Built in async generators have a feature/quirk/annoyance that all of their calls are sequential. If a call to `gen.next()` is pending, i.e. waiting on the return of a promise (`... const result = await fetchExternalData; yield result ... `), then the consumer cannot call `gen.return()` manually to abort the generator, the call to `gen.return()` will not initiate until the external fetch is awaited. This is because Async Generators (and promises more broadly) do not have cancellation as a built-in-feature.

Hand-rolled Async Generators can allow a call to `gen.return()` to be used to abort the generator; they can start immediately. Technically, they can even return out of order with that pending `gen.next()`, although it's helpful if they always return in order, like with Repeaters (https://repeater.js.org/).

We were previously using "hand-rolled" Async Generators for exactly this purpose. With this change, only `withCleanUp` and `mapAsyncIterable` stay as "hand-rolled" Async Generators, but we can use actual Async Generators in our actual incremental delivery code (within `Incremental Publisher` ) and subscription test code (`simplePubSub`).

This is good for two reasons:

A. Using JavaScript primitives is more modern/ergonomic
B. Hopefully will reduce churn and bug surface.

In terms of `B`, this PR also fixes a potential bug introduced when we upgraded TS to 5.2. That version of TypeScript requires "hand-rolled" Async Generators to include an `[Symbol.asyncDispose]` property method, but the runtime is responsible for supplying the functionality polyfill. When we upgraded, we by accident required our users to have that functionality (which is present in all of our tested versions) but not guaranteed. This change updates `mapAsyncIterable` and `withCleanUp` to fall back to `Symbol.for("asyncDispose")` which should avoid a crash. The broader codebase should not have to be aware of this level of detail when using these helpers!