### PR TITLE
website: fix build

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -868,10 +868,26 @@ export default tsConfig(
     rules: {
       ...reactHooksPlugin.configs.recommended.rules,
       'no-restricted-exports': 'off',
+      'import/extensions': [
+        'error',
+        'ignorePackages',
+        {
+          ts: 'never',
+          tsx: 'never',
+        },
+      ],
       'import/no-default-export': 'off',
+      'import/no-extraneous-dependencies': 'off',
       'import/no-nodejs-modules': 'off',
-      'import/unambiguous': 'off',
       'n/no-missing-import': 'off', // allows linting from root of project when website packages are not installed
+      'n/file-extension-in-import': [
+        'error',
+        'always',
+        {
+          '': 'never',
+        },
+      ],
+      'import/unambiguous': 'off',
     },
   },
 );

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -11,7 +11,7 @@ import {
   GraphQLWordmarkLogo,
   StackOverflowIcon,
   TwitterIcon,
-} from './icons/index.js';
+} from './icons/index';
 
 const graphQLLogo = (
   <GraphQLWordmarkLogo className="h-8 nextra-logo" title="GraphQL" />


### PR DESCRIPTION
fix regression that landed in #4301

Nextra requires the extensionless version, but we tried to go for the .js extension to satisfy some lint rules. This PR adjusts the lint rules. 