### PR TITLE
fix(validation): incorrect validation errors when variable descriptions are used

### DIFF
--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -181,7 +181,7 @@ describe('Validate: Limit maximum number of validation errors', () => {
 });
 
 describe('operation and variable definition descriptions', () => {
-  it('parses operation with description and variable descriptions', () => {
+  it('validates operation with description and variable descriptions', () => {
     const schema = buildSchema(
       'type Query { field(a: Int, b: String): String }',
     );

--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -179,3 +179,26 @@ describe('Validate: Limit maximum number of validation errors', () => {
     ).to.throw(/^Error from custom rule!$/);
   });
 });
+
+describe('operation and variable definition descriptions', () => {
+  it('parses operation with description and variable descriptions', () => {
+    const schema = buildSchema(
+      'type Query { field(a: Int, b: String): String }',
+    );
+    const query = `
+        "Operation description"
+        query myQuery(
+          "Variable a description"
+          $a: Int,
+          """Variable b\nmultiline description"""
+          $b: String
+        ) {
+          field(a: $a, b: $b)
+        }
+      `;
+    const ast = parse(query);
+    const errors = validate(schema, ast);
+    console.log(errors);
+    expect(errors.length).to.equal(0);
+  });
+});

--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -198,7 +198,6 @@ describe('operation and variable definition descriptions', () => {
       `;
     const ast = parse(query);
     const errors = validate(schema, ast);
-    console.log(errors);
     expect(errors.length).to.equal(0);
   });
 });

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -116,7 +116,7 @@ export function ValuesOfCorrectTypeRule(
     EnumValue: (node) => isValidValueNode(context, node),
     IntValue: (node) => isValidValueNode(context, node),
     FloatValue: (node) => isValidValueNode(context, node),
-    StringValue: (node) => isValidValueNode(context, node),
+    StringValue: (node, key) => key !== "description" && isValidValueNode(context, node),
     BooleanValue: (node) => isValidValueNode(context, node),
   };
 }

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -116,7 +116,12 @@ export function ValuesOfCorrectTypeRule(
     EnumValue: (node) => isValidValueNode(context, node),
     IntValue: (node) => isValidValueNode(context, node),
     FloatValue: (node) => isValidValueNode(context, node),
-    StringValue: (node, key) => key !== 'description' && isValidValueNode(context, node),
+    // Descriptions are string values that would not validate according
+    // to the below logic, but since (per the specification) descriptions must
+    // not affect validation, they are ignored entirely when visiting the AST
+    // and do not require special handling.
+    // See https://spec.graphql.org/draft/#sec-Descriptions
+    StringValue: (node) => isValidValueNode(context, node),
     BooleanValue: (node) => isValidValueNode(context, node),
   };
 }

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -116,7 +116,7 @@ export function ValuesOfCorrectTypeRule(
     EnumValue: (node) => isValidValueNode(context, node),
     IntValue: (node) => isValidValueNode(context, node),
     FloatValue: (node) => isValidValueNode(context, node),
-    StringValue: (node, key) => key !== "description" && isValidValueNode(context, node),
+    StringValue: (node, key) => key !== 'description' && isValidValueNode(context, node),
     BooleanValue: (node) => isValidValueNode(context, node),
   };
 }

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -1,9 +1,10 @@
 import { devAssert } from '../jsutils/devAssert';
+import { mapValue } from '../jsutils/mapValue';
 import type { Maybe } from '../jsutils/Maybe';
 
 import { GraphQLError } from '../error/GraphQLError';
 
-import type { DocumentNode } from '../language/ast';
+import { type DocumentNode, QueryDocumentKeys } from '../language/ast';
 import { visit, visitInParallel } from '../language/visitor';
 
 import type { GraphQLSchema } from '../type/schema';
@@ -14,6 +15,13 @@ import { TypeInfo, visitWithTypeInfo } from '../utilities/TypeInfo';
 import { specifiedRules, specifiedSDLRules } from './specifiedRules';
 import type { SDLValidationRule, ValidationRule } from './ValidationContext';
 import { SDLValidationContext, ValidationContext } from './ValidationContext';
+
+// Per the specification, descriptions must not affect validation.
+// See https://spec.graphql.org/draft/#sec-Descriptions
+const QueryDocumentKeysToValidate = mapValue(
+  QueryDocumentKeys,
+  (keys: ReadonlyArray<string>) => keys.filter((key) => key !== 'description'),
+);
 
 /**
  * Implements the "Validation" section of the spec.
@@ -76,7 +84,11 @@ export function validate(
 
   // Visit the whole document with each instance of all provided rules.
   try {
-    visit(documentAST, visitWithTypeInfo(typeInfo, visitor));
+    visit(
+      documentAST,
+      visitWithTypeInfo(typeInfo, visitor),
+      QueryDocumentKeysToValidate,
+    );
   } catch (e) {
     if (e !== abortObj) {
       throw e;

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -4,7 +4,8 @@ import type { Maybe } from '../jsutils/Maybe';
 
 import { GraphQLError } from '../error/GraphQLError';
 
-import { type DocumentNode, QueryDocumentKeys } from '../language/ast';
+import type { DocumentNode } from '../language/ast';
+import { QueryDocumentKeys } from '../language/ast';
 import { visit, visitInParallel } from '../language/visitor';
 
 import type { GraphQLSchema } from '../type/schema';


### PR DESCRIPTION
I initially reported this as an LSP error (https://github.com/graphql/graphiql/issues/4138), but turns out it's an error in `graphql-js`.
<img width="1742" height="564" alt="image" src="https://github.com/user-attachments/assets/eca78ebc-e022-4fa0-b423-8169c9c902c4" />
