### PR TITLE
fix incremental types

### DIFF
--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -67,13 +67,18 @@ const buildExecutionPlanFromDeferred = memoize2(
  *   - `incremental` is a list of the results from defer/stream directives.
  */
 export interface ExperimentalIncrementalExecutionResults<
-  TInitial = ObjMap<unknown>,
-  TSubsequent = unknown,
+  TInitialData = ObjMap<unknown>,
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
-  initialResult: InitialIncrementalExecutionResult<TInitial, TExtensions>;
+  initialResult: InitialIncrementalExecutionResult<TInitialData, TExtensions>;
   subsequentResults: AsyncGenerator<
-    SubsequentIncrementalExecutionResult<TSubsequent, TExtensions>,
+    SubsequentIncrementalExecutionResult<
+      TDeferredData,
+      TStreamItem,
+      TExtensions
+    >,
     void,
     void
   >;
@@ -81,7 +86,8 @@ export interface ExperimentalIncrementalExecutionResults<
 
 export interface FormattedExperimentalIncrementalExecutionResults<
   TInitial = ObjMap<unknown>,
-  TSubsequent = unknown,
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   initialResult: FormattedInitialIncrementalExecutionResult<
@@ -89,7 +95,11 @@ export interface FormattedExperimentalIncrementalExecutionResults<
     TExtensions
   >;
   subsequentResults: AsyncGenerator<
-    FormattedSubsequentIncrementalExecutionResult<TSubsequent, TExtensions>,
+    FormattedSubsequentIncrementalExecutionResult<
+      TDeferredData,
+      TStreamItem,
+      TExtensions
+    >,
     void,
     void
   >;
@@ -105,91 +115,102 @@ export interface InitialIncrementalExecutionResult<
 }
 
 export interface FormattedInitialIncrementalExecutionResult<
-  TData = ObjMap<unknown>,
+  TInitialData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends FormattedExecutionResult<TData, TExtensions> {
-  data: TData;
+> extends FormattedExecutionResult<TInitialData, TExtensions> {
+  data: TInitialData;
   pending: ReadonlyArray<PendingResult>;
   hasNext: boolean;
   extensions?: TExtensions;
 }
 
 export interface SubsequentIncrementalExecutionResult<
-  TData = unknown,
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  incremental?: ReadonlyArray<
+    IncrementalResult<TDeferredData, TStreamItem, TExtensions>
+  >;
   completed?: ReadonlyArray<CompletedResult>;
   hasNext: boolean;
   extensions?: TExtensions;
 }
 
 export interface FormattedSubsequentIncrementalExecutionResult<
-  TData = unknown,
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   hasNext: boolean;
   pending?: ReadonlyArray<PendingResult>;
-  incremental?: ReadonlyArray<FormattedIncrementalResult<TData, TExtensions>>;
+  incremental?: ReadonlyArray<
+    FormattedIncrementalResult<TDeferredData, TStreamItem, TExtensions>
+  >;
   completed?: ReadonlyArray<FormattedCompletedResult>;
   extensions?: TExtensions;
 }
 
 export interface IncrementalDeferResult<
-  TData = ObjMap<unknown>,
+  TDeferredData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   id: string;
   subPath?: ReadonlyArray<string | number>;
   errors?: ReadonlyArray<GraphQLError>;
-  data: TData;
+  data: TDeferredData;
   extensions?: TExtensions;
 }
 
 export interface FormattedIncrementalDeferResult<
-  TData = ObjMap<unknown>,
+  TDeferredData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  data: TData;
+  data: TDeferredData;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
 export interface IncrementalStreamResult<
-  TData = ReadonlyArray<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   id: string;
   subPath?: ReadonlyArray<string | number>;
   errors?: ReadonlyArray<GraphQLError>;
-  items: TData;
+  items: ReadonlyArray<TStreamItem>;
   extensions?: TExtensions;
 }
 
 export interface FormattedIncrementalStreamResult<
-  TData = Array<unknown>,
+  TStreamItem = Array<unknown>,
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLFormattedError>;
-  items: TData;
+  items: ReadonlyArray<TStreamItem>;
   id: string;
   subPath?: ReadonlyArray<string | number>;
   extensions?: TExtensions;
 }
 
-export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
-  | IncrementalDeferResult<TData, TExtensions>
-  | IncrementalStreamResult<TData, TExtensions>;
-
-export type FormattedIncrementalResult<
-  TData = unknown,
+export type IncrementalResult<
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > =
-  | FormattedIncrementalDeferResult<TData, TExtensions>
-  | FormattedIncrementalStreamResult<TData, TExtensions>;
+  | IncrementalDeferResult<TDeferredData, TExtensions>
+  | IncrementalStreamResult<TStreamItem, TExtensions>;
+
+export type FormattedIncrementalResult<
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
+  TExtensions = ObjMap<unknown>,
+> =
+  | FormattedIncrementalDeferResult<TDeferredData, TExtensions>
+  | FormattedIncrementalStreamResult<TStreamItem, TExtensions>;
 
 export interface PendingResult {
   id: string;

--- a/src/execution/legacyIncremental/BranchingIncrementalExecutor.ts
+++ b/src/execution/legacyIncremental/BranchingIncrementalExecutor.ts
@@ -6,14 +6,17 @@ import { memoize1 } from '../../jsutils/memoize1.js';
 import { memoize2 } from '../../jsutils/memoize2.js';
 import type { ObjMap } from '../../jsutils/ObjMap.js';
 
-import type { GraphQLError } from '../../error/GraphQLError.js';
+import type {
+  GraphQLError,
+  GraphQLFormattedError,
+} from '../../error/GraphQLError.js';
 
 import type {
   DeferUsage,
   FieldDetails,
   GroupedFieldSet,
 } from '../collectFields.js';
-import type { ExecutionResult } from '../Executor.js';
+import type { ExecutionResult, FormattedExecutionResult } from '../Executor.js';
 import type {
   DeferUsageSet,
   ExecutionPlan,
@@ -22,51 +25,70 @@ import { IncrementalExecutor } from '../incremental/IncrementalExecutor.js';
 
 import { BranchingIncrementalPublisher } from './BranchingIncrementalPublisher.js';
 
-export interface ExperimentalIncrementalExecutionResults {
-  initialResult: InitialIncrementalExecutionResult;
+export interface LegacyExperimentalIncrementalExecutionResults<
+  TInitialData = ObjMap<unknown>,
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
+  TExtensions = ObjMap<unknown>,
+> {
+  initialResult: LegacyInitialIncrementalExecutionResult<
+    TInitialData,
+    TExtensions
+  >;
   subsequentResults: AsyncGenerator<
-    SubsequentIncrementalExecutionResult,
+    LegacySubsequentIncrementalExecutionResult<
+      TDeferredData,
+      TStreamItem,
+      TExtensions
+    >,
     void,
     void
   >;
 }
 
-export interface InitialIncrementalExecutionResult<
-  TData = ObjMap<unknown>,
+export interface LegacyInitialIncrementalExecutionResult<
+  TInitialData = ObjMap<unknown>,
   TExtensions = ObjMap<unknown>,
-> extends ExecutionResult<TData, TExtensions> {
-  data: TData;
+> extends ExecutionResult<TInitialData, TExtensions> {
+  data: TInitialData;
   hasNext: true;
   extensions?: TExtensions;
 }
 
-export interface SubsequentIncrementalExecutionResult<
-  TData = unknown,
+export interface LegacySubsequentIncrementalExecutionResult<
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
-  incremental?: ReadonlyArray<IncrementalResult<TData, TExtensions>>;
+  incremental?: ReadonlyArray<
+    LegacyIncrementalResult<TDeferredData, TStreamItem, TExtensions>
+  >;
   hasNext: boolean;
   extensions?: TExtensions;
 }
 
-export type IncrementalResult<TData = unknown, TExtensions = ObjMap<unknown>> =
-  | IncrementalDeferResult<TData, TExtensions>
-  | IncrementalStreamResult<TData, TExtensions>;
-
-export interface IncrementalDeferResult<
-  TData = ObjMap<unknown>,
+export type LegacyIncrementalResult<
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
-> extends ExecutionResult<TData, TExtensions> {
+> =
+  | LegacyIncrementalDeferResult<TDeferredData, TExtensions>
+  | LegacyIncrementalStreamResult<TStreamItem, TExtensions>;
+
+export interface LegacyIncrementalDeferResult<
+  TDeferredData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends ExecutionResult<TDeferredData, TExtensions> {
   path: ReadonlyArray<string | number>;
   label?: string;
 }
 
-export interface IncrementalStreamResult<
-  TData = ReadonlyArray<unknown>,
+export interface LegacyIncrementalStreamResult<
+  TStreamItem = unknown,
   TExtensions = ObjMap<unknown>,
 > {
   errors?: ReadonlyArray<GraphQLError>;
-  items: TData | null;
+  items: ReadonlyArray<TStreamItem> | null;
   path: ReadonlyArray<string | number>;
   label?: string;
   extensions?: TExtensions;
@@ -82,11 +104,79 @@ const buildBranchingExecutionPlanFromDeferred = memoize2(
     buildBranchingExecutionPlan(groupedFieldSet, deferUsageSet),
 );
 
+export interface FormattedLegacyExperimentalIncrementalExecutionResults<
+  TInitialData = ObjMap<unknown>,
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
+  TExtensions = ObjMap<unknown>,
+> {
+  initialResult: FormattedLegacyInitialIncrementalExecutionResult<
+    TInitialData,
+    TExtensions
+  >;
+  subsequentResults: AsyncGenerator<
+    FormattedLegacySubsequentIncrementalExecutionResult<
+      TDeferredData,
+      TStreamItem,
+      TExtensions
+    >,
+    void,
+    void
+  >;
+}
+
+export interface FormattedLegacyInitialIncrementalExecutionResult<
+  TInitialData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends FormattedExecutionResult<TInitialData, TExtensions> {
+  data: TInitialData;
+  hasNext: true;
+  extensions?: TExtensions;
+}
+
+export interface FormattedLegacySubsequentIncrementalExecutionResult<
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
+  TExtensions = ObjMap<unknown>,
+> {
+  incremental?: ReadonlyArray<
+    FormattedLegacyIncrementalResult<TDeferredData, TStreamItem, TExtensions>
+  >;
+  hasNext: boolean;
+  extensions?: TExtensions;
+}
+
+export type FormattedLegacyIncrementalResult<
+  TDeferredData = ObjMap<unknown>,
+  TStreamItem = unknown,
+  TExtensions = ObjMap<unknown>,
+> =
+  | FormattedLegacyIncrementalDeferResult<TDeferredData, TExtensions>
+  | FormattedLegacyIncrementalStreamResult<TStreamItem, TExtensions>;
+
+export interface FormattedLegacyIncrementalDeferResult<
+  TDeferredData = ObjMap<unknown>,
+  TExtensions = ObjMap<unknown>,
+> extends FormattedExecutionResult<TDeferredData, TExtensions> {
+  path: ReadonlyArray<string | number>;
+  label?: string;
+}
+
+export interface FormattedLegacyIncrementalStreamResult<
+  TStreamItem = unknown,
+  TExtensions = ObjMap<unknown>,
+> {
+  errors?: ReadonlyArray<GraphQLFormattedError>;
+  items: ReadonlyArray<TStreamItem> | null;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+  extensions?: TExtensions;
+}
 /** @internal */
-export class BranchingIncrementalExecutor extends IncrementalExecutor<ExperimentalIncrementalExecutionResults> {
+export class BranchingIncrementalExecutor extends IncrementalExecutor<LegacyExperimentalIncrementalExecutionResults> {
   override createSubExecutor(
     deferUsageSet?: DeferUsageSet,
-  ): IncrementalExecutor<ExperimentalIncrementalExecutionResults> {
+  ): IncrementalExecutor<LegacyExperimentalIncrementalExecutionResults> {
     return new BranchingIncrementalExecutor(
       this.validatedExecutionArgs,
       this.sharedResolverAbortSignal,
@@ -96,7 +186,7 @@ export class BranchingIncrementalExecutor extends IncrementalExecutor<Experiment
 
   override buildResponse(
     data: ObjMap<unknown> | null,
-  ): ExecutionResult | ExperimentalIncrementalExecutionResults {
+  ): ExecutionResult | LegacyExperimentalIncrementalExecutionResults {
     const work = this.getIncrementalWork();
     const { tasks, streams } = work;
     if (tasks?.length === 0 && streams?.length === 0) {

--- a/src/execution/legacyIncremental/BranchingIncrementalPublisher.ts
+++ b/src/execution/legacyIncremental/BranchingIncrementalPublisher.ts
@@ -16,16 +16,16 @@ import { mapAsyncIterable } from '../mapAsyncIterable.js';
 import { withConcurrentAbruptClose } from '../withConcurrentAbruptClose.js';
 
 import type {
-  ExperimentalIncrementalExecutionResults,
-  IncrementalDeferResult,
-  IncrementalResult,
-  IncrementalStreamResult,
-  InitialIncrementalExecutionResult,
-  SubsequentIncrementalExecutionResult,
+  LegacyExperimentalIncrementalExecutionResults,
+  LegacyIncrementalDeferResult,
+  LegacyIncrementalResult,
+  LegacyIncrementalStreamResult,
+  LegacyInitialIncrementalExecutionResult,
+  LegacySubsequentIncrementalExecutionResult,
 } from './BranchingIncrementalExecutor.js';
 
 interface SubsequentIncrementalExecutionResultContext {
-  incremental: Array<IncrementalResult>;
+  incremental: Array<LegacyIncrementalResult>;
   hasNext: boolean;
 }
 
@@ -45,7 +45,7 @@ export class BranchingIncrementalPublisher {
     work: IncrementalWork,
     abortSignal: AbortSignal | undefined,
     onFinished: () => void,
-  ): ExperimentalIncrementalExecutionResults {
+  ): LegacyExperimentalIncrementalExecutionResults {
     const { initialStreams, events } = createWorkQueue<
       ExecutionGroupValue,
       StreamItemValue,
@@ -71,7 +71,7 @@ export class BranchingIncrementalPublisher {
       abortSignal?.removeEventListener('abort', abort);
     };
 
-    const initialResult: InitialIncrementalExecutionResult = errors.length
+    const initialResult: LegacyInitialIncrementalExecutionResult = errors.length
       ? { errors, data, hasNext: true }
       : { data, hasNext: true };
 
@@ -98,7 +98,7 @@ export class BranchingIncrementalPublisher {
       >
     >,
     onWorkQueueFinished: (() => void) | undefined,
-  ): SubsequentIncrementalExecutionResult {
+  ): LegacySubsequentIncrementalExecutionResult {
     const context: SubsequentIncrementalExecutionResultContext = {
       incremental: [],
       hasNext: true,
@@ -110,7 +110,7 @@ export class BranchingIncrementalPublisher {
 
     const { incremental, hasNext } = context;
 
-    const result: SubsequentIncrementalExecutionResult = { hasNext };
+    const result: LegacySubsequentIncrementalExecutionResult = { hasNext };
     if (incremental.length > 0) {
       result.incremental = incremental;
     }
@@ -221,12 +221,12 @@ export class BranchingIncrementalPublisher {
 
 function buildIncrementalResult(
   originalIncrementalResult:
-    | Omit<IncrementalDeferResult, 'label' | 'errors'>
-    | Omit<IncrementalStreamResult, 'label' | 'errors'>,
+    | Omit<LegacyIncrementalDeferResult, 'label' | 'errors'>
+    | Omit<LegacyIncrementalStreamResult, 'label' | 'errors'>,
   label: string | undefined,
   errors: ReadonlyArray<GraphQLError> | undefined,
-): IncrementalResult {
-  const incrementalResult: IncrementalResult = originalIncrementalResult;
+): LegacyIncrementalResult {
+  const incrementalResult: LegacyIncrementalResult = originalIncrementalResult;
   if (errors !== undefined) {
     incrementalResult.errors = errors;
   }

--- a/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
@@ -21,8 +21,8 @@ import { GraphQLSchema } from '../../../type/schema.js';
 import { buildSchema } from '../../../utilities/buildASTSchema.js';
 
 import type {
-  InitialIncrementalExecutionResult,
-  SubsequentIncrementalExecutionResult,
+  LegacyInitialIncrementalExecutionResult,
+  LegacySubsequentIncrementalExecutionResult,
 } from '../BranchingIncrementalExecutor.js';
 import { legacyExecuteIncrementally } from '../legacyExecuteIncrementally.js';
 
@@ -184,7 +184,8 @@ async function complete(
 
   if ('initialResult' in result) {
     const results: Array<
-      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+      | LegacyInitialIncrementalExecutionResult
+      | LegacySubsequentIncrementalExecutionResult
     > = [result.initialResult];
     for await (const patch of result.subsequentResults) {
       results.push(patch);
@@ -210,7 +211,8 @@ async function completeCancellation(
 
   if ('initialResult' in result) {
     const results: Array<
-      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+      | LegacyInitialIncrementalExecutionResult
+      | LegacySubsequentIncrementalExecutionResult
     > = [result.initialResult];
     for await (const patch of result.subsequentResults) {
       results.push(patch);

--- a/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
@@ -22,8 +22,8 @@ import { GraphQLSchema } from '../../../type/schema.js';
 import { buildSchema } from '../../../utilities/buildASTSchema.js';
 
 import type {
-  InitialIncrementalExecutionResult,
-  SubsequentIncrementalExecutionResult,
+  LegacyInitialIncrementalExecutionResult,
+  LegacySubsequentIncrementalExecutionResult,
 } from '../BranchingIncrementalExecutor.js';
 import { legacyExecuteIncrementally } from '../legacyExecuteIncrementally.js';
 
@@ -147,7 +147,8 @@ async function complete(
 
   if ('initialResult' in result) {
     const results: Array<
-      InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+      | LegacyInitialIncrementalExecutionResult
+      | LegacySubsequentIncrementalExecutionResult
     > = [result.initialResult];
     for await (const patch of result.subsequentResults) {
       results.push(patch);
@@ -175,7 +176,8 @@ async function completeAsync(
   const promises: Array<
     PromiseOrValue<
       IteratorResult<
-        InitialIncrementalExecutionResult | SubsequentIncrementalExecutionResult
+        | LegacyInitialIncrementalExecutionResult
+        | LegacySubsequentIncrementalExecutionResult
       >
     >
   > = [{ done: false, value: result.initialResult }];
@@ -3063,11 +3065,11 @@ describe('Execute: stream directive (legacy cancellation)', () => {
     await resolveOnNextTick();
 
     let firstResult:
-      | IteratorResult<SubsequentIncrementalExecutionResult>
+      | IteratorResult<LegacySubsequentIncrementalExecutionResult>
       | undefined;
     try {
       firstResult =
-        (await nextResultPromise) as IteratorResult<SubsequentIncrementalExecutionResult>;
+        (await nextResultPromise) as IteratorResult<LegacySubsequentIncrementalExecutionResult>;
     } catch (error) {
       expect(error).to.be.instanceOf(Error);
       expect((error as Error).message).to.equal('This operation was aborted');

--- a/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
+++ b/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
@@ -4,12 +4,14 @@ import type { ExecutionArgs } from '../execute.js';
 import { validateExecutionArgs } from '../execute.js';
 import type { ExecutionResult, ValidatedExecutionArgs } from '../Executor.js';
 
-import type { ExperimentalIncrementalExecutionResults } from './BranchingIncrementalExecutor.js';
+import type { LegacyExperimentalIncrementalExecutionResults } from './BranchingIncrementalExecutor.js';
 import { BranchingIncrementalExecutor } from './BranchingIncrementalExecutor.js';
 
 export function legacyExecuteIncrementally(
   args: ExecutionArgs,
-): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
+): PromiseOrValue<
+  ExecutionResult | LegacyExperimentalIncrementalExecutionResults
+> {
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const validatedExecutionArgs = validateExecutionArgs(args);
@@ -26,7 +28,9 @@ export function legacyExecuteIncrementally(
 
 export function legacyExecuteQueryOrMutationOrSubscriptionEvent(
   validatedExecutionArgs: ValidatedExecutionArgs,
-): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
+): PromiseOrValue<
+  ExecutionResult | LegacyExperimentalIncrementalExecutionResults
+> {
   return new BranchingIncrementalExecutor(
     validatedExecutionArgs,
   ).executeQueryOrMutationOrSubscriptionEvent();


### PR DESCRIPTION
1. the generic type parameter for deferred data extends ObjMap<uknown> while for streamed data, items is always a ReadonlyArray<StreamItemType>, so we need an additional typed parameter
2. renamed the LegacyExecutor result types to prefix with "Legacy". These types are only available to consumers via deep import.
3. provide Formatted Legacy Incremental Result types. also only available by deep imports

This is a type-level BREAKING CHANGE.