### PR TITLE
fix(build): development declaration stubs

### DIFF
--- a/integrationTests/ts-development-condition/index.cts
+++ b/integrationTests/ts-development-condition/index.cts
@@ -1,0 +1,19 @@
+import { graphqlSync } from 'graphql';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql/type';
+
+const queryType = new GraphQLObjectType({
+  name: 'Query',
+  fields: {
+    greeting: {
+      type: GraphQLString,
+      resolve: () => 'Hello world',
+    },
+  },
+});
+
+const schema = new GraphQLSchema({ query: queryType });
+const result = graphqlSync({ schema, source: '{ greeting }' });
+
+if (result.data?.greeting !== 'Hello world') {
+  throw new Error('Unexpected GraphQL result.');
+}

--- a/integrationTests/ts-development-condition/package.json
+++ b/integrationTests/ts-development-condition/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "description": "graphql-js development condition should expose valid TypeScript declarations",
+  "type": "commonjs",
+  "scripts": {
+    "test": "tsc --project tsconfig.json"
+  },
+  "dependencies": {
+    "graphql": "file:../graphql.tgz",
+    "typescript": "~6.0.3"
+  }
+}

--- a/integrationTests/ts-development-condition/tsconfig.json
+++ b/integrationTests/ts-development-condition/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "customConditions": ["development"],
+    "module": "node16",
+    "moduleResolution": "node16",
+    "noEmit": true,
+    "strict": true,
+    "target": "es2021"
+  }
+}

--- a/resources/build-npm.ts
+++ b/resources/build-npm.ts
@@ -21,6 +21,11 @@ import {
   writeGeneratedFile,
 } from './utils.ts';
 
+const devTypeFiles = [
+  ['.ts', '.js'],
+  ['.mts', '.mjs'],
+] as const;
+
 console.log('\n./npmDist');
 await buildPackage('./npmDist', false);
 showDirStats('./npmDist');
@@ -128,8 +133,8 @@ async function buildPackage(outDir: string, isESMOnly: boolean): Promise<void> {
           `${dir}/${innerName}`,
         );
 
-        const line = `export * from '${relativePathToProd}/${relativePathAndName}.mjs';`;
-        for (const typeExt of ['.ts', '.mts']) {
+        for (const [typeExt, targetExt] of devTypeFiles) {
+          const line = `export * from '${relativePathToProd}/${relativePathAndName}${targetExt}';`;
           writeGeneratedFile(
             path.join(
               devDir,

--- a/resources/integration-test.ts
+++ b/resources/integration-test.ts
@@ -51,6 +51,7 @@ describe('Integration Tests', () => {
   }
 
   testOnNodeProject('ts');
+  testOnNodeProject('ts-development-condition');
   testOnNodeProject('node');
   testOnNodeProject('webpack');
 


### PR DESCRIPTION
## Description

This fixes TypeScript resolution for the package’s `development` export condition when consumers use `moduleResolution: "node16"`.

Before this change, the generated development declaration stubs always re-exported the ESM entrypoint:

```ts
// __dev__/index.d.ts
export * from '../index.mjs';
```

That worked for ESM declaration stubs, but it broke CommonJS TypeScript consumers. In a `.cts` project using:

```json
{
  "compilerOptions": {
    "customConditions": ["development"],
    "module": "node16",
    "moduleResolution": "node16"
  }
}
```

TypeScript resolves `graphql` through the `development` condition to the CommonJS dev entrypoint, then reads `__dev__/index.d.ts`. Because that `.d.ts` re-exported `../index.mjs`, TS reported:

```text
error TS1479: The current file is a CommonJS module whose imports will produce 'require' calls;
however, the referenced file is an ECMAScript module and cannot be imported with 'require'.
```