### PR TITLE
feat: add ValidatedSubscriptionArgs and validateSubscriptionArgs

### DIFF
--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -21,6 +21,7 @@ import type {
   FieldNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
+  SubscriptionOperationDefinitionNode,
 } from '../language/ast.js';
 import { OperationTypeNode } from '../language/ast.js';
 
@@ -113,13 +114,17 @@ export interface ValidatedExecutionArgs {
   typeResolver: GraphQLTypeResolver<any, any>;
   subscribeFieldResolver: GraphQLFieldResolver<any, any>;
   perEventExecutor: (
-    validatedExecutionArgs: ValidatedExecutionArgs,
+    validatedExecutionArgs: ValidatedSubscriptionArgs,
   ) => PromiseOrValue<ExecutionResult>;
   hideSuggestions: boolean;
   errorPropagation: boolean;
   externalAbortSignal: AbortSignal | undefined;
   enableEarlyExecution: boolean;
   hooks: ExecutionHooks | undefined;
+}
+
+export interface ValidatedSubscriptionArgs extends ValidatedExecutionArgs {
+  operation: SubscriptionOperationDefinitionNode;
 }
 
 /**

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -26,7 +26,7 @@ import {
   createSourceEventStream,
   executeSubscriptionEvent,
   subscribe,
-  validateExecutionArgs,
+  validateSubscriptionArgs,
 } from '../execute.js';
 import type { ExecutionResult } from '../Executor.js';
 
@@ -188,7 +188,7 @@ function subscribeWithBadFn(
 function subscribeWithBadArgs(
   args: ExecutionArgs,
 ): PromiseOrValue<ExecutionResult | AsyncIterable<unknown>> {
-  const validatedExecutionArgs = validateExecutionArgs(args);
+  const validatedExecutionArgs = validateSubscriptionArgs(args);
   const sourceEventStreamResult =
     'schema' in validatedExecutionArgs
       ? createSourceEventStream(validatedExecutionArgs)
@@ -220,8 +220,34 @@ describe('Subscription Initialization Phase', () => {
         document: parse('subscription { foo }'),
       } as never),
     ).to.throw(
-      'Passing ExecutionArgs to createSourceEventStream() was removed in graphql-js@17.0.0; call validateExecutionArgs() first and pass the result instead, or use subscribe() for the full subscription pipeline.',
+      'Passing ExecutionArgs to createSourceEventStream() was removed in graphql-js@17.0.0; call validateSubscriptionArgs() first and pass the result instead, or use subscribe() for the full subscription pipeline.',
     );
+  });
+
+  it('throws when validateSubscriptionArgs is called with a non-subscription operation', () => {
+    const schema = new GraphQLSchema({
+      query: DummyQueryType,
+    });
+
+    expect(() =>
+      validateSubscriptionArgs({
+        schema,
+        document: parse('{ dummy }'),
+      }),
+    ).to.throw('Expected subscription operation.');
+  });
+
+  it('throws when subscribe is called with a non-subscription operation', () => {
+    const schema = new GraphQLSchema({
+      query: DummyQueryType,
+    });
+
+    expect(() =>
+      subscribe({
+        schema,
+        document: parse('{ dummy }'),
+      }),
+    ).to.throw('Expected subscription operation.');
   });
 
   it('accepts multiple subscription fields defined in schema', async () => {

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -19,6 +19,7 @@ import type {
   OperationDefinitionNode,
 } from '../language/ast.js';
 import { Kind } from '../language/kinds.js';
+import { isSubscriptionOperationDefinitionNode } from '../language/predicates.js';
 
 import { GraphQLDisableErrorPropagationDirective } from '../type/directives.js';
 import type {
@@ -36,7 +37,11 @@ import { cancellablePromise } from './cancellablePromise.js';
 import type { FieldDetailsList, FragmentDetails } from './collectFields.js';
 import { collectFields } from './collectFields.js';
 import { createSharedExecutionContext } from './createSharedExecutionContext.js';
-import type { ExecutionResult, ValidatedExecutionArgs } from './Executor.js';
+import type {
+  ExecutionResult,
+  ValidatedExecutionArgs,
+  ValidatedSubscriptionArgs,
+} from './Executor.js';
 import { Executor } from './Executor.js';
 import { ExecutorThrowingOnIncremental } from './ExecutorThrowingOnIncremental.js';
 import { getVariableSignature } from './getVariableSignature.js';
@@ -182,7 +187,7 @@ export function executeSync(args: ExecutionArgs): ExecutionResult {
 }
 
 export function executeSubscriptionEvent(
-  validatedExecutionArgs: ValidatedExecutionArgs,
+  validatedExecutionArgs: ValidatedSubscriptionArgs,
 ): PromiseOrValue<ExecutionResult> {
   return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
 }
@@ -220,7 +225,7 @@ export function subscribe(
 > {
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
-  const validatedExecutionArgs = validateExecutionArgs(args);
+  const validatedExecutionArgs = validateSubscriptionArgs(args);
 
   // Return early errors if execution context failed.
   if (!('schema' in validatedExecutionArgs)) {
@@ -268,11 +273,11 @@ export function subscribe(
  * "Supporting Subscriptions at Scale" information in the GraphQL specification.
  */
 export function createSourceEventStream(
-  validatedExecutionArgs: ValidatedExecutionArgs,
+  validatedExecutionArgs: ValidatedSubscriptionArgs,
 ): PromiseOrValue<AsyncIterable<unknown> | ExecutionResult> {
   if (!('operation' in validatedExecutionArgs)) {
     throw new GraphQLError(
-      'Passing ExecutionArgs to createSourceEventStream() was removed in graphql-js@17.0.0; call validateExecutionArgs() first and pass the result instead, or use subscribe() for the full subscription pipeline.',
+      'Passing ExecutionArgs to createSourceEventStream() was removed in graphql-js@17.0.0; call validateSubscriptionArgs() first and pass the result instead, or use subscribe() for the full subscription pipeline.',
     );
   }
 
@@ -302,7 +307,7 @@ export interface ExecutionArgs {
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   perEventExecutor?: Maybe<
     (
-      validatedExecutionArgs: ValidatedExecutionArgs,
+      validatedExecutionArgs: ValidatedSubscriptionArgs,
     ) => PromiseOrValue<ExecutionResult>
   >;
   hideSuggestions?: Maybe<boolean>;
@@ -435,6 +440,27 @@ export function validateExecutionArgs(
   };
 }
 
+export function validateSubscriptionArgs(
+  args: ExecutionArgs,
+): ReadonlyArray<GraphQLError> | ValidatedSubscriptionArgs {
+  const validatedExecutionArgs = validateExecutionArgs(args);
+  if (!('schema' in validatedExecutionArgs)) {
+    return validatedExecutionArgs;
+  }
+  assertSubscriptionExecutionArgs(validatedExecutionArgs);
+  return validatedExecutionArgs;
+}
+
+function assertSubscriptionExecutionArgs(
+  validatedExecutionArgs: ValidatedExecutionArgs,
+): asserts validatedExecutionArgs is ValidatedSubscriptionArgs {
+  if (
+    !isSubscriptionOperationDefinitionNode(validatedExecutionArgs.operation)
+  ) {
+    throw new GraphQLError('Expected subscription operation.');
+  }
+}
+
 /**
  * If a resolveType function is not given, then a default resolve behavior is
  * used which attempts two strategies:
@@ -513,7 +539,7 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
   };
 
 function mapSourceToResponse(
-  validatedExecutionArgs: ValidatedExecutionArgs,
+  validatedExecutionArgs: ValidatedSubscriptionArgs,
   resultOrStream: ExecutionResult | AsyncIterable<unknown>,
 ): AsyncGenerator<ExecutionResult, void, void> | ExecutionResult {
   if (!isAsyncIterable(resultOrStream)) {
@@ -525,7 +551,7 @@ function mapSourceToResponse(
   // This implements the "MapSourceToResponseEvent" algorithm described in
   // the GraphQL specification..
   function mapFn(payload: unknown): PromiseOrValue<ExecutionResult> {
-    const perEventExecutionArgs: ValidatedExecutionArgs = {
+    const perEventExecutionArgs: ValidatedSubscriptionArgs = {
       ...validatedExecutionArgs,
       rootValue: payload,
     };

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -12,6 +12,7 @@ export {
   defaultTypeResolver,
   subscribe,
   validateExecutionArgs,
+  validateSubscriptionArgs,
 } from './execute.js';
 export type { ExecutionArgs } from './execute.js';
 
@@ -19,6 +20,7 @@ export type { AsyncWorkFinishedInfo, ExecutionHooks } from './hooks.js';
 
 export type {
   ValidatedExecutionArgs,
+  ValidatedSubscriptionArgs,
   ExecutionResult,
   FormattedExecutionResult,
 } from './Executor.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -274,6 +274,7 @@ export {
   isTypeSystemExtensionNode,
   isTypeExtensionNode,
   isSchemaCoordinateNode,
+  isSubscriptionOperationDefinitionNode,
 } from './language/index.js';
 
 export type {
@@ -292,6 +293,7 @@ export type {
   DefinitionNode,
   ExecutableDefinitionNode,
   OperationDefinitionNode,
+  SubscriptionOperationDefinitionNode,
   VariableDefinitionNode,
   VariableNode,
   SelectionSetNode,
@@ -372,6 +374,7 @@ export {
   subscribe,
   createSourceEventStream,
   validateExecutionArgs,
+  validateSubscriptionArgs,
 } from './execution/index.js';
 
 export type {
@@ -379,6 +382,7 @@ export type {
   AsyncWorkFinishedInfo,
   ExecutionHooks,
   ValidatedExecutionArgs,
+  ValidatedSubscriptionArgs,
   ExecutionResult,
   ExperimentalIncrementalExecutionResults,
   InitialIncrementalExecutionResult,

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -356,6 +356,16 @@ export interface OperationDefinitionNode {
   readonly selectionSet: SelectionSetNode;
 }
 
+/**
+ * A narrowed OperationDefinitionNode for subscription operations.
+ * Subscription operations go through a distinct execution pipeline
+ * (source event stream + per-event execution), so narrowing the operation
+ * type allows functions in that pipeline to accept only valid input.
+ */
+export interface SubscriptionOperationDefinitionNode extends OperationDefinitionNode {
+  readonly operation: (typeof OperationTypeNode)['SUBSCRIPTION'];
+}
+
 export const OperationTypeNode = {
   QUERY: 'query' as const,
   MUTATION: 'mutation' as const,

--- a/src/language/index.ts
+++ b/src/language/index.ts
@@ -44,6 +44,7 @@ export type {
   DefinitionNode,
   ExecutableDefinitionNode,
   OperationDefinitionNode,
+  SubscriptionOperationDefinitionNode,
   VariableDefinitionNode,
   VariableNode,
   SelectionSetNode,
@@ -118,6 +119,7 @@ export {
   isTypeSystemExtensionNode,
   isTypeExtensionNode,
   isSchemaCoordinateNode,
+  isSubscriptionOperationDefinitionNode,
 } from './predicates.js';
 
 export { DirectiveLocation } from './directiveLocation.js';

--- a/src/language/predicates.ts
+++ b/src/language/predicates.ts
@@ -3,8 +3,10 @@ import type {
   ConstValueNode,
   DefinitionNode,
   ExecutableDefinitionNode,
+  OperationDefinitionNode,
   SchemaCoordinateNode,
   SelectionNode,
+  SubscriptionOperationDefinitionNode,
   TypeDefinitionNode,
   TypeExtensionNode,
   TypeNode,
@@ -12,6 +14,7 @@ import type {
   TypeSystemExtensionNode,
   ValueNode,
 } from './ast.js';
+import { OperationTypeNode } from './ast.js';
 import { Kind } from './kinds.js';
 
 export function isDefinitionNode(node: ASTNode): node is DefinitionNode {
@@ -29,6 +32,18 @@ export function isExecutableDefinitionNode(
     node.kind === Kind.OPERATION_DEFINITION ||
     node.kind === Kind.FRAGMENT_DEFINITION
   );
+}
+
+/**
+ * A type predicate for SubscriptionOperationDefinitionNode.
+ * Useful anywhere that must distinguish subscription operations from
+ * queries and mutations, such as the subscription execution pipeline
+ * which routes events through a different code path.
+ */
+export function isSubscriptionOperationDefinitionNode(
+  node: OperationDefinitionNode,
+): node is SubscriptionOperationDefinitionNode {
+  return node.operation === OperationTypeNode.SUBSCRIPTION;
 }
 
 export function isSelectionNode(node: ASTNode): node is SelectionNode {


### PR DESCRIPTION
also adds `SubscriptionOperationDefinitionNode` and `isSubscriptionOperationDefinitionNode` for support.