### PR TITLE
fix(execution): convert all promise-like results to promises

### DIFF
--- a/src/execution/AsyncWorkTracker.ts
+++ b/src/execution/AsyncWorkTracker.ts
@@ -1,5 +1,4 @@
-import { isPromise } from '../jsutils/isPromise.js';
-import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
+import { isPromiseLike } from '../jsutils/isPromise.js';
 
 /** @internal */
 export class AsyncWorkTracker {
@@ -9,9 +8,9 @@ export class AsyncWorkTracker {
     this.pendingAsyncWork = new Set<Promise<void>>();
   }
 
-  add(promise: Promise<unknown>): void {
+  add(promiseLike: PromiseLike<unknown>): void {
     const pendingAsyncWork = this.pendingAsyncWork;
-    const promiseToSettle = promise.then(
+    const promiseToSettle = Promise.resolve(promiseLike).then(
       () => {
         pendingAsyncWork.delete(promiseToSettle);
       },
@@ -22,9 +21,9 @@ export class AsyncWorkTracker {
     pendingAsyncWork.add(promiseToSettle);
   }
 
-  addValues(values: ReadonlyArray<PromiseOrValue<unknown>>): void {
+  addValues(values: ReadonlyArray<unknown>): void {
     for (const value of values) {
-      if (isPromise(value)) {
+      if (isPromiseLike(value)) {
         this.add(value);
       }
     }
@@ -40,7 +39,7 @@ export class AsyncWorkTracker {
   }
 
   promiseAllTrackOnReject<T>(
-    values: ReadonlyArray<PromiseOrValue<T>>,
+    values: ReadonlyArray<PromiseLike<T> | T>,
   ): Promise<Array<T>> {
     const promise = Promise.all(values);
     promise.then(undefined, () => {

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -2,7 +2,7 @@ import { inspect } from '../jsutils/inspect.js';
 import { invariant } from '../jsutils/invariant.js';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable.js';
 import { isIterableObject } from '../jsutils/isIterableObject.js';
-import { isPromise } from '../jsutils/isPromise.js';
+import { isPromise, isPromiseLike } from '../jsutils/isPromise.js';
 import { memoize2 } from '../jsutils/memoize2.js';
 import { memoize3 } from '../jsutils/memoize3.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
@@ -610,7 +610,7 @@ export class Executor<
       // used to represent an authenticated user, or request-specific caches.
       const result = resolveFn(source, args, contextValue, info);
 
-      if (isPromise(result)) {
+      if (isPromiseLike(result)) {
         return this.completePromisedValue(
           returnType,
           fieldDetailsList,
@@ -790,7 +790,7 @@ export class Executor<
     fieldDetailsList: FieldDetailsList,
     info: GraphQLResolveInfo,
     path: Path,
-    result: Promise<unknown>,
+    result: PromiseLike<unknown>,
     positionContext: TPositionContext | undefined,
   ): Promise<unknown> {
     try {
@@ -1052,7 +1052,7 @@ export class Executor<
     itemPath: Path,
     positionContext: TPositionContext | undefined,
   ): boolean {
-    if (isPromise(item)) {
+    if (isPromiseLike(item)) {
       completedResults.push(
         this.completePromisedListItemValue(
           item,
@@ -1130,7 +1130,7 @@ export class Executor<
   }
 
   async completePromisedListItemValue(
-    item: Promise<unknown>,
+    item: PromiseLike<unknown>,
     itemType: GraphQLOutputType,
     fieldDetailsList: FieldDetailsList,
     info: GraphQLResolveInfo,
@@ -1193,8 +1193,8 @@ export class Executor<
       returnType.resolveType ?? validatedExecutionArgs.typeResolver;
     const runtimeType = resolveTypeFn(result, contextValue, info, returnType);
 
-    if (isPromise(runtimeType)) {
-      return runtimeType.then((resolvedRuntimeType) => {
+    if (isPromiseLike(runtimeType)) {
+      return Promise.resolve(runtimeType).then((resolvedRuntimeType) => {
         if (this.aborted) {
           throw new Error('Aborted!');
         }
@@ -1303,8 +1303,8 @@ export class Executor<
         info,
       );
 
-      if (isPromise(isTypeOf)) {
-        return isTypeOf.then((resolvedIsTypeOf) => {
+      if (isPromiseLike(isTypeOf)) {
+        return Promise.resolve(isTypeOf).then((resolvedIsTypeOf) => {
           if (this.aborted) {
             throw new Error('Aborted!');
           }

--- a/src/execution/collectIteratorPromises.ts
+++ b/src/execution/collectIteratorPromises.ts
@@ -1,4 +1,4 @@
-import { isPromise } from '../jsutils/isPromise.js';
+import { isPromiseLike } from '../jsutils/isPromise.js';
 
 /**
  * Drain a sync iterator after abrupt completion so later promise rejections
@@ -6,7 +6,7 @@ import { isPromise } from '../jsutils/isPromise.js';
  */
 export function collectIteratorPromises(
   iterator: Iterator<unknown>,
-): Array<Promise<unknown>> {
+): Array<unknown> {
   const promises = [];
   try {
     while (true) {
@@ -14,7 +14,7 @@ export function collectIteratorPromises(
       if (iteration.done) {
         return promises;
       }
-      if (isPromise(iteration.value)) {
+      if (isPromiseLike(iteration.value)) {
         promises.push(iteration.value);
       }
     }

--- a/src/execution/createSharedExecutionContext.ts
+++ b/src/execution/createSharedExecutionContext.ts
@@ -1,5 +1,3 @@
-import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
-
 import type { GraphQLResolveInfoHelpers } from '../type/index.js';
 
 import { AsyncWorkTracker } from './AsyncWorkTracker.js';
@@ -10,7 +8,7 @@ export interface SharedExecutionContext {
   getAbortSignal: () => AbortSignal | undefined;
   getAsyncHelpers: () => GraphQLResolveInfoHelpers;
   promiseAll: <T>(
-    values: ReadonlyArray<PromiseOrValue<T>>,
+    values: ReadonlyArray<PromiseLike<T> | T>,
   ) => Promise<Array<T>>;
 }
 
@@ -21,7 +19,7 @@ export function createSharedExecutionContext(
   let resolveInfoHelpers: GraphQLResolveInfoHelpers | undefined;
 
   const promiseAll = <T>(
-    values: ReadonlyArray<PromiseOrValue<T>>,
+    values: ReadonlyArray<PromiseLike<T> | T>,
   ): Promise<Array<T>> => asyncWorkTracker.promiseAllTrackOnReject(values);
 
   const getAsyncHelpers = (): GraphQLResolveInfoHelpers =>

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1,7 +1,7 @@
 import { inspect } from '../jsutils/inspect.js';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable.js';
 import { isObjectLike } from '../jsutils/isObjectLike.js';
-import { isPromise } from '../jsutils/isPromise.js';
+import { isPromise, isPromiseLike } from '../jsutils/isPromise.js';
 import type { Maybe } from '../jsutils/Maybe.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
 import type { Path } from '../jsutils/Path.js';
@@ -445,7 +445,7 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
 
     // Otherwise, test each possible type.
     const possibleTypes = info.schema.getPossibleTypes(abstractType);
-    const promisedIsTypeOfResults: Array<Promise<boolean>> = [];
+    const promisedIsTypeOfResults: Array<PromiseLike<boolean>> = [];
 
     try {
       for (let i = 0; i < possibleTypes.length; i++) {
@@ -454,7 +454,7 @@ export const defaultTypeResolver: GraphQLTypeResolver<unknown, unknown> =
         if (type.isTypeOf) {
           const isTypeOfResult = type.isTypeOf(value, contextValue, info);
 
-          if (isPromise(isTypeOfResult)) {
+          if (isPromiseLike(isTypeOfResult)) {
             promisedIsTypeOfResults[i] = isTypeOfResult;
           } else if (isTypeOfResult) {
             if (promisedIsTypeOfResults.length) {
@@ -637,10 +637,11 @@ function executeSubscription(
     // used to represent an authenticated user, or request-specific caches.
     const result = resolveFn(rootValue, args, contextValue, info);
 
-    if (isPromise(result)) {
+    if (isPromiseLike(result)) {
+      const promisedResult = Promise.resolve(result);
       const promise = externalAbortSignal
-        ? cancellablePromise(result, externalAbortSignal)
-        : result;
+        ? cancellablePromise(promisedResult, externalAbortSignal)
+        : promisedResult;
       return promise
         .then(assertEventStream)
         .then(undefined, (error: unknown) => {

--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-params */
 import { invariant } from '../../jsutils/invariant.js';
-import { isPromise } from '../../jsutils/isPromise.js';
+import { isPromise, isPromiseLike } from '../../jsutils/isPromise.js';
 import { memoize1 } from '../../jsutils/memoize1.js';
 import { memoize2 } from '../../jsutils/memoize2.js';
 import type { ObjMap } from '../../jsutils/ObjMap.js';
@@ -841,7 +841,7 @@ export class IncrementalExecutor<
     info: GraphQLResolveInfo,
     itemType: GraphQLOutputType,
   ): PromiseOrValue<StreamItemResult> {
-    if (isPromise(item)) {
+    if (isPromiseLike(item)) {
       return this.completePromisedValue(
         itemType,
         fieldDetailsList,

--- a/src/jsutils/isPromise.ts
+++ b/src/jsutils/isPromise.ts
@@ -1,7 +1,11 @@
+export function isPromise(value: unknown): value is Promise<unknown> {
+  return value instanceof Promise;
+}
+
 /**
  * Returns true if the value acts like a Promise, i.e. has a "then" function,
  * otherwise returns false.
  */
-export function isPromise(value: any): value is Promise<unknown> {
+export function isPromiseLike(value: any): value is PromiseLike<unknown> {
   return typeof value?.then === 'function';
 }

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1069,11 +1069,9 @@ export interface GraphQLResolveInfoHelpers {
    *   ]);
    */
   readonly promiseAll: <T>(
-    values: ReadonlyArray<PromiseOrValue<T>>,
+    values: ReadonlyArray<PromiseLike<T> | T>,
   ) => Promise<Array<T>>;
-  readonly track: (
-    maybePromises: ReadonlyArray<PromiseOrValue<unknown>>,
-  ) => void;
+  readonly track: (maybePromises: ReadonlyArray<unknown>) => void;
 }
 
 export interface GraphQLResolveInfo {


### PR DESCRIPTION
previously, most pathways converted, but not all

in particular, pathways branching off of `isTypeOf(...)` and `resolveType(...)` as well as `createSourceEventStream` could return non-native promises even though we advertised `PromiseOrValue`.

There is also a micro-benchmark perf improvement even in sync paths, presumably because V8 can make a few more assumptions.

<img width="907" height="827" alt="image" src="https://github.com/user-attachments/assets/8285c2de-f872-47ec-88bf-ee046e0aa063" />