### PR TITLE
refactor(queue): replace stopped promise with onStop handlers

### DIFF
--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -324,7 +324,13 @@ export class IncrementalExecutor<
       task.computation.cancel(reason);
     }
     for (const stream of this.streams) {
-      stream.queue.abort(reason);
+      const aborted = stream.queue.abort(reason);
+      /* c8 ignore start */
+      // TODO: add coverage
+      if (isPromise(aborted)) {
+        aborted.catch(() => undefined);
+      }
+      /* c8 ignore stop */
     }
   }
 
@@ -597,7 +603,13 @@ export class IncrementalExecutor<
     const filteredStreams: Array<ItemStream> = [];
     for (const stream of streams) {
       if (collectedErrors.hasNulledPosition(stream.path)) {
-        stream.queue.abort(cancellationReason);
+        const aborted = stream.queue.abort(cancellationReason);
+        /* c8 ignore start */
+        // TODO: add coverage
+        if (isPromise(aborted)) {
+          aborted.catch(() => undefined);
+        }
+        /* c8 ignore stop */
       } else {
         filteredStreams.push(stream);
       }
@@ -716,18 +728,22 @@ export class IncrementalExecutor<
   ): Queue<StreamItemResult> {
     const { enableEarlyExecution } = this.validatedExecutionArgs;
     const queue = new Queue<StreamItemResult>(
-      async ({ push, stop, started, stopped }) => {
+      async ({ push, stop, onStop, started }) => {
         const cancelStreamItems = new Set<(reason?: unknown) => void>();
+        let finishedNormally = false;
+        let stopRequested = false;
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        stopped.then((reason) => {
-          cancelStreamItems.forEach((cancelStreamItem) =>
-            cancelStreamItem(reason),
-          );
+        onStop((reason) => {
+          stopRequested = true;
+          if (!finishedNormally) {
+            cancelStreamItems.forEach((cancelStreamItem) =>
+              cancelStreamItem(reason),
+            );
+          }
           returnIteratorCatchingErrors(iterator);
         });
         await (enableEarlyExecution ? Promise.resolve() : started);
-        if (queue.isStopped()) {
+        if (stopRequested) {
           return;
         }
         let index = initialIndex;
@@ -737,7 +753,7 @@ export class IncrementalExecutor<
             if (isAsync) {
               // eslint-disable-next-line no-await-in-loop
               iteration = await iterator.next();
-              if (queue.isStopped()) {
+              if (stopRequested) {
                 return;
               }
             } else {
@@ -752,7 +768,14 @@ export class IncrementalExecutor<
           }
 
           if (iteration.done) {
-            stop();
+            finishedNormally = true;
+            const stopped = stop();
+            /* c8 ignore start */
+            // TODO: add coverage
+            if (isPromise(stopped)) {
+              stopped.catch(() => undefined);
+            }
+            /* c8 ignore stop */
             return;
           }
 
@@ -778,7 +801,7 @@ export class IncrementalExecutor<
             } else {
               // eslint-disable-next-line no-await-in-loop
               streamItemResult = await streamItemResult;
-              if (queue.isStopped()) {
+              if (stopRequested) {
                 return;
               }
             }
@@ -787,7 +810,7 @@ export class IncrementalExecutor<
           if (isPromise(pushResult)) {
             // eslint-disable-next-line no-await-in-loop
             await pushResult;
-            if (queue.isStopped()) {
+            if (stopRequested) {
               return;
             }
           }

--- a/src/execution/incremental/Queue.ts
+++ b/src/execution/incremental/Queue.ts
@@ -27,9 +27,9 @@ interface BatchRequest<T> {
 
 interface QueueExecutorOptions<T> {
   push: (item: PromiseOrValue<T>) => PromiseOrValue<void>;
-  stop: (reason?: unknown) => void;
+  stop: (reason?: unknown) => PromiseOrValue<void>;
+  onStop: (cleanup: (reason?: unknown) => PromiseOrValue<void>) => void;
   started: Promise<void>;
-  stopped: Promise<unknown>;
 }
 
 /**
@@ -40,12 +40,12 @@ interface QueueExecutorOptions<T> {
  * live somewhere in between.
  *
  * The constructor takes an executor function and an optional `initialCapacity`.
- * Executors receive `{ push, stop, started, stopped }` and may return `void` or
+ * Executors receive `{ push, stop, onStop, started }` and may return `void` or
  * a promise if they perform asynchronous setup. They call `push` whenever
  * another item is ready, call `stop` when no more values will be produced
- * (optionally supplying an error), await `started` when setup should run only
- * after iteration begins, and await `stopped` to observe when the queue
- * terminates. Because `push` and `stop` are plain functions, executors can
+ * (optionally supplying an error), register stop-time cleanup via `onStop`,
+ * and await `started` when setup should run only after iteration begins.
+ * Because `push`, `stop`, and `onStop` are plain functions, executors can
  * hoist them into outside scopes or pass them to helpers. If the executor
  * throws or its returned promise rejects, the queue treats it as `stop(error)`
  * and propagates the failure.
@@ -84,17 +84,20 @@ export class Queue<T> {
   private _entries: Array<Entry<T>> = [];
   private _isStopped = false;
   private _stopRequested = false;
+  private _stopCleanupCallbacks: Array<
+    (reason?: unknown) => PromiseOrValue<void>
+  > = [];
+  private _stopCompletion: Promise<void> | undefined;
   private _batchRequests = new Set<BatchRequest<T>>();
 
   private _resolveStarted: () => void;
-  private _resolveStopped: (reason?: unknown) => void;
 
   constructor(
     executor: ({
       push,
       stop,
+      onStop,
       started,
-      stopped,
     }: QueueExecutorOptions<T>) => PromiseOrValue<void>,
     initialCapacity = 1,
   ) {
@@ -105,22 +108,25 @@ export class Queue<T> {
       promiseWithResolvers<void>();
 
     this._resolveStarted = resolveStarted;
-    const { promise: stopped, resolve: resolveStopped } =
-      promiseWithResolvers<unknown>();
-    this._resolveStopped = resolveStopped;
 
     try {
       const result = executor({
         push: this._push.bind(this),
         stop: this._stop.bind(this),
+        onStop: this._onStop.bind(this),
         started,
-        stopped,
       });
       if (isPromise(result)) {
         result.catch((error: unknown) => this._stop(error));
       }
     } catch (error) {
-      this._stop(error);
+      const stopped = this._stop(error);
+      /* c8 ignore start */
+      // TODO: add coverage
+      if (isPromise(stopped)) {
+        stopped.catch(() => undefined);
+      }
+      /* c8 ignore stop */
     }
   }
 
@@ -138,29 +144,33 @@ export class Queue<T> {
     );
   }
 
-  cancel(): void {
-    if (this._isStopped) {
-      return;
+  cancel(): PromiseOrValue<void> {
+    if (this._stopRequested) {
+      return this._stopCompletion;
     }
-    this._terminate();
-    this._batchRequests.forEach((request) => request.resolve(undefined));
-    this._batchRequests.clear();
+    return this._terminate(undefined, () => {
+      this._isStopped = true;
+      this._batchRequests.forEach((request) => request.resolve(undefined));
+      this._batchRequests.clear();
+    });
   }
 
-  abort(reason?: unknown): void {
-    if (this._isStopped) {
-      return;
+  abort(reason?: unknown): PromiseOrValue<void> {
+    if (this._stopRequested) {
+      return this._stopCompletion;
     }
-    this._terminate(reason);
-    if (this._batchRequests.size) {
-      this._batchRequests.forEach((request) => request.reject(reason));
-      this._batchRequests.clear();
-      return;
-    }
-    // save rejection for later batch requests
-    this._entries.push({
-      kind: 'item',
-      settled: { status: 'rejected', reason },
+    return this._terminate(reason, () => {
+      this._isStopped = true;
+      if (this._batchRequests.size) {
+        this._batchRequests.forEach((request) => request.reject(reason));
+        this._batchRequests.clear();
+        return;
+      }
+      // save rejection for later batch requests
+      this._entries.push({
+        kind: 'item',
+        settled: { status: 'rejected', reason },
+      });
     });
   }
 
@@ -226,6 +236,44 @@ export class Queue<T> {
     this._flush();
   }
 
+  private _onStop(cleanup: (reason?: unknown) => PromiseOrValue<void>): void {
+    if (this._stopRequested) {
+      throw new Error(
+        'Cannot register onStop cleanup after stop has been requested.',
+      );
+    }
+    this._stopCleanupCallbacks.push(cleanup);
+  }
+
+  private _runStopCleanup(
+    reason: unknown,
+    afterCleanup: () => void,
+  ): PromiseOrValue<void> {
+    this._stopRequested = true;
+    const cleanupPromises = this._stopCleanupCallbacks.flatMap(
+      (cleanupCallback): Array<Promise<unknown>> => {
+        try {
+          const result = cleanupCallback(reason);
+          return isPromise(result) ? [result] : [];
+        } /* c8 ignore start */ catch {
+          // ignore errors
+          return [];
+        } /* c8 ignore stop */
+      },
+    );
+    const cleanup =
+      cleanupPromises.length > 0
+        ? Promise.allSettled(cleanupPromises).then(() => undefined)
+        : undefined;
+    if (isPromise(cleanup)) {
+      this._stopCompletion = cleanup
+        .then(afterCleanup, afterCleanup)
+        .then(() => undefined);
+      return this._stopCompletion;
+    }
+    afterCleanup();
+  }
+
   private async *_iteratorLoop<U>(
     reducer: (
       generator: Generator<T, void, void>,
@@ -284,42 +332,48 @@ export class Queue<T> {
     return maybePushPromise;
   }
 
-  private _terminate(reason?: unknown): void {
+  private _terminate(
+    reason: unknown,
+    afterCleanup: () => void,
+  ): PromiseOrValue<void> {
     for (const entry of this._entries) {
       if (entry.kind === 'item') {
         this._release();
       }
     }
     this._entries.length = 0;
-    this._stopRequested = true;
-    this._isStopped = true;
-    this._resolveStopped(reason);
+    return this._runStopCleanup(reason, afterCleanup);
   }
 
-  private _stop(reason?: unknown): void {
+  private _stop(reason?: unknown): PromiseOrValue<void> {
     if (this._stopRequested) {
-      return;
+      return this._stopCompletion;
     }
-    this._stopRequested = true;
-    if (reason === undefined) {
-      if (this._entries.length === 0) {
-        this._isStopped = true;
-        this._resolveStopped();
+    const stopCompletion = this._runStopCleanup(reason, () => {
+      if (reason === undefined) {
+        if (this._entries.length === 0) {
+          this._isStopped = true;
+          this._deliverBatchIfReady();
+          return;
+        }
+
+        this._entries.push({ kind: 'stop' });
         this._deliverBatchIfReady();
         return;
       }
 
+      this._entries.push({
+        kind: 'item',
+        settled: { status: 'rejected', reason },
+      });
       this._entries.push({ kind: 'stop' });
       this._deliverBatchIfReady();
-      return;
-    }
-
-    this._entries.push({
-      kind: 'item',
-      settled: { status: 'rejected', reason },
     });
-    this._entries.push({ kind: 'stop' });
-    this._deliverBatchIfReady();
+
+    if (isPromise(stopCompletion)) {
+      stopCompletion.catch(() => undefined);
+    }
+    return stopCompletion;
   }
 
   private _deliverBatchIfReady(): void {
@@ -342,7 +396,6 @@ export class Queue<T> {
         this._entries.shift();
         this._release();
         this._isStopped = true;
-        this._resolveStopped(settled.reason);
         this._batchRequests = new Set();
         requests.forEach((request) => request.reject(settled.reason));
       }
@@ -361,7 +414,6 @@ export class Queue<T> {
       if (entry.kind === 'stop') {
         this._isStopped = true;
         this._entries.shift();
-        this._resolveStopped();
         return;
       }
       const settled = entry.settled;

--- a/src/execution/incremental/WorkQueue.ts
+++ b/src/execution/incremental/WorkQueue.ts
@@ -209,7 +209,7 @@ export function createWorkQueue<
   const groupNodes = new Map<G, GroupNode<T, I, G, S>>();
   const taskNodes = new Map<Task<T, I, G, S>, TaskNode<T, I, G, S>>();
   let pushGraphEvent!: (e: GraphEvent<T, I, G, S>) => PromiseOrValue<void>;
-  let stopGraphEvents!: (err?: unknown) => void;
+  let stopGraphEvents!: (err?: unknown) => PromiseOrValue<void>;
 
   const { newGroups: initialRootGroups, newStreams: initialRootStreams } =
     maybeIntegrateWork(initialWork);
@@ -224,7 +224,7 @@ export function createWorkQueue<
   }
 
   const events = new Queue<GraphEvent<T, I, G, S>>(
-    ({ push: _push, stop: _stop, started, stopped }) => {
+    ({ push: _push, stop: _stop, onStop, started }) => {
       pushGraphEvent = _push;
       stopGraphEvents = _stop;
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -237,8 +237,7 @@ export function createWorkQueue<
           startStream(stream);
         }
       });
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      stopped.then((reason) => cancel(reason));
+      onStop((reason) => cancel(reason));
     },
     1,
   ).subscribe((graphEvents) => handleGraphEvents(graphEvents));
@@ -249,39 +248,59 @@ export function createWorkQueue<
     events,
   };
 
-  function cancel(reason?: unknown): void {
+  function cancel(reason?: unknown): PromiseOrValue<void> {
+    const cancelPromises: Array<Promise<unknown>> = [];
     for (const group of rootGroups) {
-      cancelGroup(group, reason);
+      cancelGroup(group, reason, cancelPromises);
     }
     for (const stream of rootStreams) {
-      cancelStream(stream, reason);
+      cancelStream(stream, reason, cancelPromises);
+    }
+    if (cancelPromises.length > 0) {
+      return Promise.allSettled(cancelPromises).then(() => undefined);
     }
   }
 
-  function cancelGroup(group: G, reason?: unknown): void {
+  function cancelGroup(
+    group: G,
+    reason: unknown,
+    cancelPromises: Array<Promise<unknown>>,
+  ): void {
     const groupNode = groupNodes.get(group);
     if (groupNode) {
       for (const task of groupNode.tasks) {
-        cancelTask(task, reason);
+        cancelTask(task, reason, cancelPromises);
       }
       for (const childGroup of groupNode.childGroups) {
-        cancelGroup(childGroup, reason);
+        cancelGroup(childGroup, reason, cancelPromises);
       }
     }
   }
 
-  function cancelTask(task: Task<T, I, G, S>, reason?: unknown): void {
+  function cancelTask(
+    task: Task<T, I, G, S>,
+    reason: unknown,
+    cancelPromises: Array<Promise<unknown>>,
+  ): void {
     task.computation.cancel(reason);
     const taskNode = taskNodes.get(task);
     if (taskNode) {
       for (const childStream of taskNode.childStreams) {
-        cancelStream(childStream, reason);
+        cancelStream(childStream, reason, cancelPromises);
       }
     }
   }
 
-  function cancelStream(stream: S, reason?: unknown): void {
-    stream.queue.abort(reason);
+  function cancelStream(
+    stream: S,
+    reason: unknown,
+    cancelPromises: Array<Promise<unknown>>,
+  ): void {
+    const cancelResult =
+      reason === undefined ? stream.queue.cancel() : stream.queue.abort(reason);
+    if (isPromise(cancelResult)) {
+      cancelPromises.push(cancelResult);
+    }
   }
 
   function maybeIntegrateWork(
@@ -495,6 +514,7 @@ export function createWorkQueue<
     }
 
     if (rootGroups.size === 0 && rootStreams.size === 0) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       stopGraphEvents();
       workQueueEvents.push({ kind: 'WORK_QUEUE_TERMINATION' });
     }

--- a/src/execution/incremental/__tests__/Queue-test.ts
+++ b/src/execution/incremental/__tests__/Queue-test.ts
@@ -13,6 +13,88 @@ import { promiseWithResolvers } from '../../../jsutils/promiseWithResolvers.js';
 
 import { Queue } from '../Queue.js';
 
+interface StopCleanupFixture {
+  stop: (reason?: unknown) => PromiseOrValue<void>;
+  queue: Queue<number>;
+  cleanupCalls: () => number;
+  resolveCleanup: () => void;
+  nextPromise: Promise<unknown>;
+}
+
+function createQueueWithOnStopCallback(): StopCleanupFixture {
+  let stop!: (reason?: unknown) => PromiseOrValue<void>;
+  let cleanupCallsCount = 0;
+  const { promise: cleanup, resolve: resolveCleanup } =
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    promiseWithResolvers<void>();
+  const queue = new Queue<number>(({ onStop, stop: savedStop }) => {
+    stop = savedStop;
+    onStop(() => {
+      cleanupCallsCount += 1;
+      return cleanup;
+    });
+  });
+
+  return {
+    stop,
+    queue,
+    cleanupCalls: () => cleanupCallsCount,
+    resolveCleanup,
+    nextPromise: queue.subscribe().next(),
+  };
+}
+
+async function expectSingleStop(
+  fixture: StopCleanupFixture,
+  requestStops: ReadonlyArray<() => PromiseOrValue<void>>,
+): Promise<unknown> {
+  const { cleanupCalls, resolveCleanup, nextPromise } = fixture;
+  let nextSettled = false;
+  nextPromise.then(
+    () => {
+      nextSettled = true;
+    },
+    () => {
+      nextSettled = true;
+    },
+  );
+  const stopPromises = requestStops.map((requestStop) => {
+    const result = requestStop();
+    expect(isPromise(result)).to.equal(true);
+    invariant(isPromise(result));
+    return result;
+  });
+  const [firstPromise, ...otherPromises] = stopPromises;
+  for (const promise of otherPromises) {
+    expect(promise).to.equal(firstPromise);
+  }
+  expect(cleanupCalls()).to.equal(1);
+  let firstPromiseResolved = false;
+  firstPromise.then(() => {
+    firstPromiseResolved = true;
+  });
+  await resolveOnNextTick();
+  expect(firstPromiseResolved).to.equal(false);
+  expect(nextSettled).to.equal(false);
+  resolveCleanup();
+  await firstPromise;
+  expect(firstPromiseResolved).to.equal(true);
+  expect(nextSettled).to.equal(true);
+  return nextPromise;
+}
+
+const createStopRequestVariants: ReadonlyArray<
+  (
+    stop: (reason?: unknown) => PromiseOrValue<void>,
+    queue: Queue<number>,
+  ) => () => PromiseOrValue<void>
+> = [
+  (stop) => () => stop(),
+  (stop) => () => stop(new Error('ignored stop')),
+  (_stop, queue) => () => queue.cancel(),
+  (_stop, queue) => () => queue.abort(new Error('ignored abort')),
+];
+
 describe('Queue', () => {
   it('should yield sync items pushed synchronously', async () => {
     const sub = new Queue(({ push }) => {
@@ -117,7 +199,7 @@ describe('Queue', () => {
   });
 
   it('returns stopped state synchronously when completed before push', () => {
-    let stop!: (reason?: unknown) => void;
+    let stop!: (reason?: unknown) => PromiseOrValue<void>;
     const queue = new Queue(({ stop: savedStop }) => {
       stop = savedStop;
     });
@@ -148,43 +230,124 @@ describe('Queue', () => {
     expect(await sub.next()).to.deep.equal({ done: true, value: undefined });
   });
 
-  it('ignores repeated stop calls', async () => {
-    const sub = new Queue(({ stop }) => {
-      stop();
-      stop();
-    }).subscribe();
+  it('onStop fires with stop()', async () => {
+    const fixture = createQueueWithOnStopCallback();
+    const { stop } = fixture;
 
-    expect(await sub.next()).to.deep.equal({ done: true, value: undefined });
+    expect(await expectSingleStop(fixture, [() => stop()])).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
   });
 
-  it('cancel is a no-op after stopping', async () => {
-    const queue = new Queue(({ stop }) => {
-      stop();
-    });
+  it('onStop fires with stop(reason)', async () => {
+    const fixture = createQueueWithOnStopCallback();
+    const { stop } = fixture;
+    const stopReason = new Error('Stop!');
 
-    const sub = queue.subscribe();
-
-    expect(queue.isStopped()).to.equal(true);
-    queue.cancel();
-
-    expect(await sub.next()).to.deep.equal({ done: true, value: undefined });
+    await expectPromise(
+      expectSingleStop(fixture, [() => stop(stopReason)]),
+    ).toRejectWith('Stop!');
   });
 
-  it('abort is a no-op after stopping', async () => {
-    const queue = new Queue(({ stop }) => {
-      stop();
+  it('onStop fires with queue.cancel()', async () => {
+    const fixture = createQueueWithOnStopCallback();
+    const { queue } = fixture;
+
+    expect(
+      await expectSingleStop(fixture, [() => queue.cancel()]),
+    ).to.deep.equal({ done: true, value: undefined });
+  });
+
+  it('onStop fires with queue.abort()', async () => {
+    const fixture = createQueueWithOnStopCallback();
+    const { queue } = fixture;
+    const abortReason = new Error('Abort!');
+
+    await expectPromise(
+      expectSingleStop(fixture, [() => queue.abort(abortReason)]),
+    ).toRejectWith('Abort!');
+  });
+
+  it('stop requests no-op after stop()', async () => {
+    for (const followupStopRequestFactory of createStopRequestVariants) {
+      const fixture = createQueueWithOnStopCallback();
+      const { stop, queue } = fixture;
+
+      expect(
+        // eslint-disable-next-line no-await-in-loop
+        await expectSingleStop(fixture, [
+          () => stop(),
+          followupStopRequestFactory(stop, queue),
+        ]),
+      ).to.deep.equal({ done: true, value: undefined });
+    }
+  });
+
+  it('stop requests no-op after stop(reason)', async () => {
+    const stopReason = new Error('Stop!');
+    for (const followupStopRequestFactory of createStopRequestVariants) {
+      const fixture = createQueueWithOnStopCallback();
+      const { stop, queue } = fixture;
+
+      // eslint-disable-next-line no-await-in-loop
+      await expectPromise(
+        expectSingleStop(fixture, [
+          () => stop(stopReason),
+          followupStopRequestFactory(stop, queue),
+        ]),
+      ).toRejectWith('Stop!');
+    }
+  });
+
+  it('stop requests no-op after queue.cancel()', async () => {
+    for (const followupStopRequestFactory of createStopRequestVariants) {
+      const fixture = createQueueWithOnStopCallback();
+      const { stop, queue } = fixture;
+
+      expect(
+        // eslint-disable-next-line no-await-in-loop
+        await expectSingleStop(fixture, [
+          () => queue.cancel(),
+          followupStopRequestFactory(stop, queue),
+        ]),
+      ).to.deep.equal({ done: true, value: undefined });
+    }
+  });
+
+  it('stop requests no-op after queue.abort()', async () => {
+    const abortReason = new Error('Abort!');
+    for (const followupStopRequestFactory of createStopRequestVariants) {
+      const fixture = createQueueWithOnStopCallback();
+      const { stop, queue } = fixture;
+      const requestAbort = () => queue.abort(abortReason);
+      const followupStopRequest = followupStopRequestFactory(stop, queue);
+
+      // eslint-disable-next-line no-await-in-loop
+      await expectPromise(
+        expectSingleStop(fixture, [requestAbort, followupStopRequest]),
+      ).toRejectWith('Abort!');
+    }
+  });
+
+  it('throws when registering onStop after stop has been requested', () => {
+    let stop!: (reason?: unknown) => PromiseOrValue<void>;
+    let onStop!: (cleanup: (reason?: unknown) => PromiseOrValue<void>) => void;
+    const queue = new Queue(({ onStop: savedOnStop, stop: savedStop }) => {
+      onStop = savedOnStop;
+      stop = savedStop;
     });
 
-    const sub = queue.subscribe();
-
+    stop();
     expect(queue.isStopped()).to.equal(true);
-    queue.abort(new Error('ignored'));
 
-    expect(await sub.next()).to.deep.equal({ done: true, value: undefined });
+    expect(() => onStop(() => undefined)).to.throw(
+      'Cannot register onStop cleanup after stop has been requested.',
+    );
   });
 
   it('should resolve a pending next call when stopped before any pushes', async () => {
-    let stop!: (reason?: unknown) => void;
+    let stop!: (reason?: unknown) => PromiseOrValue<void>;
     const sub = new Queue(({ stop: savedStop }) => {
       stop = savedStop;
     }).subscribe();
@@ -634,50 +797,6 @@ describe('Queue', () => {
     expect(started).to.equal(true);
   });
 
-  it('should resolve stopped promise when iteration ends', async () => {
-    let stoppedPromise!: Promise<unknown>;
-    let stopped = false;
-    new Queue(({ stop, stopped: _stoppedPromise }) => {
-      stoppedPromise = _stoppedPromise;
-
-      stoppedPromise.then(() => {
-        stopped = true;
-      });
-      stop();
-    }).subscribe();
-
-    expect(stopped).to.equal(false);
-
-    await resolveOnNextTick();
-
-    expect(stopped).to.equal(true);
-  });
-
-  it('stops in an error state when calling stopped with a reason, i.e. the last call to next to reject with that reason', async () => {
-    let stoppedPromise!: Promise<unknown>;
-    let stopped = false;
-    let stoppedReason: unknown;
-    const stopReason = new Error('Oops');
-    const sub = new Queue(({ push, stop, stopped: _stoppedPromise }) => {
-      stoppedPromise = _stoppedPromise;
-
-      stoppedPromise.then((reason) => {
-        stopped = true;
-        stoppedReason = reason;
-      });
-      push(1);
-      stop(stopReason);
-    }).subscribe();
-
-    expect(stopped).to.equal(false);
-
-    expect(await sub.next()).to.deep.equal({ done: false, value: [1] });
-    await expectPromise(sub.next()).toRejectWith('Oops');
-
-    expect(stopped).to.equal(true);
-    expect(stoppedReason).to.equal(stopReason);
-  });
-
   it('cancels existing requests when calling cancel', async () => {
     const queue = new Queue(({ push }) => {
       push(
@@ -689,7 +808,7 @@ describe('Queue', () => {
     const sub = queue.subscribe();
 
     const nextPromise = sub.next();
-    queue.cancel();
+    expect(queue.cancel()).to.equal(undefined);
 
     expect(await nextPromise).to.deep.equal({ done: true, value: undefined });
   });
@@ -705,7 +824,7 @@ describe('Queue', () => {
     const sub = queue.subscribe();
 
     const nextPromise = sub.next();
-    queue.abort(new Error('Abort!'));
+    expect(queue.abort(new Error('Abort!'))).to.equal(undefined);
 
     await expectPromise(nextPromise).toRejectWith('Abort!');
   });

--- a/src/execution/incremental/__tests__/WorkQueue-test.ts
+++ b/src/execution/incremental/__tests__/WorkQueue-test.ts
@@ -6,6 +6,7 @@ import { resolveOnNextTick } from '../../../__testUtils__/resolveOnNextTick.js';
 
 import { isPromise } from '../../../jsutils/isPromise.js';
 import type { PromiseOrValue } from '../../../jsutils/PromiseOrValue.js';
+import { promiseWithResolvers } from '../../../jsutils/promiseWithResolvers.js';
 
 import { Computation } from '../Computation.js';
 import { Queue } from '../Queue.js';
@@ -109,6 +110,7 @@ function streamFrom(
       if (throwAfter) {
         throw error ?? streamFailureError;
       }
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
       stop();
     }, initialCapacity),
   };
@@ -713,7 +715,11 @@ describe('WorkQueue', () => {
     const fastTaskA = makeTask([groupA], 'A-only');
 
     const slowTaskB = makeTask([groupB], async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      const { promise: delay, resolve } =
+        // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+        promiseWithResolvers<void>();
+      setTimeout(resolve, 0);
+      await delay;
       return { value: 'B-slow' };
     });
 
@@ -966,7 +972,12 @@ describe('WorkQueue', () => {
       queue: new Queue<TestStreamItem>(async ({ push, stop }) => {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         push({ value: 1 });
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        const { promise: delay, resolve } =
+          // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+          promiseWithResolvers<void>();
+        setTimeout(resolve, 0);
+        await delay;
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         stop();
       }, 1),
     };
@@ -1205,10 +1216,13 @@ describe('WorkQueue', () => {
     const rootStream = streamFrom([{ value: 1 }]);
 
     let childStreamCancelled = false;
-    const childStreamQueue = new Queue<TestStreamItem>(({ stopped }) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      stopped.then(() => {
+    const { promise: childStreamCleanup, resolve: resolveChildStreamCleanup } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const childStreamQueue = new Queue<TestStreamItem>(({ onStop }) => {
+      onStop(() => {
         childStreamCancelled = true;
+        return childStreamCleanup;
       });
     });
     const childStream: TestStream = { queue: childStreamQueue };
@@ -1259,7 +1273,13 @@ describe('WorkQueue', () => {
       ],
       done: false,
     });
-    expect(await iterator.return()).to.deep.equal({
+    const returnPromise = iterator.return();
+
+    await resolveOnNextTick();
+
+    resolveChildStreamCleanup();
+
+    expect(await returnPromise).to.deep.equal({
       value: undefined,
       done: true,
     });
@@ -1274,9 +1294,8 @@ describe('WorkQueue', () => {
     const abortReason = new Error('Abort nested work');
 
     let childStreamCancelReason: unknown;
-    const childStreamQueue = new Queue<TestStreamItem>(({ stopped }) => {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      stopped.then((reason) => {
+    const childStreamQueue = new Queue<TestStreamItem>(({ onStop }) => {
+      onStop((reason) => {
         childStreamCancelReason = reason;
       });
     });

--- a/src/execution/incremental/__tests__/stream-test.ts
+++ b/src/execution/incremental/__tests__/stream-test.ts
@@ -2585,6 +2585,80 @@ describe('Execute: stream directive', () => {
     await returnPromise;
     assert(returned);
   });
+  it('Awaits stream source async iterable return before iterator return settles', async () => {
+    let returnCalled = false;
+    const { promise: returnCleanup, resolve: resolveReturnCleanup } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        return: async () => {
+          returnCalled = true;
+          await returnCleanup;
+          return {
+            value: undefined,
+            done: true,
+          };
+        },
+      }),
+    };
+
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+
+    const executeResult = await experimentalExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        friendList: iterable,
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [],
+      },
+      pending: [{ id: '0', path: ['friendList'] }],
+      hasNext: true,
+    });
+
+    const result2Promise = iterator.next();
+    const returnPromise = iterator.return();
+    let returnSettled = false;
+    returnPromise.then(
+      () => {
+        returnSettled = true;
+      },
+      () => {
+        returnSettled = true;
+      },
+    );
+
+    await resolveOnNextTick();
+    expect(returnCalled).to.equal(true);
+    expect(returnSettled).to.equal(false);
+
+    resolveReturnCleanup();
+
+    const result2 = await result2Promise;
+    expectJSON(result2).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+    await returnPromise;
+  });
   it('Can return async iterable when underlying iterable does not have a return method', async () => {
     let index = 0;
     const iterable = {
@@ -2969,6 +3043,83 @@ describe('Execute: stream directive (cancellation)', () => {
 
     resolveItem('value');
     await expectPromise(nextPromise).toRejectWith('This operation was aborted');
+  });
+
+  it('cancels pending stream item executors with deferred work when consumer cancels', async () => {
+    const document = parse(`
+      query {
+        todos @stream(initialCount: 0) {
+          id
+          ... @defer {
+            author {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    const { promise: itemPromise, resolve: resolveItem } =
+      promiseWithResolvers<{
+        id: string;
+        author: () => { id: string };
+      }>();
+    const { promise: secondNextStarted, resolve: resolveSecondNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    let nextCalls = 0;
+    let sourceReturnCalls = 0;
+    let deferredAuthorCalls = 0;
+
+    const todos = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        if (nextCalls === 0) {
+          nextCalls += 1;
+          return Promise.resolve({
+            value: itemPromise,
+            done: false,
+          });
+        }
+        resolveSecondNextStarted();
+        return new Promise<IteratorResult<unknown>>(() => {
+          /* never resolves */
+        });
+      },
+      return() {
+        sourceReturnCalls += 1;
+        return Promise.resolve({ value: undefined, done: true });
+      },
+    };
+
+    const result = await experimentalExecuteIncrementally({
+      schema: cancelStreamSchema,
+      document,
+      rootValue: { todos },
+      enableEarlyExecution: true,
+    });
+    assert('initialResult' in result);
+
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+
+    await secondNextStarted;
+    await expectPromise(iterator.return()).toResolve();
+    await expectPromise(nextPromise).toResolve();
+    expect(sourceReturnCalls).to.equal(1);
+
+    resolveItem({
+      id: 'todo',
+      author() {
+        deferredAuthorCalls += 1;
+        return { id: 'author' };
+      },
+    });
+    await resolveOnNextTick();
+    await resolveOnNextTick();
+    expect(deferredAuthorCalls).to.equal(0);
   });
 
   it('stops when the stream queue is back-pressured and the consumer cancels', async () => {

--- a/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
@@ -2510,6 +2510,79 @@ describe('Execute: stream directive (legacy)', () => {
     await returnPromise;
     assert(returned);
   });
+  it('Awaits stream source async iterable return before iterator return settles', async () => {
+    let returnCalled = false;
+    const { promise: returnCleanup, resolve: resolveReturnCleanup } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const iterable = {
+      [Symbol.asyncIterator]: () => ({
+        next: () =>
+          new Promise(() => {
+            /* never resolves */
+          }),
+        return: async () => {
+          returnCalled = true;
+          await returnCleanup;
+          return {
+            value: undefined,
+            done: true,
+          };
+        },
+      }),
+    };
+
+    const document = parse(`
+      query {
+        friendList @stream(initialCount: 0) {
+          id
+        }
+      }
+    `);
+
+    const executeResult = await legacyExecuteIncrementally({
+      schema,
+      document,
+      rootValue: {
+        friendList: iterable,
+      },
+    });
+    assert('initialResult' in executeResult);
+    const iterator = executeResult.subsequentResults[Symbol.asyncIterator]();
+
+    const result1 = executeResult.initialResult;
+    expectJSON(result1).toDeepEqual({
+      data: {
+        friendList: [],
+      },
+      hasNext: true,
+    });
+
+    const result2Promise = iterator.next();
+    const returnPromise = iterator.return();
+    let returnSettled = false;
+    returnPromise.then(
+      () => {
+        returnSettled = true;
+      },
+      () => {
+        returnSettled = true;
+      },
+    );
+
+    await resolveOnNextTick();
+    expect(returnCalled).to.equal(true);
+    expect(returnSettled).to.equal(false);
+
+    resolveReturnCleanup();
+
+    const result2 = await result2Promise;
+    expectJSON(result2).toDeepEqual({
+      done: true,
+      value: undefined,
+    });
+    await returnPromise;
+  });
   it('Can return async iterable when underlying iterable does not have a return method', async () => {
     let index = 0;
     const iterable = {
@@ -2886,6 +2959,84 @@ describe('Execute: stream directive (legacy cancellation)', () => {
 
     resolveItem('value');
     await expectPromise(nextPromise).toRejectWith('This operation was aborted');
+  });
+
+  it('cancels pending stream item executors with deferred work when consumer cancels', async () => {
+    const document = parse(`
+      query {
+        todos @stream(initialCount: 0) {
+          id
+          ... @defer {
+            author {
+              id
+            }
+          }
+        }
+      }
+    `);
+
+    const { promise: itemPromise, resolve: resolveItem } =
+      promiseWithResolvers<{
+        id: string;
+        author: () => { id: string };
+      }>();
+    const { promise: secondNextStarted, resolve: resolveSecondNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    let nextCalls = 0;
+    let sourceReturnCalls = 0;
+    let deferredAuthorCalls = 0;
+    const never = new Promise<IteratorResult<unknown>>(() => {
+      /* never resolves */
+    });
+
+    const todos = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        if (nextCalls === 0) {
+          nextCalls += 1;
+          return Promise.resolve({
+            value: itemPromise,
+            done: false,
+          });
+        }
+        resolveSecondNextStarted();
+        return never;
+      },
+      return() {
+        sourceReturnCalls += 1;
+        return Promise.resolve({ value: undefined, done: true });
+      },
+    };
+
+    const result = await legacyExecuteIncrementally({
+      schema: cancelStreamSchema,
+      document,
+      rootValue: { todos },
+      enableEarlyExecution: true,
+    });
+    assert('initialResult' in result);
+
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    const nextPromise = iterator.next();
+
+    await secondNextStarted;
+    await expectPromise(iterator.return()).toResolve();
+    await expectPromise(nextPromise).toResolve();
+    expect(sourceReturnCalls).to.equal(1);
+
+    resolveItem({
+      id: 'todo',
+      author() {
+        deferredAuthorCalls += 1;
+        return { id: 'author' };
+      },
+    });
+    await resolveOnNextTick();
+    await resolveOnNextTick();
+    expect(deferredAuthorCalls).to.equal(0);
   });
 
   it('stops when the stream queue is back-pressured and the consumer cancels', async () => {


### PR DESCRIPTION
motivation:
- makes stop reason propagation explicit.
- makes cleanup settling explicit and awaitable across stop/cancel/abort paths.