### PR TITLE
Use Object.create(null) over {} to avoid prototype issues

### DIFF
--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -206,7 +206,7 @@ export function getArgumentValues(
   fragmentVariableValues?: Maybe<FragmentVariableValues>,
   hideSuggestions?: Maybe<boolean>,
 ): { [argument: string]: unknown } {
-  const coercedValues: { [argument: string]: unknown } = {};
+  const coercedValues: { [argument: string]: unknown } = Object.create(null);
 
   const argumentNodes = node.arguments ?? [];
   const argNodeMap = new Map(argumentNodes.map((arg) => [arg.name.value, arg]));
@@ -224,7 +224,7 @@ export function getArgumentValues(
       hideSuggestions,
     );
   }
-  return coercedValues;
+  return { ...coercedValues };
 }
 
 // eslint-disable-next-line max-params

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -205,8 +205,8 @@ export function getArgumentValues(
   variableValues?: Maybe<VariableValues>,
   fragmentVariableValues?: Maybe<FragmentVariableValues>,
   hideSuggestions?: Maybe<boolean>,
-): { [argument: string]: unknown } {
-  const coercedValues: { [argument: string]: unknown } = Object.create(null);
+): ObjMap<unknown> {
+  const coercedValues: ObjMap<unknown> = Object.create(null);
 
   const argumentNodes = node.arguments ?? [];
   const argNodeMap = new Map(argumentNodes.map((arg) => [arg.name.value, arg]));
@@ -224,7 +224,7 @@ export function getArgumentValues(
       hideSuggestions,
     );
   }
-  return { ...coercedValues };
+  return coercedValues;
 }
 
 // eslint-disable-next-line max-params

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -2,6 +2,7 @@ import { invariant } from '../jsutils/invariant.js';
 import { isIterableObject } from '../jsutils/isIterableObject.js';
 import { isObjectLike } from '../jsutils/isObjectLike.js';
 import type { Maybe } from '../jsutils/Maybe.js';
+import type { ObjMap } from '../jsutils/ObjMap.js';
 
 import type { ValueNode, VariableNode } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
@@ -69,7 +70,7 @@ export function coerceInputValue(
       return; // Invalid: intentionally return no value.
     }
 
-    const coercedValue: any = Object.create(null);
+    const coercedValue: ObjMap<unknown> = Object.create(null);
     const fieldDefs = type.getFields();
     const hasUndefinedField = Object.keys(inputValue).some(
       (name) => !Object.hasOwn(fieldDefs, name),
@@ -109,7 +110,7 @@ export function coerceInputValue(
       }
     }
 
-    return { ...coercedValue };
+    return coercedValue;
   }
 
   const leafType = assertLeafType(type);
@@ -211,7 +212,7 @@ export function coerceInputLiteral(
       return; // Invalid: intentionally return no value.
     }
 
-    const coercedValue: { [field: string]: unknown } = {};
+    const coercedValue: ObjMap<unknown> = Object.create(null);
     const fieldDefs = type.getFields();
     const hasUndefinedField = valueNode.fields.some(
       (field) => !Object.hasOwn(fieldDefs, field.name.value),

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -69,7 +69,7 @@ export function coerceInputValue(
       return; // Invalid: intentionally return no value.
     }
 
-    const coercedValue: any = {};
+    const coercedValue: any = Object.create(null);
     const fieldDefs = type.getFields();
     const hasUndefinedField = Object.keys(inputValue).some(
       (name) => !Object.hasOwn(fieldDefs, name),
@@ -109,7 +109,7 @@ export function coerceInputValue(
       }
     }
 
-    return coercedValue;
+    return { ...coercedValue };
   }
 
   const leafType = assertLeafType(type);


### PR DESCRIPTION
Forward-port of #4631. Description from #4631 on v16

> Object.create(null) is generally safer since it is not vulnerable to prototype pollution in user code. To avoid breaking changes I've returned { ...obj } thus ensuring that the returned object still has the default Object prototype. 

But this PR skips that latter portion, return `obj` rather than `{ ...obj }`, a BREAKING CHANGE for v17 that improves performance, compare `obj-create-null-17` vs `restore-prototype`

<img width="687" height="143" alt="image" src="https://github.com/user-attachments/assets/b013f9bf-fa5c-43aa-b4a2-20152af0bc31" />