### PR TITLE
export all schema coordinate types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -343,6 +343,11 @@ export type {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
   SchemaCoordinateNode,
+  TypeCoordinateNode,
+  MemberCoordinateNode,
+  ArgumentCoordinateNode,
+  DirectiveCoordinateNode,
+  DirectiveArgumentCoordinateNode,
 } from './language/index.js';
 
 // Execute GraphQL queries.

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -97,6 +97,11 @@ export type {
   EnumTypeExtensionNode,
   InputObjectTypeExtensionNode,
   SchemaCoordinateNode,
+  TypeCoordinateNode,
+  MemberCoordinateNode,
+  ArgumentCoordinateNode,
+  DirectiveCoordinateNode,
+  DirectiveArgumentCoordinateNode,
 } from './ast.js';
 
 export {


### PR DESCRIPTION
this was (afaict) correctly done in the backport of schema coordinates to 16.x.x (#4463) but incorrect on next (#3044)