### PR TITLE
chore(release): v16.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "16.13.0",
+  "version": "16.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "16.13.0",
+      "version": "16.13.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "16.13.0",
+  "version": "16.13.1",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '16.13.0' as string;
+export const version = '16.13.1' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -12,6 +12,6 @@ export const version = '16.13.0' as string;
 export const versionInfo = Object.freeze({
   major: 16 as number,
   minor: 13 as number,
-  patch: 0 as number,
+  patch: 1 as number,
   preReleaseTag: null as string | null,
 });


### PR DESCRIPTION
## v16.13.1 (2026-03-04)

#### Docs 📝
* [#4433](https://github.com/graphql/graphql-js/pull/4433) docs: move migrate from express graphql guide to graphqlJS docs ([@sarahxsanders](https://github.com/sarahxsanders))

#### Internal 🏠
* [#4608](https://github.com/graphql/graphql-js/pull/4608) internal: backport new release flow from 17.x.x ([@yaacovCR](https://github.com/yaacovCR))

#### Committers: 2
* Sarah Sanders([@sarahxsanders](https://github.com/sarahxsanders))
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))