### PR TITLE
chore(release): v17.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "17.0.0",
+      "version": "17.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "5.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "17.0.0",
+  "version": "17.0.1",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,7 +4,7 @@
 // automatically updated by "npm version" command.
 
 /** A string containing the version of the GraphQL.js library */
-export const version = '17.0.0' as string;
+export const version = '17.0.1' as string;
 
 /** An object containing the components of the GraphQL.js version string */
 export const versionInfo: Readonly<{
@@ -15,6 +15,6 @@ export const versionInfo: Readonly<{
 }> = Object.freeze({
   major: 17,
   minor: 0,
-  patch: 0,
+  patch: 1,
   preReleaseTag: null,
 });


### PR DESCRIPTION
## v17.0.1 (2026-06-16)

#### Bug Fix 🐞
* [#4824](https://github.com/graphql/graphql-js/pull/4824) fix(diagnostics): emit asyncStart after promise settlement to match native `tracePromise` ([@logaretm](https://github.com/logaretm))

#### Internal 🏠
<details>
<summary> 2 PRs were merged </summary>

* [#4823](https://github.com/graphql/graphql-js/pull/4823) chore(npm): remove obsolete ESM-only package build ([@yaacovCR](https://github.com/yaacovCR))
* [#4825](https://github.com/graphql/graphql-js/pull/4825) chore(release): protect latest release channels ([@yaacovCR](https://github.com/yaacovCR)) </details>

#### Committers: 2
* Abdelrahman Awad([@logaretm](https://github.com/logaretm))
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))