### PR TITLE
api: export defer and stream validation rules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -411,6 +411,9 @@ export {
   specifiedRules,
   recommendedRules,
   // Individual validation rules.
+  DeferStreamDirectiveLabelRule,
+  DeferStreamDirectiveOnRootFieldRule,
+  DeferStreamDirectiveOnValidOperationsRule,
   ExecutableDefinitionsRule,
   FieldsOnCorrectTypeRule,
   FragmentsOnCompositeTypesRule,
@@ -429,6 +432,7 @@ export {
   ProvidedRequiredArgumentsRule,
   ScalarLeafsRule,
   SingleFieldSubscriptionsRule,
+  StreamDirectiveOnListFieldRule,
   UniqueArgumentNamesRule,
   UniqueDirectivesPerLocationRule,
   UniqueFragmentNamesRule,


### PR DESCRIPTION
These were already exported from validation module index, but should be exported as well from the main index.