### PR TITLE
chore(release): v15.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "graphql",
-  "version": "15.10.2",
+  "version": "15.10.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "graphql",
-      "version": "15.10.1",
+      "version": "15.10.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql",
-  "version": "15.10.2",
+  "version": "15.10.3",
   "description": "A Query Language and Runtime which can target any service.",
   "license": "MIT",
   "private": true,

--- a/src/version.js
+++ b/src/version.js
@@ -6,7 +6,7 @@
 /**
  * A string containing the version of the GraphQL.js library
  */
-export const version = '15.10.2';
+export const version = '15.10.3';
 
 /**
  * An object containing the components of the GraphQL.js version string
@@ -14,6 +14,6 @@ export const version = '15.10.2';
 export const versionInfo = Object.freeze({
   major: 15,
   minor: 10,
-  patch: 2,
+  patch: 3,
   preReleaseTag: null,
 });


### PR DESCRIPTION
## v15.10.3 (2026-08-28)

#### Internal 🏠
* [#4849](https://github.com/graphql/graphql-js/pull/4849) internal: backport release flow to 15.x.x ([@yaacovCR](https://github.com/yaacovCR))

#### Committers: 1
* Yaacov Rydzinski ([@yaacovCR](https://github.com/yaacovCR))