### PR TITLE
Fix TypeInfo.getInputType() for custom scalar list literals.

### DIFF
--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -116,6 +116,8 @@ export class TypeInfo {
     return this._inputTypeStack.at(-1);
   }
 
+  // Note: continues to expose the closest enclosing valid input type if
+  // traversal descends into syntax with no corresponding GraphQL input type.
   getParentInputType(): Maybe<GraphQLInputType> {
     return this._inputTypeStack.at(-2);
   }

--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -254,7 +254,7 @@ export class TypeInfo {
         const listType: unknown = getNullableType(this.getInputType());
         const itemType: unknown = isListType(listType)
           ? listType.ofType
-          : listType;
+          : undefined;
         // List positions never have a default value.
         this._defaultValueStack.push(undefined);
         this._inputTypeStack.push(isInputType(itemType) ? itemType : undefined);

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -451,10 +451,10 @@ describe('visitWithTypeInfo', () => {
       ['enter', 'ObjectField', null, '[String]'],
       ['enter', 'Name', 'stringListField', '[String]'],
       ['leave', 'Name', 'stringListField', '[String]'],
-      ['enter', 'ListValue', null, 'String'],
+      ['enter', 'ListValue', null, 'String' /* the item type, not list type */],
       ['enter', 'StringValue', null, 'String'],
       ['leave', 'StringValue', null, 'String'],
-      ['leave', 'ListValue', null, 'String'],
+      ['leave', 'ListValue', null, 'String' /* the item type, not list type */],
       ['leave', 'ObjectField', null, '[String]'],
       ['leave', 'ObjectValue', null, 'ComplexInput'],
     ]);
@@ -516,6 +516,106 @@ describe('visitWithTypeInfo', () => {
       ['leave', 'SelectionSet', null, 'Pet', '[Pet]'],
       ['leave', 'Field', null, 'Human', '[Pet]'],
       ['leave', 'SelectionSet', null, 'Human', 'Human'],
+    ]);
+  });
+
+  it('supports traversals of object literals of custom scalars', () => {
+    const schema = buildSchema(`
+      scalar GeoPoint
+    `);
+    const ast = parseValue('{x: 4.0, y: 2.0}');
+    const scalarType = schema.getType('GeoPoint');
+    assert(scalarType != null);
+
+    const typeInfo = new TypeInfo(schema, scalarType);
+
+    const visited: Array<any> = [];
+    visit(
+      ast,
+      visitWithTypeInfo(typeInfo, {
+        enter(node) {
+          const type = typeInfo.getInputType();
+          visited.push([
+            'enter',
+            node.kind,
+            node.kind === 'Name' ? node.value : null,
+            String(type),
+          ]);
+        },
+        leave(node) {
+          const type = typeInfo.getInputType();
+          visited.push([
+            'leave',
+            node.kind,
+            node.kind === 'Name' ? node.value : null,
+            String(type),
+          ]);
+        },
+      }),
+    );
+
+    expect(visited).to.deep.equal([
+      // Everything within ObjectValue should have type: undefined since the
+      // contents of custom scalars aren't part of GraphQL schema definitions.
+      ['enter', 'ObjectValue', null, 'GeoPoint'],
+      ['enter', 'ObjectField', null, 'undefined'],
+      ['enter', 'Name', 'x', 'undefined'],
+      ['leave', 'Name', 'x', 'undefined'],
+      ['enter', 'FloatValue', null, 'undefined'],
+      ['leave', 'FloatValue', null, 'undefined'],
+      ['leave', 'ObjectField', null, 'undefined'],
+      ['enter', 'ObjectField', null, 'undefined'],
+      ['enter', 'Name', 'y', 'undefined'],
+      ['leave', 'Name', 'y', 'undefined'],
+      ['enter', 'FloatValue', null, 'undefined'],
+      ['leave', 'FloatValue', null, 'undefined'],
+      ['leave', 'ObjectField', null, 'undefined'],
+      ['leave', 'ObjectValue', null, 'GeoPoint'],
+    ]);
+  });
+
+  it('supports traversals of list literals of custom scalars', () => {
+    const schema = buildSchema(`
+      scalar GeoPoint
+    `);
+    const ast = parseValue('[4.0, 2.0]');
+    const scalarType = schema.getType('GeoPoint');
+    assert(scalarType != null);
+
+    const typeInfo = new TypeInfo(schema, scalarType);
+
+    const visited: Array<any> = [];
+    visit(
+      ast,
+      visitWithTypeInfo(typeInfo, {
+        enter(node) {
+          const type = typeInfo.getInputType();
+          visited.push([
+            'enter',
+            node.kind,
+            node.kind === 'Name' ? node.value : null,
+            String(type),
+          ]);
+        },
+        leave(node) {
+          const type = typeInfo.getInputType();
+          visited.push([
+            'leave',
+            node.kind,
+            node.kind === 'Name' ? node.value : null,
+            String(type),
+          ]);
+        },
+      }),
+    );
+
+    expect(visited).to.deep.equal([
+      ['enter', 'ListValue', null, 'undefined'],
+      ['enter', 'FloatValue', null, 'undefined'],
+      ['leave', 'FloatValue', null, 'undefined'],
+      ['enter', 'FloatValue', null, 'undefined'],
+      ['leave', 'FloatValue', null, 'undefined'],
+      ['leave', 'ListValue', null, 'undefined'],
     ]);
   });
 

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -451,10 +451,10 @@ describe('visitWithTypeInfo', () => {
       ['enter', 'ObjectField', null, '[String]'],
       ['enter', 'Name', 'stringListField', '[String]'],
       ['leave', 'Name', 'stringListField', '[String]'],
-      ['enter', 'ListValue', null, 'String' /* the item type, not list type */],
+      ['enter', 'ListValue', null, 'String'],
       ['enter', 'StringValue', null, 'String'],
       ['leave', 'StringValue', null, 'String'],
-      ['leave', 'ListValue', null, 'String' /* the item type, not list type */],
+      ['leave', 'ListValue', null, 'String'],
       ['leave', 'ObjectField', null, '[String]'],
       ['leave', 'ObjectValue', null, 'ComplexInput'],
     ]);
@@ -519,7 +519,7 @@ describe('visitWithTypeInfo', () => {
     ]);
   });
 
-  it('supports traversals of object literals of custom scalars', () => {
+  it('supports traversals of object literals in custom scalar positions', () => {
     const schema = buildSchema(`
       scalar GeoPoint
     `);
@@ -556,7 +556,7 @@ describe('visitWithTypeInfo', () => {
 
     expect(visited).to.deep.equal([
       // Everything within ObjectValue should have type: undefined since the
-      // contents of custom scalars aren't part of GraphQL schema definitions.
+      // contents of custom scalars are not part of the GraphQL type system.
       ['enter', 'ObjectValue', null, 'GeoPoint'],
       ['enter', 'ObjectField', null, 'undefined'],
       ['enter', 'Name', 'x', 'undefined'],
@@ -574,7 +574,7 @@ describe('visitWithTypeInfo', () => {
     ]);
   });
 
-  it('supports traversals of list literals of custom scalars', () => {
+  it('supports traversals of list literals in custom scalar positions', () => {
     const schema = buildSchema(`
       scalar GeoPoint
     `);
@@ -610,6 +610,9 @@ describe('visitWithTypeInfo', () => {
     );
 
     expect(visited).to.deep.equal([
+      // Everything including ListValue should have type: undefined since the
+      // contents of custom scalars are not part of the GraphQL type system.
+      // ListValues carry the item type, so the item type is also undefined.
       ['enter', 'ListValue', null, 'undefined'],
       ['enter', 'FloatValue', null, 'undefined'],
       ['leave', 'FloatValue', null, 'undefined'],

--- a/src/utilities/__tests__/TypeInfo-test.ts
+++ b/src/utilities/__tests__/TypeInfo-test.ts
@@ -535,20 +535,24 @@ describe('visitWithTypeInfo', () => {
       visitWithTypeInfo(typeInfo, {
         enter(node) {
           const type = typeInfo.getInputType();
+          const parentType = typeInfo.getParentInputType();
           visited.push([
             'enter',
             node.kind,
             node.kind === 'Name' ? node.value : null,
             String(type),
+            String(parentType),
           ]);
         },
         leave(node) {
           const type = typeInfo.getInputType();
+          const parentType = typeInfo.getParentInputType();
           visited.push([
             'leave',
             node.kind,
             node.kind === 'Name' ? node.value : null,
             String(type),
+            String(parentType),
           ]);
         },
       }),
@@ -557,20 +561,22 @@ describe('visitWithTypeInfo', () => {
     expect(visited).to.deep.equal([
       // Everything within ObjectValue should have type: undefined since the
       // contents of custom scalars are not part of the GraphQL type system.
-      ['enter', 'ObjectValue', null, 'GeoPoint'],
-      ['enter', 'ObjectField', null, 'undefined'],
-      ['enter', 'Name', 'x', 'undefined'],
-      ['leave', 'Name', 'x', 'undefined'],
-      ['enter', 'FloatValue', null, 'undefined'],
-      ['leave', 'FloatValue', null, 'undefined'],
-      ['leave', 'ObjectField', null, 'undefined'],
-      ['enter', 'ObjectField', null, 'undefined'],
-      ['enter', 'Name', 'y', 'undefined'],
-      ['leave', 'Name', 'y', 'undefined'],
-      ['enter', 'FloatValue', null, 'undefined'],
-      ['leave', 'FloatValue', null, 'undefined'],
-      ['leave', 'ObjectField', null, 'undefined'],
-      ['leave', 'ObjectValue', null, 'GeoPoint'],
+      // getParentInputType() continues to report the closest enclosing valid
+      // input type even after traversal leaves the GraphQL input type system.
+      ['enter', 'ObjectValue', null, 'GeoPoint', 'undefined'],
+      ['enter', 'ObjectField', null, 'undefined', 'GeoPoint'],
+      ['enter', 'Name', 'x', 'undefined', 'GeoPoint'],
+      ['leave', 'Name', 'x', 'undefined', 'GeoPoint'],
+      ['enter', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'ObjectField', null, 'undefined', 'GeoPoint'],
+      ['enter', 'ObjectField', null, 'undefined', 'GeoPoint'],
+      ['enter', 'Name', 'y', 'undefined', 'GeoPoint'],
+      ['leave', 'Name', 'y', 'undefined', 'GeoPoint'],
+      ['enter', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'ObjectField', null, 'undefined', 'GeoPoint'],
+      ['leave', 'ObjectValue', null, 'GeoPoint', 'undefined'],
     ]);
   });
 
@@ -590,20 +596,24 @@ describe('visitWithTypeInfo', () => {
       visitWithTypeInfo(typeInfo, {
         enter(node) {
           const type = typeInfo.getInputType();
+          const parentType = typeInfo.getParentInputType();
           visited.push([
             'enter',
             node.kind,
             node.kind === 'Name' ? node.value : null,
             String(type),
+            String(parentType),
           ]);
         },
         leave(node) {
           const type = typeInfo.getInputType();
+          const parentType = typeInfo.getParentInputType();
           visited.push([
             'leave',
             node.kind,
             node.kind === 'Name' ? node.value : null,
             String(type),
+            String(parentType),
           ]);
         },
       }),
@@ -613,12 +623,14 @@ describe('visitWithTypeInfo', () => {
       // Everything including ListValue should have type: undefined since the
       // contents of custom scalars are not part of the GraphQL type system.
       // ListValues carry the item type, so the item type is also undefined.
-      ['enter', 'ListValue', null, 'undefined'],
-      ['enter', 'FloatValue', null, 'undefined'],
-      ['leave', 'FloatValue', null, 'undefined'],
-      ['enter', 'FloatValue', null, 'undefined'],
-      ['leave', 'FloatValue', null, 'undefined'],
-      ['leave', 'ListValue', null, 'undefined'],
+      // getParentInputType() continues to report the closest enclosing valid
+      // input type even after traversal leaves the GraphQL input type system.
+      ['enter', 'ListValue', null, 'undefined', 'GeoPoint'],
+      ['enter', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['enter', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'FloatValue', null, 'undefined', 'GeoPoint'],
+      ['leave', 'ListValue', null, 'undefined', 'GeoPoint'],
     ]);
   });
 

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -285,6 +285,8 @@ export class ValidationContext extends ASTValidationContext {
     return this._typeInfo.getInputType();
   }
 
+  // Note: continues to expose the closest enclosing valid input type if
+  // traversal descends into syntax with no corresponding GraphQL input type.
   getParentInputType(): Maybe<GraphQLInputType> {
     return this._typeInfo.getParentInputType();
   }

--- a/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
+++ b/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
@@ -533,4 +533,81 @@ describe('Validates OneOf Input Objects', () => {
       },
     ]);
   });
+
+  it('Custom scalars as arg', () => {
+    expectValid(`
+      query Query($point: GeoPoint) {
+        dog {
+          distanceFrom(loc: $point)
+        }
+      }`);
+  });
+
+  it('Forbids using custom scalar as builtin arg', () => {
+    expectErrors(`
+      query Query($point: GeoPoint) {
+        dog {
+          isAtLocation(x: $point, y: 10)
+        }
+      }
+    `).toDeepEqual([
+      {
+        locations: [
+          {
+            column: 19,
+            line: 2,
+          },
+          {
+            column: 27,
+            line: 4,
+          },
+        ],
+        message:
+          'Variable "$point" of type "GeoPoint" used in position expecting type "Int".',
+      },
+    ]);
+  });
+
+  it('Forbids using builtin scalar as custom scalar arg', () => {
+    expectErrors(`
+      query Query($x: Float) {
+        dog {
+          distanceFrom(loc: $x)
+        }
+      }
+    `).toDeepEqual([
+      {
+        locations: [
+          {
+            column: 19,
+            line: 2,
+          },
+          {
+            column: 29,
+            line: 4,
+          },
+        ],
+        message:
+          'Variable "$x" of type "Float" used in position expecting type "GeoPoint".',
+      },
+    ]);
+  });
+
+  it('Allows using variables inside object literal in custom scalar', () => {
+    expectValid(`
+      query Query($x: Float) {
+        dog {
+          distanceFrom(loc: {x: $x, y: 10.0})
+        }
+      }`);
+  });
+
+  it('Allows using variables inside list literal in custom scalar', () => {
+    expectValid(`
+      query Query($x: Float) {
+        dog {
+          distanceFrom(loc: [$x, 10.0])
+        }
+      }`);
+  });
 });

--- a/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
+++ b/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts
@@ -533,66 +533,9 @@ describe('Validates OneOf Input Objects', () => {
       },
     ]);
   });
+});
 
-  it('Custom scalars as arg', () => {
-    expectValid(`
-      query Query($point: GeoPoint) {
-        dog {
-          distanceFrom(loc: $point)
-        }
-      }`);
-  });
-
-  it('Forbids using custom scalar as builtin arg', () => {
-    expectErrors(`
-      query Query($point: GeoPoint) {
-        dog {
-          isAtLocation(x: $point, y: 10)
-        }
-      }
-    `).toDeepEqual([
-      {
-        locations: [
-          {
-            column: 19,
-            line: 2,
-          },
-          {
-            column: 27,
-            line: 4,
-          },
-        ],
-        message:
-          'Variable "$point" of type "GeoPoint" used in position expecting type "Int".',
-      },
-    ]);
-  });
-
-  it('Forbids using builtin scalar as custom scalar arg', () => {
-    expectErrors(`
-      query Query($x: Float) {
-        dog {
-          distanceFrom(loc: $x)
-        }
-      }
-    `).toDeepEqual([
-      {
-        locations: [
-          {
-            column: 19,
-            line: 2,
-          },
-          {
-            column: 29,
-            line: 4,
-          },
-        ],
-        message:
-          'Variable "$x" of type "Float" used in position expecting type "GeoPoint".',
-      },
-    ]);
-  });
-
+describe('Non-specified behavior of variables within custom scalars', () => {
   it('Allows using variables inside object literal in custom scalar', () => {
     expectValid(`
       query Query($x: Float) {

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -36,6 +36,8 @@ export const testSchema: GraphQLSchema = buildSchema(`
     DOWN
   }
 
+  scalar GeoPoint
+
   type Dog implements Pet & Mammal & Canine {
     name(surname: Boolean): String
     nickname: String
@@ -44,6 +46,7 @@ export const testSchema: GraphQLSchema = buildSchema(`
     doesKnowCommand(dogCommand: DogCommand): Boolean
     isHouseTrained(atOtherHomes: Boolean = true): Boolean
     isAtLocation(x: Int, y: Int): Boolean
+    distanceFrom(loc: GeoPoint): Float
     mother: Dog
     father: Dog
   }


### PR DESCRIPTION
Fix #4512.

Also improves test coverage of TypeInfo and the affected validation rule. See linked issue.

I've noticed an interesting existing behavior: When traversing a list literal, `TypeInfo.getInputType()` returns the list *element* type during `enter(ListValue)`. As opposed to, the list type (such as `[String]`), as some may expect. I've add a comment to document this behavior. I'm assuming we don't want to introduce a breaking change here but a maintainer can let me know if we should treat it as a bug.

The two `list literal` tests would have been broken without the fix. Other tests are added purely for extra coverage as I don't want to break things as I fix others.