### PR TITLE
fix(mapSchemaConfig): fix context for schema argument mapper

### DIFF
--- a/src/utilities/__tests__/mapSchemaConfig-test.ts
+++ b/src/utilities/__tests__/mapSchemaConfig-test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 import { dedentString } from '../../__testUtils__/dedent.ts';
 
-import { GraphQLObjectType } from '../../type/definition.ts';
+import { assertObjectType, GraphQLObjectType } from '../../type/definition.ts';
 import type { GraphQLSchemaNormalizedConfig } from '../../type/schema.ts';
 import { GraphQLSchema } from '../../type/schema.ts';
 
@@ -83,6 +83,33 @@ describe('mapSchemaConfig', () => {
           }
         `,
       );
+    });
+
+    it('provides field and parent type names when mapping field arguments', () => {
+      const sdl = `
+        type SomeType {
+          field(arg: String): String
+        }
+      `;
+
+      const schemaConfig = buildSchema(sdl).toConfig();
+      const visits: Array<string> = [];
+
+      const newSchemaConfig = mapSchemaConfig(schemaConfig, () => ({
+        [SchemaElementKind.ARGUMENT]: (
+          config,
+          fieldOrDirectiveName,
+          parentTypeName,
+        ) => {
+          visits.push(`${parentTypeName}.${fieldOrDirectiveName}`);
+          return config;
+        },
+      }));
+      const schema = new GraphQLSchema(newSchemaConfig);
+      const type = assertObjectType(schema.getType('SomeType'));
+      expect(type.getFields().field.args).to.have.lengthOf(1);
+
+      expect(visits).to.deep.equal(['SomeType.field']);
     });
   });
 

--- a/src/utilities/mapSchemaConfig.ts
+++ b/src/utilities/mapSchemaConfig.ts
@@ -321,7 +321,7 @@ export function mapSchemaConfig(
       let mappedField = {
         ...field,
         type: getType(field.type),
-        args: mapArgs(field.args, parentTypeName, fieldName),
+        args: mapArgs(field.args, fieldName, parentTypeName),
       };
       const mapper = configMapperMap[SchemaElementKind.FIELD];
       if (mapper) {


### PR DESCRIPTION
mapSchemaConfig is internal, so this bug has no direct public API surface by itself. The failure is in the context passed to SchemaElementKind.ARGUMENT mappers for field arguments: for type Query { user(id: ID): User }, the mapper received fieldOrDirectiveName = "Query" and parentTypeName = "user" instead of fieldOrDirectiveName = "user" and parentTypeName = "Query".

extendSchema and lexicographicSortSchema both traverse field arguments through mapSchemaConfig, but neither currently installs an ARGUMENT mapper, so their existing public behavior is not directly changed by the swapped parameters. The bug would surface if an internal schema utility used an ARGUMENT mapper while doing that traversal.