### PR TITLE
test: accept non-null union implementing a nullable union interface field

### DIFF
--- a/src/type/__tests__/validation-test.ts
+++ b/src/type/__tests__/validation-test.ts
@@ -3215,6 +3215,29 @@ describe('Objects must adhere to Interface they implement', () => {
     expectJSON(validateSchema(schema)).toDeepEqual([]);
   });
 
+  it('accepts an Object with a subset non-null Interface field type (union)', () => {
+    const schema = buildSchema(`
+      type Query {
+        test: AnotherObject
+      }
+
+      type SomeObject {
+        field: String
+      }
+
+      union SomeUnionType = SomeObject
+
+      interface AnotherInterface {
+        field: SomeUnionType
+      }
+
+      type AnotherObject implements AnotherInterface {
+        field: SomeUnionType!
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
+  });
+
   it('rejects an Object with a superset nullable Interface field type', () => {
     const schema = buildSchema(`
       type Query {
@@ -3667,6 +3690,29 @@ describe('Interfaces must adhere to Interface they implement', () => {
 
       interface ChildInterface implements ParentInterface {
         field: String!
+      }
+    `);
+    expectJSON(validateSchema(schema)).toDeepEqual([]);
+  });
+
+  it('accepts an Interface with a subset non-null Interface field type (union)', () => {
+    const schema = buildSchema(`
+      type Query {
+        test: ChildInterface
+      }
+
+      type SomeObject {
+        field: String
+      }
+
+      union SomeUnionType = SomeObject
+
+      interface ParentInterface {
+        field: SomeUnionType
+      }
+
+      interface ChildInterface implements ParentInterface {
+        field: SomeUnionType!
       }
     `);
     expectJSON(validateSchema(schema)).toDeepEqual([]);


### PR DESCRIPTION
Adds schema validation coverage for implementing a nullable union interface field with the non-null union (`SomeUnionType!` implementing `SomeUnionType`).

That case is already allowed by `isTypeSubTypeOf` (Non-Null is unwrapped before the abstract-type check) and by [spec `IsValidImplementationFieldType`](https://spec.graphql.org/October2021/#IsValidImplementationFieldType). The existing tests only covered it for scalars (`String!` / `String`) and for a nullable union member (`SomeObject` / `SomeUnionType`), not this combination.

**graphql-java recently found it did *not* accept this schema** ([#4467](https://github.com/graphql-java/graphql-java/pull/4467)): the union check ran before Non-Null unwrapping, so `U!` implementing `U` was rejected even though the spec allows it. graphql-js already does the right thing. Pinning that down with a test makes the behavior explicit as as-designed, rather than an accident of the comparator order.

Object and interface implementers, next to the existing "subset non-null Interface field type" tests.