### PR TITLE
docs: fix Post_body example variable

### DIFF
--- a/website/pages/docs/going-to-production.mdx
+++ b/website/pages/docs/going-to-production.mdx
@@ -149,7 +149,7 @@ const postRepository = {
 // Resolver for the `Post.body` field:
 function Post_body(source, args, context, info) {
   // return the post body only if the user is the post's author
-  return postRepository.getBody({ user: context.user, post: obj })
+  return postRepository.getBody({ user: context.user, post: source })
 }
 ```
 


### PR DESCRIPTION
## Summary

- replace the undefined `obj` variable with `source` in the `Post_body` resolver example
- keep the change scoped to the production guide docs example only

## Why

The current snippet defines `function Post_body(source, args, context, info)` but passes `post: obj`, which is undefined and causes the copied example to fail immediately.

Closes #4765.

## Validation

- `npx --yes prettier@2.6.2 --check website/pages/docs/going-to-production.mdx`
- `git diff --check`