### PR TITLE
fix: ignore undefined-valued unknown fields in input objects

### DIFF
--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -162,6 +162,12 @@ describe('coerceInputValue', () => {
       test({ foo: 123, unknownField: 123 }, TestInputObject, undefined);
     });
 
+    it('ignores unknown fields with undefined values', () => {
+      test({ foo: 123, unknownField: undefined }, TestInputObject, {
+        foo: 123,
+      });
+    });
+
     it('invalid when supplied with an array', () => {
       test([{ foo: 123 }, { bar: 456 }], TestInputObject, undefined);
     });

--- a/src/utilities/__tests__/validateInputValue-test.ts
+++ b/src/utilities/__tests__/validateInputValue-test.ts
@@ -293,6 +293,10 @@ describe('validateInputValue', () => {
       ]);
     });
 
+    it('ignores unknown fields with undefined values', () => {
+      test({ foo: 123, unknownField: undefined }, TestInputObject, []);
+    });
+
     it('returns error when supplied with an array', () => {
       test([{ foo: 123 }, { bar: 456 }], TestInputObject, [
         {
@@ -395,6 +399,10 @@ describe('validateInputValue', () => {
           path: [],
         },
       ]);
+    });
+
+    it('does not count undefined keys as provided', () => {
+      test({ foo: 123, bar: undefined }, TestInputObject, []);
     });
 
     it('returns error if the one field is null', () => {

--- a/src/utilities/__tests__/valueToLiteral-test.ts
+++ b/src/utilities/__tests__/valueToLiteral-test.ts
@@ -130,6 +130,7 @@ describe('valueToLiteral', () => {
   it('converts input objects', () => {
     test({ foo: 3, bar: '3' }, inputObj, '{ foo: 3, bar: 3 }');
     test({ foo: 3 }, inputObj, '{ foo: 3 }');
+    test({ foo: 3, unknown: undefined }, inputObj, '{ foo: 3 }');
 
     // Non-object is invalid
     test('123', inputObj, undefined);

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -72,15 +72,13 @@ export function coerceInputValue(
 
     const coercedValue: ObjMap<unknown> = Object.create(null);
     const fieldDefs = type.getFields();
-    for (const fieldName of Object.keys(inputValue)) {
-      if (
-        inputValue[fieldName] !== undefined &&
-        !Object.hasOwn(fieldDefs, fieldName)
-      ) {
-        return; // Invalid: intentionally return no value.
-      }
+    const hasUndefinedField = Object.keys(inputValue).some(
+      (name) =>
+        inputValue[name] !== undefined && !Object.hasOwn(fieldDefs, name),
+    );
+    if (hasUndefinedField) {
+      return; // Invalid: intentionally return no value.
     }
-
     for (const field of Object.values(fieldDefs)) {
       const fieldValue = inputValue[field.name];
       if (fieldValue === undefined) {

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -72,12 +72,15 @@ export function coerceInputValue(
 
     const coercedValue: ObjMap<unknown> = Object.create(null);
     const fieldDefs = type.getFields();
-    const hasUndefinedField = Object.keys(inputValue).some(
-      (name) => !Object.hasOwn(fieldDefs, name),
-    );
-    if (hasUndefinedField) {
-      return; // Invalid: intentionally return no value.
+    for (const fieldName of Object.keys(inputValue)) {
+      if (
+        inputValue[fieldName] !== undefined &&
+        !Object.hasOwn(fieldDefs, fieldName)
+      ) {
+        return; // Invalid: intentionally return no value.
+      }
     }
+
     for (const field of Object.values(fieldDefs)) {
       const fieldValue = inputValue[field.name];
       if (fieldValue === undefined) {

--- a/src/utilities/validateInputValue.ts
+++ b/src/utilities/validateInputValue.ts
@@ -144,9 +144,13 @@ function validateInputValueImpl(
       }
     }
 
-    const fields = Object.keys(inputValue);
+    const fields: Array<string> = [];
     // Ensure every provided field is defined.
-    for (const fieldName of fields) {
+    for (const fieldName of Object.keys(inputValue)) {
+      if (inputValue[fieldName] === undefined) {
+        continue;
+      }
+      fields.push(fieldName);
       if (!Object.hasOwn(fieldDefs, fieldName)) {
         const suggestion = hideSuggestions
           ? ''

--- a/src/utilities/valueToLiteral.ts
+++ b/src/utilities/valueToLiteral.ts
@@ -63,15 +63,12 @@ export function valueToLiteral(
     }
     const fields: Array<ConstObjectFieldNode> = [];
     const fieldDefs = type.getFields();
-    for (const fieldName of Object.keys(value)) {
-      if (
-        value[fieldName] !== undefined &&
-        !Object.hasOwn(fieldDefs, fieldName)
-      ) {
-        return; // Invalid: intentionally return no value.
-      }
+    const hasUndefinedField = Object.keys(value).some(
+      (name) => value[name] !== undefined && !Object.hasOwn(fieldDefs, name),
+    );
+    if (hasUndefinedField) {
+      return; // Invalid: intentionally return no value.
     }
-
     for (const field of Object.values(type.getFields())) {
       const fieldValue = value[field.name];
       if (fieldValue === undefined) {

--- a/src/utilities/valueToLiteral.ts
+++ b/src/utilities/valueToLiteral.ts
@@ -63,12 +63,15 @@ export function valueToLiteral(
     }
     const fields: Array<ConstObjectFieldNode> = [];
     const fieldDefs = type.getFields();
-    const hasUndefinedField = Object.keys(value).some(
-      (name) => !Object.hasOwn(fieldDefs, name),
-    );
-    if (hasUndefinedField) {
-      return; // Invalid: intentionally return no value.
+    for (const fieldName of Object.keys(value)) {
+      if (
+        value[fieldName] !== undefined &&
+        !Object.hasOwn(fieldDefs, fieldName)
+      ) {
+        return; // Invalid: intentionally return no value.
+      }
     }
+
     for (const field of Object.values(type.getFields())) {
       const fieldValue = value[field.name];
       if (fieldValue === undefined) {


### PR DESCRIPTION
This PR is part of a larger effort to standardize across the codebase our treatment of JS-specific value `undefined` as equivalent to absence of the value.

- #4709