### PR TITLE
refactor(execution): track pending work

### DIFF
--- a/src/execution/AsyncWorkTracker.ts
+++ b/src/execution/AsyncWorkTracker.ts
@@ -1,0 +1,42 @@
+import { isPromise } from '../jsutils/isPromise.js';
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
+
+/** @internal */
+export class AsyncWorkTracker {
+  pendingAsyncWork: Set<Promise<void>>;
+
+  constructor() {
+    this.pendingAsyncWork = new Set<Promise<void>>();
+  }
+
+  add(promise: Promise<unknown>): void {
+    const pendingAsyncWork = this.pendingAsyncWork;
+    const promiseToSettle = promise.then(
+      () => {
+        pendingAsyncWork.delete(promiseToSettle);
+      },
+      () => {
+        pendingAsyncWork.delete(promiseToSettle);
+      },
+    );
+    pendingAsyncWork.add(promiseToSettle);
+  }
+
+  addValues(values: ReadonlyArray<PromiseOrValue<unknown>>): void {
+    for (const value of values) {
+      if (isPromise(value)) {
+        this.add(value);
+      }
+    }
+  }
+
+  promiseAllTrackOnReject<T>(
+    values: ReadonlyArray<PromiseOrValue<T>>,
+  ): Promise<Array<T>> {
+    const promise = Promise.all(values);
+    promise.then(undefined, () => {
+      this.addValues(values);
+    });
+    return promise;
+  }
+}

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -236,7 +236,6 @@ export class Executor<
   promiseAll: <T>(
     values: ReadonlyArray<PromiseOrValue<T>>,
   ) => Promise<Array<T>>;
-  trackPromise: (promise: Promise<unknown>) => void;
 
   constructor(
     validatedExecutionArgs: ValidatedExecutionArgs,
@@ -255,12 +254,11 @@ export class Executor<
     } else {
       this.sharedExecutionContext = sharedExecutionContext;
     }
-    const { getAbortSignal, getAsyncHelpers, promiseAll, trackPromise } =
+    const { getAbortSignal, getAsyncHelpers, promiseAll } =
       this.sharedExecutionContext;
     this.getAbortSignal = getAbortSignal;
     this.getAsyncHelpers = getAsyncHelpers;
     this.promiseAll = promiseAll;
-    this.trackPromise = trackPromise;
   }
 
   executeQueryOrMutationOrSubscriptionEvent(): PromiseOrValue<
@@ -863,7 +861,9 @@ export class Executor<
         index++;
       }
     } catch (error) {
-      this.trackPromise(returnIteratorCatchingErrors(asyncIterator));
+      this.sharedExecutionContext.asyncWorkTracker.add(
+        returnIteratorCatchingErrors(asyncIterator),
+      );
       if (containsPromise) {
         this.sharedExecutionContext.asyncWorkTracker.addValues(
           completedResults,
@@ -875,7 +875,9 @@ export class Executor<
     // Throwing on completion outside of the loop may allow engines to better optimize
     if (this.aborted) {
       if (!iteration?.done) {
-        this.trackPromise(returnIteratorCatchingErrors(asyncIterator));
+        this.sharedExecutionContext.asyncWorkTracker.add(
+          returnIteratorCatchingErrors(asyncIterator),
+        );
       }
       throw new Error('Aborted!');
     }

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -32,6 +32,7 @@ import type {
   GraphQLObjectType,
   GraphQLOutputType,
   GraphQLResolveInfo,
+  GraphQLResolveInfoHelpers,
   GraphQLTypeResolver,
 } from '../type/definition.js';
 import {
@@ -231,6 +232,11 @@ export class Executor<
   abortResultPromise: ((reason?: unknown) => void) | undefined;
   resolverAbortController: AbortController | undefined;
   getAbortSignal: () => AbortSignal | undefined;
+  getAsyncHelpers: () => GraphQLResolveInfoHelpers;
+  promiseAll: <T>(
+    values: ReadonlyArray<PromiseOrValue<T>>,
+  ) => Promise<Array<T>>;
+  trackPromise: (promise: Promise<unknown>) => void;
 
   constructor(
     validatedExecutionArgs: ValidatedExecutionArgs,
@@ -249,8 +255,12 @@ export class Executor<
     } else {
       this.sharedExecutionContext = sharedExecutionContext;
     }
-    const { getAbortSignal } = this.sharedExecutionContext;
+    const { getAbortSignal, getAsyncHelpers, promiseAll, trackPromise } =
+      this.sharedExecutionContext;
     this.getAbortSignal = getAbortSignal;
+    this.getAsyncHelpers = getAsyncHelpers;
+    this.promiseAll = promiseAll;
+    this.trackPromise = trackPromise;
   }
 
   executeQueryOrMutationOrSubscriptionEvent(): PromiseOrValue<
@@ -261,10 +271,7 @@ export class Executor<
     if (externalAbortSignal) {
       externalAbortSignal.throwIfAborted();
       const onExternalAbort = () => {
-        const aborted = this.abort(externalAbortSignal.reason);
-        if (isPromise(aborted)) {
-          aborted.catch(() => undefined);
-        }
+        this.abort(externalAbortSignal.reason);
       };
       removeExternalAbortListener = () =>
         externalAbortSignal.removeEventListener('abort', onExternalAbort);
@@ -324,6 +331,7 @@ export class Executor<
             return this.buildResponse(null);
           },
         );
+        this.sharedExecutionContext.asyncWorkTracker.add(promise);
         const { promise: cancellablePromise, abort: abortResultPromise } =
           withCancellation(promise);
         this.abortResultPromise = abortResultPromise;
@@ -347,7 +355,7 @@ export class Executor<
     }
   }
 
-  abort(reason?: unknown): PromiseOrValue<void> {
+  abort(reason?: unknown): void {
     if (this.aborted) {
       return;
     }
@@ -506,8 +514,9 @@ export class Executor<
       }
     } catch (error) {
       if (containsPromise) {
-        // Ensure that any promises returned by other fields are handled, as they may also reject.
-        promiseForObject(results).catch(() => undefined);
+        this.sharedExecutionContext.asyncWorkTracker.addValues(
+          Object.values(results),
+        );
       }
       throw error;
     }
@@ -520,7 +529,7 @@ export class Executor<
     // Otherwise, results is a map from field name to the result of resolving that
     // field, which is possibly a promise. Return a promise that will return this
     // same map, but with any promises replaced with the values they resolved to.
-    return promiseForObject(results);
+    return promiseForObject(results, this.promiseAll);
   }
 
   /**
@@ -557,6 +566,7 @@ export class Executor<
       parentType,
       path,
       this.getAbortSignal,
+      this.getAsyncHelpers,
     );
 
     // Get the resolve function, regardless of if its result is normal or abrupt (error).
@@ -853,10 +863,11 @@ export class Executor<
         index++;
       }
     } catch (error) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      returnIteratorCatchingErrors(asyncIterator);
+      this.trackPromise(returnIteratorCatchingErrors(asyncIterator));
       if (containsPromise) {
-        Promise.all(completedResults).catch(() => undefined);
+        this.sharedExecutionContext.asyncWorkTracker.addValues(
+          completedResults,
+        );
       }
       throw error;
     }
@@ -864,13 +875,14 @@ export class Executor<
     // Throwing on completion outside of the loop may allow engines to better optimize
     if (this.aborted) {
       if (!iteration?.done) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        returnIteratorCatchingErrors(asyncIterator);
+        this.trackPromise(returnIteratorCatchingErrors(asyncIterator));
       }
       throw new Error('Aborted!');
     }
 
-    return containsPromise ? Promise.all(completedResults) : completedResults;
+    return containsPromise
+      ? this.promiseAll(completedResults)
+      : completedResults;
   }
 
   /* c8 ignore next 12 */
@@ -991,15 +1003,17 @@ export class Executor<
         index++;
       }
     } catch (error) {
-      const maybePromises = containsPromise ? completedResults : [];
-      maybePromises.push(...collectIteratorPromises(iterator));
-      if (maybePromises.length) {
-        Promise.all(maybePromises).catch(() => undefined);
+      const asyncWorkTracker = this.sharedExecutionContext.asyncWorkTracker;
+      if (containsPromise) {
+        asyncWorkTracker.addValues(completedResults);
       }
+      asyncWorkTracker.addValues(collectIteratorPromises(iterator));
       throw error;
     }
 
-    return containsPromise ? Promise.all(completedResults) : completedResults;
+    return containsPromise
+      ? this.promiseAll(completedResults)
+      : completedResults;
   }
 
   completeMaybePromisedListItemValue(

--- a/src/execution/__tests__/AsyncWorkTracker-test.ts
+++ b/src/execution/__tests__/AsyncWorkTracker-test.ts
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectEqualPromisesOrValues } from '../../__testUtils__/expectEqualPromisesOrValues.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
+
+import { AsyncWorkTracker } from '../AsyncWorkTracker.js';
+
+describe('AsyncWorkTracker', () => {
+  it('works to track promises', async () => {
+    const tracker = new AsyncWorkTracker();
+    const delayed = promiseWithResolvers<number>();
+
+    tracker.add(delayed.promise);
+    expect(tracker.pendingAsyncWork.size).to.equal(1);
+    delayed.resolve(1);
+    await resolveOnNextTick();
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+  });
+});
+
+describe('promiseAllTrackOnReject', () => {
+  it('resolves like Promise.all', async () => {
+    const tracker = new AsyncWorkTracker();
+
+    const values = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+
+    await expectEqualPromisesOrValues([
+      tracker.promiseAllTrackOnReject(values),
+      Promise.all(values),
+    ]);
+  });
+
+  it('resolves synchronous values without tracking', async () => {
+    const tracker = new AsyncWorkTracker();
+
+    const result = await tracker.promiseAllTrackOnReject([1, 2, 3]);
+
+    expect(result).to.deep.equal([1, 2, 3]);
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+  });
+
+  it('does not add an extra microtask on fulfilled promiseAll results', async () => {
+    const tracker = new AsyncWorkTracker();
+    let settled = false;
+
+    const promise = Promise.resolve(1);
+    const trackedPromise = tracker.promiseAllTrackOnReject([promise]);
+    trackedPromise.then(
+      () => {
+        settled = true;
+      },
+      () => undefined,
+    );
+    await Promise.all([promise]);
+    expect(settled).to.equal(true);
+  });
+
+  it('tracks all promises only after rejection', async () => {
+    const delayed = promiseWithResolvers<undefined>();
+    const tracker = new AsyncWorkTracker();
+    const result = tracker.promiseAllTrackOnReject([
+      Promise.reject(new Error('bad')),
+      delayed.promise,
+    ] as const);
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+
+    await result.catch(() => undefined);
+    expect(tracker.pendingAsyncWork.size).to.equal(1);
+    delayed.resolve(undefined);
+
+    await resolveOnNextTick();
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+  });
+
+  it('tracks promises until they settle and catches later rejections', async () => {
+    let unhandledRejection: unknown = null;
+    const unhandledRejectionListener = (reason: unknown) => {
+      unhandledRejection = reason;
+    };
+    // eslint-disable-next-line no-undef
+    process.on('unhandledRejection', unhandledRejectionListener);
+
+    const tracker = new AsyncWorkTracker();
+    const delayed = promiseWithResolvers<undefined>();
+    const result = tracker.promiseAllTrackOnReject([
+      Promise.reject(new Error('bad')),
+      delayed.promise,
+    ] as const);
+
+    await result.catch(() => undefined);
+    expect(tracker.pendingAsyncWork.size).to.equal(1);
+
+    delayed.reject(new Error('late bad'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // eslint-disable-next-line no-undef
+    process.removeListener('unhandledRejection', unhandledRejectionListener);
+
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+    expect(unhandledRejection).to.equal(null);
+  });
+});

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -261,7 +261,7 @@ describe('Execute: Handles basic execution tasks', () => {
       'getAsyncHelpers',
     );
     const asyncHelpers = resolvedInfo?.getAsyncHelpers();
-    expect(asyncHelpers).to.have.all.keys('trackPromise');
+    expect(asyncHelpers).to.have.all.keys('track');
 
     const operation = document.definitions[0];
     assert(operation.kind === Kind.OPERATION_DEFINITION);
@@ -300,10 +300,10 @@ describe('Execute: Handles basic execution tasks', () => {
 
     expect(resolvedInfo?.getAsyncHelpers()).to.equal(asyncHelpers);
 
-    const trackPromise = asyncHelpers?.trackPromise;
-    expect(trackPromise).to.be.a('function');
-    expect(resolvedInfo?.getAsyncHelpers().trackPromise).to.equal(trackPromise);
-    trackPromise?.(Promise.resolve());
+    const track = asyncHelpers?.track;
+    expect(track).to.be.a('function');
+    expect(resolvedInfo?.getAsyncHelpers().track).to.equal(track);
+    track?.([Promise.resolve()]);
 
     resolve();
 

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -258,7 +258,10 @@ describe('Execute: Handles basic execution tasks', () => {
       'operation',
       'variableValues',
       'getAbortSignal',
+      'getAsyncHelpers',
     );
+    const asyncHelpers = resolvedInfo?.getAsyncHelpers();
+    expect(asyncHelpers).to.have.all.keys('trackPromise');
 
     const operation = document.definitions[0];
     assert(operation.kind === Kind.OPERATION_DEFINITION);
@@ -294,6 +297,13 @@ describe('Execute: Handles basic execution tasks', () => {
     const abortSignal = resolvedInfo?.getAbortSignal();
     expect(abortSignal).to.be.instanceOf(AbortSignal);
     expect(resolvedInfo?.getAbortSignal()).to.equal(abortSignal);
+
+    expect(resolvedInfo?.getAsyncHelpers()).to.equal(asyncHelpers);
+
+    const trackPromise = asyncHelpers?.trackPromise;
+    expect(trackPromise).to.be.a('function');
+    expect(resolvedInfo?.getAsyncHelpers().trackPromise).to.equal(trackPromise);
+    trackPromise?.(Promise.resolve());
 
     resolve();
 

--- a/src/execution/createSharedExecutionContext.ts
+++ b/src/execution/createSharedExecutionContext.ts
@@ -1,12 +1,44 @@
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
+
+import type { GraphQLResolveInfoHelpers } from '../type/index.js';
+
+import { AsyncWorkTracker } from './AsyncWorkTracker.js';
+
 /** @internal */
 export interface SharedExecutionContext {
+  asyncWorkTracker: AsyncWorkTracker;
   getAbortSignal: () => AbortSignal | undefined;
+  getAsyncHelpers: () => GraphQLResolveInfoHelpers;
+  promiseAll: <T>(
+    values: ReadonlyArray<PromiseOrValue<T>>,
+  ) => Promise<Array<T>>;
+  trackPromise: (promise: Promise<unknown>) => void;
 }
 
 export function createSharedExecutionContext(
   abortSignal: AbortSignal | undefined,
 ): SharedExecutionContext {
+  const asyncWorkTracker = new AsyncWorkTracker();
+  let resolveInfoHelpers: GraphQLResolveInfoHelpers | undefined;
+
+  const promiseAll = <T>(
+    values: ReadonlyArray<PromiseOrValue<T>>,
+  ): Promise<Array<T>> => asyncWorkTracker.promiseAllTrackOnReject(values);
+
+  const trackPromise = (promise: Promise<unknown>): void => {
+    asyncWorkTracker.add(promise);
+  };
+
+  const getAsyncHelpers = (): GraphQLResolveInfoHelpers =>
+    (resolveInfoHelpers ??= {
+      trackPromise,
+    });
+
   return {
+    asyncWorkTracker,
     getAbortSignal: () => abortSignal,
+    getAsyncHelpers,
+    promiseAll,
+    trackPromise,
   };
 }

--- a/src/execution/createSharedExecutionContext.ts
+++ b/src/execution/createSharedExecutionContext.ts
@@ -12,7 +12,6 @@ export interface SharedExecutionContext {
   promiseAll: <T>(
     values: ReadonlyArray<PromiseOrValue<T>>,
   ) => Promise<Array<T>>;
-  trackPromise: (promise: Promise<unknown>) => void;
 }
 
 export function createSharedExecutionContext(
@@ -25,13 +24,9 @@ export function createSharedExecutionContext(
     values: ReadonlyArray<PromiseOrValue<T>>,
   ): Promise<Array<T>> => asyncWorkTracker.promiseAllTrackOnReject(values);
 
-  const trackPromise = (promise: Promise<unknown>): void => {
-    asyncWorkTracker.add(promise);
-  };
-
   const getAsyncHelpers = (): GraphQLResolveInfoHelpers =>
     (resolveInfoHelpers ??= {
-      trackPromise,
+      track: (maybePromises) => asyncWorkTracker.addValues(maybePromises),
     });
 
   return {
@@ -39,6 +34,5 @@ export function createSharedExecutionContext(
     getAbortSignal: () => abortSignal,
     getAsyncHelpers,
     promiseAll,
-    trackPromise,
   };
 }

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -26,6 +26,7 @@ import type {
   GraphQLFieldResolver,
   GraphQLObjectType,
   GraphQLResolveInfo,
+  GraphQLResolveInfoHelpers,
   GraphQLTypeResolver,
 } from '../type/index.js';
 import { assertValidSchema } from '../type/index.js';
@@ -440,7 +441,7 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
 
     // Otherwise, test each possible type.
     const possibleTypes = info.schema.getPossibleTypes(abstractType);
-    const promisedIsTypeOfResults = [];
+    const promisedIsTypeOfResults: Array<Promise<boolean>> = [];
 
     try {
       for (let i = 0; i < possibleTypes.length; i++) {
@@ -453,12 +454,10 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
             promisedIsTypeOfResults[i] = isTypeOfResult;
           } else if (isTypeOfResult) {
             if (promisedIsTypeOfResults.length) {
-              // Explicitly ignore any promise rejections
-              Promise.allSettled(promisedIsTypeOfResults)
-                /* c8 ignore next 3 */
-                .catch(() => {
-                  // Do nothing
-                });
+              const { trackPromise } = info.getAsyncHelpers();
+              for (const promisedIsTypeOfResult of promisedIsTypeOfResults) {
+                trackPromise(promisedIsTypeOfResult);
+              }
             }
             return type.name;
           }
@@ -466,9 +465,10 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
       }
     } catch (error) {
       if (promisedIsTypeOfResults.length) {
-        return Promise.allSettled(promisedIsTypeOfResults).then(() => {
-          throw error;
-        });
+        const { trackPromise } = info.getAsyncHelpers();
+        for (const promisedIsTypeOfResult of promisedIsTypeOfResults) {
+          trackPromise(promisedIsTypeOfResult);
+        }
       }
       throw error;
     }
@@ -609,6 +609,7 @@ function executeSubscription(
     rootType,
     path,
     sharedExecutionContext.getAbortSignal,
+    sharedExecutionContext.getAsyncHelpers,
   );
 
   try {
@@ -683,6 +684,7 @@ export function buildResolveInfo(
   parentType: GraphQLObjectType,
   path: Path,
   getAbortSignal: () => AbortSignal | undefined,
+  getAsyncHelpers: () => GraphQLResolveInfoHelpers,
 ): GraphQLResolveInfo {
   const { schema, fragmentDefinitions, rootValue, operation, variableValues } =
     validatedExecutionArgs;
@@ -700,6 +702,7 @@ export function buildResolveInfo(
     operation,
     variableValues,
     getAbortSignal,
+    getAsyncHelpers,
   };
 }
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -454,10 +454,7 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
             promisedIsTypeOfResults[i] = isTypeOfResult;
           } else if (isTypeOfResult) {
             if (promisedIsTypeOfResults.length) {
-              const { trackPromise } = info.getAsyncHelpers();
-              for (const promisedIsTypeOfResult of promisedIsTypeOfResults) {
-                trackPromise(promisedIsTypeOfResult);
-              }
+              info.getAsyncHelpers().track(promisedIsTypeOfResults);
             }
             return type.name;
           }
@@ -465,10 +462,7 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
       }
     } catch (error) {
       if (promisedIsTypeOfResults.length) {
-        const { trackPromise } = info.getAsyncHelpers();
-        for (const promisedIsTypeOfResult of promisedIsTypeOfResults) {
-          trackPromise(promisedIsTypeOfResult);
-        }
+        info.getAsyncHelpers().track(promisedIsTypeOfResults);
       }
       throw error;
     }

--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -320,25 +320,15 @@ export class IncrementalExecutor<
     );
   }
 
-  override abort(reason?: unknown): PromiseOrValue<void> {
-    const abortPromises: Array<Promise<unknown>> = [];
-    const superAborted = super.abort(reason);
-    // Executor.abort is currently synchronous
-    invariant(!isPromise(superAborted));
+  override abort(reason?: unknown): void {
+    super.abort(reason);
     for (const task of this.tasks) {
       const aborted = task.computation.abort(reason);
-      if (isPromise(aborted)) {
-        abortPromises.push(aborted);
-      }
+      invariant(!isPromise(aborted));
     }
     for (const stream of this.streams) {
       const aborted = stream.queue.abort(reason);
-      if (isPromise(aborted)) {
-        abortPromises.push(aborted);
-      }
-    }
-    if (abortPromises.length > 0) {
-      return Promise.allSettled(abortPromises).then(() => undefined);
+      invariant(!isPromise(aborted));
     }
   }
 
@@ -555,7 +545,7 @@ export class IncrementalExecutor<
         deliveryGroupMap,
       );
     } catch (error) {
-      ignoreAbortCleanup(this.abort());
+      this.abort();
       throw error;
     }
 
@@ -564,7 +554,7 @@ export class IncrementalExecutor<
         (resolved) =>
           this.buildExecutionGroupResult(deliveryGroups, path, resolved),
         (error: unknown) => {
-          ignoreAbortCleanup(this.abort());
+          this.abort();
           throw error;
         },
       );
@@ -603,7 +593,8 @@ export class IncrementalExecutor<
     const filteredTasks: Array<ExecutionGroup> = [];
     for (const task of tasks) {
       if (collectedErrors.hasNulledPosition(task.path)) {
-        ignoreAbortCleanup(task.computation.abort(cancellationReason));
+        const aborted = task.computation.abort(cancellationReason);
+        invariant(!isPromise(aborted));
       } else {
         filteredTasks.push(task);
       }
@@ -612,7 +603,8 @@ export class IncrementalExecutor<
     const filteredStreams: Array<ItemStream> = [];
     for (const stream of streams) {
       if (collectedErrors.hasNulledPosition(stream.path)) {
-        ignoreAbortCleanup(stream.queue.abort(cancellationReason));
+        const aborted = stream.queue.abort(cancellationReason);
+        invariant(!isPromise(aborted));
       } else {
         filteredStreams.push(stream);
       }
@@ -732,34 +724,26 @@ export class IncrementalExecutor<
     const { enableEarlyExecution } = this.validatedExecutionArgs;
     const queue = new Queue<StreamItemResult>(
       async ({ push, stop, onStop, started }) => {
-        const abortStreamItems = new Set<
-          (reason?: unknown) => PromiseOrValue<void>
-        >();
+        const abortStreamItems = new Set<(reason?: unknown) => void>();
         let finishedNormally = false;
         let stopRequested = false;
 
         onStop((reason) => {
           stopRequested = true;
           if (!finishedNormally) {
-            const abortPromises: Array<Promise<unknown>> = [];
             for (const abortStreamItem of abortStreamItems) {
-              const result = abortStreamItem(reason);
-              if (isPromise(result)) {
-                abortPromises.push(result);
-              }
+              abortStreamItem(reason);
             }
             if (isAsync) {
-              const returned = returnIteratorCatchingErrors(
-                iterator as AsyncIterator<unknown>,
+              this.sharedExecutionContext.trackPromise(
+                returnIteratorCatchingErrors(
+                  iterator as AsyncIterator<unknown>,
+                ),
               );
-              abortPromises.push(returned);
             } else {
-              abortPromises.push(
-                ...collectIteratorPromises(iterator as Iterator<unknown>),
+              this.sharedExecutionContext.asyncWorkTracker.addValues(
+                collectIteratorPromises(iterator as Iterator<unknown>),
               );
-            }
-            if (abortPromises.length > 0) {
-              return Promise.allSettled(abortPromises).then(() => undefined);
             }
           }
         });
@@ -872,7 +856,7 @@ export class IncrementalExecutor<
           },
         )
         .then(undefined, (error: unknown) => {
-          ignoreAbortCleanup(this.abort());
+          this.abort();
           throw error;
         });
     }
@@ -893,7 +877,7 @@ export class IncrementalExecutor<
         return this.buildStreamItemResult(null);
       }
     } catch (error) {
-      ignoreAbortCleanup(this.abort());
+      this.abort();
       throw error;
     }
 
@@ -912,7 +896,7 @@ export class IncrementalExecutor<
           },
         )
         .then(undefined, (error: unknown) => {
-          ignoreAbortCleanup(this.abort());
+          this.abort();
           throw error;
         });
     }
@@ -928,12 +912,6 @@ export class IncrementalExecutor<
     return errors.length > 0
       ? { value: { item, errors }, work }
       : { value: { item }, work };
-  }
-}
-
-function ignoreAbortCleanup(aborted: PromiseOrValue<void>): void {
-  if (isPromise(aborted)) {
-    aborted.catch(() => undefined);
   }
 }
 

--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -735,7 +735,7 @@ export class IncrementalExecutor<
               abortStreamItem(reason);
             }
             if (isAsync) {
-              this.sharedExecutionContext.trackPromise(
+              this.sharedExecutionContext.asyncWorkTracker.add(
                 returnIteratorCatchingErrors(
                   iterator as AsyncIterator<unknown>,
                 ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -213,6 +213,7 @@ export type {
   GraphQLObjectTypeConfig,
   GraphQLObjectTypeExtensions,
   GraphQLResolveInfo,
+  GraphQLResolveInfoHelpers,
   ResponsePath,
   GraphQLScalarTypeConfig,
   GraphQLScalarTypeExtensions,

--- a/src/jsutils/promiseForObject.ts
+++ b/src/jsutils/promiseForObject.ts
@@ -1,4 +1,5 @@
 import type { ObjMap } from './ObjMap.js';
+import type { PromiseOrValue } from './PromiseOrValue.js';
 
 /**
  * This function transforms a JS object `ObjMap<Promise<T>>` into
@@ -7,16 +8,20 @@ import type { ObjMap } from './ObjMap.js';
  * This is akin to bluebird's `Promise.props`, but implemented only using
  * `Promise.all` so it will work with any implementation of ES6 promises.
  */
-export async function promiseForObject<T>(
-  object: ObjMap<Promise<T>>,
+export function promiseForObject<T>(
+  object: Readonly<ObjMap<PromiseOrValue<T>>>,
+  promiseAll: <TValue>(
+    values: ReadonlyArray<PromiseOrValue<TValue>>,
+  ) => Promise<Array<TValue>>,
 ): Promise<ObjMap<T>> {
   const keys = Object.keys(object);
   const values = Object.values(object);
 
-  const resolvedValues = await Promise.all(values);
-  const resolvedObject = Object.create(null);
-  for (let i = 0; i < keys.length; ++i) {
-    resolvedObject[keys[i]] = resolvedValues[i];
-  }
-  return resolvedObject;
+  return promiseAll(values).then((resolvedValues) => {
+    const resolvedObject = Object.create(null);
+    for (let i = 0; i < keys.length; ++i) {
+      resolvedObject[keys[i]] = resolvedValues[i];
+    }
+    return resolvedObject;
+  });
 }

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1045,6 +1045,10 @@ export type GraphQLFieldResolver<
   info: GraphQLResolveInfo,
 ) => TResult;
 
+export interface GraphQLResolveInfoHelpers {
+  readonly trackPromise: (promise: Promise<unknown>) => void;
+}
+
 export interface GraphQLResolveInfo {
   readonly fieldName: string;
   readonly fieldNodes: ReadonlyArray<FieldNode>;
@@ -1057,6 +1061,7 @@ export interface GraphQLResolveInfo {
   readonly operation: OperationDefinitionNode;
   readonly variableValues: VariableValues;
   readonly getAbortSignal: () => AbortSignal | undefined;
+  readonly getAsyncHelpers: () => GraphQLResolveInfoHelpers;
 }
 
 /**

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1046,7 +1046,9 @@ export type GraphQLFieldResolver<
 ) => TResult;
 
 export interface GraphQLResolveInfoHelpers {
-  readonly trackPromise: (promise: Promise<unknown>) => void;
+  readonly track: (
+    maybePromises: ReadonlyArray<PromiseOrValue<unknown>>,
+  ) => void;
 }
 
 export interface GraphQLResolveInfo {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -121,6 +121,7 @@ export type {
   GraphQLObjectTypeConfig,
   GraphQLObjectTypeExtensions,
   GraphQLResolveInfo,
+  GraphQLResolveInfoHelpers,
   GraphQLScalarTypeConfig,
   GraphQLScalarTypeExtensions,
   GraphQLTypeResolver,


### PR DESCRIPTION
canonize async work tracking so promises started during execution are still observed after early errors or abort paths

route defaultTypeResolver through tracked async helpers to avoid dropping pending isTypeOf promise rejections

motivation:

- #4658