### PR TITLE
docs: fix inline examples, deprecation descriptions, type category

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -508,12 +508,20 @@ export {
   // Create a GraphQLType from a GraphQL language AST.
   typeFromAST,
   // Create a JavaScript value from a GraphQL language AST with a Type.
-  /** @deprecated use `coerceInputLiteral()` instead - will be removed in v18 */
+  /**
+   * Deprecated export retained for compatibility. Use `coerceInputLiteral()`
+   * instead.
+   * @deprecated use `coerceInputLiteral()` instead - will be removed in v18
+   */
   valueFromAST,
   // Create a JavaScript value from a GraphQL language AST without a Type.
   valueFromASTUntyped,
   // Create a GraphQL language AST from a JavaScript value.
-  /** @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18 */
+  /**
+   * Deprecated export retained for compatibility. Use `valueToLiteral()`
+   * instead, and take care to operate on external values.
+   * @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18
+   */
   astFromValue,
   // A helper to use within recursive-descent visitors which need to be aware of the GraphQL type system.
   TypeInfo,

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -104,9 +104,7 @@ export interface ParseOptions {
    * and arguments on fragment spreads. Fragment variable definitions will be represented
    * in the `variableDefinitions` field of the FragmentDefinitionNode.
    * Fragment spread arguments will be represented in the `arguments` field of FragmentSpreadNode.
-   *
-   * For example:
-   *
+   * @example
    * ```graphql
    * {
    *   t { ...A(var: true) }
@@ -123,7 +121,7 @@ export interface ParseOptions {
    *
    * If enabled, the parser will parse directives on directive definitions.
    * This syntax is not part of the GraphQL specification and may change.
-   *
+   * @example
    * ```graphql
    * directive @foo @bar on FIELD
    * ```

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1,4 +1,4 @@
-/** @category Definitions */
+/** @category Types */
 
 import { devAssert } from '../jsutils/devAssert.ts';
 import { didYouMean } from '../jsutils/didYouMean.ts';

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -1313,9 +1313,8 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType {
  * A list is a wrapping type which points to another type.
  * Lists are often created within the context of defining the fields of
  * an object type.
- *
- * Example:
- *
+ * @typeParam T - The GraphQL type wrapped by this list type.
+ * @example
  * ```ts
  * const PersonType = new GraphQLObjectType({
  *   name: 'Person',
@@ -1325,7 +1324,6 @@ export function assertAbstractType(type: unknown): GraphQLAbstractType {
  *   })
  * })
  * ```
- * @typeParam T - The GraphQL type wrapped by this list type.
  */
 export class GraphQLList<
   T extends GraphQLType,
@@ -1410,9 +1408,8 @@ export class GraphQLList<
  * an error is raised if this ever occurs during a request. It is useful for
  * fields which you can make a strong guarantee on non-nullability, for example
  * usually the id field of a database row will never be null.
- *
- * Example:
- *
+ * @typeParam T - The nullable GraphQL type wrapped by this non-null type.
+ * @example
  * ```ts
  * const RowType = new GraphQLObjectType({
  *   name: 'Row',
@@ -1421,8 +1418,8 @@ export class GraphQLList<
  *   })
  * })
  * ```
+ *
  * Note: the enforcement of non-nullability occurs within the executor.
- * @typeParam T - The nullable GraphQL type wrapped by this non-null type.
  */
 export class GraphQLNonNull<
   T extends GraphQLNullableType,
@@ -1939,40 +1936,6 @@ export interface GraphQLScalarTypeExtensions {
  * `null` value will be returned in the response. Prefer validating inputs
  * before execution so clients receive input diagnostics before result coercion
  * fails.
- *
- * Example:
- *
- * ```ts
- * import { GraphQLScalarType, Kind } from 'graphql';
- *
- * const ensureOdd = (value) => {
- *   if (!Number.isFinite(value)) {
- *     throw new Error(
- *       `Scalar "Odd" cannot represent "${value}" since it is not a finite number.`,
- *     );
- *   }
- *
- *   if (value % 2 === 0) {
- *     throw new Error(`Scalar "Odd" cannot represent "${value}" since it is even.`);
- *   }
- *
- *   return value;
- * };
- *
- * const OddType = new GraphQLScalarType({
- *   name: 'Odd',
- *   coerceOutputValue: (value) => {
- *     return ensureOdd(value);
- *   },
- *   coerceInputValue: (value) => {
- *     return ensureOdd(value);
- *   },
- *   valueToLiteral: (value) => {
- *     return { kind: Kind.INT, value: String(ensureOdd(value)) };
- *   }
- * });
- * ```
- *
  * Custom scalar behavior is defined via the following functions:
  *
  *  - coerceOutputValue(value): Implements "Result Coercion". Given an internal value,
@@ -2007,6 +1970,37 @@ export interface GraphQLScalarTypeExtensions {
  *    `coerceInputLiteral()` method.
  * @typeParam TInternal - Internal runtime representation for this scalar.
  * @typeParam TExternal - External representation accepted from or returned to callers.
+ * @example
+ * ```ts
+ * import { GraphQLScalarType, Kind } from 'graphql';
+ *
+ * const ensureOdd = (value) => {
+ *   if (!Number.isFinite(value)) {
+ *     throw new Error(
+ *       `Scalar "Odd" cannot represent "${value}" since it is not a finite number.`,
+ *     );
+ *   }
+ *
+ *   if (value % 2 === 0) {
+ *     throw new Error(`Scalar "Odd" cannot represent "${value}" since it is even.`);
+ *   }
+ *
+ *   return value;
+ * };
+ *
+ * const OddType = new GraphQLScalarType({
+ *   name: 'Odd',
+ *   coerceOutputValue: (value) => {
+ *     return ensureOdd(value);
+ *   },
+ *   coerceInputValue: (value) => {
+ *     return ensureOdd(value);
+ *   },
+ *   valueToLiteral: (value) => {
+ *     return { kind: Kind.INT, value: String(ensureOdd(value)) };
+ *   }
+ * });
+ * ```
  */
 export class GraphQLScalarType<
   TInternal = unknown,
@@ -2369,9 +2363,10 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  *
  * Almost all of the GraphQL types you define will be object types. Object types
  * have a name, but most importantly describe their fields.
- *
- * Example:
- *
+ * @typeParam TSource - Source object type passed to resolvers.
+ * @typeParam TContext - Context object type passed to resolvers.
+ * @typeParam TAbstract - Runtime value type used for abstract type resolution.
+ * @example
  * ```ts
  * const AddressType = new GraphQLObjectType({
  *   name: 'Address',
@@ -2387,12 +2382,10 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  *   }
  * });
  * ```
- *
+ * @example
  * When two types need to refer to each other, or a type needs to refer to
  * itself in a field, you can use a function expression (aka a closure or a
  * thunk) to supply the fields lazily.
- *
- * Example:
  *
  * ```ts
  * const PersonType = new GraphQLObjectType({
@@ -2403,9 +2396,6 @@ export interface GraphQLObjectTypeExtensions<_TSource = any, _TContext = any> {
  *   })
  * });
  * ```
- * @typeParam TSource - Source object type passed to resolvers.
- * @typeParam TContext - Context object type passed to resolvers.
- * @typeParam TAbstract - Runtime value type used for abstract type resolution.
  */
 export class GraphQLObjectType<
   TSource = any,
@@ -3424,9 +3414,9 @@ export interface GraphQLInterfaceTypeExtensions {
  * is used to describe what types are possible, what fields are in common across
  * all types, as well as a function to determine which type is actually used
  * when the field is resolved.
- *
- * Example:
- *
+ * @typeParam TSource - Source object type passed to resolvers.
+ * @typeParam TContext - Context object type passed to resolvers.
+ * @example
  * ```ts
  * const EntityType = new GraphQLInterfaceType({
  *   name: 'Entity',
@@ -3435,8 +3425,6 @@ export interface GraphQLInterfaceTypeExtensions {
  *   }
  * });
  * ```
- * @typeParam TSource - Source object type passed to resolvers.
- * @typeParam TContext - Context object type passed to resolvers.
  */
 export class GraphQLInterfaceType<
   TSource = any,
@@ -3758,9 +3746,9 @@ export interface GraphQLUnionTypeExtensions {
  * When a field can return one of a heterogeneous set of types, a Union type
  * is used to describe what types are possible as well as providing a function
  * to determine which type is actually used when the field is resolved.
- *
- * Example:
- *
+ * @typeParam TSource - Source object type passed to resolvers.
+ * @typeParam TContext - Context object type passed to resolvers.
+ * @example
  * ```ts
  * const PetType = new GraphQLUnionType({
  *   name: 'Pet',
@@ -3775,8 +3763,6 @@ export interface GraphQLUnionTypeExtensions {
  *   }
  * });
  * ```
- * @typeParam TSource - Source object type passed to resolvers.
- * @typeParam TContext - Context object type passed to resolvers.
  */
 export class GraphQLUnionType<
   TSource = any,
@@ -4052,9 +4038,7 @@ export interface GraphQLEnumTypeExtensions {
  * Enum types define leaf values whose serialized form is one of a fixed set
  * of GraphQL enum names. Internally, enum values can map to any runtime value,
  * often integers.
- *
- * Example:
- *
+ * @example
  * ```ts
  * import { GraphQLEnumType } from 'graphql/type';
  *
@@ -4808,9 +4792,7 @@ export interface GraphQLInputObjectTypeExtensions {
  * supplied to a field argument.
  *
  * Using `NonNull` will ensure that a value must be provided by the query
- *
- * Example:
- *
+ * @example
  * ```ts
  * const GeoPoint = new GraphQLInputObjectType({
  *   name: 'GeoPoint',

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -2018,17 +2018,20 @@ export class GraphQLScalarType<
   /** URL identifying the behavior specified for this custom scalar. */
   specifiedByURL: Maybe<string>;
   /**
-   * Legacy serializer used to convert internal values for response output.
+   * Deprecated legacy serializer used to convert internal values for response
+   * output. Use `coerceOutputValue()` instead.
    * @deprecated use `coerceOutputValue()` instead, `serialize()` will be removed in v18
    */
   serialize: GraphQLScalarSerializer<TExternal>;
   /**
-   * Legacy parser used to convert externally provided input values.
+   * Deprecated legacy parser used to convert externally provided input values.
+   * Use `coerceInputValue()` instead.
    * @deprecated use `coerceInputValue()` instead, `parseValue()` will be removed in v18
    */
   parseValue: GraphQLScalarValueParser<TInternal>;
   /**
-   * Legacy parser used to convert externally provided input literals.
+   * Deprecated legacy parser used to convert externally provided input
+   * literals. Use `replaceVariables()` and `coerceInputLiteral()` instead.
    * @deprecated use `replaceVariables()` and `coerceInputLiteral()` instead, `parseLiteral()` will be removed in v18
    */
   parseLiteral: GraphQLScalarLiteralParser<TInternal>;
@@ -2228,7 +2231,8 @@ export class GraphQLScalarType<
 }
 
 /**
- * Serializes a runtime value as a scalar output value.
+ * Deprecated function type that serializes a runtime value as a scalar output
+ * value. Use `GraphQLScalarOutputValueCoercer` instead.
  * @typeParam TExternal - External representation accepted from or returned to callers.
  * @deprecated Use GraphQLScalarOutputValueCoercer instead. Will be removed in v18.
  */
@@ -2245,7 +2249,8 @@ export type GraphQLScalarOutputValueCoercer<TExternal> = (
 ) => TExternal;
 
 /**
- * Parses a runtime input value as a scalar input value.
+ * Deprecated function type that parses a runtime input value as a scalar input
+ * value. Use `GraphQLScalarInputValueCoercer` instead.
  * @typeParam TInternal - Internal runtime representation for this scalar.
  * @deprecated Use GraphQLScalarInputValueCoercer instead. Will be removed in v18.
  */
@@ -2262,7 +2267,8 @@ export type GraphQLScalarInputValueCoercer<TInternal> = (
 ) => TInternal;
 
 /**
- * Parses a GraphQL value literal as a scalar input value.
+ * Deprecated function type that parses a GraphQL value literal as a scalar
+ * input value. Use `GraphQLScalarInputLiteralCoercer` instead.
  * @typeParam TInternal - Internal runtime representation for this scalar.
  * @deprecated Use GraphQLScalarInputLiteralCoercer instead. Will be removed in v18.
  */
@@ -2297,17 +2303,20 @@ export interface GraphQLScalarTypeConfig<TInternal, TExternal> {
   /** URL identifying the behavior specified for this custom scalar. */
   specifiedByURL?: Maybe<string>;
   /**
-   * Legacy serializer used to convert internal values for response output.
+   * Deprecated legacy serializer used to convert internal values for response
+   * output. Use `coerceOutputValue()` instead.
    * @deprecated use `coerceOutputValue()` instead, `serialize()` will be removed in v18
    */
   serialize?: GraphQLScalarSerializer<TExternal> | undefined;
   /**
-   * Legacy parser used to convert externally provided input values.
+   * Deprecated legacy parser used to convert externally provided input values.
+   * Use `coerceInputValue()` instead.
    * @deprecated use `coerceInputValue()` instead, `parseValue()` will be removed in v18
    */
   parseValue?: GraphQLScalarValueParser<TInternal> | undefined;
   /**
-   * Legacy parser used to convert externally provided input literals.
+   * Deprecated legacy parser used to convert externally provided input
+   * literals. Use `replaceVariables()` and `coerceInputLiteral()` instead.
    * @deprecated use `replaceVariables()` and `coerceInputLiteral()` instead, `parseLiteral()` will be removed in v18
    */
   parseLiteral?: GraphQLScalarLiteralParser<TInternal> | undefined;
@@ -2944,7 +2953,7 @@ export interface GraphQLArgumentConfig {
   /** The GraphQL type reference or runtime type for this element. */
   type: GraphQLInputType;
   /**
-   * Legacy default value for this argument.
+   * Deprecated legacy default value for this argument. Use `default` instead.
    * @deprecated use `default` instead, `defaultValue` will be removed in v18
    */
   defaultValue?: unknown;
@@ -3176,7 +3185,8 @@ export class GraphQLArgument implements GraphQLSchemaElement {
   /** The GraphQL type reference or runtime type for this element. */
   type: GraphQLInputType;
   /**
-   * Legacy default value used when no explicit value is supplied.
+   * Deprecated legacy default value used when no explicit value is supplied.
+   * Use `default` instead.
    * @deprecated use `default` instead, `defaultValue` will be removed in v18
    */
   defaultValue: unknown;
@@ -4219,6 +4229,9 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
    * Serializes a runtime enum value as a GraphQL enum name.
    * @param outputValue - Runtime enum value to serialize.
    * @returns The GraphQL enum name for the runtime value.
+   *
+   * This deprecated method delegates to `coerceOutputValue()`; call
+   * `coerceOutputValue()` directly instead.
    * @example
    * ```ts
    * import { GraphQLEnumType } from 'graphql/type';
@@ -4276,7 +4289,8 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
   }
 
   /**
-   * Legacy enum parser for externally provided input values.
+   * Deprecated legacy enum parser for externally provided input values. Use
+   * `coerceInputValue()` instead.
    * @param inputValue - External enum name to parse.
    * @param hideSuggestions - Whether suggestion text should be omitted from errors.
    * @returns The internal runtime value for the enum name.
@@ -4351,7 +4365,8 @@ export class GraphQLEnumType /* <T> */ implements GraphQLSchemaElement {
   }
 
   /**
-   * Legacy enum parser for externally provided input literals.
+   * Deprecated legacy enum parser for externally provided input literals. Use
+   * `coerceInputLiteral()` instead.
    * @param valueNode - Enum value AST node to parse.
    * @param _variables - Deprecated variable values parameter that is no longer used.
    * @param hideSuggestions - Whether suggestion text should be omitted from errors.
@@ -5089,7 +5104,8 @@ export interface GraphQLInputFieldConfig {
   /** The GraphQL type reference or runtime type for this element. */
   type: GraphQLInputType;
   /**
-   * Legacy default value for this input field.
+   * Deprecated legacy default value for this input field. Use `default`
+   * instead.
    * @deprecated use `default` instead, `defaultValue` will be removed in v18
    */
   defaultValue?: unknown;
@@ -5132,7 +5148,8 @@ export class GraphQLInputField implements GraphQLSchemaElement {
   /** The GraphQL type reference or runtime type for this element. */
   type: GraphQLInputType;
   /**
-   * Legacy default value used when no explicit value is supplied.
+   * Deprecated legacy default value used when no explicit value is supplied.
+   * Use `default` instead.
    * @deprecated use `default` instead, `defaultValue` will be removed in v18
    */
   defaultValue: unknown;

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -109,9 +109,7 @@ const schemaSymbol: unique symbol = Symbol('Schema');
  * A Schema is created by supplying the root types of each type of operation,
  * query and mutation (optional). A schema definition is then supplied to the
  * validator and executor.
- *
- * Example:
- *
+ * @example
  * ```ts
  * const MyAppQueryRootType = new GraphQLObjectType({
  *   name: 'Query',
@@ -132,12 +130,10 @@ const schemaSymbol: unique symbol = Symbol('Schema');
  *   mutation: MyAppMutationRootType,
  * });
  * ```
- *
- * Note: When the schema is constructed, by default only the types that are
- * reachable by traversing the root types are included, other types must be
- * explicitly referenced.
- *
- * Example:
+ * @example
+ * When the schema is constructed, by default only the types that are reachable
+ * by traversing the root types are included, other types must be explicitly
+ * referenced.
  *
  * ```ts
  * const characterInterface = new GraphQLInterfaceType({
@@ -176,12 +172,12 @@ const schemaSymbol: unique symbol = Symbol('Schema');
  *   types: [humanType, droidType],
  * });
  * ```
- *
- * Note: If an array of `directives` are provided to GraphQLSchema, that will be
- * the exact list of directives represented and allowed. If `directives` is not
+ * @example
+ * If an array of `directives` are provided to GraphQLSchema, that will be the
+ * exact list of directives represented and allowed. If `directives` is not
  * provided then a default set of the specified directives (e.g. `@include` and
- * `@skip`) will be used. If you wish to provide *additional* directives to these
- * specified directives, you must explicitly declare them. Example:
+ * `@skip`) will be used. If you wish to provide *additional* directives to
+ * these specified directives, you must explicitly declare them.
  *
  * ```ts
  * const MyAppSchema = new GraphQLSchema({

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -22,9 +22,7 @@ import { GraphQLID } from '../type/scalars.ts';
 /**
  * Produces a GraphQL Value AST given a JavaScript object.
  * Function will match JavaScript/JSON values to GraphQL AST schema format
- * by using suggested GraphQLInputType. For example:
- *
- *     astFromValue("value", GraphQLString)
+ * by using suggested GraphQLInputType.
  *
  * A GraphQL type must be provided, which will be used to interpret different
  * JavaScript values.

--- a/src/utilities/astFromValue.ts
+++ b/src/utilities/astFromValue.ts
@@ -27,6 +27,9 @@ import { GraphQLID } from '../type/scalars.ts';
  * A GraphQL type must be provided, which will be used to interpret different
  * JavaScript values.
  *
+ * This deprecated function will be removed in v18. Use `valueToLiteral()`
+ * instead, and take care to operate on external values.
+ *
  * | JSON Value    | GraphQL Value        |
  * | ------------- | -------------------- |
  * | Object        | Input Object         |

--- a/src/utilities/findSchemaChanges.ts
+++ b/src/utilities/findSchemaChanges.ts
@@ -127,7 +127,9 @@ export type SchemaChange = SafeChange | DangerousChange | BreakingChange;
 
 /**
  * Given two schemas, returns an Array containing descriptions of all the types
- * of breaking changes covered by the other functions down below.
+ * of breaking changes covered by the other functions down below. This
+ * deprecated wrapper will be removed in v18; use `findSchemaChanges()` instead
+ * and filter for breaking changes.
  * @param oldSchema - Schema before the change.
  * @param newSchema - Schema after the change.
  * @returns Breaking changes between the two schemas.
@@ -165,6 +167,8 @@ export function findBreakingChanges(
 /**
  * Given two schemas, returns an Array containing descriptions of all the types
  * of potentially dangerous changes covered by the other functions down below.
+ * This deprecated wrapper will be removed in v18; use `findSchemaChanges()`
+ * instead and filter for dangerous changes.
  * @param oldSchema - Schema before the change.
  * @param newSchema - Schema after the change.
  * @returns Dangerous changes between the two schemas.

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -66,7 +66,11 @@ export { typeFromAST } from './typeFromAST.ts';
 
 // Create a JavaScript value from a GraphQL language AST with a type.
 export {
-  /** @deprecated use `coerceInputLiteral()` instead - will be removed in v18 */
+  /**
+   * Deprecated export retained for compatibility. Use `coerceInputLiteral()`
+   * instead.
+   * @deprecated use `coerceInputLiteral()` instead - will be removed in v18
+   */
   valueFromAST,
 } from './valueFromAST.ts';
 
@@ -75,7 +79,11 @@ export { valueFromASTUntyped } from './valueFromASTUntyped.ts';
 
 // Create a GraphQL language AST from a JavaScript value.
 export {
-  /** @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18 */
+  /**
+   * Deprecated export retained for compatibility. Use `valueToLiteral()`
+   * instead, and take care to operate on external values.
+   * @deprecated use `valueToLiteral()` instead with care to operate on external values - `astFromValue()` will be removed in v18
+   */
   astFromValue,
 } from './astFromValue.ts';
 

--- a/src/utilities/stripIgnoredCharacters.ts
+++ b/src/utilities/stripIgnoredCharacters.ts
@@ -24,9 +24,9 @@ import { TokenKind } from '../language/tokenKind.ts';
  * Warning: It is guaranteed that this function will always produce stable results.
  * However, it's not guaranteed that it will stay the same between different
  * releases due to bugfixes or changes in the GraphQL specification.
- *
- * Query example:
- *
+ * @param source - The GraphQL source text or source object.
+ * @returns A semantically equivalent GraphQL source string without ignored characters.
+ * @example Query source
  * ```graphql
  * query SomeQuery($foo: String!, $bar: String) {
  *   someField(foo: $foo, bar: $bar) {
@@ -44,9 +44,7 @@ import { TokenKind } from '../language/tokenKind.ts';
  * ```graphql
  * query SomeQuery($foo:String!$bar:String){someField(foo:$foo bar:$bar){a b{c d}}}
  * ```
- *
- * SDL example:
- *
+ * @example SDL source
  * ```graphql
  * """
  * Type description
@@ -64,8 +62,6 @@ import { TokenKind } from '../language/tokenKind.ts';
  * ```graphql
  * """Type description""" type Foo{"""Field description""" bar:String}
  * ```
- * @param source - The GraphQL source text or source object.
- * @returns A semantically equivalent GraphQL source string without ignored characters.
  * @example
  * ```ts
  * import { stripIgnoredCharacters } from 'graphql/utilities';

--- a/src/utilities/valueFromAST.ts
+++ b/src/utilities/valueFromAST.ts
@@ -25,6 +25,9 @@ import {
  * Returns `undefined` when the value could not be validly coerced according to
  * the provided type.
  *
+ * This deprecated function will be removed in v18. Use `coerceInputLiteral()`
+ * instead.
+ *
  * | GraphQL Value        | JSON Value    |
  * | -------------------- | ------------- |
  * | Input Object         | Object        |


### PR DESCRIPTION
- Move public documentation sample blocks out of descriptions and into `@example` tags, including root package, parser option, type, schema, astFromValue, and stripIgnoredCharacters docs.
- Update every v17 '@deprecated' JSDoc block so the prose itself says the API is deprecated and points users to the replacement or migration path.
- Rename the graphql/type Definitions JSDoc category to Types so the generated API docs use the clearer category name.