### PR TITLE
refactor(execution): extract buildResolveInfo helper

### DIFF
--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -46,6 +46,7 @@ import {
 import type { GraphQLSchema } from '../type/schema.js';
 
 import { AbortedGraphQLExecutionError } from './AbortedGraphQLExecutionError.js';
+import { buildResolveInfo } from './buildResolveInfo.js';
 import { withCancellation } from './cancellablePromise.js';
 import type {
   DeferUsage,
@@ -60,7 +61,6 @@ import {
 import { collectIteratorPromises } from './collectIteratorPromises.js';
 import type { SharedExecutionContext } from './createSharedExecutionContext.js';
 import { createSharedExecutionContext } from './createSharedExecutionContext.js';
-import { buildResolveInfo } from './execute.js';
 import type { StreamUsage } from './getStreamUsage.js';
 import { getStreamUsage as _getStreamUsage } from './getStreamUsage.js';
 import type { ExecutionHooks } from './hooks.js';

--- a/src/execution/buildResolveInfo.ts
+++ b/src/execution/buildResolveInfo.ts
@@ -1,0 +1,56 @@
+import type { ObjMap } from '../jsutils/ObjMap.js';
+import type { Path } from '../jsutils/Path.js';
+
+import type {
+  FieldNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+} from '../language/ast.js';
+
+import type {
+  GraphQLField,
+  GraphQLObjectType,
+  GraphQLResolveInfo,
+  GraphQLResolveInfoHelpers,
+} from '../type/index.js';
+import type { GraphQLSchema } from '../type/schema.js';
+
+import type { VariableValues } from './values.js';
+
+export interface BuildResolveInfoExecutionArgs {
+  schema: GraphQLSchema;
+  fragmentDefinitions: ObjMap<FragmentDefinitionNode>;
+  rootValue: unknown;
+  operation: OperationDefinitionNode;
+  variableValues: VariableValues;
+}
+
+// eslint-disable-next-line max-params
+export function buildResolveInfo(
+  validatedExecutionArgs: BuildResolveInfoExecutionArgs,
+  fieldDef: GraphQLField<unknown, unknown>,
+  fieldNodes: ReadonlyArray<FieldNode>,
+  parentType: GraphQLObjectType,
+  path: Path,
+  getAbortSignal: () => AbortSignal | undefined,
+  getAsyncHelpers: () => GraphQLResolveInfoHelpers,
+): GraphQLResolveInfo {
+  const { schema, fragmentDefinitions, rootValue, operation, variableValues } =
+    validatedExecutionArgs;
+  // The resolve function's optional fourth argument is a collection of
+  // information about the current execution state.
+  return {
+    fieldName: fieldDef.name,
+    fieldNodes,
+    returnType: fieldDef.type,
+    parentType,
+    path,
+    schema,
+    fragments: fragmentDefinitions,
+    rootValue,
+    operation,
+    variableValues,
+    getAbortSignal,
+    getAsyncHelpers,
+  };
+}

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -4,7 +4,6 @@ import { isObjectLike } from '../jsutils/isObjectLike.js';
 import { isPromise, isPromiseLike } from '../jsutils/isPromise.js';
 import type { Maybe } from '../jsutils/Maybe.js';
 import type { ObjMap } from '../jsutils/ObjMap.js';
-import type { Path } from '../jsutils/Path.js';
 import { addPath, pathToArray } from '../jsutils/Path.js';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue.js';
 
@@ -23,16 +22,13 @@ import { isSubscriptionOperationDefinitionNode } from '../language/predicates.js
 
 import { GraphQLDisableErrorPropagationDirective } from '../type/directives.js';
 import type {
-  GraphQLField,
   GraphQLFieldResolver,
-  GraphQLObjectType,
-  GraphQLResolveInfo,
-  GraphQLResolveInfoHelpers,
   GraphQLTypeResolver,
 } from '../type/index.js';
 import { assertValidSchema } from '../type/index.js';
 import type { GraphQLSchema } from '../type/schema.js';
 
+import { buildResolveInfo } from './buildResolveInfo.js';
 import { cancellablePromise } from './cancellablePromise.js';
 import type { FieldDetailsList, FragmentDetails } from './collectFields.js';
 import { collectFields } from './collectFields.js';
@@ -690,40 +686,6 @@ function assertEventStream(result: unknown): AsyncIterable<unknown> {
   }
 
   return result;
-}
-
-/**
- * TODO: consider no longer exporting this function
- * @internal
- */
-// eslint-disable-next-line max-params
-export function buildResolveInfo(
-  validatedExecutionArgs: ValidatedExecutionArgs,
-  fieldDef: GraphQLField<unknown, unknown>,
-  fieldNodes: ReadonlyArray<FieldNode>,
-  parentType: GraphQLObjectType,
-  path: Path,
-  getAbortSignal: () => AbortSignal | undefined,
-  getAsyncHelpers: () => GraphQLResolveInfoHelpers,
-): GraphQLResolveInfo {
-  const { schema, fragmentDefinitions, rootValue, operation, variableValues } =
-    validatedExecutionArgs;
-  // The resolve function's optional fourth argument is a collection of
-  // information about the current execution state.
-  return {
-    fieldName: fieldDef.name,
-    fieldNodes,
-    returnType: fieldDef.type,
-    parentType,
-    path,
-    schema,
-    fragments: fragmentDefinitions,
-    rootValue,
-    operation,
-    variableValues,
-    getAbortSignal,
-    getAsyncHelpers,
-  };
 }
 
 function toNodes(fieldDetailsList: FieldDetailsList): ReadonlyArray<FieldNode> {


### PR DESCRIPTION
This is a BREAKING CHANGE for anyone using deep imports to import buildResolveInfo from execute.

Motivation: to break a cycle discovered by eslint.

extracted from #4460