### PR TITLE
fix: discriminate between GraphQLNonNull and GraphQLList

### DIFF
--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1337,6 +1337,8 @@ export class GraphQLList<
   readonly __kind: symbol;
   /** The type wrapped by this list or non-null type. */
   readonly ofType: T;
+  // eslint-disable-next-line @typescript-eslint/no-unused-private-class-members
+  declare private readonly __GraphQLListTypeBrand: never;
 
   /**
    * Creates a GraphQLList instance.
@@ -1432,6 +1434,8 @@ export class GraphQLNonNull<
   readonly __kind: symbol;
   /** The type wrapped by this list or non-null type. */
   readonly ofType: T;
+  // eslint-disable-next-line @typescript-eslint/no-unused-private-class-members
+  declare private readonly __GraphQLNonNullTypeBrand: never;
 
   /**
    * Creates a GraphQLNonNull instance.

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -37,6 +37,7 @@ import type {
   GraphQLFieldNormalizedConfigMap,
   GraphQLInputFieldNormalizedConfigMap,
   GraphQLNamedType,
+  GraphQLNullableType,
   GraphQLType,
 } from '../type/definition.ts';
 import {
@@ -413,7 +414,9 @@ export function extendSchemaImpl(
         return new GraphQLList(typeFromAST(node.type));
       }
       if (node.kind === Kind.NON_NULL_TYPE) {
-        return new GraphQLNonNull(typeFromAST(node.type));
+        return new GraphQLNonNull(
+          typeFromAST(node.type) as GraphQLNullableType,
+        );
       }
       return namedTypeFromAST(node);
     }

--- a/src/utilities/typeFromAST.ts
+++ b/src/utilities/typeFromAST.ts
@@ -8,7 +8,11 @@ import type {
 } from '../language/ast.ts';
 import { Kind } from '../language/kinds.ts';
 
-import type { GraphQLNamedType, GraphQLType } from '../type/definition.ts';
+import type {
+  GraphQLNamedType,
+  GraphQLNullableType,
+  GraphQLType,
+} from '../type/definition.ts';
 import { GraphQLList, GraphQLNonNull } from '../type/definition.ts';
 import type { GraphQLSchema } from '../type/schema.ts';
 
@@ -134,7 +138,9 @@ export function typeFromAST(
       return innerType && new GraphQLList(innerType);
     }
     case Kind.NON_NULL_TYPE: {
-      const innerType = typeFromAST(schema, typeNode.type);
+      const innerType = typeFromAST(schema, typeNode.type) as
+        | GraphQLNullableType
+        | undefined;
       return innerType && new GraphQLNonNull(innerType);
     }
     case Kind.NAMED_TYPE:


### PR DESCRIPTION
via brand field

This is a typings BREAKING CHANGE.

Previously, the below was allowed:

```ts
const list: GraphQLList<GraphQLType> = new GraphQLNonNull(GraphQLString);
const nonNull: GraphQLNonNull<GraphQLNullableType> = new GraphQLList(GraphQLString);

const type = new GraphQLNonNull(new GraphQLNonNull(GraphQLString));
```

This is now fixed.