### PR TITLE
chore(release): v17.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "17.0.0-beta.0",
+  "version": "17.0.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "17.0.0-beta.0",
+      "version": "17.0.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "17.0.0-beta.0",
+  "version": "17.0.0-beta.1",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '17.0.0-beta.0' as string;
+export const version = '17.0.0-beta.1' as string;
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -18,5 +18,5 @@ export const versionInfo: Readonly<{
   major: 17,
   minor: 0,
   patch: 0,
-  preReleaseTag: 'beta.0',
+  preReleaseTag: 'beta.1',
 });


### PR DESCRIPTION
## v17.0.0-beta.1 (2026-05-10)

#### Breaking Change 💥
* [#4729](https://github.com/graphql/graphql-js/pull/4729) subscribe: replace perEventExecutor with mapSourceToResponseEvent ([@yaacovCR](https://github.com/yaacovCR))
* [#4730](https://github.com/graphql/graphql-js/pull/4730) chore(engines): drop Node 20 support ([@yaacovCR](https://github.com/yaacovCR))
* [#4731](https://github.com/graphql/graphql-js/pull/4731) refactor(execution): extract buildResolveInfo helper ([@yaacovCR](https://github.com/yaacovCR))

#### New Feature 🚀
* [#4733](https://github.com/graphql/graphql-js/pull/4733) feat: support node v26 ([@yaacovCR](https://github.com/yaacovCR))

#### Bug Fix 🐞
* [#4725](https://github.com/graphql/graphql-js/pull/4725) chore: forward-port directives on directive definitions (#4521) ([@yaacovCR](https://github.com/yaacovCR))
* [#4727](https://github.com/graphql/graphql-js/pull/4727) chore: forward-port configuration of the `ofType` introspection depth (#4317) ([@yaacovCR](https://github.com/yaacovCR))

#### Polish 💅
* [#4728](https://github.com/graphql/graphql-js/pull/4728) polish: group FRAGMENT_VARIABLE_DEFINITION with executable defs ([@yaacovCR](https://github.com/yaacovCR))

#### Internal 🏠
<details>
<summary> 3 PRs were merged </summary>

* [#4460](https://github.com/graphql/graphql-js/pull/4460) internal: use node experimental-strip-types instead of ts-node ([@yaacovCR](https://github.com/yaacovCR))
* [#4732](https://github.com/graphql/graphql-js/pull/4732) internal: use node test instead of mocha + c8 ([@yaacovCR](https://github.com/yaacovCR))
* [#4734](https://github.com/graphql/graphql-js/pull/4734) internal: add comment re: rewriteRelativeImportExtensions ([@yaacovCR](https://github.com/yaacovCR)) </details>

#### Committers: 1
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))