### PR TITLE
test: restore GraphQLError no-stack coverage

### DIFF
--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -72,6 +72,7 @@ describe('GraphQLError', () => {
 
   it('creates new stack if original error has no stack', () => {
     const original = new Error('original');
+    delete original.stack;
     const e = new GraphQLError('msg', { originalError: original });
 
     expect(e).to.include({


### PR DESCRIPTION
This test originally used a plain object without a stack. PR #1582 changed it to new Error('original') while enabling Flow typing, which meant the test no longer exercised the no-stack fallback path.

This PR deletes the generated stack before constructing GraphQLError so the test can synthetically cover the intended branch while still passing type check.