### PR TITLE
Fix main entry point in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,
-  "main": "index",
+  "main": "index.js",
   "module": "index.mjs",
   "typesVersions": {
     ">=4.1.0": {


### PR DESCRIPTION
Without this change the file to import is ambiguous, and different tools make different choices. Some tools load `index.js`, while others load `index.mjs`. This discrepancy leads to the error `Duplicate "graphql" modules cannot be used at the same time`.

We have been using this patch for a while now with no observed issues as our test setup results in this dual-loading issue. It would be great to have it upstreamed so we can remove it from our code.