### PR TITLE
chore(release): v16.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "16.13.2",
+  "version": "16.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "16.13.2",
+      "version": "16.14.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "16.13.2",
+  "version": "16.14.0",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,14 +4,14 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '16.13.2' as string;
+export const version = '16.14.0' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
  */
 export const versionInfo = Object.freeze({
   major: 16 as number,
-  minor: 13 as number,
-  patch: 2 as number,
+  minor: 14 as number,
+  patch: 0 as number,
   preReleaseTag: null as string | null,
 });


### PR DESCRIPTION
## v16.14.0 (2026-05-03)

#### New Feature 🚀
* [#4317](https://github.com/graphql/graphql-js/pull/4317) Allow configuration of the `ofType` introspection depth ([@Nols1000](https://github.com/Nols1000))
* [#4521](https://github.com/graphql/graphql-js/pull/4521) Add experimental support for directives on directive definitions ([@BoD](https://github.com/BoD))

#### Bug Fix 🐞
* [#4652](https://github.com/graphql/graphql-js/pull/4652) Fix valueFromAST variable own-property checks ([@abishekgiri](https://github.com/abishekgiri))

#### Docs 📝
* [#4706](https://github.com/graphql/graphql-js/pull/4706) Fix mistake in GraphQLError guidance ([@benjie](https://github.com/benjie))

#### Committers: 4
* Abishek Kumar Giri([@abishekgiri](https://github.com/abishekgiri))
* Benjie([@benjie](https://github.com/benjie))
* Benoit 'BoD' Lubek([@BoD](https://github.com/BoD))
* Nils-Börge Margotti([@Nols1000](https://github.com/Nols1000))