### PR TITLE
refactor(execution): add separate entrypoints file

### DIFF
--- a/benchmark/introspectionFromSchema-benchmark.js
+++ b/benchmark/introspectionFromSchema-benchmark.js
@@ -1,4 +1,4 @@
-import { executeSync } from 'graphql/execution/execute.js';
+import { executeSync } from 'graphql/execution/entrypoints.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 import { getIntrospectionQuery } from 'graphql/utilities/getIntrospectionQuery.js';

--- a/benchmark/list-async-benchmark.js
+++ b/benchmark/list-async-benchmark.js
@@ -1,4 +1,4 @@
-import { execute } from 'graphql/execution/execute.js';
+import { execute } from 'graphql/execution/entrypoints.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 

--- a/benchmark/list-asyncIterable-benchmark.js
+++ b/benchmark/list-asyncIterable-benchmark.js
@@ -1,4 +1,4 @@
-import { execute } from 'graphql/execution/execute.js';
+import { execute } from 'graphql/execution/entrypoints.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 

--- a/benchmark/list-sync-benchmark.js
+++ b/benchmark/list-sync-benchmark.js
@@ -1,4 +1,4 @@
-import { execute } from 'graphql/execution/execute.js';
+import { execute } from 'graphql/execution/entrypoints.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 

--- a/src/execution/__tests__/abstract-test.ts
+++ b/src/execution/__tests__/abstract-test.ts
@@ -17,7 +17,7 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { execute, executeSync } from '../execute.js';
+import { execute, executeSync } from '../entrypoints.js';
 
 interface Context {
   async: boolean;

--- a/src/execution/__tests__/cancellation-test.ts
+++ b/src/execution/__tests__/cancellation-test.ts
@@ -16,7 +16,7 @@ import {
   execute,
   experimentalExecuteIncrementally,
   subscribe,
-} from '../execute.js';
+} from '../entrypoints.js';
 import type {
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,

--- a/src/execution/__tests__/collectFields-test.ts
+++ b/src/execution/__tests__/collectFields-test.ts
@@ -8,7 +8,7 @@ import { parse } from '../../language/parser.js';
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
 import { collectFields } from '../collectFields.js';
-import { validateExecutionArgs } from '../execute.js';
+import { validateExecutionArgs } from '../entrypoints.js';
 
 const schema = buildSchema(`
   type Query {

--- a/src/execution/__tests__/defer-test.ts
+++ b/src/execution/__tests__/defer-test.ts
@@ -18,7 +18,7 @@ import {
 import { GraphQLID, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { execute, experimentalExecuteIncrementally } from '../execute.js';
+import { execute, experimentalExecuteIncrementally } from '../entrypoints.js';
 import type {
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,

--- a/src/execution/__tests__/directives-test.ts
+++ b/src/execution/__tests__/directives-test.ts
@@ -7,7 +7,7 @@ import { GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { executeSync } from '../execute.js';
+import { executeSync } from '../entrypoints.js';
 
 const schema = new GraphQLSchema({
   query: new GraphQLObjectType({

--- a/src/execution/__tests__/errorPropagation-test.ts
+++ b/src/execution/__tests__/errorPropagation-test.ts
@@ -8,7 +8,7 @@ import { parse } from '../../language/parser.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { execute } from '../execute.js';
+import { execute } from '../entrypoints.js';
 import type { ExecutionResult } from '../types.js';
 
 const syncError = new Error('bar');

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -29,7 +29,7 @@ import {
 } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { execute, executeSync } from '../execute.js';
+import { execute, executeSync } from '../entrypoints.js';
 
 describe('Execute: Handles basic execution tasks', () => {
   it('executes arbitrary code', async () => {

--- a/src/execution/__tests__/lists-test.ts
+++ b/src/execution/__tests__/lists-test.ts
@@ -18,7 +18,7 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { execute, executeSync } from '../execute.js';
+import { execute, executeSync } from '../entrypoints.js';
 import type { ExecutionResult } from '../types.js';
 
 describe('Execute: Accepts any iterable as list value', () => {

--- a/src/execution/__tests__/mutations-test.ts
+++ b/src/execution/__tests__/mutations-test.ts
@@ -14,7 +14,7 @@ import {
   execute,
   executeSync,
   experimentalExecuteIncrementally,
-} from '../execute.js';
+} from '../entrypoints.js';
 
 class NumberHolder {
   theNumber: number;

--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -14,7 +14,7 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { execute, executeSync } from '../execute.js';
+import { execute, executeSync } from '../entrypoints.js';
 import type { ExecutionResult } from '../types.js';
 
 const syncError = new Error('sync');

--- a/src/execution/__tests__/oneof-test.ts
+++ b/src/execution/__tests__/oneof-test.ts
@@ -6,7 +6,7 @@ import { parse } from '../../language/parser.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { execute } from '../execute.js';
+import { execute } from '../entrypoints.js';
 import type { ExecutionResult } from '../types.js';
 
 const schema = buildSchema(`

--- a/src/execution/__tests__/resolve-test.ts
+++ b/src/execution/__tests__/resolve-test.ts
@@ -8,7 +8,7 @@ import { GraphQLObjectType } from '../../type/definition.js';
 import { GraphQLInt, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { executeSync } from '../execute.js';
+import { executeSync } from '../entrypoints.js';
 
 describe('Execute: resolve function', () => {
   function testSchema(testField: GraphQLFieldConfig<any, any>) {

--- a/src/execution/__tests__/schema-test.ts
+++ b/src/execution/__tests__/schema-test.ts
@@ -16,7 +16,7 @@ import {
 } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { executeSync } from '../execute.js';
+import { executeSync } from '../entrypoints.js';
 
 describe('Execute: Handles execution with a complex schema', () => {
   it('executes using a schema', () => {

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -19,7 +19,7 @@ import {
 import { GraphQLID, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { experimentalExecuteIncrementally } from '../execute.js';
+import { experimentalExecuteIncrementally } from '../entrypoints.js';
 import type {
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -20,12 +20,12 @@ import {
 } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import type { ExecutionArgs } from '../execute.js';
+import type { ExecutionArgs } from '../entrypoints.js';
 import {
   createSourceEventStream,
   executeSubscriptionEvent,
   subscribe,
-} from '../execute.js';
+} from '../entrypoints.js';
 import type { ExecutionResult } from '../types.js';
 
 import { SimplePubSub } from './simplePubSub.js';

--- a/src/execution/__tests__/sync-test.ts
+++ b/src/execution/__tests__/sync-test.ts
@@ -13,7 +13,7 @@ import { validate } from '../../validation/validate.js';
 
 import { graphqlSync } from '../../graphql.js';
 
-import { execute, executeSync } from '../execute.js';
+import { execute, executeSync } from '../entrypoints.js';
 
 describe('Execute: synchronously when possible', () => {
   const schema = new GraphQLSchema({

--- a/src/execution/__tests__/union-interface-test.ts
+++ b/src/execution/__tests__/union-interface-test.ts
@@ -14,7 +14,7 @@ import {
 import { GraphQLBoolean, GraphQLString } from '../../type/scalars.js';
 import { GraphQLSchema } from '../../type/schema.js';
 
-import { execute, executeSync } from '../execute.js';
+import { execute, executeSync } from '../entrypoints.js';
 
 class Dog {
   name: string;

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -32,7 +32,10 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { valueFromASTUntyped } from '../../utilities/valueFromASTUntyped.js';
 
-import { executeSync, experimentalExecuteIncrementally } from '../execute.js';
+import {
+  executeSync,
+  experimentalExecuteIncrementally,
+} from '../entrypoints.js';
 import { getVariableValues } from '../values.js';
 
 const TestFaultyScalarGraphQLError = new GraphQLError(

--- a/src/execution/entrypoints.ts
+++ b/src/execution/entrypoints.ts
@@ -1,0 +1,469 @@
+import { isObjectLike } from '../jsutils/isObjectLike.js';
+import { isPromise } from '../jsutils/isPromise.js';
+import type { Maybe } from '../jsutils/Maybe.js';
+import type { ObjMap } from '../jsutils/ObjMap.js';
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
+
+import { GraphQLError } from '../error/GraphQLError.js';
+import { locatedError } from '../error/locatedError.js';
+
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+} from '../language/ast.js';
+import { Kind } from '../language/kinds.js';
+
+import type {
+  GraphQLFieldResolver,
+  GraphQLTypeResolver,
+} from '../type/index.js';
+import { assertValidSchema } from '../type/index.js';
+import type { GraphQLSchema } from '../type/schema.js';
+
+import type { FragmentDetails } from './collectFields.js';
+import type { ValidatedExecutionArgs } from './execute.js';
+import {
+  createSourceEventStreamImpl,
+  experimentalExecuteQueryOrMutationOrSubscriptionEvent,
+  mapSourceToResponse,
+} from './execute.js';
+import { getVariableSignature } from './getVariableSignature.js';
+import type {
+  ExecutionResult,
+  ExperimentalIncrementalExecutionResults,
+} from './types.js';
+import { getVariableValues } from './values.js';
+
+const UNEXPECTED_EXPERIMENTAL_DIRECTIVES =
+  'The provided schema unexpectedly contains experimental directives (@defer or @stream). These directives may only be utilized if experimental execution features are explicitly enabled.';
+
+const UNEXPECTED_MULTIPLE_PAYLOADS =
+  'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)';
+
+/**
+ * Implements the "Executing requests" section of the GraphQL specification.
+ *
+ * Returns either a synchronous ExecutionResult (if all encountered resolvers
+ * are synchronous), or a Promise of an ExecutionResult that will eventually be
+ * resolved and never rejected.
+ *
+ * If the arguments to this function do not result in a legal execution context,
+ * a GraphQLError will be thrown immediately explaining the invalid input.
+ *
+ * This function does not support incremental delivery (`@defer` and `@stream`).
+ * If an operation which would defer or stream data is executed with this
+ * function, it will throw or return a rejected promise.
+ * Use `experimentalExecuteIncrementally` if you want to support incremental
+ * delivery.
+ */
+export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
+  if (args.schema.getDirective('defer') || args.schema.getDirective('stream')) {
+    throw new Error(UNEXPECTED_EXPERIMENTAL_DIRECTIVES);
+  }
+
+  const result = experimentalExecuteIncrementally(args);
+  // Multiple payloads could be encountered if the operation contains @defer or
+  // @stream directives and is not validated prior to execution
+  return ensureSinglePayload(result);
+}
+
+function ensureSinglePayload(
+  result: PromiseOrValue<
+    ExecutionResult | ExperimentalIncrementalExecutionResults
+  >,
+): PromiseOrValue<ExecutionResult> {
+  if (isPromise(result)) {
+    return result.then((resolved) => {
+      if ('initialResult' in resolved) {
+        throw new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
+      }
+      return resolved;
+    });
+  }
+  if ('initialResult' in result) {
+    throw new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
+  }
+  return result;
+}
+
+/**
+ * Implements the "Executing requests" section of the GraphQL specification,
+ * including `@defer` and `@stream` as proposed in
+ * https://github.com/graphql/graphql-spec/pull/742
+ *
+ * This function returns a Promise of an ExperimentalIncrementalExecutionResults
+ * object. This object either consists of a single ExecutionResult, or an
+ * object containing an `initialResult` and a stream of `subsequentResults`.
+ *
+ * If the arguments to this function do not result in a legal execution context,
+ * a GraphQLError will be thrown immediately explaining the invalid input.
+ */
+export function experimentalExecuteIncrementally(
+  args: ExecutionArgs,
+): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const validatedExecutionArgs = validateExecutionArgs(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in validatedExecutionArgs)) {
+    return { errors: validatedExecutionArgs };
+  }
+
+  return experimentalExecuteQueryOrMutationOrSubscriptionEvent(
+    validatedExecutionArgs,
+  );
+}
+
+/**
+ * Also implements the "Executing requests" section of the GraphQL specification.
+ * However, it guarantees to complete synchronously (or throw an error) assuming
+ * that all field resolvers are also synchronous.
+ */
+export function executeSync(args: ExecutionArgs): ExecutionResult {
+  const result = experimentalExecuteIncrementally(args);
+
+  // Assert that the execution was synchronous.
+  if (isPromise(result) || 'initialResult' in result) {
+    throw new Error('GraphQL execution failed to complete synchronously.');
+  }
+
+  return result;
+}
+
+/**
+ * Implements the "Executing operations" section of the spec.
+ *
+ * Returns a Promise that will eventually resolve to the data described by
+ * The "Response" section of the GraphQL specification.
+ *
+ * If errors are encountered while executing a GraphQL field, only that
+ * field and its descendants will be omitted, and sibling fields will still
+ * be executed. An execution which encounters errors will still result in a
+ * resolved Promise.
+ *
+ * Errors from sub-fields of a NonNull type may propagate to the top level,
+ * at which point we still log the error and null the parent field, which
+ * in this case is the entire response.
+ */
+export function executeQueryOrMutationOrSubscriptionEvent(
+  validatedExecutionArgs: ValidatedExecutionArgs,
+): PromiseOrValue<ExecutionResult> {
+  const result = experimentalExecuteQueryOrMutationOrSubscriptionEvent(
+    validatedExecutionArgs,
+  );
+  return ensureSinglePayload(result);
+}
+
+export function executeSubscriptionEvent(
+  validatedExecutionArgs: ValidatedExecutionArgs,
+): PromiseOrValue<ExecutionResult> {
+  return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
+}
+
+/**
+ * Implements the "Subscribe" algorithm described in the GraphQL specification.
+ *
+ * Returns a Promise which resolves to either an AsyncIterator (if successful)
+ * or an ExecutionResult (error). The promise will be rejected if the schema or
+ * other arguments to this function are invalid, or if the resolved event stream
+ * is not an async iterable.
+ *
+ * If the client-provided arguments to this function do not result in a
+ * compliant subscription, a GraphQL Response (ExecutionResult) with descriptive
+ * errors and no data will be returned.
+ *
+ * If the source stream could not be created due to faulty subscription resolver
+ * logic or underlying systems, the promise will resolve to a single
+ * ExecutionResult containing `errors` and no `data`.
+ *
+ * If the operation succeeded, the promise resolves to an AsyncIterator, which
+ * yields a stream of ExecutionResults representing the response stream.
+ *
+ * This function does not support incremental delivery (`@defer` and `@stream`).
+ * If an operation which would defer or stream data is executed with this
+ * function, a field error will be raised at the location of the `@defer` or
+ * `@stream` directive.
+ *
+ * Accepts an object with named arguments.
+ */
+export function subscribe(
+  args: ExecutionArgs,
+): PromiseOrValue<
+  AsyncGenerator<ExecutionResult, void, void> | ExecutionResult
+> {
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const validatedExecutionArgs = validateExecutionArgs(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in validatedExecutionArgs)) {
+    return { errors: validatedExecutionArgs };
+  }
+
+  const resultOrStream = createSourceEventStreamImpl(validatedExecutionArgs);
+
+  if (isPromise(resultOrStream)) {
+    return resultOrStream.then((resolvedResultOrStream) =>
+      mapSourceToResponse(validatedExecutionArgs, resolvedResultOrStream),
+    );
+  }
+
+  return mapSourceToResponse(validatedExecutionArgs, resultOrStream);
+}
+
+/**
+ * Implements the "CreateSourceEventStream" algorithm described in the
+ * GraphQL specification, resolving the subscription source event stream.
+ *
+ * Returns a Promise which resolves to either an AsyncIterable (if successful)
+ * or an ExecutionResult (error). The promise will be rejected if the schema or
+ * other arguments to this function are invalid, or if the resolved event stream
+ * is not an async iterable.
+ *
+ * If the client-provided arguments to this function do not result in a
+ * compliant subscription, a GraphQL Response (ExecutionResult) with
+ * descriptive errors and no data will be returned.
+ *
+ * If the the source stream could not be created due to faulty subscription
+ * resolver logic or underlying systems, the promise will resolve to a single
+ * ExecutionResult containing `errors` and no `data`.
+ *
+ * If the operation succeeded, the promise resolves to the AsyncIterable for the
+ * event stream returned by the resolver.
+ *
+ * A Source Event Stream represents a sequence of events, each of which triggers
+ * a GraphQL execution for that event.
+ *
+ * This may be useful when hosting the stateful subscription service in a
+ * different process or machine than the stateless GraphQL execution engine,
+ * or otherwise separating these two steps. For more on this, see the
+ * "Supporting Subscriptions at Scale" information in the GraphQL specification.
+ */
+export function createSourceEventStream(
+  args: ExecutionArgs,
+): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const validatedExecutionArgs = validateExecutionArgs(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in validatedExecutionArgs)) {
+    return { errors: validatedExecutionArgs };
+  }
+
+  return createSourceEventStreamImpl(validatedExecutionArgs);
+}
+
+export interface ExecutionArgs {
+  schema: GraphQLSchema;
+  document: DocumentNode;
+  rootValue?: unknown;
+  contextValue?: unknown;
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+  operationName?: Maybe<string>;
+  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  perEventExecutor?: Maybe<
+    (
+      validatedExecutionArgs: ValidatedExecutionArgs,
+    ) => PromiseOrValue<ExecutionResult>
+  >;
+  enableEarlyExecution?: Maybe<boolean>;
+  hideSuggestions?: Maybe<boolean>;
+  abortSignal?: Maybe<AbortSignal>;
+  /** Additional execution options. */
+  options?: {
+    /** Set the maximum number of errors allowed for coercing (defaults to 50). */
+    maxCoercionErrors?: number;
+  };
+}
+
+/**
+ * Constructs a ExecutionContext object from the arguments passed to
+ * execute, which we will pass throughout the other execution methods.
+ *
+ * Throws a GraphQLError if a valid execution context cannot be created.
+ *
+ * TODO: consider no longer exporting this function
+ * @internal
+ */
+export function validateExecutionArgs(
+  args: ExecutionArgs,
+): ReadonlyArray<GraphQLError> | ValidatedExecutionArgs {
+  const {
+    schema,
+    document,
+    rootValue,
+    contextValue,
+    variableValues: rawVariableValues,
+    operationName,
+    fieldResolver,
+    typeResolver,
+    subscribeFieldResolver,
+    perEventExecutor,
+    enableEarlyExecution,
+    abortSignal,
+    options,
+  } = args;
+
+  if (abortSignal?.aborted) {
+    return [locatedError(abortSignal.reason, undefined)];
+  }
+
+  // If the schema used for execution is invalid, throw an error.
+  assertValidSchema(schema);
+
+  let operation: OperationDefinitionNode | undefined;
+  const fragmentDefinitions: ObjMap<FragmentDefinitionNode> =
+    Object.create(null);
+  const fragments: ObjMap<FragmentDetails> = Object.create(null);
+  for (const definition of document.definitions) {
+    switch (definition.kind) {
+      case Kind.OPERATION_DEFINITION:
+        if (operationName == null) {
+          if (operation !== undefined) {
+            return [
+              new GraphQLError(
+                'Must provide operation name if query contains multiple operations.',
+              ),
+            ];
+          }
+          operation = definition;
+        } else if (definition.name?.value === operationName) {
+          operation = definition;
+        }
+        break;
+      case Kind.FRAGMENT_DEFINITION: {
+        fragmentDefinitions[definition.name.value] = definition;
+        let variableSignatures;
+        if (definition.variableDefinitions) {
+          variableSignatures = Object.create(null);
+          for (const varDef of definition.variableDefinitions) {
+            const signature = getVariableSignature(schema, varDef);
+            variableSignatures[signature.name] = signature;
+          }
+        }
+        fragments[definition.name.value] = { definition, variableSignatures };
+        break;
+      }
+      default:
+      // ignore non-executable definitions
+    }
+  }
+
+  if (!operation) {
+    if (operationName != null) {
+      return [new GraphQLError(`Unknown operation named "${operationName}".`)];
+    }
+    return [new GraphQLError('Must provide an operation.')];
+  }
+
+  const variableDefinitions = operation.variableDefinitions ?? [];
+  const hideSuggestions = args.hideSuggestions ?? false;
+
+  const variableValuesOrErrors = getVariableValues(
+    schema,
+    variableDefinitions,
+    rawVariableValues ?? {},
+    {
+      maxErrors: options?.maxCoercionErrors ?? 50,
+      hideSuggestions,
+    },
+  );
+
+  if (variableValuesOrErrors.errors) {
+    return variableValuesOrErrors.errors;
+  }
+
+  return {
+    schema,
+    fragmentDefinitions,
+    fragments,
+    rootValue,
+    contextValue,
+    operation,
+    variableValues: variableValuesOrErrors.variableValues,
+    fieldResolver: fieldResolver ?? defaultFieldResolver,
+    typeResolver: typeResolver ?? defaultTypeResolver,
+    subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
+    perEventExecutor: perEventExecutor ?? executeSubscriptionEvent,
+    enableEarlyExecution: enableEarlyExecution === true,
+    hideSuggestions,
+    abortSignal: args.abortSignal ?? undefined,
+  };
+}
+
+/**
+ * If a resolveType function is not given, then a default resolve behavior is
+ * used which attempts two strategies:
+ *
+ * First, See if the provided value has a `__typename` field defined, if so, use
+ * that value as name of the resolved type.
+ *
+ * Otherwise, test each possible type for the abstract type by calling
+ * isTypeOf for the object being coerced, returning the first type that matches.
+ */
+export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
+  function (value, contextValue, info, abstractType) {
+    // First, look for `__typename`.
+    if (isObjectLike(value) && typeof value.__typename === 'string') {
+      return value.__typename;
+    }
+
+    // Otherwise, test each possible type.
+    const possibleTypes = info.schema.getPossibleTypes(abstractType);
+    const promisedIsTypeOfResults = [];
+
+    for (let i = 0; i < possibleTypes.length; i++) {
+      const type = possibleTypes[i];
+
+      if (type.isTypeOf) {
+        const isTypeOfResult = type.isTypeOf(value, contextValue, info);
+
+        if (isPromise(isTypeOfResult)) {
+          promisedIsTypeOfResults[i] = isTypeOfResult;
+        } else if (isTypeOfResult) {
+          if (promisedIsTypeOfResults.length) {
+            // Explicitly ignore any promise rejections
+            Promise.allSettled(promisedIsTypeOfResults)
+              /* c8 ignore next 3 */
+              .catch(() => {
+                // Do nothing
+              });
+          }
+          return type.name;
+        }
+      }
+    }
+
+    if (promisedIsTypeOfResults.length) {
+      return Promise.all(promisedIsTypeOfResults).then((isTypeOfResults) => {
+        for (let i = 0; i < isTypeOfResults.length; i++) {
+          if (isTypeOfResults[i]) {
+            return possibleTypes[i].name;
+          }
+        }
+      });
+    }
+  };
+
+/**
+ * If a resolve function is not given, then a default resolve behavior is used
+ * which takes the property of the source object of the same name as the field
+ * and returns it as the result, or if it's a function, returns the result
+ * of calling that function while passing along args and context value.
+ */
+export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
+  function (source: any, args, contextValue, info) {
+    // ensure source is a value for which property access is acceptable.
+    if (isObjectLike(source) || typeof source === 'function') {
+      const property = source[info.fieldName];
+      if (typeof property === 'function') {
+        return source[info.fieldName](args, contextValue, info);
+      }
+      return property;
+    }
+  };

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -3,9 +3,7 @@ import { inspect } from '../jsutils/inspect.js';
 import { invariant } from '../jsutils/invariant.js';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable.js';
 import { isIterableObject } from '../jsutils/isIterableObject.js';
-import { isObjectLike } from '../jsutils/isObjectLike.js';
 import { isPromise } from '../jsutils/isPromise.js';
-import type { Maybe } from '../jsutils/Maybe.js';
 import { memoize3 } from '../jsutils/memoize3.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
 import type { Path } from '../jsutils/Path.js';
@@ -18,13 +16,11 @@ import { GraphQLError } from '../error/GraphQLError.js';
 import { locatedError } from '../error/locatedError.js';
 
 import type {
-  DocumentNode,
   FieldNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
 } from '../language/ast.js';
 import { OperationTypeNode } from '../language/ast.js';
-import { Kind } from '../language/kinds.js';
 
 import type {
   GraphQLAbstractType,
@@ -49,7 +45,6 @@ import {
   GraphQLStreamDirective,
 } from '../type/directives.js';
 import type { GraphQLSchema } from '../type/schema.js';
-import { assertValidSchema } from '../type/validate.js';
 
 import {
   AbortSignalListener,
@@ -68,7 +63,6 @@ import {
   collectFields,
   collectSubfields as _collectSubfields,
 } from './collectFields.js';
-import { getVariableSignature } from './getVariableSignature.js';
 import { buildIncrementalResponse } from './IncrementalPublisher.js';
 import { mapAsyncIterable } from './mapAsyncIterable.js';
 import type {
@@ -83,11 +77,7 @@ import type {
 } from './types.js';
 import { DeferredFragmentRecord } from './types.js';
 import type { VariableValues } from './values.js';
-import {
-  getArgumentValues,
-  getDirectiveValues,
-  getVariableValues,
-} from './values.js';
+import { getArgumentValues, getDirectiveValues } from './values.js';
 import { withConcurrentAbruptClose } from './withConcurrentAbruptClose.js';
 
 /* eslint-disable max-params */
@@ -181,31 +171,6 @@ interface IncrementalContext {
   deferUsageSet?: DeferUsageSet | undefined;
 }
 
-export interface ExecutionArgs {
-  schema: GraphQLSchema;
-  document: DocumentNode;
-  rootValue?: unknown;
-  contextValue?: unknown;
-  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
-  operationName?: Maybe<string>;
-  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
-  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  perEventExecutor?: Maybe<
-    (
-      validatedExecutionArgs: ValidatedExecutionArgs,
-    ) => PromiseOrValue<ExecutionResult>
-  >;
-  enableEarlyExecution?: Maybe<boolean>;
-  hideSuggestions?: Maybe<boolean>;
-  abortSignal?: Maybe<AbortSignal>;
-  /** Additional execution options. */
-  options?: {
-    /** Set the maximum number of errors allowed for coercing (defaults to 50). */
-    maxCoercionErrors?: number;
-  };
-}
-
 export interface StreamUsage {
   label: string | undefined;
   initialCount: number;
@@ -216,111 +181,6 @@ interface GraphQLWrappedResult<T> {
   rawResult: T;
   newDeferredFragmentRecords: Array<DeferredFragmentRecord> | undefined;
   incrementalDataRecords: Array<IncrementalDataRecord> | undefined;
-}
-
-const UNEXPECTED_EXPERIMENTAL_DIRECTIVES =
-  'The provided schema unexpectedly contains experimental directives (@defer or @stream). These directives may only be utilized if experimental execution features are explicitly enabled.';
-
-const UNEXPECTED_MULTIPLE_PAYLOADS =
-  'Executing this GraphQL operation would unexpectedly produce multiple payloads (due to @defer or @stream directive)';
-
-/**
- * Implements the "Executing requests" section of the GraphQL specification.
- *
- * Returns either a synchronous ExecutionResult (if all encountered resolvers
- * are synchronous), or a Promise of an ExecutionResult that will eventually be
- * resolved and never rejected.
- *
- * If the arguments to this function do not result in a legal execution context,
- * a GraphQLError will be thrown immediately explaining the invalid input.
- *
- * This function does not support incremental delivery (`@defer` and `@stream`).
- * If an operation which would defer or stream data is executed with this
- * function, it will throw or return a rejected promise.
- * Use `experimentalExecuteIncrementally` if you want to support incremental
- * delivery.
- */
-export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  if (args.schema.getDirective('defer') || args.schema.getDirective('stream')) {
-    throw new Error(UNEXPECTED_EXPERIMENTAL_DIRECTIVES);
-  }
-
-  const result = experimentalExecuteIncrementally(args);
-  // Multiple payloads could be encountered if the operation contains @defer or
-  // @stream directives and is not validated prior to execution
-  return ensureSinglePayload(result);
-}
-
-function ensureSinglePayload(
-  result: PromiseOrValue<
-    ExecutionResult | ExperimentalIncrementalExecutionResults
-  >,
-): PromiseOrValue<ExecutionResult> {
-  if (isPromise(result)) {
-    return result.then((resolved) => {
-      if ('initialResult' in resolved) {
-        throw new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
-      }
-      return resolved;
-    });
-  }
-  if ('initialResult' in result) {
-    throw new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
-  }
-  return result;
-}
-
-/**
- * Implements the "Executing requests" section of the GraphQL specification,
- * including `@defer` and `@stream` as proposed in
- * https://github.com/graphql/graphql-spec/pull/742
- *
- * This function returns a Promise of an ExperimentalIncrementalExecutionResults
- * object. This object either consists of a single ExecutionResult, or an
- * object containing an `initialResult` and a stream of `subsequentResults`.
- *
- * If the arguments to this function do not result in a legal execution context,
- * a GraphQLError will be thrown immediately explaining the invalid input.
- */
-export function experimentalExecuteIncrementally(
-  args: ExecutionArgs,
-): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
-  // If a valid execution context cannot be created due to incorrect arguments,
-  // a "Response" with only errors is returned.
-  const validatedExecutionArgs = validateExecutionArgs(args);
-
-  // Return early errors if execution context failed.
-  if (!('schema' in validatedExecutionArgs)) {
-    return { errors: validatedExecutionArgs };
-  }
-
-  return experimentalExecuteQueryOrMutationOrSubscriptionEvent(
-    validatedExecutionArgs,
-  );
-}
-
-/**
- * Implements the "Executing operations" section of the spec.
- *
- * Returns a Promise that will eventually resolve to the data described by
- * The "Response" section of the GraphQL specification.
- *
- * If errors are encountered while executing a GraphQL field, only that
- * field and its descendants will be omitted, and sibling fields will still
- * be executed. An execution which encounters errors will still result in a
- * resolved Promise.
- *
- * Errors from sub-fields of a NonNull type may propagate to the top level,
- * at which point we still log the error and null the parent field, which
- * in this case is the entire response.
- */
-export function executeQueryOrMutationOrSubscriptionEvent(
-  validatedExecutionArgs: ValidatedExecutionArgs,
-): PromiseOrValue<ExecutionResult> {
-  const result = experimentalExecuteQueryOrMutationOrSubscriptionEvent(
-    validatedExecutionArgs,
-  );
-  return ensureSinglePayload(result);
 }
 
 function errorPropagation(operation: OperationDefinitionNode): boolean {
@@ -434,137 +294,6 @@ function buildDataResponse(
     (exeContext.earlyReturns ??= new Map()),
     exeContext.abortSignalListener,
   );
-}
-
-/**
- * Also implements the "Executing requests" section of the GraphQL specification.
- * However, it guarantees to complete synchronously (or throw an error) assuming
- * that all field resolvers are also synchronous.
- */
-export function executeSync(args: ExecutionArgs): ExecutionResult {
-  const result = experimentalExecuteIncrementally(args);
-
-  // Assert that the execution was synchronous.
-  if (isPromise(result) || 'initialResult' in result) {
-    throw new Error('GraphQL execution failed to complete synchronously.');
-  }
-
-  return result;
-}
-
-/**
- * Constructs a ExecutionContext object from the arguments passed to
- * execute, which we will pass throughout the other execution methods.
- *
- * Throws a GraphQLError if a valid execution context cannot be created.
- *
- * TODO: consider no longer exporting this function
- * @internal
- */
-export function validateExecutionArgs(
-  args: ExecutionArgs,
-): ReadonlyArray<GraphQLError> | ValidatedExecutionArgs {
-  const {
-    schema,
-    document,
-    rootValue,
-    contextValue,
-    variableValues: rawVariableValues,
-    operationName,
-    fieldResolver,
-    typeResolver,
-    subscribeFieldResolver,
-    perEventExecutor,
-    enableEarlyExecution,
-    abortSignal,
-    options,
-  } = args;
-
-  if (abortSignal?.aborted) {
-    return [locatedError(abortSignal.reason, undefined)];
-  }
-
-  // If the schema used for execution is invalid, throw an error.
-  assertValidSchema(schema);
-
-  let operation: OperationDefinitionNode | undefined;
-  const fragmentDefinitions: ObjMap<FragmentDefinitionNode> =
-    Object.create(null);
-  const fragments: ObjMap<FragmentDetails> = Object.create(null);
-  for (const definition of document.definitions) {
-    switch (definition.kind) {
-      case Kind.OPERATION_DEFINITION:
-        if (operationName == null) {
-          if (operation !== undefined) {
-            return [
-              new GraphQLError(
-                'Must provide operation name if query contains multiple operations.',
-              ),
-            ];
-          }
-          operation = definition;
-        } else if (definition.name?.value === operationName) {
-          operation = definition;
-        }
-        break;
-      case Kind.FRAGMENT_DEFINITION: {
-        fragmentDefinitions[definition.name.value] = definition;
-        let variableSignatures;
-        if (definition.variableDefinitions) {
-          variableSignatures = Object.create(null);
-          for (const varDef of definition.variableDefinitions) {
-            const signature = getVariableSignature(schema, varDef);
-            variableSignatures[signature.name] = signature;
-          }
-        }
-        fragments[definition.name.value] = { definition, variableSignatures };
-        break;
-      }
-      default:
-      // ignore non-executable definitions
-    }
-  }
-
-  if (!operation) {
-    if (operationName != null) {
-      return [new GraphQLError(`Unknown operation named "${operationName}".`)];
-    }
-    return [new GraphQLError('Must provide an operation.')];
-  }
-
-  const variableDefinitions = operation.variableDefinitions ?? [];
-  const hideSuggestions = args.hideSuggestions ?? false;
-
-  const variableValuesOrErrors = getVariableValues(
-    schema,
-    variableDefinitions,
-    rawVariableValues ?? {},
-    {
-      maxErrors: options?.maxCoercionErrors ?? 50,
-      hideSuggestions,
-    },
-  );
-
-  if (variableValuesOrErrors.errors) {
-    return variableValuesOrErrors.errors;
-  }
-
-  return {
-    schema,
-    fragmentDefinitions,
-    fragments,
-    rootValue,
-    contextValue,
-    operation,
-    variableValues: variableValuesOrErrors.variableValues,
-    fieldResolver: fieldResolver ?? defaultFieldResolver,
-    typeResolver: typeResolver ?? defaultTypeResolver,
-    subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
-    perEventExecutor: perEventExecutor ?? executeSubscriptionEvent,
-    enableEarlyExecution: enableEarlyExecution === true,
-    hideSuggestions,
-    abortSignal: args.abortSignal ?? undefined,
-  };
 }
 
 function executeRootExecutionPlan(
@@ -2115,130 +1844,7 @@ function buildSubExecutionPlan(
   return executionPlan;
 }
 
-/**
- * If a resolveType function is not given, then a default resolve behavior is
- * used which attempts two strategies:
- *
- * First, See if the provided value has a `__typename` field defined, if so, use
- * that value as name of the resolved type.
- *
- * Otherwise, test each possible type for the abstract type by calling
- * isTypeOf for the object being coerced, returning the first type that matches.
- */
-export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
-  function (value, contextValue, info, abstractType) {
-    // First, look for `__typename`.
-    if (isObjectLike(value) && typeof value.__typename === 'string') {
-      return value.__typename;
-    }
-
-    // Otherwise, test each possible type.
-    const possibleTypes = info.schema.getPossibleTypes(abstractType);
-    const promisedIsTypeOfResults = [];
-
-    for (let i = 0; i < possibleTypes.length; i++) {
-      const type = possibleTypes[i];
-
-      if (type.isTypeOf) {
-        const isTypeOfResult = type.isTypeOf(value, contextValue, info);
-
-        if (isPromise(isTypeOfResult)) {
-          promisedIsTypeOfResults[i] = isTypeOfResult;
-        } else if (isTypeOfResult) {
-          if (promisedIsTypeOfResults.length) {
-            // Explicitly ignore any promise rejections
-            Promise.allSettled(promisedIsTypeOfResults)
-              /* c8 ignore next 3 */
-              .catch(() => {
-                // Do nothing
-              });
-          }
-          return type.name;
-        }
-      }
-    }
-
-    if (promisedIsTypeOfResults.length) {
-      return Promise.all(promisedIsTypeOfResults).then((isTypeOfResults) => {
-        for (let i = 0; i < isTypeOfResults.length; i++) {
-          if (isTypeOfResults[i]) {
-            return possibleTypes[i].name;
-          }
-        }
-      });
-    }
-  };
-
-/**
- * If a resolve function is not given, then a default resolve behavior is used
- * which takes the property of the source object of the same name as the field
- * and returns it as the result, or if it's a function, returns the result
- * of calling that function while passing along args and context value.
- */
-export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
-  function (source: any, args, contextValue, info) {
-    // ensure source is a value for which property access is acceptable.
-    if (isObjectLike(source) || typeof source === 'function') {
-      const property = source[info.fieldName];
-      if (typeof property === 'function') {
-        return source[info.fieldName](args, contextValue, info);
-      }
-      return property;
-    }
-  };
-
-/**
- * Implements the "Subscribe" algorithm described in the GraphQL specification.
- *
- * Returns a Promise which resolves to either an AsyncIterator (if successful)
- * or an ExecutionResult (error). The promise will be rejected if the schema or
- * other arguments to this function are invalid, or if the resolved event stream
- * is not an async iterable.
- *
- * If the client-provided arguments to this function do not result in a
- * compliant subscription, a GraphQL Response (ExecutionResult) with descriptive
- * errors and no data will be returned.
- *
- * If the source stream could not be created due to faulty subscription resolver
- * logic or underlying systems, the promise will resolve to a single
- * ExecutionResult containing `errors` and no `data`.
- *
- * If the operation succeeded, the promise resolves to an AsyncIterator, which
- * yields a stream of ExecutionResults representing the response stream.
- *
- * This function does not support incremental delivery (`@defer` and `@stream`).
- * If an operation which would defer or stream data is executed with this
- * function, a field error will be raised at the location of the `@defer` or
- * `@stream` directive.
- *
- * Accepts an object with named arguments.
- */
-export function subscribe(
-  args: ExecutionArgs,
-): PromiseOrValue<
-  AsyncGenerator<ExecutionResult, void, void> | ExecutionResult
-> {
-  // If a valid execution context cannot be created due to incorrect arguments,
-  // a "Response" with only errors is returned.
-  const validatedExecutionArgs = validateExecutionArgs(args);
-
-  // Return early errors if execution context failed.
-  if (!('schema' in validatedExecutionArgs)) {
-    return { errors: validatedExecutionArgs };
-  }
-
-  const resultOrStream = createSourceEventStreamImpl(validatedExecutionArgs);
-
-  if (isPromise(resultOrStream)) {
-    return resultOrStream.then((resolvedResultOrStream) =>
-      mapSourceToResponse(validatedExecutionArgs, resolvedResultOrStream),
-    );
-  }
-
-  return mapSourceToResponse(validatedExecutionArgs, resultOrStream);
-}
-
-function mapSourceToResponse(
+export function mapSourceToResponse(
   validatedExecutionArgs: ValidatedExecutionArgs,
   resultOrStream: ExecutionResult | AsyncIterable<unknown>,
 ): AsyncGenerator<ExecutionResult, void, void> | ExecutionResult {
@@ -2274,56 +1880,7 @@ function mapSourceToResponse(
     : mapAsyncIterable(resultOrStream, mapFn);
 }
 
-export function executeSubscriptionEvent(
-  validatedExecutionArgs: ValidatedExecutionArgs,
-): PromiseOrValue<ExecutionResult> {
-  return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
-}
-
-/**
- * Implements the "CreateSourceEventStream" algorithm described in the
- * GraphQL specification, resolving the subscription source event stream.
- *
- * Returns a Promise which resolves to either an AsyncIterable (if successful)
- * or an ExecutionResult (error). The promise will be rejected if the schema or
- * other arguments to this function are invalid, or if the resolved event stream
- * is not an async iterable.
- *
- * If the client-provided arguments to this function do not result in a
- * compliant subscription, a GraphQL Response (ExecutionResult) with
- * descriptive errors and no data will be returned.
- *
- * If the the source stream could not be created due to faulty subscription
- * resolver logic or underlying systems, the promise will resolve to a single
- * ExecutionResult containing `errors` and no `data`.
- *
- * If the operation succeeded, the promise resolves to the AsyncIterable for the
- * event stream returned by the resolver.
- *
- * A Source Event Stream represents a sequence of events, each of which triggers
- * a GraphQL execution for that event.
- *
- * This may be useful when hosting the stateful subscription service in a
- * different process or machine than the stateless GraphQL execution engine,
- * or otherwise separating these two steps. For more on this, see the
- * "Supporting Subscriptions at Scale" information in the GraphQL specification.
- */
-export function createSourceEventStream(
-  args: ExecutionArgs,
-): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
-  // If a valid execution context cannot be created due to incorrect arguments,
-  // a "Response" with only errors is returned.
-  const validatedExecutionArgs = validateExecutionArgs(args);
-
-  // Return early errors if execution context failed.
-  if (!('schema' in validatedExecutionArgs)) {
-    return { errors: validatedExecutionArgs };
-  }
-
-  return createSourceEventStreamImpl(validatedExecutionArgs);
-}
-
-function createSourceEventStreamImpl(
+export function createSourceEventStreamImpl(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
   try {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -1,19 +1,20 @@
 export { pathToArray as responsePathAsArray } from '../jsutils/Path.js';
 
+export { experimentalExecuteQueryOrMutationOrSubscriptionEvent } from './execute.js';
+export type { ValidatedExecutionArgs } from './execute.js';
+
 export {
   createSourceEventStream,
   execute,
   executeQueryOrMutationOrSubscriptionEvent,
   executeSubscriptionEvent,
   experimentalExecuteIncrementally,
-  experimentalExecuteQueryOrMutationOrSubscriptionEvent,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,
-} from './execute.js';
-
-export type { ExecutionArgs, ValidatedExecutionArgs } from './execute.js';
+} from './entrypoints.js';
+export type { ExecutionArgs } from './entrypoints.js';
 
 export type {
   ExecutionResult,

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -14,7 +14,7 @@ import { validateSchema } from './type/validate.js';
 
 import { validate } from './validation/validate.js';
 
-import { execute } from './execution/execute.js';
+import { execute } from './execution/entrypoints.js';
 import type { ExecutionResult } from './execution/types.js';
 
 /**

--- a/src/utilities/introspectionFromSchema.ts
+++ b/src/utilities/introspectionFromSchema.ts
@@ -4,7 +4,7 @@ import { parse } from '../language/parser.js';
 
 import type { GraphQLSchema } from '../type/schema.js';
 
-import { executeSync } from '../execution/execute.js';
+import { executeSync } from '../execution/entrypoints.js';
 
 import type {
   IntrospectionOptions,


### PR DESCRIPTION
cleans up our long execute file (a bit)

it's potentially a breaking change if these entrypoints were being imported directly; we will clean that up later by renaming execute.ts to something else and renaming entrypoints.ts to execute.ts, but removing the entrypoints first will hopefully allow us to preserve more history.

UPDATE: #4539 renames it back, finishing up the effort to break up the file without losing so much of the history, no longer a breaking change.