### PR TITLE
api: export legacy incremental execution functions and helpers

### DIFF
--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -15,6 +15,10 @@ export {
   validateExecutionArgs,
   validateSubscriptionArgs,
 } from './execute.ts';
+export {
+  legacyExecuteIncrementally,
+  legacyExecuteRootSelectionSet,
+} from './legacyIncremental/legacyExecuteIncrementally.ts';
 export type { ExecutionArgs, RootSelectionSetExecutor } from './execute.ts';
 
 export type { AsyncWorkFinishedInfo, ExecutionHooks } from './hooks.ts';
@@ -40,6 +44,21 @@ export type {
   FormattedIncrementalStreamResult,
   FormattedIncrementalResult,
 } from './incremental/IncrementalExecutor.ts';
+
+export type {
+  LegacyExperimentalIncrementalExecutionResults,
+  LegacyInitialIncrementalExecutionResult,
+  LegacySubsequentIncrementalExecutionResult,
+  LegacyIncrementalDeferResult,
+  LegacyIncrementalStreamResult,
+  LegacyIncrementalResult,
+  FormattedLegacyExperimentalIncrementalExecutionResults,
+  FormattedLegacyInitialIncrementalExecutionResult,
+  FormattedLegacySubsequentIncrementalExecutionResult,
+  FormattedLegacyIncrementalDeferResult,
+  FormattedLegacyIncrementalStreamResult,
+  FormattedLegacyIncrementalResult,
+} from './legacyIncremental/BranchingIncrementalExecutor.ts';
 
 export { AbortedGraphQLExecutionError } from './AbortedGraphQLExecutionError.ts';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,6 +366,8 @@ export {
   executeSubscriptionEvent,
   experimentalExecuteIncrementally,
   experimentalExecuteRootSelectionSet,
+  legacyExecuteIncrementally,
+  legacyExecuteRootSelectionSet,
   executeSync,
   defaultFieldResolver,
   defaultTypeResolver,
@@ -401,6 +403,18 @@ export type {
   FormattedIncrementalDeferResult,
   FormattedIncrementalStreamResult,
   FormattedIncrementalResult,
+  LegacyExperimentalIncrementalExecutionResults,
+  LegacyInitialIncrementalExecutionResult,
+  LegacySubsequentIncrementalExecutionResult,
+  LegacyIncrementalDeferResult,
+  LegacyIncrementalStreamResult,
+  LegacyIncrementalResult,
+  FormattedLegacyExperimentalIncrementalExecutionResults,
+  FormattedLegacyInitialIncrementalExecutionResult,
+  FormattedLegacySubsequentIncrementalExecutionResult,
+  FormattedLegacyIncrementalDeferResult,
+  FormattedLegacyIncrementalStreamResult,
+  FormattedLegacyIncrementalResult,
 } from './execution/index.ts';
 
 // Validate GraphQL documents.


### PR DESCRIPTION
Use of the legacy function/types are discouraged, but they are available!