### PR TITLE
Fix valueFromAST variable own-property checks

### DIFF
--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -252,11 +252,13 @@ describe('valueFromAST', () => {
     expectValueFrom('$var', GraphQLBoolean, { var: true }).to.equal(true);
     expectValueFrom('$var', GraphQLBoolean, { var: null }).to.equal(null);
     expectValueFrom('$var', nonNullBool, { var: null }).to.equal(undefined);
+    expectValueFrom('$toString', GraphQLBoolean, {}).to.equal(undefined);
   });
 
   it('asserts variables are provided as items in lists', () => {
     expectValueFrom('[ $foo ]', listOfBool, {}).to.deep.equal([null]);
     expectValueFrom('[ $foo ]', listOfNonNullBool, {}).to.equal(undefined);
+    expectValueFrom('[ $toString ]', listOfBool, {}).to.deep.equal([null]);
     expectValueFrom('[ $foo ]', listOfNonNullBool, {
       foo: true,
     }).to.deep.equal([true]);
@@ -282,6 +284,15 @@ describe('valueFromAST', () => {
     expectValueFrom('{ requiredBool: $foo }', testInputObj, {
       foo: true,
     }).to.deep.equal({
+      int: 42,
+      requiredBool: true,
+    });
+
+    expectValueFrom(
+      '{ int: $toString, requiredBool: true }',
+      testInputObj,
+      {},
+    ).to.deep.equal({
       int: 42,
       requiredBool: true,
     });

--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -253,10 +253,16 @@ describe('valueFromAST', () => {
     expectValueFrom('$var', GraphQLBoolean, { var: null }).to.equal(null);
     expectValueFrom('$var', nonNullBool, { var: null }).to.equal(undefined);
     expectValueFrom('$toString', GraphQLBoolean, {}).to.equal(undefined);
+    expectValueFrom('$var', GraphQLBoolean, { var: undefined }).to.equal(
+      undefined,
+    );
   });
 
   it('asserts variables are provided as items in lists', () => {
     expectValueFrom('[ $foo ]', listOfBool, {}).to.deep.equal([null]);
+    expectValueFrom('[ $foo ]', listOfBool, { foo: undefined }).to.deep.equal([
+      null,
+    ]);
     expectValueFrom('[ $foo ]', listOfNonNullBool, {}).to.equal(undefined);
     expectValueFrom('[ $toString ]', listOfBool, {}).to.deep.equal([null]);
     expectValueFrom('[ $foo ]', listOfNonNullBool, {

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -48,7 +48,7 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    if (variables == null || !hasOwnProperty(variables, variableName)) {
+    if (variables == null || variables[variableName] === undefined || !hasOwnProperty(variables, variableName)) {
       // No valid return value.
       return;
     }

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -48,7 +48,11 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    if (variables == null || variables[variableName] === undefined || !hasOwnProperty(variables, variableName)) {
+    if (
+      variables == null ||
+      variables[variableName] === undefined ||
+      !hasOwnProperty(variables, variableName)
+    ) {
       // No valid return value.
       return;
     }
@@ -168,7 +172,9 @@ function isMissingVariable(
 ): boolean {
   return (
     valueNode.kind === Kind.VARIABLE &&
-    (variables == null || !hasOwnProperty(variables, valueNode.name.value))
+    (variables == null ||
+      variables[valueNode.name.value] === undefined ||
+      !hasOwnProperty(variables, valueNode.name.value))
   );
 }
 

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -48,7 +48,7 @@ export function valueFromAST(
 
   if (valueNode.kind === Kind.VARIABLE) {
     const variableName = valueNode.name.value;
-    if (variables == null || variables[variableName] === undefined) {
+    if (variables == null || !hasOwnProperty(variables, variableName)) {
       // No valid return value.
       return;
     }
@@ -168,6 +168,10 @@ function isMissingVariable(
 ): boolean {
   return (
     valueNode.kind === Kind.VARIABLE &&
-    (variables == null || variables[valueNode.name.value] === undefined)
+    (variables == null || !hasOwnProperty(variables, valueNode.name.value))
   );
+}
+
+function hasOwnProperty(obj: ObjMap<unknown>, prop: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, prop);
 }


### PR DESCRIPTION
## Summary
Fixes an issue in valueFromAST where own-property checks were not properly enforced, which could lead to incorrect handling of inherited properties.

## Changes
- Updated own-property checks to ensure only direct properties are considered
- Prevent unintended prototype chain access

## Testing
- Verified behavior manually with edge cases
- Existing tests pass locally