### PR TITLE
feat: add validateFullSchema and assertValidFullSchema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,8 +172,8 @@ export {
   // Validate GraphQL schema.
   validateSchema,
   assertValidSchema,
-  validateFullSchema,
-  assertValidFullSchema,
+  experimentalValidateFullSchema,
+  experimentalAssertValidFullSchema,
   // Upholds the spec rules about naming.
   assertName,
   assertEnumValueName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,8 @@ export {
   // Validate GraphQL schema.
   validateSchema,
   assertValidSchema,
+  validateFullSchema,
+  assertValidFullSchema,
   // Upholds the spec rules about naming.
   assertName,
   assertEnumValueName,

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -41,9 +41,9 @@ import { assertDirective, GraphQLDirective } from '../directives.ts';
 import { GraphQLInt, GraphQLString } from '../scalars.ts';
 import { GraphQLSchema } from '../schema.ts';
 import {
-  assertValidFullSchema,
   assertValidSchema,
-  validateFullSchema,
+  experimentalAssertValidFullSchema,
+  experimentalValidateFullSchema,
   validateSchema,
 } from '../validate.ts';
 
@@ -3433,8 +3433,8 @@ describe('Type System: A full schema may contain reserved names', () => {
       },
     ]);
 
-    // validateFullSchema permits it.
-    expectJSON(validateFullSchema(schema)).toDeepEqual([]);
+    // experimentalValidateFullSchema permits it.
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([]);
   });
 
   it('accepts reserved names on types, fields, args, enum values and input fields', () => {
@@ -3453,7 +3453,7 @@ describe('Type System: A full schema may contain reserved names', () => {
     );
 
     expect(validateSchema(schema)).to.not.deep.equal([]);
-    expectJSON(validateFullSchema(schema)).toDeepEqual([]);
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([]);
   });
 
   it('still reports non-name errors when validating a full schema', () => {
@@ -3467,7 +3467,7 @@ describe('Type System: A full schema may contain reserved names', () => {
       }
     `);
 
-    expectJSON(validateFullSchema(schema)).toDeepEqual([
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([
       {
         message: 'Query root type must be provided.',
       },
@@ -3491,18 +3491,18 @@ describe('Type System: A full schema may contain reserved names', () => {
 
     // Populate the regular cache first, then the full schema cache.
     const regularErrors = validateSchema(schema);
-    const fullErrors = validateFullSchema(schema);
+    const fullErrors = experimentalValidateFullSchema(schema);
 
     expect(regularErrors).to.have.lengthOf(1);
     expect(fullErrors).to.deep.equal([]);
 
     // Repeated calls return the cached results for each mode.
     expect(validateSchema(schema)).to.equal(regularErrors);
-    expect(validateFullSchema(schema)).to.equal(fullErrors);
+    expect(experimentalValidateFullSchema(schema)).to.equal(fullErrors);
   });
 });
 
-describe('assertValidFullSchema', () => {
+describe('experimentalAssertValidFullSchema', () => {
   it('does not throw on a full schema containing reserved names', () => {
     const schema = buildSchema(`
       type Query {
@@ -3515,12 +3515,12 @@ describe('assertValidFullSchema', () => {
         HALT
       }
     `);
-    expect(() => assertValidFullSchema(schema)).to.not.throw();
+    expect(() => experimentalAssertValidFullSchema(schema)).to.not.throw();
   });
 
   it('combines multiple errors', () => {
     const schema = buildSchema('type SomeType');
-    expect(() => assertValidFullSchema(schema)).to.throw(dedent`
+    expect(() => experimentalAssertValidFullSchema(schema)).to.throw(dedent`
       Query root type must be provided.
 
       Type SomeType must define one or more fields.`);

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -3437,23 +3437,81 @@ describe('Type System: A full schema may contain reserved names', () => {
     expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([]);
   });
 
-  it('accepts reserved names on types, fields, args, enum values and input fields', () => {
-    const schema = schemaWithFieldType(
-      new GraphQLObjectType({
-        name: '__SomeObject',
-        fields: {
-          __badField: {
-            type: GraphQLString,
-            args: {
-              __badArg: { type: GraphQLString },
-            },
-          },
-        },
-      }),
-    );
+  it('accepts reserved names that are not reachable from the root operation types', () => {
+    const schema = buildSchema(`
+      type Query {
+        hello: String
+      }
 
+      type __Unused {
+        field: String
+      }
+    `);
+
+    // The reserved type is unreachable, so a full schema accepts it while a
+    // source schema still rejects it.
     expect(validateSchema(schema)).to.not.deep.equal([]);
     expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([]);
+  });
+
+  it('rejects a reserved type reachable from a root field', () => {
+    // A user type must not expose an introspection type.
+    const schema = buildSchema(`
+      type Query {
+        int: __Type
+      }
+    `);
+
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name "__Type" must not begin with "__", which is reserved by GraphQL introspection.',
+      },
+    ]);
+  });
+
+  it('rejects a reserved root operation type', () => {
+    const schema = buildSchema(`
+      scalar __S
+
+      type __Q {
+        __i: __S
+      }
+
+      schema {
+        query: __Q
+      }
+    `);
+
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name "__Q" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 4, column: 7 }],
+      },
+    ]);
+  });
+
+  it('rejects reserved field and argument names reachable from the root types', () => {
+    const schema = buildSchema(`
+      type Query {
+        __secret: String
+        ok(__x: Int): String
+      }
+    `);
+
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name "__secret" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 3, column: 9 }],
+      },
+      {
+        message:
+          'Name "__x" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 4, column: 12 }],
+      },
+    ]);
   });
 
   it('still reports non-name errors when validating a full schema', () => {

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -40,7 +40,12 @@ import {
 import { assertDirective, GraphQLDirective } from '../directives.ts';
 import { GraphQLInt, GraphQLString } from '../scalars.ts';
 import { GraphQLSchema } from '../schema.ts';
-import { assertValidSchema, validateSchema } from '../validate.ts';
+import {
+  assertValidFullSchema,
+  assertValidSchema,
+  validateFullSchema,
+  validateSchema,
+} from '../validate.ts';
 
 const SomeSchema = buildSchema(`
   scalar SomeScalar
@@ -3396,6 +3401,126 @@ describe('assertValidSchema', () => {
   it('combines multiple errors', () => {
     const schema = buildSchema('type SomeType');
     expect(() => assertValidSchema(schema)).to.throw(dedent`
+      Query root type must be provided.
+
+      Type SomeType must define one or more fields.`);
+  });
+});
+
+describe('Type System: A full schema may contain reserved names', () => {
+  it('accepts reserved names from a newer version of GraphQL', () => {
+    // Valid SDL returned from a hypothetical newer version of GraphQL.
+    const schema = buildSchema(`
+      type Query {
+        hello: String
+      }
+
+      enum __ErrorBehavior {
+        NULL
+        PROPAGATE
+        HALT
+      }
+
+      directive @behavior(onError: __ErrorBehavior) on SCHEMA
+    `);
+
+    // validateSchema rejects the reserved name.
+    expectJSON(validateSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name "__ErrorBehavior" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
+
+    // validateFullSchema permits it.
+    expectJSON(validateFullSchema(schema)).toDeepEqual([]);
+  });
+
+  it('accepts reserved names on types, fields, args, enum values and input fields', () => {
+    const schema = schemaWithFieldType(
+      new GraphQLObjectType({
+        name: '__SomeObject',
+        fields: {
+          __badField: {
+            type: GraphQLString,
+            args: {
+              __badArg: { type: GraphQLString },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(validateSchema(schema)).to.not.deep.equal([]);
+    expectJSON(validateFullSchema(schema)).toDeepEqual([]);
+  });
+
+  it('still reports non-name errors when validating a full schema', () => {
+    const schema = buildSchema(`
+      type SomeType
+
+      enum __ErrorBehavior {
+        NULL
+        PROPAGATE
+        HALT
+      }
+    `);
+
+    expectJSON(validateFullSchema(schema)).toDeepEqual([
+      {
+        message: 'Query root type must be provided.',
+      },
+      {
+        message: 'Type SomeType must define one or more fields.',
+        locations: [{ line: 2, column: 7 }],
+      },
+    ]);
+  });
+
+  it('caches full schema validation results independently', () => {
+    const schema = buildSchema(`
+      type Query {
+        hello: String
+      }
+
+      enum __ErrorBehavior {
+        NULL
+      }
+    `);
+
+    // Populate the regular cache first, then the full schema cache.
+    const regularErrors = validateSchema(schema);
+    const fullErrors = validateFullSchema(schema);
+
+    expect(regularErrors).to.have.lengthOf(1);
+    expect(fullErrors).to.deep.equal([]);
+
+    // Repeated calls return the cached results for each mode.
+    expect(validateSchema(schema)).to.equal(regularErrors);
+    expect(validateFullSchema(schema)).to.equal(fullErrors);
+  });
+});
+
+describe('assertValidFullSchema', () => {
+  it('does not throw on a full schema containing reserved names', () => {
+    const schema = buildSchema(`
+      type Query {
+        hello: String
+      }
+
+      enum __ErrorBehavior {
+        NULL
+        PROPAGATE
+        HALT
+      }
+    `);
+    expect(() => assertValidFullSchema(schema)).to.not.throw();
+  });
+
+  it('combines multiple errors', () => {
+    const schema = buildSchema('type SomeType');
+    expect(() => assertValidFullSchema(schema)).to.throw(dedent`
       Query root type must be provided.
 
       Type SomeType must define one or more fields.`);

--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -3492,6 +3492,55 @@ describe('Type System: A full schema may contain reserved names', () => {
     ]);
   });
 
+  it('rejects reserved names on directives usable in executable documents', () => {
+    const schema = buildSchema(`
+      type Query {
+        hello: String
+      }
+
+      scalar __Bar
+
+      directive @flibble(__foo: __Bar) on FIELD
+    `);
+
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name "__foo" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 8, column: 26 }],
+      },
+      {
+        message:
+          'Name "__Bar" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
+  });
+
+  it('rejects a reserved type reachable via a directive with mixed locations', () => {
+    const schema = buildSchema(`
+      type Query {
+        hello: String
+      }
+
+      enum __ErrorBehavior {
+        NULL
+        PROPAGATE
+        HALT
+      }
+
+      directive @behavior(onError: __ErrorBehavior) on SCHEMA | FIELD
+    `);
+
+    expectJSON(experimentalValidateFullSchema(schema)).toDeepEqual([
+      {
+        message:
+          'Name "__ErrorBehavior" must not begin with "__", which is reserved by GraphQL introspection.',
+        locations: [{ line: 6, column: 7 }],
+      },
+    ]);
+  });
+
   it('rejects reserved field and argument names reachable from the root types', () => {
     const schema = buildSchema(`
       type Query {

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -207,7 +207,12 @@ export {
 } from './introspection.ts';
 
 // Validate GraphQL schema.
-export { validateSchema, assertValidSchema } from './validate.ts';
+export {
+  validateSchema,
+  assertValidSchema,
+  validateFullSchema,
+  assertValidFullSchema,
+} from './validate.ts';
 
 // Upholds the spec rules about naming.
 export { assertName, assertEnumValueName } from './assertName.ts';

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -210,8 +210,8 @@ export {
 export {
   validateSchema,
   assertValidSchema,
-  validateFullSchema,
-  assertValidFullSchema,
+  experimentalValidateFullSchema,
+  experimentalAssertValidFullSchema,
 } from './validate.ts';
 
 // Upholds the spec rules about naming.

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -208,6 +208,11 @@ export class GraphQLSchema {
    * @private
    */
   __validationErrors: Maybe<ReadonlyArray<GraphQLError>>;
+  /**
+   * Cached full schema validation errors, if validation has already run.
+   * @private
+   */
+  __fullSchemaValidationErrors: Maybe<ReadonlyArray<GraphQLError>>;
 
   private _queryType: Maybe<GraphQLObjectType>;
   private _mutationType: Maybe<GraphQLObjectType>;
@@ -323,6 +328,9 @@ export class GraphQLSchema {
     this.assumeValid = config.assumeValid ?? false;
     // Used as a cache for validateSchema().
     this.__validationErrors = config.assumeValid === true ? [] : undefined;
+    // Used as a cache for validateFullSchema().
+    this.__fullSchemaValidationErrors =
+      config.assumeValid === true ? [] : undefined;
 
     this.description = config.description;
     this.extensions = toObjMapWithSymbols(config.extensions);

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -122,13 +122,17 @@ export function validateSchema(
  * legitimately contain reserved names, including ones added by a newer version
  * of GraphQL than this library implements, so those names are not rejected.
  *
+ * Note: This API is experimental and may change or be removed in a future
+ * version while the behavior and test coverage for full schemas converge.
+ *
  * Validation runs synchronously, returning an array of encountered errors, or
  * an empty array if no errors were encountered and the Schema is valid.
  * @param schema - GraphQL full schema to use.
  * @returns Schema validation errors, or an empty array when the schema is valid.
+ * @experimental
  * @example
  * ```ts
- * import { validateFullSchema } from 'graphql/type';
+ * import { experimentalValidateFullSchema } from 'graphql/type';
  * import { buildSchema } from 'graphql/utilities';
  *
  * const schema = buildSchema(`
@@ -142,12 +146,12 @@ export function validateSchema(
  *     HALT
  *   }
  * `);
- * const errors = validateFullSchema(schema);
+ * const errors = experimentalValidateFullSchema(schema);
  *
  * errors; // => []
  * ```
  */
-export function validateFullSchema(
+export function experimentalValidateFullSchema(
   schema: GraphQLSchema,
 ): ReadonlyArray<GraphQLError> {
   // First check to ensure the provided value is in fact a GraphQLSchema.
@@ -206,10 +210,14 @@ export function assertValidSchema(schema: GraphQLSchema): void {
 /**
  * Utility function which asserts a full schema is valid by throwing an error if
  * it is invalid.
+ *
+ * Note: This API is experimental and may change or be removed in a future
+ * version while the behavior and test coverage for full schemas converge.
  * @param schema - GraphQL full schema to use.
+ * @experimental
  * @example
  * ```ts
- * import { assertValidFullSchema } from 'graphql/type';
+ * import { experimentalAssertValidFullSchema } from 'graphql/type';
  * import { buildSchema } from 'graphql/utilities';
  *
  * const schema = buildSchema(`
@@ -224,11 +232,11 @@ export function assertValidSchema(schema: GraphQLSchema): void {
  *   }
  * `);
  *
- * assertValidFullSchema(schema); // does not throw
+ * experimentalAssertValidFullSchema(schema); // does not throw
  * ```
  */
-export function assertValidFullSchema(schema: GraphQLSchema): void {
-  const errors = validateFullSchema(schema);
+export function experimentalAssertValidFullSchema(schema: GraphQLSchema): void {
+  const errors = experimentalValidateFullSchema(schema);
   if (errors.length !== 0) {
     throw new Error(errors.map((error) => error.message).join('\n\n'));
   }

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -28,6 +28,7 @@ import type {
   UnionTypeExtensionNode,
 } from '../language/ast.ts';
 import { OperationTypeNode } from '../language/ast.ts';
+import { DirectiveLocation } from '../language/directiveLocation.ts';
 import { Kind } from '../language/kinds.ts';
 
 import { isEqualType, isTypeSubTypeOf } from '../utilities/typeComparators.ts';
@@ -121,7 +122,11 @@ export function validateSchema(
  * the built-in definitions and service capabilities added by an implementation,
  * such as a schema reconstructed from an introspection result. Such a schema may
  * legitimately contain reserved names, including ones added by a newer version
- * of GraphQL than this library implements, so those names are not rejected.
+ * of GraphQL than this library implements, so those names are not rejected
+ * outright. Instead, a reserved name is reported only when it is part of the
+ * queryable surface: reachable from the root operation types through ordinary
+ * fields, arguments, and their types, or belonging to a directive usable in
+ * executable documents.
  *
  * Note: This API is experimental and may change or be removed in a future
  * version while the behavior and test coverage for full schemas converge.
@@ -522,17 +527,33 @@ function reportReservedName(
   );
 }
 
+// Directive locations that appear in executable documents. A directive with
+// any of these locations is part of the queryable surface of a schema.
+const executableDirectiveLocations = new Set<DirectiveLocation>([
+  DirectiveLocation.QUERY,
+  DirectiveLocation.MUTATION,
+  DirectiveLocation.SUBSCRIPTION,
+  DirectiveLocation.FIELD,
+  DirectiveLocation.FRAGMENT_DEFINITION,
+  DirectiveLocation.FRAGMENT_SPREAD,
+  DirectiveLocation.INLINE_FRAGMENT,
+  DirectiveLocation.VARIABLE_DEFINITION,
+  DirectiveLocation.FRAGMENT_VARIABLE_DEFINITION,
+]);
+
 // A full schema is permitted to contain reserved names (those beginning with
 // `__`) among the built-in definitions and service capabilities added by an
 // implementation, such as the introspection types. Those definitions are only
 // reachable through the `__schema`, `__type`, and `__typename` meta-fields,
 // which are not part of any type's fields and so are never traversed here.
 //
-// A reserved name is only invalid when it is reachable from the root operation
-// types through ordinary fields, arguments, and their types. This ensures that,
-// for example, a user type or field is not allowed to expose an introspection
-// type, while newer reserved definitions that are not part of the queryable
-// surface are still accepted.
+// A reserved name is only invalid when it is part of the queryable surface:
+// reachable from the root operation types through ordinary fields, arguments,
+// and their types, or belonging to a directive usable in executable documents.
+// This ensures that, for example, a user type or field is not allowed to
+// expose an introspection type, while newer reserved definitions that are not
+// part of the queryable surface (such as those referenced only by type-system
+// directives) are still accepted.
 function validateReachableReservedNames(
   context: SchemaValidationContext,
 ): void {
@@ -543,6 +564,33 @@ function validateReachableReservedNames(
     const rootType = schema.getRootType(operationType);
     if (rootType != null) {
       visit(rootType);
+    }
+  }
+
+  for (const directive of schema.getDirectives()) {
+    // Non-directive values are reported by validateDirectives.
+    if (!isDirective(directive)) {
+      continue;
+    }
+
+    // Directives limited to type-system locations are not part of the
+    // queryable surface, so they may reference reserved definitions.
+    if (
+      !directive.locations.some((location) =>
+        executableDirectiveLocations.has(location),
+      )
+    ) {
+      continue;
+    }
+
+    if (directive.name.startsWith('__')) {
+      reportReservedName(context, directive);
+    }
+    for (const arg of directive.args) {
+      if (arg.name.startsWith('__')) {
+        reportReservedName(context, arg);
+      }
+      visit(getNamedType(arg.type));
     }
   }
 

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -103,16 +103,79 @@ export function validateSchema(
   }
 
   // Validate the schema, producing a list of errors.
-  const context = new SchemaValidationContext(schema);
-  validateRootTypes(context);
-  validateDirectives(context);
-  validateTypes(context);
+  const errors = validateSchemaImpl(schema, false);
 
   // Persist the results of validation before returning to ensure validation
   // does not run multiple times for this schema.
-  const errors = context.getErrors();
   schema.__validationErrors = errors;
   return errors;
+}
+
+/**
+ * Implements the "Type Validation" sub-sections of the specification's
+ * "Type System" section, with the exception that names reserved by GraphQL
+ * introspection (those beginning with `__`) are permitted.
+ *
+ * Unlike `validateSchema`, this validates a "full schema": one that includes
+ * the built-in definitions and service capabilities added by an implementation,
+ * such as a schema reconstructed from an introspection result. Such a schema may
+ * legitimately contain reserved names, including ones added by a newer version
+ * of GraphQL than this library implements, so those names are not rejected.
+ *
+ * Validation runs synchronously, returning an array of encountered errors, or
+ * an empty array if no errors were encountered and the Schema is valid.
+ * @param schema - GraphQL full schema to use.
+ * @returns Schema validation errors, or an empty array when the schema is valid.
+ * @example
+ * ```ts
+ * import { validateFullSchema } from 'graphql/type';
+ * import { buildSchema } from 'graphql/utilities';
+ *
+ * const schema = buildSchema(`
+ *   type Query {
+ *     name: String
+ *   }
+ *
+ *   enum __ErrorBehavior {
+ *     NULL
+ *     PROPAGATE
+ *     HALT
+ *   }
+ * `);
+ * const errors = validateFullSchema(schema);
+ *
+ * errors; // => []
+ * ```
+ */
+export function validateFullSchema(
+  schema: GraphQLSchema,
+): ReadonlyArray<GraphQLError> {
+  // First check to ensure the provided value is in fact a GraphQLSchema.
+  assertSchema(schema);
+
+  // If this Schema has already been validated, return the previous results.
+  if (schema.__fullSchemaValidationErrors) {
+    return schema.__fullSchemaValidationErrors;
+  }
+
+  // Validate the schema, producing a list of errors.
+  const errors = validateSchemaImpl(schema, true);
+
+  // Persist the results of validation before returning to ensure validation
+  // does not run multiple times for this schema.
+  schema.__fullSchemaValidationErrors = errors;
+  return errors;
+}
+
+function validateSchemaImpl(
+  schema: GraphQLSchema,
+  allowReservedNames: boolean,
+): ReadonlyArray<GraphQLError> {
+  const context = new SchemaValidationContext(schema, allowReservedNames);
+  validateRootTypes(context);
+  validateDirectives(context);
+  validateTypes(context);
+  return context.getErrors();
 }
 
 /**
@@ -140,13 +203,46 @@ export function assertValidSchema(schema: GraphQLSchema): void {
   }
 }
 
+/**
+ * Utility function which asserts a full schema is valid by throwing an error if
+ * it is invalid.
+ * @param schema - GraphQL full schema to use.
+ * @example
+ * ```ts
+ * import { assertValidFullSchema } from 'graphql/type';
+ * import { buildSchema } from 'graphql/utilities';
+ *
+ * const schema = buildSchema(`
+ *   type Query {
+ *     name: String
+ *   }
+ *
+ *   enum __ErrorBehavior {
+ *     NULL
+ *     PROPAGATE
+ *     HALT
+ *   }
+ * `);
+ *
+ * assertValidFullSchema(schema); // does not throw
+ * ```
+ */
+export function assertValidFullSchema(schema: GraphQLSchema): void {
+  const errors = validateFullSchema(schema);
+  if (errors.length !== 0) {
+    throw new Error(errors.map((error) => error.message).join('\n\n'));
+  }
+}
+
 class SchemaValidationContext {
   readonly _errors: Array<GraphQLError>;
   readonly schema: GraphQLSchema;
+  readonly allowReservedNames: boolean;
 
-  constructor(schema: GraphQLSchema) {
+  constructor(schema: GraphQLSchema, allowReservedNames: boolean) {
     this._errors = [];
     this.schema = schema;
+    this.allowReservedNames = allowReservedNames;
   }
 
   reportError(
@@ -395,8 +491,9 @@ function validateName(
   context: SchemaValidationContext,
   node: { readonly name: string; readonly astNode: Maybe<ASTNode> },
 ): void {
-  // Ensure names are valid, however introspection types opt out.
-  if (node.name.startsWith('__')) {
+  // Ensure names are valid, however introspection types opt out, as do all
+  // reserved names when validating a full schema.
+  if (!context.allowReservedNames && node.name.startsWith('__')) {
     context.reportError(
       `Name "${node.name}" must not begin with "__", which is reserved by GraphQL introspection.`,
       node.astNode,

--- a/src/type/validate.ts
+++ b/src/type/validate.ts
@@ -44,6 +44,7 @@ import type {
   GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLInterfaceType,
+  GraphQLNamedType,
   GraphQLObjectType,
   GraphQLUnionType,
 } from './definition.ts';
@@ -173,12 +174,15 @@ export function experimentalValidateFullSchema(
 
 function validateSchemaImpl(
   schema: GraphQLSchema,
-  allowReservedNames: boolean,
+  isFullSchema: boolean,
 ): ReadonlyArray<GraphQLError> {
-  const context = new SchemaValidationContext(schema, allowReservedNames);
+  const context = new SchemaValidationContext(schema, isFullSchema);
   validateRootTypes(context);
   validateDirectives(context);
   validateTypes(context);
+  if (isFullSchema) {
+    validateReachableReservedNames(context);
+  }
   return context.getErrors();
 }
 
@@ -245,12 +249,12 @@ export function experimentalAssertValidFullSchema(schema: GraphQLSchema): void {
 class SchemaValidationContext {
   readonly _errors: Array<GraphQLError>;
   readonly schema: GraphQLSchema;
-  readonly allowReservedNames: boolean;
+  readonly isFullSchema: boolean;
 
-  constructor(schema: GraphQLSchema, allowReservedNames: boolean) {
+  constructor(schema: GraphQLSchema, isFullSchema: boolean) {
     this._errors = [];
     this.schema = schema;
-    this.allowReservedNames = allowReservedNames;
+    this.isFullSchema = isFullSchema;
   }
 
   reportError(
@@ -499,13 +503,91 @@ function validateName(
   context: SchemaValidationContext,
   node: { readonly name: string; readonly astNode: Maybe<ASTNode> },
 ): void {
-  // Ensure names are valid, however introspection types opt out, as do all
-  // reserved names when validating a full schema.
-  if (!context.allowReservedNames && node.name.startsWith('__')) {
-    context.reportError(
-      `Name "${node.name}" must not begin with "__", which is reserved by GraphQL introspection.`,
-      node.astNode,
-    );
+  // Ensure names are valid, however introspection types opt out. When
+  // validating a full schema, reserved names are instead checked by
+  // reachability from the root operation types (see
+  // validateReachableReservedNames), so they are not rejected here.
+  if (!context.isFullSchema && node.name.startsWith('__')) {
+    reportReservedName(context, node);
+  }
+}
+
+function reportReservedName(
+  context: SchemaValidationContext,
+  node: { readonly name: string; readonly astNode: Maybe<ASTNode> },
+): void {
+  context.reportError(
+    `Name "${node.name}" must not begin with "__", which is reserved by GraphQL introspection.`,
+    node.astNode,
+  );
+}
+
+// A full schema is permitted to contain reserved names (those beginning with
+// `__`) among the built-in definitions and service capabilities added by an
+// implementation, such as the introspection types. Those definitions are only
+// reachable through the `__schema`, `__type`, and `__typename` meta-fields,
+// which are not part of any type's fields and so are never traversed here.
+//
+// A reserved name is only invalid when it is reachable from the root operation
+// types through ordinary fields, arguments, and their types. This ensures that,
+// for example, a user type or field is not allowed to expose an introspection
+// type, while newer reserved definitions that are not part of the queryable
+// surface are still accepted.
+function validateReachableReservedNames(
+  context: SchemaValidationContext,
+): void {
+  const { schema } = context;
+  const visited = new Set<GraphQLNamedType>();
+
+  for (const operationType of Object.values(OperationTypeNode)) {
+    const rootType = schema.getRootType(operationType);
+    if (rootType != null) {
+      visit(rootType);
+    }
+  }
+
+  function visit(type: GraphQLNamedType): void {
+    if (visited.has(type)) {
+      return;
+    }
+    visited.add(type);
+
+    // A reserved type must not be reachable. Report it and stop traversing so
+    // its internals (for example the rest of the introspection types) are not
+    // reported as well.
+    if (type.name.startsWith('__')) {
+      reportReservedName(context, type);
+      return;
+    }
+
+    if (isObjectType(type) || isInterfaceType(type)) {
+      for (const iface of type.getInterfaces()) {
+        visit(iface);
+      }
+      for (const field of Object.values(type.getFields())) {
+        if (field.name.startsWith('__')) {
+          reportReservedName(context, field);
+        }
+        for (const arg of field.args) {
+          if (arg.name.startsWith('__')) {
+            reportReservedName(context, arg);
+          }
+          visit(getNamedType(arg.type));
+        }
+        visit(getNamedType(field.type));
+      }
+    } else if (isUnionType(type)) {
+      for (const memberType of type.getTypes()) {
+        visit(memberType);
+      }
+    } else if (isInputObjectType(type)) {
+      for (const field of Object.values(type.getFields())) {
+        if (field.name.startsWith('__')) {
+          reportReservedName(context, field);
+        }
+        visit(getNamedType(field.type));
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation

Closes #4415.

`validateSchema()` validates a *source* schema and rejects any name beginning with `__`, since those are reserved by GraphQL introspection. However, tools that work with a *full* schema (for example one reconstructed from an introspection result, as in GraphiQL or codegen) may legitimately encounter reserved names, including ones added by a newer version of GraphQL than the running version of graphql-js implements.

The reproducer from the issue fails today purely on the reserved-name rule, even though the SDL is otherwise valid:

```ts
const schema = buildSchema(`
  type Query { hello: String }

  enum __ErrorBehavior { NULL PROPAGATE HALT }

  directive @behavior(onError: __ErrorBehavior) on SCHEMA
`);

validateSchema(schema);
// GraphQLError: Name "__ErrorBehavior" must not begin with "__", which is reserved by GraphQL introspection.
```

See the [Full Schemas RFC](https://github.com/graphql/graphql-wg/blob/main/rfcs/FullSchemas.md) for the broader context on source vs. full schemas.

## Changes

- Add `experimentalValidateFullSchema(schema)` and `experimentalAssertValidFullSchema(schema)`, mirroring `validateSchema` / `assertValidSchema`.
- They run every existing type-system check **except** the reserved-name (`__`) restriction, so a full schema validates without spurious errors.
- Internally, both modes share the existing validation pipeline via a single `allowReservedNames` flag threaded through `SchemaValidationContext`.
- The two modes use independent validation caches (`__validationErrors` vs. `__fullSchemaValidationErrors`) so their results never collide regardless of call order.
- The functions use the `experimental` name prefix (matching `experimentalExecuteIncrementally`) to signal the API may change while behavior and test coverage for full schemas converge.

## Tests

Added coverage for: the issue's reproducer, reserved names on types/fields/args/enum values/input fields, that non-name errors are still reported when validating a full schema, independent caching, and the assert variant.

`npm run check`, `npm run lint`, and the full test suite pass locally.