### PR TITLE
chore(release): v17.0.0-alpha.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "17.0.0-alpha.13",
+  "version": "17.0.0-alpha.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "17.0.0-alpha.13",
+      "version": "17.0.0-alpha.14",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "1.15.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "17.0.0-alpha.13",
+  "version": "17.0.0-alpha.14",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '17.0.0-alpha.13' as string;
+export const version = '17.0.0-alpha.14' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -18,5 +18,5 @@ export const versionInfo: Readonly<{
   major: 17 as number,
   minor: 0 as number,
   patch: 0 as number,
-  preReleaseTag: 'alpha.13' as string | null,
+  preReleaseTag: 'alpha.14' as string | null,
 });


### PR DESCRIPTION
## v17.0.0-alpha.14 (2026-03-11)

#### Internal 🏠
* [#4623](https://github.com/graphql/graphql-js/pull/4623) internal: satisfy stricter deno type/package checks ([@yaacovCR](https://github.com/yaacovCR))

#### Committers: 1
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))