### PR TITLE
fix incremental label null validation

### DIFF
--- a/src/execution/incremental/__tests__/defer-test.ts
+++ b/src/execution/incremental/__tests__/defer-test.ts
@@ -260,6 +260,76 @@ describe('Execute: defer directive', () => {
       },
     ]);
   });
+  it('Returns label from defer directive', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer(label: "defer-label")
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        pending: [{ id: '0', path: ['hero'], label: 'defer-label' }],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: {
+              name: 'Luke',
+            },
+            id: '0',
+          },
+        ],
+        completed: [{ id: '0' }],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Treats null defer label the same as no label', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer(label: null)
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { id: '1' } },
+        pending: [{ id: '0', path: ['hero'] }],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { name: 'Luke' },
+            id: '0',
+          },
+        ],
+        completed: [{ id: '0' }],
+        hasNext: false,
+      },
+    ]);
+  });
   it('Can disable defer using if argument', async () => {
     const document = parse(`
       query HeroNameQuery {

--- a/src/execution/incremental/__tests__/stream-test.ts
+++ b/src/execution/incremental/__tests__/stream-test.ts
@@ -326,6 +326,33 @@ describe('Execute: stream directive', () => {
       },
     ]);
   });
+  it('Treats null stream label the same as no label', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 1, label: null) }',
+    );
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarList: ['apple'],
+        },
+        pending: [{ id: '0', path: ['scalarList'] }],
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: ['banana', 'coconut'],
+            id: '0',
+          },
+        ],
+        completed: [{ id: '0' }],
+        hasNext: false,
+      },
+    ]);
+  });
   it('Can disable @stream using if argument', async () => {
     const document = parse(
       '{ scalarList @stream(initialCount: 0, if: false) }',

--- a/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
@@ -259,6 +259,73 @@ describe('Execute: defer directive (legacy)', () => {
       },
     ]);
   });
+  it('Returns label from defer directive', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer(label: "defer-label")
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          hero: {
+            id: '1',
+          },
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: {
+              name: 'Luke',
+            },
+            path: ['hero'],
+            label: 'defer-label',
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
+  it('Treats null defer label the same as no label', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer(label: null)
+        }
+      }
+      fragment NameFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: { id: '1' } },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            data: { name: 'Luke' },
+            path: ['hero'],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
   it('Can disable defer using if argument', async () => {
     const document = parse(`
       query HeroNameQuery {

--- a/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-stream-test.ts
@@ -284,6 +284,31 @@ describe('Execute: stream directive (legacy)', () => {
       },
     ]);
   });
+  it('Treats null stream label the same as no label', async () => {
+    const document = parse(
+      '{ scalarList @stream(initialCount: 1, label: null) }',
+    );
+    const result = await complete(document, {
+      scalarList: () => ['apple', 'banana', 'coconut'],
+    });
+    expectJSON(result).toDeepEqual([
+      {
+        data: {
+          scalarList: ['apple'],
+        },
+        hasNext: true,
+      },
+      {
+        incremental: [
+          {
+            items: ['banana', 'coconut'],
+            path: ['scalarList', 1],
+          },
+        ],
+        hasNext: false,
+      },
+    ]);
+  });
   it('Can disable @stream using if argument', async () => {
     const document = parse(
       '{ scalarList @stream(initialCount: 0, if: false) }',

--- a/src/validation/__tests__/DeferStreamDirectiveLabelRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveLabelRule-test.ts
@@ -52,14 +52,10 @@ describe('Validate: Defer/Stream directive labels', () => {
       {
         dog {
           ...dogFragmentA @defer(label: null)
-          ...dogFragmentB @defer(label: null)
         }
       }
       fragment dogFragmentA on Dog {
         name
-      }
-      fragment dogFragmentB on Dog {
-        nickname
       }
     `);
   });
@@ -145,15 +141,9 @@ describe('Validate: Defer/Stream directive labels', () => {
   it('Stream with null label', () => {
     expectValid(`
       {
-        dog {
-          ...dogFragment @defer
-        }
-        pets @stream(initialCount: 0) @stream(label: null) {
+        pets @stream(label: null) {
           name
         }
-      }
-      fragment dogFragment on Dog {
-        name
       }
     `);
   });

--- a/src/validation/__tests__/DeferStreamDirectiveLabelRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveLabelRule-test.ts
@@ -147,7 +147,6 @@ describe('Validate: Defer/Stream directive labels', () => {
       }
     `);
   });
-
   it('Stream with variable label', () => {
     expectErrors(`
       query ($label: String!) {

--- a/src/validation/__tests__/DeferStreamDirectiveLabelRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveLabelRule-test.ts
@@ -47,6 +47,23 @@ describe('Validate: Defer/Stream directive labels', () => {
     `);
   });
 
+  it('Defer fragment with null label', () => {
+    expectValid(`
+      {
+        dog {
+          ...dogFragmentA @defer(label: null)
+          ...dogFragmentB @defer(label: null)
+        }
+      }
+      fragment dogFragmentA on Dog {
+        name
+      }
+      fragment dogFragmentB on Dog {
+        nickname
+      }
+    `);
+  });
+
   it('Defer fragment with variable label', () => {
     expectErrors(`
     query($label: String) {
@@ -125,6 +142,22 @@ describe('Validate: Defer/Stream directive labels', () => {
       }
     `);
   });
+  it('Stream with null label', () => {
+    expectValid(`
+      {
+        dog {
+          ...dogFragment @defer
+        }
+        pets @stream(initialCount: 0) @stream(label: null) {
+          name
+        }
+      }
+      fragment dogFragment on Dog {
+        name
+      }
+    `);
+  });
+
   it('Stream with variable label', () => {
     expectErrors(`
       query ($label: String!) {

--- a/src/validation/rules/DeferStreamDirectiveLabelRule.ts
+++ b/src/validation/rules/DeferStreamDirectiveLabelRule.ts
@@ -30,7 +30,7 @@ export function DeferStreamDirectiveLabelRule(
           (arg) => arg.name.value === 'label',
         );
         const labelValue = labelArgument?.value;
-        if (!labelValue) {
+        if (!labelValue || labelValue.kind === Kind.NULL) {
           return;
         }
         if (labelValue.kind !== Kind.STRING) {


### PR DESCRIPTION
DeferStreamDirectiveLabelRule rejects directives whose label argument is a `null` literal, resulting in unexpected validation errors.

Example:
```graphql
# query
{ ... @defer(label:null) { __typename } }

# response
{
  "errors": [
    {
      "message": "Argument \"@defer(label:)\" must be a static string.",
      "locations": [
        {
          "line": 1,
          "column": 7
        }
      ]
    }
  ]
}
```
More failures can be found at [graphql-conformance](https://jbellenger.github.io/graphql-conformance/#/runs/79d8d08e-da02-4013-9dc2-8be1e9804b5f/impl/graphql-js-17)

These values are allowed by the spec, which defines these arguments as a nullable String. 

This PR updates the validator to exit early when it encounters a null literal.
