### PR TITLE
chore(release): v17.0.0-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "17.0.0-alpha.14",
+  "version": "17.0.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "17.0.0-alpha.14",
+      "version": "17.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@swc/core": "1.15.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "17.0.0-alpha.14",
+  "version": "17.0.0-beta.0",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,
@@ -76,6 +76,6 @@
     "typescript-eslint": "8.59.0"
   },
   "publishConfig": {
-    "tag": "alpha"
+    "tag": "beta"
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '17.0.0-alpha.14' as string;
+export const version = '17.0.0-beta.0' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -18,5 +18,5 @@ export const versionInfo: Readonly<{
   major: 17,
   minor: 0,
   patch: 0,
-  preReleaseTag: 'alpha.14',
+  preReleaseTag: 'beta.0',
 });


### PR DESCRIPTION
## v17.0.0-beta.0 (2026-05-07)

#### Breaking Change 💥
* [#4634](https://github.com/graphql/graphql-js/pull/4634) Use Object.create(null) over {} to avoid prototype issues ([@benjie](https://github.com/benjie))
* [#4700](https://github.com/graphql/graphql-js/pull/4700) Demote createSourceEventStream to helper taking ValidatedExecutionArgs ([@yaacovCR](https://github.com/yaacovCR))
* [#4703](https://github.com/graphql/graphql-js/pull/4703) rename executeQueryOrMutationOrSubscriptionEvent to executeRootSelectionSet ([@yaacovCR](https://github.com/yaacovCR))
* [#4708](https://github.com/graphql/graphql-js/pull/4708) fix(variables): treat undefined as absent with respect to variables ([@yaacovCR](https://github.com/yaacovCR))
* [#4710](https://github.com/graphql/graphql-js/pull/4710) fix: ignore undefined-valued unknown fields in input objects ([@yaacovCR](https://github.com/yaacovCR))

#### New Feature 🚀
* [#4658](https://github.com/graphql/graphql-js/pull/4658) feat(execution): expose asyncWorkFinished execution hook ([@yaacovCR](https://github.com/yaacovCR))
* [#4674](https://github.com/graphql/graphql-js/pull/4674) feat(execution): expose partial result on abort errors ([@yaacovCR](https://github.com/yaacovCR))
* [#4701](https://github.com/graphql/graphql-js/pull/4701) export validateExecutionArgs helper ([@yaacovCR](https://github.com/yaacovCR))
* [#4702](https://github.com/graphql/graphql-js/pull/4702) feat: add ValidatedSubscriptionArgs and validateSubscriptionArgs ([@yaacovCR](https://github.com/yaacovCR))

#### Bug Fix 🐞
* [#4637](https://github.com/graphql/graphql-js/pull/4637) refactor(queue): replace stopped promise with onStop handlers ([@yaacovCR](https://github.com/yaacovCR))
* [#4641](https://github.com/graphql/graphql-js/pull/4641) refactor(incremental): close stream iterator only on abnormal stop ([@yaacovCR](https://github.com/yaacovCR))
* [#4642](https://github.com/graphql/graphql-js/pull/4642) fix(incremental): await async incremental cleanup ([@yaacovCR](https://github.com/yaacovCR))
* [#4644](https://github.com/graphql/graphql-js/pull/4644) fix(withConcurrentAbruptClose): do not close unnecessarily ([@yaacovCR](https://github.com/yaacovCR))
* [#4645](https://github.com/graphql/graphql-js/pull/4645) fix(cancellablePromise): handle rejection when cancelling already-aborted promise ([@yaacovCR](https://github.com/yaacovCR))
* [#4643](https://github.com/graphql/graphql-js/pull/4643) fix(execute): handle list promise rejections ([@yaacovCR](https://github.com/yaacovCR))
* [#4646](https://github.com/graphql/graphql-js/pull/4646) fix(execute): handle defaultTypeResolver promise rejections ([@yaacovCR](https://github.com/yaacovCR))
* [#4648](https://github.com/graphql/graphql-js/pull/4648) refactor(executor): separate finish/abort orchestration ([@yaacovCR](https://github.com/yaacovCR))
* [#4655](https://github.com/graphql/graphql-js/pull/4655) fix(execution): finish executors before publishing responses ([@yaacovCR](https://github.com/yaacovCR))
* [#4661](https://github.com/graphql/graphql-js/pull/4661) fix: bubbling sync errors need not become async ([@yaacovCR](https://github.com/yaacovCR))
* [#4663](https://github.com/graphql/graphql-js/pull/4663) fix(executor): let aborted async paths reach finish ([@yaacovCR](https://github.com/yaacovCR))
* [#4657](https://github.com/graphql/graphql-js/pull/4657) refactor(execution): track pending work ([@yaacovCR](https://github.com/yaacovCR))
* [#4664](https://github.com/graphql/graphql-js/pull/4664) fix(perf): hoist error creation ([@yaacovCR](https://github.com/yaacovCR))
* [#4665](https://github.com/graphql/graphql-js/pull/4665) execution: reduce parent executor retention in incremental callbacks ([@yaacovCR](https://github.com/yaacovCR))
* [#4671](https://github.com/graphql/graphql-js/pull/4671) fix(valueFromAST): forward port #4652 ([@yaacovCR](https://github.com/yaacovCR))
* [#4672](https://github.com/graphql/graphql-js/pull/4672) fix(execution): convert all promise-like results to promises ([@yaacovCR](https://github.com/yaacovCR))
* [#4518](https://github.com/graphql/graphql-js/pull/4518) Fix TypeInfo.getInputType() for custom scalar list literals. ([@yuchenshi](https://github.com/yuchenshi))
* [#4692](https://github.com/graphql/graphql-js/pull/4692) fix incremental label null validation ([@jbellenger](https://github.com/jbellenger))
* [#4711](https://github.com/graphql/graphql-js/pull/4711) fix(coerceInputLiteral): null variable input object fields should override defaults ([@yaacovCR](https://github.com/yaacovCR))
* [#4712](https://github.com/graphql/graphql-js/pull/4712) fix: name fragment variables as such in execution errors ([@yaacovCR](https://github.com/yaacovCR))
* [#4714](https://github.com/graphql/graphql-js/pull/4714) fix: enhance runtime invalid default value error messages ([@yaacovCR](https://github.com/yaacovCR))
* [#4715](https://github.com/graphql/graphql-js/pull/4715) unify OneOf non-null and count error messages ([@yaacovCR](https://github.com/yaacovCR))
* [#4716](https://github.com/graphql/graphql-js/pull/4716) fix(OneOf): fail coercion when two fields are provided "pre-coercion-only" ([@yaacovCR](https://github.com/yaacovCR))
* [#4717](https://github.com/graphql/graphql-js/pull/4717) fix(valueFromAST): reject unknown input object fields ([@yaacovCR](https://github.com/yaacovCR))
* [#4718](https://github.com/graphql/graphql-js/pull/4718) fix(OneOf): count only known fields for one-of validation ([@yaacovCR](https://github.com/yaacovCR))
* [#4719](https://github.com/graphql/graphql-js/pull/4719) fix(OneOf): fail coercion for OneOf is the single field is invalidly provided by a default ([@yaacovCR](https://github.com/yaacovCR))

#### Polish 💅
<details>
<summary> 19 PRs were merged </summary>

* [#4635](https://github.com/graphql/graphql-js/pull/4635) polish: remove a few superfluous awaits ([@yaacovCR](https://github.com/yaacovCR))
* [#4636](https://github.com/graphql/graphql-js/pull/4636) allow forwarding of cancellation reasons within computations/queues ([@yaacovCR](https://github.com/yaacovCR))
* [#4638](https://github.com/graphql/graphql-js/pull/4638) test(queue): cover async onStop cleanup ([@yaacovCR](https://github.com/yaacovCR))
* [#4639](https://github.com/graphql/graphql-js/pull/4639) refactor(computation): rename cancel to abort ([@yaacovCR](https://github.com/yaacovCR))
* [#4640](https://github.com/graphql/graphql-js/pull/4640) refactor(workqueue): propagate async computation abort cleanup ([@yaacovCR](https://github.com/yaacovCR))
* [#4647](https://github.com/graphql/graphql-js/pull/4647) refactor(executor): rename finished state to aborted ([@yaacovCR](https://github.com/yaacovCR))
* [#4649](https://github.com/graphql/graphql-js/pull/4649) refactor(cancellablePromise): extract withCancellation ([@yaacovCR](https://github.com/yaacovCR))
* [#4650](https://github.com/graphql/graphql-js/pull/4650) refactor(executor): replace internal abort signal with lightweight version ([@yaacovCR](https://github.com/yaacovCR))
* [#4656](https://github.com/graphql/graphql-js/pull/4656) refactor(execution): introduce shared execution context ([@yaacovCR](https://github.com/yaacovCR))
* [#4653](https://github.com/graphql/graphql-js/pull/4653) fix: avoid prototype-colliding names in execution values ([@abishekgiri](https://github.com/abishekgiri))
* [#4673](https://github.com/graphql/graphql-js/pull/4673) refactor(execution): separate response construction from finish checks ([@yaacovCR](https://github.com/yaacovCR))
* [#4675](https://github.com/graphql/graphql-js/pull/4675) polish(execution): remove obsolete abort async checks ([@yaacovCR](https://github.com/yaacovCR))
* [#4686](https://github.com/graphql/graphql-js/pull/4686) refactor(benchmark): extract shared mean stats helper ([@yaacovCR](https://github.com/yaacovCR))
* [#4687](https://github.com/graphql/graphql-js/pull/4687) polish(benchmark): handle theoretical stats errors ([@yaacovCR](https://github.com/yaacovCR))
* [#4693](https://github.com/graphql/graphql-js/pull/4693) polish: add expectToThrow test helper ([@yaacovCR](https://github.com/yaacovCR))
* [#4694](https://github.com/graphql/graphql-js/pull/4694) polish: add expectPromise.toReject helper ([@yaacovCR](https://github.com/yaacovCR))
* [#4695](https://github.com/graphql/graphql-js/pull/4695) polish: clean up stream tests ([@yaacovCR](https://github.com/yaacovCR))
* [#4696](https://github.com/graphql/graphql-js/pull/4696) polish: introduce spy test helper ([@yaacovCR](https://github.com/yaacovCR))
* [#4704](https://github.com/graphql/graphql-js/pull/4704) refactor: add executionMode/serially argument to executeRootSelectionSet ([@yaacovCR](https://github.com/yaacovCR)) </details>

#### Internal 🏠
<details>
<summary> 17 PRs were merged </summary>

* [#4676](https://github.com/graphql/graphql-js/pull/4676) chore(deps): upgrade to ts v6 ([@yaacovCR](https://github.com/yaacovCR))
* [#4677](https://github.com/graphql/graphql-js/pull/4677) internal: refactor benchmark runner structure ([@yaacovCR](https://github.com/yaacovCR))
* [#4678](https://github.com/graphql/graphql-js/pull/4678) internal: run benchmarks through worker files ([@yaacovCR](https://github.com/yaacovCR))
* [#4679](https://github.com/graphql/graphql-js/pull/4679) internal: read benchmark names through dedicated worker ([@yaacovCR](https://github.com/yaacovCR))
* [#4680](https://github.com/graphql/graphql-js/pull/4680) internal: separate benchmark timing and memory sampling ([@yaacovCR](https://github.com/yaacovCR))
* [#4681](https://github.com/graphql/graphql-js/pull/4681) fix(benchmark): use node flags only for memory sampling ([@yaacovCR](https://github.com/yaacovCR))
* [#4682](https://github.com/graphql/graphql-js/pull/4682) internal: use mitata for benchmark timing ([@yaacovCR](https://github.com/yaacovCR))
* [#4683](https://github.com/graphql/graphql-js/pull/4683) refactor(benchmark): integrate run + sampling files ([@yaacovCR](https://github.com/yaacovCR))
* [#4684](https://github.com/graphql/graphql-js/pull/4684) benchmark: perform timing tests in rounds to reduce variance ([@yaacovCR](https://github.com/yaacovCR))
* [#4685](https://github.com/graphql/graphql-js/pull/4685) benchmark: stop timing after stable pairwise comparisons ([@yaacovCR](https://github.com/yaacovCR))
* [#4688](https://github.com/graphql/graphql-js/pull/4688) benchmark: cache revision archives ([@yaacovCR](https://github.com/yaacovCR))
* [#4689](https://github.com/graphql/graphql-js/pull/4689) benchmark: report paired benchmark comparisons ([@yaacovCR](https://github.com/yaacovCR))
* [#4690](https://github.com/graphql/graphql-js/pull/4690) benchmark: add async object field benchmark ([@yaacovCR](https://github.com/yaacovCR))
* [#4697](https://github.com/graphql/graphql-js/pull/4697) internal: add runtime option to benchmark ([@yaacovCR](https://github.com/yaacovCR))
* [#4713](https://github.com/graphql/graphql-js/pull/4713) benchmark: add benchmark for schema validation ([@yaacovCR](https://github.com/yaacovCR))
* [#4722](https://github.com/graphql/graphql-js/pull/4722) internal: npm release:prepare should set publishTag ([@yaacovCR](https://github.com/yaacovCR))
* [#4723](https://github.com/graphql/graphql-js/pull/4723) fix(changelog): ignore open associated PRs ([@yaacovCR](https://github.com/yaacovCR)) </details>

#### Committers: 5
* Abishek Kumar Giri([@abishekgiri](https://github.com/abishekgiri))
* Benjie([@benjie](https://github.com/benjie))
* James Bellenger([@jbellenger](https://github.com/jbellenger))
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))
* Yuchen Shi([@yuchenshi](https://github.com/yuchenshi))