### PR TITLE
fix: apply directives when SDL contains type definitions and extensions with directives

### DIFF
--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -359,6 +359,34 @@ describe('extendSchema', () => {
     expectExtensionASTNodes(foo).to.equal(extensionSDL);
   });
 
+  it('builds scalars with specifiedBy directive from extensions', () => {
+    const schema = new GraphQLSchema({});
+    const extensionSDL = dedent`
+      schema {
+        query: Query
+      }
+
+      type Query {
+        foo: Foo
+      }
+
+      scalar Foo
+
+      extend scalar Foo @specifiedBy(url: "https://example.com/foo_spec")
+    `;
+
+    const extendedSchema = extendSchema(schema, parse(extensionSDL));
+    const foo = assertScalarType(extendedSchema.getType('Foo'));
+
+    expect(foo.specifiedByURL).to.equal('https://example.com/foo_spec');
+
+    expect(validateSchema(extendedSchema)).to.deep.equal([]);
+    expectASTNode(foo).to.equal('scalar Foo');
+    expectExtensionASTNodes(foo).to.equal(
+      'extend scalar Foo @specifiedBy(url: "https://example.com/foo_spec")',
+    );
+  });
+
   it('correctly assign AST nodes to new and extended types', () => {
     const schema = buildSchema(`
       type Query

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -1439,6 +1439,34 @@ describe('extendSchema', () => {
       );
     });
 
+    it('builds directives with deprecation from extensions', () => {
+      const schema = new GraphQLSchema({});
+      const extensionSDL = dedent`
+        directive @isDeprecated on FIELD_DEFINITION
+
+        extend directive @isDeprecated @deprecated(reason: "use another directive")
+      `;
+      const extendedSchema = extendSchema(
+        schema,
+        parse(extensionSDL, {
+          experimentalDirectivesOnDirectiveDefinitions: true,
+        }),
+      );
+
+      const isDeprecatedDirective = assertDirective(
+        extendedSchema.getDirective('isDeprecated'),
+      );
+      expect(isDeprecatedDirective).to.include({
+        deprecationReason: 'use another directive',
+      });
+      expectASTNode(isDeprecatedDirective).to.equal(
+        'directive @isDeprecated on FIELD_DEFINITION',
+      );
+      expectExtensionASTNodes(isDeprecatedDirective).to.equal(
+        'extend directive @isDeprecated @deprecated(reason: "use another directive")',
+      );
+    });
+
     it('applies multiple directive extensions defined in the same document', () => {
       const schema = buildASTSchema(
         parse(

--- a/src/utilities/extendSchema.ts
+++ b/src/utilities/extendSchema.ts
@@ -640,10 +640,14 @@ export function extendSchemaImpl(
         }
         case Kind.SCALAR_TYPE_DEFINITION: {
           const extensionASTNodes = scalarExtensions.get(name) ?? [];
+          let specifiedByURL = getSpecifiedByURL(astNode);
+          for (const extensionNode of extensionASTNodes) {
+            specifiedByURL = getSpecifiedByURL(extensionNode) ?? specifiedByURL;
+          }
           return new GraphQLScalarType({
             name,
             description: astNode.description?.value,
-            specifiedByURL: getSpecifiedByURL(astNode),
+            specifiedByURL,
             astNode,
             extensionASTNodes,
           });


### PR DESCRIPTION
Previously, you could apply `@specifiedBy` programmatically on an initial schema, as a directive on a type definition within an initial schema, or as a directive on a type extension extending an existing schema, but you could not provide SDL for an initial schema where the SDL both included a scalar type definition and a type extension that added `specifiedBy`.

Re: other built-in SDL directives:

- `@deprecated` cannot apply to types (yet?), so there is no no type-extension equivalent.
- `@deprecated` can be added on extensions on fields, args, input fields, enum values but only as those schema elements are newly added to the enclosing schema element (e.g. as the field is added to the type), the schema element itself (e.g. field) cannot (yet?) be extended.
- `@oneOf` per spec must not be provided by an input-object extension.

Recently added directive on directive does have this issue, so `@deprecated` potentially could have this bug with regard to directives, but it does not, this PR adds a test demonstrating no fix necessary there.