### PR TITLE
fix: DeferStreamDirectiveOnValidOperations fragment tracking

### DIFF
--- a/src/validation/__tests__/DeferStreamDirectiveOnValidOperationsRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveOnValidOperationsRule-test.ts
@@ -201,6 +201,120 @@ describe('Validate: Defer/Stream directive on valid operations', () => {
       },
     ]);
   });
+  it('Defer fragment spread with @skip directive', () => {
+    expectValid(`
+      subscription MySubscription {
+        subscriptionField {
+          ...myFragment @skip @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer fragment spread with @skip(if: true) directive', () => {
+    expectValid(`
+      subscription MySubscription {
+        subscriptionField {
+          ...myFragment @skip(if: true) @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer fragment spread with @skip(if: false) directive', () => {
+    expectErrors(`
+      subscription MySubscription {
+        subscriptionField {
+          ...myFragment @skip(if: false) @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `).toDeepEqual([
+      {
+        locations: [{ column: 42, line: 4 }],
+        message:
+          'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
+      },
+    ]);
+  });
+  it('Defer fragment spread with @skip(if: $variable) directive', () => {
+    expectValid(`
+      subscription MySubscription($variable: Boolean) {
+        subscriptionField {
+          ...myFragment @skip(if: $variable) @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer fragment spread with @include directive', () => {
+    expectErrors(`
+      subscription MySubscription {
+        subscriptionField {
+          ...myFragment @include @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `).toDeepEqual([
+      {
+        locations: [{ column: 34, line: 4 }],
+        message:
+          'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
+      },
+    ]);
+  });
+  it('Defer fragment spread with @include(if: true) directive', () => {
+    expectErrors(`
+      subscription MySubscription {
+        subscriptionField {
+          ...myFragment @include(if: true) @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `).toDeepEqual([
+      {
+        locations: [{ column: 44, line: 4 }],
+        message:
+          'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
+      },
+    ]);
+  });
+  it('Defer fragment spread with @include(if: false) directive', () => {
+    expectValid(`
+      subscription MySubscription {
+        subscriptionField {
+          ...myFragment @include(if: false) @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer fragment spread with @include(if: $variable) directive', () => {
+    expectValid(`
+      subscription MySubscription ($variable: Boolean) {
+        subscriptionField {
+          ...myFragment @include(if: $variable) @defer
+        }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
   it('Stream on query field', () => {
     expectValid(`
       {
@@ -260,7 +374,10 @@ describe('Validate: Defer/Stream directive on valid operations', () => {
       {
         message:
           'Stream directive not supported on subscription operations. Disable `@stream` by setting the `if` argument to `false`.',
-        locations: [{ line: 8, column: 18 }],
+        locations: [
+          { line: 8, column: 18 },
+          { line: 4, column: 11 },
+        ],
       },
     ]);
   });
@@ -302,7 +419,38 @@ describe('Validate: Defer/Stream directive on valid operations', () => {
       {
         message:
           'Stream directive not supported on subscription operations. Disable `@stream` by setting the `if` argument to `false`.',
-        locations: [{ line: 15, column: 18 }],
+        locations: [
+          { line: 15, column: 18 },
+          { line: 10, column: 13 },
+        ],
+      },
+    ]);
+  });
+  it('Stream on subscription in document with fragment used multiple times', () => {
+    expectErrors(`
+      subscription MySubscription {
+        subscriptionField {
+          message {
+            ...myOtherFragment
+            ...myFragment
+          }
+        }
+      }
+      fragment myOtherFragment on Message {
+        ...myFragment
+      }
+      fragment myFragment on Message {
+        messages @stream
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Stream directive not supported on subscription operations. Disable `@stream` by setting the `if` argument to `false`.',
+        locations: [
+          { line: 14, column: 18 },
+          { line: 11, column: 9 },
+          { line: 5, column: 13 },
+        ],
       },
     ]);
   });

--- a/src/validation/__tests__/DeferStreamDirectiveOnValidOperationsRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveOnValidOperationsRule-test.ts
@@ -432,7 +432,7 @@ describe('Validate: Defer/Stream directive on valid operations', () => {
         subscriptionField {
           message {
             ...myOtherFragment
-            ...myFragment
+            ...myFragment  # not visited twice
           }
         }
       }

--- a/src/validation/__tests__/DeferStreamDirectiveOnValidOperationsRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveOnValidOperationsRule-test.ts
@@ -243,6 +243,60 @@ describe('Validate: Defer/Stream directive on valid operations', () => {
       },
     ]);
   });
+  it('Defer in fragment spread nested under @skip(if: true) directive', () => {
+    expectValid(`
+      subscription MySubscription {
+        subscriptionField {
+          ...outerFragment @skip(if: true)
+        }
+      }
+      fragment outerFragment on Message {
+        ...myFragment @defer
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer in fragment spread nested under @skip(if: false) directive', () => {
+    expectErrors(`
+      subscription MySubscription {
+        subscriptionField {
+          ...outerFragment @skip(if: false)
+        }
+      }
+      fragment outerFragment on Message {
+        ...myFragment @defer
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `).toDeepEqual([
+      {
+        locations: [
+          { column: 23, line: 8 },
+          { column: 11, line: 4 },
+        ],
+        message:
+          'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
+      },
+    ]);
+  });
+  it('Defer in fragment spread nested under @skip(if: $variable) directive', () => {
+    expectValid(`
+      subscription MySubscription($variable: Boolean) {
+        subscriptionField {
+          ...outerFragment @skip(if: $variable)
+        }
+      }
+      fragment outerFragment on Message {
+        ...myFragment @defer
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
   it('Defer fragment spread with @skip(if: $variable) directive', () => {
     expectValid(`
       subscription MySubscription($variable: Boolean) {
@@ -297,6 +351,60 @@ describe('Validate: Defer/Stream directive on valid operations', () => {
         subscriptionField {
           ...myFragment @include(if: false) @defer
         }
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer in fragment spread nested under @include(if: true) directive', () => {
+    expectErrors(`
+      subscription MySubscription {
+        subscriptionField {
+          ...outerFragment @include(if: true)
+        }
+      }
+      fragment outerFragment on Message {
+        ...myFragment @defer
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `).toDeepEqual([
+      {
+        locations: [
+          { column: 23, line: 8 },
+          { column: 11, line: 4 },
+        ],
+        message:
+          'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
+      },
+    ]);
+  });
+  it('Defer in fragment spread nested under @include(if: false) directive', () => {
+    expectValid(`
+      subscription MySubscription {
+        subscriptionField {
+          ...outerFragment @include(if: false)
+        }
+      }
+      fragment outerFragment on Message {
+        ...myFragment @defer
+      }
+      fragment myFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Defer in fragment spread nested under @include(if: $variable) directive', () => {
+    expectValid(`
+      subscription MySubscription($variable: Boolean) {
+        subscriptionField {
+          ...outerFragment @include(if: $variable)
+        }
+      }
+      fragment outerFragment on Message {
+        ...myFragment @defer
       }
       fragment myFragment on Message {
         body

--- a/src/validation/rules/DeferStreamDirectiveOnValidOperationsRule.ts
+++ b/src/validation/rules/DeferStreamDirectiveOnValidOperationsRule.ts
@@ -2,13 +2,20 @@
 
 import { GraphQLError } from '../../error/GraphQLError.ts';
 
-import type { DirectiveNode } from '../../language/ast.ts';
+import type {
+  DirectiveNode,
+  FragmentDefinitionNode,
+  FragmentSpreadNode,
+  SelectionSetNode,
+} from '../../language/ast.ts';
 import { OperationTypeNode } from '../../language/ast.ts';
 import { Kind } from '../../language/kinds.ts';
 import type { ASTVisitor } from '../../language/visitor.ts';
 
 import {
   GraphQLDeferDirective,
+  GraphQLIncludeDirective,
+  GraphQLSkipDirective,
   GraphQLStreamDirective,
 } from '../../type/directives.ts';
 
@@ -26,6 +33,49 @@ function ifArgumentCanBeFalse(node: DirectiveNode): boolean {
   } else if (ifArgument.value.kind !== Kind.VARIABLE) {
     return false;
   }
+  return true;
+}
+
+function canBeSkippedViaSkipDirective(node: DirectiveNode): boolean {
+  // @skip
+  // @skip(if: true)
+  const ifArgument = node.arguments?.find((arg) => arg.name.value === 'if');
+  if (!ifArgument) {
+    // no if argument on @skip, always skipped
+    return true;
+  }
+
+  if (ifArgument.value.kind === Kind.BOOLEAN) {
+    // If argument is a Static boolean
+    if (ifArgument.value.value) {
+      // always skipped
+      return true;
+    }
+    // Never skipped
+    return false;
+  }
+
+  // Can be skipped via variable
+  return true;
+}
+
+function canBeSkippedViaIncludeDirective(node: DirectiveNode): boolean {
+  const ifArgument = node.arguments?.find((arg) => arg.name.value === 'if');
+  if (!ifArgument) {
+    // no if argument on include, always included
+    return false;
+  }
+  if (ifArgument?.value.kind === Kind.BOOLEAN) {
+    // If argument is a Static boolean
+    if (ifArgument.value.value) {
+      // always included
+      return false;
+    }
+    // Never included
+    return true;
+  }
+
+  // Can be skipped via variable
   return true;
 }
 
@@ -88,48 +138,131 @@ function ifArgumentCanBeFalse(node: DirectiveNode): boolean {
 export function DeferStreamDirectiveOnValidOperationsRule(
   context: ValidationContext,
 ): ASTVisitor {
-  const fragmentsUsedOnSubscriptions = new Set<string>();
-
   return {
     OperationDefinition(operation) {
-      if (operation.operation === OperationTypeNode.SUBSCRIPTION) {
-        for (const fragment of context.getRecursivelyReferencedFragments(
-          operation,
-        )) {
-          fragmentsUsedOnSubscriptions.add(fragment.name.value);
-        }
+      if (operation.operation !== OperationTypeNode.SUBSCRIPTION) {
+        return;
       }
-    },
-    Directive(node, _key, _parent, _path, ancestors) {
-      const definitionNode = ancestors[2];
+      const document = context.getDocument();
+      const fragments = new Map<string, FragmentDefinitionNode>();
 
-      if (
-        'kind' in definitionNode &&
-        ((definitionNode.kind === Kind.FRAGMENT_DEFINITION &&
-          fragmentsUsedOnSubscriptions.has(definitionNode.name.value)) ||
-          (definitionNode.kind === Kind.OPERATION_DEFINITION &&
-            definitionNode.operation === OperationTypeNode.SUBSCRIPTION))
-      ) {
-        if (node.name.value === GraphQLDeferDirective.name) {
-          if (!ifArgumentCanBeFalse(node)) {
-            context.reportError(
-              new GraphQLError(
-                'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
-                { nodes: node },
-              ),
-            );
-          }
-        } else if (node.name.value === GraphQLStreamDirective.name) {
-          if (!ifArgumentCanBeFalse(node)) {
-            context.reportError(
-              new GraphQLError(
-                'Stream directive not supported on subscription operations. Disable `@stream` by setting the `if` argument to `false`.',
-                { nodes: node },
-              ),
-            );
-          }
+      for (const definition of document.definitions) {
+        if (definition.kind === Kind.FRAGMENT_DEFINITION) {
+          fragments.set(definition.name.value, definition);
         }
       }
+      const visitedFragments = new Set<string>();
+      forbidUnconditionalDeferStream({
+        context,
+        fragments,
+        selectionSet: operation.selectionSet,
+        parentNodes: [],
+        visitedFragments,
+      });
     },
   };
 }
+
+function forbidUnconditionalDeferStream({
+  context,
+  fragments,
+  selectionSet,
+  parentNodes,
+  visitedFragments,
+}: {
+  context: ValidationContext;
+  fragments: Map<string, FragmentDefinitionNode>;
+  selectionSet: SelectionSetNode;
+  parentNodes: Array<FragmentSpreadNode>;
+  visitedFragments: Set<string>;
+}) {
+  for (const selection of selectionSet.selections) {
+    const skip = selection.directives?.find(
+      (d) => d.name.value === GraphQLSkipDirective.name,
+    );
+    if (skip && canBeSkippedViaSkipDirective(skip)) {
+      continue;
+    }
+    const include = selection.directives?.find(
+      (d) => d.name.value === GraphQLIncludeDirective.name,
+    );
+    if (include && canBeSkippedViaIncludeDirective(include)) {
+      continue;
+    }
+    for (const directive of selection.directives ?? []) {
+      if (directive.name.value === GraphQLDeferDirective.name) {
+        if (!ifArgumentCanBeFalse(directive)) {
+          context.reportError(
+            new GraphQLError(
+              'Defer directive not supported on subscription operations. Disable `@defer` by setting the `if` argument to `false`.',
+              { nodes: [directive, ...parentNodes] },
+            ),
+          );
+        }
+      } else if (directive.name.value === GraphQLStreamDirective.name) {
+        if (!ifArgumentCanBeFalse(directive)) {
+          context.reportError(
+            new GraphQLError(
+              'Stream directive not supported on subscription operations. Disable `@stream` by setting the `if` argument to `false`.',
+              { nodes: [directive, ...parentNodes] },
+            ),
+          );
+        }
+      }
+    }
+    if (selection.kind === 'FragmentSpread') {
+      const fragmentName = selection.name.value;
+      if (visitedFragments.has(fragmentName)) {
+        continue;
+      }
+      visitedFragments.add(fragmentName);
+      const fragment = fragments.get(fragmentName);
+      if (fragment) {
+        forbidUnconditionalDeferStream({
+          context,
+          fragments,
+          parentNodes: [selection, ...parentNodes],
+          selectionSet: fragment?.selectionSet,
+          visitedFragments,
+        });
+      }
+    } else if (selection.selectionSet) {
+      forbidUnconditionalDeferStream({
+        context,
+        fragments,
+        selectionSet: selection.selectionSet,
+        parentNodes,
+        visitedFragments,
+      });
+    }
+  }
+}
+
+// - For each {selection} in {selectionSet}:
+//   - If {selection} provides the `@skip` directive, and the "if" argument on that
+//     directive is not the boolean value {true}:
+//     - Continue to the next {selection} in {selectionSet}.
+//   - If {selection} provides the `@include` directive, and the "if" argument on
+//     that directive is not the boolean value {false}:
+//     - Continue to the next {selection} in {selectionSet}.
+//   - For each {directive} on {selection}:
+//     - If {directive} is `@defer` or `@stream`:
+//       - Let {if} be the argument named "if" on {directive}.
+//       - {if} must be defined.
+//       - Let {argumentValue} be the value passed to {if}.
+//       - {argumentValue} must be a variable, or the boolean value "false".
+//   - If {selection} is a {FragmentSpread}:
+//     - Let {fragmentSpreadName} be the name of {selection}.
+//     - If {fragmentSpreadName} is in {visitedFragments}, continue with the next
+//       {selection} in {selectionSet}.
+//     - Add {fragmentSpreadName} to {visitedFragments}.
+//     - Let {fragment} be the Fragment in the current Document whose name is
+//       {fragmentSpreadName}.
+//     - Let {fragmentSelectionSet} be the selection set of {selection}.
+//     - {ForbidUnconditionalDeferStream(fragmentSelectionSet)}
+//   - If {selection} is an {InlineFragment}:
+//     - Let {fragmentSelectionSet} be the selection set of {selection}.
+//     - {ForbidUnconditionalDeferStream(fragmentSelectionSet)}
+//   - If {selection} is a {Field}:
+//     - Let {fieldSelectionSet} be the selection set of {selection}.
+//     - {ForbidUnconditionalDeferStream(fieldSelectionSet)}

--- a/src/validation/rules/DeferStreamDirectiveOnValidOperationsRule.ts
+++ b/src/validation/rules/DeferStreamDirectiveOnValidOperationsRule.ts
@@ -22,6 +22,8 @@ import {
 import type { ValidationContext } from '../ValidationContext.ts';
 
 function ifArgumentCanBeFalse(node: DirectiveNode): boolean {
+  // @defer(if: false) / @stream(if: false)
+  // @defer(if: $shouldDefer) / @stream(if: $shouldStream)
   const ifArgument = node.arguments?.find((arg) => arg.name.value === 'if');
   if (!ifArgument) {
     return false;
@@ -37,11 +39,12 @@ function ifArgumentCanBeFalse(node: DirectiveNode): boolean {
 }
 
 function canBeSkippedViaSkipDirective(node: DirectiveNode): boolean {
-  // @skip
   // @skip(if: true)
+  // @skip(if: $shouldSkip)
   const ifArgument = node.arguments?.find((arg) => arg.name.value === 'if');
   if (!ifArgument) {
-    // no if argument on @skip, always skipped
+    // Missing `if` is reported by ProvidedRequiredArgumentsRule. For this rule,
+    // treat malformed @skip as potentially skipped to avoid duplicate errors.
     return true;
   }
 
@@ -60,18 +63,21 @@ function canBeSkippedViaSkipDirective(node: DirectiveNode): boolean {
 }
 
 function canBeSkippedViaIncludeDirective(node: DirectiveNode): boolean {
+  // @include(if: false)
+  // @include(if: $shouldInclude)
   const ifArgument = node.arguments?.find((arg) => arg.name.value === 'if');
   if (!ifArgument) {
-    // no if argument on include, always included
+    // Missing `if` is reported by ProvidedRequiredArgumentsRule. For this rule,
+    // treat malformed @include as not skippable.
     return false;
   }
   if (ifArgument?.value.kind === Kind.BOOLEAN) {
     // If argument is a Static boolean
     if (ifArgument.value.value) {
-      // always included
+      // Never skipped
       return false;
     }
-    // Never included
+    // Always skipped
     return true;
   }
 
@@ -82,7 +88,7 @@ function canBeSkippedViaIncludeDirective(node: DirectiveNode): boolean {
 /**
  * Defer And Stream Directives Are Used On Valid Operations
  *
- * A GraphQL document is only valid if defer directives are not used on root mutation or subscription types.
+ * A GraphQL document is only valid if defer and stream directives are not used on root mutation or subscription types.
  * @param context - The validation context used while checking the document.
  * @returns A visitor that reports validation errors for this rule.
  * @example


### PR DESCRIPTION
Tracks all fragment spreads back to root usage

also properly handles skip/include on fragments