### PR TITLE
docs: remove extra asterisks from single line jsdoc comments

### DIFF
--- a/website/generate-api.js
+++ b/website/generate-api.js
@@ -3094,7 +3094,7 @@ function addCategory(comment, category) {
 
   const trailing = comment.match(/\s*$/)?.[0] ?? '';
   const body = comment.slice(0, comment.length - trailing.length);
-  const oneLine = /^(\s*)\/\*\*\s*(.*?)\s*\*\/$/.exec(body);
+  const oneLine = /^(\s*)\/\*\*[^\S\r\n]*(.*?)[^\S\r\n]*\*\/$/.exec(body);
   if (oneLine != null) {
     const [, indent, text] = oneLine;
     return `${indent}/**\n${indent} * ${text}\n${indent} *\n${indent} * @category ${category}\n${indent} */${trailing}`;

--- a/website/pages/api-v17/graphql.mdx
+++ b/website/pages/api-v17/graphql.mdx
@@ -135,7 +135,7 @@ isDevModeEnabled(); // => true
 
 #### GraphQLParseContext
 
-**Interface.** * Context published on `graphql:parse`.
+**Interface.** Context published on `graphql:parse`.
 
 <hr className="api-subsection-divider" />
 
@@ -172,7 +172,7 @@ isDevModeEnabled(); // => true
 
 #### GraphQLValidateContext
 
-**Interface.** * Context published on `graphql:validate`.
+**Interface.** Context published on `graphql:validate`.
 
 <hr className="api-subsection-divider" />
 
@@ -214,7 +214,7 @@ isDevModeEnabled(); // => true
 
 #### GraphQLExecuteContext
 
-**Interface.** * Context published on `graphql:execute`.
+**Interface.** Context published on `graphql:execute`.
 
 <hr className="api-subsection-divider" />
 
@@ -271,7 +271,7 @@ isDevModeEnabled(); // => true
 
 #### GraphQLExecuteRootSelectionSetContext
 
-**Interface.** * Context published on `graphql:execute:rootSelectionSet`.
+**Interface.** Context published on `graphql:execute:rootSelectionSet`.
 
 <hr className="api-subsection-divider" />
 
@@ -400,7 +400,7 @@ carries the `errors` array, mirroring `graphql:validate`.
 
 #### GraphQLSubscribeContext
 
-**Interface.** * Context published on `graphql:subscribe`.
+**Interface.** Context published on `graphql:subscribe`.
 
 <hr className="api-subsection-divider" />
 
@@ -457,7 +457,7 @@ carries the `errors` array, mirroring `graphql:validate`.
 
 #### GraphQLResolveContext
 
-**Interface.** * Context published on `graphql:resolve`.
+**Interface.** Context published on `graphql:resolve`.
 
 <hr className="api-subsection-divider" />
 
@@ -524,7 +524,7 @@ carries the `errors` array, mirroring `graphql:validate`.
 
 #### GraphQLChannelContextByName
 
-**Interface.** * Mapping from tracing channel name to the context type published on it.
+**Interface.** Mapping from tracing channel name to the context type published on it.
 
 <hr className="api-subsection-divider" />
 


### PR DESCRIPTION
if a single line jsdoc comment was spread across multiple lines by the asterisks themseles:

```ts
/**
 * Single-line comment
 */
 ```
 
 We don't want that asterisk to be misinterpreted.
 
 Stopgap solution.