### PR TITLE
chore(tests): add test for directive extensions without flag enabled

### DIFF
--- a/src/language/__tests__/schema-parser-test.ts
+++ b/src/language/__tests__/schema-parser-test.ts
@@ -1093,6 +1093,13 @@ input Hello {
     });
   });
 
+  it('Directive definition extensions require the experimental flag', () => {
+    expectToThrowJSON(() => parse('extend directive @foo @bar')).to.deep.equal({
+      message: 'Syntax Error: Unexpected Name "directive".',
+      locations: [{ line: 1, column: 8 }],
+    });
+  });
+
   it('Directive with incorrect locations', () => {
     expectSyntaxError(
       'directive @foo on FIELD | INCORRECT_LOCATION',


### PR DESCRIPTION
The branch in parseTypeSystemExtension where the 'directive' keyword is encountered but the parsing option was not enabled was apparently NOT covered prior to addition to this test, falsely reported by our imperfect tooling as covered.

At least it appears. This was uncovered by formatting changed of other pending work; the addition of this test should narrow the diff of any other changes.