### PR TITLE
chore: always ignore scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
We don't seem to have any dependencies that legitimately need an `install` or `postinstall` script, we already have `--ignore-scripts` in various of our `npm` commands; so let's disable it via the `.npmrc` to ensure no-one forgets to disable it.