### PR TITLE
fix(DeferStreamDirectiveOnRootFieldRule): handle fragment cycles

### DIFF
--- a/src/validation/__tests__/DeferStreamDirectiveOnRootFieldRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveOnRootFieldRule-test.ts
@@ -104,6 +104,29 @@ describe('Validate: Defer/Stream directive on root field', () => {
       },
     ]);
   });
+  it('Fragment spread cycle on root mutation field', () => {
+    expectValid(`
+      mutation {
+        ...rootFragment
+      }
+      fragment rootFragment on MutationRoot {
+        ...otherFragment
+      }
+      fragment otherFragment on MutationRoot {
+        ...rootFragment
+      }
+    `);
+  });
+  it('Self-referencing fragment spread on root mutation field', () => {
+    expectValid(`
+      mutation {
+        ...rootFragment
+      }
+      fragment rootFragment on MutationRoot {
+        ...rootFragment
+      }
+    `);
+  });
   it('Defer inline fragment spread on root mutation field', () => {
     expectErrors(`
       mutation {

--- a/src/validation/rules/DeferStreamDirectiveOnRootFieldRule.ts
+++ b/src/validation/rules/DeferStreamDirectiveOnRootFieldRule.ts
@@ -121,6 +121,7 @@ function forbidDeferStream({
       if (visitedFragments.has(fragmentName)) {
         continue;
       }
+      visitedFragments.add(fragmentName);
       const fragment = fragments.get(fragmentName);
       if (fragment) {
         const defer = getDeferDirective(selection);
@@ -141,7 +142,6 @@ function forbidDeferStream({
           visitedFragments,
         });
       }
-      visitedFragments.add(fragmentName);
     } else if (selection.kind === 'InlineFragment') {
       const defer = getDeferDirective(selection);
       if (defer !== undefined) {


### PR DESCRIPTION
This PR adjusts where visited fragments are recorded by `DeferStreamDirectiveOnRootFieldRule` to better protect against cycles.