### PR TITLE
refactor buildResolveInfo into a lazy class

### DIFF
--- a/src/execution/ResolveInfo.ts
+++ b/src/execution/ResolveInfo.ts
@@ -1,0 +1,114 @@
+import type { ObjMap } from '../jsutils/ObjMap.js';
+import type { Path } from '../jsutils/Path.js';
+
+import type {
+  FieldNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+} from '../language/ast.js';
+
+import type {
+  GraphQLField,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLResolveInfo,
+  GraphQLSchema,
+} from '../type/index.js';
+
+import type { FieldDetailsList } from './collectFields.js';
+import type { ValidatedExecutionArgs } from './execute.js';
+import type { VariableValues } from './values.js';
+
+/** @internal */
+export class ResolveInfo implements GraphQLResolveInfo {
+  private _validatedExecutionArgs: ValidatedExecutionArgs;
+  private _fieldDef: GraphQLField<unknown, unknown>;
+  private _fieldDetailsList: FieldDetailsList;
+  private _parentType: GraphQLObjectType;
+  private _path: Path;
+  private _abortSignal: AbortSignal | undefined;
+
+  private _fieldName: string | undefined;
+  private _fieldNodes: ReadonlyArray<FieldNode> | undefined;
+  private _returnType: GraphQLOutputType | undefined;
+  private _schema: GraphQLSchema | undefined;
+  private _fragments: ObjMap<FragmentDefinitionNode> | undefined;
+  private _rootValue: unknown;
+  private _rootValueDefined?: boolean;
+  private _operation: OperationDefinitionNode | undefined;
+  private _variableValues: VariableValues | undefined;
+
+  // eslint-disable-next-line max-params
+  constructor(
+    validatedExecutionArgs: ValidatedExecutionArgs,
+    fieldDef: GraphQLField<unknown, unknown>,
+    fieldDetailsList: FieldDetailsList,
+    parentType: GraphQLObjectType,
+    path: Path,
+    abortSignal: AbortSignal | undefined,
+  ) {
+    this._validatedExecutionArgs = validatedExecutionArgs;
+    this._fieldDef = fieldDef;
+    this._fieldDetailsList = fieldDetailsList;
+    this._parentType = parentType;
+    this._path = path;
+    this._abortSignal = abortSignal;
+  }
+
+  get fieldName(): string {
+    this._fieldName ??= this._fieldDef.name;
+    return this._fieldName;
+  }
+
+  get fieldNodes(): ReadonlyArray<FieldNode> {
+    this._fieldNodes ??= this._fieldDetailsList.map(
+      (fieldDetails) => fieldDetails.node,
+    );
+    return this._fieldNodes;
+  }
+
+  get returnType(): GraphQLOutputType {
+    this._returnType ??= this._fieldDef.type;
+    return this._returnType;
+  }
+
+  get parentType(): GraphQLObjectType {
+    return this._parentType;
+  }
+
+  get path(): Path {
+    return this._path;
+  }
+
+  get schema(): GraphQLSchema {
+    this._schema ??= this._validatedExecutionArgs.schema;
+    return this._schema;
+  }
+
+  get fragments(): ObjMap<FragmentDefinitionNode> {
+    this._fragments ??= this._validatedExecutionArgs.fragmentDefinitions;
+    return this._fragments;
+  }
+
+  get rootValue(): unknown {
+    if (!this._rootValueDefined) {
+      this._rootValueDefined = true;
+      this._rootValue = this._validatedExecutionArgs.rootValue;
+    }
+    return this._rootValue;
+  }
+
+  get operation(): OperationDefinitionNode {
+    this._operation ??= this._validatedExecutionArgs.operation;
+    return this._operation;
+  }
+
+  get variableValues(): VariableValues {
+    this._variableValues ??= this._validatedExecutionArgs.variableValues;
+    return this._variableValues;
+  }
+
+  get abortSignal(): AbortSignal | undefined {
+    return this._abortSignal;
+  }
+}

--- a/src/execution/__tests__/ResolveInfo-test.ts
+++ b/src/execution/__tests__/ResolveInfo-test.ts
@@ -1,0 +1,111 @@
+import { assert, expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { parse } from '../../language/parser.js';
+
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLString,
+} from '../../type/index.js';
+
+import { collectFields } from '../collectFields.js';
+import { validateExecutionArgs } from '../entrypoints.js';
+import { ResolveInfo } from '../ResolveInfo.js';
+
+describe('ResolveInfo', () => {
+  const query = new GraphQLObjectType({
+    name: 'Query',
+    fields: { test: { type: GraphQLString } },
+  });
+
+  const abortController = new AbortController();
+  const abortSignal = abortController.signal;
+
+  const validatedExecutionArgs = validateExecutionArgs({
+    schema: new GraphQLSchema({ query }),
+    document: parse(`{ test }`),
+    rootValue: { test: 'root' },
+    abortSignal,
+  });
+
+  assert('schema' in validatedExecutionArgs);
+
+  const { schema, fragments, rootValue, operation, variableValues } =
+    validatedExecutionArgs;
+
+  const collectedFields = collectFields(
+    schema,
+    fragments,
+    variableValues,
+    query,
+    operation.selectionSet,
+    false,
+  );
+
+  const fieldDetailsList = collectedFields.groupedFieldSet.get('test');
+
+  assert(fieldDetailsList != null);
+
+  const path = { key: 'test', prev: undefined, typename: 'Query' };
+  const resolveInfo = new ResolveInfo(
+    validatedExecutionArgs,
+    query.getFields().test,
+    fieldDetailsList,
+    query,
+    path,
+    abortSignal,
+  );
+
+  it('exposes fieldName', () => {
+    expect(resolveInfo.fieldName).to.equal('test');
+  });
+
+  it('exposes fieldNodes', () => {
+    const retrievedFieldNodes = resolveInfo.fieldNodes;
+    expect(retrievedFieldNodes).to.deep.equal(
+      fieldDetailsList.map((fieldDetails) => fieldDetails.node),
+    );
+    expect(retrievedFieldNodes).to.equal(resolveInfo.fieldNodes); // ensure same reference
+  });
+
+  it('exposes returnType', () => {
+    expect(resolveInfo.returnType).to.equal(query.getFields().test.type);
+  });
+
+  it('exposes parentType', () => {
+    expect(resolveInfo.parentType).to.equal(query);
+  });
+
+  it('exposes path', () => {
+    expect(resolveInfo.path).to.deep.equal(path);
+  });
+
+  it('exposes schema', () => {
+    expect(resolveInfo.schema).to.equal(schema);
+  });
+
+  it('exposes fragments', () => {
+    expect(resolveInfo.fragments).to.equal(
+      validatedExecutionArgs.fragmentDefinitions,
+    );
+  });
+
+  it('exposes rootValue', () => {
+    expect(resolveInfo.rootValue).to.equal(rootValue);
+  });
+
+  it('exposes operation', () => {
+    expect(resolveInfo.operation).to.equal(operation);
+  });
+
+  it('exposes variableValues', () => {
+    expect(resolveInfo.variableValues).to.equal(
+      validatedExecutionArgs.variableValues,
+    );
+  });
+
+  it('exposes abortSignal', () => {
+    expect(resolveInfo.abortSignal).to.equal(abortSignal);
+  });
+});

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -212,36 +212,21 @@ describe('Execute: Handles basic execution tasks', () => {
 
     executeSync({ schema, document, rootValue, variableValues });
 
-    expect(resolvedInfo).to.have.all.keys(
-      'fieldName',
-      'fieldNodes',
-      'returnType',
-      'parentType',
-      'path',
-      'schema',
-      'fragments',
-      'rootValue',
-      'operation',
-      'variableValues',
-      'abortSignal',
-    );
-
     const operation = document.definitions[0];
     assert(operation.kind === Kind.OPERATION_DEFINITION);
 
-    expect(resolvedInfo).to.include({
+    const field = operation.selectionSet.selections[0];
+
+    expect(resolvedInfo).to.deep.include({
       fieldName: 'test',
+      fieldNodes: [field],
       returnType: GraphQLString,
       parentType: testType,
+      path: { prev: undefined, key: 'result', typename: 'Test' },
       schema,
+      fragments: {},
       rootValue,
       operation,
-    });
-
-    const field = operation.selectionSet.selections[0];
-    expect(resolvedInfo).to.deep.include({
-      fieldNodes: [field],
-      path: { prev: undefined, key: 'result', typename: 'Test' },
       variableValues: {
         sources: {
           var: {
@@ -255,6 +240,7 @@ describe('Execute: Handles basic execution tasks', () => {
         },
         coerced: { var: 'abc' },
       },
+      abortSignal: undefined,
     });
   });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -24,7 +24,6 @@ import { OperationTypeNode } from '../language/ast.js';
 
 import type {
   GraphQLAbstractType,
-  GraphQLField,
   GraphQLFieldResolver,
   GraphQLLeafType,
   GraphQLList,
@@ -65,6 +64,7 @@ import {
 } from './collectFields.js';
 import { buildIncrementalResponse } from './IncrementalPublisher.js';
 import { mapAsyncIterable } from './mapAsyncIterable.js';
+import { ResolveInfo } from './ResolveInfo.js';
 import type {
   CompletedExecutionGroup,
   ExecutionResult,
@@ -657,10 +657,10 @@ function executeField(
   const returnType = fieldDef.type;
   const resolveFn = fieldDef.resolve ?? validatedExecutionArgs.fieldResolver;
 
-  const info = buildResolveInfo(
+  const info = new ResolveInfo(
     validatedExecutionArgs,
     fieldDef,
-    toNodes(fieldDetailsList),
+    fieldDetailsList,
     parentType,
     path,
     abortSignal,
@@ -745,37 +745,6 @@ function executeField(
       incrementalDataRecords: undefined,
     };
   }
-}
-
-/**
- * TODO: consider no longer exporting this function
- * @internal
- */
-export function buildResolveInfo(
-  validatedExecutionArgs: ValidatedExecutionArgs,
-  fieldDef: GraphQLField<unknown, unknown>,
-  fieldNodes: ReadonlyArray<FieldNode>,
-  parentType: GraphQLObjectType,
-  path: Path,
-  abortSignal: AbortSignal | undefined,
-): GraphQLResolveInfo {
-  const { schema, fragmentDefinitions, rootValue, operation, variableValues } =
-    validatedExecutionArgs;
-  // The resolve function's optional fourth argument is a collection of
-  // information about the current execution state.
-  return {
-    fieldName: fieldDef.name,
-    fieldNodes,
-    returnType: fieldDef.type,
-    parentType,
-    path,
-    schema,
-    fragments: fragmentDefinitions,
-    rootValue,
-    operation,
-    variableValues,
-    abortSignal,
-  };
 }
 
 function handleFieldError(
@@ -1940,19 +1909,18 @@ function executeSubscription(
   const fieldName = firstNode.name.value;
   const fieldDef = schema.getField(rootType, fieldName);
 
-  const fieldNodes = fieldDetailsList.map((fieldDetails) => fieldDetails.node);
   if (!fieldDef) {
     throw new GraphQLError(
       `The subscription field "${fieldName}" is not defined.`,
-      { nodes: fieldNodes },
+      { nodes: toNodes(fieldDetailsList) },
     );
   }
 
   const path = addPath(undefined, responseName, rootType.name);
-  const info = buildResolveInfo(
+  const info = new ResolveInfo(
     validatedExecutionArgs,
     fieldDef,
-    fieldNodes,
+    fieldDetailsList,
     rootType,
     path,
     abortSignal,
@@ -1997,14 +1965,18 @@ function executeSubscription(
         },
         (error: unknown) => {
           abortSignalListener?.disconnect();
-          throw locatedError(error, fieldNodes, pathToArray(path));
+          throw locatedError(
+            error,
+            toNodes(fieldDetailsList),
+            pathToArray(path),
+          );
         },
       );
     }
 
     return assertEventStream(result);
   } catch (error) {
-    throw locatedError(error, fieldNodes, pathToArray(path));
+    throw locatedError(error, toNodes(fieldDetailsList), pathToArray(path));
   }
 }
 


### PR DESCRIPTION
<img width="840" height="142" alt="image" src="https://github.com/user-attachments/assets/b55da6ae-d50b-40b6-b454-dc949ec4faf0" />

this is a breaking change only because `buildResolveInfo()` is technically accessible via deep import