### PR TITLE
test(validation): add empty-selection case from 16.x.x backport

### DIFF
--- a/src/validation/__tests__/ScalarLeafsRule-test.ts
+++ b/src/validation/__tests__/ScalarLeafsRule-test.ts
@@ -166,4 +166,37 @@ describe('Validate: Scalar leafs', () => {
       },
     ]);
   });
+
+  it('object type having only one selection', () => {
+    const doc: DocumentNode = {
+      kind: Kind.DOCUMENT,
+      definitions: [
+        {
+          kind: Kind.OPERATION_DEFINITION,
+          operation: OperationTypeNode.QUERY,
+          selectionSet: {
+            kind: Kind.SELECTION_SET,
+            selections: [
+              {
+                kind: Kind.FIELD,
+                name: { kind: Kind.NAME, value: 'human' },
+                selectionSet: { kind: Kind.SELECTION_SET, selections: [] },
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    // We can't leverage expectErrors since it doesn't support passing in the
+    // documentNode directly. We have to do this because this is technically
+    // an invalid document.
+    const errors = validate(testSchema, doc, [ScalarLeafsRule]);
+    expectJSON(errors).toDeepEqual([
+      {
+        message:
+          'Field "human" of type "Human" must have at least one field selected.',
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
This PR adds the `object type having only one selection` test from backport #4291 of original PR #4228