### PR TITLE
fix: treat dot as punctuator for schema coordinate parsing

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -1068,7 +1068,7 @@ describe('Parser', () => {
       expect(() => parseSchemaCoordinate('MyType.field.deep'))
         .to.throw()
         .to.deep.include({
-          message: 'Syntax Error: Expected <EOF>, found ..',
+          message: 'Syntax Error: Expected <EOF>, found ".".',
           locations: [{ line: 1, column: 13 }],
         });
     });
@@ -1194,7 +1194,7 @@ describe('Parser', () => {
       expect(() => parseSchemaCoordinate('@myDirective.field'))
         .to.throw()
         .to.deep.include({
-          message: 'Syntax Error: Expected <EOF>, found ..',
+          message: 'Syntax Error: Expected <EOF>, found ".".',
           locations: [{ line: 1, column: 13 }],
         });
     });

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -7,9 +7,10 @@ import type { Source } from './source.js';
 import { TokenKind } from './tokenKind.js';
 
 /**
- * Parser supports parsing multiple Source types, which may have differing
- * Lexer classes. This is used for schema coordinates which has its own distinct
- * SchemaCoordinateLexer class.
+ * A Lexer interface which provides common properties and methods required for
+ * lexing GraphQL source.
+ *
+ * @internal
  */
 export interface LexerInterface {
   source: Source;
@@ -110,6 +111,7 @@ export function isPunctuatorTokenKind(kind: TokenKind): boolean {
     kind === TokenKind.AMP ||
     kind === TokenKind.PAREN_L ||
     kind === TokenKind.PAREN_R ||
+    kind === TokenKind.DOT ||
     kind === TokenKind.SPREAD ||
     kind === TokenKind.COLON ||
     kind === TokenKind.EQUALS ||


### PR DESCRIPTION
this was correctly done in the backport of schema coordinates to 16.x.x (#4463) but incorrect on next (#3044)