### PR TITLE
chore(release): v16.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "16.14.0",
+  "version": "16.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "16.14.0",
+      "version": "16.14.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "16.14.0",
+  "version": "16.14.1",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,12 +4,12 @@
 // automatically updated by "npm version" command.
 
 /** A string containing the version of the GraphQL.js library */
-export const version = '16.14.0' as string;
+export const version = '16.14.1' as string;
 
 /** An object containing the components of the GraphQL.js version string */
 export const versionInfo = Object.freeze({
   major: 16 as number,
   minor: 14 as number,
-  patch: 0 as number,
+  patch: 1 as number,
   preReleaseTag: null as string | null,
 });


### PR DESCRIPTION
## v16.14.1 (2026-06-02)

#### Docs 📝
<details>
<summary> 9 PRs were merged </summary>

* [#4737](https://github.com/graphql/graphql-js/pull/4737) docs: refresh upgrade guide and v17 topics ([@yaacovCR](https://github.com/yaacovCR))
* [#4741](https://github.com/graphql/graphql-js/pull/4741) docs: add v16 API docs lint coverage ([@yaacovCR](https://github.com/yaacovCR))
* [#4748](https://github.com/graphql/graphql-js/pull/4748) docs: update banner ([@yaacovCR](https://github.com/yaacovCR))
* [#4750](https://github.com/graphql/graphql-js/pull/4750) docs: use api docs generated from inline jsdoc comments ([@yaacovCR](https://github.com/yaacovCR))
* [#4754](https://github.com/graphql/graphql-js/pull/4754) docs: update website caniuse-lite data ([@yaacovCR](https://github.com/yaacovCR))
* [#4755](https://github.com/graphql/graphql-js/pull/4755) docs: hide internal type member __validationErrors ([@yaacovCR](https://github.com/yaacovCR))
* [#4757](https://github.com/graphql/graphql-js/pull/4757) docs: fix inline examples, deprecation descriptions, type category ([@yaacovCR](https://github.com/yaacovCR))
* [#4759](https://github.com/graphql/graphql-js/pull/4759) docs: fix static export redirect config ([@yaacovCR](https://github.com/yaacovCR))
* [#4767](https://github.com/graphql/graphql-js/pull/4767) docs: fix Post_body example variable ([@fallintoplace](https://github.com/fallintoplace)) </details>

#### Polish 💅
* [#4738](https://github.com/graphql/graphql-js/pull/4738) chore(tests): add test for directive extensions without flag enabled ([@yaacovCR](https://github.com/yaacovCR))

#### Internal 🏠
* [#4778](https://github.com/graphql/graphql-js/pull/4778) fix: generated version documentation ([@yaacovCR](https://github.com/yaacovCR))

#### Committers: 2
* Minh Vu([@fallintoplace](https://github.com/fallintoplace))
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))