### PR TITLE
polish(execution): remove obsolete abort async checks

### DIFF
--- a/src/execution/ExecutorThrowingOnIncremental.ts
+++ b/src/execution/ExecutorThrowingOnIncremental.ts
@@ -1,5 +1,4 @@
 import { invariant } from '../jsutils/invariant.js';
-import { isPromise } from '../jsutils/isPromise.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
 import type { Path } from '../jsutils/Path.js';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
@@ -39,8 +38,7 @@ export class ExecutorThrowingOnIncremental extends Executor {
         '`@defer` directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
       );
       const reason = new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
-      const aborted = this.abort(reason);
-      invariant(!isPromise(aborted));
+      this.abort(reason);
       throw reason;
     }
     return this.executeRootGroupedFieldSet(
@@ -66,8 +64,7 @@ export class ExecutorThrowingOnIncremental extends Executor {
         '`@defer` directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
       );
       const reason = new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
-      const aborted = this.abort(reason);
-      invariant(!isPromise(aborted));
+      this.abort(reason);
       throw reason;
     }
 
@@ -101,8 +98,7 @@ export class ExecutorThrowingOnIncremental extends Executor {
       );
 
       const reason = new Error(UNEXPECTED_MULTIPLE_PAYLOADS);
-      const aborted = this.abort(reason);
-      invariant(!isPromise(aborted));
+      this.abort(reason);
       throw reason;
     }
 


### PR DESCRIPTION
Zombie code after #4657 made this.abort always sync.