### PR TITLE
refactor: extract ExecutionArgs types to separate file

### DIFF
--- a/src/execution/ExecutionArgs.ts
+++ b/src/execution/ExecutionArgs.ts
@@ -1,0 +1,119 @@
+/** @category Execution */
+
+import type { Maybe } from '../jsutils/Maybe.ts';
+import type { ObjMap } from '../jsutils/ObjMap.ts';
+
+import type {
+  DocumentNode,
+  FragmentDefinitionNode,
+  OperationDefinitionNode,
+  SubscriptionOperationDefinitionNode,
+} from '../language/ast.ts';
+
+import type {
+  GraphQLFieldResolver,
+  GraphQLTypeResolver,
+} from '../type/definition.ts';
+import type { GraphQLSchema } from '../type/schema.ts';
+
+import type { FragmentDetails } from './collectFields.ts';
+import type { VariableValues } from './values.ts';
+
+/** Arguments accepted by execute and executeSync. */
+export interface ExecutionArgs {
+  /** The schema used for validation or execution. */
+  schema: GraphQLSchema;
+  /** The parsed GraphQL document to execute. */
+  document: DocumentNode;
+  /** Initial root value passed to the operation. */
+  rootValue?: unknown;
+  /** Application context value passed to every resolver. */
+  contextValue?: unknown;
+  /** Runtime variable values keyed by variable name. */
+  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
+  /** Name of the operation to execute when the document contains multiple operations. */
+  operationName?: Maybe<string>;
+  /** Resolver used when a field does not define its own resolver. */
+  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  /** Resolver used when an abstract type does not define its own resolver. */
+  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
+  /** Resolver used for the root subscription field. */
+  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
+  /** Whether suggestion text should be omitted from request errors. */
+  hideSuggestions?: Maybe<boolean>;
+  /** AbortSignal used to cancel execution. */
+  abortSignal?: Maybe<AbortSignal>;
+  /** Whether incremental execution may begin eligible work early. */
+  enableEarlyExecution?: Maybe<boolean>;
+  /** Execution hooks invoked during this operation. */
+  hooks?: Maybe<ExecutionHooks>;
+  /** Additional execution options. */
+  options?: {
+    /**
+     * Set the maximum number of errors allowed for coercing (defaults to 50).
+     *
+     * @internal
+     */
+    maxCoercionErrors?: number;
+  };
+}
+
+/**
+ * Data that must be available at all points during query execution.
+ *
+ * Namely, schema of the type system that is currently executing,
+ * and the fragments defined in the query document
+ */
+export interface ValidatedExecutionArgs {
+  /** Schema used for execution. */
+  schema: GraphQLSchema;
+  // TODO: consider deprecating/removing fragmentDefinitions if/when fragment
+  // arguments are officially supported and/or the full fragment details are
+  // exposed within GraphQLResolveInfo.
+  /** Fragment definitions keyed by fragment name. */
+  fragmentDefinitions: ObjMap<FragmentDefinitionNode>;
+  /** Fragment details keyed by fragment name. */
+  fragments: ObjMap<FragmentDetails>;
+  /** Root value passed to the operation. */
+  rootValue: unknown;
+  /** Application context value passed to every resolver. */
+  contextValue: unknown;
+  /** Operation definition selected for execution. */
+  operation: OperationDefinitionNode;
+  /** Operation variable values with source metadata and coerced runtime values. */
+  variableValues: VariableValues;
+  /** Resolver used for fields without an explicit resolver. */
+  fieldResolver: GraphQLFieldResolver<any, any>;
+  /** Resolver used for abstract types without an explicit type resolver. */
+  typeResolver: GraphQLTypeResolver<any, any>;
+  /** Resolver used for subscription fields without an explicit subscribe resolver. */
+  subscribeFieldResolver: GraphQLFieldResolver<any, any>;
+  /** Whether suggestion text should be omitted from execution errors. */
+  hideSuggestions: boolean;
+  /** Whether execution should use error propagation. */
+  errorPropagation: boolean;
+  /** External signal that may abort execution. */
+  externalAbortSignal: AbortSignal | undefined;
+  /** Whether incremental execution may begin eligible work early. */
+  enableEarlyExecution: boolean;
+  /** Execution hooks supplied by the caller. */
+  hooks: ExecutionHooks | undefined;
+}
+
+/** Validated execution arguments for a subscription operation. */
+export interface ValidatedSubscriptionArgs extends ValidatedExecutionArgs {
+  /** Subscription operation definition selected for execution. */
+  operation: SubscriptionOperationDefinitionNode;
+}
+
+/** Information passed to hooks after asynchronous execution work has finished. */
+export interface AsyncWorkFinishedInfo {
+  /** Validated execution arguments for the operation that finished async work. */
+  validatedExecutionArgs: ValidatedExecutionArgs;
+}
+
+/** Optional hooks invoked during GraphQL execution. */
+export interface ExecutionHooks {
+  /** Called after all tracked asynchronous execution work has settled. */
+  asyncWorkFinished?: (info: AsyncWorkFinishedInfo) => void;
+}

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -19,24 +19,17 @@ import type { GraphQLFormattedError } from '../error/GraphQLError.ts';
 import { GraphQLError } from '../error/GraphQLError.ts';
 import { locatedError } from '../error/locatedError.ts';
 
-import type {
-  FieldNode,
-  FragmentDefinitionNode,
-  OperationDefinitionNode,
-  SubscriptionOperationDefinitionNode,
-} from '../language/ast.ts';
+import type { FieldNode } from '../language/ast.ts';
 import { OperationTypeNode } from '../language/ast.ts';
 
 import type {
   GraphQLAbstractType,
-  GraphQLFieldResolver,
   GraphQLLeafType,
   GraphQLList,
   GraphQLObjectType,
   GraphQLOutputType,
   GraphQLResolveInfo,
   GraphQLResolveInfoHelpers,
-  GraphQLTypeResolver,
 } from '../type/definition.ts';
 import {
   isAbstractType,
@@ -53,7 +46,6 @@ import { withCancellation } from './cancellablePromise.ts';
 import type {
   DeferUsage,
   FieldDetailsList,
-  FragmentDetails,
   GroupedFieldSet,
 } from './collectFields.ts';
 import {
@@ -63,12 +55,11 @@ import {
 import { collectIteratorPromises } from './collectIteratorPromises.ts';
 import type { SharedExecutionContext } from './createSharedExecutionContext.ts';
 import { createSharedExecutionContext } from './createSharedExecutionContext.ts';
+import type { ValidatedExecutionArgs } from './ExecutionArgs.ts';
 import type { StreamUsage } from './getStreamUsage.ts';
 import { getStreamUsage as _getStreamUsage } from './getStreamUsage.ts';
-import type { ExecutionHooks } from './hooks.ts';
 import { runAsyncWorkFinishedHook } from './hooks.ts';
 import { returnIteratorCatchingErrors } from './returnIteratorCatchingErrors.ts';
-import type { VariableValues } from './values.ts';
 import { getArgumentValues } from './values.ts';
 
 /* eslint-disable max-params */
@@ -96,54 +87,6 @@ import { getArgumentValues } from './values.ts';
  *
  * @internal
  */
-
-/**
- * Data that must be available at all points during query execution.
- *
- * Namely, schema of the type system that is currently executing,
- * and the fragments defined in the query document
- */
-export interface ValidatedExecutionArgs {
-  /** Schema used for execution. */
-  schema: GraphQLSchema;
-  // TODO: consider deprecating/removing fragmentDefinitions if/when fragment
-  // arguments are officially supported and/or the full fragment details are
-  // exposed within GraphQLResolveInfo.
-  /** Fragment definitions keyed by fragment name. */
-  fragmentDefinitions: ObjMap<FragmentDefinitionNode>;
-  /** Fragment details keyed by fragment name. */
-  fragments: ObjMap<FragmentDetails>;
-  /** Root value passed to the operation. */
-  rootValue: unknown;
-  /** Application context value passed to every resolver. */
-  contextValue: unknown;
-  /** Operation definition selected for execution. */
-  operation: OperationDefinitionNode;
-  /** Operation variable values with source metadata and coerced runtime values. */
-  variableValues: VariableValues;
-  /** Resolver used for fields without an explicit resolver. */
-  fieldResolver: GraphQLFieldResolver<any, any>;
-  /** Resolver used for abstract types without an explicit type resolver. */
-  typeResolver: GraphQLTypeResolver<any, any>;
-  /** Resolver used for subscription fields without an explicit subscribe resolver. */
-  subscribeFieldResolver: GraphQLFieldResolver<any, any>;
-  /** Whether suggestion text should be omitted from execution errors. */
-  hideSuggestions: boolean;
-  /** Whether execution should use error propagation. */
-  errorPropagation: boolean;
-  /** External signal that may abort execution. */
-  externalAbortSignal: AbortSignal | undefined;
-  /** Whether incremental execution may begin eligible work early. */
-  enableEarlyExecution: boolean;
-  /** Execution hooks supplied by the caller. */
-  hooks: ExecutionHooks | undefined;
-}
-
-/** Validated execution arguments for a subscription operation. */
-export interface ValidatedSubscriptionArgs extends ValidatedExecutionArgs {
-  /** Subscription operation definition selected for execution. */
-  operation: SubscriptionOperationDefinitionNode;
-}
 
 /**
  * A memoized collection of relevant subfields with regard to the return

--- a/src/execution/__tests__/executor-test.ts
+++ b/src/execution/__tests__/executor-test.ts
@@ -33,7 +33,6 @@ import {
 import { GraphQLSchema } from '../../type/schema.ts';
 
 import type { FieldDetailsList } from '../collectFields.ts';
-import type { ExecutionArgs } from '../execute.ts';
 import {
   execute as executeThrowingOnIncremental,
   executeIgnoringIncremental,
@@ -41,6 +40,7 @@ import {
   experimentalExecuteIncrementally,
   validateExecutionArgs,
 } from '../execute.ts';
+import type { ExecutionArgs } from '../ExecutionArgs.ts';
 import type { ExecutionResult } from '../Executor.ts';
 import { collectSubfields, getStreamUsage } from '../Executor.ts';
 import { legacyExecuteIncrementally } from '../legacyIncremental/legacyExecuteIncrementally.ts';

--- a/src/execution/__tests__/hooks-test.ts
+++ b/src/execution/__tests__/hooks-test.ts
@@ -20,9 +20,12 @@ import { GraphQLSchema } from '../../type/schema.ts';
 import { buildSchema } from '../../utilities/buildASTSchema.ts';
 
 import type { SharedExecutionContext } from '../createSharedExecutionContext.ts';
-import type { ExecutionArgs } from '../execute.ts';
 import { execute, experimentalExecuteIncrementally } from '../execute.ts';
-import type { ExecutionResult, ValidatedExecutionArgs } from '../Executor.ts';
+import type {
+  ExecutionArgs,
+  ValidatedExecutionArgs,
+} from '../ExecutionArgs.ts';
+import type { ExecutionResult } from '../Executor.ts';
 import { runAsyncWorkFinishedHook } from '../hooks.ts';
 
 const executeHookSchema = new GraphQLSchema({

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -22,7 +22,6 @@ import {
 } from '../../type/scalars.ts';
 import { GraphQLSchema } from '../../type/schema.ts';
 
-import type { ExecutionArgs } from '../execute.ts';
 import {
   createSourceEventStream,
   executeSubscriptionEvent,
@@ -30,6 +29,7 @@ import {
   subscribe,
   validateSubscriptionArgs,
 } from '../execute.ts';
+import type { ExecutionArgs } from '../ExecutionArgs.ts';
 import type { ExecutionResult } from '../Executor.ts';
 
 import { SimplePubSub } from './simplePubSub.ts';

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -4,7 +4,6 @@ import { inspect } from '../jsutils/inspect.ts';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable.ts';
 import { isObjectLike } from '../jsutils/isObjectLike.ts';
 import { isPromise, isPromiseLike } from '../jsutils/isPromise.ts';
-import type { Maybe } from '../jsutils/Maybe.ts';
 import type { ObjMap } from '../jsutils/ObjMap.ts';
 import { addPath, pathToArray } from '../jsutils/Path.ts';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue.ts';
@@ -14,7 +13,6 @@ import { GraphQLError } from '../error/GraphQLError.ts';
 import { locatedError } from '../error/locatedError.ts';
 
 import type {
-  DocumentNode,
   FieldNode,
   FragmentDefinitionNode,
   OperationDefinitionNode,
@@ -28,7 +26,6 @@ import type {
   GraphQLTypeResolver,
 } from '../type/index.ts';
 import { assertValidSchema } from '../type/index.ts';
-import type { GraphQLSchema } from '../type/schema.ts';
 
 import { buildResolveInfo } from './buildResolveInfo.ts';
 import { cancellablePromise } from './cancellablePromise.ts';
@@ -36,14 +33,14 @@ import type { FieldDetailsList, FragmentDetails } from './collectFields.ts';
 import { collectFields } from './collectFields.ts';
 import { createSharedExecutionContext } from './createSharedExecutionContext.ts';
 import type {
-  ExecutionResult,
+  ExecutionArgs,
   ValidatedExecutionArgs,
   ValidatedSubscriptionArgs,
-} from './Executor.ts';
+} from './ExecutionArgs.ts';
+import type { ExecutionResult } from './Executor.ts';
 import { Executor } from './Executor.ts';
 import { ExecutorThrowingOnIncremental } from './ExecutorThrowingOnIncremental.ts';
 import { getVariableSignature } from './getVariableSignature.ts';
-import type { ExecutionHooks } from './hooks.ts';
 import type { ExperimentalIncrementalExecutionResults } from './incremental/IncrementalExecutor.ts';
 import { IncrementalExecutor } from './incremental/IncrementalExecutor.ts';
 import { mapAsyncIterable } from './mapAsyncIterable.ts';
@@ -572,45 +569,6 @@ export function createSourceEventStream(
   } catch (error) {
     return { errors: [ensureGraphQLError(error)] };
   }
-}
-
-/** Arguments accepted by execute and executeSync. */
-export interface ExecutionArgs {
-  /** The schema used for validation or execution. */
-  schema: GraphQLSchema;
-  /** The parsed GraphQL document to execute. */
-  document: DocumentNode;
-  /** Initial root value passed to the operation. */
-  rootValue?: unknown;
-  /** Application context value passed to every resolver. */
-  contextValue?: unknown;
-  /** Runtime variable values keyed by variable name. */
-  variableValues?: Maybe<{ readonly [variable: string]: unknown }>;
-  /** Name of the operation to execute when the document contains multiple operations. */
-  operationName?: Maybe<string>;
-  /** Resolver used when a field does not define its own resolver. */
-  fieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  /** Resolver used when an abstract type does not define its own resolver. */
-  typeResolver?: Maybe<GraphQLTypeResolver<any, any>>;
-  /** Resolver used for the root subscription field. */
-  subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>;
-  /** Whether suggestion text should be omitted from request errors. */
-  hideSuggestions?: Maybe<boolean>;
-  /** AbortSignal used to cancel execution. */
-  abortSignal?: Maybe<AbortSignal>;
-  /** Whether incremental execution may begin eligible work early. */
-  enableEarlyExecution?: Maybe<boolean>;
-  /** Execution hooks invoked during this operation. */
-  hooks?: Maybe<ExecutionHooks>;
-  /** Additional execution options. */
-  options?: {
-    /**
-     * Set the maximum number of errors allowed for coercing (defaults to 50).
-     *
-     * @internal
-     */
-    maxCoercionErrors?: number;
-  };
 }
 
 /**

--- a/src/execution/getStreamUsage.ts
+++ b/src/execution/getStreamUsage.ts
@@ -5,7 +5,7 @@ import { OperationTypeNode } from '../language/ast.ts';
 import { GraphQLStreamDirective } from '../type/directives.ts';
 
 import type { FieldDetailsList } from './collectFields.ts';
-import type { ValidatedExecutionArgs } from './Executor.ts';
+import type { ValidatedExecutionArgs } from './ExecutionArgs.ts';
 import { getDirectiveValues } from './values.ts';
 
 /** @internal */

--- a/src/execution/hooks.ts
+++ b/src/execution/hooks.ts
@@ -1,19 +1,10 @@
 /** @category Execution */
 
 import type { SharedExecutionContext } from './createSharedExecutionContext.ts';
-import type { ValidatedExecutionArgs } from './Executor.ts';
-
-/** Information passed to hooks after asynchronous execution work has finished. */
-export interface AsyncWorkFinishedInfo {
-  /** Validated execution arguments for the operation that finished async work. */
-  validatedExecutionArgs: ValidatedExecutionArgs;
-}
-
-/** Optional hooks invoked during GraphQL execution. */
-export interface ExecutionHooks {
-  /** Called after all tracked asynchronous execution work has settled. */
-  asyncWorkFinished?: (info: AsyncWorkFinishedInfo) => void;
-}
+import type {
+  AsyncWorkFinishedInfo,
+  ValidatedExecutionArgs,
+} from './ExecutionArgs.ts';
 
 function runHookSafely<TInfo>(hook: (info: TInfo) => void, info: TInfo): void {
   try {

--- a/src/execution/incremental/IncrementalExecutor.ts
+++ b/src/execution/incremental/IncrementalExecutor.ts
@@ -33,11 +33,8 @@ import type {
 import { collectSubfields as _collectSubfields } from '../collectFields.ts';
 import { collectIteratorPromises } from '../collectIteratorPromises.ts';
 import type { SharedExecutionContext } from '../createSharedExecutionContext.ts';
-import type {
-  ExecutionResult,
-  FormattedExecutionResult,
-  ValidatedExecutionArgs,
-} from '../Executor.ts';
+import type { ValidatedExecutionArgs } from '../ExecutionArgs.ts';
+import type { ExecutionResult, FormattedExecutionResult } from '../Executor.ts';
 import { Executor } from '../Executor.ts';
 import type { StreamUsage } from '../getStreamUsage.ts';
 import { returnIteratorCatchingErrors } from '../returnIteratorCatchingErrors.ts';

--- a/src/execution/index.ts
+++ b/src/execution/index.ts
@@ -26,16 +26,16 @@ export {
   legacyExecuteIncrementally,
   legacyExecuteRootSelectionSet,
 } from './legacyIncremental/legacyExecuteIncrementally.ts';
-export type { ExecutionArgs, RootSelectionSetExecutor } from './execute.ts';
-
-export type { AsyncWorkFinishedInfo, ExecutionHooks } from './hooks.ts';
-
 export type {
+  AsyncWorkFinishedInfo,
+  ExecutionArgs,
+  ExecutionHooks,
   ValidatedExecutionArgs,
   ValidatedSubscriptionArgs,
-  ExecutionResult,
-  FormattedExecutionResult,
-} from './Executor.ts';
+} from './ExecutionArgs.ts';
+export type { RootSelectionSetExecutor } from './execute.ts';
+
+export type { ExecutionResult, FormattedExecutionResult } from './Executor.ts';
 
 export type {
   ExperimentalIncrementalExecutionResults,

--- a/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
+++ b/src/execution/legacyIncremental/legacyExecuteIncrementally.ts
@@ -2,9 +2,12 @@
 
 import type { PromiseOrValue } from '../../jsutils/PromiseOrValue.ts';
 
-import type { ExecutionArgs } from '../execute.ts';
 import { validateExecutionArgs } from '../execute.ts';
-import type { ExecutionResult, ValidatedExecutionArgs } from '../Executor.ts';
+import type {
+  ExecutionArgs,
+  ValidatedExecutionArgs,
+} from '../ExecutionArgs.ts';
+import type { ExecutionResult } from '../Executor.ts';
 
 import type { LegacyExperimentalIncrementalExecutionResults } from './BranchingIncrementalExecutor.ts';
 import { BranchingIncrementalExecutor } from './BranchingIncrementalExecutor.ts';

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -16,7 +16,7 @@ import { validateSchema } from './type/validate.ts';
 import type { ValidationOptions } from './validation/validate.ts';
 import type { ValidationRule } from './validation/ValidationContext.ts';
 
-import type { ExecutionArgs } from './execution/execute.ts';
+import type { ExecutionArgs } from './execution/ExecutionArgs.ts';
 import type { ExecutionResult } from './execution/Executor.ts';
 
 import type { GraphQLHarness } from './harness.ts';


### PR DESCRIPTION
BREAKING CHANGE only for those doing deep exports which although we don't officially support....