### PR TITLE
polish(validation): skip empty field comparisons

### DIFF
--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -313,6 +313,10 @@ function collectConflictsBetweenFieldsAndFragment(
   varMap: VariableMap | undefined,
   fragmentSpread: FragmentSpread,
 ): void {
+  if (fieldMap.size === 0) {
+    return;
+  }
+
   const { comparedFieldsAndFragmentPairs } = ruleContext;
   // Memoize so the fields and fragments are not compared for conflicts more
   // than once.
@@ -634,6 +638,9 @@ function collectConflictsBetween(
   fieldMap2: NodeAndDefCollection,
   varMap2: VariableMap | undefined,
 ): void {
+  if (fieldMap1.size === 0 || fieldMap2.size === 0) {
+    return;
+  }
   // A field map is a keyed collection, where each key represents a response
   // name and the value at that key is a list of all fields which provide that
   // response name. For any response name which appears in both provided field


### PR DESCRIPTION
Skip field comparisons when either collection is empty. This avoids traversing referenced fields when there are no local fields to compare.