### PR TITLE
feat(validation): reject directive definition cycles - rewrite #4726

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -476,6 +476,7 @@ export {
   UniqueArgumentDefinitionNamesRule,
   UniqueDirectiveNamesRule,
   PossibleTypeExtensionsRule,
+  NoDirectiveDefinitionCyclesRule,
   // Custom validation rules
   NoDeprecatedCustomRule,
   NoSchemaIntrospectionCustomRule,

--- a/src/utilities/__tests__/extendSchema-test.ts
+++ b/src/utilities/__tests__/extendSchema-test.ts
@@ -316,7 +316,7 @@ describe('extendSchema', () => {
         someScalar(arg: SomeScalar): SomeScalar
       }
 
-      directive @foo(arg: SomeScalar) on SCALAR
+      directive @foo on SCALAR
 
       input FooInput {
         foo: SomeScalar

--- a/src/validation/__tests__/NoDirectiveDefinitionCyclesRule-test.ts
+++ b/src/validation/__tests__/NoDirectiveDefinitionCyclesRule-test.ts
@@ -1,0 +1,664 @@
+import { describe, it } from 'node:test';
+
+import { expectJSON } from '../../__testUtils__/expectJSON.ts';
+
+import type {
+  DirectiveExtensionNode,
+  EnumTypeDefinitionNode,
+} from '../../language/ast.ts';
+import { DirectiveLocation } from '../../language/directiveLocation.ts';
+import { parse } from '../../language/parser.ts';
+
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+} from '../../type/definition.ts';
+import { GraphQLDirective } from '../../type/directives.ts';
+import { GraphQLString } from '../../type/scalars.ts';
+import { GraphQLSchema } from '../../type/schema.ts';
+
+import { buildSchema } from '../../utilities/buildASTSchema.ts';
+
+import { NoDirectiveDefinitionCyclesRule } from '../rules/NoDirectiveDefinitionCyclesRule.ts';
+import { validateSDL } from '../validate.ts';
+
+function expectErrors(sdlStr: string, schema?: GraphQLSchema) {
+  const doc = parse(sdlStr);
+  const errors = validateSDL(doc, schema, [NoDirectiveDefinitionCyclesRule]);
+  return expectJSON(errors);
+}
+
+function expectValid(sdlStr: string, schema?: GraphQLSchema) {
+  expectErrors(sdlStr, schema).toDeepEqual([]);
+}
+
+describe('Validate: No directive definition cycles', () => {
+  it('single reference is valid', () => {
+    expectValid(`
+      directive @a(arg: String @b) on FIELD_DEFINITION
+      directive @b on ARGUMENT_DEFINITION
+    `);
+  });
+
+  it('does not false positive on unknown directive', () => {
+    expectValid(`
+      directive @a(arg: String @unknown) on FIELD_DEFINITION
+    `);
+  });
+
+  it('rejects a self-referential directive definition', () => {
+    expectErrors(`
+      directive @self(arg: String @self) on FIELD_DEFINITION
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@self" forms a reference cycle through: "@self(arg:)", directive application "@self".',
+        locations: [
+          { line: 2, column: 23 },
+          { line: 2, column: 35 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directives applied to their own definitions', () => {
+    expectErrors(`
+      directive @self @self on DIRECTIVE_DEFINITION
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@self" forms a reference cycle through: directive application "@self".',
+        locations: [{ line: 2, column: 23 }],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions with circular references', () => {
+    expectErrors(`
+      directive @a(arg: String @b) on FIELD_DEFINITION
+      directive @b(arg: String @a) on FIELD_DEFINITION
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", directive application "@b", "@b(arg:)", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 32 },
+          { line: 3, column: 20 },
+          { line: 3, column: 32 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions with overlapping circular references', () => {
+    expectErrors(`
+      directive @a(arg: String @b) on FIELD_DEFINITION
+      directive @b(arg: String @c) on FIELD_DEFINITION
+      directive @c(first: String @a, second: String @d) on FIELD_DEFINITION
+      directive @d(arg: String @b) on FIELD_DEFINITION
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", directive application "@b", "@b(arg:)", directive application "@c", "@c(first:)", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 32 },
+          { line: 3, column: 20 },
+          { line: 3, column: 32 },
+          { line: 4, column: 20 },
+          { line: 4, column: 34 },
+        ],
+      },
+      {
+        message:
+          'Directive "@b" forms a reference cycle through: "@b(arg:)", directive application "@c", "@c(second:)", directive application "@d", "@d(arg:)", directive application "@b".',
+        locations: [
+          { line: 3, column: 20 },
+          { line: 3, column: 32 },
+          { line: 4, column: 38 },
+          { line: 4, column: 53 },
+          { line: 5, column: 20 },
+          { line: 5, column: 32 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions with multiple cycles through the same directive', () => {
+    expectErrors(`
+      directive @a(first: String @b, second: String @c) on FIELD_DEFINITION
+      directive @b(arg: String @a) on FIELD_DEFINITION
+      directive @c(arg: String @a) on FIELD_DEFINITION
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(first:)", directive application "@b", "@b(arg:)", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 34 },
+          { line: 3, column: 20 },
+          { line: 3, column: 32 },
+        ],
+      },
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(second:)", directive application "@c", "@c(arg:)", directive application "@a".',
+        locations: [
+          { line: 2, column: 38 },
+          { line: 2, column: 53 },
+          { line: 4, column: 20 },
+          { line: 4, column: 32 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions that recurse through a directive on a referenced type', () => {
+    expectErrors(`
+      directive @a(arg: InputObject) on INPUT_OBJECT
+
+      input InputObject @a {
+        value: String
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 25 },
+          { line: 4, column: 25 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions that recurse through a referenced type', () => {
+    expectErrors(`
+      directive @a(arg: InputObject) on FIELD_DEFINITION
+
+      input InputObject {
+        value: String @a
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.value", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 25 },
+          { line: 5, column: 9 },
+          { line: 5, column: 23 },
+        ],
+      },
+    ]);
+  });
+
+  it('does not duplicate cycles through recursive referenced types', () => {
+    expectErrors(`
+      directive @a(arg: InputObject) on INPUT_FIELD_DEFINITION
+      input InputObject {
+        self: InputObject @a
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.self", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 25 },
+          { line: 4, column: 9 },
+          { line: 4, column: 27 },
+        ],
+      },
+    ]);
+  });
+
+  it('allows recursive input objects without directive cycles', () => {
+    expectValid(`
+      directive @a(arg: InputObject) on FIELD_DEFINITION
+
+      input InputObject {
+        self: InputObject
+      }
+    `);
+  });
+
+  it('rejects directive definitions that recurse through a referenced enum', () => {
+    expectErrors(`
+      directive @a(arg: Enum) on ENUM
+
+      enum Enum @a {
+        VALUE
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "Enum", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 25 },
+          { line: 4, column: 17 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions that recurse through a referenced enum value', () => {
+    expectErrors(`
+      directive @a(arg: Enum) on ENUM_VALUE
+
+      enum Enum {
+        VALUE @a
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "Enum", "Enum.VALUE", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 2, column: 25 },
+          { line: 5, column: 9 },
+          { line: 5, column: 15 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive definitions that recurse through an existing enum value AST node', () => {
+    const enumTypeDefinition = parse(`enum Enum { VALUE @a }`, {
+      noLocation: true,
+    }).definitions[0] as EnumTypeDefinitionNode;
+    const schema = new GraphQLSchema({
+      types: [
+        new GraphQLEnumType({
+          name: 'Enum',
+          values: {
+            VALUE: { astNode: enumTypeDefinition.values?.[0] },
+          },
+        }),
+      ],
+      assumeValid: true,
+    });
+
+    expectErrors(
+      `
+        directive @a(arg: Enum) on ENUM_VALUE
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "Enum", "Enum.VALUE", directive application "@a".',
+        locations: [
+          { line: 2, column: 22 },
+          { line: 2, column: 27 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive cycles after reaching the type from another directive', () => {
+    expectErrors(`
+      directive @entry(arg: InputObject) on FIELD_DEFINITION
+      directive @cycle(arg: InputObject) on INPUT_FIELD_DEFINITION
+
+      input InputObject {
+        value: String @cycle
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@cycle" forms a reference cycle through: "@cycle(arg:)", "InputObject", "InputObject.value", directive application "@cycle".',
+        locations: [
+          { line: 3, column: 24 },
+          { line: 3, column: 29 },
+          { line: 6, column: 9 },
+          { line: 6, column: 23 },
+        ],
+      },
+    ]);
+  });
+
+  it('ignores directive cycles already present in the existing schema', () => {
+    const schema = buildSchema(
+      `
+        directive @cycle(arg: InputObject) on INPUT_FIELD_DEFINITION
+        input InputObject {
+          value: String @cycle
+        }
+      `,
+      { assumeValidSDL: true },
+    );
+
+    expectValid(
+      `
+        directive @unrelated on FIELD_DEFINITION
+      `,
+      schema,
+    );
+  });
+
+  it('rejects type extensions that create cycles with existing directives', () => {
+    const schema = buildSchema(
+      `
+        directive @a(arg: InputObject) on INPUT_FIELD_DEFINITION
+        input InputObject {
+          value: String
+        }
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend input InputObject {
+          recursive: String @a
+        }
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.recursive", directive application "@a".',
+        locations: [
+          { line: 3, column: 11 },
+          { line: 3, column: 29 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects type extensions that create cycles with existing directives without AST nodes', () => {
+    const inputObject = new GraphQLInputObjectType({
+      name: 'InputObject',
+      fields: {
+        value: { type: GraphQLString },
+      },
+    });
+    const schema = new GraphQLSchema({
+      directives: [
+        new GraphQLDirective({
+          name: 'a',
+          locations: [DirectiveLocation.INPUT_FIELD_DEFINITION],
+          args: {
+            arg: { type: inputObject },
+          },
+        }),
+      ],
+      types: [inputObject],
+      assumeValid: true,
+    });
+
+    expectErrors(
+      `
+        extend input InputObject {
+          recursive: String @a
+        }
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.recursive", directive application "@a".',
+        locations: [
+          { line: 3, column: 11 },
+          { line: 3, column: 29 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects type extensions that create cycles through linked existing input object types without AST nodes', () => {
+    const nestedInput = new GraphQLInputObjectType({
+      name: 'NestedInput',
+      fields: {
+        value: { type: GraphQLString },
+      },
+    });
+    const inputObject = new GraphQLInputObjectType({
+      name: 'InputObject',
+      fields: {
+        nested: { type: nestedInput },
+      },
+    });
+    const schema = new GraphQLSchema({
+      directives: [
+        new GraphQLDirective({
+          name: 'a',
+          locations: [DirectiveLocation.INPUT_FIELD_DEFINITION],
+          args: {
+            arg: { type: inputObject },
+          },
+        }),
+      ],
+      types: [inputObject, nestedInput],
+      assumeValid: true,
+    });
+
+    expectErrors(
+      `
+        extend input NestedInput {
+          recursive: String @a
+        }
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.nested", "NestedInput", "NestedInput.recursive", directive application "@a".',
+        locations: [
+          { line: 3, column: 11 },
+          { line: 3, column: 29 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directives on directive definitions when the syntax exists', () => {
+    expectErrors(`
+      directive @a @b on DIRECTIVE_DEFINITION
+      directive @b @a on DIRECTIVE_DEFINITION
+    `).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: directive application "@b", directive application "@a".',
+        locations: [
+          { line: 2, column: 20 },
+          { line: 3, column: 20 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive extensions with circular references', () => {
+    const schema = buildSchema(
+      `
+        directive @a on DIRECTIVE_DEFINITION
+        directive @b on DIRECTIVE_DEFINITION
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend directive @a @b
+        extend directive @b @a
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: directive application "@b", directive application "@a".',
+        locations: [
+          { line: 2, column: 29 },
+          { line: 3, column: 29 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive extensions that close cycles through stored directive definitions', () => {
+    const schema = buildSchema(
+      `
+        directive @a @b on DIRECTIVE_DEFINITION
+        directive @b on DIRECTIVE_DEFINITION
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend directive @b @a
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: directive application "@b", directive application "@a".',
+        locations: [{ line: 2, column: 29 }],
+      },
+    ]);
+  });
+
+  it('rejects directive extensions that close cycles through stored directive extensions', () => {
+    const schema = buildSchema(
+      `
+        directive @a on DIRECTIVE_DEFINITION
+        directive @b on DIRECTIVE_DEFINITION
+        extend directive @a @b
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend directive @b @a
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: directive application "@b", directive application "@a".',
+        locations: [{ line: 2, column: 29 }],
+      },
+    ]);
+  });
+
+  it('rejects cycles through existing directive extension AST nodes', () => {
+    const directiveExtension = parse(`extend directive @existing @cycle`, {
+      noLocation: true,
+    }).definitions[0] as DirectiveExtensionNode;
+    const schema = new GraphQLSchema({
+      directives: [
+        new GraphQLDirective({
+          name: 'existing',
+          locations: [DirectiveLocation.ARGUMENT_DEFINITION],
+          extensionASTNodes: [directiveExtension],
+        }),
+      ],
+      assumeValid: true,
+    });
+
+    expectErrors(
+      `
+        directive @cycle(arg: String @existing) on ARGUMENT_DEFINITION
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@existing" forms a reference cycle through: directive application "@cycle", "@cycle(arg:)", directive application "@existing".',
+        locations: [
+          { line: 2, column: 26 },
+          { line: 2, column: 38 },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects directive extensions that close cycles through stored type definitions', () => {
+    const schema = buildSchema(
+      `
+        directive @a(arg: InputObject) on INPUT_FIELD_DEFINITION
+        input InputObject {
+          field: String @b
+        }
+        directive @b on INPUT_FIELD_DEFINITION
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend directive @b @a
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.field", directive application "@b", directive application "@a".',
+        locations: [{ line: 2, column: 29 }],
+      },
+    ]);
+  });
+
+  it('rejects directive extensions that close cycles through stored type extensions', () => {
+    const schema = buildSchema(
+      `
+        directive @a(arg: InputObject) on DIRECTIVE_DEFINITION
+        input InputObject {
+          value: String
+        }
+        extend input InputObject @b {
+          field: String
+        }
+        directive @b on INPUT_OBJECT
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend directive @b @a
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", directive application "@b", directive application "@a".',
+        locations: [{ line: 2, column: 29 }],
+      },
+    ]);
+  });
+
+  it('rejects directive extensions that close cycles through stored input object extension fields', () => {
+    const schema = buildSchema(
+      `
+        directive @a(arg: InputObject) on DIRECTIVE_DEFINITION
+        input InputObject {
+          value: String
+        }
+        extend input InputObject {
+          field: String @b
+        }
+        directive @b on INPUT_FIELD_DEFINITION
+      `,
+      { noLocation: true },
+    );
+
+    expectErrors(
+      `
+        extend directive @b @a
+      `,
+      schema,
+    ).toDeepEqual([
+      {
+        message:
+          'Directive "@a" forms a reference cycle through: "@a(arg:)", "InputObject", "InputObject.field", directive application "@b", directive application "@a".',
+        locations: [{ line: 2, column: 29 }],
+      },
+    ]);
+  });
+});

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -118,6 +118,7 @@ export { UniqueFieldDefinitionNamesRule } from './rules/UniqueFieldDefinitionNam
 export { UniqueArgumentDefinitionNamesRule } from './rules/UniqueArgumentDefinitionNamesRule.ts';
 export { UniqueDirectiveNamesRule } from './rules/UniqueDirectiveNamesRule.ts';
 export { PossibleTypeExtensionsRule } from './rules/PossibleTypeExtensionsRule.ts';
+export { NoDirectiveDefinitionCyclesRule } from './rules/NoDirectiveDefinitionCyclesRule.ts';
 
 // Optional rules not defined by the GraphQL Specification
 export { NoDeprecatedCustomRule } from './rules/custom/NoDeprecatedCustomRule.ts';

--- a/src/validation/rules/NoDirectiveDefinitionCyclesRule.ts
+++ b/src/validation/rules/NoDirectiveDefinitionCyclesRule.ts
@@ -1,0 +1,515 @@
+/** @category Validation Rules */
+
+import type { ObjMap } from '../../jsutils/ObjMap.ts';
+
+import { GraphQLError } from '../../error/GraphQLError.ts';
+
+import type {
+  DirectiveDefinitionNode,
+  DirectiveExtensionNode,
+  DirectiveNode,
+  EnumTypeDefinitionNode,
+  EnumTypeExtensionNode,
+  EnumValueDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  InputObjectTypeExtensionNode,
+  InputValueDefinitionNode,
+  NamedTypeNode,
+  ScalarTypeDefinitionNode,
+  ScalarTypeExtensionNode,
+} from '../../language/ast.ts';
+import { Kind } from '../../language/kinds.ts';
+import type { ASTVisitor } from '../../language/visitor.ts';
+import { visit } from '../../language/visitor.ts';
+
+import type { GraphQLInputType } from '../../type/definition.ts';
+import {
+  getNamedType,
+  isEnumType,
+  isInputObjectType,
+  isInputType,
+} from '../../type/definition.ts';
+import type { GraphQLDirective } from '../../type/directives.ts';
+import { isSpecifiedDirective } from '../../type/directives.ts';
+
+import type { SDLValidationContext } from '../ValidationContext.ts';
+
+type ReferenceNode =
+  | DirectiveNode
+  | NamedTypeNode
+  | EnumValueDefinitionNode
+  | InputValueDefinitionNode;
+type TypeReferenceSourceNode =
+  | ScalarTypeDefinitionNode
+  | ScalarTypeExtensionNode
+  | EnumTypeDefinitionNode
+  | EnumTypeExtensionNode
+  | InputObjectTypeDefinitionNode
+  | InputObjectTypeExtensionNode;
+type ChildReferenceSourceNode =
+  | EnumValueDefinitionNode
+  | InputValueDefinitionNode;
+
+interface ReferenceSource {
+  readonly coordinate: string;
+  readonly directiveName?: string;
+  readonly isFromDocument: boolean;
+}
+
+interface Reference extends ReferenceSource {
+  readonly node?: ReferenceNode;
+}
+
+/**
+ * No directive definition cycles
+ *
+ * The graph of directives used within directive definitions must not form any
+ * cycles including referencing itself. This includes directives used on
+ * directive arguments and, when the experimental syntax is enabled, directives
+ * applied directly to directive definitions and extensions.
+ *
+ * See https://spec.graphql.org/draft/#sec-Type-System.Directives
+ * @param context - The validation context used while checking the document.
+ * @returns A visitor that reports validation errors for this rule.
+ * @example
+ * ```ts
+ * import { buildSchema } from 'graphql';
+ * import { NoDirectiveDefinitionCyclesRule } from 'graphql/validation';
+ *
+ * const invalidSDL = `
+ *   directive @a(arg: String @b) on ARGUMENT_DEFINITION
+ *   directive @b(arg: String @a) on ARGUMENT_DEFINITION
+ *   type Query { name: String }
+ * `;
+ *
+ * NoDirectiveDefinitionCyclesRule.name; // => 'NoDirectiveDefinitionCyclesRule'
+ * buildSchema(invalidSDL); // throws an error
+ *
+ * const validSDL = `
+ *   directive @a(arg: String @b) on FIELD_DEFINITION
+ *   directive @b on ARGUMENT_DEFINITION
+ *   type Query { name: String }
+ * `;
+ *
+ * buildSchema(validSDL); // does not throw
+ * ```
+ */
+export function NoDirectiveDefinitionCyclesRule(
+  context: SDLValidationContext,
+): ASTVisitor {
+  const schema = context.getSchema();
+  const schemaDirectives = schema?.getDirectives() ?? [];
+  const documentDirectiveNames = new Set<string>();
+
+  for (const definition of context.getDocument().definitions) {
+    if (
+      definition.kind === Kind.DIRECTIVE_DEFINITION ||
+      definition.kind === Kind.DIRECTIVE_EXTENSION
+    ) {
+      documentDirectiveNames.add(definition.name.value);
+    }
+  }
+
+  if (
+    documentDirectiveNames.size === 0 &&
+    !schemaDirectives.some(canSchemaDirectiveDefinitionHaveReferences)
+  ) {
+    return {};
+  }
+
+  const visitedDirectiveCoordinates = new Set<string>();
+  const directiveSourceByCoordinate: ObjMap<ReferenceSource> =
+    Object.create(null);
+  const pathIndexByCoordinate: ObjMap<number | undefined> = Object.create(null);
+  const referencePath: Array<Reference> = [];
+  const referencesBySourceCoordinate: ObjMap<Array<Reference>> =
+    Object.create(null);
+  const referenceSourceStack: Array<ReferenceSource | undefined> = [];
+  let currentReferenceSource: ReferenceSource | undefined;
+  const documentReferenceVisitor = createReferenceVisitor(true);
+  const schemaReferenceVisitor = createReferenceVisitor(false);
+
+  if (schema != null) {
+    for (const directive of schemaDirectives) {
+      collectSchemaDirectiveReferences(directive);
+    }
+
+    for (const type of Object.values(schema.getTypeMap())) {
+      if (!isInputType(type)) {
+        continue;
+      }
+
+      const typeSource = {
+        coordinate: type.name,
+        isFromDocument: false,
+      };
+
+      for (const node of [type.astNode, ...type.extensionASTNodes]) {
+        if (node != null) {
+          visit(node, schemaReferenceVisitor);
+        }
+      }
+
+      if (isInputObjectType(type)) {
+        for (const field of Object.values(type.getFields())) {
+          collectSchemaInputValueReferences(
+            typeSource,
+            field.name,
+            field.type,
+            field.astNode ?? undefined,
+          );
+        }
+      } else if (isEnumType(type)) {
+        for (const value of type.getValues()) {
+          collectSchemaEnumValueReferences(
+            typeSource,
+            value.name,
+            value.astNode ?? undefined,
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    ...documentReferenceVisitor,
+    Document: {
+      leave() {
+        for (const source of Object.values(directiveSourceByCoordinate)) {
+          detectCycleRecursive(source);
+        }
+      },
+    },
+  };
+
+  function createReferenceVisitor(isFromDocument: boolean): ASTVisitor {
+    const directiveReferenceSourceVisitor = {
+      enter(node: DirectiveDefinitionNode | DirectiveExtensionNode): void {
+        enterDirectiveReferenceSource(node.name.value, isFromDocument);
+      },
+      leave: leaveReferenceSource,
+    };
+    const typeReferenceSourceVisitor = {
+      enter(node: TypeReferenceSourceNode): void {
+        enterTypeReferenceSource(node.name.value, isFromDocument);
+      },
+      leave: leaveReferenceSource,
+    };
+    const childReferenceSourceVisitor = {
+      enter: enterChildReferenceSource,
+      leave: leaveReferenceSource,
+    };
+
+    return {
+      DirectiveDefinition: directiveReferenceSourceVisitor,
+      DirectiveExtension: directiveReferenceSourceVisitor,
+      ScalarTypeDefinition: typeReferenceSourceVisitor,
+      ScalarTypeExtension: typeReferenceSourceVisitor,
+      EnumTypeDefinition: typeReferenceSourceVisitor,
+      EnumTypeExtension: typeReferenceSourceVisitor,
+      InputObjectTypeDefinition: typeReferenceSourceVisitor,
+      InputObjectTypeExtension: typeReferenceSourceVisitor,
+      EnumValueDefinition: childReferenceSourceVisitor,
+      InputValueDefinition: childReferenceSourceVisitor,
+      Directive: addReferenceFromCurrentSource,
+      NamedType: addReferenceFromCurrentSource,
+    };
+  }
+
+  function enterDirectiveReferenceSource(
+    directiveName: string,
+    isFromDocument: boolean,
+  ): void {
+    pushReferenceSource(
+      addDirectiveReferenceSource(directiveName, isFromDocument),
+    );
+  }
+
+  function addDirectiveReferenceSource(
+    directiveName: string,
+    isFromDocument: boolean,
+  ): ReferenceSource {
+    const source = {
+      coordinate: '@' + directiveName,
+      directiveName,
+      isFromDocument,
+    };
+    directiveSourceByCoordinate[source.coordinate] = source;
+    return source;
+  }
+
+  function enterTypeReferenceSource(
+    typeName: string,
+    isFromDocument: boolean,
+  ): void {
+    pushReferenceSource({ coordinate: typeName, isFromDocument });
+  }
+
+  function enterChildReferenceSource(node: ChildReferenceSourceNode): void {
+    const parentSource = currentReferenceSource;
+    if (parentSource === undefined) {
+      referenceSourceStack.push(undefined);
+      return;
+    }
+
+    const childSource = {
+      coordinate: childSourceCoordinate(parentSource, node.name.value),
+      isFromDocument: parentSource.isFromDocument,
+    };
+
+    addReference(parentSource, referenceFromSource(childSource, node));
+    pushReferenceSource(childSource);
+  }
+
+  function childSourceCoordinate(
+    parentSource: ReferenceSource,
+    childName: string,
+  ): string {
+    return parentSource.directiveName !== undefined
+      ? `${parentSource.coordinate}(${childName}:)`
+      : `${parentSource.coordinate}.${childName}`;
+  }
+
+  function pushReferenceSource(source: ReferenceSource): void {
+    referenceSourceStack.push(currentReferenceSource);
+    currentReferenceSource = source;
+  }
+
+  function leaveReferenceSource(): void {
+    currentReferenceSource = referenceSourceStack.pop();
+  }
+
+  function addReferenceFromCurrentSource(
+    node: DirectiveNode | NamedTypeNode,
+  ): void {
+    if (
+      currentReferenceSource !== undefined &&
+      (node.kind !== Kind.DIRECTIVE || shouldRecordDirectiveReference(node))
+    ) {
+      addReference(
+        currentReferenceSource,
+        referenceFromNode(node, currentReferenceSource),
+      );
+    }
+  }
+
+  function shouldRecordDirectiveReference(node: DirectiveNode): boolean {
+    const directiveName = node.name.value;
+    if (documentDirectiveNames.has(directiveName)) {
+      return true;
+    }
+
+    const existingDirective = schema?.getDirective(directiveName);
+    return (
+      existingDirective != null && !isSpecifiedDirective(existingDirective)
+    );
+  }
+
+  function detectCycleRecursive(source: ReferenceSource): void {
+    if (source.directiveName !== undefined) {
+      if (visitedDirectiveCoordinates.has(source.coordinate)) {
+        return;
+      }
+      visitedDirectiveCoordinates.add(source.coordinate);
+    }
+
+    pathIndexByCoordinate[source.coordinate] = referencePath.length;
+
+    for (const reference of referencesBySourceCoordinate[source.coordinate] ??
+      []) {
+      const cycleIndex = pathIndexByCoordinate[reference.coordinate];
+
+      referencePath.push(reference);
+      if (cycleIndex === undefined) {
+        detectCycleRecursive(reference);
+      } else {
+        reportCyclesInPath(cycleIndex, reference);
+      }
+      referencePath.pop();
+    }
+
+    pathIndexByCoordinate[source.coordinate] = undefined;
+  }
+
+  function reportCyclesInPath(
+    cycleIndex: number,
+    repeatedReference: Reference,
+  ): void {
+    const cyclePath = referencePath.slice(cycleIndex);
+    if (!cyclePath.some((cycleReference) => cycleReference.isFromDocument)) {
+      return;
+    }
+
+    if (repeatedReference.directiveName !== undefined) {
+      reportCycle(repeatedReference.directiveName, cyclePath);
+      return;
+    }
+
+    for (let i = 0; i < cyclePath.length; ++i) {
+      const cycleReference = cyclePath[i];
+      if (cycleReference.directiveName !== undefined) {
+        const directiveCyclePath = cyclePath
+          .slice(i + 1)
+          .concat(cyclePath.slice(0, i + 1));
+        reportCycle(cycleReference.directiveName, directiveCyclePath);
+      }
+    }
+  }
+
+  function addReference(source: ReferenceSource, reference: Reference): void {
+    const references = (referencesBySourceCoordinate[source.coordinate] ??= []);
+    const existingReferenceIndex = references.findIndex(
+      (existingReference) =>
+        existingReference.coordinate === reference.coordinate &&
+        existingReference.isFromDocument === reference.isFromDocument,
+    );
+
+    if (existingReferenceIndex === -1) {
+      references.push(reference);
+    }
+  }
+
+  function referenceFromNode(
+    node: DirectiveNode | NamedTypeNode,
+    source: ReferenceSource,
+  ): Reference {
+    const name = node.name.value;
+    if (node.kind === Kind.DIRECTIVE) {
+      return referenceFromSource(
+        {
+          coordinate: '@' + name,
+          directiveName: name,
+          isFromDocument: source.isFromDocument,
+        },
+        node,
+      );
+    }
+
+    return referenceFromSource(
+      {
+        coordinate: name,
+        isFromDocument: source.isFromDocument,
+      },
+      node,
+    );
+  }
+
+  function referenceFromSource(
+    source: ReferenceSource,
+    node: ReferenceNode | undefined,
+  ): Reference {
+    return node === undefined ? source : { ...source, node };
+  }
+
+  function collectSchemaDirectiveReferences(directive: GraphQLDirective): void {
+    if (isSpecifiedDirective(directive)) {
+      return;
+    }
+
+    for (const node of [directive.astNode, ...directive.extensionASTNodes]) {
+      if (node != null) {
+        visit(node, schemaReferenceVisitor);
+      }
+    }
+
+    const directiveSource = addDirectiveReferenceSource(directive.name, false);
+
+    for (const arg of directive.args) {
+      collectSchemaInputValueReferences(
+        directiveSource,
+        arg.name,
+        arg.type,
+        arg.astNode ?? undefined,
+      );
+    }
+  }
+
+  function collectSchemaInputValueReferences(
+    parentSource: ReferenceSource,
+    inputValueName: string,
+    type: GraphQLInputType,
+    node: InputValueDefinitionNode | undefined,
+  ): void {
+    if (node != null) {
+      visitNodeFromSource(parentSource, node);
+    }
+
+    const inputValueSource = {
+      coordinate: childSourceCoordinate(parentSource, inputValueName),
+      isFromDocument: false,
+    };
+
+    addReference(parentSource, referenceFromSource(inputValueSource, node));
+    addReference(
+      inputValueSource,
+      referenceFromSource(
+        {
+          coordinate: getNamedType(type).name,
+          isFromDocument: false,
+        },
+        undefined,
+      ),
+    );
+  }
+
+  function collectSchemaEnumValueReferences(
+    parentSource: ReferenceSource,
+    enumValueName: string,
+    node: EnumValueDefinitionNode | undefined,
+  ): void {
+    if (node != null) {
+      visitNodeFromSource(parentSource, node);
+    }
+
+    const enumValueSource = {
+      coordinate: childSourceCoordinate(parentSource, enumValueName),
+      isFromDocument: false,
+    };
+
+    addReference(parentSource, referenceFromSource(enumValueSource, node));
+  }
+
+  function visitNodeFromSource(
+    source: ReferenceSource,
+    node: InputValueDefinitionNode | EnumValueDefinitionNode,
+  ): void {
+    pushReferenceSource(source);
+    visit(node, schemaReferenceVisitor);
+    leaveReferenceSource();
+  }
+
+  function reportCycle(
+    directiveName: string,
+    cyclePath: ReadonlyArray<Reference>,
+  ): void {
+    const viaPath = cyclePath.map(formatReference).join(', ');
+
+    context.reportError(
+      new GraphQLError(
+        `Directive "@${directiveName}" forms a reference cycle through: ${viaPath}.`,
+        {
+          nodes: cyclePath
+            .map((reference) => reference.node)
+            .filter((node) => node !== undefined),
+        },
+      ),
+    );
+  }
+}
+
+function formatReference(reference: Reference): string {
+  return reference.directiveName !== undefined
+    ? `directive application "${reference.coordinate}"`
+    : `"${reference.coordinate}"`;
+}
+
+function canSchemaDirectiveDefinitionHaveReferences(
+  directive: GraphQLDirective,
+): boolean {
+  return (
+    !isSpecifiedDirective(directive) &&
+    (directive.astNode != null ||
+      directive.extensionASTNodes.length > 0 ||
+      directive.args.length > 0)
+  );
+}

--- a/src/validation/specifiedRules.ts
+++ b/src/validation/specifiedRules.ts
@@ -31,6 +31,8 @@ import { LoneAnonymousOperationRule } from './rules/LoneAnonymousOperationRule.t
 import { LoneSchemaDefinitionRule } from './rules/LoneSchemaDefinitionRule.ts';
 // TODO: Spec Section
 import { MaxIntrospectionDepthRule } from './rules/MaxIntrospectionDepthRule.ts';
+// Spec Section: "Directives"
+import { NoDirectiveDefinitionCyclesRule } from './rules/NoDirectiveDefinitionCyclesRule.ts';
 // Spec Section: "Fragments must not form cycles"
 import { NoFragmentCyclesRule } from './rules/NoFragmentCyclesRule.ts';
 // Spec Section: "All Variable Used Defined"
@@ -148,4 +150,5 @@ export const specifiedSDLRules: ReadonlyArray<SDLValidationRule> =
     UniqueArgumentNamesRule,
     UniqueInputFieldNamesRule,
     ProvidedRequiredArgumentsOnDirectivesRule,
+    NoDirectiveDefinitionCyclesRule,
   ]);


### PR DESCRIPTION
Adds a new `NoDirectiveDefinitionCyclesRule` SDL validation rule that detects cycles in the graph of directives used within directive definitions.

A cycle arises when following the references within directive definitions leads back to the same directive. Two kinds of references are tracked:

1. **Directive argument types** — if `@foo` takes an argument of type `InputObject`, and `InputObject` has a field with directive `@foo`, that forms a cycle: `@foo → InputObject → @foo`.
2. **Directives on directive definitions** — when the experimental `experimentalDirectivesOnDirectiveDefinitions` parser option is enabled, a directive applied directly to a directive definition or extension is also a reference. If `@a` is annotated with `@b` and `@b` is annotated with `@a`, that is a cycle: `@a → @b → @a`.

Cycles make it impossible to build a well-defined schema; the spec already [forbids
them](https://spec.graphql.org/draft/#sec-Type-System.Directives.Type-Validation), and experimental directive extensions [do the
same](https://github.com/graphql/graphql-spec/pull/1206/changes#diff-30a69c5a5eded8e1aea52e53dad1181e6ec8f549ca2c50570b035153e2de1c43R2342).