### PR TITLE
Add @types/react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "build:npm": "node resources/build-npm.js",
     "build:deno": "node resources/build-deno.js"
   },
+  "peerDependencies": {
+    "@types/react": "*"
+  },
   "devDependencies": {
     "@babel/core": "7.17.9",
     "@babel/plugin-syntax-typescript": "7.16.7",


### PR DESCRIPTION
Adds @types/react as a peer dependency to match the existing react peer dependency in the package.