### PR TITLE
polish(validateInputValue): cover invalid values in iterable input

### DIFF
--- a/src/utilities/__tests__/validateInputValue-test.ts
+++ b/src/utilities/__tests__/validateInputValue-test.ts
@@ -497,7 +497,6 @@ describe('validateInputValue', () => {
     });
 
     it('returns no error for a valid iterable input', () => {
-      // TODO: put an error in this list and show it appears
       function* listGenerator() {
         yield 1;
         yield 2;
@@ -505,6 +504,26 @@ describe('validateInputValue', () => {
       }
 
       test(listGenerator(), TestList, []);
+    });
+
+    it('returns an error for an invalid iterable input', () => {
+      function* listGenerator() {
+        yield 1;
+        yield 'b';
+        yield true;
+        yield 4;
+      }
+
+      test(listGenerator(), TestList, [
+        {
+          error: 'Int cannot represent non-integer value: "b"',
+          path: [1],
+        },
+        {
+          error: 'Int cannot represent non-integer value: true',
+          path: [2],
+        },
+      ]);
     });
 
     it('returns an error for an invalid input', () => {


### PR DESCRIPTION
`validateInputValue` accepts any iterable for a list type, but the iterable test only asserted the success case and carried a `TODO: put an error in this list and show it appears`.

This adds the error case: a generator yielding an invalid item, asserting the reported error paths use the item indices. The TODO comment is removed.

No behaviour change — tests only.
