### PR TITLE
remove legacy comment

### DIFF
--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -986,7 +986,7 @@ describe('Parser', () => {
       });
     });
 
-    it('parses fragment with variable description (legacy)', () => {
+    it('parses fragment with variable description', () => {
       const result = parse('fragment Foo("desc" $foo: Int) on Bar { baz }', {
         experimentalFragmentArguments: true,
       });


### PR DESCRIPTION
the test is actually for the new version allowLegacyFragmentVariables  was the legacy option