### PR TITLE
Skip deferred fragments in collectFields only when same directive is used

### DIFF
--- a/src/execution/__tests__/collectFields-test.ts
+++ b/src/execution/__tests__/collectFields-test.ts
@@ -57,20 +57,6 @@ describe('collectFields', () => {
       expect(newDeferUsages).to.have.lengthOf(0);
     });
 
-    it('should not collect a deferred spread after a deferred spread has been collected', () => {
-      const { newDeferUsages } = collectRootFields(`
-        query {
-          ...FragmentName @defer
-          ...FragmentName @defer
-        }
-        fragment FragmentName on Query {
-          field
-        }
-      `);
-
-      expect(newDeferUsages).to.have.lengthOf(1);
-    });
-
     it('should collect a non-deferred spread after a deferred spread has been collected', () => {
       const { groupedFieldSet } = collectRootFields(`
         query {
@@ -107,7 +93,28 @@ describe('collectFields', () => {
       expect(fieldDetailsList).to.have.lengthOf(1);
     });
 
-    it('prevents infinite loop when deferred fragment is used with same label', () => {
+    it('should not collect a spread after a spread has been collected in the same defer context', () => {
+      const { newDeferUsages, groupedFieldSet } = collectRootFields(`
+        query {
+          ... @defer {
+            ...FragmentName
+            ...FragmentName
+          }
+        }
+        fragment FragmentName on Query {
+          field
+        }
+      `);
+
+      expect(newDeferUsages).to.have.lengthOf(1);
+      const fieldDetailsList = groupedFieldSet.get('field');
+
+      invariant(fieldDetailsList != null);
+
+      expect(fieldDetailsList).to.have.lengthOf(1);
+    });
+
+    it('prevents infinite loops from circular deferred fragment spreads', () => {
       const { newDeferUsages } = collectRootFields(`
         query {
           ...FragmentOne @defer(label: "Foo")

--- a/src/execution/__tests__/collectFields-test.ts
+++ b/src/execution/__tests__/collectFields-test.ts
@@ -106,5 +106,26 @@ describe('collectFields', () => {
 
       expect(fieldDetailsList).to.have.lengthOf(1);
     });
+
+    it('prevents infinite loop when deferred fragment is used with same label', () => {
+      const { newDeferUsages } = collectRootFields(`
+        query {
+          ...FragmentOne @defer(label: "Foo")
+        }
+        fragment FragmentOne on Query {
+          ...FragmentTwo @defer(label: "Bar")
+          field
+        }
+        fragment FragmentTwo on Query {
+          ...FragmentThree @defer(label: "Baz")
+          }
+        fragment FragmentThree on Query {
+          ...FragmentOne @defer(label: "Qux")
+          field
+        }
+      `);
+
+      expect(newDeferUsages).to.have.lengthOf(4);
+    });
   });
 });

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -69,12 +69,19 @@ export interface FragmentDetails {
   variableSignatures?: ObjMap<GraphQLVariableSignature> | undefined;
 }
 
+interface VisitedFragmentNames {
+  // Fragments that have been visited without @defer.
+  immediateFragments: Set<string>;
+  // Map of fragment name to a set of labels that have been visited with @defer.
+  deferredFragments: Map<string, Set<string | null>>;
+}
+
 interface CollectFieldsContext {
   schema: GraphQLSchema;
   fragments: ObjMap<FragmentDetails>;
   variableValues: VariableValues;
   runtimeType: GraphQLObjectType;
-  visitedFragmentNames: Map<string, boolean>;
+  visitedFragmentNames: VisitedFragmentNames;
   hideSuggestions: boolean;
   forbiddenDirectiveInstances: Array<DirectiveNode>;
   forbidSkipAndInclude: boolean;
@@ -110,7 +117,10 @@ export function collectFields(
     fragments,
     variableValues,
     runtimeType,
-    visitedFragmentNames: new Map(),
+    visitedFragmentNames: {
+      immediateFragments: new Set(),
+      deferredFragments: new Map(),
+    },
     hideSuggestions,
     forbiddenDirectiveInstances: [],
     forbidSkipAndInclude,
@@ -151,7 +161,10 @@ export function collectSubfields(
     fragments,
     variableValues,
     runtimeType: returnType,
-    visitedFragmentNames: new Map(),
+    visitedFragmentNames: {
+      immediateFragments: new Set(),
+      deferredFragments: new Map(),
+    },
     hideSuggestions,
     forbiddenDirectiveInstances: [],
     forbidSkipAndInclude: false,
@@ -291,26 +304,38 @@ function collectFieldsImpl(
           deferUsage,
         );
 
-        const visitedAsDeferred = visitedFragmentNames.get(fragName);
+        const visitedAsImmediate =
+          visitedFragmentNames.immediateFragments.has(fragName);
+
+        if (visitedAsImmediate) {
+          // Even if the fragment is deferred, we don't need to
+          // collect it again if it has already been visited without @defer.
+          continue;
+        }
 
         let maybeNewDeferUsage: DeferUsage | undefined;
-        if (!newDeferUsage) {
-          // If this spread is not deferred, it may be skipped when already visited
-          // as a non-deferred spread. If it was previously visited as a deferred spread,
-          // it must be revisited.
-          if (visitedAsDeferred === false) {
+
+        if (newDeferUsage) {
+          let visitedAsDeferredByLabelSet =
+            visitedFragmentNames.deferredFragments.get(fragName);
+          if (!visitedAsDeferredByLabelSet) {
+            visitedAsDeferredByLabelSet = new Set();
+            visitedFragmentNames.deferredFragments.set(
+              fragName,
+              visitedAsDeferredByLabelSet,
+            );
+          }
+          if (visitedAsDeferredByLabelSet.has(newDeferUsage.label ?? null)) {
+            // If the fragment has already been visited as deferred by the same
+            // label, skip it.
             continue;
           }
-          visitedFragmentNames.set(fragName, false);
-          maybeNewDeferUsage = deferUsage;
-        } else {
-          // If this spread is deferred, it can be skipped if it has already been visited.
-          if (visitedAsDeferred !== undefined) {
-            continue;
-          }
-          visitedFragmentNames.set(fragName, true);
           newDeferUsages.push(newDeferUsage);
           maybeNewDeferUsage = newDeferUsage;
+          visitedAsDeferredByLabelSet.add(newDeferUsage.label ?? null);
+        } else {
+          maybeNewDeferUsage = deferUsage;
+          visitedFragmentNames.immediateFragments.add(fragName);
         }
 
         const fragmentVariableSignatures = fragment.variableSignatures;

--- a/src/execution/collectFields.ts
+++ b/src/execution/collectFields.ts
@@ -25,14 +25,11 @@ import { typeFromAST } from '../utilities/typeFromAST.ts';
 
 import type { GraphQLVariableSignature } from './getVariableSignature.ts';
 import type { VariableValues } from './values.ts';
-import {
-  getArgumentValues,
-  getDirectiveValues,
-  getFragmentVariableValues,
-} from './values.ts';
+import { getArgumentValues, getFragmentVariableValues } from './values.ts';
 
 /** @internal */
 export interface DeferUsage {
+  directiveNode: DirectiveNode;
   label: string | undefined;
   parentDeferUsage: DeferUsage | undefined;
 }
@@ -69,12 +66,7 @@ export interface FragmentDetails {
   variableSignatures?: ObjMap<GraphQLVariableSignature> | undefined;
 }
 
-interface VisitedFragmentNames {
-  // Fragments that have been visited without @defer.
-  immediateFragments: Set<string>;
-  // Map of fragment name to a set of labels that have been visited with @defer.
-  deferredFragments: Map<string, Set<string | null>>;
-}
+type VisitedFragmentNames = Map<string, Set<DirectiveNode | null>>;
 
 interface CollectFieldsContext {
   schema: GraphQLSchema;
@@ -117,10 +109,7 @@ export function collectFields(
     fragments,
     variableValues,
     runtimeType,
-    visitedFragmentNames: {
-      immediateFragments: new Set(),
-      deferredFragments: new Map(),
-    },
+    visitedFragmentNames: new Map(),
     hideSuggestions,
     forbiddenDirectiveInstances: [],
     forbidSkipAndInclude,
@@ -161,10 +150,7 @@ export function collectSubfields(
     fragments,
     variableValues,
     runtimeType: returnType,
-    visitedFragmentNames: {
-      immediateFragments: new Set(),
-      deferredFragments: new Map(),
-    },
+    visitedFragmentNames: new Map(),
     hideSuggestions,
     forbiddenDirectiveInstances: [],
     forbidSkipAndInclude: false,
@@ -304,39 +290,26 @@ function collectFieldsImpl(
           deferUsage,
         );
 
-        const visitedAsImmediate =
-          visitedFragmentNames.immediateFragments.has(fragName);
+        const maybeNewDeferUsage = newDeferUsage ?? deferUsage;
+        let visitedDeferSet = visitedFragmentNames.get(fragName);
+        if (!visitedDeferSet) {
+          visitedDeferSet = new Set();
+          visitedFragmentNames.set(fragName, visitedDeferSet);
+        }
 
-        if (visitedAsImmediate) {
-          // Even if the fragment is deferred, we don't need to
-          // collect it again if it has already been visited without @defer.
+        if (
+          visitedDeferSet.has(null) ||
+          (maybeNewDeferUsage &&
+            visitedDeferSet.has(maybeNewDeferUsage.directiveNode))
+        ) {
           continue;
         }
 
-        let maybeNewDeferUsage: DeferUsage | undefined;
-
         if (newDeferUsage) {
-          let visitedAsDeferredByLabelSet =
-            visitedFragmentNames.deferredFragments.get(fragName);
-          if (!visitedAsDeferredByLabelSet) {
-            visitedAsDeferredByLabelSet = new Set();
-            visitedFragmentNames.deferredFragments.set(
-              fragName,
-              visitedAsDeferredByLabelSet,
-            );
-          }
-          if (visitedAsDeferredByLabelSet.has(newDeferUsage.label ?? null)) {
-            // If the fragment has already been visited as deferred by the same
-            // label, skip it.
-            continue;
-          }
           newDeferUsages.push(newDeferUsage);
-          maybeNewDeferUsage = newDeferUsage;
-          visitedAsDeferredByLabelSet.add(newDeferUsage.label ?? null);
-        } else {
-          maybeNewDeferUsage = deferUsage;
-          visitedFragmentNames.immediateFragments.add(fragName);
         }
+
+        visitedDeferSet.add(maybeNewDeferUsage?.directiveNode ?? null);
 
         const fragmentVariableSignatures = fragment.variableSignatures;
         let newFragmentVariableValues: FragmentVariableValues | undefined;
@@ -377,16 +350,20 @@ function getDeferUsage(
   node: FragmentSpreadNode | InlineFragmentNode,
   parentDeferUsage: DeferUsage | undefined,
 ): DeferUsage | undefined {
-  const defer = getDirectiveValues(
+  const directiveNode = node.directives?.find(
+    (directive) => directive.name.value === GraphQLDeferDirective.name,
+  );
+
+  if (!directiveNode) {
+    return;
+  }
+
+  const defer = getArgumentValues(
     GraphQLDeferDirective,
-    node,
+    directiveNode,
     variableValues,
     fragmentVariableValues,
   );
-
-  if (!defer) {
-    return;
-  }
 
   if (defer.if === false) {
     return;
@@ -394,6 +371,7 @@ function getDeferUsage(
 
   return {
     label: typeof defer.label === 'string' ? defer.label : undefined,
+    directiveNode,
     parentDeferUsage,
   };
 }

--- a/src/execution/incremental/__tests__/defer-test.ts
+++ b/src/execution/incremental/__tests__/defer-test.ts
@@ -703,34 +703,7 @@ describe('Execute: defer directive', () => {
     ]);
   });
 
-  it('Can skip deferred fragment if same label is used', async () => {
-    const document = parse(`
-      query HeroNameQuery {
-        hero {
-          ...TopFragment @defer(label: "DeferTop")
-          ...TopFragment @defer(label: "DeferTop")
-        }
-      }
-      fragment TopFragment on Hero {
-        name
-      }
-    `);
-    const result = await complete(document);
-    expectJSON(result).toDeepEqual([
-      {
-        data: { hero: {} },
-        pending: [{ id: '0', path: ['hero'], label: 'DeferTop' }],
-        hasNext: true,
-      },
-      {
-        hasNext: false,
-        incremental: [{ id: '0', data: { name: 'Luke' } }],
-        completed: [{ id: '0' }],
-      },
-    ]);
-  });
-
-  it('Can skip deferred fragment if no label is used', async () => {
+  it('Can defer same fragment with unlabeled sibling defers', async () => {
     const document = parse(`
       query HeroNameQuery {
         hero {
@@ -746,13 +719,16 @@ describe('Execute: defer directive', () => {
     expectJSON(result).toDeepEqual([
       {
         data: { hero: {} },
-        pending: [{ id: '0', path: ['hero'] }],
+        pending: [
+          { id: '0', path: ['hero'] },
+          { id: '1', path: ['hero'] },
+        ],
         hasNext: true,
       },
       {
         hasNext: false,
         incremental: [{ id: '0', data: { name: 'Luke' } }],
-        completed: [{ id: '0' }],
+        completed: [{ id: '0' }, { id: '1' }],
       },
     ]);
   });
@@ -1028,6 +1004,28 @@ describe('Execute: defer directive', () => {
         hasNext: false,
       },
     ]);
+  });
+
+  it('Does not skip non-deferred fragments when a fragment is deferred by parent defer', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          ... @defer(label: "DeferID") {
+            ...F
+          }
+          ...F
+        }
+      }
+      fragment F on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+    expectJSON(result).toDeepEqual({
+      data: {
+        hero: { name: 'Luke' },
+      },
+    });
   });
 
   it('Separately emits nested defer fragments with varying subfields of same priorities but different level of defers', async () => {

--- a/src/execution/incremental/__tests__/defer-test.ts
+++ b/src/execution/incremental/__tests__/defer-test.ts
@@ -673,6 +673,90 @@ describe('Execute: defer directive', () => {
     });
   });
 
+  it('Can defer same fragment with different labels', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          ...TopFragment @defer(label: "DeferTop1")
+          ...TopFragment @defer(label: "DeferTop2")
+        }
+      }
+      fragment TopFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: {} },
+        pending: [
+          { id: '0', path: ['hero'], label: 'DeferTop1' },
+          { id: '1', path: ['hero'], label: 'DeferTop2' },
+        ],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+        incremental: [{ id: '0', data: { name: 'Luke' } }],
+        completed: [{ id: '0' }, { id: '1' }],
+      },
+    ]);
+  });
+
+  it('Can skip deferred fragment if same label is used', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          ...TopFragment @defer(label: "DeferTop")
+          ...TopFragment @defer(label: "DeferTop")
+        }
+      }
+      fragment TopFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: {} },
+        pending: [{ id: '0', path: ['hero'], label: 'DeferTop' }],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+        incremental: [{ id: '0', data: { name: 'Luke' } }],
+        completed: [{ id: '0' }],
+      },
+    ]);
+  });
+
+  it('Can skip deferred fragment if no label is used', async () => {
+    const document = parse(`
+      query HeroNameQuery {
+        hero {
+          ...TopFragment @defer
+          ...TopFragment @defer
+        }
+      }
+      fragment TopFragment on Hero {
+        name
+      }
+    `);
+    const result = await complete(document);
+    expectJSON(result).toDeepEqual([
+      {
+        data: { hero: {} },
+        pending: [{ id: '0', path: ['hero'] }],
+        hasNext: true,
+      },
+      {
+        hasNext: false,
+        incremental: [{ id: '0', data: { name: 'Luke' } }],
+        completed: [{ id: '0' }],
+      },
+    ]);
+  });
+
   it('Can defer an inline fragment', async () => {
     const document = parse(`
       query HeroNameQuery {

--- a/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
+++ b/src/execution/legacyIncremental/__tests__/legacy-defer-test.ts
@@ -1185,7 +1185,7 @@ describe('Execute: defer directive (legacy)', () => {
     });
   });
 
-  it('Skips duplicate nested defers on the same object', async () => {
+  it('Duplicates nested defers on the same object', async () => {
     const document = parse(`
       query {
         hero {
@@ -1194,12 +1194,6 @@ describe('Execute: defer directive (legacy)', () => {
               ...FriendFrag
               ... @defer {
                 ...FriendFrag
-                ... @defer {
-                  ...FriendFrag
-                  ... @defer {
-                    ...FriendFrag
-                  }
-                }
               }
             }
           }
@@ -1220,6 +1214,9 @@ describe('Execute: defer directive (legacy)', () => {
       },
       {
         incremental: [
+          { data: { id: '2', name: 'Han' }, path: ['hero', 'friends', 0] },
+          { data: { id: '3', name: 'Leia' }, path: ['hero', 'friends', 1] },
+          { data: { id: '4', name: 'C-3PO' }, path: ['hero', 'friends', 2] },
           { data: { id: '2', name: 'Han' }, path: ['hero', 'friends', 0] },
           { data: { id: '3', name: 'Leia' }, path: ['hero', 'friends', 1] },
           { data: { id: '4', name: 'C-3PO' }, path: ['hero', 'friends', 2] },


### PR DESCRIPTION
For this case:
```graphql
query HeroNameQuery {
  hero {
    ...TopFragment @defer(label: "DeferTop1")
    ...TopFragment @defer(label: "DeferTop2")
  }
}
fragment TopFragment on Hero {
  name
}
```

Currently the second spread of TopFragment gets skipped by the visited fragment check and the result is:

```js
[
  {
    data: { hero: {} },
    pending: [
      { id: '0', path: ['hero'], label: 'DeferTop1' }
    ],
    hasNext: true,
  },
  {
    hasNext: false,
    incremental: [{ id: '0', data: { name: 'Luke' } }],
    completed: [{ id: '0' }],
  },
]
```

I think this will be an issue for clients. Since no pending is sent for the fragment with the DeferTop2 label, clients will assume this fragment has been inlined (not deferred), but the necessary fields have not been included in the initial result.

A second issue I discovered is that non-deferred fields may be incorrectly skipped:

```graphql
{
  ... @defer {
    ...F
  }
  ...F
}
fragment F on Query {
  a
}
```

The first instance of ...F populates visitedFragments with no defer condition, even though it's wrapped in a parent defer, meaning the second ...F gets skipped and a is not delivered in the initial payload.

This PR updates the visited fragment check to only skip deferred fragments that have already been collected within the same defer context, while still preventing infinite loops from circular fragment references

New response:
```js
[
  {
    data: { hero: {} },
    pending: [
      { id: '0', path: ['hero'], label: 'DeferTop1' },
      { id: '1', path: ['hero'], label: 'DeferTop2' },
    ],
    hasNext: true,
  },
  {
    hasNext: false,
    incremental: [{ id: '0', data: { name: 'Luke' } }],
    completed: [{ id: '0' }, { id: '1' }],
  },
]
```