### PR TITLE
Use `Object.create(null)` over `{}` to avoid prototype issues - v16

### DIFF
--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -75,7 +75,7 @@ function coerceVariableValues(
   inputs: { readonly [variable: string]: unknown },
   onError: (error: GraphQLError) => void,
 ): { [variable: string]: unknown } {
-  const coercedValues: { [variable: string]: unknown } = {};
+  const coercedValues: { [variable: string]: unknown } = Object.create(null);
   for (const varDefNode of varDefNodes) {
     const varName = varDefNode.variable.name.value;
     const varType = typeFromAST(schema, varDefNode.type);
@@ -138,7 +138,7 @@ function coerceVariableValues(
     );
   }
 
-  return coercedValues;
+  return { ...coercedValues };
 }
 
 /**
@@ -154,7 +154,7 @@ export function getArgumentValues(
   node: FieldNode | DirectiveNode,
   variableValues?: Maybe<ObjMap<unknown>>,
 ): { [argument: string]: unknown } {
-  const coercedValues: { [argument: string]: unknown } = {};
+  const coercedValues: { [argument: string]: unknown } = Object.create(null);
 
   // FIXME: https://github.com/graphql/graphql-js/issues/2203
   /* c8 ignore next */
@@ -222,7 +222,7 @@ export function getArgumentValues(
     }
     coercedValues[name] = coercedValue;
   }
-  return coercedValues;
+  return { ...coercedValues };
 }
 
 /**

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -95,7 +95,7 @@ function coerceInputValueImpl(
       return;
     }
 
-    const coercedValue: any = {};
+    const coercedValue: any = Object.create(null);
     const fieldDefs = type.getFields();
 
     for (const field of Object.values(fieldDefs)) {
@@ -166,7 +166,7 @@ function coerceInputValueImpl(
       }
     }
 
-    return coercedValue;
+    return { ...coercedValue };
   }
 
   if (isLeafType(type)) {

--- a/src/validation/rules/ValuesOfCorrectTypeRule.ts
+++ b/src/validation/rules/ValuesOfCorrectTypeRule.ts
@@ -10,7 +10,6 @@ import type {
   ObjectFieldNode,
   ObjectValueNode,
   ValueNode,
-  VariableDefinitionNode,
 } from '../../language/ast';
 import { Kind } from '../../language/kinds';
 import { print } from '../../language/printer';
@@ -40,17 +39,7 @@ import type { ValidationContext } from '../ValidationContext';
 export function ValuesOfCorrectTypeRule(
   context: ValidationContext,
 ): ASTVisitor {
-  let variableDefinitions: { [key: string]: VariableDefinitionNode } = {};
-
   return {
-    OperationDefinition: {
-      enter() {
-        variableDefinitions = {};
-      },
-    },
-    VariableDefinition(definition) {
-      variableDefinitions[definition.variable.name.value] = definition;
-    },
     ListValue(node) {
       // Note: TypeInfo will traverse into a list's item type, so look to the
       // parent input type to check if it is a list.


### PR DESCRIPTION
`Object.create(null)` is generally safer since it is not vulnerable to prototype pollution in user code. To avoid breaking changes I've returned `{ ...obj }` thus ensuring that the returned object still has the default Object prototype. An alternative would be `Object.setPrototypeOf(obj, Object.prototype)`, but that messes with hidden classes so I figured this solution is cleaner even though it's an additional object allocation. I've also tidied up the variables orphaned by https://github.com/graphql/graphql-js/pull/4453