### PR TITLE
internal: fix broken npm/deno deployments

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
       environment: npm-branch
       artifact_name: npmDist
       target_branch: npm
-      commit_message: "Deploy ${{github.event.workflow_run.head_sha}} to 'npm' branch"
+      commit_message: "Deploy ${{ github.sha }} to 'npm' branch"
 
   deploy-to-deno-branch:
     name: Deploy to `deno` branch
@@ -31,4 +31,4 @@ jobs:
       environment: deno-branch
       artifact_name: denoDist
       target_branch: deno
-      commit_message: "Deploy ${{github.event.workflow_run.head_sha}} to 'deno' branch"
+      commit_message: "Deploy ${{ github.sha }} to 'deno' branch"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ jobs:
   deploy-to-npm-branch:
     name: Deploy to `npm` branch
     needs: ci
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/17.x.x'
     permissions:
       contents: write # for actions/checkout and to push branch
     uses: ./.github/workflows/deploy-artifact-as-branch.yml
@@ -23,7 +23,7 @@ jobs:
   deploy-to-deno-branch:
     name: Deploy to `deno` branch
     needs: ci
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/17.x.x'
     permissions:
       contents: write # for actions/checkout and to push branch
     uses: ./.github/workflows/deploy-artifact-as-branch.yml


### PR DESCRIPTION
deploy jobs became stale on 2024-06-2 when the repository stopped using main as the default branch and moved the active default line to 16.x.x (#4131).

Issue [#4766](https://github.com/graphql/graphql-js/issues/4766) notes that the jobs were still gated on refs/heads/main.

This PR gates the npm and deno branch deployments on 17.x.x => that branch is about to become the new default.

-------

PR [#3491](https://github.com/graphql/graphql-js/issues/3491) copied `github.event.workflow_run.head_sha` into a workflow that runs on push events. Issue [#4766](https://github.com/graphql/graphql-js/issues/4766) notes that this leaves the generated npm and deno deployment commit messages without the source commit hash.

Use `github.sha` instead of `github.event.workflow_run.head_sha` so those deployment commits identify the commit that produced their artifacts.