### PR TITLE
introduce legacy incremental executor

### DIFF
--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -42,12 +42,14 @@ import {
 } from '../execute.js';
 import type { ExecutionResult } from '../Executor.js';
 import { collectSubfields, getStreamUsage } from '../Executor.js';
+import { legacyExecuteIncrementally } from '../legacyIncremental/legacyExecuteIncrementally.js';
 
 function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   return expectEqualPromisesOrValues([
     executeThrowingOnIncremental(args),
     executeIgnoringIncremental(args),
     experimentalExecuteIncrementally(args),
+    legacyExecuteIncrementally(args),
   ]) as PromiseOrValue<ExecutionResult>;
 }
 
@@ -56,6 +58,7 @@ function executeSync(args: ExecutionArgs): ExecutionResult {
     executeSyncWrappingThrowingOnIncremental(args),
     executeIgnoringIncremental(args),
     experimentalExecuteIncrementally(args),
+    legacyExecuteIncrementally(args),
   ]) as ExecutionResult;
 }
 

--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -273,6 +273,12 @@ export class IncrementalExecutor<
     this.streams = [];
   }
 
+  createSubExecutor(
+    deferUsageSet?: DeferUsageSet,
+  ): IncrementalExecutor<TExperimental> {
+    return new IncrementalExecutor(this.validatedExecutionArgs, deferUsageSet);
+  }
+
   override cancel(reason?: unknown): void {
     super.cancel(reason);
     for (const task of this.tasks) {
@@ -442,10 +448,7 @@ export class IncrementalExecutor<
     for (const [deferUsageSet, groupedFieldSet] of newGroupedFieldSets) {
       const deliveryGroups = getDeliveryGroups(deferUsageSet, deliveryGroupMap);
 
-      const executor = new IncrementalExecutor(
-        this.validatedExecutionArgs,
-        deferUsageSet,
-      );
+      const executor = this.createSubExecutor(deferUsageSet);
 
       const executionGroup: ExecutionGroup = {
         groups: deliveryGroups,
@@ -708,7 +711,7 @@ export class IncrementalExecutor<
 
           const itemPath = addPath(streamPath, index, undefined);
 
-          const executor = new IncrementalExecutor(this.validatedExecutionArgs);
+          const executor = this.createSubExecutor();
 
           let streamItemResult = executor.completeStreamItem(
             itemPath,

--- a/src/execution/legacyIncremental/BranchingIncrementalExecutor.ts
+++ b/src/execution/legacyIncremental/BranchingIncrementalExecutor.ts
@@ -1,0 +1,169 @@
+import { AccumulatorMap } from '../../jsutils/AccumulatorMap.js';
+import { getBySet } from '../../jsutils/getBySet.js';
+import { invariant } from '../../jsutils/invariant.js';
+import { isSameSet } from '../../jsutils/isSameSet.js';
+import { memoize1 } from '../../jsutils/memoize1.js';
+import { memoize2 } from '../../jsutils/memoize2.js';
+import type { ObjMap } from '../../jsutils/ObjMap.js';
+
+import type { GraphQLError } from '../../error/GraphQLError.js';
+
+import type {
+  DeferUsage,
+  FieldDetails,
+  GroupedFieldSet,
+} from '../collectFields.js';
+import type { ExecutionResult } from '../Executor.js';
+import type {
+  DeferUsageSet,
+  ExecutionPlan,
+} from '../incremental/buildExecutionPlan.js';
+import { IncrementalExecutor } from '../incremental/IncrementalExecutor.js';
+
+import { BranchingIncrementalPublisher } from './BranchingIncrementalPublisher.js';
+
+export interface ExperimentalIncrementalExecutionResults {
+  initialResult: InitialIncrementalExecutionResult;
+  subsequentResults: AsyncGenerator<
+    SubsequentIncrementalExecutionResult,
+    void,
+    void
+  >;
+}
+
+export interface InitialIncrementalExecutionResult<
+  TData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends ExecutionResult<TData, TExtensions> {
+  data: TData;
+  hasNext: true;
+  extensions?: TExtensions;
+}
+
+export interface SubsequentIncrementalExecutionResult<
+  TData = unknown,
+  TExtensions = ObjMap<unknown>,
+> {
+  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  hasNext: boolean;
+  extensions?: TExtensions;
+}
+
+export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
+  | IncrementalDeferResult<TData, TExtensions>
+  | IncrementalStreamResult<TData, TExtensions>;
+
+export interface IncrementalDeferResult<
+  TData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends ExecutionResult<TData, TExtensions> {
+  path: ReadonlyArray<string | number>;
+  label?: string;
+}
+
+export interface IncrementalStreamResult<
+  TData = ReadonlyArray<unknown>,
+  TExtensions = ObjMap<unknown>,
+> {
+  errors?: ReadonlyArray<GraphQLError>;
+  items: TData | null;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+  extensions?: TExtensions;
+}
+
+const buildBranchingExecutionPlanFromInitial = memoize1(
+  (groupedFieldSet: GroupedFieldSet) =>
+    buildBranchingExecutionPlan(groupedFieldSet),
+);
+
+const buildBranchingExecutionPlanFromDeferred = memoize2(
+  (groupedFieldSet: GroupedFieldSet, deferUsageSet: DeferUsageSet) =>
+    buildBranchingExecutionPlan(groupedFieldSet, deferUsageSet),
+);
+
+/** @internal */
+export class BranchingIncrementalExecutor extends IncrementalExecutor<ExperimentalIncrementalExecutionResults> {
+  override createSubExecutor(
+    deferUsageSet?: DeferUsageSet,
+  ): IncrementalExecutor<ExperimentalIncrementalExecutionResults> {
+    return new BranchingIncrementalExecutor(
+      this.validatedExecutionArgs,
+      deferUsageSet,
+    );
+  }
+
+  override buildResponse(
+    data: ObjMap<unknown> | null,
+  ): ExecutionResult | ExperimentalIncrementalExecutionResults {
+    const errors = this.collectedErrors.errors;
+    const work = this.getIncrementalWork();
+    const { tasks, streams } = work;
+    if (tasks?.length === 0 && streams?.length === 0) {
+      return errors.length ? { errors, data } : { data };
+    }
+
+    invariant(data !== null);
+    const incrementalPublisher = new BranchingIncrementalPublisher();
+    return incrementalPublisher.buildResponse(
+      data,
+      errors,
+      work,
+      this.validatedExecutionArgs.externalAbortSignal,
+    );
+  }
+
+  override buildRootExecutionPlan(
+    originalGroupedFieldSet: GroupedFieldSet,
+  ): ExecutionPlan {
+    return buildBranchingExecutionPlanFromInitial(originalGroupedFieldSet);
+  }
+
+  override buildSubExecutionPlan(
+    originalGroupedFieldSet: GroupedFieldSet,
+  ): ExecutionPlan {
+    return this.deferUsageSet === undefined
+      ? buildBranchingExecutionPlanFromInitial(originalGroupedFieldSet)
+      : buildBranchingExecutionPlanFromDeferred(
+          originalGroupedFieldSet,
+          this.deferUsageSet,
+        );
+  }
+}
+
+function buildBranchingExecutionPlan(
+  originalGroupedFieldSet: GroupedFieldSet,
+  parentDeferUsages: DeferUsageSet = new Set<DeferUsage>(),
+): ExecutionPlan {
+  const groupedFieldSet = new AccumulatorMap<string, FieldDetails>();
+
+  const newGroupedFieldSets = new Map<
+    DeferUsageSet,
+    AccumulatorMap<string, FieldDetails>
+  >();
+
+  for (const [responseKey, fieldGroup] of originalGroupedFieldSet) {
+    for (const fieldDetails of fieldGroup) {
+      const deferUsage = fieldDetails.deferUsage;
+      const deferUsageSet =
+        deferUsage === undefined
+          ? new Set<DeferUsage>()
+          : new Set([deferUsage]);
+      if (isSameSet(parentDeferUsages, deferUsageSet)) {
+        groupedFieldSet.add(responseKey, fieldDetails);
+      } else {
+        let newGroupedFieldSet = getBySet(newGroupedFieldSets, deferUsageSet);
+        if (newGroupedFieldSet === undefined) {
+          newGroupedFieldSet = new AccumulatorMap();
+          newGroupedFieldSets.set(deferUsageSet, newGroupedFieldSet);
+        }
+        newGroupedFieldSet.add(responseKey, fieldDetails);
+      }
+    }
+  }
+
+  return {
+    groupedFieldSet,
+    newGroupedFieldSets,
+  };
+}

--- a/src/execution/legacyIncremental/BranchingIncrementalPublisher.ts
+++ b/src/execution/legacyIncremental/BranchingIncrementalPublisher.ts
@@ -1,0 +1,235 @@
+import type { ObjMap } from '../../jsutils/ObjMap.js';
+import { addPath, pathToArray } from '../../jsutils/Path.js';
+
+import type { GraphQLError } from '../../error/GraphQLError.js';
+
+import type {
+  DeliveryGroup,
+  ExecutionGroupValue,
+  IncrementalWork,
+  ItemStream,
+  StreamItemValue,
+} from '../incremental/IncrementalExecutor.js';
+import type { WorkQueueEvent } from '../incremental/WorkQueue.js';
+import { createWorkQueue } from '../incremental/WorkQueue.js';
+import { mapAsyncIterable } from '../mapAsyncIterable.js';
+import { withConcurrentAbruptClose } from '../withConcurrentAbruptClose.js';
+
+import type {
+  ExperimentalIncrementalExecutionResults,
+  IncrementalDeferResult,
+  IncrementalResult,
+  IncrementalStreamResult,
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
+} from './BranchingIncrementalExecutor.js';
+
+interface SubsequentIncrementalExecutionResultContext {
+  incremental: Array<IncrementalResult>;
+  hasNext: boolean;
+}
+
+/**
+ * @internal
+ */
+export class BranchingIncrementalPublisher {
+  private _indices: Map<ItemStream, number>;
+
+  constructor() {
+    this._indices = new Map();
+  }
+
+  buildResponse(
+    data: ObjMap<unknown>,
+    errors: ReadonlyArray<GraphQLError>,
+    work: IncrementalWork,
+    abortSignal: AbortSignal | undefined,
+  ): ExperimentalIncrementalExecutionResults {
+    const { initialStreams, events } = createWorkQueue<
+      ExecutionGroupValue,
+      StreamItemValue,
+      DeliveryGroup,
+      ItemStream
+    >(work);
+
+    for (const stream of initialStreams) {
+      this._indices.set(stream, stream.initialCount);
+    }
+
+    function abort(): void {
+      subsequentResults.throw(abortSignal?.reason).catch(() => {
+        // Ignore errors
+      });
+    }
+
+    let onWorkQueueFinished: (() => void) | undefined;
+    if (abortSignal) {
+      abortSignal.addEventListener('abort', abort);
+      onWorkQueueFinished = () =>
+        abortSignal.removeEventListener('abort', abort);
+    }
+
+    const initialResult: InitialIncrementalExecutionResult = errors.length
+      ? { errors, data, hasNext: true }
+      : { data, hasNext: true };
+
+    const subsequentResults = withConcurrentAbruptClose(
+      mapAsyncIterable(events, (batch) =>
+        this._handleBatch(batch, onWorkQueueFinished),
+      ),
+      () => onWorkQueueFinished?.(),
+    );
+
+    return {
+      initialResult,
+      subsequentResults,
+    };
+  }
+
+  private _handleBatch(
+    batch: ReadonlyArray<
+      WorkQueueEvent<
+        ExecutionGroupValue,
+        StreamItemValue,
+        DeliveryGroup,
+        ItemStream
+      >
+    >,
+    onWorkQueueFinished: (() => void) | undefined,
+  ): SubsequentIncrementalExecutionResult {
+    const context: SubsequentIncrementalExecutionResultContext = {
+      incremental: [],
+      hasNext: true,
+    };
+
+    for (const event of batch) {
+      this._handleWorkQueueEvent(event, context, onWorkQueueFinished);
+    }
+
+    const { incremental, hasNext } = context;
+
+    const result: SubsequentIncrementalExecutionResult = { hasNext };
+    if (incremental.length > 0) {
+      result.incremental = incremental;
+    }
+
+    return result;
+  }
+
+  private _handleWorkQueueEvent(
+    event: WorkQueueEvent<
+      ExecutionGroupValue,
+      StreamItemValue,
+      DeliveryGroup,
+      ItemStream
+    >,
+    context: SubsequentIncrementalExecutionResultContext,
+    onWorkQueueFinished: (() => void) | undefined,
+  ): void {
+    switch (event.kind) {
+      case 'GROUP_VALUES': {
+        const group = event.group;
+        for (const value of event.values) {
+          context.incremental.push(
+            buildIncrementalResult(
+              {
+                data: value.data,
+                path: pathToArray(group.path),
+              },
+              group.label,
+              value.errors,
+            ),
+          );
+        }
+        break;
+      }
+      case 'GROUP_SUCCESS': {
+        break;
+      }
+      case 'GROUP_FAILURE': {
+        const group = event.group;
+        context.incremental.push(
+          buildIncrementalResult(
+            {
+              data: null,
+              path: pathToArray(group.path),
+            },
+            group.label,
+            [event.error as GraphQLError],
+          ),
+        );
+        break;
+      }
+      case 'STREAM_VALUES': {
+        const stream = event.stream;
+        const { values } = event;
+        const items: Array<unknown> = [];
+        const errors: Array<GraphQLError> = [];
+        for (const value of values) {
+          items.push(value.item);
+          if (value.errors !== undefined) {
+            errors.push(...value.errors);
+          }
+        }
+        let index = this._indices.get(stream);
+        if (index === undefined) {
+          index = stream.initialCount;
+          this._indices.set(stream, index);
+        }
+        this._indices.set(stream, index + items.length);
+        context.incremental.push(
+          buildIncrementalResult(
+            {
+              items,
+              path: pathToArray(addPath(stream.path, index, undefined)),
+            },
+            stream.label,
+            errors.length > 0 ? errors : undefined,
+          ),
+        );
+        break;
+      }
+      case 'STREAM_SUCCESS': {
+        this._indices.delete(event.stream);
+        break;
+      }
+      case 'STREAM_FAILURE': {
+        this._indices.delete(event.stream);
+        const stream = event.stream;
+        context.incremental.push(
+          buildIncrementalResult(
+            {
+              items: null,
+              path: pathToArray(stream.path),
+            },
+            stream.label,
+            [event.error as GraphQLError],
+          ),
+        );
+        break;
+      }
+      case 'WORK_QUEUE_TERMINATION': {
+        onWorkQueueFinished?.();
+        context.hasNext = false;
+        break;
+      }
+    }
+  }
+}
+
+function buildIncrementalResult(
+  originalIncrementalResult:
+    | Omit<IncrementalDeferResult, 'label' | 'errors'>
+    | Omit<IncrementalStreamResult, 'label' | 'errors'>,
+  label: string | undefined,
+  errors: ReadonlyArray<GraphQLError> | undefined,
+): IncrementalResult {
+  const incrementalResult: IncrementalResult = originalIncrementalResult;
+  if (errors !== undefined) {
+    incrementalResult.errors = errors;
+  }
+  if (label !== undefined) {
+    incrementalResult.label = label;
+  }
+  return incrementalResult;
+}

--- a/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
@@ -20,12 +20,11 @@ import { GraphQLSchema } from '../../../type/schema.js';
 
 import { buildSchema } from '../../../utilities/buildASTSchema.js';
 
-import { experimentalExecuteIncrementally } from '../../execute.js';
-
 import type {
   InitialIncrementalExecutionResult,
   SubsequentIncrementalExecutionResult,
-} from '../IncrementalExecutor.js';
+} from '../BranchingIncrementalExecutor.js';
+import { legacyExecuteIncrementally } from '../legacyExecuteIncrementally.js';
 
 const friendType = new GraphQLObjectType({
   fields: {
@@ -176,7 +175,7 @@ async function complete(
   rootValue: unknown = { hero },
   enableEarlyExecution = false,
 ) {
-  const result = await experimentalExecuteIncrementally({
+  const result = await legacyExecuteIncrementally({
     schema,
     document,
     rootValue,
@@ -201,7 +200,7 @@ async function completeCancellation(
   abortSignal: AbortSignal,
   enableEarlyExecution = false,
 ) {
-  const result = await experimentalExecuteIncrementally({
+  const result = await legacyExecuteIncrementally({
     schema: cancellationSchema,
     document,
     rootValue,
@@ -221,7 +220,7 @@ async function completeCancellation(
   return result;
 }
 
-describe('Execute: defer directive', () => {
+describe('Execute: defer directive (legacy)', () => {
   it('Can defer fragments containing scalar types', async () => {
     const document = parse(`
       query HeroNameQuery {
@@ -243,7 +242,6 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -252,10 +250,9 @@ describe('Execute: defer directive', () => {
             data: {
               name: 'Luke',
             },
-            id: '0',
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -299,17 +296,15 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
             data: { name: 'Luke' },
-            id: '0',
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -350,7 +345,6 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -359,10 +353,9 @@ describe('Execute: defer directive', () => {
             data: {
               name: 'Luke',
             },
-            id: '0',
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -408,7 +401,6 @@ describe('Execute: defer directive', () => {
             id: '1',
           },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
@@ -417,10 +409,9 @@ describe('Execute: defer directive', () => {
             data: {
               name: 'Luke',
             },
-            id: '0',
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -442,7 +433,6 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ id: '0', path: [], label: 'DeferQuery' }],
         hasNext: true,
       },
       {
@@ -453,10 +443,10 @@ describe('Execute: defer directive', () => {
                 id: '1',
               },
             },
-            id: '0',
+            path: [],
+            label: 'DeferQuery',
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -484,7 +474,6 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ id: '0', path: [], label: 'DeferQuery' }],
         hasNext: true,
       },
       {
@@ -502,10 +491,10 @@ describe('Execute: defer directive', () => {
                 path: ['hero', 'name'],
               },
             ],
-            id: '0',
+            path: [],
+            label: 'DeferQuery',
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -534,31 +523,30 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [{ id: '0', path: ['hero'], label: 'DeferTop' }],
         hasNext: true,
       },
       {
-        pending: [{ id: '1', path: ['hero'], label: 'DeferNested' }],
         incremental: [
           {
             data: {
               id: '1',
             },
-            id: '0',
+            path: ['hero'],
+            label: 'DeferTop',
           },
           {
             data: {
               friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
             },
-            id: '1',
+            path: ['hero'],
+            label: 'DeferNested',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
   });
-  it('Can defer a fragment that is also not deferred, deferred fragment is first', async () => {
+  it('Emits deferred fragments even when also selected without @defer, deferred fragment is first', async () => {
     const document = parse(`
       query HeroNameQuery {
         hero {
@@ -571,15 +559,30 @@ describe('Execute: defer directive', () => {
       }
     `);
     const result = await complete(document);
-    expectJSON(result).toDeepEqual({
-      data: {
-        hero: {
-          name: 'Luke',
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          hero: {
+            name: 'Luke',
+          },
         },
+        hasNext: true,
       },
-    });
+      {
+        incremental: [
+          {
+            data: {
+              name: 'Luke',
+            },
+            path: ['hero'],
+            label: 'DeferTop',
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
-  it('Can defer a fragment that is also not deferred, non-deferred fragment is first', async () => {
+  it('Skips deferred fragments when also selected without @defer, non-deferred fragment is first', async () => {
     const document = parse(`
       query HeroNameQuery {
         hero {
@@ -617,12 +620,16 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ id: '0', path: ['hero'], label: 'InlineDeferred' }],
         hasNext: true,
       },
       {
-        incremental: [{ data: { name: 'Luke' }, id: '0' }],
-        completed: [{ id: '0' }],
+        incremental: [
+          {
+            data: { name: 'Luke' },
+            path: ['hero'],
+            label: 'InlineDeferred',
+          },
+        ],
         hasNext: false,
       },
     ]);
@@ -667,12 +674,10 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        incremental: [{ data: { name: 'Luke' }, id: '0' }],
-        completed: [{ id: '0' }],
+        incremental: [{ data: { name: 'Luke' }, path: ['hero'] }],
         hasNext: false,
       },
     ]);
@@ -697,10 +702,6 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [
-          { id: '0', path: ['hero'], label: 'DeferID' },
-          { id: '1', path: ['hero'], label: 'DeferName' },
-        ],
         hasNext: true,
       },
       {
@@ -709,16 +710,17 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            id: '0',
+            path: ['hero'],
+            label: 'DeferID',
           },
           {
             data: {
               name: 'Luke',
             },
-            id: '1',
+            path: ['hero'],
+            label: 'DeferName',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -743,30 +745,21 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [
-          { id: '0', path: [], label: 'DeferID' },
-          { id: '1', path: [], label: 'DeferName' },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { hero: {} },
-            id: '0',
+            data: { hero: { id: '1' } },
+            path: [],
+            label: 'DeferID',
           },
           {
-            data: { id: '1' },
-            id: '0',
-            subPath: ['hero'],
-          },
-          {
-            data: { name: 'Luke' },
-            id: '1',
-            subPath: ['hero'],
+            data: { hero: { name: 'Luke' } },
+            path: [],
+            label: 'DeferName',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -796,30 +789,21 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [
-          { id: '0', path: [], label: 'DeferID' },
-          { id: '1', path: [], label: 'DeferName' },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { hero: {} },
-            id: '0',
+            data: { hero: { id: '1' } },
+            path: [],
+            label: 'DeferID',
           },
           {
-            data: { id: '1' },
-            id: '0',
-            subPath: ['hero'],
-          },
-          {
-            data: { name: 'Luke' },
-            id: '1',
-            subPath: ['hero'],
+            data: { hero: { name: 'Luke' } },
+            path: [],
+            label: 'DeferName',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -846,10 +830,6 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [
-          { id: '0', path: ['hero'], label: 'DeferID' },
-          { id: '1', path: [], label: 'DeferName' },
-        ],
         hasNext: true,
       },
       {
@@ -858,17 +838,17 @@ describe('Execute: defer directive', () => {
             data: {
               id: '1',
             },
-            id: '0',
+            path: ['hero'],
+            label: 'DeferID',
           },
           {
             data: {
-              name: 'Luke',
+              hero: { name: 'Luke' },
             },
-            id: '1',
-            subPath: ['hero'],
+            path: [],
+            label: 'DeferName',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -891,11 +871,9 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ id: '0', path: [], label: 'DeferName' }],
         hasNext: true,
       },
       {
-        pending: [{ id: '1', path: ['hero'], label: 'DeferID' }],
         incremental: [
           {
             data: {
@@ -903,16 +881,17 @@ describe('Execute: defer directive', () => {
                 name: 'Luke',
               },
             },
-            id: '0',
+            path: [],
+            label: 'DeferName',
           },
           {
             data: {
               id: '1',
             },
-            id: '1',
+            path: ['hero'],
+            label: 'DeferID',
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -947,7 +926,7 @@ describe('Execute: defer directive', () => {
       promiseWithResolvers();
     let cResolverCalled = false;
     let eResolverCalled = false;
-    const executeResult = experimentalExecuteIncrementally({
+    const executeResult = legacyExecuteIncrementally({
       schema,
       document,
       rootValue: {
@@ -973,10 +952,6 @@ describe('Execute: defer directive', () => {
     const result1 = executeResult.initialResult;
     expectJSON(result1).toDeepEqual({
       data: {},
-      pending: [
-        { id: '0', path: [] },
-        { id: '1', path: [] },
-      ],
       hasNext: true,
     });
 
@@ -988,23 +963,16 @@ describe('Execute: defer directive', () => {
     const result2 = await iterator.next();
     expectJSON(result2).toDeepEqual({
       value: {
-        pending: [{ id: '2', path: ['a'] }],
         incremental: [
           {
             data: { a: {} },
-            id: '0',
+            path: [],
           },
           {
-            data: { b: {} },
-            id: '2',
-          },
-          {
-            data: { c: { d: 'd' } },
-            id: '2',
-            subPath: ['b'],
+            data: { b: { c: { d: 'd' } } },
+            path: ['a'],
           },
         ],
-        completed: [{ id: '0' }, { id: '2' }],
         hasNext: true,
       },
       done: false,
@@ -1018,20 +986,16 @@ describe('Execute: defer directive', () => {
     const result3 = await iterator.next();
     expectJSON(result3).toDeepEqual({
       value: {
-        pending: [{ id: '3', path: ['a'] }],
         incremental: [
           {
-            data: { someField: 'someField' },
-            id: '1',
-            subPath: ['a'],
+            data: { a: { someField: 'someField' } },
+            path: [],
           },
           {
-            data: { e: { f: 'f' } },
-            id: '3',
-            subPath: ['b'],
+            data: { b: { e: { f: 'f' } } },
+            path: ['a'],
           },
         ],
-        completed: [{ id: '1' }, { id: '3' }],
         hasNext: false,
       },
       done: false,
@@ -1046,7 +1010,7 @@ describe('Execute: defer directive', () => {
     });
   });
 
-  it('Initiates unique deferred grouped field sets after those that are common to sibling defers', async () => {
+  it('Initiates unique deferred grouped field sets together with those that are common to sibling defers', async () => {
     const document = parse(`
       query {
         ... @defer {
@@ -1076,7 +1040,7 @@ describe('Execute: defer directive', () => {
       promiseWithResolvers<void>();
     let cResolverCalled = false;
     let eResolverCalled = false;
-    const executeResult = experimentalExecuteIncrementally({
+    const executeResult = legacyExecuteIncrementally({
       schema,
       document,
       rootValue: {
@@ -1102,10 +1066,6 @@ describe('Execute: defer directive', () => {
     const result1 = executeResult.initialResult;
     expectJSON(result1).toDeepEqual({
       data: {},
-      pending: [
-        { id: '0', path: [] },
-        { id: '1', path: [] },
-      ],
       hasNext: true,
     });
 
@@ -1117,17 +1077,16 @@ describe('Execute: defer directive', () => {
     const result2 = await iterator.next();
     expectJSON(result2).toDeepEqual({
       value: {
-        pending: [
-          { id: '2', path: ['a'] },
-          { id: '3', path: ['a'] },
-        ],
         incremental: [
           {
             data: { a: {} },
-            id: '0',
+            path: [],
+          },
+          {
+            data: { a: {} },
+            path: [],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: true,
       },
       done: false,
@@ -1136,7 +1095,7 @@ describe('Execute: defer directive', () => {
     resolveC();
 
     expect(cResolverCalled).to.equal(true);
-    expect(eResolverCalled).to.equal(false);
+    expect(eResolverCalled).to.equal(true);
 
     const result3 = await iterator.next();
     expectJSON(result3).toDeepEqual({
@@ -1144,15 +1103,13 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { b: { c: { d: 'd' } } },
-            id: '2',
+            path: ['a'],
           },
           {
-            data: { e: { f: 'f' } },
-            id: '3',
-            subPath: ['b'],
+            data: { b: { c: { d: 'd' }, e: { f: 'f' } } },
+            path: ['a'],
           },
         ],
-        completed: [{ id: '2' }, { id: '3' }],
         hasNext: false,
       },
       done: false,
@@ -1165,7 +1122,7 @@ describe('Execute: defer directive', () => {
     });
   });
 
-  it('Can deduplicate multiple defers on the same object', async () => {
+  it('Skips duplicate nested defers on the same object', async () => {
     const document = parse(`
       query {
         hero {
@@ -1196,26 +1153,20 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { friends: [{}, {}, {}] } },
-        pending: [
-          { id: '0', path: ['hero', 'friends', 0] },
-          { id: '1', path: ['hero', 'friends', 1] },
-          { id: '2', path: ['hero', 'friends', 2] },
-        ],
         hasNext: true,
       },
       {
         incremental: [
-          { data: { id: '2', name: 'Han' }, id: '0' },
-          { data: { id: '3', name: 'Leia' }, id: '1' },
-          { data: { id: '4', name: 'C-3PO' }, id: '2' },
+          { data: { id: '2', name: 'Han' }, path: ['hero', 'friends', 0] },
+          { data: { id: '3', name: 'Leia' }, path: ['hero', 'friends', 1] },
+          { data: { id: '4', name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
-        completed: [{ id: '0' }, { id: '1' }, { id: '2' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicates fields present in the initial payload', async () => {
+  it('Does not deduplicate fields present in the initial payload', async () => {
     const document = parse(`
       query {
         hero {
@@ -1266,24 +1217,24 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { bar: 'bar' },
-            id: '0',
-            subPath: ['nestedObject', 'deeperObject'],
+            data: {
+              nestedObject: { deeperObject: { bar: 'bar' } },
+              anotherNestedObject: { deeperObject: { foo: 'foo' } },
+            },
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicates fields present in a parent defer payload', async () => {
+  it('Does not deduplicate fields present in a parent defer payload', async () => {
     const document = parse(`
       query {
         hero {
@@ -1309,11 +1260,9 @@ describe('Execute: defer directive', () => {
         data: {
           hero: {},
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        pending: [{ id: '1', path: ['hero', 'nestedObject', 'deeperObject'] }],
         incremental: [
           {
             data: {
@@ -1321,22 +1270,22 @@ describe('Execute: defer directive', () => {
                 deeperObject: { foo: 'foo' },
               },
             },
-            id: '0',
+            path: ['hero'],
           },
           {
             data: {
+              foo: 'foo',
               bar: 'bar',
             },
-            id: '1',
+            path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicates fields with deferred fragments at multiple levels', async () => {
+  it('Skips duplicate fields with deferred fragments at multiple levels', async () => {
     const document = parse(`
       query {
         hero {
@@ -1387,37 +1336,35 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        pending: [
-          { id: '1', path: ['hero', 'nestedObject'] },
-          { id: '2', path: ['hero', 'nestedObject', 'deeperObject'] },
-        ],
         incremental: [
           {
-            data: { bar: 'bar' },
-            id: '0',
-            subPath: ['nestedObject', 'deeperObject'],
+            data: {
+              nestedObject: {
+                deeperObject: { foo: 'foo', bar: 'bar' },
+              },
+            },
+            path: ['hero'],
           },
           {
-            data: { baz: 'baz' },
-            id: '1',
-            subPath: ['deeperObject'],
+            data: {
+              deeperObject: { foo: 'foo', bar: 'bar', baz: 'baz' },
+            },
+            path: ['hero', 'nestedObject'],
           },
           {
-            data: { bak: 'bak' },
-            id: '2',
+            data: { foo: 'foo', bar: 'bar', baz: 'baz', bak: 'bak' },
+            path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }, { id: '2' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicates multiple fields from deferred fragments from different branches occurring at the same level', async () => {
+  it('Does not deduplicate multiple fields from deferred fragments from different branches occurring at the same level', async () => {
     const document = parse(`
       query {
         hero {
@@ -1453,10 +1400,6 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [
-          { id: '0', path: ['hero', 'nestedObject', 'deeperObject'] },
-          { id: '1', path: ['hero', 'nestedObject', 'deeperObject'] },
-        ],
         hasNext: true,
       },
       {
@@ -1465,22 +1408,30 @@ describe('Execute: defer directive', () => {
             data: {
               foo: 'foo',
             },
-            id: '0',
+            path: ['hero', 'nestedObject', 'deeperObject'],
           },
           {
             data: {
+              nestedObject: {
+                deeperObject: {},
+              },
+            },
+            path: ['hero'],
+          },
+          {
+            data: {
+              foo: 'foo',
               bar: 'bar',
             },
-            id: '1',
+            path: ['hero', 'nestedObject', 'deeperObject'],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicate fields with deferred fragments in different branches at multiple non-overlapping levels', async () => {
+  it('Does not deduplicate fields with deferred fragments in different branches at multiple non-overlapping levels', async () => {
     const document = parse(`
       query {
         a {
@@ -1529,30 +1480,25 @@ describe('Execute: defer directive', () => {
             },
           },
         },
-        pending: [
-          { id: '0', path: ['a', 'b'] },
-          { id: '1', path: [] },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
             data: { e: { f: 'f' } },
-            id: '0',
+            path: ['a', 'b'],
           },
           {
-            data: { g: { h: 'h' } },
-            id: '1',
+            data: { a: { b: { e: { f: 'f' } } }, g: { h: 'h' } },
+            path: [],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Correctly bundles varying subfields into incremental data records unique by defer combination, ignoring fields in a fragment masked by a parent defer', async () => {
+  it('Correctly bundles varying subfields into incremental data records, duplicating fields from a parent defer', async () => {
     const document = parse(`
       query HeroNameQuery {
         ... @defer {
@@ -1575,33 +1521,30 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [
-          { id: '0', path: [] },
-          { id: '1', path: [] },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { hero: {} },
-            id: '0',
-          },
-          {
-            data: { id: '1' },
-            id: '0',
-            subPath: ['hero'],
+            data: { hero: { id: '1' } },
+            path: [],
           },
           {
             data: {
-              name: 'Luke',
+              hero: {
+                name: 'Luke',
+                shouldBeWithNameDespiteAdditionalDefer: 'Luke',
+              },
+            },
+            path: [],
+          },
+          {
+            data: {
               shouldBeWithNameDespiteAdditionalDefer: 'Luke',
             },
-            id: '1',
-            subPath: ['hero'],
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }, { id: '1' }],
         hasNext: false,
       },
     ]);
@@ -1639,27 +1582,17 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [
-          { id: '0', path: ['a'] },
-          { id: '1', path: [] },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { b: { c: {} } },
-            id: '0',
+            data: { b: { c: { d: 'd' } } },
+            path: ['a'],
           },
           {
-            data: { d: 'd' },
-            id: '0',
-            subPath: ['b', 'c'],
-          },
-        ],
-        completed: [
-          {
-            id: '1',
+            data: { a: { b: { c: null }, someField: 'someField' } },
+            path: [],
             errors: [
               {
                 message:
@@ -1669,7 +1602,6 @@ describe('Execute: defer directive', () => {
               },
             ],
           },
-          { id: '0' },
         ],
         hasNext: false,
       },
@@ -1711,28 +1643,13 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [
-          { id: '0', path: ['a'] },
-          { id: '1', path: [] },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { b: { c: {} } },
-            id: '0',
-          },
-          {
-            data: { d: 'd' },
-            id: '1',
-            subPath: ['a', 'b', 'c'],
-          },
-        ],
-        completed: [
-          { id: '1' },
-          {
-            id: '0',
+            data: { b: { c: null }, someField: 'someField' },
+            path: ['a'],
             errors: [
               {
                 message:
@@ -1742,13 +1659,17 @@ describe('Execute: defer directive', () => {
               },
             ],
           },
+          {
+            data: { a: { b: { c: { d: 'd' } } } },
+            path: [],
+          },
         ],
         hasNext: false,
       },
     ]);
   });
 
-  it('Nulls cross defer boundaries, failed fragment with slower shared child execution groups', async () => {
+  it('Nulls cross defer boundaries, failed fragment with slower overlapping child execution groups, ignores overlap', async () => {
     const document = parse(`
       query {
         ... @defer {
@@ -1785,16 +1706,22 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [
-          { id: '0', path: ['a'] },
-          { id: '1', path: [] },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { b: { e: { f: 'f' } }, someField: 'someField' },
+            path: ['a'],
+          },
         ],
         hasNext: true,
       },
       {
-        completed: [
+        incremental: [
           {
-            id: '1',
+            data: { a: null },
+            path: [],
             errors: [
               {
                 message:
@@ -1805,21 +1732,6 @@ describe('Execute: defer directive', () => {
             ],
           },
         ],
-        hasNext: true,
-      },
-      {
-        incremental: [
-          {
-            data: { b: {}, someField: 'someField' },
-            id: '0',
-          },
-          {
-            data: { e: { f: 'f' } },
-            id: '0',
-            subPath: ['b'],
-          },
-        ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -1862,27 +1774,17 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [
-          { id: '0', path: ['a'] },
-          { id: '1', path: [] },
-        ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { b: { c: {} } },
-            id: '0',
+            data: { b: { c: { d: 'd' } } },
+            path: ['a'],
           },
           {
-            data: { d: 'd' },
-            id: '0',
-            subPath: ['b', 'c'],
-          },
-        ],
-        completed: [
-          {
-            id: '1',
+            data: { a: { b: { c: null }, someField: 'someField' } },
+            path: [],
             errors: [
               {
                 message:
@@ -1892,7 +1794,10 @@ describe('Execute: defer directive', () => {
               },
             ],
           },
-          { id: '0' },
+          {
+            data: { a: { someField: 'someField' } },
+            path: [],
+          },
         ],
         hasNext: false,
       },
@@ -1902,19 +1807,19 @@ describe('Execute: defer directive', () => {
   it('Handles multiple erroring deferred grouped field sets', async () => {
     const document = parse(`
       query {
-        ... @defer {
-          a {
-            b {
-              c {
+        a {
+          b {
+            c {
+              ... @defer {
                 someError: nonNullErrorField
               }
             }
           }
         }
-        ... @defer {
-          a {
-            b {
-              c {
+        a {
+          b {
+            c {
+              ... @defer {
                 anotherError: nonNullErrorField
               }
             }
@@ -1929,17 +1834,14 @@ describe('Execute: defer directive', () => {
     });
     expectJSON(result).toDeepEqual([
       {
-        data: {},
-        pending: [
-          { id: '0', path: [] },
-          { id: '1', path: [] },
-        ],
+        data: { a: { b: { c: {} } } },
         hasNext: true,
       },
       {
-        completed: [
+        incremental: [
           {
-            id: '0',
+            data: null,
+            path: ['a', 'b', 'c'],
             errors: [
               {
                 message:
@@ -1950,7 +1852,8 @@ describe('Execute: defer directive', () => {
             ],
           },
           {
-            id: '1',
+            data: null,
+            path: ['a', 'b', 'c'],
             errors: [
               {
                 message:
@@ -1969,25 +1872,11 @@ describe('Execute: defer directive', () => {
   it('Handles multiple erroring deferred grouped field sets for the same fragment', async () => {
     const document = parse(`
       query {
-        ... @defer {
-          a {
-            b {
-              someC: c {
-                d: d
-              }
-              anotherC: c {
-                d: d
-              }
-            }
-          }
-        }
-        ... @defer {
-          a {
-            b {
-              someC: c {
+        a {
+          b {
+            c {
+              ... @defer {
                 someError: nonNullErrorField
-              }
-              anotherC: c {
                 anotherError: nonNullErrorField
               }
             }
@@ -2002,50 +1891,30 @@ describe('Execute: defer directive', () => {
     });
     expectJSON(result).toDeepEqual([
       {
-        data: {},
-        pending: [
-          { id: '0', path: [] },
-          { id: '1', path: [] },
-        ],
+        data: { a: { b: { c: {} } } },
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { a: { b: { someC: {}, anotherC: {} } } },
-            id: '0',
-          },
-          {
-            data: { d: 'd' },
-            id: '0',
-            subPath: ['a', 'b', 'someC'],
-          },
-          {
-            data: { d: 'd' },
-            id: '0',
-            subPath: ['a', 'b', 'anotherC'],
-          },
-        ],
-        completed: [
-          {
-            id: '1',
+            data: null,
+            path: ['a', 'b', 'c'],
             errors: [
               {
                 message:
                   'Cannot return null for non-nullable field c.nonNullErrorField.',
-                locations: [{ line: 19, column: 17 }],
-                path: ['a', 'b', 'someC', 'someError'],
+                locations: [{ line: 7, column: 17 }],
+                path: ['a', 'b', 'c', 'someError'],
               },
             ],
           },
-          { id: '0' },
         ],
         hasNext: false,
       },
     ]);
   });
 
-  it('filters a payload with a null that cannot be merged', async () => {
+  it('allows payloads with overlapping null and non-null values', async () => {
     const document = parse(`
       query {
         ... @defer {
@@ -2092,31 +1961,22 @@ describe('Execute: defer directive', () => {
         data: {
           a: {},
         },
-        pending: [
-          { id: '0', path: ['a'] },
-          { id: '1', path: [] },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { b: { c: { d: 'd' } } },
+            path: ['a'],
+          },
         ],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { b: { c: {} } },
-            id: '0',
-          },
-          {
-            data: { d: 'd' },
-            id: '0',
-            subPath: ['b', 'c'],
-          },
-        ],
-        completed: [{ id: '0' }],
-        hasNext: true,
-      },
-      {
-        completed: [
-          {
-            id: '1',
+            data: { a: { b: { c: null }, someField: 'someField' } },
+            path: [],
             errors: [
               {
                 message:
@@ -2168,7 +2028,7 @@ describe('Execute: defer directive', () => {
     });
   });
 
-  it('Cancels deferred fields when initial result exhibits null bubbling cancelling new fields', async () => {
+  it('Does not cancel deferred fields when initial result exhibits null bubbling that does not reach the defer point', async () => {
     const document = parse(`
       query {
         hero {
@@ -2191,19 +2051,31 @@ describe('Execute: defer directive', () => {
       },
       true,
     );
-    expectJSON(result).toDeepEqual({
-      data: {
-        hero: null,
-      },
-      errors: [
-        {
-          message:
-            'Cannot return null for non-nullable field Hero.nonNullName.',
-          locations: [{ line: 4, column: 11 }],
-          path: ['hero', 'nonNullName'],
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          hero: null,
         },
-      ],
-    });
+        errors: [
+          {
+            message:
+              'Cannot return null for non-nullable field Hero.nonNullName.',
+            locations: [{ line: 4, column: 11 }],
+            path: ['hero', 'nonNullName'],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { hero: { name: 'Luke' } },
+            path: [],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
   it('Keeps deferred work outside nulled error paths', async () => {
@@ -2245,7 +2117,6 @@ describe('Execute: defer directive', () => {
             path: ['a', 'nonNullErrorField'],
           },
         ],
-        pending: [{ id: '0', path: ['g'] }],
         hasNext: true,
       },
       {
@@ -2254,10 +2125,9 @@ describe('Execute: defer directive', () => {
             data: {
               h: 'value',
             },
-            id: '0',
+            path: ['g'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -2287,7 +2157,6 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: {},
-        pending: [{ id: '0', path: [] }],
         hasNext: true,
       },
       {
@@ -2304,16 +2173,15 @@ describe('Execute: defer directive', () => {
                 path: ['hero', 'nonNullName'],
               },
             ],
-            id: '0',
+            path: [],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicates list fields', async () => {
+  it('Does not deduplicate list fields', async () => {
     const document = parse(`
       query {
         hero {
@@ -2329,16 +2197,30 @@ describe('Execute: defer directive', () => {
       }
     `);
     const result = await complete(document);
-    expectJSON(result).toDeepEqual({
-      data: {
-        hero: {
-          friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          hero: {
+            friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
+          },
         },
+        hasNext: true,
       },
-    });
+      {
+        incremental: [
+          {
+            data: {
+              friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
+            },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
-  it('Deduplicates async iterable list fields', async () => {
+  it('Does not deduplicate async iterable list fields', async () => {
     const document = parse(`
       query {
         hero {
@@ -2361,12 +2243,24 @@ describe('Execute: defer directive', () => {
         },
       },
     });
-    expectJSON(result).toDeepEqual({
-      data: { hero: { friends: [{ name: 'Han' }] } },
-    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { friends: [{ name: 'Han' }] } },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { friends: [{ name: 'Han' }] },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
-  it('Deduplicates empty async iterable list fields', async () => {
+  it('Does not deduplicate empty async iterable list fields', async () => {
     const document = parse(`
       query {
         hero {
@@ -2390,9 +2284,21 @@ describe('Execute: defer directive', () => {
         },
       },
     });
-    expectJSON(result).toDeepEqual({
-      data: { hero: { friends: [] } },
-    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { friends: [] } },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { friends: [] },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
   it('Does not deduplicate list fields with non-overlapping fields', async () => {
@@ -2418,34 +2324,23 @@ describe('Execute: defer directive', () => {
             friends: [{ name: 'Han' }, { name: 'Leia' }, { name: 'C-3PO' }],
           },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
-            data: { id: '2' },
-            id: '0',
-            subPath: ['friends', 0],
-          },
-          {
-            data: { id: '3' },
-            id: '0',
-            subPath: ['friends', 1],
-          },
-          {
-            data: { id: '4' },
-            id: '0',
-            subPath: ['friends', 2],
+            data: {
+              friends: [{ id: '2' }, { id: '3' }, { id: '4' }],
+            },
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
   });
 
-  it('Deduplicates list fields that return empty lists', async () => {
+  it('Does not deduplicate list fields that return empty lists', async () => {
     const document = parse(`
       query {
         hero {
@@ -2466,12 +2361,24 @@ describe('Execute: defer directive', () => {
         friends: () => [],
       },
     });
-    expectJSON(result).toDeepEqual({
-      data: { hero: { friends: [] } },
-    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { friends: [] } },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { friends: [] },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
-  it('Deduplicates null object fields', async () => {
+  it('Does not deduplicate null object fields', async () => {
     const document = parse(`
       query {
         hero {
@@ -2492,12 +2399,24 @@ describe('Execute: defer directive', () => {
         nestedObject: () => null,
       },
     });
-    expectJSON(result).toDeepEqual({
-      data: { hero: { nestedObject: null } },
-    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { nestedObject: null } },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { nestedObject: null },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
-  it('Deduplicates promise object fields', async () => {
+  it('Does not deduplicate promise object fields', async () => {
     const document = parse(`
       query {
         hero {
@@ -2517,9 +2436,21 @@ describe('Execute: defer directive', () => {
         nestedObject: () => Promise.resolve({ name: 'foo' }),
       },
     });
-    expectJSON(result).toDeepEqual({
-      data: { hero: { nestedObject: { name: 'foo' } } },
-    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { nestedObject: { name: 'foo' } } },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { nestedObject: { name: 'foo' } },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
   });
 
   it('Handles errors thrown in deferred fragments', async () => {
@@ -2545,14 +2476,12 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
         incremental: [
           {
             data: { name: null },
-            id: '0',
             errors: [
               {
                 message: 'bad',
@@ -2560,9 +2489,9 @@ describe('Execute: defer directive', () => {
                 path: ['hero', 'name'],
               },
             ],
+            path: ['hero'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     ]);
@@ -2588,13 +2517,13 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [
+        incremental: [
           {
-            id: '0',
+            data: null,
+            path: ['hero'],
             errors: [
               {
                 message:
@@ -2667,13 +2596,13 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: { id: '1' } },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        completed: [
+        incremental: [
           {
-            id: '0',
+            data: null,
+            path: ['hero'],
             errors: [
               {
                 message:
@@ -2720,25 +2649,18 @@ describe('Execute: defer directive', () => {
         data: {
           hero: { id: '1' },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        pending: [
-          { id: '1', path: ['hero', 'friends', 0] },
-          { id: '2', path: ['hero', 'friends', 1] },
-          { id: '3', path: ['hero', 'friends', 2] },
-        ],
         incremental: [
           {
             data: { name: 'slow', friends: [{}, {}, {}] },
-            id: '0',
+            path: ['hero'],
           },
-          { data: { name: 'Han' }, id: '1' },
-          { data: { name: 'Leia' }, id: '2' },
-          { data: { name: 'C-3PO' }, id: '3' },
+          { data: { name: 'Han' }, path: ['hero', 'friends', 0] },
+          { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
+          { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
-        completed: [{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
       },
     ]);
@@ -2767,28 +2689,21 @@ describe('Execute: defer directive', () => {
         data: {
           hero: { id: '1' },
         },
-        pending: [{ id: '0', path: ['hero'] }],
         hasNext: true,
       },
       {
-        pending: [
-          { id: '1', path: ['hero', 'friends', 0] },
-          { id: '2', path: ['hero', 'friends', 1] },
-          { id: '3', path: ['hero', 'friends', 2] },
-        ],
         incremental: [
           {
             data: {
               name: 'Luke',
               friends: [{}, {}, {}],
             },
-            id: '0',
+            path: ['hero'],
           },
-          { data: { name: 'Han' }, id: '1' },
-          { data: { name: 'Leia' }, id: '2' },
-          { data: { name: 'C-3PO' }, id: '3' },
+          { data: { name: 'Han' }, path: ['hero', 'friends', 0] },
+          { data: { name: 'Leia' }, path: ['hero', 'friends', 1] },
+          { data: { name: 'C-3PO' }, path: ['hero', 'friends', 2] },
         ],
-        completed: [{ id: '0' }, { id: '1' }, { id: '2' }, { id: '3' }],
         hasNext: false,
       },
     ]);
@@ -2851,7 +2766,7 @@ describe('Execute: defer directive', () => {
       }
     `);
 
-    const result = await experimentalExecuteIncrementally({
+    const result = await legacyExecuteIncrementally({
       schema: cancellationSchema,
       document,
       rootValue: {
@@ -2872,7 +2787,6 @@ describe('Execute: defer directive', () => {
           id: null,
         },
       },
-      pending: [{ id: '0', path: ['todo'] }],
       hasNext: true,
     });
 
@@ -2883,10 +2797,9 @@ describe('Execute: defer directive', () => {
         incremental: [
           {
             data: { author: { id: '1' } },
-            id: '0',
+            path: ['todo'],
           },
         ],
-        completed: [{ id: '0' }],
         hasNext: false,
       },
     });
@@ -2907,7 +2820,7 @@ describe('Execute: defer directive', () => {
       }
     `);
 
-    const resultPromise = experimentalExecuteIncrementally({
+    const resultPromise = legacyExecuteIncrementally({
       schema: cancellationSchema,
       document,
       rootValue: {
@@ -2969,7 +2882,7 @@ describe('Execute: defer directive', () => {
     const { promise: slowPromise } = promiseWithResolvers<unknown>();
     const document = parse('{ scalarList ... @defer { slowScalarList } }');
 
-    const result = await experimentalExecuteIncrementally({
+    const result = await legacyExecuteIncrementally({
       schema: cancellationSchema,
       document,
       rootValue: {
@@ -3010,7 +2923,7 @@ describe('Execute: defer directive', () => {
     const { promise: authorPromise, resolve: resolveAuthor } =
       promiseWithResolvers<{ id: string }>();
 
-    const result = await experimentalExecuteIncrementally({
+    const result = await legacyExecuteIncrementally({
       schema: cancellationSchema,
       document,
       abortSignal: abortController.signal,
@@ -3062,7 +2975,7 @@ describe('Execute: defer directive', () => {
     const { promise: authorPromise, reject: rejectAuthor } =
       promiseWithResolvers<{ id: string }>();
 
-    const result = await experimentalExecuteIncrementally({
+    const result = await legacyExecuteIncrementally({
       schema: cancellationSchema,
       document,
       abortSignal: abortController.signal,

--- a/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
@@ -1,0 +1,3188 @@
+import { assert, expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectJSON } from '../../../__testUtils__/expectJSON.js';
+import { expectPromise } from '../../../__testUtils__/expectPromise.js';
+import { resolveOnNextTick } from '../../../__testUtils__/resolveOnNextTick.js';
+
+import type { PromiseOrValue } from '../../../jsutils/PromiseOrValue.js';
+import { promiseWithResolvers } from '../../../jsutils/promiseWithResolvers.js';
+
+import type { DocumentNode } from '../../../language/ast.js';
+import { parse } from '../../../language/parser.js';
+
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+} from '../../../type/definition.js';
+import { GraphQLID, GraphQLString } from '../../../type/scalars.js';
+import { GraphQLSchema } from '../../../type/schema.js';
+
+import { buildSchema } from '../../../utilities/buildASTSchema.js';
+
+import type {
+  InitialIncrementalExecutionResult,
+  SubsequentIncrementalExecutionResult,
+} from '../BranchingIncrementalExecutor.js';
+import { legacyExecuteIncrementally } from '../legacyExecuteIncrementally.js';
+
+const friendType = new GraphQLObjectType({
+  fields: {
+    id: { type: GraphQLID },
+    name: { type: GraphQLString },
+    nonNullName: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  name: 'Friend',
+});
+
+const friends = [
+  { name: 'Luke', id: 1 },
+  { name: 'Han', id: 2 },
+  { name: 'Leia', id: 3 },
+];
+
+const query = new GraphQLObjectType({
+  fields: {
+    scalarList: {
+      type: new GraphQLList(GraphQLString),
+    },
+    scalarListList: {
+      type: new GraphQLList(new GraphQLList(GraphQLString)),
+    },
+    friendList: {
+      type: new GraphQLList(friendType),
+    },
+    nonNullFriendList: {
+      type: new GraphQLList(new GraphQLNonNull(friendType)),
+    },
+    nestedObject: {
+      type: new GraphQLObjectType({
+        name: 'NestedObject',
+        fields: {
+          scalarField: {
+            type: GraphQLString,
+          },
+          nonNullScalarField: {
+            type: new GraphQLNonNull(GraphQLString),
+          },
+          nestedFriendList: { type: new GraphQLList(friendType) },
+          deeperNestedObject: {
+            type: new GraphQLObjectType({
+              name: 'DeeperNestedObject',
+              fields: {
+                nonNullScalarField: {
+                  type: new GraphQLNonNull(GraphQLString),
+                },
+                deeperNestedFriendList: { type: new GraphQLList(friendType) },
+              },
+            }),
+          },
+        },
+      }),
+    },
+  },
+  name: 'Query',
+});
+
+const schema = new GraphQLSchema({ query });
+
+const cancellationSchema = buildSchema(`
+  type Todo {
+    id: ID
+    items: [String]
+    author: User
+  }
+
+  type User {
+    id: ID
+    name: String
+  }
+
+  type Query {
+    todo: Todo
+    nonNullableTodo: Todo!
+    blocker: String
+    scalarList: [String]
+    slowScalarList: [String]
+  }
+
+  type Mutation {
+    foo: String
+    bar: String
+  }
+
+  type Subscription {
+    foo: String
+  }
+`);
+
+const cancelStreamSchema = buildSchema(`
+  type CancelStreamUser {
+    id: String
+  }
+
+  type CancelStreamTodo {
+    id: String
+    items: [String]
+    author: CancelStreamUser
+  }
+
+  type Query {
+    todos: [CancelStreamTodo]
+  }
+`);
+
+async function complete(
+  document: DocumentNode,
+  rootValue: unknown = {},
+  enableEarlyExecution = false,
+) {
+  const result = await legacyExecuteIncrementally({
+    schema,
+    document,
+    rootValue,
+    enableEarlyExecution,
+  });
+
+  if ('initialResult' in result) {
+    const results: Array<
+      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+    > = [result.initialResult];
+    for await (const patch of result.subsequentResults) {
+      results.push(patch);
+    }
+    return results;
+  }
+  return result;
+}
+
+async function completeAsync(
+  document: DocumentNode,
+  numCalls: number,
+  rootValue: unknown = {},
+) {
+  const result = await legacyExecuteIncrementally({
+    schema,
+    document,
+    rootValue,
+  });
+
+  assert('initialResult' in result);
+
+  const iterator = result.subsequentResults[Symbol.asyncIterator]();
+
+  const promises: Array<
+    PromiseOrValue<
+      IteratorResult<
+        InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+      >
+    >
+  > = [{ done: false, value: result.initialResult }];
+  for (let i = 0; i < numCalls; i++) {
+    promises.push(iterator.next());
+  }
+  return Promise.all(promises);
+}
+
+describe('Execute: stream directive (legacy)', () => {
+  it('Can stream a list field', async () => {
+    const document = parse('{ scalarList @stream(initialCount: 1) }');
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarList: ['apple'],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: ['banana', 'coconut'],
+            path: ['scalarList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can use default value of initialCount', async () => {
+    const document = parse('{ scalarList @stream }');
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: ['apple', 'banana', 'coconut'],
+            path: ['scalarList', 0],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Negative values of initialCount throw field errors', async () => {
+    const document = parse('{ scalarList @stream(initialCount: -2) }');
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'initialCount must be a positive integer',
+          locations: [
+            {
+              line: 1,
+              column: 3,
+            },
+          ],
+          path: ['scalarList'],
+        },
+      ],
+      data: {
+        scalarList: null,
+      },
+    });
+  });
+  it('Returns label from stream directive', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 1, label: "scalar-stream") }',
+    );
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarList: ['apple'],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: ['banana', 'coconut'],
+            path: ['scalarList', 1],
+            label: 'scalar-stream',
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can disable @stream using if argument', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 0, if: false) }',
+    );
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual({
+      data: { scalarList: ['apple', 'banana', 'coconut'] },
+    });
+  });
+  it('Does not disable stream with null if argument', async () => {
+    const document = parse(
+      'query ($shouldStream: Boolean) { scalarList @stream(initialCount: 2, if: $shouldStream) }',
+    );
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: { scalarList: ['apple', 'banana'] },
+        hasNext: true,
+      },
+      {
+        incremental: [{ items: ['coconut'], path: ['scalarList', 2] }],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream multi-dimensional lists', async () => {
+    const document = parse('{ scalarListList @stream(initialCount: 1) }');
+    const result = await complete(document, {
+      scalarListList: () => [
+        ['apple', 'apple', 'apple'],
+        ['banana', 'banana', 'banana'],
+        ['coconut', 'coconut', 'coconut'],
+      ],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarListList: [['apple', 'apple', 'apple']],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [
+              ['banana', 'banana', 'banana'],
+              ['coconut', 'coconut', 'coconut'],
+            ],
+            path: ['scalarListList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream a field that returns a list of promises', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () => friends.map((f) => Promise.resolve(f)),
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            {
+              name: 'Han',
+              id: '2',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [
+              {
+                name: 'Leia',
+                id: '3',
+              },
+            ],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream in correct order with lists of promises', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () => friends.map((f) => Promise.resolve(f)),
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Luke', id: '1' }],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Han', id: '2' }],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Leia', id: '3' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Does not execute early if not specified', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+    const order: Array<number> = [];
+    const result = await complete(document, {
+      friendList: () =>
+        friends.map((f, i) => ({
+          id: async () => {
+            const slowness = 3 - i;
+            for (let j = 0; j < slowness; j++) {
+              // eslint-disable-next-line no-await-in-loop
+              await resolveOnNextTick();
+            }
+            order.push(i);
+            return f.id;
+          },
+        })),
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '1' }],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '2' }],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '3' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(order).to.deep.equal([0, 1, 2]);
+  });
+  it('Executes early if specified', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+    const order: Array<number> = [];
+    const result = await complete(
+      document,
+      {
+        friendList: () =>
+          friends.map((f, i) => ({
+            id: async () => {
+              const slowness = 3 - i;
+              for (let j = 0; j < slowness; j++) {
+                // eslint-disable-next-line no-await-in-loop
+                await resolveOnNextTick();
+              }
+              order.push(i);
+              return f.id;
+            },
+          })),
+      },
+      true,
+    );
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '1' }, { id: '2' }, { id: '3' }],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(order).to.deep.equal([2, 1, 0]);
+  });
+  it('Can stream a field that returns a list with nested promises', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () =>
+        friends.map((f) => ({
+          name: Promise.resolve(f.name),
+          id: Promise.resolve(f.id),
+        })),
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [
+            {
+              name: 'Luke',
+              id: '1',
+            },
+            {
+              name: 'Han',
+              id: '2',
+            },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [
+              {
+                name: 'Leia',
+                id: '3',
+              },
+            ],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles rejections in a field that returns a list of promises before initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () =>
+        friends.map((f, i) => {
+          if (i === 1) {
+            return Promise.reject(new Error('bad'));
+          }
+          return Promise.resolve(f);
+        }),
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        errors: [
+          {
+            message: 'bad',
+            locations: [{ line: 3, column: 9 }],
+            path: ['friendList', 1],
+          },
+        ],
+        data: {
+          friendList: [{ name: 'Luke', id: '1' }, null],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Leia', id: '3' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles rejections in a field that returns a list of promises after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () =>
+        friends.map((f, i) => {
+          if (i === 1) {
+            return Promise.reject(new Error('bad'));
+          }
+          return Promise.resolve(f);
+        }),
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [{ name: 'Luke', id: '1' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message: 'bad',
+                locations: [{ line: 3, column: 9 }],
+                path: ['friendList', 1],
+              },
+            ],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Leia', id: '3' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream a field that returns an async iterable', async () => {
+    const document = parse(`
+      query {
+        friendList @stream {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve(friends[0]);
+        yield await Promise.resolve(friends[1]);
+        yield await Promise.resolve(friends[2]);
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Luke', id: '1' }],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [
+              { name: 'Han', id: '2' },
+              { name: 'Leia', id: '3' },
+            ],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Can stream a field that returns an async iterable, using a non-zero initialCount', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve(friends[0]);
+        yield await Promise.resolve(friends[1]);
+        yield await Promise.resolve(friends[2]);
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [
+            { name: 'Luke', id: '1' },
+            { name: 'Han', id: '2' },
+          ],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ name: 'Leia', id: '3' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Negative values of initialCount throw field errors on a field that returns an async iterable', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: -2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        // no-op, not called
+      },
+    });
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'initialCount must be a positive integer',
+          locations: [{ line: 3, column: 9 }],
+          path: ['friendList'],
+        },
+      ],
+      data: {
+        friendList: null,
+      },
+    });
+  });
+  it('Does not execute early if not specified, when streaming from an async iterable', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+    const order: Array<number> = [];
+    // eslint-disable-next-line @typescript-eslint/require-await
+    const slowFriend = async (n: number) => ({
+      id: async () => {
+        const slowness = (3 - n) * 10;
+        for (let j = 0; j < slowness; j++) {
+          // eslint-disable-next-line no-await-in-loop
+          await resolveOnNextTick();
+        }
+        order.push(n);
+        return friends[n].id;
+      },
+    });
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve(slowFriend(0));
+        yield await Promise.resolve(slowFriend(1));
+        yield await Promise.resolve(slowFriend(2));
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '1' }],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '2' }],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '3' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(order).to.deep.equal([0, 1, 2]);
+  });
+  it('Executes early if specified when streaming from an async iterable', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+    const order: Array<number> = [];
+    const slowFriend = (n: number) => ({
+      id: async () => {
+        const slowness = (3 - n) * 10;
+        for (let j = 0; j < slowness; j++) {
+          // eslint-disable-next-line no-await-in-loop
+          await resolveOnNextTick();
+        }
+        order.push(n);
+        return friends[n].id;
+      },
+    });
+    const result = await complete(
+      document,
+      {
+        async *friendList() {
+          yield await Promise.resolve(slowFriend(0));
+          yield await Promise.resolve(slowFriend(1));
+          yield await Promise.resolve(slowFriend(2));
+        },
+      },
+      true,
+    );
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '1' }, { id: '2' }, { id: '3' }],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(order).to.deep.equal([2, 1, 0]);
+  });
+  it('Can handle concurrent calls to .next() without waiting', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await completeAsync(document, 2, {
+      async *friendList() {
+        yield await Promise.resolve(friends[0]);
+        yield await Promise.resolve(friends[1]);
+        yield await Promise.resolve(friends[2]);
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        done: false,
+        value: {
+          data: {
+            friendList: [
+              { name: 'Luke', id: '1' },
+              { name: 'Han', id: '2' },
+            ],
+          },
+          hasNext: true,
+        },
+      },
+      {
+        done: false,
+        value: {
+          incremental: [
+            {
+              items: [{ name: 'Leia', id: '3' }],
+              path: ['friendList', 2],
+            },
+          ],
+          hasNext: false,
+        },
+      },
+      { done: true, value: undefined },
+    ]);
+  });
+  it('Handles error thrown in async iterable before initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 2) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve(friends[0]);
+        throw new Error('bad');
+      },
+    });
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message: 'bad',
+          locations: [{ line: 3, column: 9 }],
+          path: ['friendList'],
+        },
+      ],
+      data: {
+        friendList: null,
+      },
+    });
+  });
+  it('Handles error thrown in async iterable after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve(friends[0]);
+        throw new Error('bad');
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [{ name: 'Luke', id: '1' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['friendList'],
+            errors: [
+              {
+                message: 'bad',
+                locations: [{ line: 3, column: 9 }],
+                path: ['friendList'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles null returned in non-null list items after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          name
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nonNullFriendList: () => [friends[0], null, friends[1]],
+    });
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ name: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message:
+                  'Cannot return null for non-nullable field Query.nonNullFriendList.',
+                locations: [{ line: 3, column: 9 }],
+                path: ['nonNullFriendList', 1],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles null returned in non-null async iterable list items after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          name
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *nonNullFriendList() {
+        try {
+          yield await Promise.resolve(friends[0]);
+          yield await Promise.resolve(null); /* c8 ignore start */
+          // Not reachable, early return
+        } finally {
+          /* c8 ignore stop */
+          // eslint-disable-next-line no-unsafe-finally
+          throw new Error('Oops');
+        }
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ name: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message:
+                  'Cannot return null for non-nullable field Query.nonNullFriendList.',
+                locations: [{ line: 3, column: 9 }],
+                path: ['nonNullFriendList', 1],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles errors thrown by completeValue after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        scalarList @stream(initialCount: 1)
+      }
+    `);
+    const result = await complete(document, {
+      scalarList: () => [friends[0].name, {}],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarList: ['Luke'],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message: 'String cannot represent value: {}',
+                locations: [{ line: 3, column: 9 }],
+                path: ['scalarList', 1],
+              },
+            ],
+            path: ['scalarList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () => [
+        Promise.resolve({ nonNullName: friends[0].name }),
+        Promise.resolve({
+          nonNullName: () => Promise.reject(new Error('Oops')),
+        }),
+        Promise.resolve({ nonNullName: friends[1].name }),
+      ],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['friendList', 1, 'nonNullName'],
+              },
+            ],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ nonNullName: 'Han' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles nested async errors thrown by completeValue after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    const result = await complete(document, {
+      friendList: () => [
+        { nonNullName: Promise.resolve(friends[0].name) },
+        { nonNullName: Promise.reject(new Error('Oops')) },
+        { nonNullName: Promise.resolve(friends[1].name) },
+      ],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['friendList', 1, 'nonNullName'],
+              },
+            ],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ nonNullName: 'Han' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached for a non-nullable list', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nonNullFriendList: () => [
+        Promise.resolve({ nonNullName: friends[0].name }),
+        Promise.resolve({
+          nonNullName: () => Promise.reject(new Error('Oops')),
+        }),
+        Promise.resolve({ nonNullName: friends[1].name }),
+      ],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles nested async errors thrown by completeValue after initialCount is reached for a non-nullable list', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nonNullFriendList: () => [
+        { nonNullName: Promise.resolve(friends[0].name) },
+        { nonNullName: Promise.reject(new Error('Oops')) },
+        { nonNullName: Promise.resolve(friends[1].name) },
+      ],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve({ nonNullName: friends[0].name });
+        yield await Promise.resolve({
+          nonNullName: () => Promise.reject(new Error('Oops')),
+        });
+        yield await Promise.resolve({ nonNullName: friends[1].name });
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['friendList', 1, 'nonNullName'],
+              },
+            ],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ nonNullName: 'Han' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async generator for a non-nullable list', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *nonNullFriendList() {
+        yield await Promise.resolve({ nonNullName: friends[0].name });
+        yield await Promise.resolve({
+          nonNullName: () => Promise.reject(new Error('Oops')),
+        }); /* c8 ignore start */
+      } /* c8 ignore stop */,
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list when the async iterable does not provide a return method) ', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    let count = 0;
+    const result = await complete(document, {
+      nonNullFriendList: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            switch (count++) {
+              case 0:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[0].name },
+                });
+              case 1:
+                return Promise.resolve({
+                  done: false,
+                  value: {
+                    nonNullName: () => Promise.reject(new Error('Oops')),
+                  },
+                });
+              // Not reached
+              /* c8 ignore next 5 */
+              case 2:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[1].name },
+                });
+            }
+          },
+        }),
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list when the async iterable provides concurrent next/return methods and has a slow return ', async () => {
+    const document = parse(`
+      query {
+        nonNullFriendList @stream(initialCount: 1) {
+          nonNullName
+        }
+      }
+    `);
+    let count = 0;
+    let returned = false;
+    const result = await complete(document, {
+      nonNullFriendList: {
+        [Symbol.asyncIterator]: () => ({
+          next: async () => {
+            /* c8 ignore next 3 */
+            if (returned) {
+              return Promise.resolve({ done: true });
+            }
+            switch (count++) {
+              case 0:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[0].name },
+                });
+              case 1:
+                return Promise.resolve({
+                  done: false,
+                  value: {
+                    nonNullName: () => Promise.reject(new Error('Oops')),
+                  },
+                });
+              // Not reached
+              /* c8 ignore next 5 */
+              case 2:
+                return Promise.resolve({
+                  done: false,
+                  value: { nonNullName: friends[1].name },
+                });
+            }
+          },
+          return: async () => {
+            await resolveOnNextTick();
+            returned = true;
+            return { done: true };
+          },
+        }),
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nonNullFriendList: [{ nonNullName: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: null,
+            path: ['nonNullFriendList'],
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 4, column: 11 }],
+                path: ['nonNullFriendList', 1, 'nonNullName'],
+              },
+            ],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+    expect(returned).to.equal(true);
+  });
+  it('Filters payloads that are nulled', async () => {
+    const document = parse(`
+      query {
+        nestedObject {
+          nonNullScalarField
+          nestedFriendList @stream(initialCount: 0) {
+            name
+          }
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nestedObject: {
+        nonNullScalarField: () => Promise.resolve(null),
+        async *nestedFriendList() {
+          yield await Promise.resolve(friends[0]); /* c8 ignore start */
+        } /* c8 ignore stop */,
+      },
+    });
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field NestedObject.nonNullScalarField.',
+          locations: [{ line: 4, column: 11 }],
+          path: ['nestedObject', 'nonNullScalarField'],
+        },
+      ],
+      data: {
+        nestedObject: null,
+      },
+    });
+  });
+  it('Filters payloads that are nulled by a later synchronous error', async () => {
+    const document = parse(`
+      query {
+        nestedObject {
+          nestedFriendList @stream(initialCount: 0) {
+            name
+          }
+          nonNullScalarField
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nestedObject: {
+        async *nestedFriendList() {
+          yield await Promise.resolve(friends[0]); /* c8 ignore start */
+        } /* c8 ignore stop */,
+        nonNullScalarField: () => null,
+      },
+    });
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field NestedObject.nonNullScalarField.',
+          locations: [{ line: 7, column: 11 }],
+          path: ['nestedObject', 'nonNullScalarField'],
+        },
+      ],
+      data: {
+        nestedObject: null,
+      },
+    });
+  });
+  it('Does not filter payloads when null error is in a different path', async () => {
+    const document = parse(`
+      query {
+        otherNestedObject: nestedObject {
+          ... @defer {
+            scalarField
+          }
+        }
+        nestedObject {
+          nestedFriendList @stream(initialCount: 0) {
+            name
+          }
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nestedObject: {
+        scalarField: () => Promise.reject(new Error('Oops')),
+        async *nestedFriendList() {
+          yield await Promise.resolve(friends[0]);
+        },
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          otherNestedObject: {},
+          nestedObject: { nestedFriendList: [] },
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { scalarField: null },
+            errors: [
+              {
+                message: 'Oops',
+                locations: [{ line: 5, column: 13 }],
+                path: ['otherNestedObject', 'scalarField'],
+              },
+            ],
+            path: ['otherNestedObject'],
+          },
+          {
+            items: [{ name: 'Luke' }],
+            path: ['nestedObject', 'nestedFriendList', 0],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Cancels async stream items when null bubbles past the stream', async () => {
+    const document = parse(`
+      query {
+        nestedObject {
+          nestedFriendList @stream(initialCount: 0) {
+            name
+          }
+          nonNullScalarField
+        }
+      }
+    `);
+    const { promise: friendsStarted, resolve: resolveFriendsStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: nonNullPromise, resolve: resolveNonNull } =
+      promiseWithResolvers<string | null>();
+    const { promise: namePromise, resolve: resolveName } =
+      promiseWithResolvers<string>();
+
+    const resultPromise = legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        nestedObject: {
+          nestedFriendList() {
+            resolveFriendsStarted();
+            return [{ name: namePromise }];
+          },
+          nonNullScalarField() {
+            return nonNullPromise;
+          },
+        },
+      },
+      enableEarlyExecution: true,
+    });
+
+    await friendsStarted;
+    await resolveOnNextTick();
+    resolveNonNull(null);
+
+    const result = await resultPromise;
+    assert(!('initialResult' in result));
+    expectJSON(result).toDeepEqual({
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field NestedObject.nonNullScalarField.',
+          locations: [{ line: 7, column: 11 }],
+          path: ['nestedObject', 'nonNullScalarField'],
+        },
+      ],
+      data: {
+        nestedObject: null,
+      },
+    });
+
+    resolveName('Luke');
+  });
+  it('Filters stream payloads that are nulled in a deferred payload', async () => {
+    const document = parse(`
+      query {
+        nestedObject {
+          ... @defer {
+            deeperNestedObject {
+              nonNullScalarField
+              deeperNestedFriendList @stream(initialCount: 0) {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nestedObject: {
+        deeperNestedObject: {
+          nonNullScalarField: () => Promise.resolve(null),
+          async *deeperNestedFriendList() {
+            yield await Promise.resolve(friends[0]); /* c8 ignore start */
+          } /* c8 ignore stop */,
+        },
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nestedObject: {},
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: {
+              deeperNestedObject: null,
+            },
+            errors: [
+              {
+                message:
+                  'Cannot return null for non-nullable field DeeperNestedObject.nonNullScalarField.',
+                locations: [{ line: 6, column: 15 }],
+                path: [
+                  'nestedObject',
+                  'deeperNestedObject',
+                  'nonNullScalarField',
+                ],
+              },
+            ],
+            path: ['nestedObject'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Filters defer payloads that are nulled in a stream response', async () => {
+    const document = parse(`
+    query {
+      friendList @stream(initialCount: 0) {
+        nonNullName
+        ... @defer {
+          name
+        }
+      }
+    }
+  `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve({
+          name: friends[0].name,
+          nonNullName: () => Promise.resolve(null),
+        });
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [null],
+            errors: [
+              {
+                message:
+                  'Cannot return null for non-nullable field Friend.nonNullName.',
+                locations: [{ line: 4, column: 9 }],
+                path: ['friendList', 0, 'nonNullName'],
+              },
+            ],
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+
+  it('Returns iterator and ignores errors when stream payloads are filtered', async () => {
+    let returned = false;
+    let requested = false;
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          /* c8 ignore start */
+          if (requested) {
+            // stream is filtered, next is not called, and so this is not reached.
+            return Promise.reject(new Error('Oops'));
+          } /* c8 ignore stop */
+          requested = true;
+          const friend = friends[0];
+          return Promise.resolve({
+            done: false,
+            value: {
+              name: friend.name,
+              nonNullName: null,
+            },
+          });
+        },
+        return: () => {
+          returned = true;
+          // Ignores errors from return.
+          return Promise.reject(new Error('Oops'));
+        },
+      }),
+    };
+
+    const document = parse(`
+      query {
+        nestedObject {
+          ... @defer {
+            deeperNestedObject {
+              nonNullScalarField
+              deeperNestedFriendList @stream(initialCount: 0) {
+                name
+              }
+            }
+          }
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        nestedObject: {
+          deeperNestedObject: {
+            nonNullScalarField: () => Promise.resolve(null),
+            deeperNestedFriendList: iterable,
+          },
+        },
+      },
+      enableEarlyExecution: true,
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        nestedObject: {},
+      },
+      hasNext: true,
+    });
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      done: false,
+      value: {
+        incremental: [
+          {
+            data: {
+              deeperNestedObject: null,
+            },
+            errors: [
+              {
+                message:
+                  'Cannot return null for non-nullable field DeeperNestedObject.nonNullScalarField.',
+                locations: [{ line: 6, column: 15 }],
+                path: [
+                  'nestedObject',
+                  'deeperNestedObject',
+                  'nonNullScalarField',
+                ],
+              },
+            ],
+            path: ['nestedObject'],
+          },
+        ],
+        hasNext: false,
+      },
+    });
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({ done: true, value: undefined });
+
+    assert(returned);
+  });
+  it('Handles promises returned by completeValue after initialCount is reached', async () => {
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          id
+          name
+        }
+      }
+    `);
+    const result = await complete(document, {
+      async *friendList() {
+        yield await Promise.resolve(friends[0]);
+        yield await Promise.resolve(friends[1]);
+        yield await Promise.resolve({
+          id: friends[2].id,
+          name: () => Promise.resolve(friends[2].name),
+        });
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          friendList: [{ id: '1', name: 'Luke' }],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '2', name: 'Han' }],
+            path: ['friendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '3', name: 'Leia' }],
+            path: ['friendList', 2],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Handles overlapping deferred and non-deferred streams', async () => {
+    const document = parse(`
+      query {
+        nestedObject {
+          nestedFriendList @stream(initialCount: 0) {
+            id
+          }
+        }
+        nestedObject {
+          ... @defer {
+            nestedFriendList @stream(initialCount: 0) {
+              id
+              name
+            }
+          }
+        }
+      }
+    `);
+    const result = await complete(document, {
+      nestedObject: {
+        async *nestedFriendList() {
+          yield await Promise.resolve(friends[0]);
+          yield await Promise.resolve(friends[1]);
+        },
+      },
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          nestedObject: {
+            nestedFriendList: [],
+          },
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: {
+              nestedFriendList: [],
+            },
+            path: ['nestedObject'],
+          },
+          {
+            items: [{ id: '1' }],
+            path: ['nestedObject', 'nestedFriendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '1', name: 'Luke' }],
+            path: ['nestedObject', 'nestedFriendList', 0],
+          },
+          {
+            items: [{ id: '2' }],
+            path: ['nestedObject', 'nestedFriendList', 1],
+          },
+        ],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: [{ id: '2', name: 'Han' }],
+            path: ['nestedObject', 'nestedFriendList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Re-promotes a completed stream when a slower sibling defer resolves later', async () => {
+    const { promise: slowFieldPromise, resolve: resolveSlowField } =
+      promiseWithResolvers<string>();
+    const document = parse(`
+      query {
+        nestedObject {
+          ... @defer {
+            nestedFriendList @stream { name }
+          }
+          ... @defer {
+            scalarField
+            nestedFriendList @stream { name }
+          }
+        }
+      }
+    `);
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        nestedObject: {
+          nestedFriendList: () => friends,
+          scalarField: slowFieldPromise,
+        },
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        nestedObject: {},
+      },
+      hasNext: true,
+    });
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: {
+              nestedFriendList: [],
+            },
+            path: ['nestedObject'],
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    resolveSlowField('slow');
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ name: 'Luke' }, { name: 'Han' }, { name: 'Leia' }],
+            path: ['nestedObject', 'nestedFriendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: {
+              nestedFriendList: [],
+              scalarField: 'slow',
+            },
+            path: ['nestedObject'],
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result5 = await iterator.next();
+    expectJSON(result5).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ name: 'Luke' }, { name: 'Han' }, { name: 'Leia' }],
+            path: ['nestedObject', 'nestedFriendList', 0],
+          },
+        ],
+        hasNext: false,
+      },
+      done: false,
+    });
+
+    const result6 = await iterator.next();
+    expectJSON(result6).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+  it('Returns payloads in correct order when parent deferred fragment resolves slower than stream', async () => {
+    const { promise: slowFieldPromise, resolve: resolveSlowField } =
+      promiseWithResolvers();
+    const document = parse(`
+      query {
+        nestedObject {
+          ... DeferFragment @defer
+        }
+      }
+      fragment DeferFragment on NestedObject {
+        scalarField
+        nestedFriendList @stream(initialCount: 0) {
+          name
+        }
+      }
+    `);
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        nestedObject: {
+          scalarField: () => slowFieldPromise,
+          async *nestedFriendList() {
+            yield await Promise.resolve(friends[0]);
+            yield await Promise.resolve(friends[1]);
+          },
+        },
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        nestedObject: {},
+      },
+      hasNext: true,
+    });
+
+    const result2Promise = iterator.next();
+    resolveSlowField('slow');
+    const result2 = await result2Promise;
+    expectJSON(result2).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: { scalarField: 'slow', nestedFriendList: [] },
+            path: ['nestedObject'],
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ name: 'Luke' }],
+            path: ['nestedObject', 'nestedFriendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ name: 'Han' }],
+            path: ['nestedObject', 'nestedFriendList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+      done: false,
+    });
+
+    const result5 = await iterator.next();
+    expectJSON(result5).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
+  });
+  it('Can @defer fields that are resolved after async iterable is complete', async () => {
+    const { promise: slowFieldPromise, resolve: resolveSlowField } =
+      promiseWithResolvers();
+    const {
+      promise: iterableCompletionPromise,
+      resolve: resolveIterableCompletion,
+    } = promiseWithResolvers();
+
+    const document = parse(`
+    query {
+      friendList @stream(label:"stream-label") {
+        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+        id
+      }
+    }
+    fragment NameFragment on Friend {
+      name
+    }
+  `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        async *friendList() {
+          yield await Promise.resolve(friends[0]);
+          yield await Promise.resolve({
+            id: friends[1].id,
+            name: () => slowFieldPromise,
+          });
+          await iterableCompletionPromise;
+        },
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [],
+      },
+      hasNext: true,
+    });
+
+    const result2Promise = iterator.next();
+    resolveIterableCompletion(null);
+    const result2 = await result2Promise;
+    expectJSON(result2).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ id: '1' }],
+            path: ['friendList', 0],
+            label: 'stream-label',
+          },
+          {
+            data: { name: 'Luke' },
+            path: ['friendList', 0],
+            label: 'DeferName',
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result3Promise = iterator.next();
+    resolveSlowField('Han');
+    const result3 = await result3Promise;
+    expectJSON(result3).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ id: '2' }],
+            path: ['friendList', 1],
+            label: 'stream-label',
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: { name: 'Han' },
+            path: ['friendList', 1],
+            label: 'DeferName',
+          },
+        ],
+        hasNext: false,
+      },
+      done: false,
+    });
+    const result5 = await iterator.next();
+    expectJSON(result5).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
+  });
+  it('Can @defer fields that are resolved before async iterable is complete', async () => {
+    const { promise: slowFieldPromise, resolve: resolveSlowField } =
+      promiseWithResolvers();
+    const {
+      promise: iterableCompletionPromise,
+      resolve: resolveIterableCompletion,
+    } = promiseWithResolvers();
+
+    const document = parse(`
+    query {
+      friendList @stream(initialCount: 1, label:"stream-label") {
+        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+        id
+      }
+    }
+    fragment NameFragment on Friend {
+      name
+    }
+  `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        async *friendList() {
+          yield await Promise.resolve(friends[0]);
+          yield await Promise.resolve({
+            id: friends[1].id,
+            name: () => slowFieldPromise,
+          });
+          await iterableCompletionPromise;
+        },
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [{ id: '1' }],
+      },
+      hasNext: true,
+    });
+
+    const result2Promise = iterator.next();
+    resolveSlowField('Han');
+    const result2 = await result2Promise;
+    expectJSON(result2).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: { name: 'Luke' },
+            path: ['friendList', 0],
+            label: 'DeferName',
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            items: [{ id: '2' }],
+            path: ['friendList', 1],
+            label: 'stream-label',
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      value: {
+        incremental: [
+          {
+            data: { name: 'Han' },
+            path: ['friendList', 1],
+            label: 'DeferName',
+          },
+        ],
+        hasNext: true,
+      },
+      done: false,
+    });
+
+    const result5Promise = iterator.next();
+    resolveIterableCompletion(null);
+    const result5 = await result5Promise;
+    expectJSON(result5).toDeepEqual({
+      value: {
+        hasNext: false,
+      },
+      done: false,
+    });
+
+    const result6 = await iterator.next();
+    expectJSON(result6).toDeepEqual({
+      value: undefined,
+      done: true,
+    });
+  });
+  it('Returns underlying async iterables when returned generator is returned', async () => {
+    let returned = false;
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        return: () => {
+          returned = true;
+        },
+      }),
+    };
+
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        friendList: iterable,
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [],
+      },
+      hasNext: true,
+    });
+
+    const result2Promise = iterator.next();
+    const returnPromise = iterator.return();
+
+    const result2 = await result2Promise;
+    expectJSON(result2).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+    await returnPromise;
+    assert(returned);
+  });
+  it('Can return async iterable when underlying iterable does not have a return method', async () => {
+    let index = 0;
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          const friend = friends[index++];
+          if (friend == null) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return Promise.resolve({ done: false, value: friend });
+        },
+      }),
+    };
+
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          name
+          id
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        friendList: iterable,
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [
+          {
+            id: '1',
+            name: 'Luke',
+          },
+        ],
+      },
+      hasNext: true,
+    });
+
+    await iterator.return();
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+  it('Returns underlying async iterables when returned generator is thrown', async () => {
+    let index = 0;
+    let returned = false;
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          const friend = friends[index++];
+          if (friend == null) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return Promise.resolve({ done: false, value: friend });
+        },
+        return: () => {
+          returned = true;
+        },
+      }),
+    };
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 1) {
+          ... @defer {
+            name
+          }
+          id
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        friendList: iterable,
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [
+          {
+            id: '1',
+          },
+        ],
+      },
+      hasNext: true,
+    });
+
+    await expectPromise(iterator.throw(new Error('bad'))).toRejectWith('bad');
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+
+    assert(returned);
+  });
+  it('Returns underlying async iterables when uses resource is disposed', async () => {
+    let index = 0;
+    let returned = false;
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () => {
+          const friend = friends[index++];
+          if (friend == null) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return Promise.resolve({ done: false, value: friend });
+        },
+        return: () => {
+          returned = true;
+        },
+      }),
+    };
+
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        friendList: iterable,
+      },
+    });
+    assert('initialResult' in executeResult);
+
+    {
+      await using iterator =
+        executeResult.subsequentResults[Symbol.asyncIterator]();
+
+      const result1 = executeResult.initialResult;
+      expectJSON(result1).toDeepEqual({
+        data: {
+          friendList: [],
+        },
+        hasNext: true,
+      });
+
+      expectJSON(await iterator.next()).toDeepEqual({
+        done: false,
+        value: {
+          incremental: [
+            {
+              items: [{ id: '1' }, { id: '2' }],
+              path: ['friendList', 0],
+            },
+          ],
+          hasNext: true,
+        },
+      });
+    }
+
+    assert(returned);
+  });
+  it('limits stream batches to the default capacity (100)', async () => {
+    const document = parse(`
+      query {
+        friendList @stream {
+          id
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        async *friendList() {
+          for (let i = 0; i < 101; i++) {
+            // eslint-disable-next-line no-await-in-loop
+            yield await Promise.resolve(friends[i % 3]);
+          }
+        },
+      },
+      enableEarlyExecution: true,
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [],
+      },
+      hasNext: true,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const result2 = await iterator.next();
+    expectJSON(result2).toDeepEqual({
+      done: false,
+      value: {
+        incremental: [
+          {
+            items: Array.from({ length: 100 }, (_, i) => ({
+              id: ((i % 3) + 1).toString(),
+            })),
+            path: ['friendList', 0],
+          },
+        ],
+        hasNext: true,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const result3 = await iterator.next();
+    expectJSON(result3).toDeepEqual({
+      done: false,
+      value: {
+        incremental: [
+          {
+            items: [{ id: '2' }],
+            path: ['friendList', 100],
+          },
+        ],
+        hasNext: false,
+      },
+    });
+
+    const result4 = await iterator.next();
+    expectJSON(result4).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+  });
+});
+
+describe('Execute: stream directive (legacy cancellation)', () => {
+  it('should stop streamed execution when aborted', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          items @stream
+        }
+      }
+    `);
+
+    const resultPromise = (async () => {
+      const result = await legacyExecuteIncrementally({
+        schema: cancellationSchema,
+        document,
+        rootValue: {
+          todo: {
+            id: '1',
+            items: [Promise.resolve('item')],
+          },
+        },
+        abortSignal: abortController.signal,
+      });
+
+      if ('initialResult' in result) {
+        for await (const _patch of result.subsequentResults) {
+          // Consume to surface cancellation.
+        }
+      }
+      return result;
+    })();
+
+    abortController.abort();
+
+    await expectPromise(resultPromise).toRejectWith(
+      'This operation was aborted',
+    );
+  });
+
+  it('cancels streaming when aborted during async iterator next', async () => {
+    const abortController = new AbortController();
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+
+    const { promise: nextStarted, resolve: resolveNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: nextReturned, resolve: resolveNextReturned } =
+      promiseWithResolvers<IteratorResult<unknown>>();
+    let done = false;
+    const asyncIterator = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        if (done) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        done = true;
+        resolveNextStarted();
+        return nextReturned;
+      },
+    };
+
+    const result = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        scalarList: () => asyncIterator,
+      },
+      abortSignal: abortController.signal,
+    });
+    assert('initialResult' in result);
+
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+    await nextStarted;
+    abortController.abort();
+
+    resolveNextReturned({ value: 'value', done: false });
+    await expectPromise(nextPromise).toRejectWith('This operation was aborted');
+  });
+
+  it('cancels streaming when aborted while item promise is pending', async () => {
+    const abortController = new AbortController();
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+
+    const { promise: itemPromise, resolve: resolveItem } =
+      promiseWithResolvers<string>();
+    const { promise: nextStarted, resolve: resolveNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    let done = false;
+    const asyncIterator = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        if (done) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        done = true;
+        resolveNextStarted();
+        return Promise.resolve({ value: itemPromise, done: false });
+      },
+    };
+
+    const result = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        scalarList: () => asyncIterator,
+      },
+      abortSignal: abortController.signal,
+    });
+    assert('initialResult' in result);
+
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+    await nextStarted;
+    abortController.abort();
+
+    resolveItem('value');
+    await expectPromise(nextPromise).toRejectWith('This operation was aborted');
+  });
+
+  it('stops when the stream queue is back-pressured and the consumer cancels', async () => {
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+    const { promise: reachedCapacity, resolve: resolveReachedCapacity } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    let count = 0;
+    let done = false;
+    const iterator = {
+      [Symbol.iterator]() {
+        return this;
+      },
+      next() {
+        if (done) {
+          return { value: undefined, done: true };
+        }
+        count += 1;
+        if (count === 100) {
+          resolveReachedCapacity();
+        }
+        if (count > 100) {
+          done = true;
+        }
+        return { value: String(count), done: false };
+      },
+    };
+
+    const result = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        scalarList: () => iterator,
+      },
+      enableEarlyExecution: true,
+    });
+    assert('initialResult' in result);
+
+    await reachedCapacity;
+    await resolveOnNextTick();
+    const stream = result.subsequentResults[Symbol.asyncIterator]();
+    await expectPromise(stream.return()).toResolve();
+  });
+
+  it('cancels tasks and streams when aborted before initial execution finishes', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          items @stream(initialCount: 0)
+          ... @defer {
+            author {
+              id
+            }
+          }
+        }
+        blocker
+      }
+    `);
+
+    const { promise: blockerPromise, resolve: resolveBlocker } =
+      promiseWithResolvers<string>();
+    const { promise: blockerStarted, resolve: resolveBlockerStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: itemsStarted, resolve: resolveItemsStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+
+    const resultPromise = legacyExecuteIncrementally({
+      schema: cancellationSchema,
+      document,
+      abortSignal: abortController.signal,
+      rootValue: {
+        blocker() {
+          resolveBlockerStarted();
+          return blockerPromise;
+        },
+        todo: {
+          id: 'todo',
+          items() {
+            resolveItemsStarted();
+            return ['a', 'b'];
+          },
+          author() {
+            return { id: 'author' };
+          },
+        },
+      },
+    });
+
+    await itemsStarted;
+    await blockerStarted;
+
+    abortController.abort();
+
+    await expectPromise(resultPromise).toRejectWith(
+      'This operation was aborted',
+    );
+
+    resolveBlocker('done');
+  });
+
+  it('should ignore repeated cancellation attempts during incremental execution', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          id
+          items @stream(initialCount: 0)
+          ... @defer {
+            author {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    let streamReturnCount = 0;
+    let nextPromiseResolved = false;
+    const { promise: nextStarted, resolve: resolveNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: nextPromise, resolve: resolveNext } =
+      promiseWithResolvers<IteratorResult<string>>();
+    const asyncIterator = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        if (nextPromiseResolved) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        nextPromiseResolved = true;
+        resolveNextStarted();
+        return nextPromise;
+      },
+      return() {
+        streamReturnCount += 1;
+        return Promise.resolve({ value: undefined, done: true });
+      },
+    };
+
+    const { promise: authorStarted, resolve: resolveAuthorStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: authorPromise, resolve: resolveAuthor } =
+      promiseWithResolvers<{ id: string }>();
+    const rootValue = {
+      todo: {
+        id: 'todo',
+        items: () => asyncIterator,
+        author() {
+          resolveAuthorStarted();
+          return authorPromise;
+        },
+      },
+    };
+
+    const result = await legacyExecuteIncrementally({
+      schema: cancellationSchema,
+      document,
+      rootValue,
+      enableEarlyExecution: true,
+      abortSignal: abortController.signal,
+    });
+    assert('initialResult' in result);
+
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    const nextResultPromise = iterator.next();
+
+    await authorStarted;
+    await nextStarted;
+
+    abortController.abort();
+    await resolveOnNextTick();
+
+    let firstResult:
+      | IteratorResult<SubsequentIncrementalExecutionResult>
+      | undefined;
+    try {
+      firstResult =
+        (await nextResultPromise) as IteratorResult<SubsequentIncrementalExecutionResult>;
+    } catch (error) {
+      expect(error).to.be.instanceOf(Error);
+      expect((error as Error).message).to.equal('This operation was aborted');
+    }
+    if (firstResult && !firstResult.done) {
+      try {
+        const followUp = await iterator.next();
+        expect(followUp.done).to.equal(true);
+      } catch (error) {
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.equal('This operation was aborted');
+      }
+    }
+    expect(streamReturnCount).to.equal(1);
+
+    const priorStreamReturnCount = streamReturnCount;
+    abortController.abort();
+    await resolveOnNextTick();
+
+    expect(streamReturnCount).to.equal(priorStreamReturnCount);
+
+    resolveNext({ value: 'value', done: false });
+    resolveAuthor({ id: 'author' });
+  });
+
+  it('cancels stream item executors with deferred work and nested streams', async () => {
+    const document = parse(`
+      query {
+        todos @stream(initialCount: 0) {
+          id
+          items @stream(initialCount: 0)
+          ... @defer {
+            author {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    const { promise: idPromise, resolve: resolveId } =
+      promiseWithResolvers<string>();
+    const { promise: idStarted, resolve: resolveIdStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+
+    const result = await legacyExecuteIncrementally({
+      schema: cancelStreamSchema,
+      document,
+      enableEarlyExecution: true,
+      rootValue: {
+        todos: [
+          {
+            id() {
+              resolveIdStarted();
+              return idPromise;
+            },
+            items: ['a'],
+            author: { id: 'author' },
+          },
+        ],
+      },
+    });
+    assert('initialResult' in result);
+
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    await idStarted;
+    await expectPromise(iterator.return()).toResolve();
+    await resolveOnNextTick();
+
+    resolveId('todo');
+    await resolveOnNextTick();
+  });
+
+  it('stops streaming when a pending stream item resolves after cancellation', async () => {
+    const document = parse('{ scalarList @stream(initialCount: 0) }');
+    const { promise: itemPromise, resolve: resolveItem } =
+      promiseWithResolvers<string>();
+    const { promise: nextStarted, resolve: resolveNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    let done = false;
+    const iterator = {
+      [Symbol.iterator]() {
+        return this;
+      },
+      next() {
+        if (done) {
+          return { value: undefined, done: true };
+        }
+        done = true;
+        resolveNextStarted();
+        return { value: itemPromise, done: false };
+      },
+    };
+
+    const result = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        scalarList: () => iterator,
+      },
+    });
+    assert('initialResult' in result);
+
+    const stream = result.subsequentResults[Symbol.asyncIterator]();
+    const nextPromise = stream.next();
+
+    await nextStarted;
+    const returnPromise = stream.return();
+    await resolveOnNextTick();
+
+    resolveItem('value');
+
+    await expectPromise(returnPromise).toResolve();
+    await expectPromise(nextPromise).toResolve();
+  });
+});

--- a/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
+++ b/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
@@ -1,0 +1,33 @@
+import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
+
+import type { ExecutionArgs } from '../execute.js';
+import { validateExecutionArgs } from '../execute.js';
+import type { ExecutionResult, ValidatedExecutionArgs } from '../Executor.js';
+
+import type { ExperimentalIncrementalExecutionResults } from './BranchingIncrementalExecutor.js';
+import { BranchingIncrementalExecutor } from './BranchingIncrementalExecutor.js';
+
+export function legacyExecuteIncrementally(
+  args: ExecutionArgs,
+): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const validatedExecutionArgs = validateExecutionArgs(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in validatedExecutionArgs)) {
+    return { errors: validatedExecutionArgs };
+  }
+
+  return legacyExecuteQueryOrMutationOrSubscriptionEvent(
+    validatedExecutionArgs,
+  );
+}
+
+export function legacyExecuteQueryOrMutationOrSubscriptionEvent(
+  validatedExecutionArgs: ValidatedExecutionArgs,
+): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
+  return new BranchingIncrementalExecutor(
+    validatedExecutionArgs,
+  ).executeQueryOrMutationOrSubscriptionEvent();
+}


### PR DESCRIPTION
#4319 claimed this was not possible, but I cannot understand why from my previous comment.

Note: the legacy incremental executor is a branching executor, it uses the legacy format that duplicates fields within the response as well as the underlying legacy behavior in which those fields are re-executed, with potentially conflicting field values. In particular, nulls may bubble up in one branch and not another. The transformer approach from #4319 keeps the legacy format without re-executing because it transforms the non-branching incremental executor response. 