### PR TITLE
fix(valueFromAST): reject unknown input object fields

### DIFF
--- a/src/utilities/__tests__/valueFromAST-test.ts
+++ b/src/utilities/__tests__/valueFromAST-test.ts
@@ -224,6 +224,10 @@ describe('valueFromAST', () => {
       bool: true,
       requiredBool: false,
     });
+    expectValueFrom(
+      '{ bool: true, requiredBool: false, unknown: true }',
+      testInputObj,
+    ).to.equal(undefined);
     expectValueFrom('{ int: true, requiredBool: true }', testInputObj).to.equal(
       undefined,
     );
@@ -241,6 +245,9 @@ describe('valueFromAST', () => {
     expectValueFrom('{ a: null }', testOneOfInputObj).to.equal(undefined);
     expectValueFrom('{ a: 1 }', testOneOfInputObj).to.equal(undefined);
     expectValueFrom('{ a: "abc", b: "def" }', testOneOfInputObj).to.equal(
+      undefined,
+    );
+    expectValueFrom('{ a: "abc", c: "def" }', testOneOfInputObj).to.equal(
       undefined,
     );
     expectValueFrom('{}', testOneOfInputObj).to.equal(undefined);

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -112,10 +112,17 @@ export function valueFromAST(
       return; // Invalid: intentionally return no value.
     }
     const coercedObj = Object.create(null);
+    const fieldDefs = type.getFields();
+    const hasUnknownField = valueNode.fields.some(
+      (field) => !Object.hasOwn(fieldDefs, field.name.value),
+    );
+    if (hasUnknownField) {
+      return; // Invalid: intentionally return no value.
+    }
     const fieldNodes = new Map(
       valueNode.fields.map((field) => [field.name.value, field]),
     );
-    for (const field of Object.values(type.getFields())) {
+    for (const field of Object.values(fieldDefs)) {
       const fieldNode = fieldNodes.get(field.name);
       if (fieldNode == null || isMissingVariable(fieldNode.value, variables)) {
         if (field.defaultValue !== undefined) {


### PR DESCRIPTION
Turns out this now deprecated utility incorrectly allowed unknown fields.