### PR TITLE
fix(findSchemaChanges): detect @oneOf added to or removed from an input object type

### DIFF
--- a/src/utilities/__tests__/findBreakingChanges-test.ts
+++ b/src/utilities/__tests__/findBreakingChanges-test.ts
@@ -326,6 +326,37 @@ describe('findBreakingChanges', () => {
     ]);
   });
 
+  it('should detect if an input type became a oneOf input type', () => {
+    const oldSchema = buildSchema(`
+      input InputType1 {
+        field1: String
+        field2: Int
+      }
+
+      type Query {
+        field(arg: InputType1): String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      input InputType1 @oneOf {
+        field1: String
+        field2: Int
+      }
+
+      type Query {
+        field(arg: InputType1): String
+      }
+    `);
+
+    expect(findBreakingChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        type: BreakingChangeType.INPUT_OBJECT_ONE_OF_ADDED,
+        description: '@oneOf was added to InputType1.',
+      },
+    ]);
+  });
+
   it('should detect if a type was removed from a union type', () => {
     const oldSchema = buildSchema(`
       type Type1

--- a/src/utilities/__tests__/findSchemaChanges-test.ts
+++ b/src/utilities/__tests__/findSchemaChanges-test.ts
@@ -504,4 +504,93 @@ describe('findSchemaChanges', () => {
       },
     ]);
   });
+
+  it('should detect if an input object becomes a oneOf input object', () => {
+    const oldSchema = buildSchema(`
+      input Foo {
+        x: String
+        y: String
+      }
+
+      type Query {
+        foo(arg: Foo): String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      input Foo @oneOf {
+        x: String
+        y: String
+      }
+
+      type Query {
+        foo(arg: Foo): String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description: '@oneOf was added to Foo.',
+        type: BreakingChangeType.INPUT_OBJECT_ONE_OF_ADDED,
+      },
+    ]);
+  });
+
+  it('should detect if an input object stops being a oneOf input object', () => {
+    const oldSchema = buildSchema(`
+      input Foo @oneOf {
+        x: String
+        y: String
+      }
+
+      type Query {
+        foo(arg: Foo): String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      input Foo {
+        x: String
+        y: String
+      }
+
+      type Query {
+        foo(arg: Foo): String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description: '@oneOf was removed from Foo.',
+        type: SafeChangeType.INPUT_OBJECT_ONE_OF_REMOVED,
+      },
+    ]);
+  });
+
+  it('should not detect a change when an input object stays a oneOf input object', () => {
+    const oldSchema = buildSchema(`
+      input Foo @oneOf {
+        x: String
+      }
+
+      type Query {
+        foo(arg: Foo): String
+      }
+    `);
+
+    const newSchema = buildSchema(`
+      input Foo @oneOf {
+        x: String
+        y: String
+      }
+
+      type Query {
+        foo(arg: Foo): String
+      }
+    `);
+    expect(findSchemaChanges(oldSchema, newSchema)).to.deep.equal([
+      {
+        description: 'An optional field Foo.y was added.',
+        type: DangerousChangeType.OPTIONAL_INPUT_FIELD_ADDED,
+      },
+    ]);
+  });
 });

--- a/src/utilities/findSchemaChanges.ts
+++ b/src/utilities/findSchemaChanges.ts
@@ -55,6 +55,7 @@ export const BreakingChangeType = {
   REQUIRED_DIRECTIVE_ARG_ADDED: 'REQUIRED_DIRECTIVE_ARG_ADDED' as const,
   DIRECTIVE_REPEATABLE_REMOVED: 'DIRECTIVE_REPEATABLE_REMOVED' as const,
   DIRECTIVE_LOCATION_REMOVED: 'DIRECTIVE_LOCATION_REMOVED' as const,
+  INPUT_OBJECT_ONE_OF_ADDED: 'INPUT_OBJECT_ONE_OF_ADDED' as const,
 } as const;
 
 /** Categories of schema changes that may break existing operations. */
@@ -93,6 +94,7 @@ export const SafeChangeType = {
   ARG_CHANGED_KIND_SAFE: 'ARG_CHANGED_KIND_SAFE' as const,
   ARG_DEFAULT_VALUE_ADDED: 'ARG_DEFAULT_VALUE_ADDED' as const,
   INPUT_FIELD_DEFAULT_VALUE_ADDED: 'INPUT_FIELD_DEFAULT_VALUE_ADDED' as const,
+  INPUT_OBJECT_ONE_OF_REMOVED: 'INPUT_OBJECT_ONE_OF_REMOVED' as const,
 } as const;
 
 /** Categories of schema changes that are considered safe for existing operations. */
@@ -535,6 +537,20 @@ function findInputObjectTypeChanges(
         description: `Description of input-field ${newType}.${newField.name} has changed to "${newField.description}".`,
       });
     }
+  }
+
+  // Requiring exactly one field rejects input values that were previously
+  // valid, while lifting the constraint accepts everything it used to.
+  if (!oldType.isOneOf && newType.isOneOf) {
+    schemaChanges.push({
+      type: BreakingChangeType.INPUT_OBJECT_ONE_OF_ADDED,
+      description: `@oneOf was added to ${oldType}.`,
+    });
+  } else if (oldType.isOneOf && !newType.isOneOf) {
+    schemaChanges.push({
+      type: SafeChangeType.INPUT_OBJECT_ONE_OF_REMOVED,
+      description: `@oneOf was removed from ${oldType}.`,
+    });
   }
 
   return schemaChanges;


### PR DESCRIPTION
This PR proposes teaching `findSchemaChanges` to detect `@oneOf` being added to or removed from an input object type, which is currently reported as no change at all. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/349. You can sign in with your GitHub ID to claim ownership of the project.

## What goes wrong

Adding `@oneOf` to an existing input object type is a breaking change: afterwards exactly one field may be supplied and its value must be non-null, so any operation that passed two fields of that input object stops validating.

`findInputObjectTypeChanges` in `src/utilities/findSchemaChanges.ts` compares each input field's type, default value and description, but never compares `isOneOf` on the type itself the way `findDirectiveChanges` compares `isRepeatable`. As a result `findSchemaChanges`, `findBreakingChanges` and `findDangerousChanges` all return an empty array for that edit, and a schema check built on them waves through a change that breaks every client sending more than one field.

`isOneOf` is observable to clients — it is part of the introspection query, `printSchema` emits `@oneOf`, and `buildClientSchema` round-trips it — so it is in scope for a diff whose stated purpose is comparing "client's observable changes".

## Reproduction on 17.x.x at 9c245018

```ts
import {
  buildSchema,
  findBreakingChanges,
  findSchemaChanges,
  parse,
  validate,
} from './src/index.ts';

const oldSchema = buildSchema(`
  input SearchBy { name: String, id: ID }
  type Query { search(by: SearchBy!): String }
`);
const newSchema = buildSchema(`
  input SearchBy @oneOf { name: String, id: ID }
  type Query { search(by: SearchBy!): String }
`);

const document = parse('{ search(by: { name: "a", id: "1" }) }');
console.log(findSchemaChanges(oldSchema, newSchema));
console.log(findBreakingChanges(oldSchema, newSchema));
console.log(validate(oldSchema, document).map((e) => e.message));
console.log(validate(newSchema, document).map((e) => e.message));
```

```
$ node --experimental-strip-types repro.ts
[]
[]
[]
[
  'Within OneOf Input Object type "SearchBy", exactly one field must be specified, and the value for that field must be non-null.'
]
```

The operation validates cleanly against the old schema and is rejected by the new one, and the reported difference between those two schemas is empty. With this change the first two lines become the `INPUT_OBJECT_ONE_OF_ADDED` entry below.

## The change

`findInputObjectTypeChanges` now compares `isOneOf`, mirroring the `isRepeatable` comparison in `findDirectiveChanges`, and reports one of two new members:

- `BreakingChangeType.INPUT_OBJECT_ONE_OF_ADDED` — `@oneOf was added to SearchBy.` Requiring exactly one non-null field rejects input values that were previously accepted.
- `SafeChangeType.INPUT_OBJECT_ONE_OF_REMOVED` — `@oneOf was removed from SearchBy.` Every value valid under a OneOf Input Object stays valid once the constraint is lifted, and such a type's fields are already all nullable and default-free, so nothing becomes required in the other direction.

The names follow the existing `DIRECTIVE_REPEATABLE_ADDED` / `DIRECTIVE_REPEATABLE_REMOVED` pair. Both members are additive: no existing member, description string or classification moves, so consumers are unaffected unless they switch exhaustively over the change types. This is the same shape of gap as the input-field default value one closed in #4832, in the same function.

`website/pages/api-v*` are generated snapshots, so the two members are left for the next docs regeneration; the schema-evolution guide reads them through `Object.values(BreakingChangeType)` and needs no edit.

## Verification

Four tests: `@oneOf` added, `@oneOf` removed, and an unchanged OneOf Input Object that gains a field (which must still report only `OPTIONAL_INPUT_FIELD_ADDED`) in `findSchemaChanges-test.ts`, plus one through the public `findBreakingChanges` wrapper in `findBreakingChanges-test.ts`.

Reverting only the new comparison while keeping the two members turns three of them red, and the unchanged-`@oneOf` control stays green:

```
$ npm run node:test -- "src/utilities/__tests__/findSchemaChanges-test.ts" "src/utilities/__tests__/findBreakingChanges-test.ts"
  ✖ should detect if an input type became a oneOf input type
  ✖ should detect if an input object becomes a oneOf input object
  ✖ should detect if an input object stops being a oneOf input object
  ✔ should not detect a change when an input object stays a oneOf input object
ℹ pass 56
ℹ fail 3
```

Restoring it, all four pass and the rest of the suite is unmoved from the same checks run on a clean 9c245018 tree: `npm run testonly` goes from 3031 passing / 0 failing to 3035 passing / 0 failing, and `npm run testonly:cover` keeps `findSchemaChanges.ts` and the project total at 100.00 lines / 100.00 branches / 100.00 functions. `npm run check:ts`, `npm run lint`, `npm run prettier:check` and `npm run check:spelling` are all clean.

## How this was managed

We tracked this work on a board imported from this repository's issues — 1,170 stories and 15 labels. The story behind this change is https://eastagiletracker.com/projects/349/stories/218725 and the board it sits on is https://eastagiletracker.com/projects/349.

![board](https://raw.githubusercontent.com/eastagiletracker/graphql-js/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
