### PR TITLE
Fix issue with recursive input object definitions in SDL

### DIFF
--- a/src/utilities/__tests__/buildASTSchema-test.ts
+++ b/src/utilities/__tests__/buildASTSchema-test.ts
@@ -509,6 +509,26 @@ describe('Schema Builder', () => {
     expect(cycleSDL(sdl)).to.equal(sdl);
   });
 
+  it('builds recursive input object field defaults', () => {
+    const sdl = dedent`
+      type Query {
+        depth(person: PersonInput): Int
+      }
+
+      input PersonInput {
+        parent: PersonInput = {parent: {parent: {parent: null}}}
+      }
+    `;
+
+    const schema = buildSchema(sdl);
+    const personInput = assertInputObjectType(schema.getType('PersonInput'));
+
+    expect(personInput.getFields().parent.defaultValue).to.deep.equal({
+      parent: { parent: { parent: null } },
+    });
+    expect(printSchema(schema)).to.equal(sdl);
+  });
+
   it('Simple argument field with default', () => {
     const sdl = dedent`
       type Query {

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -271,6 +271,38 @@ describe('extendSchema', () => {
     `);
   });
 
+  it('extends inputs with recursive field defaults', () => {
+    const schema = buildSchema(`
+      type Query {
+        someInput(arg: PersonInput): String
+      }
+
+      input PersonInput {
+        parent: PersonInput
+      }
+    `);
+    const extensionSDL = dedent`
+      extend input PersonInput {
+        ancestor: PersonInput = {parent: { parent: { parent: null } } }
+      }
+    `;
+    const extendedSchema = extendSchema(schema, parse(extensionSDL));
+    const personInput = assertInputObjectType(
+      extendedSchema.getType('PersonInput'),
+    );
+
+    expect(personInput.getFields().ancestor.defaultValue).to.deep.equal({
+      parent: { parent: { parent: null } },
+    });
+    expect(validateSchema(extendedSchema)).to.deep.equal([]);
+    expectSchemaChanges(schema, extendedSchema).to.equal(dedent`
+      input PersonInput {
+        parent: PersonInput
+        ancestor: PersonInput = {parent: {parent: {parent: null}}}
+      }
+    `);
+  });
+
   it('extends scalars by adding new directives', () => {
     const schema = buildSchema(`
       type Query {

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -298,15 +298,27 @@ export function extendSchemaImpl(
     const config = type.toConfig();
     const extensions = typeExtensionsMap[config.name] ?? [];
 
+    let fields: GraphQLInputFieldConfigMap | undefined;
+
     return new GraphQLInputObjectType({
       ...config,
-      fields: () => ({
-        ...mapValue(config.fields, (field) => ({
-          ...field,
-          type: replaceType(field.type),
-        })),
-        ...buildInputFieldMap(extensions),
-      }),
+      fields: () => {
+        if (fields === undefined) {
+          fields = Object.create(null) as GraphQLInputFieldConfigMap;
+          Object.assign(
+            fields,
+            mapValue(config.fields, (field) => ({
+              ...field,
+              type: replaceType(field.type),
+            })),
+          );
+          extendInputFieldMap(fields, extensions);
+          // Default values must be applied _after_ all fields are known to
+          // prevent issues with recursion.
+          applyInputFieldDefaultValues(fields, extensions);
+        }
+        return fields;
+      },
       extensionASTNodes: config.extensionASTNodes.concat(extensions),
     });
   }
@@ -545,12 +557,12 @@ export function extendSchemaImpl(
     return argConfigMap;
   }
 
-  function buildInputFieldMap(
+  function extendInputFieldMap(
+    inputFieldMap: GraphQLInputFieldConfigMap,
     nodes: ReadonlyArray<
       InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode
     >,
-  ): GraphQLInputFieldConfigMap {
-    const inputFieldMap = Object.create(null);
+  ): void {
     for (const node of nodes) {
       // FIXME: https://github.com/graphql/graphql-js/issues/2203
       const fieldsNodes = /* c8 ignore next */ node.fields ?? [];
@@ -564,13 +576,34 @@ export function extendSchemaImpl(
         inputFieldMap[field.name.value] = {
           type,
           description: field.description?.value,
-          defaultValue: valueFromAST(field.defaultValue, type),
+          // `defaultValue` will be populated later by applyInputFieldDefaultValues
+          defaultValue: undefined,
           deprecationReason: getDeprecationReason(field),
           astNode: field,
         };
       }
     }
-    return inputFieldMap;
+  }
+
+  function applyInputFieldDefaultValues(
+    inputFieldMap: GraphQLInputFieldConfigMap,
+    nodes: ReadonlyArray<
+      InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode
+    >,
+  ): void {
+    for (const node of nodes) {
+      // FIXME: https://github.com/graphql/graphql-js/issues/2203
+      const fieldsNodes = /* c8 ignore next */ node.fields ?? [];
+
+      for (const field of fieldsNodes) {
+        const type = inputFieldMap[field.name.value].type;
+
+        inputFieldMap[field.name.value].defaultValue = valueFromAST(
+          field.defaultValue,
+          type,
+        );
+      }
+    }
   }
 
   function buildEnumValueMap(
@@ -686,10 +719,20 @@ export function extendSchemaImpl(
       case Kind.INPUT_OBJECT_TYPE_DEFINITION: {
         const allNodes = [astNode, ...extensionASTNodes];
 
+        let fields: GraphQLInputFieldConfigMap | undefined;
         return new GraphQLInputObjectType({
           name,
           description: astNode.description?.value,
-          fields: () => buildInputFieldMap(allNodes),
+          fields: () => {
+            if (fields === undefined) {
+              fields = Object.create(null) as GraphQLInputFieldConfigMap;
+              extendInputFieldMap(fields, allNodes);
+              // Default values must be applied _after_ all fields are known to
+              // prevent issues with recursion.
+              applyInputFieldDefaultValues(fields, allNodes);
+            }
+            return fields;
+          },
           astNode,
           extensionASTNodes,
           isOneOf: isOneOf(astNode),


### PR DESCRIPTION
Prior to this, the following would throw "Maximum call stack size exceeded":

```ts
import { buildSchema } from './npmDist/index.mjs';
const sdl = `
type Query {
  depth(person: PersonInput): Int
}

input PersonInput {
  parent: PersonInput = {parent: null}
}
`;

buildSchema(sdl);
```

The equivalent in native code would not:

```ts
import {
  GraphQLSchema,
  GraphQLInt,
  GraphQLObjectType,
  GraphQLInputObjectType,
  printSchema,
} from './npmDist/index.mjs';

const PersonInput = new GraphQLInputObjectType({
  name: 'PersonInput',
  fields: () => ({
    parent: {
      type: PersonInput,
      defaultValue: { parent: null },
    },
  }),
});

const schema = new GraphQLSchema({
  query: new GraphQLObjectType({
    name: 'Query',
    fields: {
      depth: {
        args: {
          person: {
            type: PersonInput,
          },
        },
        type: GraphQLInt,
      },
    },
  }),
});

console.log(printSchema(schema));
```

This means if you `printSchema` on a valid schema and try to rebuild it from SDL, the rebuild _might_ fail (it will for the above schema). The reason being somewhat related to https://rfcs.graphql.org/rfcs/793/ - in code we treat the `defaultValue` as coerced, but in SDL we do the coercion of the default value ourselves, which requires us to know the definition of the types, which requires us to know the default value, which requires us to know the types, which [...infinite recursion...]

v17 solves this properly but required a breaking change. To address the issue in v16 I've made it so that the `fields()` thunk will not allow recursion (it'll return the currently-being-resolved value instead), and I've written everything except the defaultValue to the being-resolved object first, and finally I follow up with a "apply default value" pass which then adds the default values in.

I could not come up with SDL that constructs in the current v16 (i.e. doesn't throw the max depth error) that this would cause a divergence in behavior for, so I _think_ it's safe, but I could do with another pair of eyes.

- Fixes #3871