### PR TITLE
feat(execution): expose partial result on abort errors

### DIFF
--- a/src/__testUtils__/expectPromise.ts
+++ b/src/__testUtils__/expectPromise.ts
@@ -5,7 +5,7 @@ import { isPromise } from '../jsutils/isPromise.js';
 
 interface PromiseExpectation {
   toResolve: () => Promise<unknown>;
-  toRejectWith: (message: string) => Promise<void>;
+  toRejectWith: (message: string) => Promise<Error>;
 }
 
 export function expectPromise(maybePromise: unknown): PromiseExpectation {
@@ -18,7 +18,7 @@ export function expectPromise(maybePromise: unknown): PromiseExpectation {
     toResolve(): Promise<unknown> {
       return maybePromise;
     },
-    async toRejectWith(message: string): Promise<void> {
+    async toRejectWith(message: string): Promise<Error> {
       let caughtError: unknown;
       let resolved;
       let rejected = false;
@@ -38,6 +38,7 @@ export function expectPromise(maybePromise: unknown): PromiseExpectation {
 
       expect(caughtError).to.be.an.instanceOf(Error);
       expect(caughtError).to.have.property('message', message);
+      return caughtError as Error;
     },
   };
 }

--- a/src/execution/AbortedGraphQLExecutionError.ts
+++ b/src/execution/AbortedGraphQLExecutionError.ts
@@ -1,0 +1,30 @@
+import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
+
+export class AbortedGraphQLExecutionError<TResult> extends Error {
+  readonly abortedResult: PromiseOrValue<TResult>;
+
+  constructor(reason: unknown, result: PromiseOrValue<TResult>) {
+    super(getAbortReasonMessage(reason), { cause: reason });
+    this.name = 'AbortedGraphQLExecutionError';
+    this.abortedResult = result;
+  }
+
+  get [Symbol.toStringTag](): string {
+    return 'AbortedGraphQLExecutionError';
+  }
+}
+
+function getAbortReasonMessage(reason: unknown): string {
+  if (reason instanceof Error) {
+    return reason.message;
+  }
+  if (
+    typeof reason === 'object' &&
+    reason !== null &&
+    'message' in reason &&
+    typeof reason.message === 'string'
+  ) {
+    return reason.message;
+  }
+  return String(reason);
+}

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -44,6 +44,7 @@ import {
 } from '../type/definition.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
+import { AbortedGraphQLExecutionError } from './AbortedGraphQLExecutionError.js';
 import { withCancellation } from './cancellablePromise.js';
 import type {
   DeferUsage,
@@ -339,7 +340,7 @@ export class Executor<
         const { promise: cancellablePromise, abort: abortResultPromise } =
           withCancellation(promise.then((resolved) => this.finish(resolved)));
         this.abortResultPromise = () => {
-          abortResultPromise(this.abortReason);
+          abortResultPromise(this.createAbortedExecutionError(promise));
         };
         if (this.aborted) {
           this.abortResultPromise();
@@ -369,10 +370,16 @@ export class Executor<
 
   finish<T>(result: T): T {
     if (this.aborted) {
-      throw this.abortReason;
+      throw this.createAbortedExecutionError(result);
     }
     this.aborted = true;
     return result;
+  }
+
+  createAbortedExecutionError<T>(
+    result: PromiseOrValue<T>,
+  ): AbortedGraphQLExecutionError<T> {
+    return new AbortedGraphQLExecutionError(this.abortReason, result);
   }
 
   getFinishSharedExecution(): () => void {
@@ -649,10 +656,6 @@ export class Executor<
     fieldDetailsList: FieldDetailsList,
     path: Path,
   ): void {
-    if (this.aborted) {
-      throw new Error('Aborted!');
-    }
-
     const error = locatedError(
       rawError,
       toNodes(fieldDetailsList),

--- a/src/execution/__tests__/AbortedGraphQLExecutionError-test.ts
+++ b/src/execution/__tests__/AbortedGraphQLExecutionError-test.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { AbortedGraphQLExecutionError } from '../AbortedGraphQLExecutionError.js';
+
+describe('AbortedGraphQLExecutionError', () => {
+  it('uses the original Error reason message and cause', () => {
+    const reason = new Error('Original reason');
+    const result = { data: { ok: true } };
+
+    const error = new AbortedGraphQLExecutionError(reason, result);
+
+    expect(error).to.be.instanceof(Error);
+    expect(error).to.be.instanceof(AbortedGraphQLExecutionError);
+    expect(error).to.include({
+      name: 'AbortedGraphQLExecutionError',
+      message: 'Original reason',
+      cause: reason,
+      abortedResult: result,
+    });
+    expect(Object.prototype.toString.call(error)).to.equal(
+      '[object AbortedGraphQLExecutionError]',
+    );
+  });
+
+  it('uses the message property from non-Error reasons', () => {
+    const reason = { message: 'Object reason' };
+    const result = Promise.resolve({ data: null });
+
+    const error = new AbortedGraphQLExecutionError(reason, result);
+
+    expect(error).to.include({
+      message: 'Object reason',
+      cause: reason,
+      abortedResult: result,
+    });
+  });
+
+  it('stringifies reasons without a message', () => {
+    const error = new AbortedGraphQLExecutionError('String reason', {
+      data: null,
+    });
+
+    expect(error).to.include({
+      message: 'String reason',
+      cause: 'String reason',
+    });
+  });
+
+  it('stringifies null reasons', () => {
+    const error = new AbortedGraphQLExecutionError(null, { data: null });
+
+    expect(error).to.include({
+      message: 'null',
+      cause: null,
+    });
+  });
+});

--- a/src/execution/__tests__/cancellation-test.ts
+++ b/src/execution/__tests__/cancellation-test.ts
@@ -1,11 +1,13 @@
 import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { expectEqualPromisesOrValues } from '../../__testUtils__/expectEqualPromisesOrValues.js';
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
 import { expectPromise } from '../../__testUtils__/expectPromise.js';
 import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 
 import { isAsyncIterable } from '../../jsutils/isAsyncIterable.js';
+import { isPromise } from '../../jsutils/isPromise.js';
 import { promiseWithResolvers } from '../../jsutils/promiseWithResolvers.js';
 
 import { parse } from '../../language/parser.js';
@@ -21,7 +23,13 @@ import { GraphQLSchema } from '../../type/schema.js';
 
 import { buildSchema } from '../../utilities/buildASTSchema.js';
 
-import { execute, subscribe } from '../execute.js';
+import { AbortedGraphQLExecutionError } from '../AbortedGraphQLExecutionError.js';
+import {
+  execute,
+  experimentalExecuteIncrementally,
+  subscribe,
+} from '../execute.js';
+import { legacyExecuteIncrementally } from '../legacyIncremental/legacyExecuteIncrementally.js';
 
 const schema = buildSchema(`
   type Todo {
@@ -39,6 +47,7 @@ const schema = buildSchema(`
     todo: Todo
     nonNullableTodo: Todo!
     blocker: String
+    aborter: String
   }
 
   type Mutation {
@@ -162,6 +171,207 @@ describe('Execute: Cancellation', () => {
     abortController.abort(new Error('Custom abort error'));
 
     await expectPromise(resultPromise).toRejectWith('Custom abort error');
+  });
+
+  it('rejects with the aborted execution error while initial result is pending', async () => {
+    const abortController = new AbortController();
+    const abortReason = new Error('Custom abort error');
+    const { promise: fieldValue, resolve: resolveFieldValue } =
+      promiseWithResolvers<string>();
+    const { promise: fieldStarted, resolve: resolveFieldStarted } =
+      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+      promiseWithResolvers<void>();
+    const document = parse(`
+      query {
+        blocker
+      }
+    `);
+
+    const resultPromise = execute({
+      document,
+      schema,
+      abortSignal: abortController.signal,
+      rootValue: {
+        blocker: () => {
+          resolveFieldStarted(undefined);
+          return fieldValue;
+        },
+      },
+    });
+
+    await fieldStarted;
+    abortController.abort(abortReason);
+
+    const caughtError =
+      await expectPromise(resultPromise).toRejectWith('Custom abort error');
+
+    assert(caughtError instanceof AbortedGraphQLExecutionError);
+    expect(caughtError.cause).to.equal(abortReason);
+    assert(isPromise(caughtError.abortedResult));
+
+    let resultSettled = false;
+    const promisedResult = caughtError.abortedResult.then((result) => {
+      resultSettled = true;
+      return result;
+    });
+    await resolveOnNextTick();
+    expect(resultSettled).to.equal(false);
+
+    resolveFieldValue('ok');
+
+    const result = await promisedResult;
+    expectJSON(result).toDeepEqual({
+      data: { blocker: null },
+      errors: [
+        {
+          message: 'Aborted!',
+          path: ['blocker'],
+          locations: [{ line: 3, column: 9 }],
+        },
+      ],
+    });
+  });
+
+  it('throws the aborted execution error with a completed initial result in the atypical internal resolver-abort case', async () => {
+    const abortController = new AbortController();
+    const abortReason = new Error('Custom abort error');
+    const document = parse(`
+      query {
+        aborter
+      }
+    `);
+
+    const caughtError = await expectPromise(
+      Promise.resolve().then(() =>
+        execute({
+          document,
+          schema,
+          abortSignal: abortController.signal,
+          rootValue: {
+            aborter: () => {
+              abortController.abort(abortReason);
+              return 'done';
+            },
+          },
+        }),
+      ),
+    ).toRejectWith('Custom abort error');
+
+    assert(caughtError instanceof AbortedGraphQLExecutionError);
+    expect(caughtError.cause).to.equal(abortReason);
+    expect(isPromise(caughtError.abortedResult)).to.equal(false);
+    expectJSON(caughtError.abortedResult).toDeepEqual({
+      data: {
+        aborter: 'done',
+      },
+    });
+  });
+
+  it('throws the aborted execution error with an external abort while incremental initial result is still pending', async () => {
+    await expectEqualPromisesOrValues(
+      [experimentalExecuteIncrementally, legacyExecuteIncrementally].map(
+        async (executeIncrementally) => {
+          const abortController = new AbortController();
+          const abortReason = new Error('Custom abort error');
+
+          const { promise: delayedAborter, resolve: resolveAborter } =
+            promiseWithResolvers<string>();
+          const { promise: fieldStarted, resolve: resolveFieldStarted } =
+            // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+            promiseWithResolvers<void>();
+
+          delayedAborter.then(
+            () => {
+              abortController.abort(abortReason);
+            },
+            () => {
+              abortController.abort(abortReason);
+            },
+          );
+
+          const executionResult = Promise.resolve().then(() =>
+            executeIncrementally({
+              schema,
+              document: parse(`
+                query {
+                  todo {
+                    id
+                    ... @defer {
+                      items
+                    }
+                  }
+                  aborter
+                }
+              `),
+              abortSignal: abortController.signal,
+              rootValue: {
+                aborter() {
+                  resolveFieldStarted(undefined);
+                  return delayedAborter;
+                },
+                todo: {
+                  id: '1',
+                  items: ['a'],
+                },
+              },
+            }),
+          );
+
+          await fieldStarted;
+          resolveAborter('done');
+
+          const caughtError =
+            await expectPromise(executionResult).toRejectWith(
+              'Custom abort error',
+            );
+
+          assert(caughtError instanceof AbortedGraphQLExecutionError);
+          expect(caughtError.cause).to.equal(abortReason);
+          expect(isPromise(caughtError.abortedResult)).to.equal(true);
+
+          const abortedResult = await caughtError.abortedResult;
+          expect(abortedResult.initialResult).to.be.an('object');
+        },
+      ),
+    );
+  });
+
+  it('does not wrap aborts after the initial result', async () => {
+    const abortController = new AbortController();
+    const { promise: deferredItems } =
+      promiseWithResolvers<ReadonlyArray<string>>();
+
+    const result = await experimentalExecuteIncrementally({
+      schema,
+      document: parse(`
+        query {
+          todo {
+            id
+            ... @defer {
+              items
+            }
+          }
+        }
+      `),
+      enableEarlyExecution: true,
+      abortSignal: abortController.signal,
+      rootValue: {
+        todo: {
+          id: '1',
+          items: () => deferredItems,
+        },
+      },
+    });
+
+    assert('initialResult' in result);
+    const iterator = result.subsequentResults[Symbol.asyncIterator]();
+    abortController.abort();
+
+    const caughtError = await expectPromise(iterator.next()).toRejectWith(
+      'This operation was aborted',
+    );
+
+    expect(caughtError).not.to.be.an.instanceOf(AbortedGraphQLExecutionError);
   });
 
   it('should stop the execution when aborted during nested object field completion', async () => {

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -37,6 +37,8 @@ export type {
   FormattedIncrementalResult,
 } from './incremental/IncrementalExecutor.js';
 
+export { AbortedGraphQLExecutionError } from './AbortedGraphQLExecutionError.js';
+
 export {
   getArgumentValues,
   getVariableValues,

--- a/src/index.ts
+++ b/src/index.ts
@@ -356,6 +356,7 @@ export type {
 
 // Execute GraphQL queries.
 export {
+  AbortedGraphQLExecutionError,
   execute,
   executeQueryOrMutationOrSubscriptionEvent,
   executeSubscriptionEvent,


### PR DESCRIPTION
When execution is aborted while work is still resolving, the executor previously rejected with only the abort reason. That loses access to any response data and errors that execution can still produce while unwinding the in-flight operation.

This PR wraps pre-result aborts in `AbortedGraphQLExecutionError` and attach the partial result as `abortedResult`. If the response has already been produced, `abortedResult` is that response value. If root execution is still pending, `abortedResult` is the original execution promise so callers can await the eventual partial response separately from the abort rejection.

For example, if a query aborts while a field resolver is pending, `execute()` rejects with the original abort reason as the error message and cause, while `error.abortedResult` later resolves to a response such as `{ data: { blocker: null }, errors: [{ message: 'Aborted!', path: ['blocker'] }] }`.

[Incremental execution follows the same pattern for the pending initial result, but aborts after the initial incremental payload continue to surface as rejection of `next` calls on the `subsequentResults` iterator (without this new wrapper).
`abortedResult` is usually a a `Promise` rather than a value because since the `execute` promise rejects immediately, execution has not finished.]

It may sometimes be a value, i.e. if the executor aborted internally during synchronous execution, which currently can happen if a resolver triggers the external abort signal or if there is a developer error, such as using a schema or query with defer/stream directives when using `execute` (instead of using `experimentalExecuteIncrementally`).

@phryneas => Was this your original suggestion on Discord at some point?