### PR TITLE
frontport: incorrect validation errors when variable descriptions are used (#4517)

### DIFF
--- a/src/validation/__tests__/validation-test.ts
+++ b/src/validation/__tests__/validation-test.ts
@@ -144,3 +144,25 @@ describe('Validate: Limit maximum number of validation errors', () => {
     ).to.throw(/^Error from custom rule!$/);
   });
 });
+
+describe('operation and variable definition descriptions', () => {
+  it('validates operation with description and variable descriptions', () => {
+    const schema = buildSchema(
+      'type Query { field(a: Int, b: String): String }',
+    );
+    const query = `
+        "Operation description"
+        query myQuery(
+          "Variable a description"
+          $a: Int,
+          """Variable b\nmultiline description"""
+          $b: String
+        ) {
+          field(a: $a, b: $b)
+        }
+      `;
+    const ast = parse(query);
+    const errors = validate(schema, ast);
+    expect(errors.length).to.equal(0);
+  });
+});

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -1,8 +1,10 @@
+import { mapValue } from '../jsutils/mapValue.js';
 import type { Maybe } from '../jsutils/Maybe.js';
 
 import { GraphQLError } from '../error/GraphQLError.js';
 
 import type { DocumentNode } from '../language/ast.js';
+import { QueryDocumentKeys } from '../language/ast.js';
 import { visit, visitInParallel } from '../language/visitor.js';
 
 import type { GraphQLSchema } from '../type/schema.js';
@@ -21,6 +23,13 @@ export interface ValidationOptions {
   maxErrors?: number;
   hideSuggestions?: Maybe<boolean>;
 }
+
+// Per the specification, descriptions must not affect validation.
+// See https://spec.graphql.org/draft/#sec-Descriptions
+const QueryDocumentKeysToValidate = mapValue(
+  QueryDocumentKeys,
+  (keys: ReadonlyArray<string>) => keys.filter((key) => key !== 'description'),
+);
 
 /**
  * Implements the "Validation" section of the spec.
@@ -78,7 +87,11 @@ export function validate(
 
   // Visit the whole document with each instance of all provided rules.
   try {
-    visit(documentAST, visitWithTypeInfo(typeInfo, visitor));
+    visit(
+      documentAST,
+      visitWithTypeInfo(typeInfo, visitor),
+      QueryDocumentKeysToValidate,
+    );
   } catch (e: unknown) {
     if (e === abortError) {
       errors.push(abortError);


### PR DESCRIPTION
See original PR #4517 for details. 