### PR TITLE
polish: unify our formatted and non-formatted execution result types

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -51,7 +51,7 @@ export interface GraphQLErrorOptions {
  * and stack trace, it also includes information about the locations in a
  * GraphQL document and/or execution result that correspond to the Error.
  */
-export class GraphQLError extends Error {
+export class GraphQLError extends Error implements GraphQLFormattedError {
   /**
    * An array of `{ line, column }` locations within the source GraphQL document
    * which correspond to this error.
@@ -62,7 +62,7 @@ export class GraphQLError extends Error {
    *
    * Enumerable, and appears in the result of JSON.stringify().
    */
-  readonly locations: ReadonlyArray<SourceLocation> | undefined;
+  readonly locations?: ReadonlyArray<SourceLocation>;
 
   /**
    * An array describing the JSON-path into the execution response which
@@ -70,12 +70,12 @@ export class GraphQLError extends Error {
    *
    * Enumerable, and appears in the result of JSON.stringify().
    */
-  readonly path: ReadonlyArray<string | number> | undefined;
+  readonly path?: ReadonlyArray<string | number>;
 
   /**
    * An array of GraphQL AST Nodes corresponding to this error.
    */
-  readonly nodes: ReadonlyArray<ASTNode> | undefined;
+  readonly nodes?: ReadonlyArray<ASTNode>;
 
   /**
    * The source GraphQL document for the first location of this error.
@@ -83,23 +83,23 @@ export class GraphQLError extends Error {
    * Note that if this Error represents more than one node, the source may not
    * represent nodes after the first node.
    */
-  readonly source: Source | undefined;
+  readonly source?: Source;
 
   /**
    * An array of character offsets within the source GraphQL document
    * which correspond to this error.
    */
-  readonly positions: ReadonlyArray<number> | undefined;
+  readonly positions?: ReadonlyArray<number>;
 
   /**
    * The original error thrown from a field resolver during execution.
    */
-  readonly originalError: Error | undefined;
+  readonly originalError?: Error;
 
   /**
    * Extension fields to add to the formatted error.
    */
-  readonly extensions: GraphQLErrorExtensions;
+  readonly extensions?: GraphQLErrorExtensions;
 
   constructor(message: string, options: GraphQLErrorOptions = {}) {
     const { nodes, source, positions, path, originalError, extensions } =
@@ -108,13 +108,21 @@ export class GraphQLError extends Error {
     super(message);
 
     this.name = 'GraphQLError';
-    this.path = path ?? undefined;
-    this.originalError = originalError ?? undefined;
+    if (path) {
+      this.path = path;
+    }
+
+    if (originalError) {
+      this.originalError = originalError;
+    }
 
     // Compute list of blame nodes.
-    this.nodes = undefinedIfEmpty(
+    const resolvedNodes = undefinedIfEmpty(
       Array.isArray(nodes) ? nodes : nodes ? [nodes] : undefined,
     );
+    if (resolvedNodes) {
+      this.nodes = resolvedNodes;
+    }
 
     const nodeLocations = undefinedIfEmpty(
       this.nodes
@@ -123,19 +131,32 @@ export class GraphQLError extends Error {
     );
 
     // Compute locations in the source for the given nodes/positions.
-    this.source = source ?? nodeLocations?.[0]?.source;
+    const resolvedSource = source ?? nodeLocations?.[0]?.source;
+    if (resolvedSource) {
+      this.source = resolvedSource;
+    }
 
-    this.positions = positions ?? nodeLocations?.map((loc) => loc.start);
+    const resolvedPositions =
+      positions ?? nodeLocations?.map((loc) => loc.start);
+    if (resolvedPositions) {
+      this.positions = resolvedPositions;
+    }
 
-    this.locations =
+    const resolvedLocations =
       positions && source
         ? positions.map((pos) => getLocation(source, pos))
         : nodeLocations?.map((loc) => getLocation(loc.source, loc.start));
+    if (resolvedLocations) {
+      this.locations = resolvedLocations;
+    }
 
     const originalExtensions = isObjectLike(originalError?.extensions)
       ? originalError?.extensions
       : undefined;
-    this.extensions = extensions ?? originalExtensions ?? Object.create(null);
+    const resolvedExtensions = extensions ?? originalExtensions;
+    if (resolvedExtensions) {
+      this.extensions = resolvedExtensions;
+    }
 
     // Only properties prescribed by the spec should be enumerable.
     // Keep the rest as non-enumerable.

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -32,7 +32,6 @@ describe('GraphQLError', () => {
     expect(e).to.deep.include({
       name: 'GraphQLError',
       message: 'msg',
-      extensions: {},
     });
     expect(e.stack).to.be.a('string');
   });

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -111,7 +111,7 @@ describe('GraphQLError', () => {
     });
   });
 
-  it('converts node without location to undefined source, positions and locations', () => {
+  it('converts node without location to error without source, positions and locations', () => {
     const fieldNodeNoLocation = {
       ...fieldNode,
       loc: undefined,
@@ -120,9 +120,6 @@ describe('GraphQLError', () => {
     const e = new GraphQLError('msg', { nodes: fieldNodeNoLocation });
     expect(e).to.deep.include({
       nodes: [fieldNodeNoLocation],
-      source: undefined,
-      positions: undefined,
-      locations: undefined,
     });
   });
 

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -62,7 +62,7 @@ export interface SubsequentIncrementalExecutionResult<
   TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
 > {
   pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions, TError>>;
   completed?: ReadonlyArray<CompletedResult<TError>>;
   hasNext: boolean;
   extensions?: TExtensions;
@@ -92,9 +92,13 @@ export interface IncrementalStreamResult<
   extensions?: TExtensions;
 }
 
-export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
-  | IncrementalDeferResult<TData, TExtensions>
-  | IncrementalStreamResult<TData, TExtensions>;
+export type IncrementalResult<
+  TData = unknown,
+  TExtensions = ObjMap<unknown>,
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+> =
+  | IncrementalDeferResult<TData, TExtensions, TError>
+  | IncrementalStreamResult<TData, TExtensions, TError>;
 
 export interface PendingResult {
   id: string;
@@ -156,9 +160,7 @@ export interface FormattedIncrementalStreamResult<
 export type FormattedIncrementalResult<
   TData = unknown,
   TExtensions = ObjMap<unknown>,
-> =
-  | FormattedIncrementalDeferResult<TData, TExtensions>
-  | FormattedIncrementalStreamResult<TData, TExtensions>;
+> = IncrementalResult<TData, TExtensions, GraphQLFormattedError>;
 
 export interface FormattedCompletedResult
   extends CompletedResult<GraphQLFormattedError> {}

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -27,11 +27,6 @@ export interface ExecutionResult<
   extensions?: TExtensions;
 }
 
-export interface FormattedExecutionResult<
-  TData = ObjMap<unknown>,
-  TExtensions = ObjMap<unknown>,
-> extends ExecutionResult<TData, TExtensions, GraphQLFormattedError> {}
-
 export interface ExperimentalIncrementalExecutionResults<
   TInitial = ObjMap<unknown>,
   TSubsequent = unknown,
@@ -50,17 +45,6 @@ export interface ExperimentalIncrementalExecutionResults<
   >;
 }
 
-export interface FormattedExperimentalIncrementalExecutionResults<
-  TInitial = ObjMap<unknown>,
-  TSubsequent = unknown,
-  TExtensions = ObjMap<unknown>,
-> extends ExperimentalIncrementalExecutionResults<
-    TInitial,
-    TSubsequent,
-    TExtensions,
-    GraphQLFormattedError
-  > {}
-
 export interface InitialIncrementalExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
@@ -71,15 +55,6 @@ export interface InitialIncrementalExecutionResult<
   hasNext: true;
   extensions?: TExtensions;
 }
-
-export interface FormattedInitialIncrementalExecutionResult<
-  TData = ObjMap<unknown>,
-  TExtensions = ObjMap<unknown>,
-> extends InitialIncrementalExecutionResult<
-    TData,
-    TExtensions,
-    GraphQLFormattedError
-  > {}
 
 export interface SubsequentIncrementalExecutionResult<
   TData = unknown,
@@ -93,15 +68,6 @@ export interface SubsequentIncrementalExecutionResult<
   extensions?: TExtensions;
 }
 
-export interface FormattedSubsequentIncrementalExecutionResult<
-  TData = unknown,
-  TExtensions = ObjMap<unknown>,
-> extends SubsequentIncrementalExecutionResult<
-    TData,
-    TExtensions,
-    GraphQLFormattedError
-  > {}
-
 export interface IncrementalDeferResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
@@ -113,11 +79,6 @@ export interface IncrementalDeferResult<
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
-
-export interface FormattedIncrementalDeferResult<
-  TData = ObjMap<unknown>,
-  TExtensions = ObjMap<unknown>,
-> extends IncrementalDeferResult<TData, TExtensions, GraphQLFormattedError> {}
 
 export interface IncrementalStreamResult<
   TData = ReadonlyArray<unknown>,
@@ -131,21 +92,9 @@ export interface IncrementalStreamResult<
   extensions?: TExtensions;
 }
 
-export interface FormattedIncrementalStreamResult<
-  TData = Array<unknown>,
-  TExtensions = ObjMap<unknown>,
-> extends IncrementalStreamResult<TData, TExtensions, GraphQLFormattedError> {}
-
 export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
   | IncrementalDeferResult<TData, TExtensions>
   | IncrementalStreamResult<TData, TExtensions>;
-
-export type FormattedIncrementalResult<
-  TData = unknown,
-  TExtensions = ObjMap<unknown>,
-> =
-  | FormattedIncrementalDeferResult<TData, TExtensions>
-  | FormattedIncrementalStreamResult<TData, TExtensions>;
 
 export interface PendingResult {
   id: string;
@@ -159,6 +108,57 @@ export interface CompletedResult<
   id: string;
   errors?: ReadonlyArray<TError>;
 }
+
+export interface FormattedExecutionResult<
+  TData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends ExecutionResult<TData, TExtensions, GraphQLFormattedError> {}
+
+export interface FormattedExperimentalIncrementalExecutionResults<
+  TInitial = ObjMap<unknown>,
+  TSubsequent = unknown,
+  TExtensions = ObjMap<unknown>,
+> extends ExperimentalIncrementalExecutionResults<
+    TInitial,
+    TSubsequent,
+    TExtensions,
+    GraphQLFormattedError
+  > {}
+
+export interface FormattedInitialIncrementalExecutionResult<
+  TData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends InitialIncrementalExecutionResult<
+    TData,
+    TExtensions,
+    GraphQLFormattedError
+  > {}
+
+export interface FormattedSubsequentIncrementalExecutionResult<
+  TData = unknown,
+  TExtensions = ObjMap<unknown>,
+> extends SubsequentIncrementalExecutionResult<
+    TData,
+    TExtensions,
+    GraphQLFormattedError
+  > {}
+
+export interface FormattedIncrementalDeferResult<
+  TData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends IncrementalDeferResult<TData, TExtensions, GraphQLFormattedError> {}
+
+export interface FormattedIncrementalStreamResult<
+  TData = Array<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends IncrementalStreamResult<TData, TExtensions, GraphQLFormattedError> {}
+
+export type FormattedIncrementalResult<
+  TData = unknown,
+  TExtensions = ObjMap<unknown>,
+> =
+  | FormattedIncrementalDeferResult<TData, TExtensions>
+  | FormattedIncrementalStreamResult<TData, TExtensions>;
 
 export interface FormattedCompletedResult
   extends CompletedResult<GraphQLFormattedError> {}

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -20,7 +20,7 @@ import type {
 export interface ExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > {
   errors?: ReadonlyArray<TError>;
   data?: TData | null;
@@ -31,7 +31,7 @@ export interface ExperimentalIncrementalExecutionResults<
   TInitial = ObjMap<unknown>,
   TSubsequent = unknown,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > {
   initialResult: InitialIncrementalExecutionResult<
     TInitial,
@@ -48,7 +48,7 @@ export interface ExperimentalIncrementalExecutionResults<
 export interface InitialIncrementalExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > extends ExecutionResult<TData, TExtensions, TError> {
   data: TData;
   pending: ReadonlyArray<PendingResult>;
@@ -59,7 +59,7 @@ export interface InitialIncrementalExecutionResult<
 export interface SubsequentIncrementalExecutionResult<
   TData = unknown,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > {
   pending?: ReadonlyArray<PendingResult>;
   incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions, TError>>;
@@ -71,7 +71,7 @@ export interface SubsequentIncrementalExecutionResult<
 export interface IncrementalDeferResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > {
   errors?: ReadonlyArray<TError>;
   data: TData;
@@ -83,7 +83,7 @@ export interface IncrementalDeferResult<
 export interface IncrementalStreamResult<
   TData = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > {
   errors?: ReadonlyArray<TError>;
   items: TData;
@@ -95,7 +95,7 @@ export interface IncrementalStreamResult<
 export type IncrementalResult<
   TData = unknown,
   TExtensions = ObjMap<unknown>,
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > =
   | IncrementalDeferResult<TData, TExtensions, TError>
   | IncrementalStreamResult<TData, TExtensions, TError>;
@@ -107,7 +107,7 @@ export interface PendingResult {
 }
 
 export interface CompletedResult<
-  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+  TError extends GraphQLFormattedError = GraphQLError,
 > {
   id: string;
   errors?: ReadonlyArray<TError>;

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-object-type */
 import type { BoxedPromiseOrValue } from '../jsutils/BoxedPromiseOrValue.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
 import type { Path } from '../jsutils/Path.js';
@@ -19,8 +20,9 @@ import type {
 export interface ExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
 > {
-  errors?: ReadonlyArray<GraphQLError>;
+  errors?: ReadonlyArray<TError>;
   data?: TData | null;
   extensions?: TExtensions;
 }
@@ -28,29 +30,42 @@ export interface ExecutionResult<
 export interface FormattedExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> {
-  errors?: ReadonlyArray<GraphQLFormattedError>;
-  data?: TData | null;
-  extensions?: TExtensions;
-}
+> extends ExecutionResult<TData, TExtensions, GraphQLFormattedError> {}
 
 export interface ExperimentalIncrementalExecutionResults<
   TInitial = ObjMap<unknown>,
   TSubsequent = unknown,
   TExtensions = ObjMap<unknown>,
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
 > {
-  initialResult: InitialIncrementalExecutionResult<TInitial, TExtensions>;
+  initialResult: InitialIncrementalExecutionResult<
+    TInitial,
+    TExtensions,
+    TError
+  >;
   subsequentResults: AsyncGenerator<
-    SubsequentIncrementalExecutionResult<TSubsequent, TExtensions>,
+    SubsequentIncrementalExecutionResult<TSubsequent, TExtensions, TError>,
     void,
     void
   >;
 }
 
+export interface FormattedExperimentalIncrementalExecutionResults<
+  TInitial = ObjMap<unknown>,
+  TSubsequent = unknown,
+  TExtensions = ObjMap<unknown>,
+> extends ExperimentalIncrementalExecutionResults<
+    TInitial,
+    TSubsequent,
+    TExtensions,
+    GraphQLFormattedError
+  > {}
+
 export interface InitialIncrementalExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends ExecutionResult<TData, TExtensions> {
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+> extends ExecutionResult<TData, TExtensions, TError> {
   data: TData;
   pending: ReadonlyArray<PendingResult>;
   hasNext: true;
@@ -60,20 +75,20 @@ export interface InitialIncrementalExecutionResult<
 export interface FormattedInitialIncrementalExecutionResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends FormattedExecutionResult<TData, TExtensions> {
-  data: TData;
-  pending: ReadonlyArray<PendingResult>;
-  hasNext: boolean;
-  extensions?: TExtensions;
-}
+> extends InitialIncrementalExecutionResult<
+    TData,
+    TExtensions,
+    GraphQLFormattedError
+  > {}
 
 export interface SubsequentIncrementalExecutionResult<
   TData = unknown,
   TExtensions = ObjMap<unknown>,
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
 > {
   pending?: ReadonlyArray<PendingResult>;
   incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
-  completed?: ReadonlyArray<CompletedResult>;
+  completed?: ReadonlyArray<CompletedResult<TError>>;
   hasNext: boolean;
   extensions?: TExtensions;
 }
@@ -81,23 +96,19 @@ export interface SubsequentIncrementalExecutionResult<
 export interface FormattedSubsequentIncrementalExecutionResult<
   TData = unknown,
   TExtensions = ObjMap<unknown>,
-> {
-  hasNext: boolean;
-  pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
-  completed?: ReadonlyArray<FormattedCompletedResult>;
-  extensions?: TExtensions;
-}
-
-interface ExecutionGroupResult<TData = ObjMap<unknown>> {
-  errors?: ReadonlyArray<GraphQLError>;
-  data: TData;
-}
+> extends SubsequentIncrementalExecutionResult<
+    TData,
+    TExtensions,
+    GraphQLFormattedError
+  > {}
 
 export interface IncrementalDeferResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends ExecutionGroupResult<TData> {
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+> {
+  errors?: ReadonlyArray<TError>;
+  data: TData;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
@@ -106,23 +117,15 @@ export interface IncrementalDeferResult<
 export interface FormattedIncrementalDeferResult<
   TData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> {
-  errors?: ReadonlyArray<GraphQLFormattedError>;
-  data: TData;
-  id: string;
-  subPath?: ReadonlyArray<string | number>;
-  extensions?: TExtensions;
-}
-
-interface StreamItemsRecordResult<TData = ReadonlyArray<unknown>> {
-  errors?: ReadonlyArray<GraphQLError>;
-  items: TData;
-}
+> extends IncrementalDeferResult<TData, TExtensions, GraphQLFormattedError> {}
 
 export interface IncrementalStreamResult<
   TData = ReadonlyArray<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends StreamItemsRecordResult<TData> {
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+> {
+  errors?: ReadonlyArray<TError>;
+  items: TData;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
@@ -131,13 +134,7 @@ export interface IncrementalStreamResult<
 export interface FormattedIncrementalStreamResult<
   TData = Array<unknown>,
   TExtensions = ObjMap<unknown>,
-> {
-  errors?: ReadonlyArray<GraphQLFormattedError>;
-  items: TData;
-  id: string;
-  subPath?: ReadonlyArray<string | number>;
-  extensions?: TExtensions;
-}
+> extends IncrementalStreamResult<TData, TExtensions, GraphQLFormattedError> {}
 
 export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
   | IncrementalDeferResult<TData, TExtensions>
@@ -156,15 +153,15 @@ export interface PendingResult {
   label?: string;
 }
 
-export interface CompletedResult {
+export interface CompletedResult<
+  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
+> {
   id: string;
-  errors?: ReadonlyArray<GraphQLError>;
+  errors?: ReadonlyArray<TError>;
 }
 
-export interface FormattedCompletedResult {
-  id: string;
-  errors?: ReadonlyArray<GraphQLFormattedError>;
-}
+export interface FormattedCompletedResult
+  extends CompletedResult<GraphQLFormattedError> {}
 
 export function isPendingExecutionGroup(
   incrementalDataRecord: IncrementalDataRecord,
@@ -185,7 +182,10 @@ export function isCompletedExecutionGroup(
 export interface SuccessfulExecutionGroup {
   pendingExecutionGroup: PendingExecutionGroup;
   path: Array<string | number>;
-  result: ExecutionGroupResult;
+  result: {
+    errors?: ReadonlyArray<GraphQLError>;
+    data: ObjMap<unknown>;
+  };
   newDeferredFragmentRecords: ReadonlyArray<DeferredFragmentRecord> | undefined;
   incrementalDataRecords: ReadonlyArray<IncrementalDataRecord> | undefined;
   errors?: never;
@@ -266,7 +266,10 @@ export interface StreamRecord {
 export interface StreamItemsResult {
   streamRecord: StreamRecord;
   errors?: ReadonlyArray<GraphQLError>;
-  result?: StreamItemsRecordResult;
+  result?: {
+    errors?: ReadonlyArray<GraphQLError>;
+    items: ReadonlyArray<unknown>;
+  };
   newDeferredFragmentRecords?:
     | ReadonlyArray<DeferredFragmentRecord>
     | undefined;


### PR DESCRIPTION
via using a new generic type parameter with this pattern:

```ts
export interface ExecutionResult<
  TData = ObjMap<unknown>,
  TExtensions = ObjMap<unknown>,
  TError extends GraphQLError | GraphQLFormattedError = GraphQLError,
> {
  errors?: ReadonlyArray<TError>;
  data?: TData | null;
  extensions?: TExtensions;
}

export interface FormattedExecutionResult<
  TData = ObjMap<unknown>,
  TExtensions = ObjMap<unknown>,
> extends ExecutionResult<TData, TExtensions, GraphQLFormattedError> {}
```

This should remove maintenance burden, as we explicitly say that the formatted types only differ from the unformatted in that they have a formatted error type.

See:
https://github.com/graphql/graphql-js/pull/4481/
https://github.com/graphql/graphql-js/issues/4333