### PR TITLE
docs: fix inline examples, deprecation descriptions, type category

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -136,6 +136,8 @@ export class GraphQLError extends Error {
    * Creates a GraphQLError instance.
    * @param message - Human-readable error message.
    * @param options - Error metadata such as source locations, response path, original error, and extensions.
+   * This positional-arguments constructor overload is deprecated. Use the
+   * `GraphQLError(message, options)` overload instead.
    * @example
    * ```ts
    * // Create an error from AST nodes and response metadata.
@@ -178,8 +180,9 @@ export class GraphQLError extends Error {
   constructor(message: string, options?: GraphQLErrorOptions);
   /**
    * Creates a GraphQLError instance using the legacy positional constructor.
-   * Prefer the `GraphQLErrorOptions` object overload, which keeps optional error
-   * metadata in a single options bag.
+   * This deprecated overload will be removed in v17. Prefer the
+   * `GraphQLErrorOptions` object overload, which keeps optional error metadata
+   * in a single options bag.
    * @param message - Human-readable error message.
    * @param nodes - AST node or nodes associated with this error.
    * @param source - Source document used to derive error locations.
@@ -409,9 +412,9 @@ export interface GraphQLFormattedError {
 
 /**
  * Prints a GraphQLError to a string, representing useful location information
- * about the error's position in the source. This helper is retained for
- * backwards compatibility; call `error.toString()` instead because printError
- * will be removed in v17.
+ * about the error's position in the source. This deprecated helper is retained
+ * for backwards compatibility; call `error.toString()` instead because
+ * printError will be removed in v17.
  * @param error - The error to format.
  * @returns The printed string representation.
  * @example
@@ -430,9 +433,9 @@ export function printError(error: GraphQLError): string {
 
 /**
  * Given a GraphQLError, format it according to the rules described by the
- * Response Format, Errors section of the GraphQL Specification. This helper is
- * retained for backwards compatibility; call `error.toJSON()` instead because
- * formatError will be removed in v17.
+ * Response Format, Errors section of the GraphQL Specification. This deprecated
+ * helper is retained for backwards compatibility; call `error.toJSON()`
+ * instead because formatError will be removed in v17.
  * @param error - The error to format.
  * @returns The JSON-serializable formatted error.
  * @example

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -481,7 +481,9 @@ function buildResponse(
 
 /**
  * Essential assertions before executing to provide developer feedback for
- * improper use of the GraphQL library.
+ * improper use of the GraphQL library. This deprecated internal helper will be
+ * removed in v17; call `assertValidSchema()` and rely on TypeScript checks
+ * instead.
  *
  * @deprecated will be removed in v17 in favor of assertValidSchema() and TS checks
  * @internal

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -284,8 +284,8 @@ export async function createSourceEventStream(
 ): Promise<AsyncIterable<unknown> | ExecutionResult>;
 /**
  * Creates the source event stream for a subscription operation using the legacy
- * positional argument overload. Use the args object overload instead; this
- * overload will be removed in the next major version.
+ * positional argument overload. This deprecated overload will be removed in the
+ * next major version; use the args object overload instead.
  * @param schema - GraphQL schema to use.
  * @param document - The parsed GraphQL document containing the subscription
  * operation.

--- a/src/language/ast.ts
+++ b/src/language/ast.ts
@@ -552,7 +552,11 @@ export interface FragmentDefinitionNode {
   /** Name node identifying this AST node. */
   readonly name: NameNode;
   /**
-   * Variable definitions declared by this legacy fragment definition.
+   * Deprecated variable definitions declared by this legacy fragment
+   * definition. This legacy fragment variable syntax will be removed in v17.
+   * Move variable definitions to operations for spec-compliant documents; if
+   * you need variables or arguments scoped to fragments, v17 has a more
+   * complete experimental fragment-arguments feature.
    * @deprecated variableDefinitions will be removed in v17.0.0
    */
   readonly variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;

--- a/src/language/directiveLocation.ts
+++ b/src/language/directiveLocation.ts
@@ -46,9 +46,11 @@ enum DirectiveLocation {
 export { DirectiveLocation };
 
 /**
- * Legacy alias for the enum type representing directive location values. This
- * is retained for backwards compatibility; use `DirectiveLocation` instead
- * because DirectiveLocationEnum will be removed in v17.
- * @deprecated Please use `DirectiveLocation`. Will be removed in v17.
+ * Deprecated legacy alias for the enum type representing directive location
+ * values. This alias will be removed in v17. In v17, `DirectiveLocation` is
+ * exported as the single public symbol for both the runtime object and the
+ * corresponding TypeScript type.
+ * @deprecated Will be removed in v17. In v17, use `DirectiveLocation` as both
+ * the runtime value and the type.
  */
 export type DirectiveLocationEnum = typeof DirectiveLocation;

--- a/src/language/kinds.ts
+++ b/src/language/kinds.ts
@@ -115,9 +115,11 @@ enum Kind {
 export { Kind };
 
 /**
- * Legacy alias for the enum type representing the possible kind values of AST
- * nodes. This is retained for backwards compatibility; use `Kind` instead
- * because KindEnum will be removed in v17.
- * @deprecated Please use `Kind`. Will be removed in v17.
+ * Deprecated legacy alias for the enum type representing the possible kind
+ * values of AST nodes. This alias will be removed in v17. In v17, `Kind` is
+ * exported as the single public symbol for both the runtime object and the
+ * corresponding TypeScript type.
+ * @deprecated Will be removed in v17. In v17, use `Kind` as both the runtime
+ * value and the type.
  */
 export type KindEnum = typeof Kind;

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -97,7 +97,11 @@ export interface ParseOptions {
   maxTokens?: number | undefined;
 
   /**
-   * Allows legacy fragment variable definitions to be parsed.
+   * Deprecated option that allows legacy fragment variable definitions to be
+   * parsed. This legacy fragment variable syntax will be removed in v17. Move
+   * variable definitions to operations for spec-compliant documents; if you
+   * need variables or arguments scoped to fragments, v17 has a more complete
+   * experimental fragment-arguments feature.
    * @example
    * The syntax is identical to normal, query-defined variables.
    *

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -98,19 +98,19 @@ export interface ParseOptions {
 
   /**
    * Allows legacy fragment variable definitions to be parsed.
-   * @deprecated will be removed in the v17.0.0
-   *
-   * If enabled, the parser will understand and parse variable definitions
-   * contained in a fragment definition. They'll be represented in the
-   * `variableDefinitions` field of the FragmentDefinitionNode.
-   *
-   * The syntax is identical to normal, query-defined variables. For example:
+   * @example
+   * The syntax is identical to normal, query-defined variables.
    *
    * ```graphql
    * fragment A($var: Boolean = false) on T {
    *   ...
    * }
    * ```
+   * @deprecated will be removed in the v17.0.0
+   *
+   * If enabled, the parser will understand and parse variable definitions
+   * contained in a fragment definition. They'll be represented in the
+   * `variableDefinitions` field of the FragmentDefinitionNode.
    */
   allowLegacyFragmentVariables?: boolean;
 
@@ -119,7 +119,7 @@ export interface ParseOptions {
    *
    * If enabled, the parser will parse directives on directive definitions.
    * This syntax is not part of the GraphQL specification and may change.
-   *
+   * @example
    * ```graphql
    * directive @foo @bar on FIELD
    * ```

--- a/src/language/tokenKind.ts
+++ b/src/language/tokenKind.ts
@@ -55,9 +55,11 @@ enum TokenKind {
 export { TokenKind };
 
 /**
- * Legacy alias for the enum type representing token kind values. This is
- * retained for backwards compatibility; use `TokenKind` instead because
- * TokenKindEnum will be removed in v17.
- * @deprecated Please use `TokenKind`. Will be removed in v17.
+ * Deprecated legacy alias for the enum type representing token kind values.
+ * This alias will be removed in v17. In v17, `TokenKind` is exported as the
+ * single public symbol for both the runtime object and the corresponding
+ * TypeScript type.
+ * @deprecated Will be removed in v17. In v17, use `TokenKind` as both the
+ * runtime value and the type.
  */
 export type TokenKindEnum = typeof TokenKind;

--- a/src/language/visitor.ts
+++ b/src/language/visitor.ts
@@ -91,8 +91,8 @@ type ReducedField<T, R> = T extends null | undefined
   : R;
 
 /**
- * Legacy visitor key map type retained for compatibility. Inline this mapped
- * type at use sites; ASTVisitorKeyMap will be removed in v17.
+ * Deprecated visitor key map type retained for compatibility. Inline this
+ * mapped type at use sites because ASTVisitorKeyMap will be removed in v17.
  * @deprecated Please inline it. Will be removed in v17
  */
 export type ASTVisitorKeyMap = {
@@ -508,9 +508,9 @@ export function getEnterLeaveForKind(
 
 /**
  * Given a visitor instance, if it is leaving or not, and a node kind, return
- * the function the visitor runtime should call. This compatibility helper
- * delegates to `getEnterLeaveForKind`; call `getEnterLeaveForKind` directly
- * because getVisitFn will be removed in v17.
+ * the function the visitor runtime should call. This deprecated compatibility
+ * helper delegates to `getEnterLeaveForKind`; call `getEnterLeaveForKind`
+ * directly because getVisitFn will be removed in v17.
  * @param visitor - The visitor object to inspect.
  * @param kind - The AST node kind to resolve a handler for.
  * @param isLeaving - Whether to resolve the leave handler instead of the enter handler.

--- a/src/subscription/index.ts
+++ b/src/subscription/index.ts
@@ -15,9 +15,9 @@
 import type { ExecutionArgs } from '../execution/execute';
 
 /**
- * Legacy alias for ExecutionArgs retained by the subscription module. Use
- * `ExecutionArgs` directly instead because SubscriptionArgs will be removed in
- * v17.
+ * Deprecated legacy alias for ExecutionArgs retained by the subscription
+ * module. Use `ExecutionArgs` directly instead because SubscriptionArgs will be
+ * removed in v17.
  *
  * ExecutionArgs has been broadened to include all properties within SubscriptionArgs.
  * The SubscriptionArgs type is retained for backwards compatibility.

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1115,9 +1115,8 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType {
  * A list is a wrapping type which points to another type.
  * Lists are often created within the context of defining the fields of
  * an object type.
- *
- * Example:
- *
+ * @typeParam T - The GraphQL type wrapped by this list type.
+ * @example
  * ```ts
  * const PersonType = new GraphQLObjectType({
  *   name: 'Person',
@@ -1127,7 +1126,6 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType {
  *   })
  * })
  * ```
- * @typeParam T - The GraphQL type wrapped by this list type.
  */
 export class GraphQLList<T extends GraphQLType> {
   /** The type wrapped by this list or non-null type. */
@@ -1207,9 +1205,8 @@ export class GraphQLList<T extends GraphQLType> {
  * an error is raised if this ever occurs during a request. It is useful for
  * fields which you can make a strong guarantee on non-nullability, for example
  * usually the id field of a database row will never be null.
- *
- * Example:
- *
+ * @typeParam T - The nullable GraphQL type wrapped by this non-null type.
+ * @example
  * ```ts
  * const RowType = new GraphQLObjectType({
  *   name: 'Row',
@@ -1218,8 +1215,8 @@ export class GraphQLList<T extends GraphQLType> {
  *   })
  * })
  * ```
+ *
  * Note: the enforcement of non-nullability occurs within the executor.
- * @typeParam T - The nullable GraphQL type wrapped by this non-null type.
  */
 export class GraphQLNonNull<T extends GraphQLNullableType> {
   /** The type wrapped by this list or non-null type. */
@@ -1719,9 +1716,9 @@ export interface GraphQLScalarTypeExtensions {
  * (i.e. it returns `undefined`) then an error will be raised and a `null`
  * value will be returned in the response. Prefer validating inputs before
  * execution so clients receive input diagnostics before result coercion fails.
- *
- * Example:
- *
+ * @typeParam TInternal - The internal runtime representation accepted by this scalar.
+ * @typeParam TExternal - The serialized representation exposed in GraphQL results.
+ * @example
  * ```ts
  * const OddType = new GraphQLScalarType({
  *   name: 'Odd',
@@ -1739,8 +1736,6 @@ export interface GraphQLScalarTypeExtensions {
  *   }
  * });
  * ```
- * @typeParam TInternal - The internal runtime representation accepted by this scalar.
- * @typeParam TExternal - The serialized representation exposed in GraphQL results.
  */
 export class GraphQLScalarType<TInternal = unknown, TExternal = TInternal> {
   /** The GraphQL name for this schema element. */
@@ -2013,9 +2008,9 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  *
  * Almost all of the GraphQL types you define will be object types. Object types
  * have a name, but most importantly describe their fields.
- *
- * Example:
- *
+ * @typeParam TSource - Source object type passed to resolvers.
+ * @typeParam TContext - Context object type passed to resolvers.
+ * @example
  * ```ts
  * const AddressType = new GraphQLObjectType({
  *   name: 'Address',
@@ -2031,12 +2026,10 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  *   }
  * });
  * ```
- *
+ * @example
  * When two types need to refer to each other, or a type needs to refer to
  * itself in a field, you can use a function expression (aka a closure or a
  * thunk) to supply the fields lazily.
- *
- * Example:
  *
  * ```ts
  * const PersonType = new GraphQLObjectType({
@@ -2047,8 +2040,6 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  *   })
  * });
  * ```
- * @typeParam TSource - Source object type passed to resolvers.
- * @typeParam TContext - Context object type passed to resolvers.
  */
 export class GraphQLObjectType<TSource = any, TContext = any> {
   /** The GraphQL name for this schema element. */
@@ -2734,9 +2725,7 @@ export interface GraphQLInterfaceTypeExtensions {
  * is used to describe what types are possible, what fields are in common across
  * all types, as well as a function to determine which type is actually used
  * when the field is resolved.
- *
- * Example:
- *
+ * @example
  * ```ts
  * const EntityType = new GraphQLInterfaceType({
  *   name: 'Entity',
@@ -3057,9 +3046,7 @@ export interface GraphQLUnionTypeExtensions {
  * When a field can return one of a heterogeneous set of types, a Union type
  * is used to describe what types are possible as well as providing a function
  * to determine which type is actually used when the field is resolved.
- *
- * Example:
- *
+ * @example
  * ```ts
  * const PetType = new GraphQLUnionType({
  *   name: 'Pet',
@@ -3347,9 +3334,7 @@ export interface GraphQLEnumTypeExtensions {
  * Enum types define leaf values whose serialized form is one of a fixed set
  * of GraphQL enum names. Internally, enum values can map to any runtime value,
  * often integers.
- *
- * Example:
- *
+ * @example
  * ```ts
  * import { GraphQLEnumType } from 'graphql/type';
  *
@@ -3869,9 +3854,7 @@ export interface GraphQLInputObjectTypeExtensions {
  * supplied to a field argument.
  *
  * Using `NonNull` will ensure that a value must be provided by the query
- *
- * Example:
- *
+ * @example
  * ```ts
  * const GeoPoint = new GraphQLInputObjectType({
  *   name: 'GeoPoint',

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1,4 +1,4 @@
-/** @category Definitions */
+/** @category Types */
 
 import { devAssert } from '../jsutils/devAssert';
 import { didYouMean } from '../jsutils/didYouMean';

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -101,9 +101,7 @@ export interface GraphQLSchemaExtensions {
  * A Schema is created by supplying the root types of each type of operation,
  * query and mutation (optional). A schema definition is then supplied to the
  * validator and executor.
- *
- * Example:
- *
+ * @example
  * ```ts
  * const MyAppQueryRootType = new GraphQLObjectType({
  *   name: 'Query',
@@ -124,12 +122,10 @@ export interface GraphQLSchemaExtensions {
  *   mutation: MyAppMutationRootType,
  * });
  * ```
- *
- * Note: When the schema is constructed, by default only the types that are
- * reachable by traversing the root types are included, other types must be
- * explicitly referenced.
- *
- * Example:
+ * @example
+ * When the schema is constructed, by default only the types that are reachable
+ * by traversing the root types are included, other types must be explicitly
+ * referenced.
  *
  * ```ts
  * const characterInterface = new GraphQLInterfaceType({
@@ -168,12 +164,12 @@ export interface GraphQLSchemaExtensions {
  *   types: [humanType, droidType],
  * });
  * ```
- *
- * Note: If an array of `directives` are provided to GraphQLSchema, that will be
- * the exact list of directives represented and allowed. If `directives` is not
+ * @example
+ * If an array of `directives` are provided to GraphQLSchema, that will be the
+ * exact list of directives represented and allowed. If `directives` is not
  * provided then a default set of the specified directives (e.g. `@include` and
- * `@skip`) will be used. If you wish to provide *additional* directives to these
- * specified directives, you must explicitly declare them. Example:
+ * `@skip`) will be used. If you wish to provide *additional* directives to
+ * these specified directives, you must explicitly declare them.
  *
  * ```ts
  * const MyAppSchema = new GraphQLSchema({

--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -134,7 +134,8 @@ export class TypeInfo {
     initialType?: Maybe<GraphQLType>,
 
     /**
-     * Legacy field definition lookup override.
+     * Deprecated field definition lookup override. Use TypeInfo's built-in
+     * field definition lookup instead because this hook will be removed in v17.
      * @deprecated will be removed in 17.0.0
      */
     getFieldDefFn?: GetFieldDefFn,

--- a/src/utilities/assertValidName.ts
+++ b/src/utilities/assertValidName.ts
@@ -8,9 +8,9 @@ import { assertName } from '../type/assertName';
 
 /* c8 ignore start */
 /**
- * Upholds the spec rules about naming. This helper is retained for backwards
- * compatibility; call `assertName` instead because assertValidName will be
- * removed in v17.
+ * Upholds the spec rules about naming. This deprecated helper is retained for
+ * backwards compatibility; call `assertName` instead because assertValidName
+ * will be removed in v17.
  * @param name - The GraphQL name to validate.
  * @returns The validated GraphQL name.
  * @example
@@ -31,9 +31,9 @@ export function assertValidName(name: string): string {
 }
 
 /**
- * Returns an Error if a name is invalid. This helper is retained for backwards
- * compatibility; call `assertName` and catch the thrown GraphQLError instead
- * because isValidNameError will be removed in v17.
+ * Returns an Error if a name is invalid. This deprecated helper is retained for
+ * backwards compatibility; call `assertName` and catch the thrown GraphQLError
+ * instead because isValidNameError will be removed in v17.
  * @param name - The GraphQL name to validate.
  * @returns A GraphQLError if the name is invalid; otherwise undefined.
  * @example

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -22,9 +22,7 @@ import { GraphQLID } from '../type/scalars';
 /**
  * Produces a GraphQL Value AST given a JavaScript object.
  * Function will match JavaScript/JSON values to GraphQL AST schema format
- * by using suggested GraphQLInputType. For example:
- *
- *     astFromValue("value", GraphQLString)
+ * by using suggested GraphQLInputType.
  *
  * A GraphQL type must be provided, which will be used to interpret different
  * JavaScript values.

--- a/src/utilities/getOperationRootType.ts
+++ b/src/utilities/getOperationRootType.ts
@@ -11,9 +11,10 @@ import type { GraphQLObjectType } from '../type/definition';
 import type { GraphQLSchema } from '../type/schema';
 
 /**
- * Extracts the root type of the operation from the schema. This helper is
- * retained for backwards compatibility; call `GraphQLSchema.getRootType` instead
- * because getOperationRootType will be removed in v17.
+ * Extracts the root type of the operation from the schema. This deprecated
+ * helper is retained for backwards compatibility; call
+ * `GraphQLSchema.getRootType` instead because getOperationRootType will be
+ * removed in v17.
  * @param schema - GraphQL schema to use.
  * @param operation - The operation definition to inspect.
  * @returns The resolved operation root type.

--- a/src/utilities/stripIgnoredCharacters.ts
+++ b/src/utilities/stripIgnoredCharacters.ts
@@ -24,9 +24,9 @@ import { TokenKind } from '../language/tokenKind';
  * Warning: It is guaranteed that this function will always produce stable results.
  * However, it's not guaranteed that it will stay the same between different
  * releases due to bugfixes or changes in the GraphQL specification.
- *
- * Query example:
- *
+ * @param source - The GraphQL source text or source object.
+ * @returns A semantically equivalent GraphQL source string without ignored characters.
+ * @example Query source
  * ```graphql
  * query SomeQuery($foo: String!, $bar: String) {
  *   someField(foo: $foo, bar: $bar) {
@@ -44,9 +44,7 @@ import { TokenKind } from '../language/tokenKind';
  * ```graphql
  * query SomeQuery($foo:String!$bar:String){someField(foo:$foo bar:$bar){a b{c d}}}
  * ```
- *
- * SDL example:
- *
+ * @example SDL source
  * ```graphql
  * """
  * Type description
@@ -64,8 +62,6 @@ import { TokenKind } from '../language/tokenKind';
  * ```graphql
  * """Type description""" type Foo{"""Field description""" bar:String}
  * ```
- * @param source - The GraphQL source text or source object.
- * @returns A semantically equivalent GraphQL source string without ignored characters.
  * @example
  * ```ts
  * import { stripIgnoredCharacters } from 'graphql/utilities';

--- a/src/validation/validate.ts
+++ b/src/validation/validate.ts
@@ -114,7 +114,8 @@ export function validate(
   options?: ValidationOptions,
 
   /**
-   * TypeInfo instance used to track traversal state during validation.
+   * Deprecated TypeInfo instance used to track traversal state during
+   * validation. Omit this argument so validate creates the TypeInfo instance.
    * @deprecated will be removed in 17.0.0
    */
   typeInfo: TypeInfo = new TypeInfo(schema),


### PR DESCRIPTION
- Move public documentation sample blocks out of descriptions and into `@example` tags, including root package, parser option, type, schema, astFromValue, and stripIgnoredCharacters docs.
- Update every public v16 `@deprecated` JSDoc block so the prose itself says the API is deprecated and points users to the replacement or migration path.
- Rename the graphql/type Definitions JSDoc category to Types so the generated API docs use the clearer category name.