### PR TITLE
fix: detect default-value changes on input object fields

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -979,6 +979,55 @@ describe('findDangerousChanges', () => {
     ]);
   });
 
+  it('should detect if a defaultValue changed on an input field', () => {
+    const oldSDL = `
+      input InputType1 {
+        withDefaultValue: String = "TO BE DELETED"
+        stringField: String = "test"
+        emptyArray: [Int!] = []
+        withoutDefaultValue: String
+      }
+
+      type Query {
+        field1(arg: InputType1): String
+      }
+    `;
+
+    const oldSchema = buildSchema(oldSDL);
+    const copyOfOldSchema = buildSchema(oldSDL);
+    expect(findDangerousChanges(oldSchema, copyOfOldSchema)).to.deep.equal([]);
+
+    const newSchema = buildSchema(`
+      input InputType1 {
+        withDefaultValue: String
+        stringField: String = "Test"
+        emptyArray: [Int!] = [7]
+        withoutDefaultValue: String = "now has one"
+      }
+
+      type Query {
+        field1(arg: InputType1): String
+      }
+    `);
+
+    expect(findDangerousChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: DangerousChangeType.INPUT_FIELD_DEFAULT_VALUE_CHANGE,
+        description: 'InputType1.withDefaultValue defaultValue was removed.',
+      },
+      {
+        type: DangerousChangeType.INPUT_FIELD_DEFAULT_VALUE_CHANGE,
+        description:
+          'InputType1.stringField has changed defaultValue from "test" to "Test".',
+      },
+      {
+        type: DangerousChangeType.INPUT_FIELD_DEFAULT_VALUE_CHANGE,
+        description:
+          'InputType1.emptyArray has changed defaultValue from [] to [7].',
+      },
+    ]);
+  });
+
   it('should ignore changes in field order of defaultValue', () => {
     const oldSchema = buildSchema(`
       input Input1 {

--- a/src/utilities/findSchemaChanges.ts
+++ b/src/utilities/findSchemaChanges.ts
@@ -70,6 +70,7 @@ export const DangerousChangeType = {
   OPTIONAL_ARG_ADDED: 'OPTIONAL_ARG_ADDED' as const,
   IMPLEMENTED_INTERFACE_ADDED: 'IMPLEMENTED_INTERFACE_ADDED' as const,
   ARG_DEFAULT_VALUE_CHANGE: 'ARG_DEFAULT_VALUE_CHANGE' as const,
+  INPUT_FIELD_DEFAULT_VALUE_CHANGE: 'INPUT_FIELD_DEFAULT_VALUE_CHANGE' as const,
 } as const;
 
 /** Categories of schema changes that may be dangerous for existing operations. */
@@ -91,6 +92,7 @@ export const SafeChangeType = {
   FIELD_CHANGED_KIND_SAFE: 'FIELD_CHANGED_KIND_SAFE' as const,
   ARG_CHANGED_KIND_SAFE: 'ARG_CHANGED_KIND_SAFE' as const,
   ARG_DEFAULT_VALUE_ADDED: 'ARG_DEFAULT_VALUE_ADDED' as const,
+  INPUT_FIELD_DEFAULT_VALUE_ADDED: 'INPUT_FIELD_DEFAULT_VALUE_ADDED' as const,
 } as const;
 
 /** Categories of schema changes that are considered safe for existing operations. */
@@ -490,10 +492,33 @@ function findInputObjectTypeChanges(
       oldField.type,
       newField.type,
     );
+
+    const oldDefaultValueStr = getDefaultValue(oldField);
+    const newDefaultValueStr = getDefaultValue(newField);
     if (!isSafe) {
       schemaChanges.push({
         type: BreakingChangeType.FIELD_CHANGED_KIND,
         description: `Field ${newField} changed type from ${oldField.type} to ${newField.type}.`,
+      });
+    } else if (oldDefaultValueStr !== undefined) {
+      if (newDefaultValueStr === undefined) {
+        schemaChanges.push({
+          type: DangerousChangeType.INPUT_FIELD_DEFAULT_VALUE_CHANGE,
+          description: `${oldField} defaultValue was removed.`,
+        });
+      } else if (oldDefaultValueStr !== newDefaultValueStr) {
+        schemaChanges.push({
+          type: DangerousChangeType.INPUT_FIELD_DEFAULT_VALUE_CHANGE,
+          description: `${oldField} has changed defaultValue from ${oldDefaultValueStr} to ${newDefaultValueStr}.`,
+        });
+      }
+    } else if (
+      newDefaultValueStr !== undefined &&
+      oldDefaultValueStr === undefined
+    ) {
+      schemaChanges.push({
+        type: SafeChangeType.INPUT_FIELD_DEFAULT_VALUE_ADDED,
+        description: `${oldField} added a defaultValue ${newDefaultValueStr}.`,
       });
     } else if (oldField.type.toString() !== newField.type.toString()) {
       schemaChanges.push({


### PR DESCRIPTION
`findSchemaChanges`, `findDangerousChanges` and `findBreakingChanges` detect a default-value change on a field argument and on a directive argument, but not on an input object field. Changing the default value of an input-object field is a dangerous change: a client that omits that field gets different behavior after the change. Tooling and CI gates that rely on these functions (schema registries, the graphql-inspector action, custom "is this change safe" checks) ship such a change with no warning.

## Cause

`src/utilities/findSchemaChanges.ts`, `findInputObjectTypeChanges` compares the field type and description but never compares the default value, unlike the sibling `findArgChanges`. The gap is long-standing (v16 has the same omission).

## Fix

Compare the input-field default value the same way `findArgChanges` does (via `getDefaultValue`, which runs `sortValueNode` so object-field reordering is ignored), and report:

- `INPUT_FIELD_DEFAULT_VALUE_CHANGE` (dangerous) when a default is changed or removed,
- `INPUT_FIELD_DEFAULT_VALUE_ADDED` (safe) when a default is added.

These are new members alongside the existing `REQUIRED_INPUT_FIELD_ADDED` / `OPTIONAL_INPUT_FIELD_ADDED`, so an input-field change is reported under an input-field type rather than reusing the argument type.

Added a test in `findBreakingChanges-test.ts` covering a removed, changed, and list default. It fails before this change (the input-field changes are not reported); the `findBreakingChanges` and `findSchemaChanges` suites (55) stay green, and tsc, eslint and prettier pass.
