### PR TITLE
Fix mistake in GraphQLError guidance

### DIFF
--- a/website/pages/upgrade-guides/v16-v17.mdx
+++ b/website/pages/upgrade-guides/v16-v17.mdx
@@ -79,8 +79,8 @@ behavior will be exposed as `default: { literal: <literal> }`.
 The `GraphQLError` constructor now only accepts a message and options object as arguments. Previously, it also accepted positional arguments.
 
 ```diff
-- new GraphQLError('message', 'source', 'positions', 'path', 'originalError', 'extensions');
-+ new GraphQLError('message', { source, positions, path, originalError, extensions });
+- new GraphQLError('message', nodes, source, positions, path, originalError, extensions);
++ new GraphQLError('message', { nodes, source, positions, path, originalError, extensions });
 ```
 
 ## `createSourceEventStream` arguments


### PR DESCRIPTION
The guidance currently suggests that the second argument to `GraphQLError` was `source` but it's actually `nodes`; here's the type definition for the second argument onward:

https://github.com/graphql/graphql-js/blob/8eb6383ae7447514343457abb2063c40e5dc81bc/src/error/GraphQLError.ts#L45-L54