### PR TITLE
chore(release): v17.0.0-alpha.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "17.0.0-alpha.10",
+  "version": "17.0.0-alpha.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "17.0.0-alpha.10",
+      "version": "17.0.0-alpha.11",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "1.15.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "17.0.0-alpha.10",
+  "version": "17.0.0-alpha.11",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '17.0.0-alpha.10' as string;
+export const version = '17.0.0-alpha.11' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -13,5 +13,5 @@ export const versionInfo = Object.freeze({
   major: 17 as number,
   minor: 0 as number,
   patch: 0 as number,
-  preReleaseTag: 'alpha.10' as string | null,
+  preReleaseTag: 'alpha.11' as string | null,
 });


### PR DESCRIPTION
## v17.0.0-alpha.11 (2026-03-01)

#### Internal 🏠
<details>
<summary> 6 PRs were merged </summary>

* [#4599](https://github.com/graphql/graphql-js/pull/4599) add changesets to 17.x.x alpha ([@yaacovCR](https://github.com/yaacovCR))
* [#4600](https://github.com/graphql/graphql-js/pull/4600) pin node 25 to 25.6 ([@yaacovCR](https://github.com/yaacovCR))
* [#4601](https://github.com/graphql/graphql-js/pull/4601) internal: switch from changesets to simpler release automation ([@yaacovCR](https://github.com/yaacovCR))
* [#4603](https://github.com/graphql/graphql-js/pull/4603) internal: remove version/preversion scripts ([@yaacovCR](https://github.com/yaacovCR))
* [#4604](https://github.com/graphql/graphql-js/pull/4604) fix(changelog): adjust end-ref to not skip last PR ([@yaacovCR](https://github.com/yaacovCR))
* [#4605](https://github.com/graphql/graphql-js/pull/4605) lock down supported scenarios for gen-changelog ([@yaacovCR](https://github.com/yaacovCR))
</details>

#### Committers: 1
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))
