### PR TITLE
fix(OverlappingFieldsCanMerge): fix var scope for fragment comparison cache

### DIFF
--- a/src/utilities/TypeInfo.ts
+++ b/src/utilities/TypeInfo.ts
@@ -459,8 +459,8 @@ export class TypeInfo {
   }
 
   /**
-   * Returns the current fragment signature.
-   * @returns The fragment signature for the current fragment definition.
+   * Returns the fragment signature referenced by the current fragment spread.
+   * @returns The referenced fragment signature, if available.
    * @example
    * ```ts
    * import { parse, visit } from 'graphql/language';

--- a/src/validation/ValidationContext.ts
+++ b/src/validation/ValidationContext.ts
@@ -672,8 +672,8 @@ export class ValidationContext extends ASTValidationContext {
   }
 
   /**
-   * Returns the fragment signature at the current traversal position.
-   * @returns The current fragment signature, if one is active.
+   * Returns the fragment signature referenced by the current fragment spread.
+   * @returns The referenced fragment signature, if available.
    * @example
    * ```ts
    * import { parse, visit } from 'graphql/language';

--- a/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
+++ b/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts
@@ -1503,6 +1503,39 @@ describe('Validate: Overlapping fields can be merged', () => {
       ]);
     });
 
+    it('checks fragment arguments in each variable scope', () => {
+      expectErrors(`
+        fragment Outer($x: Int, $y: Int) on Type {
+          ...WithArgs(x: $x)
+          ...WithArgs(x: $y)
+        }
+        fragment WithArgs($x: Int) on Type {
+          a(x: $x)
+        }
+        query Example($x: Int, $y: Int) {
+          ...WithArgs(x: $x)
+          ...WithArgs(x: $y)
+        }
+      `).toDeepEqual([
+        {
+          message:
+            'Spreads "WithArgs" conflict because WithArgs(x: $x) and WithArgs(x: $y) have different fragment arguments.',
+          locations: [
+            { line: 3, column: 11 },
+            { line: 4, column: 11 },
+          ],
+        },
+        {
+          message:
+            'Spreads "WithArgs" conflict because WithArgs(x: $x) and WithArgs(x: $y) have different fragment arguments.',
+          locations: [
+            { line: 10, column: 11 },
+            { line: 11, column: 11 },
+          ],
+        },
+      ]);
+    });
+
     it('allows operations with overlapping fields with arguments using identical operation variables', () => {
       expectValid(`
         query ($y: Int = 1) {

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -117,8 +117,20 @@ export function OverlappingFieldsCanBeMergedRule(
   // times, so this improves the performance of this validator.
   const cachedFieldsAndFragmentSpreads: FieldsAndFragmentSpreadsCache =
     new Map();
+  let fragmentVarMap: Map<string, ValueNode> | undefined;
 
   return {
+    FragmentDefinition: {
+      enter(node) {
+        const fragmentName = node.name.value;
+        const fragmentSignature =
+          context.getFragmentSignatureByName()(fragmentName);
+        fragmentVarMap = getVarMap(fragmentSignature, fragmentName);
+      },
+      leave() {
+        fragmentVarMap = undefined;
+      },
+    },
     SelectionSet(selectionSet) {
       const conflicts = findConflictsWithinSelectionSet(
         context,
@@ -127,6 +139,7 @@ export function OverlappingFieldsCanBeMergedRule(
         comparedFragmentPairs,
         context.getParentType(),
         selectionSet,
+        fragmentVarMap,
       );
       for (const [[responseName, reason], fields1, fields2] of conflicts) {
         const reasonMsg = reasonMessage(reason);
@@ -235,9 +248,9 @@ function findConflictsWithinSelectionSet(
   comparedFragmentPairs: PairSet<string>,
   parentType: Maybe<GraphQLNamedType>,
   selectionSet: SelectionSetNode,
+  varMap: Map<string, ValueNode> | undefined,
 ): Array<Conflict> {
   const conflicts: Array<Conflict> = [];
-  const varMap = getVarMap(context.getFragmentSignature());
 
   const [fieldMap, fragmentSpreads] = getFieldsAndFragmentSpreads(
     context,


### PR DESCRIPTION
Previously, `OverlappingFieldsCanMerge` mistakenly used `getFragmentSignature()` while visiting a `SelectionSet`. `getFragmentSignature()` is a helper only populated while visiting a `FragmentSpread` to assist with argument validation. This mistake led to processing of selection sets inside fragment definitions without their fragment variable scope.

Without the scope, the comparison cache confuses identical-looking spreads from a fragment definition and an operation. After checking the fragment, `OverlappingFieldsCanMerge` would incorrectly skip the operation's separate conflict. For example:

```graphql
    fragment Outer($x: Int, $y: Int) on Type {
      ...WithArgs(x: $x)
      ...WithArgs(x: $y)
    }

    fragment WithArgs($x: Int) on Type {
      a(x: $x)
    }

    query Example($x: Int, $y: Int) {
      ...WithArgs(x: $x)
      ...WithArgs(x: $y)
    }
```

Previously, the conflict in `Outer` was reported but the conflict in `Example` was not. This PR fixes that mistake by using `getFragmentSignatureByName()` while entering the enclosing `FragmentDefinition` and saving the current fragment.