### PR TITLE
feat(execution): expose asyncWorkFinished execution hook

### DIFF
--- a/src/execution/AsyncWorkTracker.ts
+++ b/src/execution/AsyncWorkTracker.ts
@@ -30,6 +30,15 @@ export class AsyncWorkTracker {
     }
   }
 
+  wait(): Promise<void> | void {
+    // wait can complete synchronously when there is no tracked async work,
+    // which allows synchronous execution paths to remain synchronous.
+    if (this.pendingAsyncWork.size === 0) {
+      return;
+    }
+    return this.waitForPendingAsyncWork();
+  }
+
   promiseAllTrackOnReject<T>(
     values: ReadonlyArray<PromiseOrValue<T>>,
   ): Promise<Array<T>> {
@@ -38,5 +47,12 @@ export class AsyncWorkTracker {
       this.addValues(values);
     });
     return promise;
+  }
+
+  private async waitForPendingAsyncWork(): Promise<void> {
+    while (this.pendingAsyncWork.size > 0) {
+      // eslint-disable-next-line no-await-in-loop
+      await Promise.allSettled(Array.from(this.pendingAsyncWork));
+    }
   }
 }

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -61,6 +61,8 @@ import { createSharedExecutionContext } from './createSharedExecutionContext.js'
 import { buildResolveInfo } from './execute.js';
 import type { StreamUsage } from './getStreamUsage.js';
 import { getStreamUsage as _getStreamUsage } from './getStreamUsage.js';
+import type { ExecutionHooks } from './hooks.js';
+import { runAsyncWorkFinishedHook } from './hooks.js';
 import { returnIteratorCatchingErrors } from './returnIteratorCatchingErrors.js';
 import type { VariableValues } from './values.js';
 import { getArgumentValues } from './values.js';
@@ -116,6 +118,7 @@ export interface ValidatedExecutionArgs {
   errorPropagation: boolean;
   externalAbortSignal: AbortSignal | undefined;
   enableEarlyExecution: boolean;
+  hooks: ExecutionHooks | undefined;
 }
 
 /**
@@ -370,6 +373,20 @@ export class Executor<
     this.aborted = true;
   }
 
+  finishSharedExecution(): void {
+    this.resolverAbortController?.abort();
+    const asyncWorkFinishedHook =
+      this.validatedExecutionArgs.hooks?.asyncWorkFinished;
+    if (asyncWorkFinishedHook === undefined) {
+      return;
+    }
+    runAsyncWorkFinishedHook(
+      this.validatedExecutionArgs,
+      this.sharedExecutionContext,
+      asyncWorkFinishedHook,
+    );
+  }
+
   /**
    * Given a completed execution context and data, build the `{ errors, data }`
    * response defined by the "Response" section of the GraphQL specification.
@@ -377,10 +394,10 @@ export class Executor<
   buildResponse(
     data: ObjMap<unknown> | null,
   ): ExecutionResult | TAlternativeInitialResponse {
+    this.finishSharedExecution();
     this.finish();
     const errors = this.collectedErrors.errors;
     const result = errors.length ? { errors, data } : { data };
-    this.resolverAbortController?.abort();
     return result;
   }
 

--- a/src/execution/__tests__/AsyncWorkTracker-test.ts
+++ b/src/execution/__tests__/AsyncWorkTracker-test.ts
@@ -103,3 +103,83 @@ describe('promiseAllTrackOnReject', () => {
     expect(unhandledRejection).to.equal(null);
   });
 });
+
+describe('wait', () => {
+  it('returns synchronously when there is no pending async work', () => {
+    const tracker = new AsyncWorkTracker();
+    expect(tracker.wait()).to.equal(undefined);
+  });
+
+  it('waits when tracked async work is present', async () => {
+    const tracker = new AsyncWorkTracker();
+
+    const delayed = promiseWithResolvers<undefined>();
+    tracker.add(delayed.promise);
+
+    let settled = false;
+    const maybeWait = tracker.wait();
+    expect(maybeWait).to.be.instanceOf(Promise);
+    const wait = Promise.resolve(maybeWait).then(() => {
+      settled = true;
+    });
+    await resolveOnNextTick();
+    expect(settled).to.equal(false);
+
+    delayed.resolve(undefined);
+    await wait;
+    expect(settled).to.equal(true);
+  });
+
+  it('keeps waiting when tracked async work is followed by more tracked async work', async () => {
+    const tracker = new AsyncWorkTracker();
+
+    const delayed = promiseWithResolvers<undefined>();
+    tracker.add(delayed.promise);
+
+    let settled = false;
+    const maybeWait = tracker.wait();
+    expect(maybeWait).to.be.instanceOf(Promise);
+    const wait = Promise.resolve(maybeWait).then(() => {
+      settled = true;
+    });
+    await resolveOnNextTick();
+    expect(settled).to.equal(false);
+
+    delayed.resolve(undefined);
+
+    const anotherDelayed = promiseWithResolvers<undefined>();
+    tracker.add(anotherDelayed.promise);
+    await resolveOnNextTick();
+    expect(settled).to.equal(false);
+
+    anotherDelayed.resolve(undefined);
+
+    await wait;
+    expect(settled).to.equal(true);
+  });
+
+  it('does not wait for side-effect promiseAll tracking added on next microtask', async () => {
+    const tracker = new AsyncWorkTracker();
+    const delayed = promiseWithResolvers<undefined>();
+
+    tracker
+      .promiseAllTrackOnReject([
+        Promise.reject(new Error('bad')),
+        delayed.promise,
+      ])
+      .catch(() => undefined);
+
+    const maybeWait = tracker.wait();
+    expect(maybeWait).to.equal(undefined);
+
+    await resolveOnNextTick();
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+    await resolveOnNextTick();
+    expect(tracker.pendingAsyncWork.size).to.be.greaterThan(0);
+
+    delayed.resolve(undefined);
+    await Promise.allSettled(Array.from(tracker.pendingAsyncWork));
+    await resolveOnNextTick();
+    expect(tracker.pendingAsyncWork.size).to.equal(0);
+  });
+});

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -261,7 +261,7 @@ describe('Execute: Handles basic execution tasks', () => {
       'getAsyncHelpers',
     );
     const asyncHelpers = resolvedInfo?.getAsyncHelpers();
-    expect(asyncHelpers).to.have.all.keys('track');
+    expect(asyncHelpers).to.have.all.keys('promiseAll', 'track');
 
     const operation = document.definitions[0];
     assert(operation.kind === Kind.OPERATION_DEFINITION);
@@ -299,6 +299,10 @@ describe('Execute: Handles basic execution tasks', () => {
     expect(resolvedInfo?.getAbortSignal()).to.equal(abortSignal);
 
     expect(resolvedInfo?.getAsyncHelpers()).to.equal(asyncHelpers);
+
+    const promiseAll = asyncHelpers?.promiseAll;
+    expect(promiseAll).to.be.a('function');
+    expect(resolvedInfo?.getAsyncHelpers().promiseAll).to.equal(promiseAll);
 
     const track = asyncHelpers?.track;
     expect(track).to.be.a('function');

--- a/src/execution/__tests__/hooks-test.ts
+++ b/src/execution/__tests__/hooks-test.ts
@@ -1,0 +1,537 @@
+import { assert, expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectPromise } from '../../__testUtils__/expectPromise.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
+
+import { isPromise } from '../../jsutils/isPromise.js';
+import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.js';
+import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
+
+import { parse } from '../../language/parser.js';
+
+import type { GraphQLResolveInfo } from '../../type/definition.js';
+import { GraphQLObjectType } from '../../type/definition.js';
+import { GraphQLString } from '../../type/scalars.js';
+import { GraphQLSchema } from '../../type/schema.js';
+
+import { buildSchema } from '../../utilities/buildASTSchema.js';
+
+import type { ExecutionArgs } from '../execute.js';
+import { execute, experimentalExecuteIncrementally } from '../execute.js';
+import type { ExecutionResult } from '../Executor.js';
+
+const executeHookSchema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      test: {
+        type: GraphQLString,
+        resolve: () => 'ok',
+      },
+    },
+  }),
+});
+
+const cancellationHookSchema = buildSchema(`
+  type Todo {
+    id: ID
+    items: [String]
+  }
+
+  type Query {
+    todo: Todo
+  }
+`);
+
+function executeAndWaitForAsyncWorkFinished(
+  args: ExecutionArgs,
+): PromiseOrValue<ExecutionResult> {
+  const userAsyncWorkFinishedHook = args.hooks?.asyncWorkFinished;
+  const { promise: hookFinished, resolve: resolveHookFinished } =
+    // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+    promiseWithResolvers<void>();
+  let hookHasFired = false;
+
+  const result = execute({
+    ...args,
+    hooks: {
+      ...args.hooks,
+      asyncWorkFinished(info) {
+        try {
+          userAsyncWorkFinishedHook?.(info);
+        } finally {
+          hookHasFired = true;
+          resolveHookFinished();
+        }
+      },
+    },
+  });
+
+  return hookHasFired ? result : hookFinished.then(() => result);
+}
+
+describe('Execute: Hooks', () => {
+  it('ignores errors thrown by hooks', async () => {
+    const calls: Array<string> = [];
+    const { promise: hooksFinished, resolve: resolveHooksFinished } =
+      promiseWithResolvers<undefined>();
+
+    const result = execute({
+      schema: executeHookSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          calls.push('asyncWork');
+          resolveHooksFinished(undefined);
+          throw new Error('asyncWorkFinished failed');
+        },
+      },
+    });
+
+    expect(result).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+    await hooksFinished;
+    expect(calls).to.deep.equal(['asyncWork']);
+  });
+
+  it('runs post execution hooks synchronously when no async work is tracked', () => {
+    const calls: Array<string> = [];
+
+    const result = execute({
+      schema: executeHookSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          calls.push('asyncWork');
+        },
+      },
+    });
+
+    expect(result).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+    expect(calls).to.deep.equal(['asyncWork']);
+  });
+
+  it('runs post execution hooks for asynchronous execution', async () => {
+    const { promise: resolvedValue, resolve } = promiseWithResolvers<string>();
+    const calls: Array<string> = [];
+    const { promise: hooksFinished, resolve: resolveHooksFinished } =
+      promiseWithResolvers<undefined>();
+    const asyncSchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          test: {
+            type: GraphQLString,
+            resolve: () => resolvedValue,
+          },
+        },
+      }),
+    });
+
+    const resultPromise = execute({
+      schema: asyncSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          calls.push('asyncWork');
+          resolveHooksFinished(undefined);
+        },
+      },
+    });
+
+    expect(calls).to.deep.equal([]);
+    resolve('ok');
+
+    const result = await resultPromise;
+    expect(result).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+    await hooksFinished;
+    expect(calls).to.deep.equal(['asyncWork']);
+  });
+
+  it('does not wait for un-awaited promiseAll helper usage before asyncWorkFinished', async () => {
+    const { promise: pendingCleanup, resolve: resolveCleanup } =
+      promiseWithResolvers<undefined>();
+    const { promise: asyncWorkFinished, resolve: resolveAsyncWorkFinished } =
+      promiseWithResolvers<undefined>();
+    const sideEffectPromiseAllSchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          test: {
+            type: GraphQLString,
+            resolve: (_source, _args, _context, info: GraphQLResolveInfo) => {
+              // Anti-pattern: promiseAll used as un-awaited async side-effect.
+              // Tracking starts in a later microtask, so asyncWorkFinished
+              // can run before the sibling promise is observed.
+              info
+                .getAsyncHelpers()
+                .promiseAll([Promise.reject(new Error('bad')), pendingCleanup])
+                .catch(() => undefined);
+              return 'ok';
+            },
+          },
+        },
+      }),
+    });
+
+    const result = execute({
+      schema: sideEffectPromiseAllSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          resolveAsyncWorkFinished(undefined);
+        },
+      },
+    });
+
+    expect(result).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+
+    await asyncWorkFinished;
+
+    let cleanupSettled = false;
+    const cleanupObserved = pendingCleanup.then(() => {
+      cleanupSettled = true;
+    });
+    await resolveOnNextTick();
+    expect(cleanupSettled).to.equal(false);
+
+    resolveCleanup(undefined);
+    await cleanupObserved;
+  });
+
+  it('waits for track(...) helper usage before asyncWorkFinished', async () => {
+    const { promise: pendingCleanup, resolve: resolveCleanup } =
+      promiseWithResolvers<undefined>();
+    const { promise: asyncWorkFinished, resolve: resolveAsyncWorkFinished } =
+      promiseWithResolvers<undefined>();
+    const trackedSideEffectSchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          test: {
+            type: GraphQLString,
+            resolve: (_source, _args, _context, info: GraphQLResolveInfo) => {
+              info
+                .getAsyncHelpers()
+                .track([pendingCleanup.catch(() => undefined)]);
+              return 'ok';
+            },
+          },
+        },
+      }),
+    });
+
+    const result = execute({
+      schema: trackedSideEffectSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          resolveAsyncWorkFinished(undefined);
+        },
+      },
+    });
+
+    expect(result).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+
+    let hookSettled = false;
+    const hookObserved = asyncWorkFinished.then(() => {
+      hookSettled = true;
+    });
+    await resolveOnNextTick();
+    expect(hookSettled).to.equal(false);
+
+    resolveCleanup(undefined);
+    await hookObserved;
+    expect(hookSettled).to.equal(true);
+  });
+
+  it('wrapper returns synchronously when asyncWorkFinished fires during execute', () => {
+    const calls: Array<string> = [];
+    const wrappedResult = executeAndWaitForAsyncWorkFinished({
+      schema: executeHookSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          calls.push('asyncWork');
+        },
+      },
+    });
+
+    assert(!isPromise(wrappedResult));
+    expect(wrappedResult).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+    expect(calls).to.deep.equal(['asyncWork']);
+  });
+
+  it('wrapper returns a promise and resolves after asyncWorkFinished for track(...) side effects', async () => {
+    const { promise: pendingCleanup, resolve: resolveCleanup } =
+      promiseWithResolvers<undefined>();
+    const calls: Array<string> = [];
+    const trackedSideEffectSchema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          test: {
+            type: GraphQLString,
+            resolve: (_source, _args, _context, info: GraphQLResolveInfo) => {
+              info.getAsyncHelpers().track([pendingCleanup]);
+              return 'ok';
+            },
+          },
+        },
+      }),
+    });
+
+    const wrappedResult = executeAndWaitForAsyncWorkFinished({
+      schema: trackedSideEffectSchema,
+      document: parse('{ test }'),
+      hooks: {
+        asyncWorkFinished() {
+          calls.push('asyncWork');
+        },
+      },
+    });
+
+    assert(isPromise(wrappedResult));
+    expect(calls).to.deep.equal([]);
+
+    let settled = false;
+    wrappedResult.then(
+      () => {
+        settled = true;
+      },
+      () => undefined,
+    );
+    await resolveOnNextTick();
+    expect(settled).to.equal(false);
+    expect(calls).to.deep.equal([]);
+
+    resolveCleanup(undefined);
+
+    const result = await wrappedResult;
+    expect(result).to.deep.equal({
+      data: {
+        test: 'ok',
+      },
+    });
+    expect(calls).to.deep.equal(['asyncWork']);
+  });
+
+  it('runs post execution hooks for aborted execution', async () => {
+    const abortController = new AbortController();
+    const { promise: pendingCleanup, resolve: resolveCleanup } =
+      promiseWithResolvers<string>();
+    const { promise: asyncWorkFinished, resolve: resolveAsyncWorkFinished } =
+      promiseWithResolvers<undefined>();
+    const calls: Array<string> = [];
+    const document = parse(`
+      query {
+        todo {
+          id
+        }
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema: cancellationHookSchema,
+      abortSignal: abortController.signal,
+      hooks: {
+        asyncWorkFinished() {
+          calls.push('asyncWork');
+          resolveAsyncWorkFinished(undefined);
+        },
+      },
+      rootValue: {
+        todo: (_args: any, _context: any, info: GraphQLResolveInfo) => {
+          const abortSignal = info.getAbortSignal();
+          assert(abortSignal instanceof AbortSignal);
+          const abortPromise = new Promise<never>((_resolve, reject) => {
+            abortSignal.addEventListener('abort', () => {
+              reject(new Error('This operation was aborted'));
+            });
+          });
+          return info
+            .getAsyncHelpers()
+            .promiseAll([abortPromise, pendingCleanup]);
+        },
+      },
+    });
+
+    abortController.abort();
+    await expectPromise(resultPromise).toRejectWith(
+      'This operation was aborted',
+    );
+    expect(calls).to.deep.equal([]);
+
+    resolveCleanup('done');
+    await asyncWorkFinished;
+
+    expect(calls).to.deep.equal(['asyncWork']);
+  });
+
+  it('fires asyncWorkFinished after async iterator return cleanup', async () => {
+    const abortController = new AbortController();
+    const document = parse(`
+      query {
+        todo {
+          items
+        }
+      }
+    `);
+    const { promise: nextReturned, resolve: resolveNextReturned } =
+      promiseWithResolvers<IteratorResult<string>>();
+    const { promise: nextStarted, resolve: resolveNextStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: returnStarted, resolve: resolveReturnStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const { promise: returnFinished, resolve: resolveReturnFinished } =
+      promiseWithResolvers<IteratorResult<string>>();
+    const { promise: asyncWorkFinished, resolve: resolveAsyncWorkFinished } =
+      promiseWithResolvers<undefined>();
+    const asyncIterator = {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next() {
+        resolveNextStarted(undefined);
+        return nextReturned;
+      },
+      return() {
+        resolveReturnStarted(undefined);
+        return returnFinished;
+      },
+    };
+
+    const resultPromise = execute({
+      schema: cancellationHookSchema,
+      document,
+      abortSignal: abortController.signal,
+      hooks: {
+        asyncWorkFinished() {
+          resolveAsyncWorkFinished(undefined);
+        },
+      },
+      rootValue: {
+        todo: {
+          items: asyncIterator,
+        },
+      },
+    });
+
+    await nextStarted;
+    abortController.abort();
+    resolveNextReturned({ value: 'value', done: false });
+
+    await expectPromise(resultPromise).toRejectWith(
+      'This operation was aborted',
+    );
+    await returnStarted;
+
+    let asyncWorkHookCalled = false;
+    const asyncWorkObserved = asyncWorkFinished.then(() => {
+      asyncWorkHookCalled = true;
+    });
+    await resolveOnNextTick();
+    expect(asyncWorkHookCalled).to.equal(false);
+
+    resolveReturnFinished({ value: undefined, done: true });
+    await asyncWorkFinished;
+    await asyncWorkObserved;
+  });
+
+  it('fires asyncWorkFinished after all incremental payloads are delivered', async () => {
+    const { promise: deferredItems, resolve: resolveDeferredItems } =
+      promiseWithResolvers<ReadonlyArray<string>>();
+    const { promise: asyncWorkFinished, resolve: resolveAsyncWorkFinished } =
+      promiseWithResolvers<undefined>();
+    let hookCalls = 0;
+
+    const result = await experimentalExecuteIncrementally({
+      schema: cancellationHookSchema,
+      document: parse(`
+        query {
+          todo {
+            id
+            ... @defer {
+              items
+            }
+          }
+        }
+      `),
+      enableEarlyExecution: true,
+      hooks: {
+        asyncWorkFinished() {
+          hookCalls += 1;
+          resolveAsyncWorkFinished(undefined);
+        },
+      },
+      rootValue: {
+        todo: {
+          id: '1',
+          items: () => deferredItems,
+        },
+      },
+    });
+
+    assert('initialResult' in result);
+    expect(result.initialResult.hasNext).to.equal(true);
+
+    let asyncWorkHookCalled = false;
+    const asyncWorkObserved = asyncWorkFinished.then(() => {
+      asyncWorkHookCalled = true;
+    });
+    await resolveOnNextTick();
+    expect(asyncWorkHookCalled).to.equal(false);
+
+    const nextPromise = result.subsequentResults.next();
+    let nextSettled = false;
+    nextPromise.then(
+      () => {
+        nextSettled = true;
+      },
+      () => {
+        nextSettled = true;
+      },
+    );
+    await resolveOnNextTick();
+    expect(nextSettled).to.equal(false);
+    expect(asyncWorkHookCalled).to.equal(false);
+
+    resolveDeferredItems(['a']);
+    const nextResult = await nextPromise;
+    expect(nextResult.done).to.equal(false);
+    if (nextResult.done) {
+      throw new Error('Expected an incremental payload.');
+    }
+    expect(nextResult.value.hasNext).to.equal(false);
+    await asyncWorkFinished;
+    await asyncWorkObserved;
+    expect(hookCalls).to.equal(1);
+  });
+});

--- a/src/execution/createSharedExecutionContext.ts
+++ b/src/execution/createSharedExecutionContext.ts
@@ -26,6 +26,7 @@ export function createSharedExecutionContext(
 
   const getAsyncHelpers = (): GraphQLResolveInfoHelpers =>
     (resolveInfoHelpers ??= {
+      promiseAll,
       track: (maybePromises) => asyncWorkTracker.addValues(maybePromises),
     });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -40,6 +40,7 @@ import type { ExecutionResult, ValidatedExecutionArgs } from './Executor.js';
 import { Executor } from './Executor.js';
 import { ExecutorThrowingOnIncremental } from './ExecutorThrowingOnIncremental.js';
 import { getVariableSignature } from './getVariableSignature.js';
+import type { ExecutionHooks } from './hooks.js';
 import type { ExperimentalIncrementalExecutionResults } from './incremental/IncrementalExecutor.js';
 import { IncrementalExecutor } from './incremental/IncrementalExecutor.js';
 import { mapAsyncIterable } from './mapAsyncIterable.js';
@@ -298,6 +299,7 @@ export interface ExecutionArgs {
   hideSuggestions?: Maybe<boolean>;
   abortSignal?: Maybe<AbortSignal>;
   enableEarlyExecution?: Maybe<boolean>;
+  hooks?: Maybe<ExecutionHooks>;
   /** Additional execution options. */
   options?: {
     /** Set the maximum number of errors allowed for coercing (defaults to 50). */
@@ -330,6 +332,7 @@ export function validateExecutionArgs(
     perEventExecutor,
     abortSignal: externalAbortSignal,
     enableEarlyExecution,
+    hooks,
     options,
   } = args;
 
@@ -419,6 +422,7 @@ export function validateExecutionArgs(
     errorPropagation,
     externalAbortSignal: externalAbortSignal ?? undefined,
     enableEarlyExecution: enableEarlyExecution === true,
+    hooks: hooks ?? undefined,
   };
 }
 
@@ -468,13 +472,16 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
     }
 
     if (promisedIsTypeOfResults.length) {
-      return Promise.all(promisedIsTypeOfResults).then((isTypeOfResults) => {
-        for (let i = 0; i < isTypeOfResults.length; i++) {
-          if (isTypeOfResults[i]) {
-            return possibleTypes[i].name;
+      return info
+        .getAsyncHelpers()
+        .promiseAll(promisedIsTypeOfResults)
+        .then((isTypeOfResults) => {
+          for (let i = 0; i < isTypeOfResults.length; i++) {
+            if (isTypeOfResults[i]) {
+              return possibleTypes[i].name;
+            }
           }
-        }
-      });
+        });
     }
   };
 

--- a/src/execution/hooks.ts
+++ b/src/execution/hooks.ts
@@ -1,0 +1,35 @@
+import type { SharedExecutionContext } from './createSharedExecutionContext.js';
+import type { ValidatedExecutionArgs } from './Executor.js';
+
+export interface AsyncWorkFinishedInfo {
+  validatedExecutionArgs: ValidatedExecutionArgs;
+}
+
+export interface ExecutionHooks {
+  asyncWorkFinished?: (info: AsyncWorkFinishedInfo) => void;
+}
+
+function runHookSafely<TInfo>(hook: (info: TInfo) => void, info: TInfo): void {
+  try {
+    hook?.(info);
+  } catch {
+    // ignore hook errors
+  }
+}
+
+export function runAsyncWorkFinishedHook(
+  validatedExecutionArgs: ValidatedExecutionArgs,
+  sharedExecutionContext: SharedExecutionContext,
+  asyncWorkFinishedHook: (info: AsyncWorkFinishedInfo) => void,
+): void {
+  const maybeWaitForAsyncWork = sharedExecutionContext.asyncWorkTracker.wait();
+  if (maybeWaitForAsyncWork === undefined) {
+    runHookSafely(asyncWorkFinishedHook, { validatedExecutionArgs });
+    return;
+  }
+  maybeWaitForAsyncWork
+    .then(() => {
+      runHookSafely(asyncWorkFinishedHook, { validatedExecutionArgs });
+    })
+    .catch(() => undefined);
+}

--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -354,7 +354,7 @@ export class IncrementalExecutor<
       errors,
       work,
       this.validatedExecutionArgs.externalAbortSignal,
-      () => this.resolverAbortController?.abort(),
+      () => this.finishSharedExecution(),
     ) as TExperimental;
   }
 

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -14,6 +14,8 @@ export {
 } from './execute.js';
 export type { ExecutionArgs } from './execute.js';
 
+export type { AsyncWorkFinishedInfo, ExecutionHooks } from './hooks.js';
+
 export type {
   ValidatedExecutionArgs,
   ExecutionResult,

--- a/src/execution/legacyIncremental/BranchingIncrementalExecutor.ts
+++ b/src/execution/legacyIncremental/BranchingIncrementalExecutor.ts
@@ -202,7 +202,7 @@ export class BranchingIncrementalExecutor extends IncrementalExecutor<LegacyExpe
       errors,
       work,
       this.validatedExecutionArgs.externalAbortSignal,
-      () => this.resolverAbortController?.abort(),
+      () => this.finishSharedExecution(),
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,6 +374,8 @@ export {
 
 export type {
   ExecutionArgs,
+  AsyncWorkFinishedInfo,
+  ExecutionHooks,
   ValidatedExecutionArgs,
   ExecutionResult,
   ExperimentalIncrementalExecutionResults,

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1046,6 +1046,31 @@ export type GraphQLFieldResolver<
 ) => TResult;
 
 export interface GraphQLResolveInfoHelpers {
+  /**
+   * Promise.all wrapper that allows rejected branches to be tracked
+   * as execution async work.
+   *
+   * Intended use: return or await this promise from resolver work.
+   * Un-awaited async side effects are an anti-pattern:
+   *
+   *   const { promiseAll } = info.getAsyncHelpers();
+   *   promiseAll([someAsyncWork(), someOtherAsyncWork()]).catch(() => undefined);
+   *
+   * In that anti-pattern, tracking starts only after rejection (on a
+   * later microtask), so this work is not guaranteed to delay
+   * `hooks.asyncWorkFinished`.
+   *
+   * Use `track(...)` for un-awaited async side effects:
+   *
+   *   const { track } = info.getAsyncHelpers();
+   *   track([
+   *     someAsyncWork().catch(() => undefined),
+   *     someOtherAsyncWork().catch(() => undefined)
+   *   ]);
+   */
+  readonly promiseAll: <T>(
+    values: ReadonlyArray<PromiseOrValue<T>>,
+  ) => Promise<Array<T>>;
   readonly track: (
     maybePromises: ReadonlyArray<PromiseOrValue<unknown>>,
   ) => void;


### PR DESCRIPTION
Cancelled async work may still be running even after the result returns. This hook allows interested execution harnesses to track when this async work completes.

Depends on:

- #4657

The hook is available through `hooks.asyncWorkFinished` on execution args.

An `execute` wrapper that waits for all tracked async work can be written as:

```ts
function executeAndWaitForAsyncWorkFinished(
  args: ExecutionArgs,
): PromiseOrValue<ExecutionResult> {
  let hookHasFired = false;
  const { promise: hookFinished, resolve: resolveHookFinished } =
    Promise.withResolvers<void>();

  const userAsyncWorkFinishedHook = args.hooks?.asyncWorkFinished;
  const result = execute({
    ...args,
    hooks: {
      ...args.hooks,
      asyncWorkFinished(info) {
        try {
          userAsyncWorkFinishedHook?.(info);
        } finally {
          hookHasFired = true;
          resolveHookFinished();
        }
      },
    },
  });

  return hookHasFired ? result : hookFinished.then(() => result);
}
```

To ensure resolver-side async work is also tracked and awaited, use `info.getAsyncHelpers().track(...)` or `info.getAsyncHelpers().promiseAll(...)`.

`promiseAll(...)` is optimized for the common case where the returned promise is awaited (or returned) from the resolver. It only starts tracking on rejection, and does so as a side-effect. Un-awaited async side effects are an anti-pattern:

```ts
resolve(_source, _args, _context, info) {
  const { promiseAll } = info.getAsyncHelpers();
  promiseAll([Promise.reject(new Error('bad')), pendingCleanup]).catch(
    () => undefined,
  );
  return 'ok';
}
```

In that anti-pattern, tracking starts only after rejection (on a later microtask), so this work is not guaranteed to delay `hooks.asyncWorkFinished`.

Use `track(...)` for un-awaited async side effects:

```ts
resolve(_source, _args, _context, info) {
  const { track } = info.getAsyncHelpers();
  track([doCleanupAsync().catch(() => undefined)]);
  return 'ok';
}
```