### PR TITLE
polish(introspection): cover __Type.description on wrapping types

### DIFF
--- a/src/type/__tests__/introspection-test.ts
+++ b/src/type/__tests__/introspection-test.ts
@@ -1796,6 +1796,64 @@ describe('Introspection', () => {
     });
   });
 
+  it('returns null for descriptions of wrapping types', () => {
+    const schema = buildSchema(`
+      """Object description"""
+      type SomeObject {
+        listField: [SomeObject]
+        nonNullField: SomeObject!
+      }
+
+      schema {
+        query: SomeObject
+      }
+    `);
+
+    const source = `
+      {
+        __type(name: "SomeObject") {
+          description
+          fields {
+            name
+            type {
+              kind
+              description
+              ofType {
+                description
+              }
+            }
+          }
+        }
+      }
+    `;
+
+    expect(graphqlSync({ schema, source })).to.deep.equal({
+      data: {
+        __type: {
+          description: 'Object description',
+          fields: [
+            {
+              name: 'listField',
+              type: {
+                kind: 'LIST',
+                description: null,
+                ofType: { description: 'Object description' },
+              },
+            },
+            {
+              name: 'nonNullField',
+              type: {
+                kind: 'NON_NULL',
+                description: null,
+                ofType: { description: 'Object description' },
+              },
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('executes an introspection query without calling global resolvers', () => {
     const schema = buildSchema(`
       type Query {

--- a/src/type/introspection.ts
+++ b/src/type/introspection.ts
@@ -282,8 +282,6 @@ export const __Type: GraphQLObjectType = new GraphQLObjectType({
       description: {
         type: GraphQLString,
         resolve: (type) =>
-          // FIXME: add test case
-          /* node:coverage ignore next */
           'description' in type ? type.description : undefined,
       },
       specifiedByURL: {


### PR DESCRIPTION
Adds a test asserting __Type.description resolves to null for LIST and NON_NULL wrapping types, which have no description of their own, while ofType.description still resolves. getIntrospectionQuery() never hit this branch: it asks for description only on named types and for kind/name on ofType.

This was the last uncovered branch in the resolver, so the `node:coverage ignore` pragma and its FIXME are removed. Coverage stays at 100% without them.