### PR TITLE
fix(OneOf): fail coercion for OneOf is the single field is invalidly provided by a default

### DIFF
--- a/src/utilities/__tests__/coerceInputValue-test.ts
+++ b/src/utilities/__tests__/coerceInputValue-test.ts
@@ -190,6 +190,13 @@ describe('coerceInputValue', () => {
       },
       isOneOf: true,
     });
+    const TestInvalidOneOfInputObjectWithDefault = new GraphQLInputObjectType({
+      name: 'TestInvalidOneOfInputObjectWithDefault',
+      fields: {
+        foo: { type: GraphQLInt, default: { value: 123 } },
+      },
+      isOneOf: true,
+    });
 
     it('returns for valid input', () => {
       test({ foo: 123 }, TestInputObject, { foo: 123 });
@@ -201,6 +208,18 @@ describe('coerceInputValue', () => {
 
     it('invalid if the one field is null', () => {
       test({ bar: null }, TestInputObject, undefined);
+    });
+
+    it('invalid if an omitted field would be filled by a default', () => {
+      test({}, TestInvalidOneOfInputObjectWithDefault, undefined);
+    });
+
+    it('invalid if an undefined field would be filled by a default', () => {
+      test(
+        { foo: undefined },
+        TestInvalidOneOfInputObjectWithDefault,
+        undefined,
+      );
     });
 
     it('invalid for an invalid field', () => {

--- a/src/utilities/coerceInputValue.ts
+++ b/src/utilities/coerceInputValue.ts
@@ -73,12 +73,15 @@ export function coerceInputValue(
 
     const coercedValue: ObjMap<unknown> = Object.create(null);
     const fieldDefs = type.getFields();
-    const hasUndefinedField = Object.keys(inputValue).some(
-      (name) =>
-        inputValue[name] !== undefined && !Object.hasOwn(fieldDefs, name),
-    );
-    if (hasUndefinedField) {
-      return; // Invalid: intentionally return no value.
+    let definedFieldCount = 0;
+    for (const fieldName of Object.keys(inputValue)) {
+      if (inputValue[fieldName] === undefined) {
+        continue;
+      }
+      definedFieldCount++;
+      if (!Object.hasOwn(fieldDefs, fieldName)) {
+        return; // Invalid: intentionally return no value.
+      }
     }
     for (const field of Object.values(fieldDefs)) {
       const fieldValue = inputValue[field.name];
@@ -101,7 +104,7 @@ export function coerceInputValue(
 
     if (type.isOneOf) {
       const keys = Object.keys(coercedValue);
-      if (keys.length !== 1) {
+      if (definedFieldCount !== 1 || keys.length !== 1) {
         return; // Invalid: intentionally return no value.
       }
 


### PR DESCRIPTION
~~This PR is~~ This PR was part of a larger effort to standardize across the codebase our treatment of JS-specific value `undefined` as equivalent to absence of the value.
- #4709

But then it turns out that because #4716 only applied to `coerceInputLiteral`, `coerceInputValue` only checked the post-coercion key number, so the distinction between omitted and undefined didn't matter. But there is a case where it does matter, if we choose to -- and we should -- fail coercion if a OneOf provides no keys but has a single default. This is an invalid case, as defaults are not allowed for OneOf, because they will all be filled in, but we should still fail coercion by checking the pre-coercion number of keys, which would be 0. And once we do that, we should treat undefined the same as omitted!