### PR TITLE
Move maxTokens check to lexer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -242,6 +242,7 @@ export {
 
 export type {
   ParseOptions,
+  LexerOptions,
   SourceLocation,
   TokenKindEnum,
   KindEnum,

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -8,9 +8,11 @@ import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery';
 import { inspect } from '../../jsutils/inspect';
 
 import { Kind } from '../kinds';
+import { Lexer } from '../lexer';
 import {
   parse,
   parseConstValue,
+  Parser,
   parseSchemaCoordinate,
   parseType,
   parseValue,
@@ -112,6 +114,18 @@ describe('Parser', () => {
     ).to.not.throw();
     expect(() => parse('#\n{\n#\na\n#\na\n#\n}\n#', { maxTokens: 8 })).to.throw(
       'Syntax Error: Document contains more that 8 tokens. Parsing aborted.',
+    );
+  });
+
+  it('forbids maxTokens and lexer together', () => {
+    expect(
+      () =>
+        new Parser('{a}', {
+          maxTokens: 10,
+          lexer: new Lexer(new Source('{a}')),
+        }),
+    ).to.throw(
+      'Setting maxTokens has no effect when a custom lexer is supplied',
     );
   });
 

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -106,6 +106,13 @@ describe('Parser', () => {
     expect(() => parse('{ foo(bar: "baz") }', { maxTokens: 7 })).to.throw(
       'Syntax Error: Document contains more that 7 tokens. Parsing aborted.',
     );
+
+    expect(() =>
+      parse('#\n{\n#\na\n#\na\n#\n}\n#', { maxTokens: 9 }),
+    ).to.not.throw();
+    expect(() => parse('#\n{\n#\na\n#\na\n#\n}\n#', { maxTokens: 8 })).to.throw(
+      'Syntax Error: Document contains more that 8 tokens. Parsing aborted.',
+    );
   });
 
   it('parses variable inline values', () => {

--- a/src/language/__tests__/schemaCoordinateLexer-test.ts
+++ b/src/language/__tests__/schemaCoordinateLexer-test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import { expectToThrowJSON } from '../../__testUtils__/expectJSON';
 
+import type { Token } from '../ast';
 import { SchemaCoordinateLexer } from '../schemaCoordinateLexer';
 import { Source } from '../source';
 import { TokenKind } from '../tokenKind';
@@ -48,5 +49,14 @@ describe('SchemaCoordinateLexer', () => {
       message: 'Syntax Error: Invalid character: " ".',
       locations: [{ line: 1, column: 4 }],
     });
+  });
+
+  it('counts tokens', () => {
+    const lexer = new SchemaCoordinateLexer(new Source('Name.field'));
+    let token: Token;
+    do {
+      token = lexer.advance();
+    } while (token.kind !== TokenKind.EOF);
+    expect(lexer.tokenCount).to.eq(3);
   });
 });

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -12,6 +12,7 @@ export { TokenKind } from './tokenKind';
 export type { TokenKindEnum } from './tokenKind';
 
 export { Lexer } from './lexer';
+export type { LexerOptions } from './lexer';
 
 export {
   parse,

--- a/src/language/lexer.ts
+++ b/src/language/lexer.ts
@@ -7,13 +7,30 @@ import type { Source } from './source';
 import { TokenKind } from './tokenKind';
 
 /**
+ * Configuration options to control lexer behavior
+ */
+export interface LexerOptions {
+  /**
+   * Parser CPU and memory usage is linear to the number of tokens in a document
+   * however in extreme cases it becomes quadratic due to memory exhaustion.
+   * Parsing happens before validation so even invalid queries can burn lots of
+   * CPU time and memory.
+   * To prevent this you can set a maximum number of tokens allowed within a document.
+   */
+  maxTokens?: number | undefined;
+}
+
+/**
  * A Lexer interface which provides common properties and methods required for
  * lexing GraphQL source.
  *
  * @internal
  */
 export interface LexerInterface {
-  source: Source;
+  readonly _options: Readonly<LexerOptions>;
+  _tokenCounter: number;
+  readonly source: Source;
+  tokenCount: number;
   lastToken: Token;
   token: Token;
   line: number;
@@ -31,6 +48,11 @@ export interface LexerInterface {
  * whenever called.
  */
 export class Lexer implements LexerInterface {
+  /** @internal */
+  readonly _options: Readonly<LexerOptions>;
+  /** @internal */
+  _tokenCounter: number;
+
   source: Source;
 
   /**
@@ -53,9 +75,11 @@ export class Lexer implements LexerInterface {
    */
   lineStart: number;
 
-  constructor(source: Source) {
+  constructor(source: Source, options: LexerOptions = {}) {
     const startOfFileToken = new Token(TokenKind.SOF, 0, 0, 0, 0);
 
+    this._options = options;
+    this._tokenCounter = 0;
     this.source = source;
     this.lastToken = startOfFileToken;
     this.token = startOfFileToken;
@@ -65,6 +89,10 @@ export class Lexer implements LexerInterface {
 
   get [Symbol.toStringTag]() {
     return 'Lexer';
+  }
+
+  get tokenCount(): number {
+    return this._tokenCounter;
   }
 
   /**
@@ -200,8 +228,19 @@ export function createToken(
   end: number,
   value?: string,
 ): Token {
+  const { maxTokens } = lexer._options;
   const line = lexer.line;
   const col = 1 + start - lexer.lineStart;
+  if (kind !== TokenKind.EOF) {
+    ++lexer._tokenCounter;
+    if (maxTokens !== undefined && lexer._tokenCounter > maxTokens) {
+      throw syntaxError(
+        lexer.source,
+        start,
+        `Document contains more that ${maxTokens} tokens. Parsing aborted.`,
+      );
+    }
+  }
   return new Token(kind, start, end, line, col, value);
 }
 

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -247,7 +247,7 @@ export class Parser {
     if (lexer) {
       if (options.maxTokens != null) {
         throw new Error(
-          'Setting maxTokens has no effect when a custom lexer is passed',
+          'Setting maxTokens has no effect when a custom lexer is supplied',
         );
       }
       this._lexer = lexer;

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -111,10 +111,17 @@ export interface ParseOptions {
    * ```
    */
   allowLegacyFragmentVariables?: boolean;
+}
 
+/**
+ * @internal
+ */
+export interface ParseOptionsInternal extends ParseOptions {
   /**
    * You may override the Lexer class used to lex the source; this is used by
    * schema coordinates to introduce a lexer with a restricted syntax.
+   *
+   * Cannot be set if `maxTokens` is set.
    */
   lexer?: LexerInterface | undefined;
 }
@@ -204,10 +211,15 @@ export function parseType(
  */
 export function parseSchemaCoordinate(
   source: string | Source,
+  options?: ParseOptions | undefined,
 ): SchemaCoordinateNode {
   const sourceObj = isSource(source) ? source : new Source(source);
-  const lexer = new SchemaCoordinateLexer(sourceObj);
-  const parser = new Parser(source, { lexer });
+  const lexer = new SchemaCoordinateLexer(sourceObj, options);
+  const parser = new Parser(source, {
+    ...options,
+    maxTokens: undefined, // Handled by SchemaCoordinateLexer
+    lexer,
+  });
   parser.expectToken(TokenKind.SOF);
   const coordinate = parser.parseSchemaCoordinate();
   parser.expectToken(TokenKind.EOF);
@@ -226,26 +238,30 @@ export function parseSchemaCoordinate(
  * @internal
  */
 export class Parser {
-  protected _options: Omit<ParseOptions, 'lexer'>;
+  protected _options: ParseOptions;
   protected _lexer: LexerInterface;
-  protected _tokenCounter: number;
 
-  constructor(source: string | Source, options: ParseOptions = {}) {
+  constructor(source: string | Source, options: ParseOptionsInternal = {}) {
     const { lexer, ..._options } = options;
 
     if (lexer) {
+      if (options.maxTokens != null) {
+        throw new Error(
+          'Setting maxTokens has no effect when a custom lexer is passed',
+        );
+      }
       this._lexer = lexer;
     } else {
       const sourceObj = isSource(source) ? source : new Source(source);
-      this._lexer = new Lexer(sourceObj);
+      const { maxTokens } = options;
+      this._lexer = new Lexer(sourceObj, { maxTokens });
     }
 
     this._options = _options;
-    this._tokenCounter = 0;
   }
 
   get tokenCount(): number {
-    return this._tokenCounter;
+    return this._lexer.tokenCount;
   }
 
   /**
@@ -1690,19 +1706,7 @@ export class Parser {
   }
 
   advanceLexer(): void {
-    const { maxTokens } = this._options;
-    const token = this._lexer.advance();
-
-    if (token.kind !== TokenKind.EOF) {
-      ++this._tokenCounter;
-      if (maxTokens !== undefined && this._tokenCounter > maxTokens) {
-        throw syntaxError(
-          this._lexer.source,
-          token.start,
-          `Document contains more that ${maxTokens} tokens. Parsing aborted.`,
-        );
-      }
-    }
+    this._lexer.advance();
   }
 }
 

--- a/src/language/schemaCoordinateLexer.ts
+++ b/src/language/schemaCoordinateLexer.ts
@@ -14,6 +14,8 @@ import { TokenKind } from './tokenKind';
  * source lexes, the final Token emitted by the lexer will be of kind
  * EOF, after which the lexer will repeatedly return the same EOF token
  * whenever called.
+ *
+ * @internal
  */
 export class SchemaCoordinateLexer implements LexerInterface {
   /** @internal */

--- a/src/language/schemaCoordinateLexer.ts
+++ b/src/language/schemaCoordinateLexer.ts
@@ -2,7 +2,7 @@ import { syntaxError } from '../error/syntaxError';
 
 import { Token } from './ast';
 import { isNameStart } from './characterClasses';
-import type { LexerInterface } from './lexer';
+import type { LexerInterface, LexerOptions } from './lexer';
 import { createToken, printCodePointAt, readName } from './lexer';
 import type { Source } from './source';
 import { TokenKind } from './tokenKind';
@@ -16,6 +16,11 @@ import { TokenKind } from './tokenKind';
  * whenever called.
  */
 export class SchemaCoordinateLexer implements LexerInterface {
+  /** @internal */
+  public readonly _options: Readonly<LexerOptions>;
+  /** @internal */
+  public _tokenCounter: number;
+
   source: Source;
 
   /**
@@ -40,9 +45,11 @@ export class SchemaCoordinateLexer implements LexerInterface {
    */
   lineStart: 0 = 0 as const;
 
-  constructor(source: Source) {
+  constructor(source: Source, options: LexerOptions = {}) {
     const startOfFileToken = new Token(TokenKind.SOF, 0, 0, 0, 0);
 
+    this._options = options;
+    this._tokenCounter = 0;
     this.source = source;
     this.lastToken = startOfFileToken;
     this.token = startOfFileToken;
@@ -50,6 +57,10 @@ export class SchemaCoordinateLexer implements LexerInterface {
 
   get [Symbol.toStringTag]() {
     return 'SchemaCoordinateLexer';
+  }
+
+  get tokenCount(): number {
+    return this._tokenCounter;
   }
 
   /**


### PR DESCRIPTION
By checking `maxTokens` inside the `createToken` function we can be sure that it's applied consistently.

I've also moved ParserOptions.lexer to be an internal property (it should only be used by the schema coordinates parser, it was never intended to be a public interface) and implemented an assertion that forbids `lexer` and `maxTokens` together (since if they were both set, `maxTokens` would be ignored). I've also marked the SchemaCoordinateLexer as internal; we don't expose it via `index.ts` anyway, but best to signal the intent anyway.

I'm not super happy about mutating the internal state of the lexer from `createToken` - really I'd rather `createToken` were a method on the lexer class - but I don't want the two Lexers to have to implement it each and we don't like to extend classes so I think we can accept it in this one place. I'm not happy about it though, so if you have ideas for a better approach, please go ahead!

