### PR TITLE
build: strip private discriminator from package types

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,9 @@ import { defineConfig } from 'eslint/config';
 
 import { parser as tsParser, plugin as tsPlugin } from 'typescript-eslint';
 
+const publicJsdocBlock =
+  'JsdocBlock:not(:has(JsdocTag[tag="internal"])):not(:has(JsdocTag[tag="private"]))';
+
 export default defineConfig(
   {
     ignores: [
@@ -777,51 +780,51 @@ export default defineConfig(
           contexts: [
             {
               context: 'ClassDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'PropertyDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSEnumDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSEnumMember',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSInterfaceDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSPropertySignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSTypeAliasDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'VariableDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'ClassDeclaration',
@@ -868,19 +871,19 @@ export default defineConfig(
           contexts: [
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition:not([kind="get"]):not([kind="set"])',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
           ],
         },
@@ -897,22 +900,22 @@ export default defineConfig(
           contexts: [
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
           ],
-          exemptedBy: ['internal'],
+          exemptedBy: ['internal', 'private'],
         },
       ],
       'jsdoc/require-param-description': [
@@ -921,19 +924,19 @@ export default defineConfig(
           contexts: [
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
           ],
         },
@@ -944,19 +947,19 @@ export default defineConfig(
           contexts: [
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
           ],
         },
@@ -974,22 +977,22 @@ export default defineConfig(
           contexts: [
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
           ],
-          exemptedBy: ['internal'],
+          exemptedBy: ['internal', 'private'],
         },
       ],
       'jsdoc/require-returns-check': 'off',
@@ -999,19 +1002,19 @@ export default defineConfig(
           contexts: [
             {
               context: 'FunctionDeclaration',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSDeclareFunction',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'MethodDefinition',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
             {
               context: 'TSMethodSignature',
-              comment: 'JsdocBlock:not(:has(JsdocTag[tag="internal"]))',
+              comment: publicJsdocBlock,
             },
           ],
         },

--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -9,6 +9,7 @@ import {
   changeExtensionInImportPathsInBundle,
 } from './change-extension-in-import-paths.ts';
 import { inlineInvariant } from './inline-invariant.ts';
+import { stripPrivateDeclarations } from './strip-private-declarations.ts';
 import type { PlatformConditionalExports } from './utils.ts';
 import {
   buildCJSDevModeStub,
@@ -262,7 +263,10 @@ function emitTSFiles(options: {
     undefined,
     undefined,
     {
-      afterDeclarations: [changeExtensionInImportPathsInBundle({ extension })],
+      afterDeclarations: [
+        stripPrivateDeclarations(),
+        changeExtensionInImportPathsInBundle({ extension }),
+      ],
     },
   );
 

--- a/resources/eslint-internal-rules/require-graphql-public-api-docs.js
+++ b/resources/eslint-internal-rules/require-graphql-public-api-docs.js
@@ -53,7 +53,7 @@ function requireGraphqlPublicApiDocs(context) {
 
   function checkPublicDoc(node, label, fileCategory, options = {}) {
     const comment = parsedCommentFor(node);
-    if (comment == null || comment.tags.has('internal')) {
+    if (comment == null || hasNonPublicTag(comment)) {
       return;
     }
 
@@ -77,6 +77,10 @@ function requireGraphqlPublicApiDocs(context) {
       typeParameterNames(node),
       label,
     );
+  }
+
+  function hasNonPublicTag(comment) {
+    return comment.tags.has('internal') || comment.tags.has('private');
   }
 
   function checkPublicMemberDocs(declaration, ownerName) {

--- a/resources/eslint-internal-rules/require-public-api-exports.js
+++ b/resources/eslint-internal-rules/require-public-api-exports.js
@@ -33,12 +33,16 @@ function requirePublicApiExports(context) {
 
   function hasPublicDoc(node) {
     const comment = ownJsdocComment(node);
-    return comment != null && !hasTag(comment, 'internal');
+    return comment != null && !hasNonPublicTag(comment);
   }
 
   function hasInternalDoc(node) {
     const comment = ownJsdocComment(node);
-    return comment != null && hasTag(comment, 'internal');
+    return comment != null && hasNonPublicTag(comment);
+  }
+
+  function hasNonPublicTag(comment) {
+    return hasTag(comment, 'internal') || hasTag(comment, 'private');
   }
 
   function ownJsdocComment(node) {
@@ -73,14 +77,14 @@ function requirePublicApiExports(context) {
   function reportUnexpectedInternalDoc(node, name) {
     context.report({
       node,
-      message: `Public API declaration "${name}" is exported by a public index.ts file and must not have @internal JSDoc.`,
+      message: `Public API declaration "${name}" is exported by a public index.ts file and must not have @internal or @private JSDoc.`,
     });
   }
 
   function reportMissingInternalDoc(node, name) {
     context.report({
       node,
-      message: `Internal declaration "${name}" is exported from src but is not exported by a public index.ts file and must have @internal JSDoc.`,
+      message: `Internal declaration "${name}" is exported from src but is not exported by a public index.ts file and must have @internal or @private JSDoc.`,
     });
   }
 

--- a/resources/eslint-internal-rules/require-to-string-tag.js
+++ b/resources/eslint-internal-rules/require-to-string-tag.js
@@ -18,7 +18,10 @@ function requireToStringTag(context) {
 
       const jsDoc = context.getSourceCode().getJSDocComment(classNode)?.value;
       // FIXME: use proper TSDoc parser instead of includes once we fix TSDoc comments
-      if (jsDoc?.includes('@internal') === true) {
+      if (
+        jsDoc?.includes('@internal') === true ||
+        jsDoc?.includes('@private') === true
+      ) {
         return;
       }
 

--- a/resources/strip-private-declarations.ts
+++ b/resources/strip-private-declarations.ts
@@ -1,0 +1,84 @@
+import ts from 'typescript';
+
+export function stripPrivateDeclarations(): ts.TransformerFactory<
+  ts.SourceFile | ts.Bundle
+> {
+  return (
+    context: ts.TransformationContext,
+  ): ts.Transformer<ts.SourceFile | ts.Bundle> => {
+    const transformSourceFile = (sourceFile: ts.SourceFile): ts.SourceFile => {
+      const visitNode = (
+        node: ts.Node,
+      ): ts.VisitResult<ts.Node | undefined> => {
+        if (isStripCandidate(node) && hasPrivateTag(node, sourceFile)) {
+          return undefined;
+        }
+
+        return ts.visitEachChild(node, visitNode, context);
+      };
+
+      return ts.visitEachChild(sourceFile, visitNode, context);
+    };
+
+    return (rootNode: ts.SourceFile | ts.Bundle): ts.SourceFile | ts.Bundle =>
+      ts.isBundle(rootNode)
+        ? context.factory.updateBundle(
+            rootNode,
+            rootNode.sourceFiles.map(transformSourceFile),
+          )
+        : transformSourceFile(rootNode);
+  };
+}
+
+function isStripCandidate(node: ts.Node): boolean {
+  return (
+    ts.isClassDeclaration(node) ||
+    ts.isFunctionDeclaration(node) ||
+    ts.isInterfaceDeclaration(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isMethodSignature(node) ||
+    ts.isModuleDeclaration(node) ||
+    ts.isPropertyDeclaration(node) ||
+    ts.isPropertySignature(node) ||
+    ts.isTypeAliasDeclaration(node) ||
+    ts.isVariableStatement(node)
+  );
+}
+
+function hasPrivateTag(node: ts.Node, sourceFile: ts.SourceFile): boolean {
+  if (
+    ts.getJSDocTags(node).some((tag) => tag.tagName.text === 'private') ||
+    hasSyntheticPrivateTag(node) ||
+    hasSourcePrivateTag(node, sourceFile)
+  ) {
+    return true;
+  }
+
+  return (
+    ts.isVariableStatement(node) &&
+    node.declarationList.declarations.some((declaration) =>
+      hasPrivateTag(declaration, sourceFile),
+    )
+  );
+}
+
+function hasSyntheticPrivateTag(node: ts.Node): boolean {
+  return (
+    ts
+      .getSyntheticLeadingComments(node)
+      ?.some((comment) => comment.text.includes('@private')) === true
+  );
+}
+
+function hasSourcePrivateTag(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+): boolean {
+  return (
+    ts
+      .getLeadingCommentRanges(sourceFile.text, node.pos)
+      ?.some((comment) =>
+        sourceFile.text.slice(comment.pos, comment.end).includes('@private'),
+      ) === true
+  );
+}

--- a/src/language/source.ts
+++ b/src/language/source.ts
@@ -8,6 +8,7 @@ interface Location {
   column: number;
 }
 
+/** @private */
 const sourceSymbol: unique symbol = Symbol('Source');
 
 /**
@@ -18,7 +19,10 @@ const sourceSymbol: unique symbol = Symbol('Source');
  * The `line` and `column` properties in `locationOffset` are 1-indexed.
  */
 export class Source {
-  /** Internal runtime marker used to identify Source instances. */
+  /**
+   * Internal runtime marker used to identify Source instances.
+   * @private
+   */
   readonly __kind: symbol;
 
   /** The GraphQL source text. */

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -118,6 +118,7 @@ export function assertType(type: unknown): GraphQLType {
   return type;
 }
 
+/** @private */
 const scalarSymbol: unique symbol = Symbol('Scalar');
 
 /**
@@ -175,6 +176,7 @@ export function assertScalarType(type: unknown): GraphQLScalarType {
   return type;
 }
 
+/** @private */
 const objectSymbol: unique symbol = Symbol('Object');
 
 /**
@@ -244,6 +246,7 @@ export function assertObjectType(type: unknown): GraphQLObjectType {
   return type;
 }
 
+/** @private */
 const fieldSymbol: unique symbol = Symbol('Field');
 
 /**
@@ -289,6 +292,7 @@ export function assertField(field: unknown): GraphQLField {
   return field;
 }
 
+/** @private */
 const argumentSymbol: unique symbol = Symbol('Argument');
 
 /**
@@ -334,6 +338,7 @@ export function assertArgument(arg: unknown): GraphQLArgument {
   return arg;
 }
 
+/** @private */
 const interfaceSymbol: unique symbol = Symbol('Interface');
 
 /**
@@ -405,6 +410,7 @@ export function assertInterfaceType(type: unknown): GraphQLInterfaceType {
   return type;
 }
 
+/** @private */
 const unionSymbol: unique symbol = Symbol('Union');
 
 /**
@@ -478,6 +484,7 @@ export function assertUnionType(type: unknown): GraphQLUnionType {
   return type;
 }
 
+/** @private */
 const enumSymbol: unique symbol = Symbol('Enum');
 
 /**
@@ -541,6 +548,7 @@ export function assertEnumType(type: unknown): GraphQLEnumType {
   return type;
 }
 
+/** @private */
 const enumValueSymbol: unique symbol = Symbol('EnumValue');
 
 /**
@@ -588,6 +596,7 @@ export function assertEnumValue(value: unknown): GraphQLEnumValue {
   return value;
 }
 
+/** @private */
 const inputObjectSymbol: unique symbol = Symbol('InputObject');
 
 /**
@@ -661,6 +670,7 @@ export function assertInputObjectType(type: unknown): GraphQLInputObjectType {
   return type;
 }
 
+/** @private */
 const inputFieldSymbol: unique symbol = Symbol('InputField');
 
 /**
@@ -708,6 +718,7 @@ export function assertInputField(field: unknown): GraphQLInputField {
   return field;
 }
 
+/** @private */
 const listSymbol: unique symbol = Symbol('List');
 
 /**
@@ -801,6 +812,7 @@ export function assertListType(type: unknown): GraphQLList<GraphQLType> {
   return type;
 }
 
+/** @private */
 const nonNullSymbol: unique symbol = Symbol('NonNull');
 
 /**
@@ -1318,7 +1330,10 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType {
 export class GraphQLList<
   T extends GraphQLType,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLList instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLList instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The type wrapped by this list or non-null type. */
   readonly ofType: T;
@@ -1410,7 +1425,10 @@ export class GraphQLList<
 export class GraphQLNonNull<
   T extends GraphQLNullableType,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLNonNull instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLNonNull instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The type wrapped by this list or non-null type. */
   readonly ofType: T;
@@ -1990,7 +2008,10 @@ export class GraphQLScalarType<
   TInternal = unknown,
   TExternal = TInternal,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLScalarType instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLScalarType instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The GraphQL name for this schema element. */
   name: string;
@@ -2387,7 +2408,10 @@ export class GraphQLObjectType<
   TContext = any,
   TAbstract = any,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLObjectType instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLObjectType instances.
+   * @private
+   */
   readonly __kind: typeof objectSymbol = objectSymbol;
   /** The GraphQL name for this schema element. */
   name: string;
@@ -2971,7 +2995,10 @@ export class GraphQLField<
   TContext = any,
   TArgs = any,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLField instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLField instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** Object or interface type that owns this field, if known. */
   parentType:
@@ -3141,7 +3168,10 @@ export class GraphQLField<
 
 /** A resolved GraphQL argument definition. */
 export class GraphQLArgument implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLArgument instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLArgument instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** Field or directive that owns this argument. */
   parent: GraphQLField | GraphQLDirective;
@@ -3402,7 +3432,10 @@ export class GraphQLInterfaceType<
   TSource = any,
   TContext = any,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLInterfaceType instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLInterfaceType instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The GraphQL name for this schema element. */
   name: string;
@@ -3739,7 +3772,10 @@ export class GraphQLUnionType<
   TSource = any,
   TContext = any,
 > implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLUnionType instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLUnionType instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The GraphQL name for this schema element. */
   name: string;
@@ -4028,7 +4064,10 @@ export interface GraphQLEnumTypeExtensions {
  * will be used as its internal value.
  */
 export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLEnumType instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLEnumType instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The GraphQL name for this schema element. */
   name: string;
@@ -4604,7 +4643,10 @@ export interface GraphQLEnumValueNormalizedConfig extends GraphQLEnumValueConfig
 
 /** A resolved GraphQL enum value definition. */
 export class GraphQLEnumValue implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLEnumValue instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLEnumValue instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** Enum type that owns this enum value. */
   parentEnum: GraphQLEnumType;
@@ -4771,7 +4813,10 @@ export interface GraphQLInputObjectTypeExtensions {
  * ```
  */
 export class GraphQLInputObjectType implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLInputObjectType instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLInputObjectType instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The GraphQL name for this schema element. */
   name: string;
@@ -5081,7 +5126,10 @@ export type GraphQLInputFieldNormalizedConfigMap =
 
 /** A resolved GraphQL input field definition. */
 export class GraphQLInputField implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLInputField instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLInputField instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** Input object type that owns this input field. */
   parentType: GraphQLInputObjectType;

--- a/src/type/directives.ts
+++ b/src/type/directives.ts
@@ -24,6 +24,7 @@ import type {
 import { GraphQLArgument, GraphQLNonNull } from './definition.ts';
 import { GraphQLBoolean, GraphQLInt, GraphQLString } from './scalars.ts';
 
+/** @private */
 const directiveSymbol: unique symbol = Symbol('Directive');
 
 /**
@@ -92,7 +93,10 @@ export interface GraphQLDirectiveExtensions {
  * behavior. Type system creators will usually not create these directly.
  */
 export class GraphQLDirective implements GraphQLSchemaElement {
-  /** Internal runtime marker used to identify GraphQLDirective instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLDirective instances.
+   * @private
+   */
   readonly __kind: symbol;
   /** The GraphQL name for this schema element. */
   name: string;

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -100,6 +100,7 @@ export interface GraphQLSchemaExtensions {
   [attributeName: string | symbol]: unknown;
 }
 
+/** @private */
 const schemaSymbol: unique symbol = Symbol('Schema');
 
 /**
@@ -190,7 +191,10 @@ const schemaSymbol: unique symbol = Symbol('Schema');
  * ```
  */
 export class GraphQLSchema {
-  /** Internal runtime marker used to identify GraphQLSchema instances. */
+  /**
+   * Internal runtime marker used to identify GraphQLSchema instances.
+   * @private
+   */
   readonly __kind: typeof schemaSymbol = schemaSymbol;
   /** Human-readable description for this schema element, if provided. */
   description: Maybe<string>;


### PR DESCRIPTION
GraphQL Schema Elements and `Source` objects have a `__kind` discriminator introduced in v17 that we use for predicates, but is private. This change hides the discriminator from our types.

It is a potential breaking change only from previous pre-releases, if users were directly relying on the discriminator.