### PR TITLE
benchmark: add benchmark for schema validation

### DIFF
--- a/benchmark/list-async-benchmark.js
+++ b/benchmark/list-async-benchmark.js
@@ -2,7 +2,9 @@ import { execute } from 'graphql/execution/execute.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 
-const schema = buildSchema('type Query { listField: [String] }');
+const schema = buildSchema('type Query { listField: [String] }', {
+  assumeValid: true,
+});
 const document = parse('{ listField }');
 
 function listField() {

--- a/benchmark/list-asyncIterable-benchmark.js
+++ b/benchmark/list-asyncIterable-benchmark.js
@@ -2,7 +2,9 @@ import { execute } from 'graphql/execution/execute.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 
-const schema = buildSchema('type Query { listField: [String] }');
+const schema = buildSchema('type Query { listField: [String] }', {
+  assumeValid: true,
+});
 const document = parse('{ listField }');
 
 async function* listField() {

--- a/benchmark/list-sync-benchmark.js
+++ b/benchmark/list-sync-benchmark.js
@@ -2,7 +2,9 @@ import { execute } from 'graphql/execution/execute.js';
 import { parse } from 'graphql/language/parser.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 
-const schema = buildSchema('type Query { listField: [String] }');
+const schema = buildSchema('type Query { listField: [String] }', {
+  assumeValid: true,
+});
 const document = parse('{ listField }');
 
 function listField() {

--- a/benchmark/object-async-benchmark.js
+++ b/benchmark/object-async-benchmark.js
@@ -10,6 +10,7 @@ const fieldNames = Array.from(
 
 const schema = buildSchema(
   `type Query { ${fieldNames.map((fieldName) => `${fieldName}: Int`).join(' ')} }`,
+  { assumeValid: true },
 );
 
 const document = parse(`{ ${fieldNames.join(' ')} }`);

--- a/benchmark/repeated-fields-benchmark.js
+++ b/benchmark/repeated-fields-benchmark.js
@@ -1,7 +1,9 @@
 import { graphqlSync } from 'graphql/graphql.js';
 import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
 
-const schema = buildSchema('type Query { hello: String! }');
+const schema = buildSchema('type Query { hello: String! }', {
+  assumeValid: true,
+});
 const source = `{ ${'hello '.repeat(250)}}`;
 
 export const benchmark = {

--- a/benchmark/validateSchema-benchmark.js
+++ b/benchmark/validateSchema-benchmark.js
@@ -1,0 +1,18 @@
+import { validateSchema } from 'graphql/type/validate.js';
+import { buildSchema } from 'graphql/utilities/buildASTSchema.js';
+
+import { bigSchemaSDL } from './fixtures.js';
+
+const schema = buildSchema(bigSchemaSDL, {
+  assumeValidSDL: true,
+});
+
+export const benchmark = {
+  name: 'Validate Schema',
+  measure: () => {
+    // validateSchema caches results on the schema, so clear the cache to
+    // measure validation itself without also measuring schema construction.
+    schema.__validationErrors = undefined;
+    return validateSchema(schema);
+  },
+};


### PR DESCRIPTION
also explicitly removes schema validation from execution benchmarks (although this would have been cached after warmup anyway)