### PR TITLE
subscribe: replace perEventExecutor with mapSourceToResponseEvent

### DIFF
--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -113,9 +113,6 @@ export interface ValidatedExecutionArgs {
   fieldResolver: GraphQLFieldResolver<any, any>;
   typeResolver: GraphQLTypeResolver<any, any>;
   subscribeFieldResolver: GraphQLFieldResolver<any, any>;
-  perEventExecutor: (
-    validatedExecutionArgs: ValidatedSubscriptionArgs,
-  ) => PromiseOrValue<ExecutionResult>;
   hideSuggestions: boolean;
   errorPropagation: boolean;
   externalAbortSignal: AbortSignal | undefined;

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -25,6 +25,7 @@ import type { ExecutionArgs } from '../execute.js';
 import {
   createSourceEventStream,
   executeSubscriptionEvent,
+  mapSourceToResponseEvent,
   subscribe,
   validateSubscriptionArgs,
 } from '../execute.js';
@@ -394,7 +395,7 @@ describe('Subscription Initialization Phase', () => {
     });
   });
 
-  it('uses a custom default perEventExecutor', async () => {
+  it('maps a source stream to response events with a custom rootSelectionSetExecutor', async () => {
     const schema = new GraphQLSchema({
       query: DummyQueryType,
       subscription: new GraphQLObjectType({
@@ -410,15 +411,26 @@ describe('Subscription Initialization Phase', () => {
     }
 
     let count = 0;
-    const subscription = subscribe({
+    const validatedExecutionArgs = validateSubscriptionArgs({
       schema,
       document: parse('subscription { foo }'),
       rootValue: { foo: fooGenerator },
-      perEventExecutor: (validatedArgs) => {
+    });
+    assert('schema' in validatedExecutionArgs);
+
+    const resultOrStream = await createSourceEventStream(
+      validatedExecutionArgs,
+    );
+    assert(isAsyncIterable(resultOrStream));
+
+    const subscription = mapSourceToResponseEvent(
+      validatedExecutionArgs,
+      resultOrStream,
+      (validatedArgs) => {
         count++;
         return executeSubscriptionEvent(validatedArgs);
       },
-    });
+    );
     assert(isAsyncIterable(subscription));
 
     expect(await subscription.next()).to.deep.equal({

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -54,6 +54,10 @@ import { getArgumentValues, getVariableValues } from './values.js';
 const UNEXPECTED_EXPERIMENTAL_DIRECTIVES =
   'The provided schema unexpectedly contains experimental directives (@defer or @stream). These directives may only be utilized if experimental execution features are explicitly enabled.';
 
+export type RootSelectionSetExecutor = (
+  validatedExecutionArgs: ValidatedSubscriptionArgs,
+) => PromiseOrValue<ExecutionResult>;
+
 /**
  * Implements the "Executing requests" section of the GraphQL specification.
  *
@@ -232,11 +236,18 @@ export function subscribe(
 
   if (isPromise(resultOrStream)) {
     return resultOrStream.then((resolvedResultOrStream) =>
-      mapSourceToResponse(validatedExecutionArgs, resolvedResultOrStream),
+      isAsyncIterable(resolvedResultOrStream)
+        ? mapSourceToResponseEvent(
+            validatedExecutionArgs,
+            resolvedResultOrStream,
+          )
+        : resolvedResultOrStream,
     );
   }
 
-  return mapSourceToResponse(validatedExecutionArgs, resultOrStream);
+  return isAsyncIterable(resultOrStream)
+    ? mapSourceToResponseEvent(validatedExecutionArgs, resultOrStream)
+    : resultOrStream;
 }
 
 /**
@@ -301,11 +312,6 @@ export interface ExecutionArgs {
   fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
   typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  perEventExecutor?: Maybe<
-    (
-      validatedExecutionArgs: ValidatedSubscriptionArgs,
-    ) => PromiseOrValue<ExecutionResult>
-  >;
   hideSuggestions?: Maybe<boolean>;
   abortSignal?: Maybe<AbortSignal>;
   enableEarlyExecution?: Maybe<boolean>;
@@ -339,7 +345,6 @@ export function validateExecutionArgs(
     fieldResolver,
     typeResolver,
     subscribeFieldResolver,
-    perEventExecutor,
     abortSignal: externalAbortSignal,
     enableEarlyExecution,
     hooks,
@@ -427,7 +432,6 @@ export function validateExecutionArgs(
     fieldResolver: fieldResolver ?? defaultFieldResolver,
     typeResolver: typeResolver ?? defaultTypeResolver,
     subscribeFieldResolver: subscribeFieldResolver ?? defaultFieldResolver,
-    perEventExecutor: perEventExecutor ?? executeSubscriptionEvent,
     hideSuggestions,
     errorPropagation,
     externalAbortSignal: externalAbortSignal ?? undefined,
@@ -534,35 +538,35 @@ export const defaultFieldResolver: GraphQLFieldResolver<unknown, unknown> =
     }
   };
 
-function mapSourceToResponse(
+/**
+ * Implements the "MapSourceToResponseEvent" algorithm described in the
+ * GraphQL specification, mapping each event from a subscription source event
+ * stream to an ExecutionResult in the response stream.
+ */
+export function mapSourceToResponseEvent(
   validatedExecutionArgs: ValidatedSubscriptionArgs,
-  resultOrStream: ExecutionResult | AsyncIterable<unknown>,
-): AsyncGenerator<ExecutionResult, void, void> | ExecutionResult {
-  if (!isAsyncIterable(resultOrStream)) {
-    return resultOrStream;
-  }
-
+  sourceEventStream: AsyncIterable<unknown>,
+  rootSelectionSetExecutor: RootSelectionSetExecutor = executeSubscriptionEvent,
+): AsyncGenerator<ExecutionResult, void, void> {
   // For each payload yielded from a subscription, map it over the normal
   // GraphQL `execute` function, with `payload` as the rootValue.
-  // This implements the "MapSourceToResponseEvent" algorithm described in
-  // the GraphQL specification..
   function mapFn(payload: unknown): PromiseOrValue<ExecutionResult> {
     const perEventExecutionArgs: ValidatedSubscriptionArgs = {
       ...validatedExecutionArgs,
       rootValue: payload,
     };
-    return validatedExecutionArgs.perEventExecutor(perEventExecutionArgs);
+    return rootSelectionSetExecutor(perEventExecutionArgs);
   }
 
   const externalAbortSignal = validatedExecutionArgs.externalAbortSignal;
   if (externalAbortSignal) {
-    const generator = mapAsyncIterable(resultOrStream, mapFn);
+    const generator = mapAsyncIterable(sourceEventStream, mapFn);
     return {
       ...generator,
       next: () => cancellablePromise(generator.next(), externalAbortSignal),
     };
   }
-  return mapAsyncIterable(resultOrStream, mapFn);
+  return mapAsyncIterable(sourceEventStream, mapFn);
 }
 
 function executeSubscription(

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -10,11 +10,12 @@ export {
   experimentalExecuteRootSelectionSet,
   defaultFieldResolver,
   defaultTypeResolver,
+  mapSourceToResponseEvent,
   subscribe,
   validateExecutionArgs,
   validateSubscriptionArgs,
 } from './execute.js';
-export type { ExecutionArgs } from './execute.js';
+export type { ExecutionArgs, RootSelectionSetExecutor } from './execute.js';
 
 export type { AsyncWorkFinishedInfo, ExecutionHooks } from './hooks.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,12 +374,14 @@ export {
   getDirectiveValues,
   subscribe,
   createSourceEventStream,
+  mapSourceToResponseEvent,
   validateExecutionArgs,
   validateSubscriptionArgs,
 } from './execution/index.js';
 
 export type {
   ExecutionArgs,
+  RootSelectionSetExecutor,
   AsyncWorkFinishedInfo,
   ExecutionHooks,
   ValidatedExecutionArgs,


### PR DESCRIPTION
Remove the `perEventExecutor` execution arg and expose the subscription response-stream mapping step as `mapSourceToResponseEvent`.

Subscription customization now has a full pipeline of helpers:

  `validateSubscriptionArgs`
  `createSourceEventStream`
  `mapSourceToResponseEvent`

Replacing `subscribe` with a custom executor was already theoretically possible by calling `createSourceEventStream` and writing the mapping helper yourself. By exporting the helper and removing `perEventExecutor`, there is now one supported way to customize `subscribe`: compose the subscription pipeline directly.

Having a single customization path reduces the documentation and maintenance surface.

`perEventExecutor` was only released on the v17 alpha line, so this is a breaking change from previous v17 pre-releases, but not a breaking change from v16.