### PR TITLE
fix: remove unnecessary native promise coercion

### DIFF
--- a/src/execution/AsyncWorkTracker.ts
+++ b/src/execution/AsyncWorkTracker.ts
@@ -2,15 +2,15 @@ import { isPromiseLike } from '../jsutils/isPromise.ts';
 
 /** @internal */
 export class AsyncWorkTracker {
-  pendingAsyncWork: Set<Promise<void>>;
+  pendingAsyncWork: Set<PromiseLike<void>>;
 
   constructor() {
-    this.pendingAsyncWork = new Set<Promise<void>>();
+    this.pendingAsyncWork = new Set();
   }
 
   add(promiseLike: PromiseLike<unknown>): void {
     const pendingAsyncWork = this.pendingAsyncWork;
-    const promiseToSettle = Promise.resolve(promiseLike).then(
+    const promiseToSettle = promiseLike.then(
       () => {
         pendingAsyncWork.delete(promiseToSettle);
       },

--- a/src/execution/Executor.ts
+++ b/src/execution/Executor.ts
@@ -1173,7 +1173,7 @@ export class Executor<
     const runtimeType = resolveTypeFn(result, contextValue, info, returnType);
 
     if (isPromiseLike(runtimeType)) {
-      return Promise.resolve(runtimeType).then((resolvedRuntimeType) => {
+      return runtimeType.then((resolvedRuntimeType) => {
         if (this.aborted) {
           throw new Error('Aborted!');
         }
@@ -1285,7 +1285,7 @@ export class Executor<
       );
 
       if (isPromiseLike(isTypeOf)) {
-        return Promise.resolve(isTypeOf).then((resolvedIsTypeOf) => {
+        return isTypeOf.then((resolvedIsTypeOf) => {
           if (this.aborted) {
             throw new Error('Aborted!');
           }


### PR DESCRIPTION
retain one for api simplification in executeSubscription, we'd rather return a Promise than a PromiseLike