### PR TITLE
test: cover isCompositeType identity across package entrypoints

### DIFF
--- a/integrationTests/conditions/check.mjs
+++ b/integrationTests/conditions/check.mjs
@@ -1,15 +1,40 @@
 import assert from 'node:assert';
 
-import { GraphQLObjectType as ESMGraphQLObjectType } from 'graphql';
+import {
+  GraphQLObjectType as ESMGraphQLObjectType,
+  GraphQLString as ESMGraphQLString,
+  isCompositeType as ESMIsCompositeType,
+} from 'graphql';
+import {
+  GraphQLObjectType as ESMTypeGraphQLObjectType,
+  GraphQLString as ESMTypeGraphQLString,
+  isCompositeType as ESMTypeIsCompositeType,
+} from 'graphql/type';
 
-import { CJSGraphQLObjectType, cjsPath } from './cjs-importer.cjs';
+import {
+  CJSGraphQLObjectType,
+  CJSGraphQLString,
+  CJSIsCompositeType,
+  cjsPath,
+  CJSTypeGraphQLObjectType,
+  CJSTypeGraphQLString,
+  CJSTypeIsCompositeType,
+  cjsTypePath,
+} from './cjs-importer.cjs';
 
 const moduleSync = process.env.MODULE_SYNC === 'true';
 const expectedExtension = moduleSync ? '.mjs' : '.js';
-assert.ok(
-  cjsPath.endsWith(expectedExtension),
-  `require('graphql') should resolve to a file with extension "${expectedExtension}", but got "${cjsPath}".`,
-);
+const resolvedPaths = [
+  ["require('graphql')", cjsPath],
+  ["require('graphql/type')", cjsTypePath],
+];
+
+for (const [specifier, resolvedPath] of resolvedPaths) {
+  assert.ok(
+    resolvedPath.endsWith(expectedExtension),
+    `${specifier} should resolve to a file with extension "${expectedExtension}", but got "${resolvedPath}".`,
+  );
+}
 
 const isSameModule = ESMGraphQLObjectType === CJSGraphQLObjectType;
 assert.strictEqual(
@@ -18,4 +43,88 @@ assert.strictEqual(
   'ESM and CJS imports should be the same module instances.',
 );
 
-console.log('Module identity and path checks passed.');
+assert.strictEqual(
+  ESMGraphQLObjectType,
+  ESMTypeGraphQLObjectType,
+  'Root and graphql/type ESM imports should use the same GraphQLObjectType instance.',
+);
+assert.strictEqual(
+  CJSGraphQLObjectType,
+  CJSTypeGraphQLObjectType,
+  'Root and graphql/type CJS imports should use the same GraphQLObjectType instance.',
+);
+assert.strictEqual(
+  ESMIsCompositeType,
+  ESMTypeIsCompositeType,
+  'Root and graphql/type ESM imports should use the same isCompositeType predicate.',
+);
+assert.strictEqual(
+  CJSIsCompositeType,
+  CJSTypeIsCompositeType,
+  'Root and graphql/type CJS imports should use the same isCompositeType predicate.',
+);
+assert.strictEqual(
+  ESMIsCompositeType,
+  CJSIsCompositeType,
+  'ESM and CJS imports should use the same isCompositeType predicate.',
+);
+assert.strictEqual(
+  ESMGraphQLString,
+  ESMTypeGraphQLString,
+  'Root and graphql/type ESM imports should use the same GraphQLString instance.',
+);
+assert.strictEqual(
+  CJSGraphQLString,
+  CJSTypeGraphQLString,
+  'Root and graphql/type CJS imports should use the same GraphQLString instance.',
+);
+
+const objectTypes = [
+  [
+    'ESM root GraphQLObjectType',
+    new ESMGraphQLObjectType({
+      name: 'ESMRootObjectType',
+      fields: { field: { type: ESMGraphQLString } },
+    }),
+  ],
+  [
+    'ESM graphql/type GraphQLObjectType',
+    new ESMTypeGraphQLObjectType({
+      name: 'ESMTypeObjectType',
+      fields: { field: { type: ESMTypeGraphQLString } },
+    }),
+  ],
+  [
+    'CJS root GraphQLObjectType',
+    new CJSGraphQLObjectType({
+      name: 'CJSRootObjectType',
+      fields: { field: { type: CJSGraphQLString } },
+    }),
+  ],
+  [
+    'CJS graphql/type GraphQLObjectType',
+    new CJSTypeGraphQLObjectType({
+      name: 'CJSTypeObjectType',
+      fields: { field: { type: CJSTypeGraphQLString } },
+    }),
+  ],
+];
+
+const predicates = [
+  ['ESM root isCompositeType', ESMIsCompositeType],
+  ['ESM graphql/type isCompositeType', ESMTypeIsCompositeType],
+  ['CJS root isCompositeType', CJSIsCompositeType],
+  ['CJS graphql/type isCompositeType', CJSTypeIsCompositeType],
+];
+
+for (const [objectTypeLabel, objectType] of objectTypes) {
+  for (const [predicateLabel, isCompositeType] of predicates) {
+    assert.strictEqual(
+      isCompositeType(objectType),
+      true,
+      `${predicateLabel} should return true for ${objectTypeLabel}.`,
+    );
+  }
+}
+
+console.log('Module identity, subpath identity, and path checks passed.');

--- a/integrationTests/conditions/cjs-importer.cjs
+++ b/integrationTests/conditions/cjs-importer.cjs
@@ -1,11 +1,27 @@
 'use strict';
 
-const { GraphQLObjectType } = require('graphql');
+const {
+  GraphQLObjectType,
+  GraphQLString,
+  isCompositeType,
+} = require('graphql');
+const {
+  GraphQLObjectType: TypeGraphQLObjectType,
+  GraphQLString: TypeGraphQLString,
+  isCompositeType: typeIsCompositeType,
+} = require('graphql/type');
 
 const cjsPath = require.resolve('graphql');
+const cjsTypePath = require.resolve('graphql/type');
 
 // eslint-disable-next-line import/no-commonjs
 module.exports = {
   CJSGraphQLObjectType: GraphQLObjectType,
+  CJSGraphQLString: GraphQLString,
+  CJSIsCompositeType: isCompositeType,
+  CJSTypeGraphQLObjectType: TypeGraphQLObjectType,
+  CJSTypeGraphQLString: TypeGraphQLString,
+  CJSTypeIsCompositeType: typeIsCompositeType,
   cjsPath,
+  cjsTypePath,
 };


### PR DESCRIPTION
## Summary

Adds integration coverage for `isCompositeType` identity across GraphQL.js package entrypoints and module conditions.

This is related to #4830, where upstream code using:

```ts
Object.values(schema.getTypeMap()).filter(isCompositeType)
```

can observe no composite types if GraphQL type instances and predicates come from different evaluated `graphql` module instances.

## What changed

- Extended the conditional exports integration check to verify that:
  - `graphql` and `graphql/type` share the same `GraphQLObjectType`
  - `graphql` and `graphql/type` share the same `GraphQLString`
  - `graphql` and `graphql/type` share the same `isCompositeType`
  - ESM and CJS imports share the same `isCompositeType`
  - object types constructed through root, subpath, ESM, and CJS entrypoints are accepted by all `isCompositeType` predicates
- Added `require('graphql/type')` path checks alongside the existing `require('graphql')` path check.

## Why

GraphQL.js v17 type predicates rely on internal `__kind` brand symbols. If supported package entrypoints or module conditions accidentally evaluate separate GraphQL.js module instances, a type created by one entrypoint can fail a predicate imported from another entrypoint.

This test does not change duplicate-module semantics. It only ensures that the supported package entrypoints and CJS/ESM conditions preserve predicate identity for the same built package.

## Tests

Ran:

```sh
npm run node:test -- "src/type/__tests__/predicate-test.ts"
npm run node:test -- "src/jsutils/__tests__/instanceOf-test.ts"
npm run build:npm
npx prettier --check integrationTests/conditions/check.mjs integrationTests/conditions/cjs-importer.cjs
npx eslint --max-warnings 0 integrationTests/conditions/check.mjs integrationTests/conditions/cjs-importer.cjs
node --check integrationTests/conditions/check.mjs
node --check integrationTests/conditions/cjs-importer.cjs
```

Also ran a smoke check against the built npm package:

```text
Module identity, subpath identity, and path checks passed.
```

Not run:

```sh
npm run check:integrations
```

because it requires the full Docker-based integration test environment.

Refs #4830
