### PR TITLE
fix(diagnostics): emit asyncStart after promise settlement to match native `tracePromise`

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -427,17 +427,18 @@ export function traceMixed<TResult, TContext extends TraceLifecycleContext>(
     }
 
     channel.end.publish(context);
-    channel.asyncStart.publish(context);
 
     return result.then(
       (value) => {
         context.result = value;
+        channel.asyncStart.publish(context);
         channel.asyncEnd.publish(context);
         return value;
       },
       (err: unknown) => {
         context.error = err;
         channel.error.publish(context);
+        channel.asyncStart.publish(context);
         channel.asyncEnd.publish(context);
         throw err;
       },

--- a/src/execution/__tests__/diagnostics-execute-test.ts
+++ b/src/execution/__tests__/diagnostics-execute-test.ts
@@ -121,6 +121,7 @@ describe('execute diagnostics channel', () => {
             rawVariableValues: undefined,
             operationName: undefined,
             operationType: OperationTypeNode.QUERY,
+            result,
           },
         },
         {
@@ -201,17 +202,18 @@ describe('execute diagnostics channel', () => {
           },
         },
         {
-          channel: 'asyncStart',
+          channel: 'error',
           context: {
             schema: asyncDeferSchema,
             document,
             rawVariableValues: undefined,
             operationName: 'Deferred',
             operationType: OperationTypeNode.QUERY,
+            error,
           },
         },
         {
-          channel: 'error',
+          channel: 'asyncStart',
           context: {
             schema: asyncDeferSchema,
             document,
@@ -456,6 +458,7 @@ describe('execute root selection set diagnostics channel', () => {
             rawVariableValues: undefined,
             operationName: undefined,
             operationType: OperationTypeNode.QUERY,
+            result,
           },
         },
         {

--- a/src/execution/__tests__/diagnostics-resolve-test.ts
+++ b/src/execution/__tests__/diagnostics-resolve-test.ts
@@ -130,6 +130,7 @@ describe('resolve diagnostics channel', () => {
             args: {},
             isDefaultResolver: true,
             fieldPath: 'async',
+            result: 'hello-async',
           },
         },
         {
@@ -207,6 +208,7 @@ describe('resolve diagnostics channel', () => {
             args: {},
             isDefaultResolver: true,
             fieldPath: 'async',
+            result: 'hello-thenable',
           },
         },
         {
@@ -325,7 +327,7 @@ describe('resolve diagnostics channel', () => {
           },
         },
         {
-          channel: 'asyncStart',
+          channel: 'error',
           context: {
             fieldName: 'asyncFail',
             alias: 'asyncFail',
@@ -334,10 +336,11 @@ describe('resolve diagnostics channel', () => {
             args: {},
             isDefaultResolver: true,
             fieldPath: 'asyncFail',
+            error,
           },
         },
         {
-          channel: 'error',
+          channel: 'asyncStart',
           context: {
             fieldName: 'asyncFail',
             alias: 'asyncFail',

--- a/src/execution/__tests__/diagnostics-subscribe-test.ts
+++ b/src/execution/__tests__/diagnostics-subscribe-test.ts
@@ -145,6 +145,7 @@ describe('subscribe diagnostics channel', () => {
             rawVariableValues: undefined,
             operationName: undefined,
             operationType: OperationTypeNode.SUBSCRIPTION,
+            result,
           },
         },
         {
@@ -474,6 +475,7 @@ describe('subscribe diagnostics channel', () => {
             rawVariableValues: undefined,
             operationName: 'S',
             operationType: OperationTypeNode.SUBSCRIPTION,
+            result,
           },
         },
         {


### PR DESCRIPTION
@yaacovCR This is a minor correction for `traceMixed` that was introduced in #4670 

Once v17 RC was released, I made a round of tests against the observability ecosystem. One thing that I noticed was that OTEL's proposed API for tracing channels in https://github.com/open-telemetry/opentelemetry-js/pull/6387 was mis-parenting async resolvers sometimes.

The reason for this was `asyncStart` was emitted when the promise was first returned, rather than when the promise settled. Emitting it early meant subscribers that temporarily activate context between asyncStart and asyncEnd could leak that context into overlapping sibling operations.

This did not show up in earlier tests because most subscribers only used `start` for context creation and `asyncEnd` for completion. This should not be a breaking change because the terminal `end/asyncEnd` semantics and result/error payloads remain the same. This is an invisible change for most users, and is only correcting a slight mismatch.

We had to manually implement the async lifecycle in `traceMixed` here because we needed to preserve the `sync/async` return paths in resolvers.

I discussed this with @qard and this should be a more faithful implementation to how `tracePromise` works under the hood timing-wise. 