### PR TITLE
polish: add expectToThrow test helper

### DIFF
--- a/src/__testUtils__/__tests__/expectToThrow-test.ts
+++ b/src/__testUtils__/__tests__/expectToThrow-test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { expectToThrow } from '../expectToThrow.js';
+
+describe('expectToThrow', () => {
+  it('returns the thrown error', () => {
+    const error = new Error('oops');
+    expect(
+      expectToThrow(() => {
+        throw error;
+      }),
+    ).to.equal(error);
+  });
+
+  it('returns the same thrown error instance', () => {
+    const error = new Error('oops');
+    expect(
+      expectToThrow(() => {
+        throw error;
+      }),
+    ).to.equal(error);
+  });
+
+  it('throws if callback does not throw', () => {
+    expect(() => expectToThrow(() => 123)).to.throw(
+      'Expected function to throw, but it completed successfully.',
+    );
+  });
+});

--- a/src/__testUtils__/expectToThrow.ts
+++ b/src/__testUtils__/expectToThrow.ts
@@ -1,0 +1,11 @@
+import { assert } from 'chai';
+
+export function expectToThrow(fn: () => unknown): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+
+  assert.fail('Expected function to throw, but it completed successfully.');
+}

--- a/src/language/__tests__/lexer-test.ts
+++ b/src/language/__tests__/lexer-test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent.js';
 import { expectToThrowJSON } from '../../__testUtils__/expectJSON.js';
+import { expectToThrow } from '../../__testUtils__/expectToThrow.js';
 
 import { inspect } from '../../jsutils/inspect.js';
 
@@ -173,12 +174,9 @@ describe('Lexer', () => {
   });
 
   it('errors respect whitespace', () => {
-    let caughtError;
-    try {
-      lexOne(['', '', ' ~', ''].join('\n'));
-    } catch (error) {
-      caughtError = error;
-    }
+    const caughtError = expectToThrow(() =>
+      lexOne(['', '', ' ~', ''].join('\n')),
+    );
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Unexpected character: "~".
 
@@ -191,14 +189,11 @@ describe('Lexer', () => {
   });
 
   it('updates line numbers in error for file context', () => {
-    let caughtError;
-    try {
+    const caughtError = expectToThrow(() => {
       const str = ['', '', '     ~', ''].join('\n');
       const source = new Source(str, 'foo.js', { line: 11, column: 12 });
       new Lexer(source).advance();
-    } catch (error) {
-      caughtError = error;
-    }
+    });
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Unexpected character: "~".
 
@@ -211,13 +206,10 @@ describe('Lexer', () => {
   });
 
   it('updates column numbers in error for file context', () => {
-    let caughtError;
-    try {
+    const caughtError = expectToThrow(() => {
       const source = new Source('~', 'foo.js', { line: 1, column: 5 });
       new Lexer(source).advance();
-    } catch (error) {
-      caughtError = error;
-    }
+    });
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Unexpected character: "~".
 

--- a/src/language/__tests__/parser-test.ts
+++ b/src/language/__tests__/parser-test.ts
@@ -6,6 +6,7 @@ import {
   expectJSON,
   expectToThrowJSON,
 } from '../../__testUtils__/expectJSON.js';
+import { expectToThrow } from '../../__testUtils__/expectToThrow.js';
 import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery.js';
 
 import { inspect } from '../../jsutils/inspect.js';
@@ -27,12 +28,7 @@ function expectSyntaxError(text: string) {
 
 describe('Parser', () => {
   it('parse provides useful errors', () => {
-    let caughtError;
-    try {
-      parse('{');
-    } catch (error) {
-      caughtError = error;
-    }
+    const caughtError = expectToThrow(() => parse('{'));
 
     expect(caughtError).to.deep.contain({
       message: 'Syntax Error: Expected Name, found <EOF>.',
@@ -78,12 +74,9 @@ describe('Parser', () => {
   });
 
   it('parse provides useful error when using source', () => {
-    let caughtError;
-    try {
-      parse(new Source('query', 'MyQuery.graphql'));
-    } catch (error) {
-      caughtError = error;
-    }
+    const caughtError = expectToThrow(() =>
+      parse(new Source('query', 'MyQuery.graphql')),
+    );
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Expected "{", found <EOF>.
 

--- a/src/utilities/__tests__/stripIgnoredCharacters-test.ts
+++ b/src/utilities/__tests__/stripIgnoredCharacters-test.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import { describe, it } from 'mocha';
 
 import { dedent } from '../../__testUtils__/dedent.js';
+import { expectToThrow } from '../../__testUtils__/expectToThrow.js';
 import { kitchenSinkQuery } from '../../__testUtils__/kitchenSinkQuery.js';
 import { kitchenSinkSDL } from '../../__testUtils__/kitchenSinkSDL.js';
 
@@ -78,13 +79,9 @@ describe('stripIgnoredCharacters', () => {
   });
 
   it('report document with invalid token', () => {
-    let caughtError;
-
-    try {
-      stripIgnoredCharacters('{ foo(arg: "\n"');
-    } catch (e) {
-      caughtError = e;
-    }
+    const caughtError = expectToThrow(() =>
+      stripIgnoredCharacters('{ foo(arg: "\n"'),
+    );
 
     expect(String(caughtError)).to.equal(dedent`
       Syntax Error: Unterminated string.


### PR DESCRIPTION
extracted from #4670 (where this was originally called `catchThrownError`)