### PR TITLE
add assumeValidNames to allow skipping name validation when building a trusted schema

### DIFF
--- a/benchmark/buildASTSchema-benchmark.js
+++ b/benchmark/buildASTSchema-benchmark.js
@@ -9,6 +9,6 @@ export const benchmark = {
   name: 'Build Schema from AST',
   count: 10,
   measure() {
-    buildASTSchema(schemaAST, { assumeValid: true });
+    buildASTSchema(schemaAST, { assumeValid: true, assumeValidNames: true });
   },
 };

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -680,6 +680,7 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
   implements GraphQLSchemaElement
 {
   readonly __kind: symbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   specifiedByURL: Maybe<string>;
@@ -699,7 +700,8 @@ export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal>
 
   constructor(config: Readonly<GraphQLScalarTypeConfig<TInternal, TExternal>>) {
     this.__kind = scalarSymbol;
-    this.name = assertName(config.name);
+    this.nameAssumedValid = config.assumeValidNames === true;
+    this.name = this.nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.specifiedByURL = config.specifiedByURL;
     this.serialize =
@@ -803,6 +805,7 @@ export type GraphQLScalarValueToLiteral = (
 ) => ConstValueNode | undefined;
 
 export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   specifiedByURL?: Maybe<string>;
@@ -829,7 +832,10 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
 }
 
 export interface GraphQLScalarTypeNormalizedConfig<TInternal, TExternal>
-  extends GraphQLScalarTypeConfig<TInternal, TExternal> {
+  extends Omit<
+    GraphQLScalarTypeConfig<TInternal, TExternal>,
+    'assumeValidNames'
+  > {
   serialize: GraphQLScalarSerializer<TExternal>;
   parseValue: GraphQLScalarValueParser<TInternal>;
   parseLiteral: GraphQLScalarLiteralParser<TInternal>;
@@ -900,6 +906,7 @@ export class GraphQLObjectType<TSource = any, TContext = any>
   implements GraphQLSchemaElement
 {
   readonly __kind = objectSymbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   isTypeOf: Maybe<GraphQLIsTypeOfFn<TSource, TContext>>;
@@ -912,7 +919,8 @@ export class GraphQLObjectType<TSource = any, TContext = any>
 
   constructor(config: Readonly<GraphQLObjectTypeConfig<TSource, TContext>>) {
     this.__kind = objectSymbol;
-    this.name = assertName(config.name);
+    this.nameAssumedValid = config.assumeValidNames === true;
+    this.name = this.nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.isTypeOf = config.isTypeOf;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -988,6 +996,7 @@ function defineFieldMap<TSource, TContext>(
 }
 
 export interface GraphQLObjectTypeConfig<TSource, TContext> {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   interfaces?: ThunkReadonlyArray<GraphQLInterfaceType> | undefined;
@@ -999,7 +1008,7 @@ export interface GraphQLObjectTypeConfig<TSource, TContext> {
 }
 
 export interface GraphQLObjectTypeNormalizedConfig<TSource, TContext>
-  extends GraphQLObjectTypeConfig<any, any> {
+  extends Omit<GraphQLObjectTypeConfig<any, any>, 'assumeValidNames'> {
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
   fields: GraphQLFieldNormalizedConfigMap<any, any>;
   extensions: Readonly<GraphQLObjectTypeExtensions<TSource, TContext>>;
@@ -1130,6 +1139,7 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
     | GraphQLObjectType<TSource, TContext>
     | GraphQLInterfaceType<TSource, TContext>
     | undefined;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   type: GraphQLOutputType;
@@ -1150,7 +1160,9 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
   ) {
     this.__kind = fieldSymbol;
     this.parentType = parentType;
-    this.name = assertName(name);
+    this.nameAssumedValid =
+      parentType === undefined || parentType.nameAssumedValid;
+    this.name = this.nameAssumedValid ? name : assertName(name);
     this.description = config.description;
     this.type = config.type;
 
@@ -1202,6 +1214,7 @@ export class GraphQLField<TSource = any, TContext = any, TArgs = any>
 export class GraphQLArgument implements GraphQLSchemaElement {
   readonly __kind: symbol;
   parent: GraphQLField | GraphQLDirective;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   type: GraphQLInputType;
@@ -1218,7 +1231,8 @@ export class GraphQLArgument implements GraphQLSchemaElement {
   ) {
     this.__kind = argumentSymbol;
     this.parent = parent;
-    this.name = assertName(name);
+    this.nameAssumedValid = parent.nameAssumedValid;
+    this.name = this.nameAssumedValid ? name : assertName(name);
     this.description = config.description;
     this.type = config.type;
     this.defaultValue = config.defaultValue;
@@ -1307,6 +1321,7 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
   implements GraphQLSchemaElement
 {
   readonly __kind: symbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   resolveType: Maybe<GraphQLTypeResolver<TSource, TContext>>;
@@ -1319,7 +1334,8 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
 
   constructor(config: Readonly<GraphQLInterfaceTypeConfig<TSource, TContext>>) {
     this.__kind = interfaceSymbol;
-    this.name = assertName(config.name);
+    this.nameAssumedValid = config.assumeValidNames === true;
+    this.name = this.nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.resolveType = config.resolveType;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1374,6 +1390,7 @@ export class GraphQLInterfaceType<TSource = any, TContext = any>
 }
 
 export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   interfaces?: ThunkReadonlyArray<GraphQLInterfaceType> | undefined;
@@ -1390,7 +1407,7 @@ export interface GraphQLInterfaceTypeConfig<TSource, TContext> {
 }
 
 export interface GraphQLInterfaceTypeNormalizedConfig<TSource, TContext>
-  extends GraphQLInterfaceTypeConfig<any, any> {
+  extends Omit<GraphQLInterfaceTypeConfig<any, any>, 'assumeValidNames'> {
   interfaces: ReadonlyArray<GraphQLInterfaceType>;
   fields: GraphQLFieldNormalizedConfigMap<TSource, TContext>;
   extensions: Readonly<GraphQLInterfaceTypeExtensions>;
@@ -1436,6 +1453,7 @@ export interface GraphQLUnionTypeExtensions {
  */
 export class GraphQLUnionType implements GraphQLSchemaElement {
   readonly __kind: symbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   resolveType: Maybe<GraphQLTypeResolver<any, any>>;
@@ -1447,7 +1465,8 @@ export class GraphQLUnionType implements GraphQLSchemaElement {
 
   constructor(config: Readonly<GraphQLUnionTypeConfig<any, any>>) {
     this.__kind = unionSymbol;
-    this.name = assertName(config.name);
+    this.nameAssumedValid = config.assumeValidNames === true;
+    this.name = this.nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.resolveType = config.resolveType;
     this.extensions = toObjMapWithSymbols(config.extensions);
@@ -1496,6 +1515,7 @@ function defineTypes(
 }
 
 export interface GraphQLUnionTypeConfig<TSource, TContext> {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   types: ThunkReadonlyArray<GraphQLObjectType>;
@@ -1511,7 +1531,7 @@ export interface GraphQLUnionTypeConfig<TSource, TContext> {
 }
 
 export interface GraphQLUnionTypeNormalizedConfig
-  extends GraphQLUnionTypeConfig<any, any> {
+  extends Omit<GraphQLUnionTypeConfig<any, any>, 'assumeValidNames'> {
   types: ReadonlyArray<GraphQLObjectType>;
   extensions: Readonly<GraphQLUnionTypeExtensions>;
   extensionASTNodes: ReadonlyArray<UnionTypeExtensionNode>;
@@ -1555,6 +1575,7 @@ export interface GraphQLEnumTypeExtensions {
  */
 export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
   readonly __kind: symbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   extensions: Readonly<GraphQLEnumTypeExtensions>;
@@ -1570,7 +1591,8 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
 
   constructor(config: Readonly<GraphQLEnumTypeConfig /* <T> */>) {
     this.__kind = enumSymbol;
-    this.name = assertName(config.name);
+    this.nameAssumedValid = config.assumeValidNames === true;
+    this.name = this.nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);
     this.astNode = config.astNode;
@@ -1736,6 +1758,7 @@ function didYouMeanEnumValue(
 }
 
 export interface GraphQLEnumTypeConfig {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   values: ThunkObjMap<GraphQLEnumValueConfig /* <T> */>;
@@ -1744,7 +1767,8 @@ export interface GraphQLEnumTypeConfig {
   extensionASTNodes?: Maybe<ReadonlyArray<EnumTypeExtensionNode>>;
 }
 
-export interface GraphQLEnumTypeNormalizedConfig extends GraphQLEnumTypeConfig {
+export interface GraphQLEnumTypeNormalizedConfig
+  extends Omit<GraphQLEnumTypeConfig, 'assumeValidNames'> {
   values: GraphQLEnumValueNormalizedConfigMap;
   extensions: Readonly<GraphQLEnumTypeExtensions>;
   extensionASTNodes: ReadonlyArray<EnumTypeExtensionNode>;
@@ -1785,6 +1809,7 @@ export interface GraphQLEnumValueNormalizedConfig
 export class GraphQLEnumValue implements GraphQLSchemaElement {
   readonly __kind: symbol;
   parentEnum: GraphQLEnumType;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   value: any /* T */;
@@ -1799,7 +1824,8 @@ export class GraphQLEnumValue implements GraphQLSchemaElement {
   ) {
     this.__kind = enumValueSymbol;
     this.parentEnum = parentEnum;
-    this.name = assertEnumValueName(name);
+    this.nameAssumedValid = parentEnum.nameAssumedValid;
+    this.name = this.nameAssumedValid ? name : assertEnumValueName(name);
     this.description = config.description;
     this.value = config.value !== undefined ? config.value : name;
     this.deprecationReason = config.deprecationReason;
@@ -1866,6 +1892,7 @@ export interface GraphQLInputObjectTypeExtensions {
  */
 export class GraphQLInputObjectType implements GraphQLSchemaElement {
   readonly __kind: symbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   extensions: Readonly<GraphQLInputObjectTypeExtensions>;
@@ -1877,7 +1904,8 @@ export class GraphQLInputObjectType implements GraphQLSchemaElement {
 
   constructor(config: Readonly<GraphQLInputObjectTypeConfig>) {
     this.__kind = inputObjectSymbol;
-    this.name = assertName(config.name);
+    this.nameAssumedValid = config.assumeValidNames === true;
+    this.name = this.nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);
     this.astNode = config.astNode;
@@ -1932,6 +1960,7 @@ function defineInputFieldMap(
 }
 
 export interface GraphQLInputObjectTypeConfig {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   fields: ThunkObjMap<GraphQLInputFieldConfig>;
@@ -1942,7 +1971,7 @@ export interface GraphQLInputObjectTypeConfig {
 }
 
 export interface GraphQLInputObjectTypeNormalizedConfig
-  extends GraphQLInputObjectTypeConfig {
+  extends Omit<GraphQLInputObjectTypeConfig, 'assumeValidNames'> {
   fields: GraphQLInputFieldNormalizedConfigMap;
   extensions: Readonly<GraphQLInputObjectTypeExtensions>;
   extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>;
@@ -1986,6 +2015,7 @@ export type GraphQLInputFieldNormalizedConfigMap =
 export class GraphQLInputField implements GraphQLSchemaElement {
   readonly __kind: symbol;
   parentType: GraphQLInputObjectType;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   type: GraphQLInputType;
@@ -2007,7 +2037,8 @@ export class GraphQLInputField implements GraphQLSchemaElement {
 
     this.__kind = inputFieldSymbol;
     this.parentType = parentType;
-    this.name = assertName(name);
+    this.nameAssumedValid = parentType.nameAssumedValid;
+    this.name = this.nameAssumedValid ? name : assertName(name);
     this.description = config.description;
     this.type = config.type;
     this.defaultValue = config.defaultValue;

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -56,6 +56,7 @@ export interface GraphQLDirectiveExtensions {
  */
 export class GraphQLDirective implements GraphQLSchemaElement {
   readonly __kind: symbol;
+  nameAssumedValid: boolean;
   name: string;
   description: Maybe<string>;
   locations: ReadonlyArray<DirectiveLocation>;
@@ -66,7 +67,9 @@ export class GraphQLDirective implements GraphQLSchemaElement {
 
   constructor(config: Readonly<GraphQLDirectiveConfig>) {
     this.__kind = directiveSymbol;
-    this.name = assertName(config.name);
+    const nameAssumedValid = config.assumeValidNames === true;
+    this.nameAssumedValid = nameAssumedValid;
+    this.name = nameAssumedValid ? config.name : assertName(config.name);
     this.description = config.description;
     this.locations = config.locations;
     this.isRepeatable = config.isRepeatable ?? false;
@@ -119,6 +122,7 @@ export class GraphQLDirective implements GraphQLSchemaElement {
 }
 
 export interface GraphQLDirectiveConfig {
+  assumeValidNames?: Maybe<boolean>;
   name: string;
   description?: Maybe<string>;
   locations: ReadonlyArray<DirectiveLocation>;
@@ -129,7 +133,7 @@ export interface GraphQLDirectiveConfig {
 }
 
 export interface GraphQLDirectiveNormalizedConfig
-  extends GraphQLDirectiveConfig {
+  extends Omit<GraphQLDirectiveConfig, 'assumeValidNames'> {
   args: GraphQLFieldNormalizedConfigArgumentMap;
   isRepeatable: boolean;
   extensions: Readonly<GraphQLDirectiveExtensions>;

--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -1088,6 +1088,61 @@ describe('Schema Builder', () => {
     buildSchema(sdl, { assumeValidSDL: true });
   });
 
+  it('validates enum value names by default for hand-rolled AST', () => {
+    const document: any = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        {
+          kind: Kind.ENUM_TYPE_DEFINITION,
+          name: { kind: Kind.NAME, value: 'SomeEnum' },
+          directives: [],
+          values: [
+            {
+              kind: Kind.ENUM_VALUE_DEFINITION,
+              name: { kind: Kind.NAME, value: 'true' },
+              directives: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const schema = buildASTSchema(document, {
+      assumeValidSDL: true,
+    });
+    const enumType = assertEnumType(schema.getType('SomeEnum'));
+    expect(() => enumType.getValues()).to.throw(
+      'Enum values cannot be named: true',
+    );
+  });
+
+  it('can skip name validation when assumeValidNames is set', () => {
+    const document: any = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        {
+          kind: Kind.ENUM_TYPE_DEFINITION,
+          name: { kind: Kind.NAME, value: 'SomeEnum' },
+          directives: [],
+          values: [
+            {
+              kind: Kind.ENUM_VALUE_DEFINITION,
+              name: { kind: Kind.NAME, value: 'true' },
+              directives: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const schema = buildASTSchema(document, {
+      assumeValidSDL: true,
+      assumeValidNames: true,
+    });
+    const enumType = assertEnumType(schema.getType('SomeEnum'));
+    expect(() => enumType.getValues()).to.not.throw();
+  });
+
   it('Throws on unknown types', () => {
     const sdl = `
       type Query {

--- a/src/utilities/buildASTSchema.ts
+++ b/src/utilities/buildASTSchema.ts
@@ -18,6 +18,12 @@ export interface BuildSchemaOptions extends GraphQLSchemaValidationOptions {
    * Default: false
    */
   assumeValidSDL?: boolean | undefined;
+  /**
+   * Set to true to skip validating type system names while building schema.
+   *
+   * Default: false
+   */
+  assumeValidNames?: boolean | undefined;
 }
 
 /**
@@ -99,5 +105,6 @@ export function buildSchema(
   return buildASTSchema(document, {
     assumeValidSDL: options?.assumeValidSDL,
     assumeValid: options?.assumeValid,
+    assumeValidNames: options?.assumeValidNames,
   });
 }

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -73,6 +73,12 @@ interface Options extends GraphQLSchemaValidationOptions {
    * Default: false
    */
   assumeValidSDL?: boolean | undefined;
+  /**
+   * Set to true to skip validating type system names while building schema.
+   *
+   * Default: false
+   */
+  assumeValidNames?: boolean | undefined;
 }
 
 /**
@@ -197,6 +203,8 @@ export function extendSchemaImpl(
     return schemaConfig;
   }
 
+  const assumeValidNames = options?.assumeValidNames === true;
+
   return mapSchemaConfig(schemaConfig, (context) => {
     const { getNamedType, setNamedType, getNamedTypes } = context;
     return {
@@ -238,10 +246,15 @@ export function extendSchemaImpl(
           assumeValid: options?.assumeValid ?? false,
         };
       },
+      [SchemaElementKind.DIRECTIVE]: (config) => ({
+        ...config,
+        assumeValidNames,
+      }),
       [SchemaElementKind.INPUT_OBJECT]: (config) => {
         const extensions = inputObjectExtensions.get(config.name) ?? [];
         return {
           ...config,
+          assumeValidNames,
           fields: () => ({
             ...config.fields(),
             ...buildInputFieldMap(extensions),
@@ -253,6 +266,7 @@ export function extendSchemaImpl(
         const extensions = enumExtensions.get(config.name) ?? [];
         return {
           ...config,
+          assumeValidNames,
           values: () => ({
             ...config.values(),
             ...buildEnumValueMap(extensions),
@@ -268,6 +282,7 @@ export function extendSchemaImpl(
         }
         return {
           ...config,
+          assumeValidNames,
           specifiedByURL,
           extensionASTNodes: config.extensionASTNodes.concat(extensions),
         };
@@ -276,6 +291,7 @@ export function extendSchemaImpl(
         const extensions = objectExtensions.get(config.name) ?? [];
         return {
           ...config,
+          assumeValidNames,
           interfaces: () => [
             ...config.interfaces(),
             ...buildInterfaces(extensions),
@@ -291,6 +307,7 @@ export function extendSchemaImpl(
         const extensions = interfaceExtensions.get(config.name) ?? [];
         return {
           ...config,
+          assumeValidNames,
           interfaces: () => [
             ...config.interfaces(),
             ...buildInterfaces(extensions),
@@ -306,6 +323,7 @@ export function extendSchemaImpl(
         const extensions = unionExtensions.get(config.name) ?? [];
         return {
           ...config,
+          assumeValidNames,
           types: () => [...config.types(), ...buildUnionTypes(extensions)],
           extensionASTNodes: config.extensionASTNodes.concat(extensions),
         };
@@ -356,6 +374,7 @@ export function extendSchemaImpl(
 
     function buildDirective(node: DirectiveDefinitionNode): GraphQLDirective {
       return new GraphQLDirective({
+        assumeValidNames,
         name: node.name.value,
         description: node.description?.value,
         // @ts-expect-error
@@ -498,6 +517,7 @@ export function extendSchemaImpl(
           const allNodes = [astNode, ...extensionASTNodes];
 
           return new GraphQLObjectType({
+            assumeValidNames,
             name,
             description: astNode.description?.value,
             interfaces: () => buildInterfaces(allNodes),
@@ -511,6 +531,7 @@ export function extendSchemaImpl(
           const allNodes = [astNode, ...extensionASTNodes];
 
           return new GraphQLInterfaceType({
+            assumeValidNames,
             name,
             description: astNode.description?.value,
             interfaces: () => buildInterfaces(allNodes),
@@ -524,6 +545,7 @@ export function extendSchemaImpl(
           const allNodes = [astNode, ...extensionASTNodes];
 
           return new GraphQLEnumType({
+            assumeValidNames,
             name,
             description: astNode.description?.value,
             values: () => buildEnumValueMap(allNodes),
@@ -536,6 +558,7 @@ export function extendSchemaImpl(
           const allNodes = [astNode, ...extensionASTNodes];
 
           return new GraphQLUnionType({
+            assumeValidNames,
             name,
             description: astNode.description?.value,
             types: () => buildUnionTypes(allNodes),
@@ -546,6 +569,7 @@ export function extendSchemaImpl(
         case Kind.SCALAR_TYPE_DEFINITION: {
           const extensionASTNodes = scalarExtensions.get(name) ?? [];
           return new GraphQLScalarType({
+            assumeValidNames,
             name,
             description: astNode.description?.value,
             specifiedByURL: getSpecifiedByURL(astNode),
@@ -558,6 +582,7 @@ export function extendSchemaImpl(
           const allNodes = [astNode, ...extensionASTNodes];
 
           return new GraphQLInputObjectType({
+            assumeValidNames,
             name,
             description: astNode.description?.value,
             fields: () => buildInputFieldMap(allNodes),


### PR DESCRIPTION
i.e. a schema from a parser that would throw with invalid names

see #4362