### PR TITLE
fix: do not copy over stack from error cause

### DIFF
--- a/src/error/GraphQLError.ts
+++ b/src/error/GraphQLError.ts
@@ -167,10 +167,8 @@ export class GraphQLError extends Error {
 
     this.name = 'GraphQLError';
     this.path = path ?? undefined;
-    const underlyingError:
-      | (Error & { readonly extensions?: unknown })
-      | undefined =
-      originalError ?? (errorCause instanceof Error ? errorCause : undefined);
+    const underlyingError: typeof originalError =
+      originalError ?? (cause instanceof Error ? cause : undefined);
     this.originalError = underlyingError;
 
     // Compute list of blame nodes.
@@ -214,9 +212,13 @@ export class GraphQLError extends Error {
     });
 
     // Include (non-enumerable) stack trace.
-    if (underlyingError?.stack != null) {
+    // Do not copy over the stack trace of the Error.cause, since the tooling
+    // already nicely prints/reports the cause chains.
+    // Preserve the copy-over behavior of the `originalError`, since users may
+    // expect it to work the way it did originally.
+    if (originalError?.stack != null) {
       Object.defineProperty(this, 'stack', {
-        value: underlyingError.stack,
+        value: originalError.stack,
         writable: true,
         configurable: true,
       });

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -63,7 +63,7 @@ describe('GraphQLError', () => {
     ]);
   });
 
-  it('uses the stack of cause when possible', () => {
+  it('does not copy over the stack of cause', () => {
     const original = new Error('original');
     const e = new GraphQLError('msg', {
       cause: original,
@@ -72,9 +72,9 @@ describe('GraphQLError', () => {
     expect(e).to.include({
       name: 'GraphQLError',
       message: 'msg',
-      stack: original.stack,
       cause: original,
     });
+    expect(e.stack).to.not.equal(original.stack);
   });
 
   it('uses the stack of an original error via originalError', () => {
@@ -107,7 +107,6 @@ describe('GraphQLError', () => {
     expect(e).to.deep.include({
       name: 'GraphQLError',
       message: 'msg',
-      stack: cause.stack,
       cause,
       originalError: cause,
       extensions: { original: 'extensions' },
@@ -136,19 +135,6 @@ describe('GraphQLError', () => {
       originalError,
       stack: originalError.stack,
     });
-  });
-
-  it('creates new stack if cause has no stack', () => {
-    const original = new Error('original');
-    delete original.stack;
-    const e = new GraphQLError('msg', { originalError: original });
-
-    expect(e).to.include({
-      name: 'GraphQLError',
-      message: 'msg',
-      cause: original,
-    });
-    expect(e.stack).to.be.a('string');
   });
 
   it('creates new stack if original error has no stack', () => {

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -137,6 +137,20 @@ describe('GraphQLError', () => {
     });
   });
 
+  it('creates new stack if cause has no stack', () => {
+    const cause = new Error('cause');
+    delete cause.stack;
+    const e = new GraphQLError('msg', { cause });
+
+    expect(e).to.include({
+      name: 'GraphQLError',
+      message: 'msg',
+      cause,
+      originalError: cause,
+    });
+    expect(e.stack).to.be.a('string');
+  });
+
   it('creates new stack if original error has no stack', () => {
     const original = new Error('original');
     delete original.stack;

--- a/src/error/__tests__/GraphQLError-test.ts
+++ b/src/error/__tests__/GraphQLError-test.ts
@@ -1,4 +1,5 @@
 import { describe, it } from 'node:test';
+import { inspect as nodeInspect } from 'node:util';
 
 import { assert, expect } from 'chai';
 
@@ -64,10 +65,17 @@ describe('GraphQLError', () => {
   });
 
   it('does not copy over the stack of cause', () => {
-    const original = new Error('original');
+    function createOriginalError(): Error {
+      return new Error('original');
+    }
+    const original = createOriginalError();
     const e = new GraphQLError('msg', {
       cause: original,
     });
+    const originalStackFrame = original.stack
+      ?.split('\n')
+      .find((line) => line.includes('createOriginalError'));
+    assert(originalStackFrame != null);
 
     expect(e).to.include({
       name: 'GraphQLError',
@@ -75,6 +83,10 @@ describe('GraphQLError', () => {
       cause: original,
     });
     expect(e.stack).to.not.equal(original.stack);
+
+    const inspectedError = nodeInspect(e);
+    expect(inspectedError).to.include('[cause]: Error: original');
+    expect(inspectedError).to.include(originalStackFrame.trim());
   });
 
   it('uses the stack of an original error via originalError', () => {


### PR DESCRIPTION
I've authored #4485 long time ago. Since that PR sat there for a while, I didn't get a chance to amend the design to not copy over the stack from the `cause`. 

Copying over the stack will just double up the same stack trace twice in the reporting tooling / console logs.