### PR TITLE
chore(release): v17.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "17.0.0-beta.1",
+  "version": "17.0.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "17.0.0-beta.1",
+      "version": "17.0.0-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "17.0.0-beta.1",
+  "version": "17.0.0-beta.2",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 // automatically updated by "npm version" command.
 
 /** A string containing the version of the GraphQL.js library */
-export const version = '17.0.0-beta.1' as string;
+export const version = '17.0.0-beta.2' as string;
 
 /** An object containing the components of the GraphQL.js version string */
 export const versionInfo: Readonly<{
@@ -16,5 +16,5 @@ export const versionInfo: Readonly<{
   major: 17,
   minor: 0,
   patch: 0,
-  preReleaseTag: 'beta.1',
+  preReleaseTag: 'beta.2',
 });


### PR DESCRIPTION
## v17.0.0-beta.2 (2026-06-02)

#### Breaking Change 💥
* [#4751](https://github.com/graphql/graphql-js/pull/4751) build: strip private discriminator from package types ([@yaacovCR](https://github.com/yaacovCR))
* [#4752](https://github.com/graphql/graphql-js/pull/4752) fix: discriminate between GraphQLNonNull and GraphQLList ([@yaacovCR](https://github.com/yaacovCR))
* [#4770](https://github.com/graphql/graphql-js/pull/4770) refactor: extract ExecutionArgs types to separate file ([@yaacovCR](https://github.com/yaacovCR))

#### New Feature 🚀
* [#4485](https://github.com/graphql/graphql-js/pull/4485) Adopt Error.cause in favor of originalError ([@Malien](https://github.com/Malien))

#### Bug Fix 🐞
* [#4739](https://github.com/graphql/graphql-js/pull/4739) chore(tests): add test for directive extensions without flag enabled (#4738) ([@yaacovCR](https://github.com/yaacovCR))
* [#4743](https://github.com/graphql/graphql-js/pull/4743) api: export VariableValues ([@yaacovCR](https://github.com/yaacovCR))
* [#4744](https://github.com/graphql/graphql-js/pull/4744) api: export ValidationOptions ([@yaacovCR](https://github.com/yaacovCR))
* [#4745](https://github.com/graphql/graphql-js/pull/4745) api: export SchemaChange ([@yaacovCR](https://github.com/yaacovCR))
* [#4746](https://github.com/graphql/graphql-js/pull/4746) api: export defer and stream validation rules ([@yaacovCR](https://github.com/yaacovCR))
* [#4747](https://github.com/graphql/graphql-js/pull/4747) api: export legacy incremental execution functions and helpers ([@yaacovCR](https://github.com/yaacovCR))
* [#4753](https://github.com/graphql/graphql-js/pull/4753) fix(build): development declaration stubs ([@yaacovCR](https://github.com/yaacovCR))
* [#4773](https://github.com/graphql/graphql-js/pull/4773) fix: FragmentVariableValueSource.value can be non-constant ([@yaacovCR](https://github.com/yaacovCR))
* [#4775](https://github.com/graphql/graphql-js/pull/4775) fix: remove unnecessary native promise coercion ([@yaacovCR](https://github.com/yaacovCR))

#### Docs 📝
<details>
<summary> 3 PRs were merged </summary>

* [#4742](https://github.com/graphql/graphql-js/pull/4742) docs: add v17 API docs lint coverage ([@yaacovCR](https://github.com/yaacovCR))
* [#4756](https://github.com/graphql/graphql-js/pull/4756) docs: hide private internals `schema.__validationErrors` and `inputValue._memoizedCoercedDefaultValue` ([@yaacovCR](https://github.com/yaacovCR))
* [#4758](https://github.com/graphql/graphql-js/pull/4758) docs: fix inline examples, deprecation descriptions, type category ([@yaacovCR](https://github.com/yaacovCR)) </details>

#### Polish 💅
* [#4774](https://github.com/graphql/graphql-js/pull/4774) test: restore GraphQLError no-stack coverage ([@yaacovCR](https://github.com/yaacovCR))

#### Internal 🏠
<details>
<summary> 3 PRs were merged </summary>

* [#4771](https://github.com/graphql/graphql-js/pull/4771) internal: drop node 20 integration tests ([@yaacovCR](https://github.com/yaacovCR))
* [#4772](https://github.com/graphql/graphql-js/pull/4772) internal: add deno 2.8.x to CI ([@yaacovCR](https://github.com/yaacovCR))
* [#4777](https://github.com/graphql/graphql-js/pull/4777) fix: preserve generated version documentation ([@yaacovCR](https://github.com/yaacovCR)) </details>

#### Committers: 2
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))
* Yaroslav Petryk([@Malien](https://github.com/Malien))