### PR TITLE
fix(coerceInputLiteral): null variable input object fields should override defaults

### DIFF
--- a/src/execution/__tests__/variables-test.ts
+++ b/src/execution/__tests__/variables-test.ts
@@ -404,6 +404,38 @@ describe('Execute: Handles inputs', () => {
         });
       });
 
+      it('preserves explicit null variables within input object literals', () => {
+        const result = executeQuery(
+          `
+          query q($input: String) {
+            fieldWithObjectInput(input: { a: $input, c: "baz" })
+          }`,
+          { input: null },
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            fieldWithObjectInput: '{ a: null, c: "baz" }',
+          },
+        });
+      });
+
+      it('treats explicitly undefined variable values as omitted', () => {
+        const result = executeQuery(
+          `
+          query q($input: String = "Default value") {
+            fieldWithNullableStringInput(input: $input)
+          }`,
+          { input: undefined },
+        );
+
+        expect(result).to.deep.equal({
+          data: {
+            fieldWithNullableStringInput: '"Default value"',
+          },
+        });
+      });
+
       it('uses default value when not provided', () => {
         const result = executeQuery(`
           query ($input: TestInputObject = {a: "foo", b: ["bar"], c: "baz"}) {

--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -640,6 +640,16 @@ describe('coerceInputLiteral', () => {
       { int: 42, requiredBool: true },
     );
   });
+
+  it('preserves explicit null variables in input object fields', () => {
+    testWithVariables(
+      '($foo: Boolean)',
+      { foo: null },
+      '{ int: $foo, requiredBool: true }',
+      testInputObj,
+      { int: null, requiredBool: true },
+    );
+  });
 });
 
 describe('coerceDefaultValue', () => {

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -229,11 +229,11 @@ export function coerceInputLiteral(
       if (
         !fieldNode ||
         (fieldNode.value.kind === Kind.VARIABLE &&
-          getCoercedVariableValue(
+          isMissingVariable(
             fieldNode.value,
             variableValues,
             fragmentVariableValues,
-          ) == null)
+          ))
       ) {
         if (isRequiredInputField(field)) {
           return; // Invalid: intentionally return no value.
@@ -294,6 +294,19 @@ function getCoercedVariableValue(
   }
 
   return variableValues?.coerced[varName];
+}
+
+function isMissingVariable(
+  variableNode: VariableNode,
+  variableValues: Maybe<VariableValues>,
+  fragmentVariableValues: Maybe<FragmentVariableValues>,
+): boolean {
+  const varName = variableNode.name.value;
+  const scopedValues =
+    fragmentVariableValues?.sources[varName] !== undefined
+      ? fragmentVariableValues.coerced
+      : variableValues?.coerced;
+  return scopedValues?.[varName] === undefined;
 }
 
 interface InputValue {


### PR DESCRIPTION
PR #3092 added coerceInputLiteral() and was authored by @leebyron. That version preserved explicit null variable values in input object fields by checking whether a variable was missing, not whether its value was nullish.

PR #3809 was the rebase of that work by @yaacovCR on top of the fragment variable work. In adapting the lookup to account for fragment variables, the missing-variable check was incorrectly replaced with a nullish value check, causing explicit null variables to be treated as omitted fields.

Only missing or explicitly undefined variables should omit/default input object fields. Explicit null variable values must be preserved for nullable fields.