### PR TITLE
fix(variables): treat undefined as absent with respect to variables

### DIFF
--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -451,6 +451,22 @@ describe('Execute: Handles inputs', () => {
         });
       });
 
+      it('treats explicitly undefined variable values as omitted', () => {
+        const result = executeQuery(
+          `
+          query q($input: String = "Default value") {
+            fieldWithNullableStringInput(input: $input)
+          }`,
+          { input: undefined },
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            fieldWithNullableStringInput: '"Default value"',
+          },
+        });
+      });
+
       it('uses null default value when not provided', () => {
         const result = executeQuery(
           `
@@ -1709,6 +1725,16 @@ describe('Execute: Handles inputs', () => {
       });
       assert('variableValues' in result);
       expect(result.variableValues.coerced.toString).to.equal('value');
+    });
+
+    it('treats explicit undefined values as omitted', () => {
+      const result = getVariableValues(schema, variableDefinitions, {
+        toString: undefined,
+      });
+      assert('variableValues' in result);
+      expect(Object.hasOwn(result.variableValues.coerced, 'toString')).to.equal(
+        false,
+      );
     });
   });
 });

--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -1726,13 +1726,26 @@ describe('Execute: Handles inputs', () => {
       assert('variableValues' in result);
       expect(result.variableValues.coerced.toString).to.equal('value');
     });
+  });
+
+  describe('getVariableValues: explicit undefined values', () => {
+    const doc = parse(`
+      query ($input: String) {
+        fieldWithNullableStringInput(input: $input)
+      }
+    `);
+
+    const operation = doc.definitions[0];
+    assert(operation.kind === Kind.OPERATION_DEFINITION);
+    const { variableDefinitions } = operation;
+    assert(variableDefinitions != null);
 
     it('treats explicit undefined values as omitted', () => {
       const result = getVariableValues(schema, variableDefinitions, {
-        toString: undefined,
+        input: undefined,
       });
       assert('variableValues' in result);
-      expect(Object.hasOwn(result.variableValues.coerced, 'toString')).to.equal(
+      expect(Object.hasOwn(result.variableValues.coerced, 'input')).to.equal(
         false,
       );
     });

--- a/src/execution/values.ts
+++ b/src/execution/values.ts
@@ -113,8 +113,8 @@ function coerceVariableValues(
     }
 
     const { name: varName, type: varType } = varSignature;
-    let value: unknown;
-    if (!Object.hasOwn(inputs, varName)) {
+    const value = Object.hasOwn(inputs, varName) ? inputs[varName] : undefined;
+    if (value === undefined) {
       sources[varName] = { signature: varSignature };
       if (varDefNode.defaultValue) {
         coerced[varName] = coerceInputLiteral(varDefNode.defaultValue, varType);
@@ -124,7 +124,6 @@ function coerceVariableValues(
         continue;
       }
     } else {
-      value = inputs[varName];
       sources[varName] = { signature: varSignature, value };
     }
 


### PR DESCRIPTION
This PR is part of a larger effort to standardize across the codebase our treatment of JS-specific value `undefined` as equivalent to absence of the value.

- #4709