### PR TITLE
rename executeQueryOrMutationOrSubscriptionEvent to executeRootSelectionSet

### DIFF
--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -272,7 +272,7 @@ export class Executor<
     this.promiseAll = promiseAll;
   }
 
-  executeQueryOrMutationOrSubscriptionEvent(): PromiseOrValue<
+  executeRootSelectionSet(): PromiseOrValue<
     ExecutionResult | TAlternativeInitialResponse
   > {
     const externalAbortSignal = this.validatedExecutionArgs.externalAbortSignal;

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -82,7 +82,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
     return { errors: validatedExecutionArgs };
   }
 
-  return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
+  return executeRootSelectionSet(validatedExecutionArgs);
 }
 
 /**
@@ -109,9 +109,7 @@ export function experimentalExecuteIncrementally(
     return { errors: validatedExecutionArgs };
   }
 
-  return experimentalExecuteQueryOrMutationOrSubscriptionEvent(
-    validatedExecutionArgs,
-  );
+  return experimentalExecuteRootSelectionSet(validatedExecutionArgs);
 }
 
 export function executeIgnoringIncremental(
@@ -126,9 +124,7 @@ export function executeIgnoringIncremental(
     return { errors: validatedExecutionArgs };
   }
 
-  return executeQueryOrMutationOrSubscriptionEventIgnoringIncremental(
-    validatedExecutionArgs,
-  );
+  return executeRootSelectionSetIgnoringIncremental(validatedExecutionArgs);
 }
 
 /**
@@ -146,28 +142,26 @@ export function executeIgnoringIncremental(
  * at which point we still log the error and null the parent field, which
  * in this case is the entire response.
  */
-export function executeQueryOrMutationOrSubscriptionEvent(
+export function executeRootSelectionSet(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<ExecutionResult> {
   return new ExecutorThrowingOnIncremental(
     validatedExecutionArgs,
-  ).executeQueryOrMutationOrSubscriptionEvent();
+  ).executeRootSelectionSet();
 }
 
-export function experimentalExecuteQueryOrMutationOrSubscriptionEvent(
+export function experimentalExecuteRootSelectionSet(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
   return new IncrementalExecutor(
     validatedExecutionArgs,
-  ).executeQueryOrMutationOrSubscriptionEvent();
+  ).executeRootSelectionSet();
 }
 
-export function executeQueryOrMutationOrSubscriptionEventIgnoringIncremental(
+export function executeRootSelectionSetIgnoringIncremental(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<ExecutionResult | ExperimentalIncrementalExecutionResults> {
-  return new Executor(
-    validatedExecutionArgs,
-  ).executeQueryOrMutationOrSubscriptionEvent();
+  return new Executor(validatedExecutionArgs).executeRootSelectionSet();
 }
 
 /**
@@ -189,7 +183,7 @@ export function executeSync(args: ExecutionArgs): ExecutionResult {
 export function executeSubscriptionEvent(
   validatedExecutionArgs: ValidatedSubscriptionArgs,
 ): PromiseOrValue<ExecutionResult> {
-  return executeQueryOrMutationOrSubscriptionEvent(validatedExecutionArgs);
+  return executeRootSelectionSet(validatedExecutionArgs);
 }
 
 /**

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -3,11 +3,11 @@ export { pathToArray as responsePathAsArray } from '../jsutils/Path.js';
 export {
   createSourceEventStream,
   execute,
-  executeQueryOrMutationOrSubscriptionEvent,
+  executeRootSelectionSet,
   executeSubscriptionEvent,
   executeSync,
   experimentalExecuteIncrementally,
-  experimentalExecuteQueryOrMutationOrSubscriptionEvent,
+  experimentalExecuteRootSelectionSet,
   defaultFieldResolver,
   defaultTypeResolver,
   subscribe,

--- a/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
+++ b/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
@@ -21,17 +21,15 @@ export function legacyExecuteIncrementally(
     return { errors: validatedExecutionArgs };
   }
 
-  return legacyExecuteQueryOrMutationOrSubscriptionEvent(
-    validatedExecutionArgs,
-  );
+  return legacyExecuteRootSelectionSet(validatedExecutionArgs);
 }
 
-export function legacyExecuteQueryOrMutationOrSubscriptionEvent(
+export function legacyExecuteRootSelectionSet(
   validatedExecutionArgs: ValidatedExecutionArgs,
 ): PromiseOrValue<
   ExecutionResult | LegacyExperimentalIncrementalExecutionResults
 > {
   return new BranchingIncrementalExecutor(
     validatedExecutionArgs,
-  ).executeQueryOrMutationOrSubscriptionEvent();
+  ).executeRootSelectionSet();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,10 +360,10 @@ export type {
 export {
   AbortedGraphQLExecutionError,
   execute,
-  executeQueryOrMutationOrSubscriptionEvent,
+  executeRootSelectionSet,
   executeSubscriptionEvent,
   experimentalExecuteIncrementally,
-  experimentalExecuteQueryOrMutationOrSubscriptionEvent,
+  experimentalExecuteRootSelectionSet,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,


### PR DESCRIPTION
this is a breaking change only from the prior alphas, export did not exist in 16.x.x