### PR TITLE
internal: read benchmark names through dedicated worker

### DIFF
--- a/resources/benchmark/run.ts
+++ b/resources/benchmark/run.ts
@@ -3,9 +3,10 @@ import path from 'node:path';
 import { getArguments } from './args.js';
 import { cyan, printBenchmarkResults, red } from './output.js';
 import { prepareBenchmarkProjects } from './projects.js';
-import { collectSamples, sampleModule } from './sampling.js';
+import { collectSamples } from './sampling.js';
 import { computeStats } from './statistics.js';
 import type { BenchmarkProject, BenchmarkResult } from './types.js';
+import { getBenchmarkName } from './workers.js';
 
 export function runBenchmarks(): void {
   // Get the revisions and make things happen!
@@ -28,8 +29,7 @@ function runBenchmark(
     const modulePath = path.join(projectPath, benchmark);
 
     if (i === 0) {
-      const { name } = sampleModule(modulePath);
-      console.log('\u23F1   ' + name);
+      console.log('\u23F1   ' + getBenchmarkName(modulePath));
     }
 
     try {

--- a/resources/benchmark/sampling.ts
+++ b/resources/benchmark/sampling.ts
@@ -5,8 +5,6 @@ import { yellow } from './output.js';
 import type { BenchmarkSample } from './types.js';
 import { sampleModule } from './workers.js';
 
-export { sampleModule };
-
 export function collectSamples(modulePath: string): Array<BenchmarkSample> {
   let numOfConsequentlyRejectedSamples = 0;
   const samples: Array<BenchmarkSample> = [];

--- a/resources/benchmark/types.ts
+++ b/resources/benchmark/types.ts
@@ -4,7 +4,6 @@ export interface BenchmarkProject {
 }
 
 export interface BenchmarkSample {
-  name: string;
   clocked: number;
   memUsed: number;
   involuntaryContextSwitches: number;

--- a/resources/benchmark/worker-name.js
+++ b/resources/benchmark/worker-name.js
@@ -1,0 +1,11 @@
+import {
+  loadBenchmark,
+  readModulePath,
+  runWorker,
+  writeResult,
+} from './worker-utils.js';
+
+runWorker(async () => {
+  const benchmark = await loadBenchmark(readModulePath());
+  writeResult(benchmark.name);
+});

--- a/resources/benchmark/worker-timing.js
+++ b/resources/benchmark/worker-timing.js
@@ -21,7 +21,6 @@ runWorker(async () => {
   const resourcesEnd = process.resourceUsage();
 
   writeResult({
-    name: benchmark.name,
     clocked: timeDiff / benchmark.count,
     memUsed: (process.memoryUsage().heapUsed - memBaseline) / benchmark.count,
     involuntaryContextSwitches:

--- a/resources/benchmark/workers.ts
+++ b/resources/benchmark/workers.ts
@@ -6,6 +6,13 @@ import { localRepoPath } from '../utils.js';
 import { nodeFlags } from './config.js';
 import type { BenchmarkSample } from './types.js';
 
+export function getBenchmarkName(modulePath: string): string {
+  return runWorkerFile(
+    localRepoPath('resources/benchmark/worker-name.js'),
+    modulePath,
+  ) as string;
+}
+
 export function sampleModule(modulePath: string): BenchmarkSample {
   return runWorkerFile(
     localRepoPath('resources/benchmark/worker-timing.js'),


### PR DESCRIPTION
previously, we ran a sampling benchmark just to retrieve the name